### PR TITLE
DBZ-6821 Dbz crashes on DDL statement (non Latin chars in variables)

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -1357,14 +1357,14 @@ STRING_USER_NAME_MARIADB:            (
                                      )  '@';
 LOCAL_ID:                               '@'
                                      (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | SQUOTA_STRING
                                         | DQUOTA_STRING
                                         | BQUOTA_STRING
                                     );
 GLOBAL_ID:                              '@' '@'
                                     (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | BQUOTA_STRING
                                     );
 

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -680,3 +680,13 @@ SELECT 1;
 
 END
 #end
+
+#begin
+CREATE DEFINER=`peuser`@`%` PROCEDURE `test_utf`()
+BEGIN
+    SET @Ν_greece := 1, @N_latin := 'test';
+SELECT
+    @Ν_greece
+     ,@N_latin;
+END
+#end


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6821