### PR TITLE
[jenkins-jobs] Clean project befor rebuild for snapshots

### DIFF
--- a/jenkins-jobs/pipelines/release/release-pipeline.groovy
+++ b/jenkins-jobs/pipelines/release/release-pipeline.groovy
@@ -248,7 +248,7 @@ def mvnRelease(repoDir, repoName, branchName, buildArgs = '') {
             repoId = match[0][1]
             echo "Using staging repository $repoId"
         }
-        sh "mvn install -DskipTests -DskipITs -Passembly $buildArgs"
+        sh "mvn clean install -DskipTests -DskipITs -Passembly $buildArgs"
     }
     return repoId
 }


### PR DESCRIPTION
Oracle re-build fails after OLR was introduced due to protoc generated sources. The re-build (unless clean is provided) fails with Compilation unit is not of SOURCE kind: ".../debezium-connector-oracle/target/generated-sources/oracle.json"