### PR TITLE
DBZ-7018 Allow SQL statements greater than 40kb

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRowTooLargeException.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRowTooLargeException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.events;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.Scn;
+
+/**
+ * A specialized exception that signals that the consumption of a LogMiner event's SQL
+ * has reached a defined maximum and cannot be ingested.
+ *
+ * @author Chris Cranford
+ */
+public class LogMinerEventRowTooLargeException extends DebeziumException {
+    public LogMinerEventRowTooLargeException(String tableName, Long limitInKiloBytes, Scn scn) {
+        super(String.format("A row has been found for table %s that exceeds %dKb with SCN %s.", tableName, limitInKiloBytes, scn));
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
@@ -183,7 +183,7 @@ public class LogMinerEventRowTest {
         char[] chars = new char[4000];
         Arrays.fill(chars, 'a');
         when(resultSet.getString(2)).thenReturn(new String(chars));
-        when(resultSet.getInt(6)).thenReturn(1);
+        when(resultSet.getInt(6)).thenReturn(1, 1, 1, 1, 1, 1, 1, 1, 1, 0);
 
         row = LogMinerEventRow.fromResultSet(resultSet, CATALOG_NAME, true);
         assertThat(row.getRedoSql().length()).isEqualTo(40_000);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7018

### Description	
In some corner cases, users may have unusually large SQL statements that need to be buffered due to the number of columns paired with the data in those columns. Previously we capped this to 4000*10 or 40kb primarily to address situations with LOB operations that could lead to OOM scenarios. The new code rather logs a warning when exceeding 100kb and hard faults ony when the connector sees Integer.MAX_VALUE number of SQL lines for a single SQL buffer.