### PR TITLE
DBZ-6651 Avoid confusing label and IPv6 address

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -1349,7 +1349,7 @@ STRING_USER_NAME:                    (
                                      );
 IP_ADDRESS:                          (
                                        [0-9]+ '.' [0-9.]+
-                                       | [0-9A-F:]+ ':' [0-9A-F:]+
+                                       | [0-9A-F]* ':' [0-9A-F]* ':' [0-9A-F:]+
                                      );
 STRING_USER_NAME_MARIADB:            (
                                         SQUOTA_STRING | DQUOTA_STRING

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
@@ -131,6 +131,7 @@ alter user 'user'@'%' identified by 'newpassword' retain current password;
 ALTER USER 'mattias.hultman' DEFAULT ROLE `prod-spain-mysql-read-only`@`%`;
 rename user user1@100.200.1.1 to user2@100.200.1.2;
 rename user user1@100.200.1.1 to user2@2001:0db8:85a3:0000:0000:8a2e:0370:7334;
+rename user user1@100.200.1.1 to user2@::1;
 ALTER USER 'test_dual_pass'@'%' IDENTIFIED BY RANDOM PASSWORD RETAIN CURRENT PASSWORD;
 ALTER USER 'test_dual_pass'@'%' IDENTIFIED BY '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19' RETAIN CURRENT PASSWORD;
 ALTER USER 'test_dual_pass'@'%' IDENTIFIED WITH 'mysql_native_password';

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -447,7 +447,8 @@ END -- //-- delimiter ;
 -- Create procedure
 -- delimiter //
 CREATE PROCEDURE doiterate(p1 INT)
-label2:BEGIN
+-- label which can be parsed as a beginning of IPv6 address
+aaa:BEGIN
   label1:LOOP
     SET p1 = p1 + 1;
     IF p1 < 10 THEN ITERATE label1; END IF;


### PR DESCRIPTION
Some label combined with some keywords (when written without a space in between, which is valid for MySQL) can look like beginning of an IPv6 address, e.g.

    aaa:BEGIN

is currectly prased as IPv6 address `aaa:be` and leads to a parsing failure.

Make parsing of IPv6 address more robust and require at least two `:` to make sure there is no confusion with labels.

Upstream PR: https://github.com/antlr/grammars-v4/pull/3606