### PR TITLE
DBZ-6980 Relocates conditional delimiter

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -320,10 +320,10 @@ For example, in a typical deployment, the {prodname} connector files are stored 
 To use a signaling channel with a connector, add the converter JAR file to the connector's subdirectory.
 
 NOTE: To use a custom notification channel with multiple connectors, you must place a copy of the notification channel JAR file in each connector subdirectory.
-endif::community[]
 
 //   Type: procedure
 [id="configuring-connectors-to-use-a-custom-notification-channel"]
 === Configuring connectors to use a custom notification channel
 
 In the connector configuration, add the name of the custom notification channel to the `notification.enabled.channels` property.
+endif::community[]


### PR DESCRIPTION
[DBZ-6980](https://issues.redhat.com/browse/DBZ-6980)

Moves closing delimiter for `community` conditional to end of file to include custom notifications topic not supported in productization release. 