### PR TITLE
Dbz 6704 config properties inconsistently classified as advanced vs required

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1582,17 +1582,6 @@ To match the name of a namespace, {prodname} applies the regular expression that
 That is, the specified expression is matched against the entire name string of the namespace; it does not match substrings that might be present in a database name. +
 If you include this property in the configuration, do not set the `collection.include.list` property.
 
-|[[mongodb-property-snapshot-mode]]<<mongodb-property-snapshot-mode, `+snapshot.mode+`>>
-|`initial`
-|Specifies the criteria for performing a snapshot when the connector starts.
-Set the property to one of the following values:
-
-`initial`::
-When the connector starts, if it does not detect a value in its offsets topic, it performs a snapshot of the database.
-
-`never`::
-When the connector starts, it skips the snapshot process and immediately begins to stream change events for operations that the database records to the oplog.
-
 |[[mongodb-property-capture-mode]]<<mongodb-property-capture-mode, `+capture.mode+`>>
 |`change_streams_update_full`
 |Specifies the method that the connector uses to capture `update` event changes from a MongoDB server.
@@ -1623,16 +1612,6 @@ The full document that the connector then receives in response to its query refl
 
 `change_streams_with_pre_image`::
 `update` events do not include the full document, but include a field that represents the state of the document `before` the change.
-
-|[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
-| All collections specified in `collection.include.list`
-|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>_._<collectionName>_`) of the schemas that you want to include in a snapshot.
-The specified items must be named in the connectors's xref:mongodb-property-collection-include-list[`collection.include.list`] property.
-This property takes effect only if the connector's xref:mongodb-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `never`. +
-This property does not affect the behavior of incremental snapshots. +
-
-To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the schema; it does not match substrings that might be present in a schema name.
 
 |[[mongodb-property-capture-scope]]<<mongodb-property-capture-scope, `+capture.scope+`>>
 |`deployment`
@@ -1675,10 +1654,6 @@ This property has an effect only when the connector is connected to a sharded Mo
 When the xref:mongodb-property-mongodb-connection-mode[`mongodb.connection.mode`] is set to `sharded`, or if the connector is connected to an unsharded MongoDB replica set deployment, the connector ignores this setting, and defaults to using only a single task.
 ====
 
-|[[mongodb-property-snapshot-max-threads]]<<mongodb-property-snapshot-max-threads, `+snapshot.max.threads+`>>
-|`1`
-|Positive integer value that specifies the maximum number of threads used to perform an intial sync of the collections in a replica set. Defaults to 1.
-
 |[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 |Controls whether a _delete_ event is followed by a tombstone event. +
@@ -1688,17 +1663,6 @@ When the xref:mongodb-property-mongodb-connection-mode[`mongodb.connection.mode`
 `false` - only a _delete_ event is emitted. +
  +
 After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row in case {link-kafka-docs}/#compaction[log compaction] is enabled for the topic.
-
-|[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
-|No default
-|An interval in milliseconds that the connector should wait before taking a snapshot after starting up; +
-Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
-
-|[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
-|`0`
-|Specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot.
-The connector will read the collection contents in multiple batches of this size. +
-Defaults to 0, which indicates that the server chooses an appropriate fetch size.
 
 |[[mongodb-property-schema-name-adjustment-mode]]<<mongodb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
 |none
@@ -1810,6 +1774,41 @@ By default, for consistency with other Debezium connectors, truncate operations 
 
 For each collection that you specify, also specify another configuration property: `snapshot.collection.filter.overrides._databaseName_._collectionName_`. For example, the name of the other configuration property might be: `snapshot.collection.filter.overrides.customers.orders`. Set this property to a valid filter expression that retrieves only the items that you want in the snapshot. When the connector performs a snapshot, it retrieves only the items that matches the filter expression.
 
+|[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
+|No default
+|An interval in milliseconds that the connector should wait before taking a snapshot after starting up; +
+Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+
+|[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
+|`0`
+|Specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot.
+The connector will read the collection contents in multiple batches of this size. +
+Defaults to 0, which indicates that the server chooses an appropriate fetch size.
+
+|[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
+| All collections specified in `collection.include.list`
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>_._<collectionName>_`) of the schemas that you want to include in a snapshot.
+The specified items must be named in the connectors's xref:mongodb-property-collection-include-list[`collection.include.list`] property.
+This property takes effect only if the connector's xref:mongodb-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `never`. +
+This property does not affect the behavior of incremental snapshots. +
+
+To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+That is, the specified expression is matched against the entire name string of the schema; it does not match substrings that might be present in a schema name.
+
+|[[mongodb-property-snapshot-max-threads]]<<mongodb-property-snapshot-max-threads, `+snapshot.max.threads+`>>
+|`1`
+|Positive integer value that specifies the maximum number of threads used to perform an intial sync of the collections in a replica set. Defaults to 1.
+
+|[[mongodb-property-snapshot-mode]]<<mongodb-property-snapshot-mode, `+snapshot.mode+`>>
+|`initial`
+|Specifies the criteria for performing a snapshot when the connector starts.
+Set the property to one of the following values:
+
+`initial`::
+When the connector starts, if it does not detect a value in its offsets topic, it performs a snapshot of the database.
+
+`never`::
+When the connector starts, it skips the snapshot process and immediately begins to stream change events for operations that the database records to the oplog.
 
 |[[mongodb-property-provide-transaction-metadata]]<<mongodb-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2974,31 +2974,6 @@ This option is deprecated, please use xref:mysql-property-event-processing-failu
  +
 `skip` passes over the problematic event and does not log anything.
 
