### PR TITLE
DBZ-6937 MySql connector get NPE when snapshot.mode is set to never and signal data collection configured

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
@@ -347,4 +347,22 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
         assertThat(dbChanges).contains(entry(1, Arrays.asList(0, null)));
         assertFalse(logInterceptor.containsWarnMessage("Invalid length when read MySQL DATE value. BIN_LEN_DATE is 0."));
     }
+
+    @Test
+    @FixFor("DBZ-6937")
+    public void incrementalSnapshotOnly() throws Exception {
+        // Testing.Print.enable();
+
+        populateTable();
+        final Configuration config = config().with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER).build();
+        start(connectorClass(), config, loggingCompletion());
+
+        sendAdHocSnapshotSignal();
+
+        final int expectedRecordCount = ROW_COUNT;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            assertThat(dbChanges).contains(entry(i + 1, i));
+        }
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -141,6 +141,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     @Override
     public void processSchemaChange(P partition, OffsetContext offsetContext, DataCollectionId dataCollectionId) throws InterruptedException {
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
         if (dataCollectionId != null && (context.currentDataCollectionId() != null) &&
                 dataCollectionId.equals(context.currentDataCollectionId().getId())) {
             rereadChunk(partition, offsetContext);


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-6937