### PR TITLE
DBZ-6213 Adjust connector restart

### DIFF
--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -42,7 +42,7 @@ public class BaseSourceTaskTest {
     public void verifyTaskStartsAndStops() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.poll();
         assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
@@ -57,11 +57,11 @@ public class BaseSourceTaskTest {
     public void verifyStartAndStopWithoutPolling() {
         baseSourceTask.initialize(mock(SourceTaskContext.class));
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
-        assertEquals(0, baseSourceTask.startCount.get());
+        assertEquals(1, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());
     }
 
@@ -69,14 +69,10 @@ public class BaseSourceTaskTest {
     public void verifyTaskCanBeStartedAfterStopped() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
-        baseSourceTask.poll();
         assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
-        baseSourceTask.poll();
         assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
@@ -105,33 +101,33 @@ public class BaseSourceTaskTest {
                 CommonConnectorConfig.RETRIABLE_RESTART_WAIT.name(), "1" // wait 1ms between restarts
         );
         baseSourceTask.start(config);
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
+        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
         pollAndIgnoreRetryException(baseSourceTask);
         assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
-        sleep(100); // wait 10ms in order to satisfy retriable wait
+        sleep(1); // wait 1ms in order to satisfy retriable wait
         pollAndIgnoreRetryException(baseSourceTask);
         assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
-        sleep(100); // wait 10ms in order to satisfy retriable wait
+        sleep(1); // wait 1ms in order to satisfy retriable wait
         baseSourceTask.poll();
         assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(3, baseSourceTask.startCount.get());
-        assertEquals(3, baseSourceTask.stopCount.get());
+        assertEquals(2, baseSourceTask.stopCount.get());
         verify(baseSourceTask.coordinator, times(1)).stop();
     }
 
     @Test
     public void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
         baseSourceTask.poll();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
-        assertEquals(0, baseSourceTask.startCount.get());
+        assertEquals(1, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());
     }
 


### PR DESCRIPTION
* Try to start the connector in BaseSourceTask::start(). This is the root cause of DBZ-6213 as EmbeddedEngine calls start() and assumes it really tries to start the connector.
* Simplify the code by removing unnecessary checks and restartDelay.hasElapsed() call.

https://issues.redhat.com/browse/DBZ-6213