### PR TITLE
[docs] Fixed "SQL Server on Azure" link to examples.

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -181,6 +181,7 @@ Jan Hendrik Dolling
 Jan Werner
 Jannik Steinmann
 Jason Schweier
+Jesse Ehrenzweig
 Jiabao Sun
 Juan Fiallo
 Jun Zhao

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1664,7 +1664,7 @@ If the result is empty, verify that the user has privileges to access both the c
 === SQL Server on Azure
 
 The {prodname} SQL Server connector can be used with SQL Server on Azure.
-Refer to https://docs.microsoft.com/en-us/samples/azure-samples/azure-sql-db-change-stream-debezium/azure-sql-db-change-stream-debezium/[this example] for configuring CDC for SQL Server on Azure and using it with {prodname}.
+Refer to https://learn.microsoft.com/en-us/samples/azure-samples/azure-sql-db-change-stream-debezium/azure-sql--sql-server-change-stream-with-debezium/[this example] for configuring CDC for SQL Server on Azure and using it with {prodname}.
 
 ifdef::community[]
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -211,3 +211,4 @@ umachi,Hidetomi Umaki
 sclarkson-zoomcare,Stephen Clarkson
 gongchanghua,Gong Chang Hua
 angsdey2,Angshuman Dey
+jehrenzweig-pi,Jesse Ehrenzweig


### PR DESCRIPTION
The link to the examples page was broken.