### PR TITLE
DBZ-6480 fix mysql datetime long value

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -534,3 +534,4 @@ Miguel Angel Sotomayor
 Stephen Clarkson
 Gurps Bassi
 Massimo Fortunat
+xieshujian

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -7,6 +7,8 @@ package io.debezium.connector.mysql;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -50,6 +52,8 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
      * to connector to disable it on its own.
      */
     static final String TEST_DISABLE_GLOBAL_LOCKING = "test.disable.global.locking";
+
+    public static final String DATABASE_CONNECTION_TIME_ZONE = "database.connectionTimeZone";
 
     /**
      * The set of predefined BigIntUnsignedHandlingMode options or aliases.
@@ -959,6 +963,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
     private final Predicate<String> gtidSourceFilter;
     private final EventProcessingFailureHandlingMode inconsistentSchemaFailureHandlingMode;
     private final boolean readOnlyConnection;
+    private final ZoneId zoneId;
 
     public MySqlConnectorConfig(Configuration config) {
         super(
@@ -991,6 +996,14 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                 : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
 
         this.storeOnlyCapturedDatabasesDdl = config.getBoolean(STORE_ONLY_CAPTURED_DATABASES_DDL);
+
+        // set up time zone offset from database.connectionTimeZone
+        ZoneId tmpZoneId = ZoneOffset.UTC;
+        String connectionTimeZone = config.getString(DATABASE_CONNECTION_TIME_ZONE);
+        if (connectionTimeZone != null) {
+            tmpZoneId = ZoneId.of(connectionTimeZone);
+        }
+        this.zoneId = tmpZoneId;
     }
 
     public boolean useCursorFetch() {
@@ -1184,5 +1197,9 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
      */
     boolean useGlobalLock() {
         return !"true".equals(config.getString(TEST_DISABLE_GLOBAL_LOCKING));
+    }
+
+    public ZoneId getZoneId() {
+        return zoneId;
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -214,9 +215,12 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
         BigIntUnsignedMode bigIntUnsignedMode = bigIntUnsignedHandlingMode.asBigIntUnsignedMode();
 
         final boolean timeAdjusterEnabled = configuration.getConfig().getBoolean(MySqlConnectorConfig.ENABLE_TIME_ADJUSTER);
+
+        ZoneId zoneId = configuration.getZoneId();
+
         return new MySqlValueConverters(decimalMode, timePrecisionMode, bigIntUnsignedMode,
                 configuration.binaryHandlingMode(), timeAdjusterEnabled ? MySqlValueConverters::adjustTemporal : x -> x,
-                MySqlValueConverters::defaultParsingErrorHandler);
+                MySqlValueConverters::defaultParsingErrorHandler, zoneId);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -16,6 +16,7 @@ import java.sql.Types;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
@@ -149,7 +150,27 @@ public class MySqlValueConverters extends JdbcValueConverters {
     public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
                                 BinaryHandlingMode binaryMode,
                                 TemporalAdjuster adjuster, ParsingErrorHandler parsingErrorHandler) {
-        super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, adjuster, bigIntUnsignedMode, binaryMode);
+        this(decimalMode, temporalPrecisionMode, bigIntUnsignedMode, binaryMode, adjuster, parsingErrorHandler, ZoneOffset.UTC);
+    }
+
+    /**
+     * Create a new instance that always uses UTC for the default time zone when converting values without timezone information
+     * to values that require timezones.
+     * <p>
+     *
+     * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+     *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
+     * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
+     * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
+     *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
+     * @param binaryMode how binary columns should be represented
+     * @param adjuster a temporal adjuster to make a database specific time modification before conversion
+     * @param zoneId database time zone
+     */
+    public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
+                                BinaryHandlingMode binaryMode,
+                                TemporalAdjuster adjuster, ParsingErrorHandler parsingErrorHandler, ZoneId zoneId) {
+        super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, adjuster, bigIntUnsignedMode, binaryMode, zoneId);
         this.parsingErrorHandler = parsingErrorHandler;
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -58,6 +58,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
     private static final TemporalAdjuster ADJUSTER = MySqlValueConverters::adjustTemporal;
 
     private Configuration config;
+    private ZoneOffset zoneOffset = ZonedDateTime.now(DATABASE.timezone()).getOffset();
 
     @Before
     public void beforeEach() {
@@ -183,7 +184,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 long c3Millis = c3 % 1000;
                 LocalDateTime c3DateTime = LocalDateTime.ofEpochSecond(c3Seconds,
                         (int) TimeUnit.MILLISECONDS.toNanos(c3Millis),
-                        ZoneOffset.UTC);
+                        zoneOffset);
 
                 assertThat(c3DateTime.getYear()).isEqualTo(2014);
                 assertThat(c3DateTime.getMonth()).isEqualTo(Month.SEPTEMBER);
@@ -192,7 +193,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(c3DateTime.getMinute()).isEqualTo(51);
                 assertThat(c3DateTime.getSecond()).isEqualTo(4);
                 assertThat(c3DateTime.getNano()).isEqualTo((int) TimeUnit.MILLISECONDS.toNanos(780));
-                assertThat(io.debezium.time.Timestamp.toEpochMillis(c3DateTime, ADJUSTER)).isEqualTo(c3);
+                assertThat(io.debezium.time.Timestamp.toEpochMillis(c3DateTime, ADJUSTER, DATABASE.timezone())).isEqualTo(c3);
 
                 // '2014-09-08 17:51:04.777'
                 String c4 = after.getString("c4"); // timestamp
