### PR TITLE
DBZ-6901 ExtractNewRecordState's schema cache is not updated with arrival of the ddl change event

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -553,7 +553,7 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
         private final Schema schema;
         private final String operation;
 
-        public NewRecordValueMetadata(Schema schema, String operation) {
+        NewRecordValueMetadata(Schema schema, String operation) {
             this.schema = schema;
             this.operation = operation;
         }

--- a/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
@@ -75,14 +75,40 @@ public abstract class AbstractExtractStateTest {
     }
 
     protected SourceRecord createCreateRecord() {
-        final Struct before = new Struct(recordSchema);
+        final Struct after = new Struct(recordSchema);
         final Struct source = new Struct(sourceSchema);
 
-        before.put("id", (byte) 1);
-        before.put("name", "myRecord");
+        after.put("id", (byte) 1);
+        after.put("name", "myRecord");
         source.put("lsn", 1234);
         source.put("ts_ms", 12836);
-        final Struct payload = envelope.create(before, source, Instant.now());
+        final Struct payload = envelope.create(after, source, Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", envelope.schema(), payload);
+    }
+
+    protected SourceRecord createCreateRecordAddingColumn(String columnName, long columnValue) {
+        final Schema recordSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT8_SCHEMA)
+                .field("name", Schema.STRING_SCHEMA)
+                .field(columnName, Schema.OPTIONAL_INT64_SCHEMA)
+                .build();
+
+        final Struct after = new Struct(recordSchema);
+        final Struct source = new Struct(sourceSchema);
+
+        after.put("id", (byte) 1);
+        after.put("name", "myRecord");
+        after.put(columnName, columnValue);
+
+        source.put("lsn", 1234);
+        source.put("ts_ms", 12836);
+
+        final Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+        final Struct payload = envelope.create(after, source, Instant.now());
         return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", envelope.schema(), payload);
     }
 

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -225,7 +225,7 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
     }
 
     @Test
-    @FixFor("DBZ-1452")
+    @FixFor({ "DBZ-1452", "DBZ-6901" })
     public void testAddField() {
         try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
             final Map<String, String> props = new HashMap<>();
@@ -235,6 +235,14 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
             final SourceRecord createRecord = createCreateRecord();
             final SourceRecord unwrapped = transform.apply(createRecord);
             assertThat(((Struct) unwrapped.value()).get("__op")).isEqualTo(Envelope.Operation.CREATE.code());
+
+            SourceRecord createRecordAddingColumn = createCreateRecordAddingColumn("started_at", 1694587158123L);
+            SourceRecord unwrappedAddingColumn = transform.apply(createRecordAddingColumn);
+            assertThat(((Struct) unwrappedAddingColumn.value()).get("started_at")).isEqualTo(1694587158123L);
+
+            createRecordAddingColumn = createCreateRecordAddingColumn("started_at", 1694587158789L);
+            unwrappedAddingColumn = transform.apply(createRecordAddingColumn);
+            assertThat(((Struct) unwrappedAddingColumn.value()).get("started_at")).isEqualTo(1694587158789L);
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6901