### PR TITLE
DBZ-6552 Notify when incremental snapshot fails

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
@@ -31,6 +31,7 @@ public class IncrementalSnapshotNotificationService<P extends Partition, O exten
     public static final String NONE = "<none>";
     public static final String CONNECTOR_NAME = "connector_name";
     public static final String TOTAL_ROWS_SCANNED = "total_rows_scanned";
+    public static final String STATUS = "status";
     public static final String LIST_DELIMITER = ",";
 
     private final NotificationService<P, O> notificationService;
@@ -43,6 +44,15 @@ public class IncrementalSnapshotNotificationService<P extends Partition, O exten
         IN_PROGRESS,
         TABLE_SCAN_COMPLETED,
         COMPLETED
+    }
+
+    public enum TableScanCompletionStatus {
+        EMPTY,
+        NO_PRIMARY_KEY,
+        SKIPPED,
+        SQL_EXCEPTION,
+        SUCCEEDED,
+        UNKNOWN_SCHEMA
     }
 
     public IncrementalSnapshotNotificationService(NotificationService<P, O> notificationService) {
@@ -96,7 +106,7 @@ public class IncrementalSnapshotNotificationService<P extends Partition, O exten
     }
 
     public <T extends DataCollectionId> void notifyTableScanCompleted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext,
-                                                                      long totalRowsScanned) {
+                                                                      long totalRowsScanned, TableScanCompletionStatus status) {
 
         String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
                 .map(DataCollectionId::identifier)
@@ -105,7 +115,8 @@ public class IncrementalSnapshotNotificationService<P extends Partition, O exten
         notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.TABLE_SCAN_COMPLETED,
                 Map.of(
                         DATA_COLLECTIONS, dataCollections,
-                        TOTAL_ROWS_SCANNED, String.valueOf(totalRowsScanned)),
+                        TOTAL_ROWS_SCANNED, String.valueOf(totalRowsScanned),
+                        STATUS, status.name()),
                 offsetContext),
                 Offsets.of(partition, offsetContext));
     }

--- a/debezium-core/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.notification;
 
+import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationService.TableScanCompletionStatus.SUCCEEDED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -120,12 +121,13 @@ public class IncrementalSnapshotNotificationServiceTest {
     @Test
     public void notifyTableScanCompleted() {
 
-        incrementalSnapshotNotificationService.notifyTableScanCompleted(incrementalSnapshotContext, partition, offsetContext, 100L);
+        incrementalSnapshotNotificationService.notifyTableScanCompleted(incrementalSnapshotContext, partition, offsetContext, 100L, SUCCEEDED);
 
         Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "TABLE_SCAN_COMPLETED", Map.of(
                 "connector_name", "connector-test",
                 "data_collections", "db.inventory.product,db.inventory.customer",
-                "total_rows_scanned", "100"));
+                "total_rows_scanned", "100",
+                "status", "SUCCEEDED"));
 
         verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6552

Send `TABLE_SCAN_COMPLETED` notification even when incremental snapshot of a table fails.
Add information about incremental snapshot completion status to the `additional_data` field in `TABLE_SCAN_COMPLETED` notification.
The status can take one of the values:

```
EMPTY,
NO_PRIMARY_KEY,
SKIPPED,
SQL_EXCEPTION,
SUCCEEDED,
UNKNOWN_SCHEMA
```