### PR TITLE
DBZ-6590 Support MySQL CAST AS DEC

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2349,7 +2349,7 @@ convertedDataType
       | typeName=CHAR lengthOneDimension? (charSet charsetName)?
       | typeName=(DATE | DATETIME | TIME | JSON | INT | INTEGER)
       | typeName=(DECIMAL | DEC) lengthTwoOptionalDimension?
-      | (SIGNED | UNSIGNED) INTEGER?
+      | (SIGNED | UNSIGNED) (INTEGER | INT)?
     ) ARRAY?
     ;
 

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2348,7 +2348,7 @@ convertedDataType
       typeName=(BINARY| NCHAR) lengthOneDimension?
       | typeName=CHAR lengthOneDimension? (charSet charsetName)?
       | typeName=(DATE | DATETIME | TIME | JSON | INT | INTEGER)
-      | typeName=DECIMAL lengthTwoOptionalDimension?
+      | typeName=(DECIMAL | DEC) lengthTwoOptionalDimension?
       | (SIGNED | UNSIGNED) INTEGER?
     ) ARRAY?
     ;

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
@@ -132,6 +132,9 @@ select  t.*, tt.* FROM wptests_terms AS t  INNER JOIN wptests_term_taxonomy AS t
 -- cast as integer
 SELECT CAST('1' AS INT);
 SELECT CAST('1' AS INTEGER);
+-- cast as decimal
+SELECT CAST('1' AS DECIMAL);
+SELECT CAST('1' AS DEC);
 #end
 #begin
 -- JSON functions

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
@@ -132,6 +132,10 @@ select  t.*, tt.* FROM wptests_terms AS t  INNER JOIN wptests_term_taxonomy AS t
 -- cast as integer
 SELECT CAST('1' AS INT);
 SELECT CAST('1' AS INTEGER);
+SELECT CAST('1' AS SIGNED INTEGER);
+SELECT CAST('1' AS UNSIGNED INTEGER);
+SELECT CAST('1' AS SIGNED INT);
+SELECT CAST('1' AS UNSIGNED INT);
 -- cast as decimal
 SELECT CAST('1' AS DECIMAL);
 SELECT CAST('1' AS DEC);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6590

Upstream PR: https://github.com/antlr/grammars-v4/pull/3545


CLI example:

    > SELECT CAST('1' AS DEC);
    +------------------+
    | CAST('1' AS DEC) |
    +------------------+
    |                1 |
    +------------------+