### PR TITLE
DBZ-6729 Use default of 10000 for snapshot/query fetch sizes

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -68,7 +68,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     protected final static int DEFAULT_TRANSACTION_EVENTS_THRESHOLD = 0;
 
-    protected final static int DEFAULT_QUERY_FETCH_SIZE = 2_000;
+    protected final static int DEFAULT_QUERY_FETCH_SIZE = 10_000;
 
     protected final static Duration MAX_SLEEP_TIME = Duration.ofMillis(3_000);
     protected final static Duration DEFAULT_SLEEP_TIME = Duration.ofMillis(1_000);
@@ -684,6 +684,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 new SystemTablesPredicate(config),
                 x -> x.schema() + "." + x.table(),
                 true,
+                DEFAULT_QUERY_FETCH_SIZE,
                 ColumnFilterMode.SCHEMA,
                 false);
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -157,7 +157,7 @@ public class OracleConnectorConfigTest {
                 Configuration.create()
                         .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .build());
-        assertEquals(connectorConfig.getQueryFetchSize(), 2_000);
+        assertEquals(connectorConfig.getQueryFetchSize(), 10_000);
     }
 
     @Test
@@ -166,9 +166,9 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
                         .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
-                        .with(OracleConnectorConfig.QUERY_FETCH_SIZE, 10_000)
+                        .with(OracleConnectorConfig.QUERY_FETCH_SIZE, 15_000)
                         .build());
-        assertEquals(connectorConfig.getQueryFetchSize(), 10_000);
+        assertEquals(connectorConfig.getQueryFetchSize(), 15_000);
     }
 
     @Test

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3192,12 +3192,12 @@ After the connector inserts records into the configured table, it is able to rec
 Use this property to prevent snapshot interruptions when you start multiple connectors in a cluster, which might cause re-balancing of connectors.
 
 |[[oracle-property-snapshot-fetch-size]]<<oracle-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
-|`2000`
+|`10000`
 |Specifies the maximum number of rows that should be read in one go from each table while taking a snapshot.
 The connector reads table contents in multiple batches of the specified size.
 
 |[[oracle-property-query-fetch-size]]<<oracle-property-query-fetch-size, `+query.fetch.size+`>>
-|`2000`
+|`10000`
 |Specifies the number of rows that will be fetched for each database round-trip of a given query.
 Using a value of `0` will use the JDBC driver's default fetch size.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6729