### PR TITLE
DBZ-7021 Update links to Streams docs targets

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -23,4 +23,4 @@ You can still use the REST API to retrieve information.
 .Additional resources
 
 * link:{LinkConfiguringStreamsOpenShift}#proc-kafka-connect-config-str[Configuring Kafka Connect] in {NameStreamsOpenShift}.
-* link:{LinkDeployStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Creating a new container image automatically using {StreamsName} in {NameDeployStreamsOpenShift}].
+* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically] in {NameDeployManageStreamsOpenShift}].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -10,8 +10,8 @@ After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` 
 .Prerequisites
 * You have access to an OpenShift cluster on which the cluster Operator is installed.
 * The {StreamsName} Operator is running.
-* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
-* link:{LinkDeployStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployManageStreamsOpenShift}#kafka-cluster-str[{NameDeployManageStreamsOpenShift}].
+* link:{LinkDeployManageStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {StreamsName}]
 * You have a {prodnamefull} license.
 * The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html-single/cli_tools/index#installing-openshift-cli[OpenShift `oc` CLI] client is installed or you have access to the OpenShift Container Platform web console.
 * Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:
@@ -20,10 +20,10 @@ To store the build image in an image registry, such as Red Hat Quay.io or Docker
 ** An account and permissions to create and manage images in the registry.
 
 To store the build image as a native OpenShift ImageStream::
-** An link:{LinkConfiguringStreamsOpenShift}#literal_output_literal[ImageStream] resource is deployed to the cluster for storing new container images.
+** An ImageStream resource is deployed to the cluster for storing new container images.
 You must explicitly create an ImageStream for the cluster.
 ImageStreams are not available by default.
-For more information about ImageStreams, see link:{LinkCreatingManagingOpenShiftImages}#managing-image-streams[Managing image streams on OpenShift Container Platform].
+For more information about ImageStreams, see link:{LinkCreatingManagingOpenShiftImages}#managing-image-streams[Managing image streams] in the OpenShift Container Platform documentation.
 
 .Procedure
 


### PR DESCRIPTION
[DBZ-7021](https://issues.redhat.com/browse/DBZ-7021)

(cherry picked from commit 73790f0a0c1956da3610bd3b031293f28563da79)
Fixes links in connector deployment instructions that broke after the target content was refactored to become part of a different document. 
This change was preceded by a commit that was merged to the downstream docs repo  ([!1463](https://gitlab.cee.redhat.com/red-hat-integration-documentation/integration/-/merge_requests/1463)).
The change has no effect on the community version of the content.