### PR TITLE
DBZ-7046 Formatting and xref fixes; addresses downstream build errors

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -82,14 +82,15 @@ The following example shows a typical notification that provides the status of a
 {
     "id": "5563ae14-49f8-4579-9641-c1bbc2d76f99",
     "aggregate_type": "Initial Snapshot",
-    "type": "COMPLETED" <1>,
+    "type": "COMPLETED", // <1>
     "additional_data" : {
         "connector_name": "myConnector"
     },
     "timestamp": "1695817046353"
 }
 ----
-<1> The type field can contain one of the following values:
+
+<1> The `type` field can contain one of the following values:
 
 * `STARTED`
 * `COMPLETED`
@@ -190,18 +191,22 @@ a|[source, json]
       "data_collection":"table1, table2",
       "scanned_collection":"table1",
       "total_rows_scanned":"100",
-      "status":"SUCCEEDED" // <1>
+      "status":"SUCCEEDED"
    },
    "timestamp": "1695817046353"
 }
 ----
-<1> The possible values are:
-* EMPTY - table is empty
-* NO_PRIMARY_KEY - table has no primary key necessary for snapshot
-* SKIPPED - snapshot for this kind of table is not supported, check logs for details
-* SQL_EXCEPTION - SQL exception caught while processing a snapshot
-* SUCCEEDED - snapshot completed successfully
-* UNKNOWN_SCHEMA - schema not found for table, check logs for the list of known tables
+In the preceding example, the `additional_data.status` field can contain one of the following values:
+
+`EMPTY`:: The table contains no values.
+`NO_PRIMARY_KEY`:: Cannot complete snapshot; table has no primary key.
+`SKIPPED`:: Cannot complete a snapshots for this type of table.
+Refer to the logs for details.
+`SQL_EXCEPTION`:: A SQL exception occurred while performing the snapshot.
+`SUCCEEDED`:: The snapshot completed successfully.
+`UNKNOWN_SCHEMA`:: Could not find a schema for the table.
+Check the logs for the list of known tables.
+
 |Completed
 a|[source, json]
 ----

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -175,7 +175,7 @@ After you enable the signaling channel, a Kafka consumer is created to consume s
 ====
 To use Kafka signaling to trigger ad hoc incremental snapshots for most connectors, you must first xref:debezium-signaling-enabling-source-signaling-channel[enable a `source` signaling channel] in the connector configuration.
 The source channel implements a watermarking mechanism to deduplicate events that might be captured by an incremental snapshot and then captured again after streaming resumes.
-Enabling the source channel is not required when using a signaling channel to trigger an incremental snapshot of a read-only MySQL database that has {link-prefix}:link-mysql-connector}#enable-mysql-gtids[GTIDs enabled].
+Enabling the source channel is not required when using a signaling channel to trigger an incremental snapshot of a read-only MySQL database that has {link-prefix}:{link-mysql-connector}#enable-mysql-gtids[GTIDs enabled].
 For more information, see {link-prefix}:{link-mysql-connector}#mysql-read-only-incremental-snapshots[MySQL read only incremental snapshot]
 ====
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -308,7 +308,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
 1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
-3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+3. Initiate an xref:debezium-db2-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
 If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -727,7 +727,7 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:mysql-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:debezium-mysql-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots
@@ -2160,7 +2160,7 @@ mysql> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 FROM performance_schema.global_variables WHERE variable_name='log_bin';
 ----
 
-. If you run MySQL on Amazon RDS, you must enable automated backups for your database instance for binary logging to occur. 
+. If you run MySQL on Amazon RDS, you must enable automated backups for your database instance for binary logging to occur.
 If the database instance is not configured to perform automated backups, the binlog is disabled, even if you apply the settings described in the previous steps.
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -84,28 +84,7 @@ After the connector processes the message, it begins the snapshot operation.
 The snapshot process reads the first and last primary key values and uses those values as the start and end point for each {data-collection}.
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
-For more information, see xref:{context}-incremental-snapshots[Incremental snapshots].
-////
-.Prerequisites
-
-* xref:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled].
-
-.Procedure
-
-* Trigger a snapshot by submitting a SQL query to add a signal to the signaling {data-collection} that uses the following format:
-+
-[source,sql,subs="+attributes,+quotes"]
-----
-INSERT INTO _<signalingCollection>_ VALUES('_<signalName>_','_<signalType>_', '{"data-collections": ["_<dataCollection>_","_<dataCollectionN>_"]}')
-----
-+
-For example:
-+
-[source,sql]
-----
-INSERT INTO myschema.debezium_signal VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema2.table2"]}')
-----
-////
+For more information, see xref:debezium-{context}-incremental-snapshots[Incremental snapshots].
 
 .Triggering an ad hoc blocking snapshot
 
@@ -114,4 +93,4 @@ After the connector processes the message, it begins the snapshot operation.
 The connector temporarily stops streaming, and then initiates a snapshot of the specified {data-collection}, following the same process that it uses during an initial snapshot.
 After the snapshot completes, the connector resumes streaming.
 
-For more information, see xref:#{context}-blocking-snapshots[Blocking snapshots].
+For more information, see xref:{context}-blocking-snapshots[Blocking snapshots].


### PR DESCRIPTION
[DBZ-7046](https://issues.redhat.com/browse/DBZ-7046)

Fixes invalid formatting and incorrect link targets. Some of these errors caused the downstream documentation build to fail, or required manual intervention to enable content to render as expected.

Tested in an local Antora build and local downstream build.