### PR TITLE
DBZ-6640 Keep exception details when a SQLException is caught whilst reading the maximum key for a table

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -361,7 +361,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                         context.maximumKey(maximumKey);
                     }
                     catch (SQLException e) {
-                        LOGGER.error("Failed to read maximum key for table {}", currentTableId, e);
+                        LOGGER.error("Failed to read maximum key for table " + currentTableId, e);
                         notificationService.incrementalSnapshotNotificationService().notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned,
                                 SQL_EXCEPTION);
                         nextDataCollection(partition, offsetContext);


### PR DESCRIPTION
In  AbstractIncrementalSnapshotChangeEventSource#readChunk, the signature of org.sl4j.logger.error currently used for
`LOGGER.error("Failed to read maximum key for table {}", currentTableId, e);` 
is:
`void error(String var1, Object var2, Object var3);`

As there are no placeholders for the 2nd variable, that 2nd variable is unused. Here the 2nd variable is the exception. As a result the exception details are lost.

This PR switches to the following signature:
`void error(String var1, Throwable var2);`