### PR TITLE
DBZ-6648 Use String fallback when interval handling mode is String

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -830,7 +830,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
     }
 
     protected Object convertInterval(Column column, Field fieldDefn, Object data) {
-        return convertValue(column, fieldDefn, data, NumberConversions.LONG_FALSE, (r) -> {
+        Object fallback = intervalMode == IntervalHandlingMode.STRING ? Interval.toIsoString(0, 0, 0, 0, 0, new BigDecimal(0)) : NumberConversions.LONG_FALSE;
+        return convertValue(column, fieldDefn, data, fallback, (r) -> {
             if (data instanceof Number) {
                 final long micros = ((Number) data).longValue();
                 if (intervalMode == IntervalHandlingMode.STRING) {


### PR DESCRIPTION
The root cause of DBZ-6648 is using long number as a fallback value, while String is expected and thus falling conversion and returning `null`.

Use String fallback when interval handling mode is String.

https://issues.redhat.com/browse/DBZ-6648