@@ -461,7 +462,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 long c3Millis = c3.getTime() % 1000;
                 LocalDateTime c3DateTime = LocalDateTime.ofEpochSecond(c3Seconds,
                         (int) TimeUnit.MILLISECONDS.toNanos(c3Millis),
-                        ZoneOffset.UTC);
+                        zoneOffset);
                 assertThat(c3DateTime.getYear()).isEqualTo(2014);
                 assertThat(c3DateTime.getMonth()).isEqualTo(Month.SEPTEMBER);
                 assertThat(c3DateTime.getDayOfMonth()).isEqualTo(8);
@@ -469,7 +470,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(c3DateTime.getMinute()).isEqualTo(51);
                 assertThat(c3DateTime.getSecond()).isEqualTo(4);
                 assertThat(c3DateTime.getNano()).isEqualTo((int) TimeUnit.MILLISECONDS.toNanos(780));
-                assertThat(io.debezium.time.Timestamp.toEpochMillis(c3DateTime, ADJUSTER)).isEqualTo(c3.getTime());
+                assertThat(io.debezium.time.Timestamp.toEpochMillis(c3DateTime, ADJUSTER, DATABASE.timezone())).isEqualTo(c3.getTime());
 
                 // '2014-09-08 17:51:04.777'
                 String c4 = after.getString("c4"); // MySQL timestamp, so always ZonedTimestamp

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -663,6 +663,7 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("DATE_TIME_TABLE"))
                 .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
+                .with("database.connectionTimeZone", DATABASE.timezone())
                 .build();
         start(MySqlConnector.class, config);
 
@@ -694,17 +695,17 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         String value2 = "2018-01-03 00:00:10";
         long toEpochMillis1 = Timestamp.toEpochMillis(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse(value2)),
-                MySqlValueConverters::adjustTemporal);
+                MySqlValueConverters::adjustTemporal, DATABASE.timezone());
         assertThat(schemaC.defaultValue()).isEqualTo(toEpochMillis1);
 
         String value3 = "2018-01-03 00:00:10.7";
         long toEpochMillis2 = Timestamp.toEpochMillis(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S").parse(value3)),
-                MySqlValueConverters::adjustTemporal);
+                MySqlValueConverters::adjustTemporal, DATABASE.timezone());
         assertThat(schemaD.defaultValue()).isEqualTo(toEpochMillis2);
 
         String value4 = "2018-01-03 00:00:10.123456";
         long toEpochMicro = MicroTimestamp.toEpochMicros(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS").parse(value4)),
-                MySqlValueConverters::adjustTemporal);
+                MySqlValueConverters::adjustTemporal, DATABASE.timezone());
         assertThat(schemaE.defaultValue()).isEqualTo(toEpochMicro);
 
         assertThat(schemaF.defaultValue()).isEqualTo(2001);

--- a/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
@@ -6,6 +6,7 @@
 package io.debezium.time;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjuster;
 
@@ -66,11 +67,27 @@ public class MicroTimestamp {
      * @throws IllegalArgumentException if the value is not an instance of the acceptable types
      */
     public static long toEpochMicros(Object value, TemporalAdjuster adjuster) {
+        return toEpochMicros(value, adjuster, ZoneOffset.UTC);
+    }
+
+    /**
+     * Get the number of microseconds past epoch of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
+     * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
+     * {@link java.sql.Timestamp}.
+     *
+     * @param value the local or SQL date, time, or timestamp value; may not be null
+     * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
+     * adjustment is necessary
+     * @param zoneId database timezone
+     * @return the epoch microseconds
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     */
+    public static long toEpochMicros(Object value, TemporalAdjuster adjuster, ZoneId zoneId) {
         LocalDateTime dateTime = Conversions.toLocalDateTime(value);
         if (adjuster != null) {
             dateTime = dateTime.with(adjuster);
         }
-        return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
+        return Conversions.toEpochMicros(dateTime.atZone(zoneId).toInstant());
     }
 
     private MicroTimestamp() {

--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -6,6 +6,7 @@
 package io.debezium.time;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjuster;
 
@@ -66,6 +67,22 @@ public class Timestamp {
      * @throws IllegalArgumentException if the value is not an instance of the acceptable types
      */
     public static long toEpochMillis(Object value, TemporalAdjuster adjuster) {
+        return toEpochMillis(value, adjuster, ZoneOffset.UTC);
+    }
+
+    /**
+     * Get the number of milliseconds past epoch of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
+     * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
+     * {@link java.sql.Timestamp}.
+     *
+     * @param value the local or SQL date, time, or timestamp value; may not be null
+     * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
+     * adjustment is necessary
+     * @param zoneId database timezone
+     * @return the epoch milliseconds
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     */
+    public static long toEpochMillis(Object value, TemporalAdjuster adjuster, ZoneId zoneId) {
         if (value instanceof Long) {
             return (Long) value;
         }
@@ -74,7 +91,7 @@ public class Timestamp {
             dateTime = dateTime.with(adjuster);
         }
 
-        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        return dateTime.atZone(zoneId).toInstant().toEpochMilli();
     }
 
     private Timestamp() {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -220,3 +220,4 @@ Ychopada,Yashashree Chopada
 gurpiarbassi, Gurps Bassi
 mfortunat, Massimo Fortunat
 ryanvanhuuksloot, Ryan van Huuksloot
+xie-shujian,xieshujian


### PR DESCRIPTION
Debezium just use UTC time zone to convet the datetime to long value and ignores the actual time zone used by the mysql database.
This change will fix the issue.
I reuses the parameter database.connectionTimeZone to determin the database time zone.
It is a break change and enabling this parameter will result in different results than before.

About date time 2023-08-04T17:51:03.
If you don't config it, default is UTC time zone, the long value will be 1691171463
If database.connectionTimeZone=Asia/Shanghai, its value will be 1691142663
If database.connectionTimeZone=US/Samoa, its value will be 1691211063