### PR TITLE
DBZ-6841 Fix randomly failing BaseSourceTaskTest#verifyTaskRestartsSuccessfully

### DIFF
--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -88,7 +88,7 @@ public class BaseSourceTaskTest {
             @Override
             protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
                 ChangeEventSourceCoordinator<Partition, OffsetContext> result = super.start(config);
-                if (startCount.get() < 3) {
+                if (startCount.get() < 4) {
                     throw new RetriableException("Retry " + startCount.get());
                 }
 
@@ -101,6 +101,7 @@ public class BaseSourceTaskTest {
                 CommonConnectorConfig.RETRIABLE_RESTART_WAIT.name(), "1" // wait 1ms between restarts
         );
         baseSourceTask.start(config);
+        sleep(1); // wait 1ms in order to satisfy retriable wait
         assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
         pollAndIgnoreRetryException(baseSourceTask);
         assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
@@ -113,8 +114,8 @@ public class BaseSourceTaskTest {
         baseSourceTask.stop();
         assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
-        assertEquals(3, baseSourceTask.startCount.get());
-        assertEquals(2, baseSourceTask.stopCount.get());
+        assertEquals(4, baseSourceTask.startCount.get());
+        assertEquals(3, baseSourceTask.stopCount.get());
         verify(baseSourceTask.coordinator, times(1)).stop();
     }
 


### PR DESCRIPTION
Test was passing locally and in the CI as the start was very fast and after the first start retriable wait condition wasn't met, so we actually sleep and while the sleep we doesn't increment the counter and the state is still `RESTARTING`. On slower machines when start takes longer time and we don't wait, the test is actualy wrong. The correct test either should remove last assert for `RESTARTING` state or increase number of failures and add a sleep time after initial start, so that there is no retry wait time.
This PR implements the later option.

https://issues.redhat.com/browse/DBZ-6841