### PR TITLE
DBZ-6619 Fix Connector postgres driver v42.5.0 has a vulnerability  CVE-2022-41946 issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.apicurio>2.4.1.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.5.1</version.postgresql.driver>
+        <version.postgresql.driver>42.6.0</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
         <version.mysql.binlog>0.27.2</version.mysql.binlog>
         <version.mongo.driver>4.7.1</version.mongo.driver>


### PR DESCRIPTION
DBZ-6619 Connector postgres driver v42.5.0 has a vulnerability CVE-2022-41946, Upgrade driver to v42.6.0
https://issues.redhat.com/browse/DBZ-6619
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41946