### PR TITLE
Dbz 6997 further refactoring of incremental snapshots topics

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -22,16 +22,16 @@ Notifications can be sent to the following channels:
 SinkNotificationChannel:: Sends notifications through the Connect API to a configured topic.
 LogNotificationChannel:: Notifications are appended to the log.
 JmxNotificationChannel:: Notifications are exposed as an attribute in a JMX bean.
+ifdef::community[]
 Custom:: Notifications are sent to a xref:debezium-notification-custom-channel[custom channel] that you implement.
-
+endif::community[]
 ifdef::product[]
 For details about {prodname} notifications, see the following topics::
 
 * xref:debezium-notifications-description-of-the-format-of-debezium-notifications[]
 * xref:debezium-notifications-types-of-debezium-notifications[]
 * xref:debezium-notifications-enabling-debezium-to-emit-events-to-notification-channels[]
-* xref:debezium-notification-custom-channel[]
-
+//   * xref:debezium-notification-custom-channel[]
 endif::product[]
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -134,12 +134,21 @@ As a result, the {prodname} Db2 connector cannot retrieve the entire history of 
 To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the tables that are in xref:putting-tables-in-capture-mode[capture mode].
 For each change that the snapshot captures, the connector emits a `read` event to the Kafka topic for the captured table.
 
+ifdef::product[]
+
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-db2-ad-hoc-snapshots[]
+* xref:debezium-db2-incremental-snapshots[]
+
+endif::product[]
+
+.Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
+
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:db2-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
 If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
-
-.Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
 
 1. Establish a connection to the database.
 
