### PR TITLE
DBZ-6881 Deprecating MongoDB 4.4 in Debezium 2.5

### DIFF
--- a/.github/workflows/debezium-workflow.yml
+++ b/.github/workflows/debezium-workflow.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version-mongo-server: ["4.4", "5.0", "6.0", "7.0"]
+        version-mongo-server: ["5.0", "6.0", "7.0"]
       fail-fast: false
     steps:
       - name: Checkout Action


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6881