### PR TITLE
DBZ-6734: Add new STOPPED state for connectors to testing library

### DIFF
--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/Connector.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/Connector.java
@@ -21,7 +21,9 @@ public class Connector {
     public enum State {
         UNASSIGNED,
         RUNNING,
+        RESTARTING,
         PAUSED,
+        STOPPED,
         FAILED,
         DESTROYED
     }


### PR DESCRIPTION
[KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect) added a new `STOPPED` state for connectors that causes the `Connector` instance to be paused and all `Task` instances to be shut down (as opposed to left ready-but-idling, which is the case for the `PAUSED` state). See [this section](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect#KIP875:FirstclassoffsetssupportinKafkaConnect-Newtargetstate:STOPPED) of the KIP for more details.

Tasks will never appear in the `STOPPED` state, only connectors.

This PR adds that state to the testcontainers library to make custom testing easier (e.g., with `DebeziumContainer::ensureConnectorState`).

I'm unsure about the backporting policy here but if this change is approved, it may also be suitable to port over to the 2.4 branch. Happy to re-target this PR at 2.4 or open up a separate PR against that branch if it helps.