### PR TITLE
DBZ-6570 Fix ConcurrentModificationException in KafkaSignal

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -94,29 +94,6 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
     }
 
     @Override
-    public void init(MySqlPartition partition, OffsetContext offsetContext) {
-        super.init(partition, offsetContext);
-
-        if (isKafkaChannelEnabled()) {
-
-            restoreOffset();
-        }
-    }
-
-    private void restoreOffset() {
-
-        KafkaSignalChannel kafkaSignal = dispatcher.getSignalProcessor().getSignalChannel(KafkaSignalChannel.class);
-
-        if (getContext().getSignalOffset() != null) {
-            kafkaSignal.reset(getContext().getSignalOffset());
-        }
-    }
-
-    private boolean isKafkaChannelEnabled() {
-        return connectorConfig.getEnabledChannels().contains(KafkaSignalChannel.CHANNEL_NAME);
-    }
-
-    @Override
     public void processMessage(MySqlPartition partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6579

Getting ConcurrentModificationException because KafkaSignal `init` is getting called from the connector task thread and KafkaSignal `reset` is getting called from the `change-event-source-coordinator` thread.

```
Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted   [org.apache.kafka.connect.runtime.WorkerTask] thread=task-thread-test_connector-0
org.apache.kafka.connect.errors.ConnectException: An exception occurred in the change event producer. This connector will be stopped.
 at io.debezium.pipeline.ErrorHandler.setProducerThrowable(ErrorHandler.java:72)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$start$0(ChangeEventSourceCoordinator.java:125)
 at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
 at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
 at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
 at org.apache.kafka.clients.consumer.KafkaConsumer.acquire(KafkaConsumer.java:2491)
 at org.apache.kafka.clients.consumer.KafkaConsumer.acquireAndEnsureOpen(KafkaConsumer.java:2475)
 at org.apache.kafka.clients.consumer.KafkaConsumer.seek(KafkaConsumer.java:1593)
 at io.debezium.pipeline.signal.channels.KafkaSignalChannel.reset(KafkaSignalChannel.java:154)
 at io.debezium.connector.mysql.MySqlReadOnlyIncrementalSnapshotChangeEventSource.restoreOffset(MySqlReadOnlyIncrementalSnapshotChangeEventSource.java:111)
 at io.debezium.connector.mysql.MySqlReadOnlyIncrementalSnapshotChangeEventSource.init(MySqlReadOnlyIncrementalSnapshotChangeEventSource.java:102)
 at io.debezium.connector.mysql.MySqlReadOnlyIncrementalSnapshotChangeEventSource.init(MySqlReadOnlyIncrementalSnapshotChangeEventSource.java:80)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$initStreamEvents$3(ChangeEventSourceCoordinator.java:221)
 at java.base/java.util.Optional.ifPresent(Optional.java:178)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.initStreamEvents(ChangeEventSourceCoordinator.java:221)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.streamEvents(ChangeEventSourceCoordinator.java:203)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.executeChangeEventSources(ChangeEventSourceCoordinator.java:172)
 at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$start$0(ChangeEventSourceCoordinator.java:118)
 ... 5 more 
 ```

Moving `reset` call to the `MySQLConnectorTask`
 
 
 