### PR TITLE
DBZ-6659 Fixing junit dependencies

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -51,6 +51,8 @@
 
         <!-- Testing -->
         <version.junit>4.13.1</version.junit>
+        <version.junit5>5.7.2</version.junit5>
+        <version.junit.platform.launcher>1.7.2</version.junit.platform.launcher>
         <version.fest>1.4</version.fest>
         <version.assertj>3.11.1</version.assertj>
         <version.jmh>1.21</version.jmh>
@@ -485,6 +487,16 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${version.junit5}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${version.junit.platform.launcher}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -51,8 +51,8 @@
 
         <!-- Testing -->
         <version.junit>4.13.1</version.junit>
-        <version.junit5>5.7.2</version.junit5>
-        <version.junit.platform.launcher>1.7.2</version.junit.platform.launcher>
+        <version.junit5>5.9.1</version.junit5>
+        <version.junit.platform.launcher>1.9.3</version.junit.platform.launcher>
         <version.fest>1.4</version.fest>
         <version.assertj>3.11.1</version.assertj>
         <version.jmh>1.21</version.jmh>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -115,6 +115,16 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-testing-testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -113,6 +113,16 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-testing-testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
-import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.FileOffsetBackingStore;
 import org.apache.kafka.connect.util.Callback;
 import org.junit.Assert;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.doc.FixFor;
 import io.debezium.document.Document;
 import io.debezium.document.DocumentReader;
+import io.debezium.embedded.KafkaConnectUtil;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.DebeziumEngine.CompletionCallback;
@@ -214,8 +214,8 @@ public class DebeziumEngineIT {
 
     public static class TestOffsetStore extends FileOffsetBackingStore {
 
-        public TestOffsetStore(Converter keyConverter) {
-            super(keyConverter);
+        public TestOffsetStore() {
+            super(KafkaConnectUtil.converterForOffsetStore());
         }
 
         @Override

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -18,8 +18,6 @@
     <version.commons.compress>1.21</version.commons.compress>
     <version.strimzi>0.28.0</version.strimzi>
     <version.strimzi.kafka>${version.kafka}</version.strimzi.kafka>
-    <version.junit5>5.7.2</version.junit5>
-    <version.junit.platform.launcher>1.7.2</version.junit.platform.launcher>
     <version.assertj>3.11.1</version.assertj>
     <version.apicurio>2.2.0.Final</version.apicurio>
     <version.apicurio.model>2.2.0.Final</version.apicurio.model>
@@ -311,14 +309,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${version.junit5}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>${version.junit.platform.launcher}</version>
       <scope>test</scope>
     </dependency>
 

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -57,6 +57,14 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6659


A proper test would be to switch to junit vintage and get rid of these issue once and for all. 

For what it's worth I tried running the test and replacing `junit:junit` with `org.junit.vintage:junit-vintage-engine` seems to be enough. I am opened to try replacing it in all modules and seeing what happens. 