### PR TITLE
DBZ-6635 Send heartbeats also before processing first event

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -227,9 +227,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 lsnFlushingAllowed = true;
             }
             else {
-                if (offsetContext.hasCompletelyProcessedPosition()) {
-                    dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
-                }
+                dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                 noMessageIterations++;
                 if (noMessageIterations >= THROTTLE_NO_MESSAGE_BEFORE_PAUSE) {
                     noMessageIterations = 0;


### PR DESCRIPTION
We should send heartbeats no matter if there is already any DB record processed or not. This prevents situation when after the start there is no new record in the Db and Debezium is not sending neither DB events nor heartbeats.

https://issues.redhat.com/browse/DBZ-6635