### PR TITLE
DBZ-6725 Include beforeRecord if the delete handling mode is REWRITE

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -144,6 +144,7 @@ Emmanuel Brard
 Emrul Islam
 Enzo Cappa
 Erdinç Taşkın
+Eric Pangiawan
 Eric Slep
 Eric Weaver
 Eric S. Kreiseir

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -202,7 +202,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
 
         // insert || replace || update with capture.mode="change_streams_update_full" or "change_streams_update_full_with_pre_image"
         if (afterRecord.value() != null) {
-            valueDocument = getAfterFullDocument(afterRecord, keyDocument);
+            valueDocument = getFullDocument(afterRecord, keyDocument);
         }
 
         // update
@@ -216,6 +216,10 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
             if (handleDeletes.equals(DeleteHandling.DROP)) {
                 LOGGER.trace("Delete {} arrived and requested to be dropped", record.key());
                 return null;
+            }
+
+            if (beforeRecord.value() != null && handleDeletes.equals(DeleteHandling.REWRITE)) {
+                valueDocument = getFullDocument(beforeRecord, keyDocument);
             }
 
             isDeletion = true;
@@ -337,7 +341,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return valueDocument;
     }
 
-    private BsonDocument getAfterFullDocument(R record, BsonDocument key) {
+    private BsonDocument getFullDocument(R record, BsonDocument key) {
         return BsonDocument.parse(record.value().toString());
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -1920,7 +1920,7 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
     @Test
     @FixFor("DBZ-6725")
     @SkipWhenDatabaseVersion(check = LESS_THAN, major = 6, reason = "Pre-image support in Change Stream is officially released in Mongo 6.0.")
-    public void shouldGenerateRecordForDeleteEventsDeleteHandlingRewrite() throws InterruptedException{
+    public void shouldGenerateRecordForDeleteEventsDeleteHandlingRewrite() throws InterruptedException {
         Configuration config = getBaseConfigBuilder()
                 .with(MongoDbConnectorConfig.CAPTURE_MODE, MongoDbConnectorConfig.CaptureMode.CHANGE_STREAMS_WITH_PRE_IMAGE)
                 .build();

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -53,6 +53,7 @@ linhnh,Linh Nguyen Hoang
 victorxiang30,Victor Xiang
 AndreyIg,Andrey Ignatenko
 eric-weaver,Eric Weaver
+ericpangiawan, Eric Pangiawan
 karamel,Michael Wang
 alisator,Alisa Houskova
 ani-sha,Anisha Mohanty


### PR DESCRIPTION
Adding Integration Test and the feature to add beforeRecord in delete events of event flattening with delete handling mode rewrite. Works only if the collection has ChangeStreamPreAndPostImagesOptions turned on and capture mode is *_with_pre_image (MongoDB 6.0 or later)