### PR TITLE
DBZ-7055 Upgrade maven-surefire-plugin to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.javadoc.plugin>3.4.0</version.javadoc.plugin>
         <version.code.formatter>2.20.0</version.code.formatter>
-        <version.surefire.plugin>3.0.0-M6</version.surefire.plugin>
+        <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.impsort>1.8.0</version.impsort>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7055

This is to see whether this fixes the GitHub Actions stability issue in this repository with the error:
```
[WARNING] Corrupted channel by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file /home/runner/work/debezium/debezium/debezium-connector-mysql/target/failsafe-reports/2023-10-18T23-08-57_003-jvmRun1.dumpstream
```
If it does, we can replicate this to other sibling repositories.