### PR TITLE
DBZ-6720: handle unchanged toasted uuid array

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Helper that returns placeholder values for unchanged toasted columns.
@@ -25,10 +26,12 @@ public class UnchangedToastedPlaceholder {
     private final byte[] toastPlaceholderBinary;
     private final String toastPlaceholderString;
     private final Map<String, String> toastPlaceholderHstore = new HashMap<>();
+    private final String toastPlaceholderUuid;
 
     public UnchangedToastedPlaceholder(PostgresConnectorConfig connectorConfig) {
         toastPlaceholderBinary = connectorConfig.getUnavailableValuePlaceholder();
         toastPlaceholderString = new String(toastPlaceholderBinary);
+        toastPlaceholderUuid = UUID.nameUUIDFromBytes(toastPlaceholderBinary).toString();
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE, toastPlaceholderString);
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_TEXT_ARRAY_TOAST_VALUE,
                 Arrays.asList(toastPlaceholderString));
@@ -44,6 +47,7 @@ public class UnchangedToastedPlaceholder {
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_BIGINT_ARRAY_TOAST_VALUE, toastedLongArrayPlaceholder);
         toastPlaceholderHstore.put(toastPlaceholderString, toastPlaceholderString);
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_HSTORE_TOAST_VALUE, toastPlaceholderHstore);
+        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_UUID_TOAST_VALUE, Arrays.asList(toastPlaceholderUuid));
     }
 
     public Optional<Object> getValue(Object obj) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
@@ -29,6 +29,7 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
     public static final Object UNCHANGED_INT_ARRAY_TOAST_VALUE = new Object();
     public static final Object UNCHANGED_BIGINT_ARRAY_TOAST_VALUE = new Object();
     public static final Object UNCHANGED_HSTORE_TOAST_VALUE = new Object();
+    public static final Object UNCHANGED_UUID_TOAST_VALUE = new Object();
 
     private Object unchangedToastValue;
 
@@ -76,6 +77,10 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
                 break;
             case "hstore":
                 unchangedToastValue = UNCHANGED_HSTORE_TOAST_VALUE;
+                break;
+            case "uuid[]":
+            case "_uuid":
+                unchangedToastValue = UNCHANGED_UUID_TOAST_VALUE;
                 break;
             default:
                 unchangedToastValue = UNCHANGED_TOAST_VALUE;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 public class DecoderDifferences {
     static final String TOASTED_VALUE_PLACEHOLDER = "__debezium_unavailable_value";
     static final String TOASTED_VALUE_NUMBER_STRING = "95, 95, 100, 101, 98, 101, 122, 105, 117, 109, 95, 117, 110, 97, 118, 97, 105, 108, 97, 98, 108, 101, 95, 118, 97, 108, 117, 101";
+    static final String TOASTED_VALUE_UUID_STRING = "b68a35a7-17ad-35b3-af2a-ae46edb4545a"; // UUID encoding of string `__debezium_unavailable_value`
 
     private static boolean pgoutput() {
         return TestHelper.decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.PGOUTPUT;
@@ -30,6 +31,10 @@ public class DecoderDifferences {
 
     public static String mandatoryToastedValuePlaceholder() {
         return TOASTED_VALUE_PLACEHOLDER;
+    }
+
+    public static String mandatoryToastedValueUuidPlaceholder() {
+        return TOASTED_VALUE_UUID_STRING;
     }
 
     public static byte[] mandatoryToastedValueBinaryPlaceholder() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -44,7 +44,6 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import io.debezium.data.SchemaAndValueField;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -2005,6 +2004,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 consumer.remove(),
                 Envelope.FieldName.AFTER);
     }
+
     @Test
     @FixFor("DBZ-1029")
     public void shouldReceiveChangesForTableWithoutPrimaryKey() throws Exception {


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/DBZ-6720

The designated format for an unchanged toasted UUID array is a singleton array containing a UUID element that represents the encoded UUID of the placeholder string.
The uuid encoding of the default placeholder value `__debezium_unavailable_value` is `b68a35a7-17ad-35b3-af2a-ae46edb4545a`.