### PR TITLE
DBZ-6714 Set precision of MySQL unsigned bigints in output decimal type

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -43,6 +42,7 @@ import io.debezium.annotation.Immutable;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.data.Json;
+import io.debezium.data.SpecialValueDecimal;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
@@ -208,7 +208,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
                 case PRECISE:
                     // In order to capture unsigned INT 64-bit data source, org.apache.kafka.connect.data.Decimal:Byte will be required to safely capture all valid values with scale of 0
                     // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
-                    return Decimal.builder(0);
+                    return SpecialValueDecimal.builder(DecimalMode.PRECISE, 20, 0);
             }
         }
         if ((matches(typeName, "FLOAT")

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerIT.java
@@ -31,7 +31,7 @@ import io.debezium.util.Testing;
  */
 public class MySqlUnsignedIntegerIT extends AbstractConnectorTest {
     private static final String PRECISION_PARAMETER_KEY = "connect.decimal.precision";
-    private static final Schema BIGINT_PRECISE_SCHEMA = Decimal.builder(0).optional().parameter(PRECISION_PARAMETER_KEY, "20").build();
+    private static final Schema BIGINT_PRECISE_SCHEMA = Decimal.builder(0).parameter(PRECISION_PARAMETER_KEY, "20").build();
 
     private static final Path SCHEMA_HISTORY_PATH = Testing.Files.createTestingPath("file-schema-history-json.txt")
             .toAbsolutePath();
@@ -375,7 +375,7 @@ public class MySqlUnsignedIntegerIT extends AbstractConnectorTest {
         Integer i = after.getInt32("id");
         assertThat(i).isNotNull();
         // Validate the schema first, we are expecting org.apache.kafka.connect.data.Decimal:Byte since we are dealing with unsignd-bigint
-        // So Unsigned BIGINY would be an int32 type
+        // So Unsigned BIGINT would be an int32 type
         assertThat(after.schema().field("c1").schema()).isEqualTo(BIGINT_PRECISE_SCHEMA);
         assertThat(after.schema().field("c2").schema()).isEqualTo(BIGINT_PRECISE_SCHEMA);
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerIT.java
@@ -30,6 +30,8 @@ import io.debezium.util.Testing;
  * @author Omar Al-Safi
  */
 public class MySqlUnsignedIntegerIT extends AbstractConnectorTest {
+    private static final String PRECISION_PARAMETER_KEY = "connect.decimal.precision";
+    private static final Schema BIGINT_PRECISE_SCHEMA = Decimal.builder(0).optional().parameter(PRECISION_PARAMETER_KEY, "20").build();
 
     private static final Path SCHEMA_HISTORY_PATH = Testing.Files.createTestingPath("file-schema-history-json.txt")
             .toAbsolutePath();
@@ -374,8 +376,8 @@ public class MySqlUnsignedIntegerIT extends AbstractConnectorTest {
         assertThat(i).isNotNull();
         // Validate the schema first, we are expecting org.apache.kafka.connect.data.Decimal:Byte since we are dealing with unsignd-bigint
         // So Unsigned BIGINY would be an int32 type
-        assertThat(after.schema().field("c1").schema()).isEqualTo(Decimal.builder(0).schema());
-        assertThat(after.schema().field("c2").schema()).isEqualTo(Decimal.builder(0).schema());
+        assertThat(after.schema().field("c1").schema()).isEqualTo(BIGINT_PRECISE_SCHEMA);
+        assertThat(after.schema().field("c2").schema()).isEqualTo(BIGINT_PRECISE_SCHEMA);
 
         // Validate the schema first, we are expecting int-64 since we are dealing with signed-bigint.
         // So Signed BIGINT would be an INT64 type
@@ -449,7 +451,7 @@ public class MySqlUnsignedIntegerIT extends AbstractConnectorTest {
         assertThat(records).hasSize(3);
         for (int i = 0; i < 3; i++) {
             final Struct after = ((Struct) records.get(i).value()).getStruct(Envelope.FieldName.AFTER);
-            assertThat(after.schema().field("id").schema()).isEqualTo(Decimal.builder(0).schema());
+            assertThat(after.schema().field("id").schema()).isEqualTo(BIGINT_PRECISE_SCHEMA);
             final BigDecimal id = (BigDecimal) after.get("id");
             assertThat(id).isNotNull();
             assertThat(id).isEqualTo(expected[i]);


### PR DESCRIPTION
When using the "precise" configuration for `bigint.unsigned.handling.mode`, the output decimal types were not specifying a precision. Adjust the code to generate an Avro schema with a decimal precision of 20, which is sufficient to represent all possible unsigned bigints.

**Warning to reviewer:** I couldn't get the tests running locally, so I was only able to test that this compiled, not that the test succeeded.