### PR TITLE
DBZ-6628 Correct formatting in `additional-condition` examples

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -410,7 +410,7 @@ endif::community[]
 |Key | Value
 
 |test_connector
-|`{"type":"execute-snapshot","data": {"data-collections": ["public.MyFirstTable"], "type": "INCREMENTAL", "additional-condition":"color=blue AND brand=MyBrand"}}`
+|`{"type":"execute-snapshot","data": {"data-collections": ["public.MyFirstTable"], "type": "INCREMENTAL", "additional-condition":"color='blue' AND brand='MyBrand'"}}`
 
 |===
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
@@ -15,7 +15,7 @@ The signal type is `execute-snapshot`, and the `data` field must have the follow
 
 |`type`
 |`incremental`
-| The type of the snapshot to be executed. 
+| The type of the snapshot to be executed.
 Currently {prodname} supports only the `incremental` type.  +
 See the next section for more details.
 
@@ -49,18 +49,18 @@ When the snapshot request includes an `additional-condition`, the `additional-co
 
 `SELECT * FROM _<tableName>_ WHERE _<additional-condition>_ ....`
 
-For example, given a `products` {data-collection} with the columns `id` (primary key), `color`, and `brand`, if you want a snapshot to include only content for which `color=blue`, when you request the snapshot, you could append an `additional-condition` statement to filter the content:
+For example, given a `products` {data-collection} with the columns `id` (primary key), `color`, and `brand`, if you want a snapshot to include only content for which `color='blue'`, when you request the snapshot, you could append an `additional-condition` statement to filter the content:
 ----
 Key = `test_connector`
 
-Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.products"], "type": "INCREMENTAL", "additional-condition":"color=blue"}}`
+Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.products"], "type": "INCREMENTAL", "additional-condition":"color='blue'"}}`
 ----
 
 You can use the `additional-condition` statement to pass conditions based on multiple columns.
-For example, using the same `products` {data-collection} as in the previous example, if you want a snapshot to include only the content from the `products` {data-collection} for which `color=blue`, and `brand=MyBrand`, you could send the following request:
+For example, using the same `products` {data-collection} as in the previous example, if you want a snapshot to include only the content from the `products` {data-collection} for which `color='blue'`, and `brand='MyBrand'`, you could send the following request:
 
 ----
 Key = `test_connector`
 
-Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.products"], "type": "INCREMENTAL", "additional-condition":"color=blue AND brand=MyBrand"}}`
+Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.products"], "type": "INCREMENTAL", "additional-condition":"color='blue' AND brand='MyBrand'"}}`
 ----

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
@@ -60,7 +60,7 @@ values ('ad-hoc-1',   // <2>
     'execute-snapshot',  // <3>
     '{"data-collections": ["schema1.table1", "schema2.table2"], // <4>
     "type":"incremental", // <5>
-    "additional-condition":"color=blue", // <6>
+    "additional-condition":"color='blue'", // <6>
     "surrogate-key":"tenant-id"}'); // <7>
 ----
 end::sql-based-snapshot[]
@@ -165,19 +165,19 @@ For example, suppose you have a `products` {data-collection} that contains the f
 * `color`
 * `quantity`
 
-If you want an incremental snapshot of the `products` {data-collection} to include only the data items where `color=blue`, you can use the following SQL statement to trigger the snapshot:
+If you want an incremental snapshot of the `products` {data-collection} to include only the data items where `color='blue'`, you can use the following SQL statement to trigger the snapshot:
 
 [source,sql,indent=0,subs="+attributes"]
 ----
-INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color=blue"}');
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color='blue'"}');
 ----
 
 The `additional-condition` parameter also enables you to pass conditions that are based on more than on column.
-For example, using the `products` {data-collection} from the previous example, you can submit a query that triggers an incremental snapshot that includes the data of only those items for which `color=blue` and `quantity>10`:
+For example, using the `products` {data-collection} from the previous example, you can submit a query that triggers an incremental snapshot that includes the data of only those items for which `color='blue'` and `quantity>10`:
 
 [source,sql,indent=0,subs="+attributes"]
 ----
-INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color=blue AND quantity>10"}');
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color='blue' AND quantity>10"}');
 ----
 
 end::sql-based-snapshot[]


### PR DESCRIPTION
[DBZ-6628](https://issues.redhat.com/browse/DBZ-6628)

Updates formatting of string values in `additional-condition` examples.
The original examples incorrectly omitted single quotes around string values for the parameter.

This bug fix should be backported to 2.3