### PR TITLE
DBZ-6811 Send heartbeats when there are no updates in the DB

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -189,6 +189,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 // There is no change in the database
                 if (toLsn.compareTo(lastProcessedPosition.getCommitLsn()) <= 0 && streamingExecutionContext.getShouldIncreaseFromLsn()) {
                     LOGGER.debug("No change in the database");
+                    dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                     return false;
                 }
 


### PR DESCRIPTION
Heartbeats should be sent when Debezium is not sending any events obatined from the DB. Send heartbeat before finishing itteration which doesn't contain any updates from the DB.

https://issues.redhat.com/browse/DBZ-6811