### PR TITLE
DBZ-6219 Doc update to explain default snapshot behavior for capturing schema history

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -144,8 +144,9 @@ If you configure a different snapshot mode, the connector completes the snapshot
 1. Establish a connection to the database.
 
 2. Determine which tables are in capture mode and should be included in the snapshot.
-  By default, the connector captures all non-system tables.
-  To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:db2-property-table-include-list[`table.include.list`] or xref:db2-property-table-exclude-list[`table.exclude.list`].
+   By default, the connector captures the data for all non-system tables.
+   After the snapshot completes, the connector continues to stream data for the specified tables.
+   If you want the connector to capture data only from specific tables you can direct the connector to capture the data for only a subset of tables or table elements by setting properties such as xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-table-exclude-list[`table.exclude.list`].
 
 3. Obtain a lock on each of the tables in capture mode.
   This lock ensures that no schema changes can occur in those tables until the snapshot completes.
@@ -153,18 +154,16 @@ If you configure a different snapshot mode, the connector completes the snapshot
 
 4. Read the highest (most recent) LSN position in the server's transaction log.
 
-5. Capture the schema of all tables that are in capture mode.
-The connector persists this information in its internal database schema history topic.
+5. Capture the schema of all tables or all tables that are designated for capture.
+The connector persists schema information in its internal database schema history topic.
 The schema history provides information about the structure that is in effect when a change event occurs. +
 +
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
-However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+If tables are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
 
-There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
-When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
-If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+For more information about why snapshots persist schema information for tables that you did not include in the initial snapshot, see xref:understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables[Understanding why initial snapshots capture the schema for all tables].
 ====
 
 6. Release any locks obtained in Step 3.
@@ -204,7 +203,7 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 Schema data::
 DDL statements that describe the structural changes that are applied to tables.
 Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
@@ -213,18 +212,17 @@ After you run an initial snapshot, you might notice that the snapshot captures s
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
 Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-
-For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
-It does not capture table data.
+If the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 In some cases, you might want to limit schema capture in the initial snapshot.
 This can be useful when you want to reduce the time required to complete a snapshot.
-But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
+Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
 * xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
-* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
+* Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
+* Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.
 
 // Type: procedure
 [id="db2-capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
@@ -297,7 +295,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -137,7 +137,7 @@ For each change that the snapshot captures, the connector emits a `read` event t
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:db2-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
-If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
+If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
 
 .Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
 
@@ -439,28 +439,18 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-////
-{prodname}requires the schema history so that it can apply the table structure in effect at the time an event occurs.
-When the connector is stopped and restarted if the database metadata has changed so that the current structure of the table does not match the structure that was in effect at the point in time we're reading changes from; which is why the topic is needed.
+To ensure correct processing of events that occur after a schema change, the {prodname} Db2 connector stores a snapshot of the new schema based on the structures of the Db2 change data tables, which mirror the structures of their associated data tables.
+The connector stores the table schema information, together with the LSN of operations the result in schema changes, in the database schema history Kafka topic.
+The connector uses the stored schema representation to produce change events that correctly mirror the structure of tables at the time of each insert, update, or delete operation.
 
-The connector reads offsets at start-up if they exist.
-It then uses the position to recover the schema history topic, but only up to the position specified by the offsets.
+When the connector restarts after either a crash or a graceful stop, it resumes reading entries in the Db2 change data tables from the last position that it read.
+Based on the schema information that the connector reads from the database schema history topic, the connector applies the table structures that existed at the position where the connector restarts.
 
-If you apply schema changes to a table after the position of the last event that is recorded in the offsets, when the connector restarts, it starts from its last known position, which, according to the offsets file, excludes the most recent schema data in the dbhistory file
-It ignores the subsequent schema changes, skipping over them without reporting their presence.
-So the connector tries to process the event at the next offset without having the schema data.
+If you update the schema of a Db2 table that is in capture mode, it's important that you also update the schema of the corresponding change table.
+You must be a Db2 database administrator with elevated privileges to update database schema.
+For more information about how to update Db2 database schema in {prodname} environments, see xref:db2-schema-evolution[Schema history eveolution].
 
-////
-
-To ensure correct processing of changes that occur after a schema change, Db2 includes in the transaction log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the transaction log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
-The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
-In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the transaction log where each DDL statement appeared.
-
-When the connector restarts after either a crash or a graceful stop, it starts reading the transaction log from a specific position, that is, from a specific point in time.
-The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the transaction log where the connector is starting.
-
-This database schema history topic is for connector use only.
+The database schema history topic is for internal connector use only.
 Optionally, the connector can also xref:about-the-debezium-db2-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 .Additional resources

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -275,6 +275,34 @@ To configure custom topic names, you specify regular expressions in the logical 
 For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
+// ModuleID: how-debezium-db2-connectors-handle-database-schema-changes
+// Title: How {prodname} Db2 connectors handle database schema changes
+[[db2-schema-history-topic]]
+=== Schema history topic
+
+When a database client queries a database, the client uses the database’s current schema.
+However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
+Also, a connector cannot necessarily apply the current schema to every event.
+If an event is relatively old, it's possible that it was recorded before the current schema was applied.
+
+To ensure correct processing of changes that occur after a schema change, Db2 includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+
+When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+
+This database schema history topic is for connector use only.
+Optionally, the connector can also xref:about-the-debezium-db2-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+
+When the Db2 connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
+The connector needs to be configured to capture change to these helper tables.
+If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+
+For more information, see xref:db2-topic-names[default names for topics] that receive {prodname} event records.
+
+// Type: concept
 // Title: About the {prodname} Db2 connector schema change topic
 [id="about-the-debezium-db2-connector-schema-change-topic"]
 === Schema change topic

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -201,60 +201,46 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
 ==== Understanding why initial snapshots capture the schema history for all tables
 
-When a connector runs an initial snapshot, it captures two types of information:
+The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
 DDL statements that describe the structural changes that are applied to tables.
+Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
 
 After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
-This is not an error.
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
-The captured schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
-Although the default behavior of an intial snapshot captures the schema all tables, if a table is not designated for capture (that is, not named in the `snapshot.include.collection.list`), the snapshot captures only the table structure.
-It does not capture any data from the table.
-
+Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-A table schema can change at any time.
-Columns can be added or removed, or column names can be changed.
-If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
-When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
-If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-If the initial snapshot did not capture schema data for a table, you must perform additional steps before {prodname} can capture the table.
+For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
+It does not capture table data.
+
+In some cases, you might want to limit schema capture in the initial snapshot.
+This can be useful when you want to reduce the time required to complete a snapshot.
+But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 .Additional information
- * xref:capturing-data-from-tables-not-captured-by-the-initial-snapshot[]
+* xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
+* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
 
 // Type: procedure
-[id="capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
-==== Capturing data from tables not captured by the initial snapshot
+[id="db2-capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
+==== Capturing data from tables not captured by the initial snapshot (no schema change)
 
-For a connector to capture data from a table, information about the table's schema must be present in the schema history topic.
-If you specified a list of tables for the connector to capture by configuring a `table.include.list`, when the connector runs its initial snapshot, it captures data from only the tables that are named in the list.
-However, by default, the initial snapshot captures the schema of every table in the database, not just the tables that you specified in the `include` list.
-This default behavior facilitates future additions to the list of tables to capture.
+In some cases, you might want the connector to capture data from a table whose schema was not captured by the initial snapshot.
+Depending on the connector configuration, the initial snapshot might capture the table schema only for specific tables in the database.
+If the table schema is not present in the history topic, the connector fails to capture the table, and reports a missing schema error.
 
-[NOTE]
-====
-The xref:{context}-property-snapshot-include-collection-list[snapshot.include.collection.list] property specifies the list of tables that a snapshot captures.
-If you do not set this property, snapshots default to capturing all tables specified in the `table.include.list`.
-====
-
-The default behavior applies only when `schema.history.internal.store.only.captured.tables.ddl` is set to its default value of `false`.
-If the initial snapshot runs when `schema.history.internal.store.only.captured.tables.ddl` is set to `true`, the snapshot captures only the schema of tables specified in the `include` list.
-Then, if you later decide to capture from a table that was not part of the original `include` list, the connector returns an error, reporting that the table schema is not available.
-{prodname} does not automatically repopulate the schema history topic with the schema of newly added tables.
-
-You can still capture data from the new table, but you must perform additional steps.
-Complete the following steps to configure the connector to capture data from a table that was not captured by the initial snaphot.
-These steps assume that all records in the table use the same schema (that is, no schema change was applied to the table).
-For tables that have undergone structural changes, see xref:capturing-data-from-new-tables-with-schema-changes[].
+You might still be able to capture data from the table, but you must perform additional steps to add the table schema.
 
 .Prerequisites
+
 * You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
 * No schema changes were applied to the table between the LSNs of the earliest and latest change table entry that the connector reads.
+For information about capturing data from a new table that has undergone structural changes, see xref:db2-capturing-data-from-new-tables-with-schema-changes[].
 
 .Procedure
 
@@ -268,7 +254,7 @@ For more information about how to remove offsets, see the link:https://debezium.
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
 This operation is potentially destructive, and should be performed only as a last resort.
 ====
-3. Set values for properties in the connector configuration as described in the following steps:
+4. Apply the following changes to the connector configuration:
 .. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
 This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables. +
 +
@@ -284,64 +270,84 @@ If you select this option, consider setting the value of the xref:{context}-prop
 Unlike a full data snapshot, this option does not capture any table data.
 Use this option if ou want to restart the connector more quickly than with a full snapshot.
 
-4. Restart the connector.
+5. Restart the connector.
 The connector completes the type of snapshot specified by the `snapshot.mode`.
-5. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
 The connector runs the snapshot while it continues to stream real-time changes from the tables.
 Running an incremental snapshot captures the following data changes:
 +
-* For tables that were previously being captured, it captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
-* For newly added tables, it captures all existing table rows.
+* For tables that the connector previously captured, the incremental snapsot captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
+* For newly added tables, the incremental snapshot captures all existing table rows.
 
+// Type: procedure
+[id="db2-capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot (schema change)
 
-[id="capturing-data-from-new-tables-with-schema-changes"]
-==== Capturing data from tables not captured by the initial snapshot if a schema change was applied
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-If you want to capture data from a table that was not captured by the initial snapshot and the schema of that table was modified, you cannot use the process for enabling capture when no schema change is involved.
+If you want to capture data from a table that was not captured by the initial snapshot, and the schema of the table was modified, you must add the schema to the history topic, if it is not already available.
+You can add the schema by running a new schema snapshot, or by running an initial snapshot for the table.
 
-In such a case, you have two options, depending on whether the initial snapshot captured the schema for all tables.
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* A schema change was applied to the table so that the records to be captured do not have a uniform structure.
 
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
-The schema history topic captured schema changes only for the tables designated for capture.
-The schema history topic does not contain schema information for tables that you later add to the `include` list.
-In this case, to capture changes from the table, complete one of the following procedures:
+If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
 
-Procedure 1:::
+Procedure 1: Schema snapshot, followed by incremental snapshot:::
 In this procedure, the connector first performs a schema snapshot.
 You can then initiate an incremental snapshot to enable the connector to synchronize data.
 1. Stop the connector.
-2. Remove the connector offsets and history topic.
-3. Set values for properties in the connector configuration as described in the following steps:
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Set values for properties in the connector configuration as described in the following steps:
 .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
 .. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
-4. Restart the connector.
-5. Wait for {prodname} to capture the schema of the new and existing tables.
+5. Restart the connector.
+6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-6. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
-
-Procedure 2:::
-This option requires the connector to perform a full initial snapshot of the database.
+Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
+In this procedure the connector performs a full initial snapshot of the database.
 As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+After the snapshot completes, you can optionally trigger an incremental snapshot to capture any changes that occur while the connector is off-line.
 
 1. Stop the connector.
-2. Remove the connector offsets and history topic.
- Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
-3. Set values for properties in the connector configuration as described in the following steps:
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Set values for properties in the connector configuration as described in the following steps:
 .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
 .. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
-4. Restart the connector.
+6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-5. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
-
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -206,12 +206,12 @@ When a connector runs an initial snapshot, it captures two types of information:
 Table data::
 Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
-DDL statements that describe changes that occur to the structure of tables.
+DDL statements that describe the structural changes that are applied to tables.
 
 After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
 This is not an error.
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
-The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+The captured schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
 Although the default behavior of an intial snapshot captures the schema all tables, if a table is not designated for capture (that is, not named in the `snapshot.include.collection.list`), the snapshot captures only the table structure.
 It does not capture any data from the table.
 
@@ -234,7 +234,7 @@ If the initial snapshot did not capture schema data for a table, you must perfor
 For a connector to capture data from a table, information about the table's schema must be present in the schema history topic.
 If you specified a list of tables for the connector to capture by configuring a `table.include.list`, when the connector runs its initial snapshot, it captures data from only the tables that are named in the list.
 However, by default, the initial snapshot captures the schema of every table in the database, not just the tables that you specified in the `include` list.
-This default behavior, which occurs when the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property is set to `false`, facilitates future additions to the list of tables to capture.
+This default behavior facilitates future additions to the list of tables to capture.
 
 [NOTE]
 ====
@@ -335,7 +335,7 @@ As with any initial snapshot, in a database with many large tables, running an i
 2. Remove the connector offsets and history topic.
  Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
 3. Set values for properties in the connector configuration as described in the following steps:
-.. .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
 .. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
 4. Restart the connector.
 The connector takes a full database snapshot.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -328,11 +328,9 @@ The connector rebuilds the table structures that existed at this point in time b
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:about-the-debezium-db2-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
-When the Db2 connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
-The connector needs to be configured to capture change to these helper tables.
-If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+.Additional resources
 
-For more information, see xref:db2-topic-names[default names for topics] that receive {prodname} event records.
+* xref:db2-topic-names[Default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // Title: About the {prodname} Db2 connector schema change topic

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -168,12 +168,12 @@ If you're certain that it won't be necessary to capture data from other tables i
 ====
 
 6. Release any locks obtained in Step 3.
-  Other database clients can now write to the database.
+  Other database clients can now write to any previously locked tables.
 
 7. At the LSN position read in Step 4, the connector scans the tables that are designated for capture.
   During the scan, the connector completes the following tasks:
 
-.. Confirms that the table being scanned was created before the snapshot began.
+.. Confirms that the table was created before the snapshot began.
   If the table was created after the snapshot began, the connector skips the table.
   After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -79,7 +79,7 @@ that enable SQL Replication in Db2. A capture agent:
 * Generates change-data tables for tables that are in capture mode.
 * Monitors tables in capture mode and stores change events for updates to those tables in their corresponding change-data tables.
 
-The {prodname} connector uses a SQL interface to query change-data tables for  change events.
+The {prodname} connector uses a SQL interface to query change-data tables for change events.
 
 The database administrator must put the tables for which you want to capture changes into capture mode.
 For convenience and for automating testing, there are xref:db2-management[{prodname} management user-defined functions (UDFs)] in C that you can compile and then use to do the following management tasks:
@@ -91,9 +91,16 @@ For convenience and for automating testing, there are xref:db2-management[{prodn
 
 Alternatively, you can use Db2 control commands to accomplish these tasks.
 
-After the tables of interest are in capture mode, the connector reads their corresponding change-data tables to obtain change events for table updates. The connector emits a change event for each row-level insert, update, and delete operation to a Kafka topic that has the same name as the changed table. This is default behavior that you can modify. Client applications read the Kafka topics that correspond to the database tables of interest and can react to each row-level change event.
+After the tables of interest are in capture mode, the connector reads their corresponding change-data tables to obtain change events for table updates.
+The connector emits a change event for each row-level insert, update, and delete operation to a Kafka topic that has the same name as the changed table.
+This is default behavior that you can modify.
+Client applications read the Kafka topics that correspond to the database tables of interest and can react to each row-level change event.
 
-Typically, the database administrator puts a table into capture mode in the middle of the life of a table. This means that the connector does not have the complete history of all changes that have been made to the table. Therefore, when the Db2 connector first connects to a particular Db2 database, it starts by performing a _consistent snapshot_ of each table that is in capture mode. After the connector completes the snapshot, the connector streams change events from the point at which the snapshot was made. In this way, the connector starts with a consistent view of the tables that are in capture mode, and does not drop any changes that were made while it was performing the snapshot.
+Typically, the database administrator puts a table into capture mode in the middle of the life of a table.
+This means that the connector does not have the complete history of all changes that have been made to the table.
+Therefore, when the Db2 connector first connects to a particular Db2 database, it starts by performing a _consistent snapshot_ of each table that is in capture mode.
+After the connector completes the snapshot, the connector streams change events from the point at which the snapshot was made.
+In this way, the connector starts with a consistent view of the tables that are in capture mode, and does not drop any changes that were made while it was performing the snapshot.
 
 {prodname} connectors are tolerant of failures. As the connector reads and produces change events, it records the log sequence number (LSN) of the change-data table entry. The LSN is the position of the change event in the database log. If the connector stops for any reason, including communication failures, network problems, or crashes, upon restarting it continues reading the change-data tables where it left off. This includes snapshots. That is, if the snapshot was not complete when the connector stopped, upon restart the connector begins a new snapshot.
 
@@ -122,21 +129,71 @@ endif::product[]
 [[db2-snapshots]]
 === Snapshots
 
-Db2`s replication feature is not designed to store the complete history of database changes. Consequently, when a {prodname} Db2 connector connects to a database for the first time, it takes a consistent snapshot of tables that are in capture mode and streams this state to Kafka. This establishes the baseline for table content.
+Db2`s replication feature is not designed to store the complete history of database changes.
+As a result, the {prodname} Db2 connector cannot retrieve the entire history of the database from the logs.
+To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the tables that are in xref:putting-tables-in-capture-mode[capture mode].
+For each change that the snapshot captures, the connector emits a `read` event to the Kafka topic for the captured table.
 
-By default, when a Db2 connector performs a snapshot, it does the following:
+The following workflow lists the steps that {prodname} takes to create a snapshot.
+These steps describe the process for a snapshot when the xref:db2-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
+You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
+If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
 
-. Determines which tables are in capture mode, and thus must be included in the snapshot. By default, all non-system tables are in capture mode. Connector configuration properties, such as `table.exclude.list` and `table.include.list` let you specify which tables should be in capture mode.
-. Obtains a lock on each of the tables in capture mode. This ensures that no schema changes can occur in those tables during the snapshot.
-The level of the lock is determined by the `snapshot.isolation.mode` connector  configuration property.
-. Reads the highest (most recent) LSN position in the server's transaction log.
-. Captures the schema of all tables that are in capture mode. The connector persists this information in its internal database schema history topic.
-. Optional, releases the locks obtained in step 2. Typically, these locks are held for only a short time.
-. At the LSN position read in step 3, the connector scans the capture mode tables as well as their schemas. During the scan, the connector:
-.. Confirms that the table was created before the start of the snapshot. If it was not, the snapshot skips that table. After the snapshot is complete, and the connector starts emitting change events, the connector produces change events for any tables that were created during the snapshot.
-.. Produces a _read_ event for each row in each table that is in capture mode. All _read_ events contain the same LSN position, which is the LSN position that was obtained in step 3.
-.. Emits each _read_ event to the Kafka topic that has the same name as the table.
-. Records the successful completion of the snapshot in the connector offsets.
+.Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
+
+1. Establish a connection to the database.
+
+2. Determine which tables are in capture mode and should be included in the snapshot.
+  By default, the connector captures all non-system tables.
+  To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:db2-property-table-include-list[`table.include.list`] or xref:db2-property-table-exclude-list[`table.exclude.list`].
+
+3. Obtain a lock on each of the tables in capture mode.
+  This lock ensures that no schema changes can occur in those tables until the snapshot completes.
+  The level of the lock is determined by the `snapshot.isolation.mode` connector configuration property.
+
+4. Read the highest (most recent) LSN position in the server's transaction log.
+
+5. Capture the schema of all tables that are in capture mode.
+The connector persists this information in its internal database schema history topic.
+The schema history provides information about the structure that is in effect when a change event occurs. +
++
+[NOTE]
+====
+By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
+However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+
+There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
+When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
+If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+====
+
+6. Release any locks obtained in Step 3.
+  Other database clients can now write to the database.
+
+7. At the LSN position read in Step 4, the connector scans the tables that are designated for capture.
+  During the scan, the connector completes the following tasks:
+
+.. Confirms that the table being scanned was created before the snapshot began.
+  If the table was created after the snapshot began, the connector skips the table.
+  After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
+
+.. Produces a `read` event for each row that is captured from a table.
+  All `read` events contain the same LSN position, which is the LSN position that was obtained in step 4.
+
+.. Emits each `read` event to the Kafka topic for the source table.
+
+.. Releases data table locks, if applicable.
+
+8. Record the successful completion of the snapshot in the connector offsets.
+
+The resulting initial snapshot captures the current state of each row in the captured tables.
+From this baseline state, the connector captures subsequent changes as they occur.
+
+After the snapshot process begins, if the process is interrupted due to connector failure, rebalancing, or other reasons, the process restarts after the connector restarts.
+
+After the connector completes the initial snapshot, it continues streaming from the position that it read in Step 4 so that it does not miss any updates.
+
+If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots
@@ -235,7 +292,7 @@ Messages that the connector sends to the schema change topic contain a payload t
 
 `databaseName`:: The name of the database to which the statements are applied.
 The value of `databaseName` serves as the message key.
-`pos`:: The position in the binlog where the statements appear.
+`pos`:: The position in the transaction log where the statements appear.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -1391,6 +1448,7 @@ endif::product[]
 // Type: procedure
 // ModuleID: configuring-db2-tables-for-change-data-capture
 // Title: Configuring Db2 tables for change data capture
+[id="putting-tables-in-capture-mode"]
 === Putting tables into capture mode
 
 To put tables into capture mode, {prodname} provides a set of user-defined functions (UDFs) for your convenience.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -208,18 +208,21 @@ Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are
 Schema data::
 DDL statements that describe changes that occur to the structure of tables.
 
-By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
-For tables that are not designated for capture, the snapshot captures only the table structure.
-It does not capture any table data.
+After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
+This is not an error.
+By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
 The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+Although the default behavior of an intial snapshot captures the schema all tables, if a table is not designated for capture (that is, not named in the `snapshot.include.collection.list`), the snapshot captures only the table structure.
+It does not capture any data from the table.
 
-Users might be surprised to see that an initial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
-But initial snapshots capture schema information for all tables by design.
-To capture a table, {prodname} requires its DDL, including the schema history in case of schema changes result in records with different table structures.
-By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
+A table schema can change at any time.
+Columns can be added or removed, or column names can be changed.
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
-Then, if the connector later stops, when it resumes reading from the transaction log, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+If the initial snapshot did not capture schema data for a table, you must perform additional steps before {prodname} can capture the table.
 
 .Additional information
  * xref:capturing-data-from-tables-not-captured-by-the-initial-snapshot[]

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -213,19 +213,132 @@ For tables that are not designated for capture, the snapshot captures only the t
 It does not capture any table data.
 The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
 
-Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
-But inital snapshots capture schema information for all tables by design.
+Users might be surprised to see that an initial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
+But initial snapshots capture schema information for all tables by design.
+To capture a table, {prodname} requires its DDL, including the schema history in case of schema changes result in records with different table structures.
 By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
 
 Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
-Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+Then, if the connector later stops, when it resumes reading from the transaction log, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
 
-If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
-Additional manual steps are required to add the new table's schema to the schema history topic.
+.Additional information
+ * xref:capturing-data-from-tables-not-captured-by-the-initial-snapshot[]
 
-In general, it's best to leave the default configuration in place.
-But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
-For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+// Type: procedure
+[id="capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
+==== Capturing data from tables not captured by the initial snapshot
+
+For a connector to capture data from a table, information about the table's schema must be present in the schema history topic.
+If you specified a list of tables for the connector to capture by configuring a `table.include.list`, when the connector runs its initial snapshot, it captures data from only the tables that are named in the list.
+However, by default, the initial snapshot captures the schema of every table in the database, not just the tables that you specified in the `include` list.
+This default behavior, which occurs when the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property is set to `false`, facilitates future additions to the list of tables to capture.
+
+[NOTE]
+====
+The xref:{context}-property-snapshot-include-collection-list[snapshot.include.collection.list] property specifies the list of tables that a snapshot captures.
+If you do not set this property, snapshots default to capturing all tables specified in the `table.include.list`.
+====
+
+The default behavior applies only when `schema.history.internal.store.only.captured.tables.ddl` is set to its default value of `false`.
+If the initial snapshot runs when `schema.history.internal.store.only.captured.tables.ddl` is set to `true`, the snapshot captures only the schema of tables specified in the `include` list.
+Then, if you later decide to capture from a table that was not part of the original `include` list, the connector returns an error, reporting that the table schema is not available.
+{prodname} does not automatically repopulate the schema history topic with the schema of newly added tables.
+
+You can still capture data from the new table, but you must perform additional steps.
+Complete the following steps to configure the connector to capture data from a table that was not captured by the initial snaphot.
+These steps assume that all records in the table use the same schema (that is, no schema change was applied to the table).
+For tables that have undergone structural changes, see xref:capturing-data-from-new-tables-with-schema-changes[].
+
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* No schema changes were applied to the table between the LSNs of the earliest and latest change table entry that the connector reads.
+
+.Procedure
+
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+3. Set values for properties in the connector configuration as described in the following steps:
+.. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
+This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables. +
++
+[NOTE]
+====
+Snapshots that capture the schema for all tables require more time to complete.
+====
+.. Add the tables that you want the connector to capture to xref:{context}-property-table-include-list[`table.include.list`].
+.. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to one of the following values:
+`initial`:: When you restart the connector, it takes a full snapshot of the database that captures the table data and table structures. +
+If you select this option, consider setting the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] property to `false` to enable the connector to capture the schema of all tables.
+`schema_only`:: When you restart the connector, it takes a snapshot that captures only the table schema.
+Unlike a full data snapshot, this option does not capture any table data.
+Use this option if ou want to restart the connector more quickly than with a full snapshot.
+
+4. Restart the connector.
+The connector completes the type of snapshot specified by the `snapshot.mode`.
+5. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+The connector runs the snapshot while it continues to stream real-time changes from the tables.
+Running an incremental snapshot captures the following data changes:
++
+* For tables that were previously being captured, it captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
+* For newly added tables, it captures all existing table rows.
+
+
+[id="capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot if a schema change was applied
+
+If you want to capture data from a table that was not captured by the initial snapshot and the schema of that table was modified, you cannot use the process for enabling capture when no schema change is involved.
+
+In such a case, you have two options, depending on whether the initial snapshot captured the schema for all tables.
+
+.Procedure
+
+Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+2. Restart the connector.
+3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+
+Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
+The schema history topic captured schema changes only for the tables designated for capture.
+The schema history topic does not contain schema information for tables that you later add to the `include` list.
+In this case, to capture changes from the table, complete one of the following procedures:
+
+Procedure 1:::
+In this procedure, the connector first performs a schema snapshot.
+You can then initiate an incremental snapshot to enable the connector to synchronize data.
+1. Stop the connector.
+2. Remove the connector offsets and history topic.
+3. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
+.. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+4. Restart the connector.
+5. Wait for {prodname} to capture the schema of the new and existing tables.
+Data changes that occurred any tables after the connector stopped are not captured.
+6. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+
+
+Procedure 2:::
+This option requires the connector to perform a full initial snapshot of the database.
+As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+
+1. Stop the connector.
+2. Remove the connector offsets and history topic.
+ Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+3. Set values for properties in the connector configuration as described in the following steps:
+.. .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
+.. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+4. Restart the connector.
+The connector takes a full database snapshot.
+After the snapshot completes, the connector transitions to streaming.
+5. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+
 
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots
@@ -317,13 +430,26 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, Db2 includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
-The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
-In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+////
+{prodname}requires the schema history so that it can apply the table structure in effect at the time an event occurs.
+When the connector is stopped and restarted if the database metadata has changed so that the current structure of the table does not match the structure that was in effect at the point in time we're reading changes from; which is why the topic is needed.
 
-When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
-The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+The connector reads offsets at start-up if they exist.
+It then uses the position to recover the schema history topic, but only up to the position specified by the offsets.
+
+If you apply schema changes to a table after the position of the last event that is recorded in the offsets, when the connector restarts, it starts from its last known position, which, according to the offsets file, excludes the most recent schema data in the dbhistory file
+It ignores the subsequent schema changes, skipping over them without reporting their presence.
+So the connector tries to process the event at the next offset without having the schema data.
+
+////
+
+To ensure correct processing of changes that occur after a schema change, Db2 includes in the transaction log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the transaction log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the transaction log where each DDL statement appeared.
+
+When the connector restarts after either a crash or a graceful stop, it starts reading the transaction log from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the transaction log where the connector is starting.
 
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:about-the-debezium-db2-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
@@ -337,7 +463,7 @@ Optionally, the connector can also xref:about-the-debezium-db2-connector-schema-
 [id="about-the-debezium-db2-connector-schema-change-topic"]
 === Schema change topic
 
-You can configure a {prodname} Db2 connector to produce schema change events that describe schema changes that are applied to captured tables in the database.
+You can configure a {prodname} Db2 connector to produce schema change events that describe schema changes that are applied to tables in the database.
 
 {prodname} emits a message to the schema change topic when:
 
@@ -1248,7 +1374,7 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 [[db2-data-types]]
 == Data type mappings
 
-Db2's data types are described in https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0008483.html[Db2 SQL Data Types].
+For a complete description of the data types that Db2 supports, see https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0008483.html[Data Types] in the Db2 documentation.
 
 The Db2 connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. How that value is represented in the event depends on the Db2 data type of the column. This section describes these mappings.
 If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
@@ -1266,7 +1392,7 @@ endif::product[]
 [id="db2-basic-types"]
 === Basic types
 
-The following table describes how the connector maps each of the Db2 data types to a _literal type_ and a _semantic type_ in event fields.
+The following table describes how the connector maps each Db2 data type to a _literal type_ and a _semantic type_ in event fields.
 
 * _literal type_ describes how the value is represented using Kafka Connect schema types: `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
 
@@ -1377,7 +1503,8 @@ endif::community[]
 [[db2-temporal-types]]
 === Temporal types
 
-Other than Db2's `DATETIMEOFFSET` data type, which contains time zone information, how temporal types are mapped depends on the value of the `time.precision.mode` connector configuration property. The following sections describe these mappings:
+Except for the `DATETIMEOFFSET` data type, which contains time zone information, Db2 maps temporal types based on the value of the `time.precision.mode` connector configuration property.
+The following sections describe these mappings:
 
 * xref:db2-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
 * xref:db2-time-precision-mode-connect[`time.precision.mode=connect`]
@@ -2675,7 +2802,7 @@ Do this after you put a table into capture mode or after you remove a table from
 
 While a {prodname} Db2 connector can capture schema changes, to update a schema, you must collaborate with a database administrator to ensure that the connector continues to produce change events. This is required by the way that Db2 implements replication.
 
-For each table in capture mode, Db2's replication feature creates a change-data table that contains all changes to that source table. However, change-data table schemas are static. If you update the schema for a table in capture mode then you must also update the schema of its corresponding change-data table. A {prodname} Db2 connector cannot do this. A database administrator with elevated privileges must update schemas for tables that are in capture mode.
+For each table in capture mode, the replication feature in Db2 creates a change-data table that contains all changes to that source table. However, change-data table schemas are static. If you update the schema for a table in capture mode then you must also update the schema of its corresponding change-data table. A {prodname} Db2 connector cannot do this. A database administrator with elevated privileges must update schemas for tables that are in capture mode.
 
 [WARNING]
 ====

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -195,6 +195,38 @@ After the connector completes the initial snapshot, it continues streaming from 
 
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
+// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// Title: Description of why initial snapshots capture the schema history for all tables
+// Type: concept
+[id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
+==== Understanding why initial snapshots capture the schema history for all tables
+
+When a connector runs an initial snapshot, it captures two types of information:
+
+Table data::
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Schema data::
+DDL statements that describe changes that occur to the structure of tables.
+
+By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
+For tables that are not designated for capture, the snapshot captures only the table structure.
+It does not capture any table data.
+The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+
+Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
+But inital snapshots capture schema information for all tables by design.
+By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+
+Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
+Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+
+If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
+Additional manual steps are required to add the new table's schema to the schema history topic.
+
+In general, it's best to leave the default configuration in place.
+But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
+For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots
 [id="db2-ad-hoc-snapshots"]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -470,8 +470,9 @@ After the connector completes the initial snapshot, it continues streaming from 
 
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
-If the connector stops for long enough, the binlog files that record the connector's position can expire.
-If the database purges the expired binlog files, the connector's position is lost, which causes the connector to revert to the _initial snapshot_ for its starting position.
+After the connector restarts, if the logs have been pruned, the connector's position in the logs might no longer available.
+The connector then fails, and returns an error that indicates that a new snapshot is required.
+To configure the connector to automatically initiate a snapshot in this situation, set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `when_needed`.
 For more tips on troubleshooting the {prodname} MySQL connector, see xref:mysql-when-things-go-wrong[behavior when things go wrong].
 
 // Type: concept
@@ -543,6 +544,7 @@ a|Commit the transaction.
 
 |9
 |Release the table-level locks.
+Other database clients can now write to any previously locked tables.
 
 |10
 a|Record the successful completion of the snapshot in the connector offsets.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -552,10 +552,10 @@ a|Record the successful completion of the snapshot in the connector offsets.
 
 |===
 
-// ModuleID: description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept
-[id="{context}-understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
+[id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
 ==== Understanding why initial snapshots capture the schema history for all tables
 
 When a connector runs an initial snapshot, it captures two types of information:
@@ -566,27 +566,20 @@ Schema data::
 DDL statements that describe changes that occur to the structure of tables.
 
 By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
-For tables that are not designated for capture, the snapshot does not capture any table data; it captures only the table structure.
-Schema data is persisted to the both the internal schema history topic, and to the configured schema change topic.
+For tables that are not designated for capture, the snapshot captures only the table structure.
+It does not capture any table data.
+The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
 
-Users who notice that an intial snapshot captures schema information for non-captured tables might question whether an error occurred.
-But the capture of schema information for all tables is very much by design.
+Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
+But inital snapshots capture schema information for all tables by design.
 By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
 
-The database schema can change at any time.
-For this reason, it's important for {prodname} to be able to identify the schema that is in effect for a table at the time that any event occurs.
+Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
 Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
 
-//   Should we add information about what to do if you change the default to exclude schema for non-captured tables, but then you later want to capture data from such a table?
-//    you may have to perform additional manual steps to add the new table's schema to the schema history topic in the future for actions
-//   Fro example, take a new (schema) snapshot, which requires the snapshotted table's schema to exist in the schema history topic prior to taking the incremental snapshot.
-//   remove/clean schema history topic and set snapshot.mode to schema_only_recovery
-//   schema_only_recovery should can only be used if you can guarantee that the tables you were previously capturing have had no schema changes made to them between now and the point in the past where the connector was still reading changes from.
-//   chema history recovery takes the current JDBC structures of the tables and publishes those to the history topic.
-//   If we then begin to read the binlog from the last read offset and the structure of a table differs from what is in the schema history now, that could be cause for schema inconsistencies, so it's important to be careful when using recovery that you know the table's haven't had any DDL changes.
-//   Delete the existing history topic, and then use schema_only_recovery to repopulate it=, so yo can ensure that the history topic of the captured table exists.
-//   Rebuild the history topic by re-deploying the connector using the snapshot.mode schema_only_recovery to make things work fine, if not, we do get errors like this:
-//   Caused by: io.debezium.DebeziumException: Encountered change event for table dbName.yourTableName whose schema isn't known to this connector
+If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
+Additional manual steps are required to add the new table's schema to the schema history topic.
+
 In general, it's best to leave the default configuration in place.
 But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
 For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -127,10 +127,12 @@ This database schema history topic is for connector use only.
 The connector can optionally xref:mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
-The connector needs to be configured to capture change to these helper tables.
-If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+You must configure the connector to capture changes that occur in these helper tables.
+If consumers do not need the records the the connector generates for helper tables, configure a {link-prefix}:{link-filtering}#message-filtering[single message transform (SMT)] to remove these records from the messages that the connector emits.
 
-For more information, see xref:mysql-topic-names[default names for topics] that receive {prodname} event records.
+.Additional resources
+
+* xref:mysql-topic-names[Default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // ModuleID: how-debezium-mysql-connectors-expose-database-schema-changes

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -115,16 +115,16 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, MySQL includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+To ensure correct processing of events that occur after a schema change, MySQL includes in the transaction log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector encounters these DDL statements in the binlog, it parses them and updates an in-memory representation of each table’s schema.
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
 In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
 
 When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
 The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
 
-This database schema history topic is for connector use only.
-The connector can optionally xref:mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+This database schema history topic is for internal connector use only.
+Optionally, the connector can also xref:mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
 You must configure the connector to capture changes that occur in these helper tables.
@@ -392,6 +392,8 @@ The {prodname} MySQL connector completes different steps when it performs an ini
 [id="initial-snapshot-workflow-with-global-read-lock"]
 ==== Initial snapshots that use a global read lock
 The following workflow lists the steps that {prodname} takes to create a snapshot with a global read lock.
+You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
+If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
 For information about the snapshot process in environments that do not permit global read locks, see the xref:snapshot-workflow-with-table-level-locks[snapshot workflow for table-level locks].
 
 .Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with a global read lock
@@ -404,7 +406,7 @@ a|Establish a connection to the database.
 
 |2
 |Determine the tables to be captured.
-By default, the connector captures all non-system tables.
+By default, the connector captures data from all non-system tables.
 To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:mysql-property-table-include-list[`table.include.list`] or xref:mysql-property-table-exclude-list[`table.exclude.list`].
 
 |3

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -373,54 +373,118 @@ For more information, see xref:mysql-schema-history-topic[schema history topic].
 [[mysql-snapshots]]
 === Snapshots
 
-When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how the connector creates this snapshot. This flow is for the default snapshot mode, which is `initial`.
-For information about other snapshot modes, see the xref:mysql-property-snapshot-mode[MySQL connector `snapshot.mode` configuration property].
+When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database.
+This snapshot enables the connector to establish a baseline for the current state of the database.
 
-.Workflow for performing an initial snapshot with a global read lock
+{prodname} can use different modes when it runs a snapshot.
+The snapshot mode is determined by the xref:mysql-property-snapshot-mode[`snapshot.mode`] configuration property.
+The default value of the property is `initial`.
+You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
+
+The connector completes a series of tasks when it performs the snapshot.
+The exact steps vary with the snapshot mode and with the table locking policy that is in effect for the database.
+The {prodname} MySQL connector completes different steps when it performs an initial snapshot that uses a xref:initial-snapshot-workflow-with-global-read-lock[global read lock] or xref:initial-snapshot-workflow-with-table-level-locks[table-level locks].
+
+[id="initial-snapshot-workflow-with-global-read-lock"]
+==== Initial snapshots that use a global read lock
+The following workflow lists the steps that {prodname} takes to create a snapshot with a global read lock.
+For information about the snapshot process in environments that do not permit global read locks, see the xref:snapshot-workflow-with-table-level-locks[snapshot workflow for table-level locks].
+
+.Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with a global read lock
 [cols="1,9",options="header",subs="+attributes"]
 |===
 |Step |Action
 
 |1
-a| Grabs a global read lock that blocks _writes_ by other database clients. +
- +
-The snapshot itself does not prevent other clients from applying DDL that might interfere with the connector's attempt to read the binlog position and table schemas. The connector keeps the global read lock while it reads the binlog position, and releases the lock as described in a later step.
+a|Establish a connection to the database.
 
 |2
-a|Starts a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
+|Determine the tables to be captured.
+By default, the connector captures all non-system tables.
+To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:mysql-property-table-include-list[`table.include.list`] or xref:mysql-property-table-exclude-list[`table.exclude.list`].
 
 |3
-a|Reads the current binlog position.
+|Obtain a global read lock on the tables to be captured to block _writes_ by other database clients. +
+
+The snapshot itself does not prevent other clients from applying DDL that might interfere with the connector's attempt to read the binlog position and table schemas.
+The connector retains the global read lock while it reads the binlog position, and releases the lock as described in a later step.
 
 |4
-a|Reads the schema of the databases and tables for which the connector is configured to capture changes.
+a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_. +
+ +
+[NOTE]
+====
+The use of these isolation semantics can slow the progress of the snapshot.
+If the snapshot takes too long to complete, consider using a different isolation configuration, or skip the initial snapshot and run an xref:"mysql-incremental-snapshots[incremental snapshot] instead.
+====
 
 |5
-a|Releases the global read lock. Other database clients can now write to the database.
+|Read the current binlog position.
 
 |6
-a|If applicable, writes the DDL changes to the schema change topic, including all necessary `DROP...` and `CREATE...` DDL statements.
+a|Capture the structure of tables in the database.
+The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements. +
+The schema history provides information about the structure that is in effect when a change event occurs.
+ +
+[NOTE]
+====
+By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
+However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+
+There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
+When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
+If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+====
 
 |7
-a|Scans the database tables. For each row, the connector emits `CREATE` events to the relevant table-specific Kafka topics.
+|Release the global read lock obtained in Step 3.
+Other database clients can now write to the database.
 
 |8
-a|Commits the transaction.
+a|At the binlog position that the connector read in Step 5, the connector begins to scan the tables that are designated for capture.
+  During the scan, the connector completes the following tasks:
+
+. Confirms that the table being scanned was created before the snapshot began.
+   If the table was created after the snapshot began, the connector skips the table.
+   After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
+. Produces a `read` event for each row that is captured from a table.
+   All `read` events contain the same binlog position, which is the position that was obtained in step 5.
+. Emits each `read` event to the Kafka topic for the source table.
+. Releases data table locks, if applicable.
 
 |9
-a|Records the completed snapshot in the connector offsets.
+|Commit the transaction.
+
+|10
+|Record the successful completion of the snapshot in the connector offsets.
 
 |===
 
-Connector restarts::
-If the connector fails, stops, or is rebalanced while performing the _initial snapshot_, then after the connector restarts, it performs a new snapshot. After that _intial snapshot_ is completed, the {prodname} MySQL connector restarts from the same position in the binlog so it does not miss any updates.
-+
-If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:mysql-when-things-go-wrong[behavior when things go wrong].
+The resulting initial snapshot captures the current state of each row in the captured tables.
+From this baseline state, the connector captures subsequent changes as they occur.
 
-Global read locks not allowed::
-Some environments do not allow global read locks. If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks instead and performs a snapshot with this method. This requires the database user for the {prodname} connector to have `LOCK TABLES` privileges.
-+
-.Workflow for performing an initial snapshot with table-level locks
+After the snapshot process begins, if the process is interrupted due to connector failure, rebalancing, or other reasons, the process restarts after the connector restarts.
+
+After the connector completes the initial snapshot, it continues streaming from the position that it read in Step 5 so that it does not miss any updates.
+
+If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
+
+If the connector stops for long enough, the binlog files that record the connector's position can expire.
+If the database purges the expired binlog files, the connector's position is lost, which causes the connector to revert to the _initial snapshot_ for its starting position.
+For more tips on troubleshooting the {prodname} MySQL connector, see xref:mysql-when-things-go-wrong[behavior when things go wrong].
+
+[id="initial-snapshot-workflow-with-table-level-locks"]
+==== Initial snapshots that use table-level locks
+
+In some database environments administrators do not permit global read locks.
+If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks when it performs snapshots.
+For the connector to perform a snapshot that uses table-level locks, the database account that the {prodname} connector uses to connect to MySQL must have `LOCK TABLES` privileges.
+
+.Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with table-level locks
+The following workflow lists the steps that {prodname} takes to create a snapshot with table-level read locks.
+For information about the snapshot process in environments that do not permit global read locks, see the xref:default-snapshot-workflow-with-global-read-lock[snapshot workflow for global read locks].
+
+[id="snapshot-workflow-with-table-level-locks"]
 [cols="1,9",options="header",subs="+attributes"]
 |===
 |Step |Action

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -140,7 +140,7 @@ If consumers do not need the records the the connector generates for helper tabl
 [id="mysql-schema-change-topic"]
 === Schema change topic
 
-You can configure a {prodname} MySQL connector to produce schema change events that describe schema changes that are applied to captured tables in the database.
+You can configure a {prodname} MySQL connector to produce schema change events that describe schema changes that are applied to tables in the database.
 The connector writes schema change events to a Kafka topic named `_<topicPrefix>_`, where `_topicPrefix_` is the namespace specified in the xref:mysql-property-topic-prefix[`topic.prefix`] connector configuration property.
 Messages that the connector sends to the schema change topic contain a payload, and, optionally, also contain the schema of the change event message.
 
@@ -560,31 +560,130 @@ a|Record the successful completion of the snapshot in the connector offsets.
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
 ==== Understanding why initial snapshots capture the schema history for all tables
 
-When a connector runs an initial snapshot, it captures two types of information:
+The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
-DDL statements that describe changes that occur to the structure of tables.
+DDL statements that describe the structural changes that are applied to tables.
+Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
 
-By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
-For tables that are not designated for capture, the snapshot captures only the table structure.
-It does not capture any table data.
-The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
+By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
+Connectors require that the table's schema is present in the schema history topic before they can capture a table.
+By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
 
-Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
-But inital snapshots capture schema information for all tables by design.
-By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
+It does not capture table data.
 
-Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
-Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+In some cases, you might want to limit schema capture in the initial snapshot.
+This can be useful when you want to reduce the time required to complete a snapshot.
+But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
-If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
-Additional manual steps are required to add the new table's schema to the schema history topic.
+.Additional information
+* xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
+* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
 
-In general, it's best to leave the default configuration in place.
-But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
-For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+// Type: procedure
+[id="mysql-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change"]
+==== Capturing data from tables not captured by the initial snapshot (no schema change)
+
+In some cases, you might want the connector to capture data from a table whose schema was not captured by the initial snapshot.
+Depending on the connector configuration, the initial snapshot might capture the table schema only for specific tables in the database.
+If the table schema is not present in the history topic, the connector fails to capture the table, and reports a missing schema error.
+
+You might still be able to capture data from the table, but you must perform additional steps to add the table schema.
+
+.Prerequisites
+
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* In the transaction log, all entries for the table use the same schema.
+For information about capturing data from a new table that has undergone structural changes, see xref:mysql-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)].
+
+.Procedure
+
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Apply the following changes to the connector configuration:
+.. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to `schema_only_recovery`.
+.. Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+.. Add the tables that you want the connector to capture to `table.include.list`.
+This guarantees that in the future, the connector can reconstruct the schema history for all tables.
+4. Restart the connector.
+The snapshot recovery process rebuilds the schema history based on the current structure of the tables.
+5. (Optional) After the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
+6. (Optional) Reset the `snapshot.mode` back to `schema_only` to prevent the connector from initiating recovery after a future restart.
+
+// Type: procedure
+[id="mysql-capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot (schema change)
+
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
+
+If you want to capture data from a table that was not captured by the initial snapshot, and the schema of the table was modified, you must add the schema to the history topic, if it is not already available.
+You can add the schema by running a new schema snapshot, or by running an initial snapshot for the table.
+
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* A schema change was applied to the table so that the records to be captured do not have a uniform structure.
+
+.Procedure
+
+Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+2. Restart the connector.
+3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+
+Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
+If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
+
+Procedure 1: Schema snapshot, followed by incremental snapshot:::
+In this procedure, the connector first performs a schema snapshot.
+You can then initiate an incremental snapshot to enable the connector to synchronize data.
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
+.. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Restart the connector.
+6. Wait for {prodname} to capture the schema of the new and existing tables.
+Data changes that occurred any tables after the connector stopped are not captured.
+7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+
+Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
+In this procedure the connector performs a full initial snapshot of the database.
+As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+After the snapshot completes, you can optionally trigger an incremental snapshot to capture any changes that occur while the connector is off-line.
+
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
+.. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+6. Restart the connector.
+The connector takes a full database snapshot.
+After the snapshot completes, the connector transitions to streaming.
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -119,7 +119,7 @@ As the connector reads the binlog and comes across these DDL statements, it pars
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
 In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
 
-When the connector restarts after having crashed or been stopped gracefully, the connector starts reading the binlog from a specific position, that is, from a specific point in time.
+When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
 The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
 
 This database schema history topic is for connector use only.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -385,6 +385,7 @@ The connector completes a series of tasks when it performs the snapshot.
 The exact steps vary with the snapshot mode and with the table locking policy that is in effect for the database.
 The {prodname} MySQL connector completes different steps when it performs an initial snapshot that uses a xref:initial-snapshot-workflow-with-global-read-lock[global read lock] or xref:initial-snapshot-workflow-with-table-level-locks[table-level locks].
 
+// Type: concept
 [id="initial-snapshot-workflow-with-global-read-lock"]
 ==== Initial snapshots that use a global read lock
 The following workflow lists the steps that {prodname} takes to create a snapshot with a global read lock.
@@ -444,7 +445,7 @@ Other database clients can now write to the database.
 a|At the binlog position that the connector read in Step 5, the connector begins to scan the tables that are designated for capture.
   During the scan, the connector completes the following tasks:
 
-. Confirms that the table being scanned was created before the snapshot began.
+. Confirms that the table was created before the snapshot began.
    If the table was created after the snapshot began, the connector skips the table.
    After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
 . Produces a `read` event for each row that is captured from a table.
@@ -473,6 +474,7 @@ If the connector stops for long enough, the binlog files that record the connect
 If the database purges the expired binlog files, the connector's position is lost, which causes the connector to revert to the _initial snapshot_ for its starting position.
 For more tips on troubleshooting the {prodname} MySQL connector, see xref:mysql-when-things-go-wrong[behavior when things go wrong].
 
+// Type: concept
 [id="initial-snapshot-workflow-with-table-level-locks"]
 ==== Initial snapshots that use table-level locks
 
@@ -490,36 +492,100 @@ For information about the snapshot process in environments that do not permit gl
 |Step |Action
 
 |1
-|Obtains table-level locks.
+|Establish a connection to the database.
 
 |2
-a|Starts a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
+|Determine the tables to be captured.
+By default, the connector captures all non-system tables.
+To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:mysql-property-table-include-list[`table.include.list`] or xref:mysql-property-table-exclude-list[`table.exclude.list`].
 
 |3
-|Reads and filters the names of the databases and tables.
+|Obtain table-level locks.
 
 |4
-a|Reads the current binlog position.
+a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
+
+//  |5
+//  |Read and filter the names of the databases and tables.
 
 |5
-a|Reads the schema of the databases and tables for which the connector is configured to capture changes.
+a|Read the current binlog position.
 
 |6
-a|If applicable, writes the DDL changes to the schema change topic, including all necessary `DROP...` and `CREATE...` DDL statements.
+a|Read the schema of the databases and tables for which the connector is configured to capture changes.
+The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements. +
+The schema history provides information about the structure that is in effect when a change event occurs.
+ +
+[NOTE]
+====
+By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
+However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+
+There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
+When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
+If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+====
 
 |7
-a|Scans the database tables. For each row, the connector emits `CREATE` events to the relevant table-specific Kafka topics.
+a|At the binlog position that the connector read in Step 5, the connector begins to scan the tables that are designated for capture.
+  During the scan, the connector completes the following tasks:
+
+. Confirms that the table was created before the snapshot began.
+   If the table was created after the snapshot began, the connector skips the table.
+   After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
+. Produces a `read` event for each row that is captured from a table.
+   All `read` events contain the same binlog position, which is the position that was obtained in step 5.
+. Emits each `read` event to the Kafka topic for the source table.
+. Releases data table locks, if applicable.
 
 |8
-a|Commits the transaction.
+a|Commit the transaction.
 
 |9
-|Releases the table-level locks.
+|Release the table-level locks.
 
 |10
-a|Records the completed snapshot in the connector offsets.
+a|Record the successful completion of the snapshot in the connector offsets.
 
 |===
+// ModuleID: description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// Title: Description of why initial snapshots capture the schema history for all tables
+// Type: concept
+[id="{context}-understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
+==== Understanding why initial snapshots capture the schema history for all tables
+
+When a connector runs an initial snapshot, it captures two types of information:
+
+Table data::
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Schema data::
+DDL statements that describe changes that occur to the structure of tables.
+
+By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
+For tables that are not designated for capture, the snapshot does not capture any table data; it captures only the table structure.
+Schema data is persisted to the both the internal schema history topic, and to the configured schema change topic.
+
+Users who notice that an intial snapshot captures schema information for non-captured tables might question whether an error occurred.
+But the capture of schema information for all tables is very much by design.
+By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+
+The database schema can change at any time.
+For this reason, it's important for {prodname} to be able to identify the schema that is in effect for a table at the time that any event occurs.
+Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+
+//   Should we add information about what to do if you change the default to exclude schema for non-captured tables, but then you later want to capture data from such a table?
+//    you may have to perform additional manual steps to add the new table's schema to the schema history topic in the future for actions
+//   Fro example, take a new (schema) snapshot, which requires the snapshotted table's schema to exist in the schema history topic prior to taking the incremental snapshot.
+//   remove/clean schema history topic and set snapshot.mode to schema_only_recovery
+//   schema_only_recovery should can only be used if you can guarantee that the tables you were previously capturing have had no schema changes made to them between now and the point in the past where the connector was still reading changes from.
+//   chema history recovery takes the current JDBC structures of the tables and publishes those to the history topic.
+//   If we then begin to read the binlog from the last read offset and the structure of a table differs from what is in the schema history now, that could be cause for schema inconsistencies, so it's important to be careful when using recovery that you know the table's haven't had any DDL changes.
+//   Delete the existing history topic, and then use schema_only_recovery to repopulate it=, so yo can ensure that the history topic of the captured table exists.
+//   Rebuild the history topic by re-deploying the connector using the snapshot.mode schema_only_recovery to make things work fine, if not, we do get errors like this:
+//   Caused by: io.debezium.DebeziumException: Encountered change event for table dbName.yourTableName whose schema isn't known to this connector
+In general, it's best to leave the default configuration in place.
+But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
+For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
 
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -112,9 +112,10 @@ Because these hosted options do not allow a global read lock, table-level locks 
 
 When a database client queries a database, the client uses the database’s current schema.
 However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
-Also, a connector cannot just use the current schema because the connector might be processing events that are relatively old that were recorded before the tables' schemas were changed.
+Also, a connector cannot necessarily apply the current schema to every event.
+If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, MySQL includes in the binlog not only the row-level changes to the data, but also the DDL statements that are applied to the database.
+To ensure correct processing of changes that occur after a schema change, MySQL includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
 As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
 In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
@@ -550,6 +551,7 @@ Other database clients can now write to any previously locked tables.
 a|Record the successful completion of the snapshot in the connector offsets.
 
 |===
+
 // ModuleID: description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -397,7 +397,7 @@ If you configure a different snapshot mode, the connector completes the snapshot
 For information about the snapshot process in environments that do not permit global read locks, see the xref:snapshot-workflow-with-table-level-locks[snapshot workflow for table-level locks].
 
 .Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with a global read lock
-[cols="1,9",options="header",subs="+attributes"]
+[cols="1a,9a",options="header",subs="+attributes"]
 |===
 |Step |Action
 
@@ -406,8 +406,9 @@ a|Establish a connection to the database.
 
 |2
 |Determine the tables to be captured.
-By default, the connector captures data from all non-system tables.
-To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:mysql-property-table-include-list[`table.include.list`] or xref:mysql-property-table-exclude-list[`table.exclude.list`].
+By default, the connector captures the data for all non-system tables.
+After the snapshot completes, the connector continues to stream data for the specified tables.
+If you want the connector to capture data only from specific tables you can direct the connector to capture the data for only a subset of tables or table elements by setting properties such as xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-table-exclude-list[`table.exclude.list`].
 
 |3
 |Obtain a global read lock on the tables to be captured to block _writes_ by other database clients. +
@@ -428,18 +429,16 @@ If the snapshot takes too long to complete, consider using a different isolation
 |Read the current binlog position.
 
 |6
-a|Capture the structure of tables in the database.
+a|Capture the structure of all tables in the database, or all tables that are designated for capture.
 The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements. +
 The schema history provides information about the structure that is in effect when a change event occurs.
  +
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
-However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+If tables are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
 
-There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
-When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
-If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+For more information about why snapshots persist schema information for tables that you did not include in the initial snapshot, see xref:understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables[Understanding why initial snapshots capture the schema for all tables].
 ====
 
 |7
@@ -525,11 +524,9 @@ The schema history provides information about the structure that is in effect wh
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
-However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+If tables are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
 
-There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
-When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
-If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+For more information about why snapshots persist schema information for tables that you did not include in the initial snapshot, see xref:understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables[Understanding why initial snapshots capture the schema for all tables].
 ====
 
 |7
@@ -565,7 +562,7 @@ a|Record the successful completion of the snapshot in the connector offsets.
 The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 Schema data::
 DDL statements that describe the structural changes that are applied to tables.
 Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
@@ -574,18 +571,18 @@ After you run an initial snapshot, you might notice that the snapshot captures s
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
 Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-
-For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
-It does not capture table data.
+If the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 In some cases, you might want to limit schema capture in the initial snapshot.
 This can be useful when you want to reduce the time required to complete a snapshot.
-But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
+Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
 * xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
-* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
+* Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
+* Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.
+
 
 // Type: procedure
 [id="mysql-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change"]
@@ -635,7 +632,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -242,6 +242,34 @@ To configure custom topic names, you specify regular expressions in the logical 
 For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
+// ModuleID: how-debezium-oracle-connectors-handle-database-schema-changes
+// Title: How {prodname} Oracle connectors handle database schema changes
+[[oracle-schema-history-topic]]
+=== Schema history topic
+
+When a database client queries a database, the client uses the database’s current schema.
+However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
+Also, a connector cannot necessarily apply the current schema to every event.
+If an event is relatively old, it's possible that it was recorded before the current schema was applied.
+
+To ensure correct processing of changes that occur after a schema change, Oracle includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+
+When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+
+This database schema history topic is for connector use only.
+Optionally, the connector can also xref:oracle-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+
+When the Oracle connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
+The connector needs to be configured to capture change to these helper tables.
+If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+
+For more information, see xref:oracle-topic-names[default names for topics] that receive {prodname} event records.
+
+// Type: concept
 // ModuleID: how-debezium-oracle-connectors-expose-database-schema-changes
 // Title: How {prodname} Oracle connectors expose database schema changes
 [[oracle-schema-change-topic]]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -86,7 +86,7 @@ To enable the connector to establish a baseline for the current state of the dat
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`]  configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changig the value of the `snapshot.mode` property.
-If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
+If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
 
 [NOTE]
 ====
@@ -390,7 +390,7 @@ In a separate database schema history Kafka topic, the connector records all DDL
 When the connector restarts after either a crash or a graceful stop, it starts reading the redo log from a specific position, that is, from a specific point in time.
 The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the redo log where the connector is starting.
 
-This database schema history topic is for connector use only.
+This database schema history topic is internal for connector use only.
 Optionally, the connector can also xref:oracle-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 .Additional resources

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -179,6 +179,38 @@ WARNING: Do not use this mode to perform a snapshot if schema changes were commi
 
 For more information, see xref:oracle-property-snapshot-mode[`snapshot.mode`] in the table of connector configuration properties.
 
+// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// Title: Description of why initial snapshots capture the schema history for all tables
+// Type: concept
+[id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
+==== Understanding why initial snapshots capture the schema history for all tables
+
+When a connector runs an initial snapshot, it captures two types of information:
+
+Table data::
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Schema data::
+DDL statements that describe changes that occur to the structure of tables.
+
+By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
+For tables that are not designated for capture, the snapshot captures only the table structure.
+It does not capture any table data.
+The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+
+Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
+But inital snapshots capture schema information for all tables by design.
+By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+
+Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
+Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+
+If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
+Additional manual steps are required to add the new table's schema to the schema history topic.
+
+In general, it's best to leave the default configuration in place.
+But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
+For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+
 // Type: concept
 // ModuleID: debezium-oracle-ad-hoc-snapshots
 [id="oracle-ad-hoc-snapshots"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -382,15 +382,15 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, Oracle includes in the redo log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the redo log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+To ensure correct processing of events that occur after a schema change, Oracle includes in the redo log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector encounters these DDL statements in the redo log, it parses them and updates an in-memory representation of each table’s schema.
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
 In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the redo log where each DDL statement appeared.
 
 When the connector restarts after either a crash or a graceful stop, it starts reading the redo log from a specific position, that is, from a specific point in time.
 The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the redo log where the connector is starting.
 
-This database schema history topic is internal for connector use only.
+This database schema history topic is internal for internal connector use only.
 Optionally, the connector can also xref:oracle-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 .Additional resources

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -88,6 +88,12 @@ These steps describe the process for a snapshot when the xref:{context}-property
 You can customize the way that the connector creates snapshots by changig the value of the `snapshot.mode` property.
 If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
 
+[NOTE]
+====
+If the time needed to complete the initial snapshot exceeds the `UNDO_RETENTION` time that is set for the database (fifteen minutes, by default), an ORA-01555 exception can occur.
+For more information about the error, and about the steps that you can take to recover from it, see the xref:what-causes-ora-01555-and-how-to-handle-it"[Frequently asked questions].
+====
+
 [[default-workflow-for-performing-an-initial-snapshot]]
 .Default workflow that the Oracle connector uses to perform an initial snapshot
 When the snapshot mode is set to the default, the connector completes the following tasks to create a snapshot:
@@ -95,15 +101,15 @@ When the snapshot mode is set to the default, the connector completes the follow
 1. Establish a connection to the database.
 
 2. Determine the tables to be captured.
-By default, the connector captures all non-system tables.
+By default, the connector captures all tables except those with xref:schemas-that-the-debezium-oracle-connector-excludes-when-capturing-change-events[schemas that exclude them from capture].
 To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:oracle-property-table-include-list[`table.include.list`] or xref:oracle-property-table-exclude-list[`table.exclude.list`].
 
-3. Obtains a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot.
+3. Obtain a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot.
    {prodname} holds the locks for only a short time.
 
-4. Reads the current system change number (SCN) position from the server's redo log.
+4. Read the current system change number (SCN) position from the server's redo log.
 
-5. Captures the structure of all database tables.
+5. Capture the structure of all database tables.
 The connector persists this information in its internal database schema history topic.
 The schema history provides information about the structure that is in effect when a change event occurs. +
 +
@@ -117,13 +123,13 @@ When {prodname} has information about the structure of all existing tables, it c
 If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
 ====
 
-6. Releases the locks obtained in Step 3.
-Other database clients can now write to the database.
+6. Release the locks obtained in Step 3.
+Other database clients can now write to any previously locked tables.
 
-7. At the SCN position that was read in Step 4, the connectors scans the tables that are designated for capture (`SELECT * FROM ... AS OF SCN 123`).
+7. At the SCN position that was read in Step 4, the connector scans the tables that are designated for capture (`SELECT * FROM ... AS OF SCN 123`).
 During the scan, the connector completes the following tasks:
 
-.. Confirms that the table being scanned was created before the snapshot began.
+.. Confirms that the table was created before the snapshot began.
 If the table was created after the snapshot began, the connector skips the table.
 After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
 
@@ -134,7 +140,7 @@ All `read` events contain the same SCN position, which is the SCN position that 
 
 .. Releases data table locks, if applicable.
 
-8. Records the successful completion of the snapshot in the connector offsets.
+8. Record the successful completion of the snapshot in the connector offsets.
 
 The resulting initial snapshot captures the current state of each row in the captured tables.
 From this baseline state, the connector captures subsequent changes as they occur.
@@ -4280,6 +4286,7 @@ database.url=jdbc:oracle:thin:username/password!@(DESCRIPTION=(ENABLE=broken)(AD
 The preceding steps configure the TCP network stack to send keep-alive packets every 60 seconds.
 As a result, the AWS Gateway Load Balancer does not timeout when JDBC calls to the LogMiner API take more than 350 seconds to complete, enabling the connector to continue to read changes from the database's transaction logs.
 
+[id="what-causes-ora-0155-and-how-to-handle-it"]
 *What's the cause for ORA-01555 and how to handle it?*::
 The {prodname} Oracle connector uses flashback queries when the initial snapshot phase executes.
 A flashback query is a special type of query that relies on the flashback area, maintained by the database's `UNDO_RETENTION` database parameter, to return the results of a query based on what the contents of the table had at a given time, or in our case at a given SCN.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -102,25 +102,23 @@ When the snapshot mode is set to the default, the connector completes the follow
 
 2. Determine the tables to be captured.
 By default, the connector captures all tables except those with xref:schemas-that-the-debezium-oracle-connector-excludes-when-capturing-change-events[schemas that exclude them from capture].
-To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:oracle-property-table-include-list[`table.include.list`] or xref:oracle-property-table-exclude-list[`table.exclude.list`].
+After the snapshot completes, the connector continues to stream data for the specified tables.
+If you want the connector to capture data only from specific tables you can direct the connector to capture the data for only a subset of tables or table elements by setting properties such as xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-table-exclude-list[`table.exclude.list`].
 
 3. Obtain a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot.
    {prodname} holds the locks for only a short time.
 
 4. Read the current system change number (SCN) position from the server's redo log.
 
-5. Capture the structure of all database tables.
-The connector persists this information in its internal database schema history topic.
+5. Capture the structure of all database tables, or all tables that are designated for capture.
+The connector persists schema information in its internal database schema history topic.
 The schema history provides information about the structure that is in effect when a change event occurs. +
 +
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
-However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
-
-There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
-When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
-If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+If tables are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+For more information about why snapshots persist schema information for tables that you did not include in the initial snapshot, see xref:understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables[Understanding why initial snapshots capture the schema for all tables].
 ====
 
 6. Release the locks obtained in Step 3.
@@ -188,7 +186,7 @@ For more information, see xref:oracle-property-snapshot-mode[`snapshot.mode`] in
 The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 Schema data::
 DDL statements that describe the structural changes that are applied to tables.
 Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
@@ -197,18 +195,17 @@ After you run an initial snapshot, you might notice that the snapshot captures s
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
 Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-
-For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
-It does not capture table data.
+If the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 In some cases, you might want to limit schema capture in the initial snapshot.
 This can be useful when you want to reduce the time required to complete a snapshot.
-But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
+Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
 * xref:oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:oracle-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
-* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
+* Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
+* Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.
 
 // Type: procedure
 [id="oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change"]
@@ -257,7 +254,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -185,31 +185,129 @@ For more information, see xref:oracle-property-snapshot-mode[`snapshot.mode`] in
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
 ==== Understanding why initial snapshots capture the schema history for all tables
 
-When a connector runs an initial snapshot, it captures two types of information:
+The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
-DDL statements that describe changes that occur to the structure of tables.
+DDL statements that describe the structural changes that are applied to tables.
+Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
 
-By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
-For tables that are not designated for capture, the snapshot captures only the table structure.
-It does not capture any table data.
-The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
+By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
+Connectors require that the table's schema is present in the schema history topic before they can capture a table.
+By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
 
-Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
-But inital snapshots capture schema information for all tables by design.
-By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
+It does not capture table data.
 
-Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
-Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+In some cases, you might want to limit schema capture in the initial snapshot.
+This can be useful when you want to reduce the time required to complete a snapshot.
+But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
-If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
-Additional manual steps are required to add the new table's schema to the schema history topic.
+.Additional information
+* xref:oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:oracle-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
+* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
 
-In general, it's best to leave the default configuration in place.
-But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
-For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+// Type: procedure
+[id="oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change"]
+==== Capturing data from tables not captured by the initial snapshot (no schema change)
+
+In some cases, you might want the connector to capture data from a table whose schema was not captured by the initial snapshot.
+Depending on the connector configuration, the initial snapshot might capture the table schema only for specific tables in the database.
+If the table schema is not present in the history topic, the connector fails to capture the table, and reports a missing schema error.
+
+You might still be able to capture data from the table, but you must perform additional steps to add the table schema.
+
+.Prerequisites
+
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* All entries for the table in the transaction log use the same schema.
+For information about capturing data from a new table that has undergone structural changes, see xref:oracle-capturing-data-from-new-tables-with-schema-changes[].
+
+.Procedure
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. In the connector configuration:
+.. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to `schema_only_recovery`.
+.. Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+.. Add the tables that you want the connector to capture to `table.include.list`.
+This guarantees that in the future, the connector can reconstruct the schema history for all tables.
+4. Restart the connector.
+The snapshot recovery process rebuilds the schema history based on the current structure of the tables.
+5. (Optional) After the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
+6. (Optional) Reset the `snapshot.mode` back to `schema_only` to prevent the connector from initiating recovery after a future restart.
+
+// Type: procedure
+[id="oracle-capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot (schema change)
+
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
+
+If you want to capture data from a table that was not captured by the initial snapshot, and the schema of the table was modified, you must add the schema to the history topic, if it is not already available.
+You can add the schema by running a new schema snapshot, or by running an initial snapshot for the table.
+
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* A schema change was applied to the table so that the records to be captured do not have a uniform structure.
+
+.Procedure
+
+Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+2. Restart the connector.
+3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+
+Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
+If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
+
+Procedure 1: Schema snapshot, followed by incremental snapshot:::
+In this procedure, the connector first performs a schema snapshot.
+You can then initiate an incremental snapshot to enable the connector to synchronize data.
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
+.. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Restart the connector.
+6. Wait for {prodname} to capture the schema of the new and existing tables.
+Data changes that occurred any tables after the connector stopped are not captured.
+7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+
+Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
+In this procedure the connector performs a full initial snapshot of the database.
+As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+After the snapshot completes, you can optionally trigger an incremental snapshot to capture any changes that occur while the connector is off-line.
+
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
+.. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+6. Restart the connector.
+The connector takes a full database snapshot.
+After the snapshot completes, the connector transitions to streaming.
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-oracle-ad-hoc-snapshots
@@ -284,13 +382,13 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, Oracle includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+To ensure correct processing of changes that occur after a schema change, Oracle includes in the redo log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the redo log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
-In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the redo log where each DDL statement appeared.
 
-When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
-The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+When the connector restarts after either a crash or a graceful stop, it starts reading the redo log from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the redo log where the connector is starting.
 
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:oracle-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
@@ -305,10 +403,17 @@ Optionally, the connector can also xref:oracle-schema-change-topic[emit schema c
 [[oracle-schema-change-topic]]
 === Schema change topic
 
-You can configure a {prodname} Oracle connector to produce schema change events that describe structural changes that are applied to captured tables in the database.
+You can configure a {prodname} Oracle connector to produce schema change events that describe structural changes that are applied to tables in the database.
 The connector writes schema change events to a Kafka topic named `_<serverName>_`, where `_topicName_` is the namespace that is specified in the xref:oracle-property-topic-prefix[`topic.prefix`] configuration property.
 
-{prodname} emits a new message to this topic whenever it streams data from a new table.
+{prodname} emits a new message to the schema change topic whenever it streams data from a new table, or when the structure of the table is altered.
+
+ifdef::community[]
+[NOTE]
+====
+Following a change in table structure, you must follow (the xref:surrogate-schema-evolution[schema evolution procedure]).
+====
+endif::community[]
 
 Messages that the connector sends to the schema change topic contain a payload, and, optionally, also contain the schema of the change event message.
 The payload of a schema change event message includes the following elements:
@@ -357,14 +462,6 @@ The schema change topic message format is in an incubating state and might chang
 ====
 endif::community[]
 
-ifdef::community[]
-{prodname} emits a new message to this topic whenever it streams data from a new table, or when the structure of the table is altered.
-
-[NOTE]
-====
-Following a change in table structure, you must follow (the xref:surrogate-schema-evolution[schema evolution procedure]).
-====
-endif::community[]
 
 .Example: Message emitted to the Oracle connector schema change topic
 The following example shows a typical schema change message in JSON format.
@@ -3375,7 +3472,7 @@ Any transaction that exceeds this configured value is discarded entirely, and th
 The default behavior automatically selects the first valid, local configured destination.
 However, you can use a specific destination can be used by providing the destination name, for example, `LOG_ARCHIVE_DEST_5`.
 
-|[[oracle-property-log-mining-username-exclude-list]]<<oracle-property-log-mining-username-exclude-list, `+log.mining.username.include.list+`>>
+|[[oracle-property-log-mining-username-include-list]]<<oracle-property-log-mining-username-include-list, `+log.mining.username.include.list+`>>
 |No default
 |List of database users to include from the LogMiner query.
 It can be useful to set this property if you want the capturing process to include changes from the specified users.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -83,20 +83,61 @@ Typically, the redo logs on an Oracle server are configured to not retain the co
 As a result, the {prodname} Oracle connector cannot retrieve the entire history of the database from the logs.
 To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
 
-You can customize the way that the connector creates snapshots by setting the value of the xref:oracle-property-snapshot-mode[`snapshot.mode`] connector configuration property.
-By default, the connector's snapshot mode is set to `initial`.
+The following workflow lists the steps that {prodname} takes to create a snapshot.
+These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`]  configuration property is set to its default value, which is `initial`.
+You can customize the way that the connector creates snapshots by changig the value of the `snapshot.mode` property.
+If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
 
 [[default-workflow-for-performing-an-initial-snapshot]]
-.Default connector workflow for creating an initial snapshot
+.Default workflow that the Oracle connector uses to perform an initial snapshot
 When the snapshot mode is set to the default, the connector completes the following tasks to create a snapshot:
 
-1. Determines the tables to be captured.
-2. Obtains a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot. {prodname} holds the locks for only a short time.
-3. Reads the current system change number (SCN) position from the server's redo log.
-4. Captures the structure of all relevant tables.
-5. Releases the locks obtained in Step 2.
-6. Scans all of the relevant database tables and schemas as valid at the SCN position that was read in Step 3 (`SELECT * FROM ... AS OF SCN 123`), generates a `READ` event for each row, and then writes the event records to the table-specific Kafka topic.
-7. Records the successful completion of the snapshot in the connector offsets.
+1. Establish a connection to the database.
+
+2. Determine the tables to be captured.
+By default, the connector captures all non-system tables.
+To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:oracle-property-table-include-list[`table.include.list`] or xref:oracle-property-table-exclude-list[`table.exclude.list`].
+
+3. Obtains a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot.
+   {prodname} holds the locks for only a short time.
+
+4. Reads the current system change number (SCN) position from the server's redo log.
+
+5. Captures the structure of all database tables.
+The connector persists this information in its internal database schema history topic.
+The schema history provides information about the structure that is in effect when a change event occurs. +
++
+[NOTE]
+====
+By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
+However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+
+There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
+When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
+If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+====
+
+6. Releases the locks obtained in Step 3.
+Other database clients can now write to the database.
+
+7. At the SCN position that was read in Step 4, the connectors scans the tables that are designated for capture (`SELECT * FROM ... AS OF SCN 123`).
+During the scan, the connector completes the following tasks:
+
+.. Confirms that the table being scanned was created before the snapshot began.
+If the table was created after the snapshot began, the connector skips the table.
+After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
+
+.. Produces a `read` event for each row that is captured from a table.
+All `read` events contain the same SCN position, which is the SCN position that was obtained in step 4.
+
+.. Emits each `read` event to the Kafka topic for the source table.
+
+.. Releases data table locks, if applicable.
+
+8. Records the successful completion of the snapshot in the connector offsets.
+
+The resulting initial snapshot captures the current state of each row in the captured tables.
+From this baseline state, the connector captures subsequent changes as they occur.
 
 After the snapshot process begins, if the process is interrupted due to connector failure, rebalancing, or other reasons, the process restarts after the connector restarts.
 After the connector completes the initial snapshot, it continues streaming from the position that it read in Step 3 so that it does not miss any updates.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -295,11 +295,9 @@ The connector rebuilds the table structures that existed at this point in time b
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:oracle-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
-When the Oracle connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
-The connector needs to be configured to capture change to these helper tables.
-If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+.Additional resources
 
-For more information, see xref:oracle-topic-names[default names for topics] that receive {prodname} event records.
+* xref:oracle-topic-names[Default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // ModuleID: how-debezium-oracle-connectors-expose-database-schema-changes

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -183,6 +183,37 @@ After the connector completes the initial snapshot, it continues streaming from 
 
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
+// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// Title: Description of why initial snapshots capture the schema history for all tables
+// Type: concept
+[id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
+==== Understanding why initial snapshots capture the schema history for all tables
+
+When a connector runs an initial snapshot, it captures two types of information:
+
+Table data::
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Schema data::
+DDL statements that describe changes that occur to the structure of tables.
+
+By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
+For tables that are not designated for capture, the snapshot captures only the table structure.
+It does not capture any table data.
+The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+
+Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
+But inital snapshots capture schema information for all tables by design.
+By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+
+Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
+Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+
+If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
+Additional manual steps are required to add the new table's schema to the schema history topic.
+
+In general, it's best to leave the default configuration in place.
+But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
+For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
 
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -166,10 +166,10 @@ If you're certain that it won't be necessary to capture data from other tables i
 If the table was created after the snapshot began, the connector skips the table.
 After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
 
-.. Produces a _read_ event for each row that is captured from a table.
-   All _read_ events contain the same LSN position, which is the LSN position that was obtained in step 4.
+.. Produces a `read` event for each row that is captured from a table.
+   All `read` events contain the same LSN position, which is the LSN position that was obtained in step 4.
 
-.. Emits each _read_ event to the Kafka topic for the table.
+.. Emits each `read` event to the Kafka topic for the table.
 
 8. Records the successful completion of the snapshot in the connector offsets.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -189,61 +189,46 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
 ==== Understanding why initial snapshots capture the schema history for all tables
 
-When a connector runs an initial snapshot, it captures two types of information:
+The initial snapshot that a connector runs captures two types of information:
 
 Table data::
 Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
-DDL statements that describe structural changes that are applied to tables.
+DDL statements that describe the structural changes that are applied to tables.
+Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
 
 After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
-This is not an error.
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
-The captured schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
-Although the default behavior of an intial snapshot captures the schema all tables, if a table is not designated for capture (that is, not named in the `snapshot.include.collection.list`), the snapshot captures only the table structure.
-It does not capture any data from the table.
-
+Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-A table schema can change at any time.
-Columns can be added or removed, or column names can be changed.
-If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
-When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
-If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-If the initial snapshot did not capture schema data for a table, you must perform additional steps before {prodname} can capture the table.
+For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
+It does not capture table data.
+
+In some cases, you might want to limit schema capture in the initial snapshot.
+This can be useful when you want to reduce the time required to complete a snapshot.
+But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 .Additional information
-* xref:capturing-data-from-tables-not-captured-by-the-initial-snapshot[]
+* xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
+* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
 
-//
 // Type: procedure
-[id="capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
-==== Capturing data from tables not captured by the initial snapshot
+[id="sqlserver-capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
+==== Capturing data from tables not captured by the initial snapshot (no schema change)
 
-For a connector to capture data from a table, information about the table's schema must be present in the schema history topic.
-If you specified a list of tables for the connector to capture by configuring a `table.include.list`, when the connector runs its initial snapshot, it captures data from only the tables that are named in the list.
-However, by default, the initial snapshot captures the schema of every table in the database, not just the tables that you specified in the `include` list.
-This default behavior facilitates future additions to the list of tables to capture.
+In some cases, you might want the connector to capture data from a table whose schema was not captured by the initial snapshot.
+Depending on the connector configuration, the initial snapshot might capture the table schema only for specific tables in the database.
+If the table schema is not present in the history topic, the connector fails to capture the table, and reports a missing schema error.
 
-[NOTE]
-====
-The xref:{context}-property-snapshot-include-collection-list[snapshot.include.collection.list] property specifies the list of tables that a snapshot captures.
-If you do not set this property, snapshots default to capturing all tables specified in the `table.include.list`.
-====
-
-The default behavior applies only when `schema.history.internal.store.only.captured.tables.ddl` is set to its default value of `false`.
-If the initial snapshot runs when `schema.history.internal.store.only.captured.tables.ddl` is set to `true`, the snapshot captures only the schema of tables specified in the `include` list.
-Then, if you later decide to capture from a table that was not part of the original `include` list, the connector returns an error, reporting that the table schema is not available.
-{prodname} does not automatically repopulate the schema history topic with the schema of newly added tables.
-
-You can still capture data from the new table, but you must perform additional steps.
-Complete the following steps to configure the connector to capture data from a table that was not captured by the initial snaphot.
-These steps assume that all records in the table use the same schema (that is, no schema change was applied to the table).
-For tables that have undergone structural changes, see xref:capturing-data-from-new-tables-with-schema-changes[].
+You might still be able to capture data from the table, but you must perform additional steps to add the table schema.
 
 .Prerequisites
+
 * You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
 * No schema changes were applied to the table between the LSNs of the earliest and latest change table entry that the connector reads.
+For information about capturing data from a new table that has undergone structural changes, see xref:db2-capturing-data-from-new-tables-with-schema-changes[].
 
 .Procedure
 
@@ -257,7 +242,7 @@ For more information about how to remove offsets, see the link:https://debezium.
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
 This operation is potentially destructive, and should be performed only as a last resort.
 ====
-3. Set values for properties in the connector configuration as described in the following steps:
+4. Apply the following changes to the connector configuration:
 .. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
 This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables. +
 +
@@ -273,63 +258,84 @@ If you select this option, consider setting the value of the xref:{context}-prop
 Unlike a full data snapshot, this option does not capture any table data.
 Use this option if ou want to restart the connector more quickly than with a full snapshot.
 
-4. Restart the connector.
+5. Restart the connector.
 The connector completes the type of snapshot specified by the `snapshot.mode`.
-5. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
 The connector runs the snapshot while it continues to stream real-time changes from the tables.
 Running an incremental snapshot captures the following data changes:
 +
-* For tables that were previously being captured, it captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
-* For newly added tables, it captures all existing table rows.
+* For tables that the connector previously captured, the incremental snapsot captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
+* For newly added tables, the incremental snapshot captures all existing table rows.
 
+// Type: procedure
+[id="sqlserver-capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot (schema change)
 
-[id="capturing-data-from-new-tables-with-schema-changes"]
-==== Capturing data from tables not captured by the initial snapshot if a schema change was applied
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-If you want to capture data from a table that was not captured by the initial snapshot and the schema of that table was modified, you cannot use the process for enabling capture when no schema change is involved.
+If you want to capture data from a table that was not captured by the initial snapshot, and the schema of the table was modified, you must add the schema to the history topic, if it is not already available.
+You can add the schema by running a new schema snapshot, or by running an initial snapshot for the table.
 
-In such a case, you have two options, depending on whether the initial snapshot captured the schema for all tables.
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* A schema change was applied to the table so that the records to be captured do not have a uniform structure.
 
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
-The schema history topic captured schema changes only for the tables designated for capture.
-The schema history topic does not contain schema information for tables that you later add to the `include` list.
-In this case, to capture changes from the table, complete one of the following procedures:
+If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
 
-Procedure 1:::
+Procedure 1: Schema snapshot, followed by incremental snapshot:::
 In this procedure, the connector first performs a schema snapshot.
 You can then initiate an incremental snapshot to enable the connector to synchronize data.
 1. Stop the connector.
-2. Remove the connector offsets and history topic.
-3. Set values for properties in the connector configuration as described in the following steps:
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Set values for properties in the connector configuration as described in the following steps:
 .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
 .. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
-4. Restart the connector.
-5. Wait for {prodname} to capture the schema of the new and existing tables.
+5. Restart the connector.
+6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-6. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
-
-Procedure 2:::
-This option requires the connector to perform a full initial snapshot of the database.
+Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
+In this procedure the connector performs a full initial snapshot of the database.
 As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+After the snapshot completes, you can optionally trigger an incremental snapshot to capture any changes that occur while the connector is off-line.
 
 1. Stop the connector.
-2. Remove the connector offsets and history topic.
-Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
-3. Set values for properties in the connector configuration as described in the following steps:
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+4. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+5. Set values for properties in the connector configuration as described in the following steps:
 .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
 .. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
-4. Restart the connector.
+6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-5. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -295,6 +295,34 @@ If the default topic name do not meet your requirements, you can configure custo
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
 For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
+// Type: concept
+// ModuleID: how-debezium-sql-server-connectors-handle-database-schema-changes
+// Title: How {prodname} SQL Server connectors handle database schema changes
+[[sqlserver-schema-history-topic]]
+=== Schema history topic
+
+When a database client queries a database, the client uses the database’s current schema.
+However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
+Also, a connector cannot necessarily apply the current schema to every event.
+If an event is relatively old, it's possible that it was recorded before the current schema was applied.
+
+To ensure correct processing of changes that occur after a schema change, SQL Server includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+
+When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+
+This database schema history topic is for connector use only.
+Optionally, the connector can also xref:about-the-debezium-sqlserver-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+
+When the SQL Server connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
+The connector needs to be configured to capture change to these helper tables.
+If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+
+For more information, see xref:sqlserver-topic-names[default names for topics] that receive {prodname} event records.
+
 
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-uses-the-schema-change-topic

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -128,7 +128,7 @@ The initial snapshot captures the structure and data of the tables in the databa
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
-If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
+If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
 
 .Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
 
@@ -459,15 +459,18 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, SQL Server includes in the transaction log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the transaction log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
-The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
-In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the transaction log where each DDL statement appeared.
+To ensure correct processing of change events that occur after a schema change, the {prodname} SQL Server connector stores a snapshot of the new schema based on the structure in the SQL Server change tables, which mirror the structure of their associated data tables.
+The connector stores the table schema information, together with the LSN of operations the result in schema changes, in the database schema history Kafka topic.
+The connector uses the stored schema representation to produce change events that correctly mirror the structure of tables at the time of each insert, update, or delete operation.
 
-When the connector restarts after either a crash or a graceful stop, it starts reading the transaction log from a specific position, that is, from a specific point in time.
-The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the transaction log where the connector is starting.
+When the connector restarts after either a crash or a graceful stop, it resumes reading entries in the SQL Server CDC tables from the last position that it read.
+Based on the schema information that the connector reads from the database schema history topic, the connector applies the table structures that existed at the position where the connector restarts.
 
-This database schema history topic is for connector use only.
+If you update the schema of a Db2 table that is in capture mode, it's important that you also update the schema of the corresponding change table.
+You must be a SQL Server database administrator with elevated privileges to update database schema.
+For more information about updating SQL Server database schema in {prodname} environmenbts, see xref:sqlserver-schema-evolution[Database schema evolution].
+
+The database schema history topic is for internal connector use only.
 Optionally, the connector can also xref:about-the-debezium-sqlserver-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 .Additional resources

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -122,27 +122,66 @@ endif::product[]
 === Snapshots
 
 SQL Server CDC is not designed to store a complete history of database changes.
-For the {prodname} SQL Server connector to establish a baseline for the current state of the database,
-it uses a process called _snapshotting_.
+For the {prodname} SQL Server connector to establish a baseline for the current state of the database, it uses a process called _snapshotting_.
+The initial snapshot captures the structure and data of the tables in the database.
 
-You can configure how the connector creates snapshots.
-By default, the connector's snapshot mode is set to `initial`.
-Based on this `initial` snapshot mode, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
-This initial snapshot captures the structure and data for any tables that match the criteria defined by the `include` and `exclude` properties that are configured for the connector (for example, `table.include.list`, `column.include.list`, `table.exclude.list`, and so forth).
+The following workflow lists the steps that {prodname} takes to create a snapshot.
+These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
+You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
+If you configure a different snapshot mode, the completes the snapshot by using a modified version of this workflow.
 
-When the connector creates a snapshot, it completes the following tasks:
+.Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
 
-1. Determines the tables to be captured.
-2. Obtains a lock on the SQL Server tables for which CDC is enabled to prevent structural changes from occurring during creation of the snapshot.
-The level of the lock is determined by `snapshot.isolation.mode` configuration option.
-3. Reads the maximum log sequence number (LSN) position in the server's transaction log.
-4. Captures the structure of all relevant tables.
-5. Releases the locks obtained in Step 2, if necessary. In most cases, locks are held for only a short period of time.
-6. Scans the SQL Server source tables and schemas to be captured based on the LSN position that was read in Step 3, generates a `READ` event for each row in the table, and writes the events to the Kafka topic for the table.
-7. Records the successful completion of the snapshot in the connector offsets.
+1.  Establish a connection to the database.
+
+2.  Determine the tables to be captured.
+   By default, the connector captures all non-system tables.
+   To have the connector capture a subset of tables or table elements, you can set a number of `include` and `exclude` properties to filter the data, for example, xref:sqlserver-property-table-include-list[`table.include.list`] or xref:sqlserver-property-table-exclude-list[`table.exclude.list`].
+
+3. Obtain a lock on the SQL Server tables for which CDC is enabled to prevent structural changes from occurring during creation of the snapshot.
+   The level of the lock is determined by the xref:sqlserver-property-snapshot-isolation-mode[`snapshot.isolation.mode`] configuration property.
+
+4. Read the maximum log sequence number (LSN) position in the server's transaction log.
+
+5. Capture the structure of all non-system tables.
+The connector persists this information in its internal database schema history topic.
+The schema history provides information about the structure that is in effect when a change event occurs. +
++
+[NOTE]
+====
+By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
+However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+
+There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
+When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
+If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+====
+
+6. Release the locks obtained in Step 3, if necessary.
+
+7. At the LSN position read in Step 4, the connector scans the tables to be captured.
+   During the scan, the connector completes the following tasks:
+
+.. Confirms that the table being scanned was created before the snapshot began.
+If the table was created after the snapshot began, the connector skips the table.
+After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
+
+.. Produces a _read_ event for each row that is captured from a table.
+   All _read_ events contain the same LSN position, which is the LSN position that was obtained in step 4.
+
+.. Emits each _read_ event to the Kafka topic for the table.
+
+8. Records the successful completion of the snapshot in the connector offsets.
 
 The resulting initial snapshot captures the current state of each row in the tables that are enabled for CDC.
 From this baseline state, the connector captures subsequent changes as they occur.
+
+After the snapshot process begins, if the process is interrupted due to connector failure, rebalancing, or other reasons, the process restarts after the connector restarts.
+
+After the connector completes the initial snapshot, it continues streaming from the position that it read in Step 4 so that it does not miss any updates.
+
+If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
+
 
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -348,12 +348,9 @@ The connector rebuilds the table structures that existed at this point in time b
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:about-the-debezium-sqlserver-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
-When the SQL Server connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
-The connector needs to be configured to capture change to these helper tables.
-If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
+.Additional resources
 
-For more information, see xref:sqlserver-topic-names[default names for topics] that receive {prodname} event records.
-
+* xref:sqlserver-topic-names[Default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-uses-the-schema-change-topic

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -158,11 +158,12 @@ If you're certain that it won't be necessary to capture data from other tables i
 ====
 
 6. Release the locks obtained in Step 3, if necessary.
+Other database clients can now write to any previously locked tables.
 
 7. At the LSN position read in Step 4, the connector scans the tables to be captured.
    During the scan, the connector completes the following tasks:
 
-.. Confirms that the table being scanned was created before the snapshot began.
+.. Confirms that the table was created before the snapshot began.
 If the table was created after the snapshot began, the connector skips the table.
 After the snapshot is complete, and the connector transitions to streaming, it emits change events for any tables that were created after the snapshot began.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -192,28 +192,144 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 When a connector runs an initial snapshot, it captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are designated by the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
 Schema data::
-DDL statements that describe changes that occur to the structure of tables.
+DDL statements that describe structural changes that are applied to tables.
 
-By default, the snapshot captures schema data for every table that is present in the database, not only from tables that are designated for capture.
-For tables that are not designated for capture, the snapshot captures only the table structure.
-It does not capture any table data.
-The captured schema data is persisted to the both the internal schema history topic, and to the schema change topic, if one is configured.
+After you run an initial snapshot, you might notice that the snapshot captures schema information for tables that are not designated for capture.
+This is not an error.
+By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
+The captured schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
+Although the default behavior of an intial snapshot captures the schema all tables, if a table is not designated for capture (that is, not named in the `snapshot.include.collection.list`), the snapshot captures only the table structure.
+It does not capture any data from the table.
 
-Users might be surprised to see that an intial snapshot captured schema information for non-captured tables, and might assume that an error occurred.
-But inital snapshots capture schema information for all tables by design.
-By persisting schema data for tables that are not part of the original capture set, the connector prepares itself to readily capture event data from these tables should that later become necessary.
+By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
+A table schema can change at any time.
+Columns can be added or removed, or column names can be changed.
+If a schema change is applied to a table, records that are committed before the schema change have different structures than those that were committed after the change.
+When {prodname} captures data from a table, it reads the schema history to ensure that it applies the correct schema to each event.
+If the schema is not present in the schema history topic, the connector is unable to capture the table, and an error results.
 
-Because the database schema can change at any time, {prodname} must be able to identify the schema that is in effect for a table at the time that any event occurs.
-Then, if the connector later stops, when it resumes reading from the binlog, it can correlate event information with information from the schema history topic to ensure that it applies the correct schema to each event.
+If the initial snapshot did not capture schema data for a table, you must perform additional steps before {prodname} can capture the table.
 
-If you exclude schema capture for non-captured tables, and you later want to capture data from such a table, an exception results due to the unknown schema.
-Additional manual steps are required to add the new table's schema to the schema history topic.
+.Additional information
+* xref:capturing-data-from-tables-not-captured-by-the-initial-snapshot[]
 
-In general, it's best to leave the default configuration in place.
-But you are sure that you have no future need to capture data from any existing tables, you can exclude non-captured tables from schema capture.
-For more information, see the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property.
+//
+// Type: procedure
+[id="capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
+==== Capturing data from tables not captured by the initial snapshot
+
+For a connector to capture data from a table, information about the table's schema must be present in the schema history topic.
+If you specified a list of tables for the connector to capture by configuring a `table.include.list`, when the connector runs its initial snapshot, it captures data from only the tables that are named in the list.
+However, by default, the initial snapshot captures the schema of every table in the database, not just the tables that you specified in the `include` list.
+This default behavior facilitates future additions to the list of tables to capture.
+
+[NOTE]
+====
+The xref:{context}-property-snapshot-include-collection-list[snapshot.include.collection.list] property specifies the list of tables that a snapshot captures.
+If you do not set this property, snapshots default to capturing all tables specified in the `table.include.list`.
+====
+
+The default behavior applies only when `schema.history.internal.store.only.captured.tables.ddl` is set to its default value of `false`.
+If the initial snapshot runs when `schema.history.internal.store.only.captured.tables.ddl` is set to `true`, the snapshot captures only the schema of tables specified in the `include` list.
+Then, if you later decide to capture from a table that was not part of the original `include` list, the connector returns an error, reporting that the table schema is not available.
+{prodname} does not automatically repopulate the schema history topic with the schema of newly added tables.
+
+You can still capture data from the new table, but you must perform additional steps.
+Complete the following steps to configure the connector to capture data from a table that was not captured by the initial snaphot.
+These steps assume that all records in the table use the same schema (that is, no schema change was applied to the table).
+For tables that have undergone structural changes, see xref:capturing-data-from-new-tables-with-schema-changes[].
+
+.Prerequisites
+* You want to capture data from a table with a schema that the connector did not capture during the initial snapshot.
+* No schema changes were applied to the table between the LSNs of the earliest and latest change table entry that the connector reads.
+
+.Procedure
+
+1. Stop the connector.
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
+For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
++
+[WARNING]
+====
+Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
+This operation is potentially destructive, and should be performed only as a last resort.
+====
+3. Set values for properties in the connector configuration as described in the following steps:
+.. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
+This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables. +
++
+[NOTE]
+====
+Snapshots that capture the schema for all tables require more time to complete.
+====
+.. Add the tables that you want the connector to capture to xref:{context}-property-table-include-list[`table.include.list`].
+.. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to one of the following values:
+`initial`:: When you restart the connector, it takes a full snapshot of the database that captures the table data and table structures. +
+If you select this option, consider setting the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] property to `false` to enable the connector to capture the schema of all tables.
+`schema_only`:: When you restart the connector, it takes a snapshot that captures only the table schema.
+Unlike a full data snapshot, this option does not capture any table data.
+Use this option if ou want to restart the connector more quickly than with a full snapshot.
+
+4. Restart the connector.
+The connector completes the type of snapshot specified by the `snapshot.mode`.
+5. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+The connector runs the snapshot while it continues to stream real-time changes from the tables.
+Running an incremental snapshot captures the following data changes:
++
+* For tables that were previously being captured, it captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
+* For newly added tables, it captures all existing table rows.
+
+
+[id="capturing-data-from-new-tables-with-schema-changes"]
+==== Capturing data from tables not captured by the initial snapshot if a schema change was applied
+
+If you want to capture data from a table that was not captured by the initial snapshot and the schema of that table was modified, you cannot use the process for enabling capture when no schema change is involved.
+
+In such a case, you have two options, depending on whether the initial snapshot captured the schema for all tables.
+
+.Procedure
+
+Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+2. Restart the connector.
+3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+
+Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
+The schema history topic captured schema changes only for the tables designated for capture.
+The schema history topic does not contain schema information for tables that you later add to the `include` list.
+In this case, to capture changes from the table, complete one of the following procedures:
+
+Procedure 1:::
+In this procedure, the connector first performs a schema snapshot.
+You can then initiate an incremental snapshot to enable the connector to synchronize data.
+1. Stop the connector.
+2. Remove the connector offsets and history topic.
+3. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
+.. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+4. Restart the connector.
+5. Wait for {prodname} to capture the schema of the new and existing tables.
+Data changes that occurred any tables after the connector stopped are not captured.
+6. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+
+
+Procedure 2:::
+This option requires the connector to perform a full initial snapshot of the database.
+As with any initial snapshot, in a database with many large tables, running an initial snapshot can be a time-consuming operation.
+
+1. Stop the connector.
+2. Remove the connector offsets and history topic.
+Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+3. Set values for properties in the connector configuration as described in the following steps:
+.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `initial`.
+.. (Optional) Set xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
+4. Restart the connector.
+The connector takes a full database snapshot.
+After the snapshot completes, the connector transitions to streaming.
+5. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots
@@ -337,13 +453,13 @@ However, the database schema can be changed at any time, which means that the co
 Also, a connector cannot necessarily apply the current schema to every event.
 If an event is relatively old, it's possible that it was recorded before the current schema was applied.
 
-To ensure correct processing of changes that occur after a schema change, SQL Server includes in the binlog not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
-As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+To ensure correct processing of changes that occur after a schema change, SQL Server includes in the transaction log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector reads the transaction log and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
 The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
-In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the transaction log where each DDL statement appeared.
 
-When the connector restarts after either a crash or a graceful stop, it starts reading the binlog from a specific position, that is, from a specific point in time.
-The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+When the connector restarts after either a crash or a graceful stop, it starts reading the transaction log from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the transaction log where the connector is starting.
 
 This database schema history topic is for connector use only.
 Optionally, the connector can also xref:about-the-debezium-sqlserver-connector-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
@@ -358,7 +474,7 @@ Optionally, the connector can also xref:about-the-debezium-sqlserver-connector-s
 [[about-the-debezium-sqlserver-connector-schema-change-topic]]
 === Schema change topic
 
-For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of the schema change events that are applied to captured tables in the database.
+For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of the schema change events that are applied to tables in the database.
 The connector writes schema change events to a Kafka topic named `_<topicPrefix>_`, where `_topicPrefix_` is the logical server name that is specified in the xref:sqlserver-property-topic-prefix[`topic.prefix`] configuration property.
 
 Messages that the connector sends to the schema change topic contain a payload, and, optionally, also contain the schema of the change event message.
@@ -2722,7 +2838,7 @@ Use the following format to specify the collection name: +
 |`false`
 | Allow schema changes during an incremental snapshot. When enabled the connector will detect schema change during an incremental snapshot and re-select a current chunk to avoid locking DDLs. +
  +
-Note that changes to a primary key are not supported and can cause incorrect results if performed during an incremental snapshot. Another limitation is that if a schema change affects only columns' default values, then the change won't be detected until the DDL is processed from the binlog stream. This doesn't affect the snapshot events' values, but the schema of snapshot events may have outdated defaults.
+Note that changes to a primary key are not supported and can cause incorrect results if performed during an incremental snapshot. Another limitation is that if a schema change affects only columns' default values, then the change won't be detected until the DDL is processed from the transaction log stream. This doesn't affect the snapshot events' values, but the schema of snapshot events may have outdated defaults.
 
 |[[sqlserver-property-incremental-snapshot-chunk-size]]<<sqlserver-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -143,18 +143,15 @@ If you configure a different snapshot mode, the connector completes the snapshot
 
 4. Read the maximum log sequence number (LSN) position in the server's transaction log.
 
-5. Capture the structure of all non-system tables.
+5. Capture the structure of all non-system, or all tables that are designated for capture.
 The connector persists this information in its internal database schema history topic.
 The schema history provides information about the structure that is in effect when a change event occurs. +
 +
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
-However, for tables that are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
-
-There is a benefit to persisting schema information for tables that you did not include in the initial snapshot.
-When {prodname} has information about the structure of all existing tables, it can readily capture events from any existing table should you later decide that is needed.
-If you're certain that it won't be necessary to capture data from other tables in the future, you can modify the default behavior by changing the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to `true`.
+If tables are not configured for capture, the initial snapshot captures only their structure; it does not capture any table data.
+For more information about why snapshots persist schema information for tables that you did not include in the initial snapshot, see xref:understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables[Understanding why initial snapshots capture the schema for all tables].
 ====
 
 6. Release the locks obtained in Step 3, if necessary.
@@ -192,7 +189,7 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 The initial snapshot that a connector runs captures two types of information:
 
 Table data::
-Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property.
+Information about `INSERT`, `UPDATE`, and `DELETE` operations in tables that are named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 Schema data::
 DDL statements that describe the structural changes that are applied to tables.
 Schema data is persisted to both the internal schema history topic, and to the connector's schema change topic, if one is configured.
@@ -201,18 +198,17 @@ After you run an initial snapshot, you might notice that the snapshot captures s
 By default, initial snapshots are designed to capture schema information for every table that is present in the database, not only from tables that are designated for capture.
 Connectors require that the table's schema is present in the schema history topic before they can capture a table.
 By enabling the initial snapshot to capture schema data for tables that are not part of the original capture set, {prodname} prepares the connector to readily capture event data from these tables should that later become necessary.
-
-For tables that are designated for capture in the `snapshot.include.collection.list`, the snapshot captures only the table structure.
-It does not capture table data.
+If the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
 
 In some cases, you might want to limit schema capture in the initial snapshot.
 This can be useful when you want to reduce the time required to complete a snapshot.
-But if the initial snapshot does not capture a table's schema, you must add the schema to the history topic before the connector can capture data from the table.
+Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
 * xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
-* xref:{context}-property-database-history-store-only-captured-tables-ddl[Using the `schema.history.internal.store.only.captured.tables.ddl` property to configure schema capture in an initial snapshot.  ].
+* Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
+* Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.
 
 // Type: procedure
 [id="sqlserver-capturing-data-from-tables-not-captured-by-the-initial-snapshot"]
@@ -285,7 +281,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`] property to specify the tables that you want to capture.
+1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
 3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -38,24 +38,24 @@ Skipping should be used only with care as it can lead to data loss or mangling w
 
 |[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+schema.history.internal.store.only.captured.tables.ddl+`>>
 |`false`
-|A Boolean value that specifies whether the connector should record all DDL statements from specified schema or database +
+|A Boolean value that specifies whether the connector records schema structures from all tables in a schema or database, or only from tables that are designated for capture. +
 Specify one of the following values:
 
-`false` (default):: During a database snapshot, the connector collects the schema data collected for all non-system tables in the database, including tables that are not designated for capture.
+`false` (default):: During a database snapshot, the connector records the schema data for all non-system tables in the database, including tables that are not designated for capture.
 It's best to retain the default setting.
 If you later decide to capture changes from tables that you did not originally designate for capture, the connector can easily begin to capture data from those tables, because their schema structure is already stored in the schema history topic.
 {prodname} requires the schema history of a table so that it can identify the structure that was present at the time that a change event occurred.
 
-`true`:: The snapshot records only those DDL statements that are relevant to the tables from which {prodname} captures change events.
+`true`:: During a database snapshot, the connector records the table schemas only for the tables from which {prodname} captures change events.
 If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
 |`false`
-|A Boolean value that specifies whether the connector should record all DDL statements +
+|A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance. +
 Specify one of the following values:
 
-`true`:: Records only those DDL statements that are relevant to database/schema's tables whose changes are being captured by {prodname}.
-`false`:: The schema history topics stores incoming DDL statements for all databases. +
+`true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
+`false`:: The connector records schema structures for all logical databases. +
 
 NOTE: The default value is `true` for MySQL Connector +
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -39,16 +39,23 @@ Skipping should be used only with care as it can lead to data loss or mangling w
 |[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+schema.history.internal.store.only.captured.tables.ddl+`>>
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements from specified schema or database +
+Specify one of the following values:
 
-`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
+`false` (default):: During a database snapshot, the connector collects the schema data collected for all non-system tables in the database, including tables that are not designated for capture.
+It's best to retain the default setting.
+If you later decide to capture changes from tables that you did not originally designate for capture, the connector can easily begin to capture data from those tables, because their schema structure is already stored in the schema history topic.
+{prodname} requires the schema history of a table so that it can identify the structure that was present at the time that a change event occurred.
 
-The safe default is `false`.
+`true`:: The snapshot records only those DDL statements that are relevant to the tables from which {prodname} captures change events.
+If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements +
+Specify one of the following values:
 
-`true` records only those DDL statements that are relevant to database/schema's tables whose changes are being captured by {prodname}. `false` will store all incoming DDL statements. +
+`true`:: Records only those DDL statements that are relevant to database/schema's tables whose changes are being captured by {prodname}.
+`false`:: The schema history topics stores incoming DDL statements for all databases. +
 
 NOTE: The default value is `true` for MySQL Connector +
 


### PR DESCRIPTION
[DBZ-6219](https://issues.redhat.com/browse/DBZ-6219)

Replaces PR #4530 
This version incorporates feedback received for the original PR.

Enhance the connector documentation to describe default schema capture behavior during initial snapshots, how to modify the defaults, and how to capture tables whose schema were not captured:

[x] Update description of schema.history.internal.store.only.captured.tables.ddl property in shared file (ref-connector-configuration-database-history-properties.adoc).
[x] Update Db2 snapshots topic
[x] Update MySQL snapshots topic
[x] Update Oracle snapshots topic
[x] Update SQL Server snapshots topic
[x] Add subtopic to Snapshots section that explains why snapshots do not honor the table.include.list settings when capturing the table schema
- [x] MySQL
- [x] Db2
- [x] Oracle
- [x] SQL Server

[ ] Add steps for adding tables excluded from initial snapshot
- [x] Db2
- [x] MySQL
- [x] Oracle
- [x] SQL Server 

Please backport to 2.3.