### PR TITLE
DBZ-3642 CloudEventsConverter can retrieve metadata from headers

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -400,6 +400,7 @@ Renato Mefi
 René Kerner
 Robert Hana
 Roman Kuchar
+Roman Kudryashov
 Rotem Adhoh
 Sagar Rao
 Sahan Dilshan

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/converters/MongoDbCloudEventsProvider.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/converters/MongoDbCloudEventsProvider.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.mongodb.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
 import io.debezium.connector.mongodb.Module;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -26,8 +24,8 @@ public class MongoDbCloudEventsProvider implements CloudEventsProvider {
     }
 
     @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new MongoDbRecordParser(schema, record);
+    public RecordParser createParser(RecordAndMetadata recordAndMetadata) {
+        return new MongoDbRecordParser(recordAndMetadata);
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/converters/MongoDbRecordParser.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/converters/MongoDbRecordParser.java
@@ -7,11 +7,10 @@ package io.debezium.connector.mongodb.converters;
 
 import java.util.Set;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
 import io.debezium.connector.mongodb.MongoDbFieldName;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -34,8 +33,8 @@ public class MongoDbRecordParser extends RecordParser {
             COLLECTION,
             WALL_TIME);
 
-    public MongoDbRecordParser(Schema schema, Struct record) {
-        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER, MongoDbFieldName.UPDATE_DESCRIPTION);
+    public MongoDbRecordParser(RecordAndMetadata recordAndMetadata) {
+        super(recordAndMetadata, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER, MongoDbFieldName.UPDATE_DESCRIPTION);
     }
 
     @Override

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
@@ -7,15 +7,26 @@ package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.HeaderFrom;
 import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.SnapshotMode;
+import io.debezium.connector.mongodb.transforms.outbox.MongoEventRouter;
 import io.debezium.converters.CloudEventsConverterTest;
 import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
 import io.debezium.util.Testing;
 
 /**
@@ -25,34 +36,34 @@ import io.debezium.util.Testing;
  */
 public class CloudEventsConverterIT extends AbstractMongoConnectorIT {
 
-    @Test
-    public void testCorrectFormat() throws Exception {
+    protected static final String SERVER_NAME = "mongo1";
+    protected static final String DB_NAME = "dbA";
+    protected static final String COLLECTION_NAME = "c1";
+
+    @Before
+    public void beforeEach() {
         Testing.Print.enable();
-        config = TestHelper.getConfiguration(mongo)
-                .edit()
-                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
-                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .build();
-
+        config = getConfiguration();
         context = new MongoDbTaskContext(config);
-
-        TestHelper.cleanDatabase(mongo, "dbA");
-
+        TestHelper.cleanDatabase(mongo, DB_NAME);
         start(MongoDbConnector.class, config);
         assertConnectorIsRunning();
+    }
 
+    @Test
+    public void testCorrectFormat() throws Exception {
         // Wait for snapshot completion
         waitForSnapshotToBeCompleted("mongodb", "mongo1");
 
         List<Document> documentsToInsert = loadTestDocuments("restaurants1.json");
-        insertDocuments("dbA", "c1", documentsToInsert.toArray(new Document[0]));
+        insertDocuments(DB_NAME, COLLECTION_NAME, documentsToInsert.toArray(new Document[0]));
         Document updateObj = new Document()
                 .append("$set", new Document()
                         .append("name", "Closed"));
-        updateDocument("dbA", "c1", Document.parse("{\"restaurant_id\": \"30075445\"}"), updateObj);
+        updateDocument(DB_NAME, COLLECTION_NAME, Document.parse("{\"restaurant_id\": \"30075445\"}"), updateObj);
         // Pause is necessary to make sure that fullDocument fro change streams is caputred before delete
         Thread.sleep(1000);
-        deleteDocuments("dbA", "c1", Document.parse("{\"restaurant_id\": \"30075445\"}"));
+        deleteDocuments(DB_NAME, COLLECTION_NAME, Document.parse("{\"restaurant_id\": \"30075445\"}"));
 
         // 6 INSERTs + 1 UPDATE + 1 DELETE
         final int recCount = 8;
@@ -78,7 +89,62 @@ public class CloudEventsConverterIT extends AbstractMongoConnectorIT {
         CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithDataAsAvro(updateRecord, MongoDbFieldName.UPDATE_DESCRIPTION, false);
         CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithDataAsAvro(updateRecord, Envelope.FieldName.AFTER, false);
         CloudEventsConverterTest.shouldConvertToCloudEventsInAvro(updateRecord, "mongodb", "mongo1", false);
+    }
 
-        stopConnector();
+    @Test
+    @FixFor({ "DBZ-3642" })
+    public void shouldConvertToCloudEventsInJsonWithMetadataInHeadersAfterOutboxEventRouter() throws Exception {
+        HeaderFrom<SourceRecord> headerFrom = new HeaderFrom.Value<>();
+        Map<String, String> headerFromConfig = new LinkedHashMap<>();
+        headerFromConfig.put("fields", "source,op,transaction");
+        headerFromConfig.put("headers", "source,op,transaction");
+        headerFromConfig.put("operation", "copy");
+        headerFromConfig.put("header.converter.schemas.enable", "true");
+        headerFrom.configure(headerFromConfig);
+
+        MongoEventRouter<SourceRecord> outboxEventRouter = new MongoEventRouter<>();
+        Map<String, String> outboxEventRouterConfig = new LinkedHashMap<>();
+        outboxEventRouterConfig.put("collection.expand.json.payload", "true");
+        outboxEventRouter.configure(outboxEventRouterConfig);
+
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME)
+                    .insertOne(new Document()
+                            .append("aggregateid", "10711fa5")
+                            .append("aggregatetype", "User")
+                            .append("type", "UserCreated")
+                            .append("payload", new Document()
+                                    .append("_id", new ObjectId("000000000000000000000000"))
+                                    .append("someField1", "some value 1")
+                                    .append("someField2", 7005L)));
+        }
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic("mongo1.dbA.c1").get(0);
+        SourceRecord recordWithMetadataHeaders = headerFrom.apply(record);
+        SourceRecord routedEvent = outboxEventRouter.apply(recordWithMetadataHeaders);
+
+        assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
+        assertThat(routedEvent.keySchema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(routedEvent.key()).isEqualTo("10711fa5");
+        assertThat(routedEvent.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithMetadataInHeaders(routedEvent, "mongodb", "mongo1");
+
+        headerFrom.close();
+        outboxEventRouter.close();
+    }
+
+    private Configuration getConfiguration() {
+        return TestHelper.getConfiguration(mongo)
+                .edit()
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + COLLECTION_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
+                .build();
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlCloudEventsProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlCloudEventsProvider.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.mysql.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
 import io.debezium.connector.mysql.Module;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -26,8 +24,8 @@ public class MySqlCloudEventsProvider implements CloudEventsProvider {
     }
 
     @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new MySqlRecordParser(schema, record);
+    public RecordParser createParser(RecordAndMetadata recordAndMetadata) {
+        return new MySqlRecordParser(recordAndMetadata);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlRecordParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlRecordParser.java
@@ -7,10 +7,9 @@ package io.debezium.connector.mysql.converters;
 
 import java.util.Set;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -41,8 +40,8 @@ public class MySqlRecordParser extends RecordParser {
             THREAD_KEY,
             QUERY_KEY);
 
-    public MySqlRecordParser(Schema schema, Struct record) {
-        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
+    public MySqlRecordParser(RecordAndMetadata recordAndMetadata) {
+        super(recordAndMetadata, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
     }
 
     @Override

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/CloudEventsConverterIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/CloudEventsConverterIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.mysql;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.converters.AbstractCloudEventsConverterTest;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import io.debezium.util.Testing;
+
+/**
+ * Integration test for {@link io.debezium.converters.CloudEventsConverter} with {@link MySqlConnector}
+ *
+ * @author Roman Kudryashov
+ */
+public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<MySqlConnector> {
+
+    private static final Path SCHEMA_HISTORY_PATH = Testing.Files.createTestingPath("file-schema-history-connect.txt").toAbsolutePath();
+
+    private final UniqueDatabase DATABASE = new UniqueDatabase("myServer1", "empty")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private JdbcConnection connection;
+
+    private static final String SETUP_OUTBOX_TABLE = "CREATE TABLE outbox " +
+            "(" +
+            "  id            varchar(36)  not null," +
+            "  aggregatetype varchar(255) not null," +
+            "  aggregateid   varchar(255) not null," +
+            "  type          varchar(255) not null," +
+            "  payload       json," +
+            "  CONSTRAINT outbox_pk PRIMARY KEY (id));";
+
+    @Before
+    @Override
+    public void beforeEach() throws Exception {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName());) {
+            this.connection = db.connect();
+        }
+        super.beforeEach();
+    }
+
+    @After
+    public void afterEach() throws Exception {
+        try {
+            stopConnector();
+        }
+        finally {
+            Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Override
+    protected Class<MySqlConnector> getConnectorClass() {
+        return MySqlConnector.class;
+    }
+
+    @Override
+    protected String getConnectorName() {
+        return "mysql";
+    }
+
+    @Override
+    protected String getServerName() {
+        return DATABASE.getServerName();
+    }
+
+    @Override
+    protected JdbcConnection databaseConnection() {
+        return this.connection;
+    }
+
+    @Override
+    protected Configuration.Builder getConfigurationBuilder() {
+        return DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
+    }
+
+    @Override
+    protected String tableName() {
+        return tableNameId().toQuotedString('`');
+    }
+
+    @Override
+    protected String topicName() {
+        return DATABASE.topicForTable("outbox");
+    }
+
+    @Override
+    protected void createTable() throws Exception {
+        this.connection.execute(SETUP_OUTBOX_TABLE);
+    }
+
+    @Override
+    protected String createInsert(String eventId,
+                                  String eventType,
+                                  String aggregateType,
+                                  String aggregateId,
+                                  String payloadJson,
+                                  String additional) {
+        StringBuilder insert = new StringBuilder();
+        insert.append("INSERT INTO outbox VALUES (");
+        insert.append("'").append(UUID.fromString(eventId)).append("'");
+        insert.append(", '").append(aggregateType).append("'");
+        insert.append(", '").append(aggregateId).append("'");
+        insert.append(", '").append(eventType).append("'");
+
+        if (payloadJson == null) {
+            insert.append(", null");
+        }
+        else if (payloadJson.isEmpty()) {
+            insert.append(", ''");
+        }
+        else {
+            insert.append(", '").append(payloadJson).append("'");
+        }
+
+        if (additional != null) {
+            insert.append(additional);
+        }
+        insert.append(")");
+
+        return insert.toString();
+    }
+
+    @Override
+    protected void waitForStreamingStarted() throws InterruptedException {
+        waitForStreamingRunning("mysql", DATABASE.getServerName());
+    }
+
+    private TableId tableNameId() {
+        return tableNameId("a");
+    }
+
+    private TableId tableNameId(String table) {
+        return TableId.parse(DATABASE.qualifiedTableName(table));
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleCloudEventsProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleCloudEventsProvider.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.oracle.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
 import io.debezium.connector.oracle.Module;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -26,8 +24,8 @@ public class OracleCloudEventsProvider implements CloudEventsProvider {
     }
 
     @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new OracleRecordParser(schema, record);
+    public RecordParser createParser(RecordAndMetadata recordAndMetadata) {
+        return new OracleRecordParser(recordAndMetadata);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleRecordParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleRecordParser.java
@@ -7,10 +7,9 @@ package io.debezium.connector.oracle.converters;
 
 import java.util.Set;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -29,8 +28,8 @@ public class OracleRecordParser extends RecordParser {
             COMMIT_SCN_KEY,
             LCR_POSITION_KEY);
 
-    public OracleRecordParser(Schema schema, Struct record) {
-        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
+    public OracleRecordParser(RecordAndMetadata recordAndMetadata) {
+        super(recordAndMetadata, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresCloudEventsProvider.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresCloudEventsProvider.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.postgresql.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
 import io.debezium.connector.postgresql.Module;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -26,8 +24,8 @@ public class PostgresCloudEventsProvider implements CloudEventsProvider {
     }
 
     @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new PostgresRecordParser(schema, record);
+    public RecordParser createParser(RecordAndMetadata recordAndMetadata) {
+        return new PostgresRecordParser(recordAndMetadata);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresRecordParser.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresRecordParser.java
@@ -7,10 +7,9 @@ package io.debezium.connector.postgresql.converters;
 
 import java.util.Set;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -33,8 +32,8 @@ public class PostgresRecordParser extends RecordParser {
             LSN_KEY,
             SEQUENCE_KEY);
 
-    public PostgresRecordParser(Schema schema, Struct record) {
-        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
+    public PostgresRecordParser(RecordAndMetadata recordAndMetadata) {
+        super(recordAndMetadata, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import java.util.UUID;
+
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.converters.AbstractCloudEventsConverterTest;
+import io.debezium.jdbc.JdbcConnection;
+
+/**
+ * Integration test for {@link io.debezium.converters.CloudEventsConverter} with {@link PostgresConnector}
+ *
+ * @author Roman Kudryashov
+ */
+public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<PostgresConnector> {
+
+    private static final String SETUP_OUTBOX_SCHEMA = "DROP SCHEMA IF EXISTS outboxsmtit CASCADE;" +
+            "CREATE SCHEMA outboxsmtit;";
+
+    private static final String SETUP_OUTBOX_TABLE = "CREATE TABLE outboxsmtit.outbox " +
+            "(" +
+            "  id            uuid         not null" +
+            "    constraint outbox_pk primary key," +
+            "  aggregatetype varchar(255) not null," +
+            "  aggregateid   varchar(255) not null," +
+            "  type          varchar(255) not null," +
+            "  payload       jsonb" +
+            ");";
+
+    @Before
+    @Override
+    public void beforeEach() throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+        super.beforeEach();
+    }
+
+    @Override
+    protected Class<PostgresConnector> getConnectorClass() {
+        return PostgresConnector.class;
+    }
+
+    @Override
+    protected String getConnectorName() {
+        return "postgresql";
+    }
+
+    @Override
+    protected String getServerName() {
+        return TestHelper.TEST_SERVER;
+    }
+
+    @Override
+    protected JdbcConnection databaseConnection() {
+        return TestHelper.create();
+    }
+
+    @Override
+    protected Configuration.Builder getConfigurationBuilder() {
+        return TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "outboxsmtit")
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "outboxsmtit\\.outbox");
+    }
+
+    @Override
+    protected String tableName() {
+        return "outboxsmtit.outbox";
+    }
+
+    @Override
+    protected String topicName() {
+        return TestHelper.topicName("outboxsmtit.outbox");
+    }
+
+    @Override
+    protected void createTable() throws Exception {
+        TestHelper.execute(SETUP_OUTBOX_SCHEMA);
+        TestHelper.execute(SETUP_OUTBOX_TABLE);
+    }
+
+    @Override
+    protected String createInsert(String eventId,
+                                  String eventType,
+                                  String aggregateType,
+                                  String aggregateId,
+                                  String payloadJson,
+                                  String additional) {
+        StringBuilder insert = new StringBuilder();
+        insert.append("INSERT INTO outboxsmtit.outbox VALUES (");
+        insert.append("'").append(UUID.fromString(eventId)).append("'");
+        insert.append(", '").append(aggregateType).append("'");
+        insert.append(", '").append(aggregateId).append("'");
+        insert.append(", '").append(eventType).append("'");
+
+        if (payloadJson == null) {
+            insert.append(", null::jsonb");
+        }
+        else if (payloadJson.isEmpty()) {
+            insert.append(", ''");
+        }
+        else {
+            insert.append(", '").append(payloadJson).append("'::jsonb");
+        }
+
+        if (additional != null) {
+            insert.append(additional);
+        }
+        insert.append(")");
+
+        return insert.toString();
+    }
+
+    @Override
+    protected void waitForStreamingStarted() throws InterruptedException {
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerCloudEventsProvider.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerCloudEventsProvider.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.sqlserver.converters;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-
 import io.debezium.connector.sqlserver.Module;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;
@@ -26,8 +24,8 @@ public class SqlServerCloudEventsProvider implements CloudEventsProvider {
     }
 
     @Override
-    public RecordParser createParser(Schema schema, Struct record) {
-        return new SqlServerRecordParser(schema, record);
+    public RecordParser createParser(RecordAndMetadata recordAndMetadata) {
+        return new SqlServerRecordParser(recordAndMetadata);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerRecordParser.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerRecordParser.java
@@ -7,10 +7,9 @@ package io.debezium.connector.sqlserver.converters;
 
 import java.util.Set;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -31,8 +30,8 @@ public class SqlServerRecordParser extends RecordParser {
             COMMIT_LSN_KEY,
             EVENT_SERIAL_NO_KEY);
 
-    public SqlServerRecordParser(Schema schema, Struct record) {
-        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
+    public SqlServerRecordParser(RecordAndMetadata recordAndMetadata) {
+        super(recordAndMetadata, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.storage.ConverterConfig;
 
 import io.debezium.config.CommonConnectorConfig.SchemaNameAdjustmentMode;
+import io.debezium.config.EnumeratedValue;
 import io.debezium.converters.spi.SerializerType;
 
 /**
@@ -32,6 +33,10 @@ public class CloudEventsConverterConfig extends ConverterConfig {
             + "'avro' replaces the characters that cannot be used in the Avro type name with underscore (default)"
             + "'none' does not apply any adjustment";
 
+    public static final String CLOUDEVENTS_METADATA_LOCATION_CONFIG = "metadata.location";
+    public static final String CLOUDEVENTS_METADATA_LOCATION_DEFAULT = "value";
+    private static final String CLOUDEVENTS_METADATA_LOCATION_DOC = "Specify from where to retrieve metadata";
+
     private static final ConfigDef CONFIG;
 
     static {
@@ -43,6 +48,8 @@ public class CloudEventsConverterConfig extends ConverterConfig {
                 CLOUDEVENTS_DATA_SERIALIZER_TYPE_DOC);
         CONFIG.define(CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_CONFIG, ConfigDef.Type.STRING, CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DEFAULT, ConfigDef.Importance.LOW,
                 CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DOC);
+        CONFIG.define(CLOUDEVENTS_METADATA_LOCATION_CONFIG, ConfigDef.Type.STRING, CLOUDEVENTS_METADATA_LOCATION_DEFAULT, ConfigDef.Importance.HIGH,
+                CLOUDEVENTS_METADATA_LOCATION_DOC);
     }
 
     public static ConfigDef configDef() {
@@ -78,5 +85,60 @@ public class CloudEventsConverterConfig extends ConverterConfig {
      */
     public SchemaNameAdjustmentMode schemaNameAdjustmentMode() {
         return SchemaNameAdjustmentMode.parse(getString(CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_CONFIG));
+    }
+
+    /**
+     * Return from where to retrieve metadata
+     *
+     * @return metadata location
+     */
+    public MetadataLocation metadataLocation() {
+        return MetadataLocation.parse(getString(CLOUDEVENTS_METADATA_LOCATION_CONFIG));
+    }
+
+    /**
+     * The set of predefined MetadataLocation options
+     */
+    public enum MetadataLocation implements EnumeratedValue {
+
+        /**
+         * Get metadata from the value
+         */
+        VALUE("value"),
+
+        /**
+         * Get metadata from the header
+         */
+        HEADER("header");
+
+        private final String value;
+
+        MetadataLocation(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied values is one of the predefined options
+         *
+         * @param value the configuration property value ; may not be null
+         * @return the matching option, or null if the match is not found
+         */
+        public static MetadataLocation parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (MetadataLocation option : MetadataLocation.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
@@ -27,5 +27,5 @@ public interface RecordAndMetadata {
 
     Struct transaction();
 
-    SchemaAndValue ts_ms();
+    SchemaAndValue timestamp();
 }

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters.recordandmetadata;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Common interface for a structure containing a record and its metadata
+ *
+ * @author Roman Kudryashov
+ */
+public interface RecordAndMetadata {
+
+    Struct record();
+
+    Schema dataSchema(String... dataFields);
+
+    Struct source();
+
+    String operation();
+
+    Struct transaction();
+
+    SchemaAndValue ts_ms();
+}

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataBaseImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataBaseImpl.java
@@ -53,7 +53,7 @@ public class RecordAndMetadataBaseImpl implements RecordAndMetadata {
     }
 
     @Override
-    public SchemaAndValue ts_ms() {
+    public SchemaAndValue timestamp() {
         String ts_ms = record.getInt64(Envelope.FieldName.TIMESTAMP).toString();
         Schema ts_msSchema = dataSchema.field(Envelope.FieldName.TIMESTAMP).schema();
         return new SchemaAndValue(ts_msSchema, ts_ms);

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataBaseImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataBaseImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters.recordandmetadata;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+
+public class RecordAndMetadataBaseImpl implements RecordAndMetadata {
+
+    private final Struct record;
+
+    private final Schema dataSchema;
+
+    public RecordAndMetadataBaseImpl(Struct record, Schema dataSchema) {
+        this.record = record;
+        this.dataSchema = dataSchema;
+    }
+
+    @Override
+    public Struct record() {
+        return record;
+    }
+
+    @Override
+    public Schema dataSchema(String... dataFields) {
+        Struct source = record.getStruct(Envelope.FieldName.SOURCE);
+        String connectorType = source.getString(AbstractSourceInfo.DEBEZIUM_CONNECTOR_KEY);
+        return getDataSchema(this.dataSchema, connectorType, dataFields);
+    }
+
+    @Override
+    public Struct source() {
+        return record.getStruct(Envelope.FieldName.SOURCE);
+    }
+
+    @Override
+    public String operation() {
+        return record.getString(Envelope.FieldName.OPERATION);
+    }
+
+    @Override
+    public Struct transaction() {
+        return record.schema().field(Envelope.FieldName.TRANSACTION) != null ? record.getStruct(Envelope.FieldName.TRANSACTION) : null;
+    }
+
+    @Override
+    public SchemaAndValue ts_ms() {
+        String ts_ms = record.getInt64(Envelope.FieldName.TIMESTAMP).toString();
+        Schema ts_msSchema = dataSchema.field(Envelope.FieldName.TIMESTAMP).schema();
+        return new SchemaAndValue(ts_msSchema, ts_ms);
+    }
+
+    private static Schema getDataSchema(Schema schema, String connectorType, String... fields) {
+        String dataSchemaName = "io.debezium.connector." + connectorType + ".Data";
+        SchemaBuilder builder = SchemaBuilder.struct().name(dataSchemaName);
+
+        for (String field : fields) {
+            builder.field(field, schema.field(field).schema());
+        }
+
+        return builder.build();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters.recordandmetadata;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import io.debezium.data.Envelope;
+
+public class RecordAndMetadataHeaderImpl implements RecordAndMetadata {
+
+    private final Struct record;
+    private final Schema dataSchema;
+    private final Struct source;
+    private final String operation;
+    private final Struct transaction;
+    private final SchemaAndValue ts_ms;
+
+    public RecordAndMetadataHeaderImpl(Struct record, Schema dataSchema, Headers headers, JsonConverter jsonHeaderConverter) {
+        this.record = record;
+        this.dataSchema = dataSchema;
+        this.source = (Struct) getHeaderSchemaAndValue(headers, Envelope.FieldName.SOURCE, jsonHeaderConverter).value();
+        this.operation = (String) getHeaderSchemaAndValue(headers, Envelope.FieldName.OPERATION, jsonHeaderConverter).value();
+        this.transaction = (Struct) getHeaderSchemaAndValue(headers, Envelope.FieldName.TRANSACTION, jsonHeaderConverter).value();
+        String ts_ms = source.getInt64(Envelope.FieldName.TIMESTAMP).toString();
+        Schema ts_msSchema = source.schema().field(Envelope.FieldName.TIMESTAMP).schema();
+        this.ts_ms = new SchemaAndValue(ts_msSchema, ts_ms);
+    }
+
+    @Override
+    public Struct record() {
+        return this.record;
+    }
+
+    @Override
+    public Schema dataSchema(String... dataFields) {
+        return this.dataSchema;
+    }
+
+    @Override
+    public Struct source() {
+        return this.source;
+    }
+
+    @Override
+    public String operation() {
+        return this.operation;
+    }
+
+    @Override
+    public Struct transaction() {
+        return this.transaction;
+    }
+
+    @Override
+    public SchemaAndValue ts_ms() {
+        return this.ts_ms;
+    }
+
+    private static SchemaAndValue getHeaderSchemaAndValue(Headers headers, String headerName, JsonConverter jsonHeaderConverter) {
+        Header header = headers.lastHeader(headerName);
+        return jsonHeaderConverter.toConnectData(null, header.value());
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
@@ -61,7 +61,7 @@ public class RecordAndMetadataHeaderImpl implements RecordAndMetadata {
     }
 
     @Override
-    public SchemaAndValue ts_ms() {
+    public SchemaAndValue timestamp() {
         return this.ts_ms;
     }
 

--- a/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsProvider.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsProvider.java
@@ -5,8 +5,7 @@
  */
 package io.debezium.converters.spi;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
+import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 
 /**
  * A {@link java.util.ServiceLoader} interface that connectors should implement if they wish to provide
@@ -25,11 +24,10 @@ public interface CloudEventsProvider {
     /**
      * Create a concrete parser of a change record for the connector.
      *
-     * @param schema the schema of the record
-     * @param record the value of the record
+     * @param recordAndMetadata record and its metadata
      * @return a concrete parser
      */
-    RecordParser createParser(Schema schema, Struct record);
+    RecordParser createParser(RecordAndMetadata recordAndMetadata);
 
     /**
      * Create a concrete CloudEvents maker using the outputs of a record parser. Also need to specify the data content

--- a/debezium-core/src/main/java/io/debezium/converters/spi/RecordParser.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/RecordParser.java
@@ -45,8 +45,8 @@ public abstract class RecordParser {
         this.transaction = recordAndMetadata.transaction();
         this.op = recordAndMetadata.operation();
         this.opSchema = Schema.STRING_SCHEMA;
-        this.ts_ms = (String) recordAndMetadata.ts_ms().value();
-        this.ts_msSchema = recordAndMetadata.ts_ms().schema();
+        this.ts_ms = (String) recordAndMetadata.timestamp().value();
+        this.ts_msSchema = recordAndMetadata.timestamp().schema();
         this.connectorType = source.getString(AbstractSourceInfo.DEBEZIUM_CONNECTOR_KEY);
         this.dataSchema = recordAndMetadata.dataSchema(dataFields);
     }

--- a/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.HeaderFrom;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.transforms.outbox.EventRouter;
+
+/**
+ * A unified test of all {@link CloudEventsConverter} behavior which all connectors should extend.
+ *
+ * @author Roman Kudryashov
+ */
+public abstract class AbstractCloudEventsConverterTest<T extends SourceConnector> extends AbstractConnectorTest {
+
+    protected EventRouter<SourceRecord> outboxEventRouter;
+
+    protected HeaderFrom<SourceRecord> headerFrom;
+
+    protected abstract Class<T> getConnectorClass();
+
+    protected abstract String getConnectorName();
+
+    protected abstract String getServerName();
+
+    protected abstract JdbcConnection databaseConnection();
+
+    protected abstract Configuration.Builder getConfigurationBuilder();
+
+    protected abstract String topicName();
+
+    protected abstract String tableName();
+
+    protected abstract void createTable() throws Exception;
+
+    protected abstract String createInsert(String eventId, String eventType, String aggregateType,
+                                           String aggregateId, String payloadJson, String additional);
+
+    protected abstract void waitForStreamingStarted() throws InterruptedException;
+
+    @Before
+    public void beforeEach() throws Exception {
+        createTable();
+
+        headerFrom = new HeaderFrom.Value<>();
+        Map<String, String> headerFromConfig = new LinkedHashMap<>();
+        headerFromConfig.put("fields", "source,op,transaction");
+        headerFromConfig.put("headers", "source,op,transaction");
+        headerFromConfig.put("operation", "copy");
+        headerFromConfig.put("header.converter.schemas.enable", "true");
+        headerFrom.configure(headerFromConfig);
+
+        outboxEventRouter = new EventRouter<>();
+        Map<String, String> outboxEventRouterConfig = new LinkedHashMap<>();
+        outboxEventRouterConfig.put("table.expand.json.payload", "true");
+        outboxEventRouter.configure(outboxEventRouterConfig);
+
+        startConnector();
+    }
+
+    @After
+    public void afterEach() throws Exception {
+        stopConnector();
+        assertNoRecordsToConsume();
+        databaseConnection().close();
+        headerFrom.close();
+        outboxEventRouter.close();
+    }
+
+    @Test
+    @FixFor({ "DBZ-3642" })
+    public void shouldConvertToCloudEventsInJsonWithMetadataInHeadersAfterOutboxEventRouter() throws Exception {
+        databaseConnection().execute(createInsert(
+                "59a42efd-b015-44a9-9dde-cb36d9002425",
+                "UserCreated",
+                "User",
+                "10711fa5",
+                "{" +
+                        "\"someField1\": \"some value 1\"," +
+                        "\"someField2\": 7005" +
+                        "}",
+                ""));
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic(topicName()).get(0);
+        SourceRecord recordWithMetadataHeaders = headerFrom.apply(record);
+        SourceRecord routedEvent = outboxEventRouter.apply(recordWithMetadataHeaders);
+
+        assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
+        assertThat(routedEvent.keySchema()).isEqualTo(Schema.STRING_SCHEMA);
+        assertThat(routedEvent.key()).isEqualTo("10711fa5");
+        assertThat(routedEvent.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithMetadataInHeaders(routedEvent, getConnectorName(), getServerName());
+    }
+
+    private void startConnector() throws Exception {
+        Configuration.Builder configBuilder = getConfigurationBuilder();
+        start(getConnectorClass(), configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingStarted();
+        assertNoRecordsToConsume();
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -232,3 +232,4 @@ vsantona,Vincenzo Santoynastaso
 rolevinks,Stein Rolevink
 matan-cohen,Matan Cohen
 BigGillyStyle,Andy Pickler
+rkudryashov,Roman Kudryashov


### PR DESCRIPTION
This makes Outbox SMT (that removes source info) + CloudEventsConverter working (by getting source info from headers), that is to publish events from `outbox` table converted to CloudEvents format.

 This works when the connector is configured in appropriate way, particularly:
* filter unwanted messages, such as, heartbeats and tombstones (this is only needed for `HeaderFrom` transform)
* add `source`, `op`, `transaction` headers
* enable schemas for header converter

The following is an example of a configured connector:

```
{
  "name": "book-db-source-connector",
  "config": {
    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
    "plugin.name": "pgoutput",
    "database.hostname": "book-db",
    "database.port": "5432",
    "database.user": "postgres",
    "database.password": "password",
    "database.dbname": "book",
    "database.server.name": "book",
    "topic.prefix": "book",
    "topic.creation.default.replication.factor": 1,
    "topic.creation.default.partitions": 6,
    "table.include.list": "public.outbox",
    "heartbeat.interval.ms": "5000",
    "slot.name": "book_debezium",
    "publication.name": "book_publication",
    "tombstones.on.delete": false,
    "transforms": "addSourceHeaders,outbox",
    "predicates": "isHeartbeat",
    "predicates.isHeartbeat.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
    "predicates.isHeartbeat.pattern": "__debezium-heartbeat.*",
    "transforms.addSourceHeaders.type": "org.apache.kafka.connect.transforms.HeaderFrom$Value",
    "transforms.addSourceHeaders.fields": "source,op,transaction",
    "transforms.addSourceHeaders.headers": "source,op,transaction",
    "transforms.addSourceHeaders.operation": "copy",
    "transforms.addSourceHeaders.predicate": "isHeartbeat",
    "transforms.addSourceHeaders.negate": true,
    "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
    "transforms.outbox.table.field.event.key": "event_key",
    "transforms.outbox.table.expand.json.payload": true,
    "transforms.outbox.route.by.field": "aggregate_type",
    "transforms.outbox.route.topic.replacement": "outbox.event.library",
    "value.converter": "io.debezium.converters.CloudEventsConverter",
    "value.converter.source.location": "header",
    "header.converter": "org.apache.kafka.connect.json.JsonConverter",
    "header.converter.schemas.enable": true,
    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
    "key.converter.schemas.enable": false
  }
}
```

An example of a message:

```
{
	"id": "name:book;lsn:27733536;txId:751;sequence:[\"27733312\",\"27733536\"]",
	"source": "/debezium/postgresql/book",
	"specversion": "1.0",
	"type": "io.debezium.postgresql.datachangeevent",
	"time": "2023-09-03T17:15:09.228Z",
	"datacontenttype": "application/json",
	"iodebeziumop": "c",
	"iodebeziumversion": "2.4.0-SNAPSHOT",
	"iodebeziumconnector": "postgresql",
	"iodebeziumname": "book",
	"iodebeziumtsms": "1693761309228",
	"iodebeziumsnapshot": "false",
	"iodebeziumdb": "book",
	"iodebeziumsequence": "[\"27733312\",\"27733536\"]",
	"iodebeziumschema": "public",
	"iodebeziumtable": "outbox",
	"iodebeziumtxId": "751",
	"iodebeziumlsn": "27733536",
	"iodebeziumxmin": null,
	"iodebeziumtxid": null,
	"iodebeziumtxtotalorder": null,
	"iodebeziumtxdatacollectionorder": null,
	"data": {
		"schema": {
			"type": "struct",
			"fields": [
				{
					"type": "int32",
					"optional": true,
					"field": "id"
				},
				{
					"type": "string",
					"optional": true,
					"field": "name"
				},
				{
					"type": "int32",
					"optional": true,
					"field": "publicationYear"
				}
			],
			"optional": true,
			"name": "payload"
		},
		"payload": {
			"id": 11,
			"name": "a book",
			"publicationYear": 1824
		}
	}
}
```

Side effect: `"header.converter.schemas.enable": true,` causes all other headers to be added with their schemas.

UPD: added transaction header parsing