### PR TITLE
DBZ-7194 Enable running Oracle 23 Free Edition

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseVersion.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseVersion.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  */
 public class OracleDatabaseVersion {
     private final static Pattern VERSION_PATTERN = Pattern
-            .compile("(?:.*)(?:Release )([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:.*)");
+            .compile("(?:.*)(?:\bRelease \b)([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:.*)");
     private final static Pattern VERSION_18_1_PATTERN = Pattern
             .compile("(?:.*)(?:\\- Production(?:\\r\\n|\\r|\\n)(?:Version ))([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)");
 


### PR DESCRIPTION
match only to the first occurrence of `Release ` substring in Oracle Banner. For certain versions of oracle databases the current regular expression fails to parse the version.

Old Regexp:
Oracle Database 12c Enterprise Edition Release 12.2.0.1.0 - 64bit Production => ✅ => 12.2.0.1.0 is correctly parsed
Oracle Database 23c Free, Release 23.0.0.0.0 - Developer-Release Version 23.2.0.0.0 => ❌ => failed to parse version

new Regexp only matches until the first occurrence of `Release `:
Oracle Database 12c Enterprise Edition Release 12.2.0.1.0 - 64bit Production => ✅ => 12.2.0.1.0 is correctly parsed
Oracle Database 23c Free, Release 23.0.0.0.0 - Developer-Release Version 23.2.0.0.0 => ✅ => 23.2.0.0.0 is correctly parsed
