### PR TITLE
Dbz 6474 doc non pdb prefix for oracle snapshot.include.collection.list

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -173,13 +173,13 @@ When the signal type is set to `execute-snapshot`, the `data` field must include
 
 |`type`
 |`incremental`
-| The type of the snapshot to run. 
+| The type of the snapshot to run.
 Currently {prodname} supports only the `incremental` type.
 
 |`data-collections`
 |_N/A_
 | An array of comma-separated regular expressions that match the fully-qualified names of the tables to include in the snapshot. +
-Specify the names by using the same format as is required for the xref:{context}-property-signal-data-collection[signal.data.collection] configuration option.
+Specify the names by using the same format as is required for the `signal.data.collection` configuration option.
 
 |`additional-condition`
 |_N/A_
@@ -243,7 +243,7 @@ image::jmx-signal-operation.png[Using JConsole to send an `execute-snapshot` sig
 // Type: concept
 [id="debezium-custom-signaling-channel"]
 == Custom signaling channel
-The signaling mechanism is designed to be extensible. 
+The signaling mechanism is designed to be extensible.
 You can implement channels as needed to send signals to {prodname} in a manner that works best in your environment.
 
 Adding a signaling channel involves several steps:
@@ -274,12 +274,12 @@ public interface SignalChannelReader {
     void close(); // <4>
 }
 ----
-<1> The name of the reader. 
+<1> The name of the reader.
 To enable {prodname} to use the channel, specify this name in the connector's `signal.enabled.channels` property.
 <2> Initializes specific configuration, variables, or connections that the channel requires.
-<3> Reads signal from the channel. 
+<3> Reads signal from the channel.
 The `SignalProcessor` class calls this method to retrieve the signal to process.
-<4> Closes all allocated resources. 
+<4> Closes all allocated resources.
 {prodname} calls this methods when the connector is stopped.
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3276,7 +3276,7 @@ Any transaction that exceeds this configured value is discarded entirely, and th
 The default behavior automatically selects the first valid, local configured destination.
 However, you can use a specific destination can be used by providing the destination name, for example, `LOG_ARCHIVE_DEST_5`.
 
-|[[oracle-property-log-mining-username-exclude-list]]<<oracle-property-log-mining-username-exclude-list, `+log.mining.username.include.list+`>>
+|[[oracle-property-log-mining-username-include-list]]<<oracle-property-log-mining-username-include-list, `+log.mining.username.include.list+`>>
 |No default
 |List of database users to include from the LogMiner query.
 It can be useful to set this property if you want the capturing process to include changes from the specified users.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2647,7 +2647,8 @@ For example, to define a `selector` parameter that specifies the subset of colum
 
 |[[oracle-property-database-dbname]]<<oracle-property-database-dbname, `+database.dbname+`>>
 |No default
-|Name of the database to connect to. Must be the CDB name when working with the CDB + PDB model.
+|Name of the database to connect to.
+In a container database environment, specify the name of the root container database (CDB), not the name of an included pluggable database (PDB).
 
 |[[oracle-property-database-url]]<<oracle-property-database-url, `+database.url+`>>
 |No default
@@ -2720,20 +2721,25 @@ You can set the following values:
   Use this setting only if no schema changes might occur during the creation of the snapshot.
 
 |[[oracle-property-snapshot-include-collection-list]]<<oracle-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
-| All tables specified in `table.include.list`
-|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>_._<tableName>_`) of the tables to include in a snapshot.
+| All tables specified in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`__<databaseName>.____<schemaName>__.__<tableName>__`) of the tables to include in a snapshot.
+
+In a multitenant container database (CDB) environment, the regular expression must include the xref:oracle-property-database-pdb-name[pluggable database (PDB) name], using the format `__<pdbName>__.__<schemaName>__.__<tableName>__`.
+
+To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name. +
 ifdef::product[]
 Only POSIX regular expressions are valid.
 endif::product[]
 ifdef::community[]
 In environments that use the LogMiner implementation, you must use POSIX regular expressions only.
 endif::community[]
-The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+
+A snapshot can only include tables that are named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+
 This property takes effect only if the connector's xref:oracle-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `never`. +
 This property does not affect the behavior of incremental snapshots. +
 
-To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
 
 |[[oracle-property-snapshot-select-statement-overrides]]<<oracle-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -3362,7 +3368,7 @@ Use the following format to specify the collection name: +
 
 |[[oracle-property-signal-enabled-channels]]<<oracle-property-signal-enabled-channels, `+signal.enabled.channels+`>>
 |source
-| List of the signaling channel names that are enabled for the connector. 
+| List of the signaling channel names that are enabled for the connector.
 By default, the following channels are available:
 
 * `source`
@@ -3375,7 +3381,7 @@ Optionally, you can also implement a {link-prefix}:{link-signalling}#debezium-si
 |[[oracle-property-notification-enabled-channels]]<<oracle-property-notification-enabled-channels, `+notification.enabled.channels+`>>
 |No default
 | List of notification channel names that are enabled for the connector.
-By default, the following channels are available: 
+By default, the following channels are available:
 
 * `sink`
 * `log`


### PR DESCRIPTION
[DBZ-6474](https://issues.redhat.com/browse/DBZ-6474)

Updates descriptions for Oracle connector `database.dname` and `snapshot.include.collection.list`

Tested in local Antora build.

Please backport to 2.3.