### PR TITLE
DBZ-6707 Specifies Boolean values for debezium.sink.redis.ssl.enabled

### DIFF
--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -966,8 +966,8 @@ The Stream is a data type which models a _log data structure_ in a more abstract
 |(Optional) A password (of respective user) used to communicate with Redis. A password must be set if a user is set.
 
 |[[redis-ssl-enabled]]<<redis-ssl-enabled, `debezium.sink.redis.ssl.enabled`>>
-|
-|(Optional) Use SSL to communicate with Redis. Default 'false'
+| false
+|(Optional) A Boolean value that specifies whether connections to Redis require SSL. 
 
 |[[redis-null-key]]<<redis-null-key, `debezium.sink.redis.null.key`>>
 |`default`


### PR DESCRIPTION
[DBZ-6707](https://issues.redhat.com/browse/DBZ-6707)

This change specifies that the `debezium.sink.redis.ssl.enabled` configuration property accepts a Boolean value. 
For this PR I did not comprehensively review all Debezium configuration properties to ensure that each of them specifies the required data type.   