### PR TITLE
DBZ-6690 

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -1,28 +1,28 @@
 // Common
 tag::common-snapshot[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<topic.prefix>_`.
 end::common-snapshot[]
 
 tag::common-streaming[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<topic.prefix>_`.
 end::common-streaming[]
 
 
 // MongoDB
 tag::mongodb-snapshot[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_,task=_<task.id>_`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<topic.prefix>_,task=_<task.id>_`.
 end::mongodb-snapshot[]
 
 tag::mongodb-streaming[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_,task=_<task.id>_`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<topic.prefix>_,task=_<task.id>_`.
 end::mongodb-streaming[]
 
 
 // SQL Server
 tag::sqlserver-snapshot[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=snapshot`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<topic.prefix>_,task=_<task.id>_,context=snapshot`.
 end::sqlserver-snapshot[]
 
 tag::sqlserver-streaming[]
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=streaming`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<topic.prefix>_,task=_<task.id>_,context=streaming`.
 end::sqlserver-streaming[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -1,4 +1,4 @@
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<{context}.server.name>_`.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_`.
 
 The following table lists the schema history metrics that are available.
 


### PR DESCRIPTION
DBZ-6690 - Updated connector metrics mbean references to use "server=<topic.prefix>" instead of database.server.name