### PR TITLE
DBZ-6783 Upgrade MySQL Binlog Client to v0.28.1

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -403,6 +403,7 @@ Ruslan Gibaiev
 Russell Ballard
 Russell Mora
 Ruud H.G. van Tol
+Ryan van Huuksloot
 Sage Pierce
 Sairam Polavarapu
 Sanjay Kr Singh

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -37,8 +37,8 @@ public class SourceInfoTest {
     private static final String FILENAME = "mysql-bin.00001";
     private static final String GTID_SET = "gtid-set"; // can technically be any string
     private static final String SERVER_NAME = "my-server"; // can technically be any string
-    private static final UUID IdA= UUID.fromString("123e4567-e89b-12d3-a456-426655440000");
-    private static final UUID IdB= UUID.fromString("123e4567-e89b-12d3-a456-426655440001");
+    private static final UUID IdA = UUID.fromString("123e4567-e89b-12d3-a456-426655440000");
+    private static final UUID IdB = UUID.fromString("123e4567-e89b-12d3-a456-426655440001");
 
     private SourceInfo source;
     private MySqlOffsetContext offsetContext;

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -219,3 +219,4 @@ agukasian,Artur Gukasian
 Ychopada,Yashashree Chopada
 gurpiarbassi, Gurps Bassi
 mfortunat, Massimo Fortunat
+ryanvanhuuksloot, Ryan van Huuksloot

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.6.0</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
-        <version.mysql.binlog>0.27.2</version.mysql.binlog>
+        <version.mysql.binlog>0.28.1</version.mysql.binlog>
         <version.mongo.driver>4.7.1</version.mongo.driver>
         <version.sqlserver.driver>10.2.1.jre8</version.sqlserver.driver>
         <version.oracle.driver>21.6.0.0</version.oracle.driver>


### PR DESCRIPTION
In regards to this JIRA issue: https://issues.redhat.com/browse/DBZ-6783

We have internally upgraded the Binlog Client to v0.28.1 for MySQL to take advantage of https://github.com/osheroff/mysql-binlog-connector-java/issues/98

We wanted to bring it upstream to share it with the community.

Here are some performance enhancements we have seen with the async-profiler:

Old:
![image](https://github.com/debezium/debezium/assets/15604960/58137260-f94a-4d85-ad0a-d1f21d2d92f3)
New:
![image](https://github.com/debezium/debezium/assets/15604960/e54e3a0f-6850-48bf-9658-1b57e84cff97)
