### PR TITLE
DBZ-6798 Expose SCN-based metrics as `BigInteger`

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetrics.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle;
 
+import java.math.BigInteger;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -283,8 +284,8 @@ public class OracleStreamingChangeEventSourceMetrics extends DefaultStreamingCha
     }
 
     @Override
-    public String getCurrentScn() {
-        return currentScn.get().toString();
+    public BigInteger getCurrentScn() {
+        return currentScn.get().asBigInteger();
     }
 
     @Override
@@ -541,18 +542,18 @@ public class OracleStreamingChangeEventSourceMetrics extends DefaultStreamingCha
     }
 
     @Override
-    public String getOldestScn() {
-        return oldestScn.get().toString();
+    public BigInteger getOldestScn() {
+        return oldestScn.get().asBigInteger();
     }
 
     @Override
-    public String getCommittedScn() {
-        return committedScn.get().toString();
+    public BigInteger getCommittedScn() {
+        return committedScn.get().asBigInteger();
     }
 
     @Override
-    public String getOffsetScn() {
-        return offsetScn.get().toString();
+    public BigInteger getOffsetScn() {
+        return offsetScn.get().asBigInteger();
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetricsMXBean.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle;
 
+import java.math.BigInteger;
 import java.util.Set;
 
 import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetricsMXBean;
@@ -17,7 +18,7 @@ public interface OracleStreamingChangeEventSourceMetricsMXBean extends Streaming
     /**
      * @return the current system change number of the database
      */
-    String getCurrentScn();
+    BigInteger getCurrentScn();
 
     /**
      * @return array of current filenames to be used by the mining session.
@@ -237,17 +238,17 @@ public interface OracleStreamingChangeEventSourceMetricsMXBean extends Streaming
     /**
      * @return the oldest SCN in the transaction buffer
      */
-    String getOldestScn();
+    BigInteger getOldestScn();
 
     /**
      * @return the last committed SCN from the transaction buffer
      */
-    String getCommittedScn();
+    BigInteger getCommittedScn();
 
     /**
      * @return the current offset SCN
      */
-    String getOffsetScn();
+    BigInteger getOffsetScn();
 
     /**
      * Lag can temporarily be inaccurate on DST changes.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
@@ -80,6 +80,10 @@ public class Scn implements Comparable<Scn> {
         return isNull() ? 0 : scn.longValue();
     }
 
+    public BigInteger asBigInteger() {
+        return scn;
+    }
+
     /**
      * Returns a {@code SCn} whose value is {@code (this + value)}.
      *

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3810,19 +3810,19 @@ The {prodname} Oracle connector also provides the following additional streaming
 |Attributes |Type |Description
 
 |[[oracle-streaming-metrics-currentscn]]<<oracle-streaming-metrics-currentscn, `+CurrentScn+`>>
-|`string`
+|`BigInteger`
 |The most recent system change number that has been processed.
 
 |[[oracle-streaming-metrics-oldest-scn]]<<oracle-streaming-metrics-oldest-scn, `+OldestScn+`>>
-|`string`
+|`BigInteger`
 |The oldest system change number in the transaction buffer.
 
 |[[oracle-streaming-metrics-committed-scn]]<<oracle-streaming-metrics-committed-scn, `+CommittedScn+`>>
-|`string`
+|`BigInteger`
 |The last committed system change number from the transaction buffer.
 
 |[[oracle-streaming-metrics-offset-scn]]<<oracle-streaming-metrics-offset-scn, `+OffsetScn+`>>
-|`string`
+|`BigInteger`
 |The system change number currently written to the connector's offsets.
 
 |[[oracle-streaming-metrics-currentredologfilename]]<<oracle-streaming-metrics-currentredologfilename, `+CurrentRedoLogFileName+`>>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6798

The SCN data types were previously exposed as `String` types, which is not consumable by Grafana and Prometheus. By using `BigInteger`, we can now make these accessible on dashboards.