### PR TITLE
DBZ-6725 Include beforeRecord if the delete handling mode is REWRITE

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -202,7 +202,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
 
         // insert || replace || update with capture.mode="change_streams_update_full" or "change_streams_update_full_with_pre_image"
         if (afterRecord.value() != null) {
-            valueDocument = getAfterFullDocument(afterRecord, keyDocument);
+            valueDocument = getFullDocument(afterRecord, keyDocument);
         }
 
         // update
@@ -216,6 +216,10 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
             if (handleDeletes.equals(DeleteHandling.DROP)) {
                 LOGGER.trace("Delete {} arrived and requested to be dropped", record.key());
                 return null;
+            }
+
+            if (beforeRecord.value() != null && handleDeletes.equals(DeleteHandling.REWRITE)) {
+                valueDocument = getFullDocument(beforeRecord, keyDocument);
             }
 
             isDeletion = true;
@@ -337,7 +341,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return valueDocument;
     }
 
-    private BsonDocument getAfterFullDocument(R record, BsonDocument key) {
+    private BsonDocument getFullDocument(R record, BsonDocument key) {
         return BsonDocument.parse(record.value().toString());
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -1938,6 +1938,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // insert
         try (var client = connect()) {
+            MongoDatabase db1 = client.getDatabase(DB_NAME);
+            CreateCollectionOptions options = new CreateCollectionOptions();
+            options.changeStreamPreAndPostImagesOptions(new ChangeStreamPreAndPostImagesOptions(true));
+            db1.createCollection(this.getCollectionName(), options);
+
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName()).insertOne(obj);
         }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -1917,6 +1917,69 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         assertThat(getSourceRecordHeaderByKey(transformed, "prefix.updateDescription_updatedFields")).isEqualTo(expectedUpdateFields);
     }
 
+    @Test
+    @FixFor("DBZ-6725")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 6, reason = "Pre-image support in Change Stream is officially released in Mongo 6.0.")
+    public void shouldGenerateRecordForDeleteEventsDeleteHandlingModeRewrite() throws InterruptedException{
+        Configuration config = getBaseConfigBuilder()
+                .with(MongoDbConnectorConfig.CAPTURE_MODE, MongoDbConnectorConfig.CaptureMode.CHANGE_STREAMS_WITH_PRE_IMAGE)
+                .build();
+        restartConnectorWithConfig(config);
+        waitForStreamingRunning();
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(HANDLE_DELETES, "rewrite");
+        transformation.configure(props);
+
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("dataStr", "Hello");
+
+        // insert
+        try (var client = connect()) {
+            MongoDatabase db1 = client.getDatabase(DB_NAME);
+            CreateCollectionOptions options = new CreateCollectionOptions();
+            options.changeStreamPreAndPostImagesOptions(new ChangeStreamPreAndPostImagesOptions(true));
+            db1.createCollection(this.getCollectionName(), options);
+
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName()).insertOne(obj);
+        }
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(1);
+        assertNoRecordsToConsume();
+
+        // delete
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .deleteOne(RawBsonDocument.parse("{ '_id' : { '$oid' : '" + objId + "'}}"));
+        }
+
+        records = consumeRecordsByTopic(2);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(2);
+        assertNoRecordsToConsume();
+
+        // Perform transformation
+        final SourceRecord transformed = transformation.apply(records.allRecordsInOrder().get(0));
+
+        Struct key = (Struct) transformed.key();
+        Struct value = (Struct) transformed.value();
+
+        // then assert key and its schema
+        assertThat(key.schema()).isSameAs(transformed.keySchema());
+        assertThat(key.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(key.get("id")).isEqualTo(objId.toString());
+
+        // assert value and its schema
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("dataStr").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("__deleted").schema()).isEqualTo(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
+        assertThat(value.get("dataStr")).isEqualTo("Hello");
+        assertThat(value.get("__deleted")).isEqualTo(true);
+    }
+
     private SourceRecords createCreateRecordFromJson(String pathOnClasspath) throws Exception {
         final List<Document> documents = loadTestDocuments(pathOnClasspath);
         try (var client = connect()) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -1917,6 +1917,64 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         assertThat(getSourceRecordHeaderByKey(transformed, "prefix.updateDescription_updatedFields")).isEqualTo(expectedUpdateFields);
     }
 
+    @Test
+    @FixFor("DBZ-6725")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 6, reason = "Pre-image support in Change Stream is officially released in Mongo 6.0.")
+    public void shouldGenerateRecordForDeleteEventsDeleteHandlingModeRewrite() throws InterruptedException{
+        Configuration config = getBaseConfigBuilder()
+                .with(MongoDbConnectorConfig.CAPTURE_MODE, MongoDbConnectorConfig.CaptureMode.CHANGE_STREAMS_WITH_PRE_IMAGE)
+                .build();
+        restartConnectorWithConfig(config);
+        waitForStreamingRunning();
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(HANDLE_DELETES, "rewrite");
+        transformation.configure(props);
+
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("dataStr", "Hello");
+
+        // insert
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName()).insertOne(obj);
+        }
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(1);
+        assertNoRecordsToConsume();
+
+        // delete
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .deleteOne(RawBsonDocument.parse("{ '_id' : { '$oid' : '" + objId + "'}}"));
+        }
+
+        records = consumeRecordsByTopic(2);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(2);
+        assertNoRecordsToConsume();
+
+        // Perform transformation
+        final SourceRecord transformed = transformation.apply(records.allRecordsInOrder().get(0));
+
+        Struct key = (Struct) transformed.key();
+        Struct value = (Struct) transformed.value();
+
+        // then assert key and its schema
+        assertThat(key.schema()).isSameAs(transformed.keySchema());
+        assertThat(key.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(key.get("id")).isEqualTo(objId.toString());
+
+        // assert value and its schema
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("dataStr").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("__deleted").schema()).isEqualTo(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
+        assertThat(value.get("dataStr")).isEqualTo("Hello");
+        assertThat(value.get("__deleted")).isEqualTo(true);
+    }
+
     private SourceRecords createCreateRecordFromJson(String pathOnClasspath) throws Exception {
         final List<Document> documents = loadTestDocuments(pathOnClasspath);
         try (var client = connect()) {


### PR DESCRIPTION
When performing delete events and event flattening, normally in other relational databases we would get the information of the data before it's being deleted (when delete.handling.mode was set to REWRITE). But, in MongoDB 6.0 or later, especially when the capture.mode was set to *_with_pre_image, and the collection has ChangeStreamPreAndPostImagesOptions activated, we're not able to see the information of the data inside value payload. This PR will allows us to get the record information before it's deleted for capture.mode *_with_pre_image, and allow ChangeStreamPreAndPostImagesOptions to the designated collection, and delete.handling.mode is REWRITE