### PR TITLE
[docs] Fix typo in ModuleID comment

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -254,7 +254,7 @@ Adding a signaling channel involves several steps:
 
 // Type: procedure
 // Title: Providing a custom {prodname} signaling channel
-// ModuleID: debezium-signaling-providing-a custom-signaling-channel
+// ModuleID: debezium-signaling-providing-a-custom-signaling-channel
 [id="debezium-signaling-enabling-custom-signaling-channel"]
 === Provide custom signaling channel
 


### PR DESCRIPTION
Inserts missing hyphen between words in ModuleID string.

The missing character causes results in a downstream build error, which prevents the topic from rendering.