### PR TITLE
Skip RecordsStreamProducerIT#shouldReceiveChangesForInfinityNumericWithInfinity on Postgres < 14

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -24,7 +24,7 @@
         <postgres.db.name>postgres</postgres.db.name>
         <postgres.encoding>UTF8</postgres.encoding>
         <postgres.system.lang>en_US.utf8</postgres.system.lang>
-        <postgres.image>debezium/postgres:${version.postgres.server}</postgres.image>
+        <postgres.image>quay.io/debezium/postgres:${version.postgres.server}</postgres.image>
         <postgres.config.file>/usr/share/postgresql/postgresql.conf.sample</postgres.config.file>
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1159,7 +1159,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @FixFor("DBZ-6758")
-    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, reason = "Database version less than or equal 14.0")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, reason = "Infinity support for numeric type was added in Postgres 14")
     public void shouldReceiveChangesForInfinityNumericWithInfinity() throws Exception {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -12,7 +12,7 @@ import static io.debezium.connector.postgresql.TestHelper.TYPE_NAME_PARAMETER_KE
 import static io.debezium.connector.postgresql.TestHelper.TYPE_SCALE_PARAMETER_KEY;
 import static io.debezium.connector.postgresql.TestHelper.topicName;
 import static io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIs.DecoderPluginName.PGOUTPUT;
-import static io.debezium.junit.EqualityCheck.LESS_THAN_OR_EQUAL;
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1159,7 +1159,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @FixFor("DBZ-6758")
-    @SkipWhenDatabaseVersion(check = LESS_THAN_OR_EQUAL, major = 10, reason = "Database version less than or equal 10.0")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, reason = "Database version less than or equal 14.0")
     public void shouldReceiveChangesForInfinityNumericWithInfinity() throws Exception {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 


### PR DESCRIPTION
* Use quay.io image as a base images for postgres test image
* Skip RecordsStreamProducerIT#shouldReceiveChangesForInfinityNumericWithInfinity on Postgres < 14

https://issues.redhat.com/browse/DBZ-6986