### PR TITLE
[docs] Add initial to table snapshot.mode in postgresql.adoc

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -106,6 +106,7 @@ Daan Roosen
 Daniel Petisme
 Dave Cramer
 Dave Cumberland
+David Beck
 David Chen
 David Feinblum
 David Haglund

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -161,6 +161,9 @@ If the connector fails, is rebalanced, or stops after Step 1 begins but before S
 |`never`
 |The connector never performs snapshots. When a connector is configured this way, its behavior when it starts is as follows. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. If no LSN has been stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. The `never` snapshot mode is useful only when you know all data of interest is still reflected in the WAL.
 
+|`initial` (default)
+|The connector performs a database snapshot when no Kafka offsets topic exists. After the database snapshot completes the Kafka offsets topic is written. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position.
+
 |`initial_only`
 |The connector performs a database snapshot and stops before streaming any change event records. If the connector had started but did not complete a snapshot before stopping, the connector restarts the snapshot process and stops when the snapshot completes.
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -212,3 +212,4 @@ sclarkson-zoomcare,Stephen Clarkson
 gongchanghua,Gong Chang Hua
 angsdey2,Angshuman Dey
 jehrenzweig-pi,Jesse Ehrenzweig
+TechIsCool,David Beck


### PR DESCRIPTION
This adds a bit more clarity into the `initial` mode since it was very confusing as a new user to understand that `initial` was the default value but didn't exist in the table.