@@ -194,7 +203,7 @@ After the connector completes the initial snapshot, it continues streaming from 
 
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
-// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// ModuleID: db2-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
@@ -350,13 +359,14 @@ After the snapshot completes, the connector transitions to streaming.
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots
 [id="db2-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
 
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+1]
 
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-db2-incremental-snapshots
 [id="db2-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
 
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
@@ -366,24 +376,28 @@ The {prodname} connector for Db2 does not support schema changes while an increm
 ====
 
 // Type: procedure
+// ModuleID: debezium-db2-triggering-an-incremental-snapshot
 [id="db2-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-db2-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="db2-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-db2-stopping-an-incremental-snapshot
 [id="db2-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-db2-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="db2-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -279,7 +279,7 @@ Use this option if ou want to restart the connector more quickly than with a ful
 
 5. Restart the connector.
 The connector completes the type of snapshot specified by the `snapshot.mode`.
-6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:db2-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
 The connector runs the snapshot while it continues to stream real-time changes from the tables.
 Running an incremental snapshot captures the following data changes:
 +
@@ -330,7 +330,7 @@ This operation is potentially destructive, and should be performed only as a las
 5. Restart the connector.
 6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:db2-incremental-snapshots[incremental snapshot].
 
 Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
 In this procedure the connector performs a full initial snapshot of the database.
@@ -354,7 +354,7 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:db2-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-db2-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -593,9 +593,44 @@ The {prodname} JDBC sink connector has several configuration properties that you
 Many properties have default values.
 Information about the properties is organized as follows:
 
+* xref:jdbc-connector-properties-generic[JDBC connector generic properties]
 * xref:jdbc-connector-properties-connection[JDBC connector connection properties]
 * xref:jdbc-connector-properties-runtime[JDBC connector runtime properties]
 * xref:jdbc-connector-properties-extendable[JDBC connector extendable properties]
+
+[[jdbc-connector-properties-generic]]
+.Generic properties
+[cols="30%a,25%a,45%a"]
+|===
+|Property |Default |Description
+
+|[[jdbc-property-connection-name]]<<jdbc-property-connection-name, `+name+`>>
+|No default
+|Unique name for the connector.
+A failure results if you attempt to reuse this name when registering a connector.
+This property is required by all Kafka Connect connectors.
+
+|[[jdbc-property-connection-class]]<<jdbc-property-connection-class, `+connector.class+`>>
+|No default
+|The name of the Java class for the connector.
+For the {prodname} JDBC connector, specify the value `io.debezium.connector.jdbc.JdbcSinkConnector`.
+
+|[[jdbc-property-connection-task]]<<jdbc-property-connection-task, `+tasks.max+`>>
+|1
+|Maximum number of tasks to use for this connector.
+
+|[[jdbc-property-connection-topics]]<<jdbc-property-connection-topics, `+topics+`>>
+|No default
+|List of topics to consume, separated by commas.
+Do not use this property in combination with the xref:jdbc-property-connection-topics-regex[`topics.regex`] property.
+
+|[[jdbc-property-connection-topics-regex]]<<jdbc-property-connection-topics-regex, `+topics.regex+`>>
+|No default
+|A regular expression that specifies the topics to consume.
+Internally, the regular expression is compiled to a `java.util.regex.Pattern`.
+Do not use this property in combination with the xref:jdbc-property-connection-topics[`topics`] property.
+
+|===
 
 [[jdbc-connector-properties-connection]]
 .JDBC connector connection properties

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -199,14 +199,15 @@ We recommend logical names begin with an alphabetic or underscore character, and
 [[mongodb-performing-a-snapshot]]
 === Performing a snapshot
 
-When a task starts up using a replica set, it uses the connector's logical name and the replica set name to find an _offset_ that describes the position where the connector previously stopped reading changes.
+When a {prodname} task starts to use a replica set, it uses the connector's logical name and the replica set name to find an _offset_ that describes the position where the connector previously stopped reading changes.
 If an offset can be found and it still exists in the oplog, then the task immediately proceeds with xref:mongodb-streaming-changes[streaming changes], starting at the recorded offset position.
 
-However, if no offset is found or if the oplog no longer contains that position, the task must first obtain the current state of the replica set contents by performing a _snapshot_.
+However, if no offset is found, or if the oplog no longer contains that position, the task must first obtain the current state of the replica set contents by performing a _snapshot_.
 This process starts by recording the current position of the oplog and recording that as the offset (along with a flag that denotes a snapshot has been started).
-The task will then proceed to copy each collection, spawning as many threads as possible (up to the value of the `snapshot.max.threads` configuration property) to perform this work in parallel.
-The connector will record a separate _read event_ for each document it sees, and that read event will contain the object's identifier, the complete state of the object, and _source_ information about the MongoDB replica set where the object was found.
-The source information will also include a flag that denotes the event was produced during a snapshot.
+The task then proceeds to copy each collection, spawning as many threads as possible (up to the value of the `snapshot.max.threads` configuration property) to perform this work in parallel.
+The connector records a separate _read event_ for each document it sees.
+Each read event contains the object's identifier, the complete state of the object, and _source_ information about the MongoDB replica set where the object was found.
+The source information also includes a flag that denotes that the event was produced during a snapshot.
 
 This snapshot will continue until it has copied all collections that match the connector's filters.
 If the connector is stopped before the tasks' snapshots are completed, upon restart the connector begins the snapshot again.
@@ -218,15 +219,24 @@ The connector generates log messages to report on the progress of the snapshot.
 To provide for the greatest control, run a separate Kafka Connect cluster for each connector.
 ====
 
+ifdef::product[]
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-postgresql-ad-hoc-snapshots[]
+* xref:debezium-postgresql-incremental-snapshots[]
+endif::product[]
+
 // Type: concept
+// ModuleID: debezium-mongodb-ad-hoc-snapshots
 [id="mongodb-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
 
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-mongodb-incremental-snapshots
 [id="mongodb-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
 
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
@@ -256,23 +266,28 @@ To use incremental snapshots with sharded MongoDB clusters, you must set specifi
 * Set xref:mongodb-property-incremental-snapshot-chunk-size[`incremental.snapshot.chunk.size`] to a value that is high enough to compensate for the link:https://www.mongodb.com/docs/manual/administration/change-streams-production-recommendations/#sharded-clusters[increased complexity] of change stream pipelines.
 
 // Type: procedure
+// ModuleID: debezium-mongodb-triggering-an-incremental-snapshot
 [id="mongodb-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mongdb-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="mongodb-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
+
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mongodb-stopping-an-incremental-snapshot
 [id="mongodb-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mongodb-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="mongodb-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1807,8 +1807,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-s
 
 include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-notification-configuration-properties.adoc[leveloffset=+1]
 
-include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-notification-configuration-properties.adoc[leveloffset=+1]
-
 // Type: assembly
 // ModuleID: monitoring-debezium-mongodb-connector-performance
 // Title: Monitoring {prodname} MongoDB connector performance

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1812,12 +1812,12 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |===
 
-[id="debezium-{context}-connector-kafka-signals-configuration-properties"]
+[id="debezium-mongodb-connector-kafka-signals-configuration-properties"]
 ==== {prodname} connector Kafka signals configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-signals-configuration-properties.adoc[leveloffset=+1]
 
-[id="debezium-{context}-connector-kafka-notifications-configuration-properties"]
+[id="debezium-mongodb-connector-kafka-notifications-configuration-properties"]
 ==== {prodname} connector sink notifications configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-notification-configuration-properties.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -433,7 +433,7 @@ a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}
 [NOTE]
 ====
 The use of these isolation semantics can slow the progress of the snapshot.
-If the snapshot takes too long to complete, consider using a different isolation configuration, or skip the initial snapshot and run an xref:{context}-incremental-snapshots[incremental snapshot] instead.
+If the snapshot takes too long to complete, consider using a different isolation configuration, or skip the initial snapshot and run an xref:mysql-incremental-snapshots[incremental snapshot] instead.
 ====
 
 |5
@@ -622,7 +622,7 @@ For information about capturing data from a new table that has undergone structu
 This guarantees that in the future, the connector can reconstruct the schema history for all tables.
 4. Restart the connector.
 The snapshot recovery process rebuilds the schema history based on the current structure of the tables.
-5. (Optional) After the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
+5. (Optional) After the snapshot completes, initiate an xref:mysql-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
 6. (Optional) Reset the `snapshot.mode` back to `schema_only` to prevent the connector from initiating recovery after a future restart.
 
 // Type: procedure
@@ -645,7 +645,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
 1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
-3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+3. Initiate an xref:mysql-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
 If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
@@ -669,7 +669,7 @@ This operation is potentially destructive, and should be performed only as a las
 5. Restart the connector.
 6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:mysql-incremental-snapshots[incremental snapshot].
 
 Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
 In this procedure the connector performs a full initial snapshot of the database.
@@ -693,7 +693,7 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:mysql-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -384,19 +384,30 @@ The snapshot mode is determined by the xref:mysql-property-snapshot-mode[`snapsh
 The default value of the property is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
 
+ifdef::product[]
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-mysql-ad-hoc-snapshots[]
+* xref:debezium-mysql-incremental-snapshots[]
+endif::product[]
+
+
 The connector completes a series of tasks when it performs the snapshot.
 The exact steps vary with the snapshot mode and with the table locking policy that is in effect for the database.
 The {prodname} MySQL connector completes different steps when it performs an initial snapshot that uses a xref:initial-snapshot-workflow-with-global-read-lock[global read lock] or xref:initial-snapshot-workflow-with-table-level-locks[table-level locks].
 
 // Type: concept
+// ModuleID: debezium-mysql-description-of-the-workflow-for-initial-snapshots-that-use-a-global-read-lock
 [id="initial-snapshot-workflow-with-global-read-lock"]
 ==== Initial snapshots that use a global read lock
-The following workflow lists the steps that {prodname} takes to create a snapshot with a global read lock.
+
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
 If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
 For information about the snapshot process in environments that do not permit global read locks, see the xref:snapshot-workflow-with-table-level-locks[snapshot workflow for table-level locks].
 
 .Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with a global read lock
+The following table shows the steps in the workflow that {prodname} follows to create a snapshot with a global read lock.
+
 [cols="1a,9a",options="header",subs="+attributes"]
 |===
 |Step |Action
@@ -553,7 +564,7 @@ a|Record the successful completion of the snapshot in the connector offsets.
 
 |===
 
-// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// ModuleID: mysql-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
@@ -687,28 +698,33 @@ After the snapshot completes, the connector transitions to streaming.
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots
 [id="mysql-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+1]
 
-
-
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-mysql-incremental-snapshots
 [id="mysql-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mysql-triggering-an-incremental-snapshot
 [id="mysql-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mysql-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="mysql-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
+
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-mysql-stopping-an-incremental-snapshot
 [id="mysql-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -715,8 +715,10 @@ include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-sna
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
-[id="db2-stopping-an-incremental-snapshot-kafka"]
+// ModuleID: debezium-mysql-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
+[id="mysql-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
+
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -210,7 +210,7 @@ This can be useful when you want to reduce the time required to complete a snaps
 Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
-* xref:oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:oracle-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:oracle-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
 * Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
 * Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.
@@ -241,7 +241,7 @@ For information about capturing data from a new table that has undergone structu
 This guarantees that in the future, the connector can reconstruct the schema history for all tables.
 4. Restart the connector.
 The snapshot recovery process rebuilds the schema history based on the current structure of the tables.
-5. (Optional) After the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
+5. (Optional) After the snapshot completes, initiate an xref:oracle-incremental-snapshots[incremental snapshot] to capture existing data for newly added tables along with changes to other tables that occurred while that connector was off-line.
 6. (Optional) Reset the `snapshot.mode` back to `schema_only` to prevent the connector from initiating recovery after a future restart.
 
 // Type: procedure
@@ -262,9 +262,9 @@ You can add the schema by running a new schema snapshot, or by running an initia
 .Procedure
 
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
-1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
+1. Edit the xref:oracle-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
-3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+3. Initiate an xref:oracle-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
 If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
@@ -283,12 +283,12 @@ Removing offsets should be performed only by advanced users who have experience 
 This operation is potentially destructive, and should be performed only as a last resort.
 ====
 4. Set values for properties in the connector configuration as described in the following steps:
-.. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
-.. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
+.. Set the value of the xref:oracle-property-snapshot-mode[`snapshot.mode`] property to `schema_only`.
+.. Edit the xref:oracle-property-table-include-list[`table.include.list`] to add the tables that you want to capture.
 5. Restart the connector.
 6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:oracle-incremental-snapshots[incremental snapshot].
 
 Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
 In this procedure the connector performs a full initial snapshot of the database.
@@ -296,7 +296,7 @@ As with any initial snapshot, in a database with many large tables, running an i
 After the snapshot completes, you can optionally trigger an incremental snapshot to capture any changes that occur while the connector is off-line.
 
 1. Stop the connector.
-2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+2. Remove the internal database schema history topic that is specified by the xref:oracle-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
 For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
 +
@@ -312,7 +312,7 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:oracle-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-oracle-ad-hoc-snapshots
@@ -4524,7 +4524,7 @@ database.url=jdbc:oracle:thin:username/password!@(DESCRIPTION=(ENABLE=broken)(AD
 The preceding steps configure the TCP network stack to send keep-alive packets every 60 seconds.
 As a result, the AWS Gateway Load Balancer does not timeout when JDBC calls to the LogMiner API take more than 350 seconds to complete, enabling the connector to continue to read changes from the database's transaction logs.
 
-[id="what-causes-ora-0155-and-how-to-handle-it"]
+[id="what-causes-ora-01555-and-how-to-handle-it"]
 *What's the cause for ORA-01555 and how to handle it?*::
 The {prodname} Oracle connector uses flashback queries when the initial snapshot phase executes.
 A flashback query is a special type of query that relies on the flashback area, maintained by the database's `UNDO_RETENTION` database parameter, to return the results of a query based on what the contents of the table had at a given time, or in our case at a given SCN.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -83,19 +83,27 @@ Typically, the redo logs on an Oracle server are configured to not retain the co
 As a result, the {prodname} Oracle connector cannot retrieve the entire history of the database from the logs.
 To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
 
-The following workflow lists the steps that {prodname} takes to create a snapshot.
-These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`]  configuration property is set to its default value, which is `initial`.
-You can customize the way that the connector creates snapshots by changig the value of the `snapshot.mode` property.
-If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
-
 [NOTE]
 ====
 If the time needed to complete the initial snapshot exceeds the `UNDO_RETENTION` time that is set for the database (fifteen minutes, by default), an ORA-01555 exception can occur.
 For more information about the error, and about the steps that you can take to recover from it, see the xref:what-causes-ora-01555-and-how-to-handle-it"[Frequently asked questions].
 ====
 
+ifdef::product[]
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-oracle-ad-hoc-snapshots[]
+* xref:debezium-oracle-incremental-snapshots[]
+endif::product[]
+
+
 [[default-workflow-for-performing-an-initial-snapshot]]
 .Default workflow that the Oracle connector uses to perform an initial snapshot
+The following workflow lists the steps that {prodname} takes to create a snapshot.
+These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`]  configuration property is set to its default value, which is `initial`.
+You can customize the way that the connector creates snapshots by changig the value of the `snapshot.mode` property.
+If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
+
 When the snapshot mode is set to the default, the connector completes the following tasks to create a snapshot:
 
 1. Establish a connection to the database.
@@ -177,7 +185,7 @@ WARNING: Do not use this mode to perform a snapshot if schema changes were commi
 
 For more information, see xref:oracle-property-snapshot-mode[`snapshot.mode`] in the table of connector configuration properties.
 
-// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// ModuleID: oracle-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
@@ -309,12 +317,13 @@ After the snapshot completes, the connector transitions to streaming.
 // Type: concept
 // ModuleID: debezium-oracle-ad-hoc-snapshots
 [id="oracle-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-oracle-incremental-snapshots
 [id="oracle-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [WARNING]
@@ -323,24 +332,28 @@ The {prodname} connector for Oracle does not support schema changes while an inc
 ====
 
 // Type: procedure
+// ModuleID: debezium-oracle-triggering-an-incremental-snapshot
 [id="oracle-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
+
 [id="oracle-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
-
+// ModuleID: debezium-oracle-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-oracle-stopping-an-incremental-snapshot
 [id="oracle-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
+// ModuleID: debezium-oracle-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="oracle-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -86,7 +86,7 @@ To enable the connector to establish a baseline for the current state of the dat
 [NOTE]
 ====
 If the time needed to complete the initial snapshot exceeds the `UNDO_RETENTION` time that is set for the database (fifteen minutes, by default), an ORA-01555 exception can occur.
-For more information about the error, and about the steps that you can take to recover from it, see the xref:what-causes-ora-01555-and-how-to-handle-it"[Frequently asked questions].
+For more information about the error, and about the steps that you can take to recover from it, see the xref:what-causes-ora-01555-and-how-to-handle-it[Frequently asked questions].
 ====
 
 ifdef::product[]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -134,6 +134,15 @@ For more information about PostgreSQL logical replication security, see the link
 Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments.
 This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL.
 Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
+
+ifdef::product[]
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-postgresql-ad-hoc-snapshots[]
+* xref:debezium-postgresql-incremental-snapshots[]
+endif::product[]
+
+.Default workflow behavior of initial snapshots
 The default behavior for performing a snapshot consists of the following steps.
 You can change this behavior by setting the xref:postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
 
@@ -180,12 +189,15 @@ endif::community[]
 // Type: concept
 // ModuleID: debezium-postgresql-ad-hoc-snapshots
 [id="postgresql-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-postgresql-incremental-snapshots
 [id="postgresql-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
 [WARNING]
@@ -195,24 +207,28 @@ If a schema change is performed _before_ the incremental snapshot start but _aft
 ====
 
 // Type: procedure
+// ModuleID: debezium-postgresql-triggering-an-incremental-snapshot
 [id="postgresql-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-postgresql-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="postgresql-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-postgresql-stopping-an-incremental-snapshot
 [id="postgresql-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-postgresql-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="postgresql-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -125,12 +125,19 @@ SQL Server CDC is not designed to store a complete history of database changes.
 For the {prodname} SQL Server connector to establish a baseline for the current state of the database, it uses a process called _snapshotting_.
 The initial snapshot captures the structure and data of the tables in the database.
 
+ifdef::product[]
+You can find more information about snapshots in the following sections:
+
+* xref:debezium-sqlserver-ad-hoc-snapshots[]
+* xref:debezium-sqlserver-incremental-snapshots[]
+endif::product[]
+
+.Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
+
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.
 If you configure a different snapshot mode, the connector completes the snapshot by using a modified version of this workflow.
-
-.Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
 
 1.  Establish a connection to the database.
 
@@ -180,7 +187,7 @@ After the connector completes the initial snapshot, it continues streaming from 
 
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
-// ModuleID: {context}-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
+// ModuleID: sqlserver-description-of-why-initial-snapshots-capture-the-schema-history-for-all-tables
 // Title: Description of why initial snapshots capture the schema history for all tables
 // Type: concept
 [id="understanding-why-initial-snapshots-capture-the-schema-history-for-all-tables"]
@@ -336,12 +343,13 @@ After the snapshot completes, the connector transitions to streaming.
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots
 [id="sqlserver-ad-hoc-snapshots"]
-==== Ad hoc snapshots
+=== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+1]
 
-// Type: concept
+// Type: assembly
+// ModuleID: debezium-sqlserver-incremental-snapshots
 [id="sqlserver-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
 [WARNING]
@@ -350,24 +358,28 @@ The {prodname} connector for SQL Server does not support schema changes while an
 ====
 
 // Type: procedure
+// ModuleID: debezium-sqlserver-triggering-an-incremental-snapshot
 [id="sqlserver-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-sqlserver-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="sqlserver-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-sqlserver-stopping-an-incremental-snapshot
 [id="sqlserver-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
+// ModuleID: debezium-sqlserver-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="sqlserver-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -263,7 +263,7 @@ Use this option if you want to restart the connector more quickly than with a fu
 
 5. Restart the connector.
 The connector completes the type of snapshot specified by the `snapshot.mode`.
-6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:{context}-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
+6. (Optional) If the connector performed a `schema_only` snapshot, after the snapshot completes, initiate an xref:sqlserver-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
 The connector runs the snapshot while it continues to stream real-time changes from the tables.
 Running an incremental snapshot captures the following data changes:
 +
@@ -290,7 +290,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
 1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
-3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+3. Initiate an xref:sqlserver-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
 If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:
@@ -314,7 +314,7 @@ This operation is potentially destructive, and should be performed only as a las
 5. Restart the connector.
 6. Wait for {prodname} to capture the schema of the new and existing tables.
 Data changes that occurred any tables after the connector stopped are not captured.
-7. To ensure that no data is lost, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. To ensure that no data is lost, initiate an xref:sqlserver-incremental-snapshots[incremental snapshot].
 
 Procedure 2: Initial snapshot, followed by optional incremental snapshot:::
 In this procedure the connector performs a full initial snapshot of the database.
@@ -338,18 +338,20 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:{context}-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:sqlserver-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-sqlserver-ad-hoc-snapshots
 [id="sqlserver-ad-hoc-snapshots"]
 === Ad hoc snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: debezium-sqlserver-incremental-snapshots
 [id="sqlserver-incremental-snapshots"]
 === Incremental snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
 [WARNING]

--- a/documentation/modules/ROOT/pages/transformations/event-changes.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-changes.adoc
@@ -130,7 +130,9 @@ transforms.changes.header.unchanged.name=Unchanged
 The connector might emit many types of event messages (heartbeat messages, tombstone messages, or metadata messages about transactions or schema changes).
 To apply the transformation to a subset of events, you can define xref:options-for-applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
 
+
 // Type: concept
+// ModuleID: options-for-applying-the-event-changes-transformation-selectively
 [id="applying-the-event-changes-transformation-selectively"]
 == Options for applying the event changes transformation selectively
 

--- a/documentation/modules/ROOT/pages/transformations/event-changes.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-changes.adoc
@@ -130,7 +130,8 @@ transforms.changes.header.unchanged.name=Unchanged
 The connector might emit many types of event messages (heartbeat messages, tombstone messages, or metadata messages about transactions or schema changes).
 To apply the transformation to a subset of events, you can define xref:options-for-applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
 
-[id="options-for-applying-the-event-flattening-transformation-selectively"]
+// Type: concept
+[id="applying-the-event-changes-transformation-selectively"]
 == Options for applying the event changes transformation selectively
 
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -176,7 +176,7 @@ transforms.unwrap.add.fields=table,lsn
 
 .Customizing the configuration
 The connector might emit many types of event messages (heartbeat messages, tombstone messages, or metadata messages about transactions or schema changes).
-To apply the transformation to a subset of events, you can define xref:options-for-applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
+To apply the transformation to a subset of events, you can define xref:applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
 
 // Type: concept
 // ModuleID: example-of-adding-debezium-metadata-to-the-kafka-record
@@ -229,7 +229,7 @@ To add metadata to a simplified Kafka record that is for a `DELETE` operation, y
 // Type: concept
 // Title: Options for applying the event flattening transformation selectively
 // ModuleID: options-for-applying-the-event-flattening-transformation-selectively
-[id="options-for-applying-the-event-flattening-transformation-selectively"]
+[id="applying-the-event-flattening-transformation-selectively"]
 == Options for applying the event-flattening transformation selectively
 
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -235,7 +235,7 @@ To add metadata to a simplified Kafka record that is for a `DELETE` operation, y
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-the-event-flattening-transformation-selectively[Configure an SMT predicate for the transformation].
 
 ifdef::community[]
 [id="configuration-options"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -66,7 +66,7 @@ The snapshot process reads the first and last primary key values and uses those 
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
 Currently, the `execute-snapshot` action type triggers {link-prefix}:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
-For more information, see xref:#{context}-incremental-snapshots[Incremental snapshots].
+For more information, see xref:{context}-incremental-snapshots[Incremental snapshots].
 ////
 .Prerequisites
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-kafka-signals-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-kafka-signals-configuration-properties.adoc
@@ -38,4 +38,4 @@ The {prodname} connector provides for pass-through configuration of the signals 
 Pass-through signals properties begin with the prefix `signals.consumer.*`.
 For example, the connector passes properties such as `signal.consumer.security.protocol=SSL` to the Kafka consumer.
 
-As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database schema history clients], {prodname} strips the prefixes from the properties before it passes them to the Kafka signals consumer.
+{prodname} strips the prefixes from the properties before it passes the properties to the Kafka signals consumer.


### PR DESCRIPTION
[DBZ-6997](https://issues.redhat.com/browse/DBZ-6997)

Updates to fix downstream build issues.

Unfortunately, I did not achieve the main goal of this change, which was to expose the instructions for using Kafka signals to trigger and stop incremental snapshots.
But the other build fixes were also necessary. 
To explore a downstream one-off change to  fix the target issue for the Q4 product.  

Tested in a local Antora build. Antora continues to correctly render the content, so no adverse effects in the community docs.

Merging these changes into the 2.3 branch. I'll port these same changes to `main` later, but I don't think we'll be able to drop them in as-is, so a separate PR will be necessary.