### PR TITLE
DBZ-6839 Fix PostgresConnectorIT#shouldAddNewFieldToSourceInfo

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomPostgresSourceInfoStructMaker.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomPostgresSourceInfoStructMaker.java
@@ -37,7 +37,6 @@ public class CustomPostgresSourceInfoStructMaker extends PostgresSourceInfoStruc
     @Override
     public Struct struct(SourceInfo sourceInfo) {
         Struct result = super.struct(sourceInfo);
-        Long lsn = result.getInt64(SourceInfo.LSN_KEY);
         result.put("newField", "newFieldValue");
         return result;
     }


### PR DESCRIPTION
PostgresConnectorIT#shouldAddNewFieldToSourceInfo fails only when run together with other tests and the failure is random. It seem there is a caching issue in Apicuro, when `test_server.s1.a-value` artifact references `io.debezium.connector.postgresql.Source` version 1, which hasnt't `newField` field and this reference is used also in `shouldAddNewFieldToSourceInfo` where artifact with version 2 should be used. Using dedicated table and thus creating new artifact in Apucurio should fix this issue.

Also remove unused variable from `CustomPostgresSourceInfoStructMaker`.

https://issues.redhat.com/browse/DBZ-6839