### PR TITLE
DBZ-6673 Fix flaky Oracle test

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -127,6 +127,11 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     public static void beforeClass() throws SQLException {
         connection = TestHelper.testConnection();
 
+        // Several tests in this class expect the existence of the following tables and only these
+        // tables; however if other tests fail or end prematurely, they could taint the number of
+        // tables.
+        TestHelper.dropAllTables();
+
         TestHelper.dropTable(connection, "debezium.customer");
         TestHelper.dropTable(connection, "debezium.masked_hashed_column_table");
         TestHelper.dropTable(connection, "debezium.truncated_column_table");


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6673

The shouldCaptureChangesForTransactionsAcrossSnapshotBoundaryWithoutReemittingDDLChanges test only expects the tables created by the entire test to exist but tables from other tests not, and it would appear this commonly happens when another test fails to cleanup after itself.

This fix is to guarantee that the Oracle database state is set properly so that tests from within this class are executed with the right number of tables expected to exist.