-|[[mysql-property-max-batch-size]]<<mysql-property-max-batch-size, `+max.batch.size+`>>
-|`2048`
-|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
-
-|[[mysql-property-max-queue-size]]<<mysql-property-max-queue-size, `+max.queue.size+`>>
-|`8192`
-|Positive integer value that specifies the maximum number of records that the blocking queue can hold.
-When {prodname} reads events streamed from the database, it places the events in the blocking queue before it writes them to Kafka.
-The blocking queue can provide backpressure for reading change events from the database
-in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
-Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
-
-|[[mysql-property-max-queue-size-in-bytes]]<<mysql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
-|`0`
-|A long integer value that specifies the maximum volume of the blocking queue in bytes.
-By default, volume limits are not specified for the blocking queue.
-To specify the number of bytes that the queue can consume, set this property to a positive long value. +
-If xref:mysql-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
-For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
-
-|[[mysql-property-poll-interval-ms]]<<mysql-property-poll-interval-ms, `+poll.interval.ms+`>>
-|`500`
-|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 500 milliseconds, or 0.5 second.
-
 |[[mysql-property-connect-timeout-ms]]<<mysql-property-connect-timeout-ms, `+connect.timeout.ms+`>>
 |`30000`
 |A positive integer value that specifies the maximum time in milliseconds this connector should wait after trying to connect to the MySQL database server before timing out. Defaults to 30 seconds.
@@ -3160,6 +3135,31 @@ If the size of the transaction is larger than the buffer then {prodname} must re
 NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
 endif::community[]
 
+|[[mysql-property-max-batch-size]]<<mysql-property-max-batch-size, `+max.batch.size+`>>
+|`2048`
+|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
+
+|[[mysql-property-max-queue-size]]<<mysql-property-max-queue-size, `+max.queue.size+`>>
+|`8192`
+|Positive integer value that specifies the maximum number of records that the blocking queue can hold.
+When {prodname} reads events streamed from the database, it places the events in the blocking queue before it writes them to Kafka.
+The blocking queue can provide backpressure for reading change events from the database
+in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
+Events that are held in the queue are disregarded when the connector periodically records offsets.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
+
+|[[mysql-property-max-queue-size-in-bytes]]<<mysql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
+|`0`
+|A long integer value that specifies the maximum volume of the blocking queue in bytes.
+By default, volume limits are not specified for the blocking queue.
+To specify the number of bytes that the queue can consume, set this property to a positive long value. +
+If xref:mysql-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
+For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
+
+|[[mysql-property-poll-interval-ms]]<<mysql-property-poll-interval-ms, `+poll.interval.ms+`>>
+|`500`
+|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 500 milliseconds, or 0.5 second.
+
 |[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot when the connector starts. Possible settings are: +
@@ -3294,7 +3294,7 @@ Use the following format to specify the collection name: +
 
 |[[mysql-property-signal-enabled-channels]]<<mysql-property-signal-enabled-channels, `+signal.enabled.channels+`>>
 |source
-|List of the signaling channel names that are enabled for the connector. 
+|List of the signaling channel names that are enabled for the connector.
 By default, the following channels are available:
 
 * `source`
@@ -3307,7 +3307,7 @@ Optionally, you can also implement a {link-prefix}:{link-signalling}#debezium-si
 |[[mysql-property-notification-enabled-channels]]<<mysql-property-notification-enabled-channels, `+notification.enabled.channels+`>>
 |No default
 | List of notification channel names that are enabled for the connector.
-By default, the following channels are available: 
+By default, the following channels are available:
 
 * `sink`
 * `log`

--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -45,13 +45,19 @@ You configure custom converters to act on all columns of a certain type, or you 
 The converter function intercepts data type conversion requests for any columns that match a specified criteria, and then performs the specified conversion.
 The converter ignores columns that do not match the specified criteria.
 
-Custom converters are Java classes that implement the Debezium service provider interface (SPI).
+Custom converters are Java classes that implement the {prodname} service provider interface (SPI).
 You enable and configure a custom converter by setting the `converters` property in the connector configuration.
 The `converters` property specifies the converters that are available to a connector, and can include sub-properties that further modify conversion behavior.
 
 After you start a connector, the converters that are enabled in the connector configuration are instantiated and are added to a registry.
 The registry associates each converter with the columns or fields for it to process.
 Whenever {prodname} processes a new change event, it invokes the configured converter to convert the columns or fields for which it is registered.
+
+[NOTE]
+====
+The instructions that follow apply to {prodname} relational database connectors only.
+You cannot use this information to create a custom converter for the {prodname} MongoDB connector.
+====
 
 // Type: assembly
 // Title: Creating a {prodname} custom data type converter


### PR DESCRIPTION
[DBZ-6704](https://issues.redhat.com/browse/DBZ-6704)

For consistency, this change moves properties in the MongoDB and MySQL connector documentation from the Required connector properties table to the Advanced connector properties table. 

In addressing this change it became apparent that the MongoDB connector documentation does not reference the `converters` configuration property, but the Custom converters documentation does not explicitly state that you cannot create custom converters for MongoDB. 

To complete this work, one of the following further updates is required, depending on whether the content about custom converters applies to  MongoDB:

~~* Add the `converters` property to the table of Advanced MongoDB connector configuration properties.~~
* Add a note to the Custom converters documentation, to explicitly state that you cannot use custom converters with the MongoDB connector.  **DONE**