### PR TITLE
DBZ-6499 Support restarting JDBC connections

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -478,6 +478,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDescription(
                     "The maximum number of milliseconds that a LogMiner session lives for before being restarted. Defaults to 0 (indefinite until a log switch occurs)");
 
+    public static final Field LOG_MINING_RESTART_CONNECTION = Field.create("log.mining.restart.connection")
+            .withDisplayName("Restarts Oracle database connection when reaching maximum session time or database log switch")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(false)
+            .withDescription("Debezium opens a database connection and keeps that connection open throughout the entire streaming phase. " +
+                    "In some situations, this can lead to excessive SGA memory usage. " +
+                    "By setting this option to 'true' (the default is 'false'), the connector will close and re-open a database connection " +
+                    "after every detected log switch or if the log.mining.session.max.ms has been reached.");
+
     public static final Field LOG_MINING_TRANSACTION_SNAPSHOT_BOUNDARY_MODE = Field.createInternal("log.mining.transaction.snapshot.boundary.mode")
             .withEnum(TransactionSnapshotBoundaryMode.class, TransactionSnapshotBoundaryMode.SKIP)
             .withWidth(Width.SHORT)
@@ -581,7 +592,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_TRANSACTION_SNAPSHOT_BOUNDARY_MODE,
                     LOG_MINING_READ_ONLY,
                     LOG_MINING_FLUSH_TABLE_NAME,
-                    LOG_MINING_QUERY_FILTER_MODE)
+                    LOG_MINING_QUERY_FILTER_MODE,
+                    LOG_MINING_RESTART_CONNECTION)
             .create();
 
     /**
@@ -643,6 +655,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final Boolean logMiningReadOnly;
     private final String logMiningFlushTableName;
     private final LogMiningQueryFilterMode logMiningQueryFilterMode;
+    private final Boolean logMiningRestartConnection;
 
     public OracleConnectorConfig(Configuration config) {
         super(
@@ -701,6 +714,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningReadOnly = config.getBoolean(LOG_MINING_READ_ONLY);
         this.logMiningFlushTableName = config.getString(LOG_MINING_FLUSH_TABLE_NAME);
         this.logMiningQueryFilterMode = LogMiningQueryFilterMode.parse(config.getString(LOG_MINING_QUERY_FILTER_MODE));
+        this.logMiningRestartConnection = config.getBoolean(LOG_MINING_RESTART_CONNECTION);
     }
 
     private static String toUpperCase(String property) {
@@ -1645,6 +1659,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public LogMiningQueryFilterMode getLogMiningQueryFilterMode() {
         return logMiningQueryFilterMode;
+    }
+
+    /**
+     * @return whether the connector should restart the JDBC connection after log switches or maximum session windows.
+     */
+    public boolean isLogMiningRestartConnection() {
+        return logMiningRestartConnection;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -138,8 +138,8 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             return;
         }
         try {
-            // We explicitly expect auto-commit to be disabled
-            jdbcConnection.setAutoCommit(false);
+
+            prepareConnection(jdbcConnection, false);
 
             this.effectiveOffset = offsetContext;
             startScn = offsetContext.getScn();
@@ -160,7 +160,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             "Online REDO LOG files or archive log files do not contain the offset scn " + startScn + ".  Please perform a new snapshot.");
                 }
 
-                setNlsSessionParameters(jdbcConnection);
                 checkDatabaseAndTableState(jdbcConnection, connectorConfig.getPdbName(), schema);
 
                 logOnlineRedoLogSizes(connectorConfig);
@@ -214,6 +213,9 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             // With one mining session, it grows and maybe there is another way to flush PGA.
                             // At this point we use a new mining session
                             endMiningSession(jdbcConnection, offsetContext);
+                            if (connectorConfig.isLogMiningRestartConnection()) {
+                                prepareConnection(jdbcConnection, true);
+                            }
                             initializeRedoLogsForMining(jdbcConnection, true, startScn);
 
                             // log switch or restart required, re-create a new stop watch
@@ -246,6 +248,18 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             LOGGER.info("Streaming metrics dump: {}", streamingMetrics.toString());
             LOGGER.info("Offsets: {}", offsetContext);
         }
+    }
+
+    private void prepareConnection(OracleConnection connection, boolean closeAndReconnect) throws SQLException {
+        if (closeAndReconnect) {
+            // Close and reconnect
+            LOGGER.debug("Log switch or maximum session threshold detected, restarting Oracle JDBC connection.");
+            connection.close();
+        }
+
+        // We explicitly expect auto-commit to be disabled
+        connection.setAutoCommit(false);
+        setNlsSessionParameters(connection);
     }
 
     private void logOnlineRedoLogSizes(OracleConnectorConfig config) throws SQLException {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -139,7 +139,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         }
         try {
 
-            prepareConnection(jdbcConnection, false);
+            prepareConnection(false);
 
             this.effectiveOffset = offsetContext;
             startScn = offsetContext.getScn();
@@ -214,7 +214,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             // At this point we use a new mining session
                             endMiningSession(jdbcConnection, offsetContext);
                             if (connectorConfig.isLogMiningRestartConnection()) {
-                                prepareConnection(jdbcConnection, true);
+                                prepareConnection(true);
                             }
                             initializeRedoLogsForMining(jdbcConnection, true, startScn);
 
@@ -250,16 +250,16 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         }
     }
 
-    private void prepareConnection(OracleConnection connection, boolean closeAndReconnect) throws SQLException {
+    private void prepareConnection(boolean closeAndReconnect) throws SQLException {
         if (closeAndReconnect) {
             // Close and reconnect
             LOGGER.debug("Log switch or maximum session threshold detected, restarting Oracle JDBC connection.");
-            connection.close();
+            jdbcConnection.close();
         }
 
         // We explicitly expect auto-commit to be disabled
-        connection.setAutoCommit(false);
-        setNlsSessionParameters(connection);
+        jdbcConnection.setAutoCommit(false);
+        setNlsSessionParameters(jdbcConnection);
     }
 
     private void logOnlineRedoLogSizes(OracleConnectorConfig config) throws SQLException {

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3203,6 +3203,13 @@ For low volume systems, a LogMiner session may consume too much PGA memory when 
 The default behavior is to only use a new LogMiner session when a log switch is detected.
 By setting this value to something greater than `0`, this specifies the maximum number of milliseconds a LogMiner session can be active before it gets stopped and started to deallocate and reallocate PGA memory.
 
+|[[oracle-property-log-mining-restart-connection]]<<oracle-property-log-mining-restart-connection, `+log.mining.restart.connection+`>>
+|`false`
+|Specifies whether the JDBC connection will be closed and re-opened on log switches or when mining session has reached maximum lifetime threshold. +
+ +
+By default, the JDBC connection is not closed across log switches or maximum session lifetimes. +
+This should be enabled if you experience excessive Oracle SGA growth with LogMiner.
+
 |[[oracle-property-log-mining-batch-size-min]]<<oracle-property-log-mining-batch-size-min, `+log.mining.batch.size.min+`>>
 |`1000`
 |The minimum SCN interval size that this connector attempts to read from redo/archive logs. Active batch size is also increased/decreased by this amount for tuning connector throughput when needed.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6499

### Changes

Introduces a new configuration option, `log.mining.restart.connection`, which closes and re-opens the JDBC connection when an Oracle Log switch occurs or when the optionally configured log mining session max lifetime is reached.

@jpechane I'm open to renaming the option if you think a better name is useful.