### PR TITLE
DBZ-6870 throw producer exception during poll() even if the queue isn't empty yet.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -260,6 +260,7 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
             try {
                 this.lock.lock();
                 List<T> records = new ArrayList<>(Math.min(maxBatchSize, queue.size()));
+                throwProducerExceptionIfPresent();
                 while (drainRecords(records, maxBatchSize - records.size()) < maxBatchSize
                         && (maxQueueSizeInBytes == 0 || currentQueueSizeInBytes < maxQueueSizeInBytes)
                         && !timeout.expired()) {


### PR DESCRIPTION
…'t empty yet