### PR TITLE
DBZ-7037 com.github.shyiko.mysql.binlog.event.deserialization.MissingTableMapEventException: No TableMapEventData has been found for table id:137

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -255,8 +255,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                     }
 
                     // DBZ-5126 Clean cache on rotate event to prevent it from growing indefinitely.
-                    if (event.getHeader().getEventType() == EventType.ROTATE
-                        && event.getHeader().getTimestamp() != 0) {
+                    if (event.getHeader().getEventType() == EventType.ROTATE && event.getHeader().getTimestamp() != 0) {
                         tableMapEventByTableId.clear();
                     }
                     return event;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -255,7 +255,8 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                     }
 
                     // DBZ-5126 Clean cache on rotate event to prevent it from growing indefinitely.
-                    if (event.getHeader().getEventType() == EventType.ROTATE) {
+                    if (event.getHeader().getEventType() == EventType.ROTATE
+                        && event.getHeader().getTimestamp() != 0) {
                         tableMapEventByTableId.clear();
                     }
                     return event;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5891
https://issues.redhat.com/browse/DBZ-7026
https://issues.redhat.com/browse/DBZ-7037

Fake Rotates Event skip tableMapEventByTableId clear

When the connection to the Mysql database is lost, a fake Rotate Event occurs in communication with the master. Currently, even when initializing tableMapEventByTableId when a fake Rotate Event occurs, an error occurs because the corresponding tableMapEvent for the tableId cannot be found.

I think this could be the issue with this problem. What do you think?

https://mariadb.com/kb/en/fake-rotate_event/
https://github.com/go-mysql-org/go-mysql/blob/3a75f6a26d8819c2a88629e54c7de0b7698ae05c/replication/backup.go#L59

