### PR TITLE
DBZ-6993 Add support for JSON columns to Oracle connector

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -48,6 +48,7 @@ Anton Kondratev
 Anton Martynov
 Arik Cohen
 Arkoprabho Chakraborti
+Artem Shubovych
 artiship
 Artur Gukasian
 Ashhar Hasan

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -80,7 +80,7 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
                         table.id(), oldKey, newKey, reselectColumns.stream().map(Column::name).collect(Collectors.toList()));
 
                 final JdbcConfiguration jdbcConfig = connectorConfig.getJdbcConfig();
-                try (OracleConnection connection = new OracleConnection(jdbcConfig, false)) {
+                try (OracleConnection connection = new OracleConnection(new OracleConnection.OracleConnectionConfiguration(jdbcConfig), false)) {
                     final String query = getReselectQuery(reselectColumns, table, connection);
                     if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
                         connection.setSessionToPdb(connectorConfig.getPdbName());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -92,7 +92,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
         // PDB when reading snapshot records.
         return Optional.of(new OracleSignalBasedIncrementalSnapshotChangeEventSource(
                 configuration,
-                new OracleConnection(connectionFactory.mainConnection().config()),
+                new OracleConnection(new OracleConnection.OracleConnectionConfiguration(connectionFactory.mainConnection().config())),
                 dispatcher,
                 schema,
                 clock,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -790,7 +790,7 @@ public class OracleConnection extends JdbcConnection {
 
             final Configuration.Builder jdbcConfigBuilder = dbConfig
                     .edit()
-                    .with(JDBC_PROPERTY_JSON_DEFAULT_GET_OBJECT_TYPE, "java.lang.String");
+                    .withDefault(JDBC_PROPERTY_JSON_DEFAULT_GET_OBJECT_TYPE, "java.lang.String");
 
             this.jdbcConfig = JdbcConfiguration.adapt(jdbcConfigBuilder.build());
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -780,9 +780,9 @@ public class OracleConnection extends JdbcConnection {
         private final ConnectionFactory factory;
 
         public OracleConnectionConfiguration(JdbcConfiguration config) {
-            // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
-            // to give us better JDBC database metadata behavior, including using UTF-8 for the client-side character encoding
-            // per https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html
+            // Set up the JDBC connection without actually connecting, with extra Oracle-specific properties
+            // to handle JSON columns in Oracle 23+ as per
+            // https://docs.oracle.com/en//database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_JSON_DEFAULT_GET_OBJECT_TYPE
             this.config = config;
 
             final Configuration dbConfig = config

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -591,7 +591,7 @@ public class OracleConnection extends JdbcConnection {
         else if (OracleTypes.NUMBER == column.jdbcType()) {
             column.scale().filter(s -> s == ORACLE_UNSET_SCALE).ifPresent(s -> column.scale(null));
         }
-        else if ("JSON".equals(column.typeName())) {
+        else if (OracleTypes.JSON == column.jdbcType() || "JSON".equals(column.typeName())) {
             column.jdbcType(OracleTypes.JSON);
         }
         return column;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnector.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.RelationalBaseSourceConnector;
+import io.debezium.connector.oracle.OracleConnection.OracleConnectionConfiguration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.util.Strings;
@@ -75,7 +76,7 @@ public class OracleConnector extends RelationalBaseSourceConnector {
         final ConfigValue userValue = configValues.get(RelationalDatabaseConnectorConfig.USER.name());
 
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        try (OracleConnection connection = new OracleConnection(connectorConfig.getJdbcConfig())) {
+        try (OracleConnection connection = new OracleConnection(new OracleConnectionConfiguration(connectorConfig.getJdbcConfig()))) {
             LOGGER.debug("Successfully tested connection for {} with user '{}'", OracleConnection.connectionString(connectorConfig.getJdbcConfig()),
                     connection.username());
         }
@@ -96,7 +97,8 @@ public class OracleConnector extends RelationalBaseSourceConnector {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
         final String databaseName = connectorConfig.getCatalogName();
 
-        try (OracleConnection connection = new OracleConnection(connectorConfig.getJdbcConfig(), false)) {
+        OracleConnectionConfiguration connectionConfiguration = new OracleConnectionConfiguration(connectorConfig.getJdbcConfig());
+        try (OracleConnection connection = new OracleConnection(connectionConfiguration, false)) {
             if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
                 connection.setSessionToPdb(connectorConfig.getPdbName());
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -631,6 +631,14 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withValidation(Field::isNonNegativeInteger)
             .withDescription("The number of attempts to retry database errors during snapshots before failing.");
 
+    public static final Field JSON_DEFAULT_GET_OBJECT_TYPE = Field.create(DRIVER_CONFIG_PREFIX + "oracle.jdbc.jsonDefaultGetObjectType")
+            .withDisplayName("Type used to parse JSON columns")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDescription("This property sets the default return type of getObject() methods when the column type is JSON")
+            .withDefault("java.lang.String");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("Oracle")
             .excluding(
@@ -702,7 +710,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     OLR_SOURCE,
                     OLR_HOST,
                     OLR_PORT,
-                    SNAPSHOT_DATABASE_ERRORS_MAX_RETRIES)
+                    SNAPSHOT_DATABASE_ERRORS_MAX_RETRIES,
+                    JSON_DEFAULT_GET_OBJECT_TYPE)
             .events(SOURCE_INFO_STRUCT_MAKER)
             .create();
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -69,7 +69,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         JdbcConfiguration jdbcConfig = connectorConfig.getJdbcConfig();
         MainConnectionProvidingConnectionFactory<OracleConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
-                () -> new OracleConnection(jdbcConfig));
+                () -> new OracleConnection(new OracleConnection.OracleConnectionConfiguration(jdbcConfig)));
         jdbcConnection = connectionFactory.mainConnection();
 
         OracleValueConverters valueConverters = connectorConfig.getAdapter().getValueConverter(connectorConfig, jdbcConnection);
@@ -198,7 +198,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
     }
 
     private OracleConnection getHeartbeatConnection(OracleConnectorConfig connectorConfig, JdbcConfiguration jdbcConfig) {
-        final OracleConnection connection = new OracleConnection(jdbcConfig);
+        final OracleConnection connection = new OracleConnection(new OracleConnection.OracleConnectionConfiguration(jdbcConfig));
         if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
             connection.setSessionToPdb(connectorConfig.getPdbName());
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.connector.oracle.logminer.UnistrHelper;
+import io.debezium.data.Json;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.jdbc.JdbcValueConverters;
@@ -165,6 +166,8 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return SchemaBuilder.string();
             case OracleTypes.ROWID:
                 return SchemaBuilder.string();
+            case OracleTypes.JSON:
+                return Json.builder();
             default: {
                 SchemaBuilder builder = super.schemaBuilder(column);
                 logger.debug("JdbcValueConverters returned '{}' for column '{}'", builder != null ? builder.getClass().getName() : null, column.name());
@@ -220,6 +223,7 @@ public class OracleValueConverters extends JdbcValueConverters {
             case Types.STRUCT:
             case Types.CLOB:
             case OracleTypes.ROWID:
+            case OracleTypes.JSON:
                 return data -> convertString(column, fieldDefn, data);
             case Types.BLOB:
                 return data -> convertBinary(column, fieldDefn, data, binaryMode);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -143,7 +143,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter<LogMinerStreamingC
         // that prevents switching from a PDB to the root CDB and if invoking the LogMiner APIs on
         // such a connection, the use of commit/rollback by LogMiner will drop/invalidate the save
         // point as well. A separate connection is necessary to preserve the save point.
-        try (OracleConnection conn = new OracleConnection(connection.config(), false)) {
+        try (OracleConnection conn = new OracleConnection(new OracleConnection.OracleConnectionConfiguration(connection.config()), false)) {
             conn.setAutoCommit(false);
             if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
                 // The next stage cannot be run within the PDB, reset the connection to the CDB.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/CommitLogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/CommitLogWriterFlushStrategy.java
@@ -67,7 +67,7 @@ public class CommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
     public CommitLogWriterFlushStrategy(OracleConnectorConfig connectorConfig, JdbcConfiguration jdbcConfig) throws SQLException {
         this.flushTableName = connectorConfig.getLogMiningFlushTableName();
         this.databasePdbName = connectorConfig.getPdbName();
-        this.connection = new OracleConnection(jdbcConfig);
+        this.connection = new OracleConnection(new OracleConnection.OracleConnectionConfiguration(jdbcConfig));
         this.connection.setAutoCommit(false);
         this.closeConnectionOnClose = true;
         createFlushTableIfNotExists();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnection.NonRelationalTableException;
+import io.debezium.connector.oracle.OracleConnection.OracleConnectionConfiguration;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
@@ -305,7 +306,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         final String pdbName = connectorConfig.getPdbName();
         // A separate connection must be used for this out-of-bands query while processing the Xstream callback.
         // This should have negligible overhead as this should happen rarely.
-        try (OracleConnection connection = new OracleConnection(connectorConfig.getJdbcConfig(), false)) {
+        try (OracleConnection connection = new OracleConnection(new OracleConnectionConfiguration(connectorConfig.getJdbcConfig()), false)) {
             if (!Strings.isNullOrBlank(pdbName)) {
                 connection.setSessionToPdb(pdbName);
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnection.OracleConnectionConfiguration;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleDatabaseVersion;
@@ -107,7 +108,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
                 TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection)),
                 this, streamingMetrics);
 
-        try (OracleConnection xsConnection = new OracleConnection(jdbcConnection.config())) {
+        try (OracleConnection xsConnection = new OracleConnection(new OracleConnectionConfiguration(jdbcConnection.config()))) {
             try {
                 // 1. connect
                 final byte[] startPosition;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle;
 
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +21,7 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.Configuration;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 
@@ -27,6 +30,7 @@ public class OracleConnectionTest {
     private Statement statement;
     private JdbcConfiguration jdbcConfiguration;
     private JdbcConnection.ConnectionFactory connectionFactory;
+    private Configuration.Builder configurationBuilder;
 
     @Before
     public void setUp() throws Exception {
@@ -37,6 +41,13 @@ public class OracleConnectionTest {
         statement = mock(Statement.class);
         when(connection.createStatement()).thenReturn(statement);
         when(connectionFactory.connect(jdbcConfiguration)).thenReturn(connection);
+
+        configurationBuilder = mock(Configuration.Builder.class);
+        when(jdbcConfiguration.subset(anyString(), anyBoolean())).thenReturn(jdbcConfiguration);
+        when(jdbcConfiguration.merge(jdbcConfiguration)).thenReturn(jdbcConfiguration);
+        when(jdbcConfiguration.edit()).thenReturn(configurationBuilder);
+        when(configurationBuilder.with(anyString(), anyString())).thenReturn(configurationBuilder);
+        when(configurationBuilder.build()).thenReturn(jdbcConfiguration);
 
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
@@ -46,7 +46,7 @@ public class OracleConnectionTest {
         when(jdbcConfiguration.subset(anyString(), anyBoolean())).thenReturn(jdbcConfiguration);
         when(jdbcConfiguration.merge(jdbcConfiguration)).thenReturn(jdbcConfiguration);
         when(jdbcConfiguration.edit()).thenReturn(configurationBuilder);
-        when(configurationBuilder.with(anyString(), anyString())).thenReturn(configurationBuilder);
+        when(configurationBuilder.withDefault(anyString(), anyString())).thenReturn(configurationBuilder);
         when(configurationBuilder.build()).thenReturn(jdbcConfiguration);
 
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
@@ -46,6 +46,7 @@ public class OracleConnectionTest {
         when(statement.executeQuery(any()))
                 .thenThrow(new SQLRecoverableException("IO Error: The Network Adapter could not establish the connection (CONNECTION_ID=u/VErjYySfO0HgLtwdCuTQ==)"));
 
-        assertThrows(RetriableException.class, () -> new OracleConnection(jdbcConfiguration, connectionFactory, true));
+        assertThrows(RetriableException.class,
+                () -> new OracleConnection(new OracleConnection.OracleConnectionConfiguration(jdbcConfiguration), connectionFactory, true));
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
@@ -373,7 +373,7 @@ public class OracleJSONDataTypeIT extends AbstractConnectorTest {
     }
 
     @JsonAutoDetect
-    class Person {
+    public static class Person {
         public String _id;
         public Integer index;
         public String guid;
@@ -403,13 +403,13 @@ public class OracleJSONDataTypeIT extends AbstractConnectorTest {
         public String favoriteFruit;
 
         @JsonAutoDetect
-        public class Name {
+        public static class Name {
             public String first;
             public String last;
         }
 
         @JsonAutoDetect
-        public class Friend {
+        public static class Friend {
             public Integer id;
             public String name;
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.junit.SkipWhenDatabaseVersion;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for JSON data type support.
+ *
+ * @author Artem Shubovych
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "LogMiner specific tests")
+@SkipWhenDatabaseVersion(check = LESS_THAN, major = 21, reason = "JSON columns are only supported in Oracle 21+")
+public class OracleJSONDataTypeIT extends AbstractConnectorTest {
+
+    private static final String JSON_DATA_RAW = Files.readResourceAsString("data/test_lob_data.json");
+
+    @Rule
+    public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
+
+    private OracleConnection connection;
+
+    @Before
+    public void before() {
+        connection = TestHelper.testConnection();
+        setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);
+        initializeConnectorTestFramework();
+        Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-6993")
+    public void shouldSnapshotTableWithJsonColumnType() throws Exception {
+        TestHelper.dropTable(connection, "dbz6993");
+        try {
+            connection.execute("CREATE TABLE DBZ6993 (ID numeric(9,0), DATA JSON, primary key(ID))");
+            TestHelper.streamTable(connection, "dbz6993");
+
+            connection.prepareQuery("insert into dbz6993 values (1, ?)", ps -> ps.setString(1, JSON_DATA_RAW), null);
+            connection.commit();
+
+            Configuration config = getDefaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6993")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            SourceRecord record = topicRecords.get(0);
+            VerifyRecord.isValidRead(record, "ID", 1);
+
+            Struct after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(JSON_DATA_RAW);
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz6993");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-6993")
+    public void shouldStreamTableWithJsonColumnType() throws Exception {
+        TestHelper.dropTable(connection, "dbz6993");
+        try {
+            connection.execute("CREATE TABLE DBZ6993 (ID numeric(9,0), DATA JSON, primary key(ID))");
+            TestHelper.streamTable(connection, "dbz6993");
+
+            Configuration config = getDefaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6993")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final List<Person> jsonRecords = Arrays.asList(new ObjectMapper().readValue(JSON_DATA_RAW, Person[].class));
+            final List<Person> page1 = jsonRecords.stream().limit(20).collect(Collectors.toList());
+            final String page1Raw = new ObjectMapper().writeValueAsString(page1);
+
+            connection.prepareQuery("insert into dbz6993 values (1, ?)", ps -> ps.setString(1, page1Raw), null);
+            connection.commit();
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            SourceRecord record = topicRecords.get(0);
+            VerifyRecord.isValidInsert(record, "ID", 1);
+
+            Struct after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page1Raw);
+
+            final List<Person> page2 = jsonRecords.stream().skip(20).limit(20).collect(Collectors.toList());
+            final String page2Raw = new ObjectMapper().writeValueAsString(page2);
+
+            connection.prepareQuery("UPDATE dbz6993 SET data = ? WHERE id = 1", ps -> ps.setString(1, page2Raw), null);
+            connection.commit();
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidUpdate(record, "ID", 1);
+
+            after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page2Raw);
+
+            connection.execute("DELETE FROM dbz6993 WHERE id = 1");
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidDelete(record, "ID", 1);
+
+            after = before(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page2Raw);
+
+            assertThat(after(record)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz6993");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-6993")
+    public void shouldStreamTableWithJsonTypeColumnAndOtherNonJsonColumns() throws Exception {
+        // This tests makes sure there are no special requirements when a table is keyless
+        TestHelper.dropTable(connection, "dbz6993");
+        try {
+            // Explicitly no key.
+            connection.execute("CREATE TABLE DBZ6993 (ID numeric(9,0), DATA JSON, DATA2 varchar2(50))");
+            TestHelper.streamTable(connection, "dbz6993");
+
+            Configuration config = getDefaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6993")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final List<Person> jsonRecords = Arrays.asList(new ObjectMapper().readValue(JSON_DATA_RAW, Person[].class));
+            final List<Person> page1 = jsonRecords.stream().limit(20).collect(Collectors.toList());
+            final String page1Raw = new ObjectMapper().writeValueAsString(page1);
+
+            connection.prepareQuery("insert into dbz6993 values (1, ?, 'Acme')", ps -> ps.setString(1, page1Raw), null);
+            connection.commit();
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            SourceRecord record = topicRecords.get(0);
+            VerifyRecord.isValidInsert(record, false);
+
+            Struct after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(JSON_DATA_RAW);
+            assertThat(after.get("DATA2")).isEqualTo("Acme");
+
+            // Update only RAW
+            final List<Person> page2 = jsonRecords.stream().skip(20).limit(20).collect(Collectors.toList());
+            final String page2Raw = new ObjectMapper().writeValueAsString(page2);
+
+            connection.prepareQuery("UPDATE dbz6993 SET data = ? WHERE id=1", ps -> ps.setString(1, page2Raw), null);
+            connection.commit();
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidUpdate(record, false);
+
+            after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page2Raw);
+            assertThat(after.get("DATA2")).isEqualTo("Acme");
+
+            // Update RAW and non-RAW
+            connection.prepareQuery("UPDATE dbz6993 SET data = ?, DATA2 = 'Data' WHERE id=1", ps -> ps.setString(1, page1Raw), null);
+            connection.commit();
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidUpdate(record, false);
+
+            after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page1Raw);
+            assertThat(after.get("DATA2")).isEqualTo("Data");
+
+            // Update only non-RAW
+            connection.execute("UPDATE dbz6993 SET DATA2 = 'Acme' WHERE id=1");
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidUpdate(record, false);
+
+            after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page1Raw);
+            assertThat(after.get("DATA2")).isEqualTo("Acme");
+
+            connection.execute("DELETE FROM dbz6993 WHERE id = 1");
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidDelete(record, false);
+
+            after = before(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page1Raw);
+            assertThat(after.get("DATA2")).isEqualTo("Acme");
+
+            assertThat(after(record)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz6993");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-6993")
+    public void shouldStreamTableWithNoPrimaryKeyWithJsonTypeColumn() throws Exception {
+        // This tests makes sure there are no special requirements when a table is keyless
+        TestHelper.dropTable(connection, "dbz6993");
+        try {
+            // Explicitly no key.
+            connection.execute("CREATE TABLE DBZ6993 (ID numeric(9,0), DATA JSON)");
+            TestHelper.streamTable(connection, "dbz6993");
+
+            Configuration config = getDefaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6993")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final List<Person> jsonRecords = Arrays.asList(new ObjectMapper().readValue(JSON_DATA_RAW, Person[].class));
+            final List<Person> page1 = jsonRecords.stream().limit(20).collect(Collectors.toList());
+            final String page1Raw = new ObjectMapper().writeValueAsString(page1);
+
+            connection.prepareQuery("insert into dbz6993 values (1,?)", ps -> ps.setString(1, page1Raw), null);
+            connection.commit();
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            SourceRecord record = topicRecords.get(0);
+            VerifyRecord.isValidInsert(record, false);
+
+            Struct after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page1Raw);
+
+            final List<Person> page2 = jsonRecords.stream().skip(20).limit(20).collect(Collectors.toList());
+            final String page2Raw = new ObjectMapper().writeValueAsString(page2);
+
+            connection.prepareQuery("UPDATE dbz6993 SET data = ? WHERE id=1", ps -> ps.setObject(1, page2Raw), null);
+            connection.commit();
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidUpdate(record, false);
+
+            after = after(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page2Raw);
+
+            connection.execute("DELETE FROM dbz6993 WHERE id = 1");
+
+            records = consumeRecordsByTopic(1);
+            topicRecords = records.recordsForTopic(topicName("DBZ6993"));
+            assertThat(topicRecords).hasSize(1);
+
+            record = topicRecords.get(0);
+            VerifyRecord.isValidDelete(record, false);
+
+            after = before(record);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(page2Raw);
+
+            assertThat(after(record)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz6993");
+        }
+    }
+
+    private Configuration.Builder getDefaultConfig() {
+        return TestHelper.defaultConfig();
+    }
+
+    private static String topicName(String tableName) {
+        return TestHelper.SERVER_NAME + ".DEBEZIUM." + tableName;
+    }
+
+    private static Struct before(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+    }
+
+    private static Struct after(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+    }
+
+    @JsonAutoDetect
+    class Person {
+        public String _id;
+        public Integer index;
+        public String guid;
+        public Boolean isActive;
+        public String balance;
+        public String picture;
+        public Integer age;
+        public String eyeColor;
+
+        public Name name;
+        public String company;
+        public String email;
+        public String phone;
+        public String address;
+        public String about;
+        public String registered;
+        public String latitude;
+        public String longitude;
+
+        public List<String> tags;
+
+        public List<Integer> range;
+
+        public List<Friend> friends;
+
+        public String greeting;
+        public String favoriteFruit;
+
+        @JsonAutoDetect
+        public class Name {
+            public String first;
+            public String last;
+        }
+
+        @JsonAutoDetect
+        public class Friend {
+            public Integer id;
+            public String name;
+        }
+    }
+
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
@@ -5,8 +5,25 @@
  */
 package io.debezium.connector.oracle;
 
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
@@ -16,21 +33,6 @@ import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.SkipWhenDatabaseVersion;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static io.debezium.junit.EqualityCheck.LESS_THAN;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for JSON data type support.

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
@@ -40,7 +40,7 @@ import io.debezium.junit.SkipWhenDatabaseVersion;
  * @author Artem Shubovych
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "LogMiner specific tests")
-@SkipWhenDatabaseVersion(check = LESS_THAN, major = 19, reason = "JSON columns are only supported in Oracle 19+")
+@SkipWhenDatabaseVersion(check = LESS_THAN, major = 23, reason = "JSON columns are only supported in Oracle 23+")
 public class OracleJSONDataTypeIT extends AbstractConnectorTest {
 
     private static final String JSON_DATA_RAW = Files.readResourceAsString("data/test_lob_data.json");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJSONDataTypeIT.java
@@ -40,7 +40,7 @@ import io.debezium.junit.SkipWhenDatabaseVersion;
  * @author Artem Shubovych
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "LogMiner specific tests")
-@SkipWhenDatabaseVersion(check = LESS_THAN, major = 21, reason = "JSON columns are only supported in Oracle 21+")
+@SkipWhenDatabaseVersion(check = LESS_THAN, major = 19, reason = "JSON columns are only supported in Oracle 19+")
 public class OracleJSONDataTypeIT extends AbstractConnectorTest {
 
     private static final String JSON_DATA_RAW = Files.readResourceAsString("data/test_lob_data.json");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -706,9 +706,9 @@ public class TestHelper {
 
     // expects user passed in the config to be any local user account on the Oracle DB instance
     private static OracleConnection createConnection(ConnectorConfiguration config, boolean autoCommit) {
-        Configuration testConnectionConfig = getTestConnectionConfiguration(config);
-        OracleConnectionConfiguration connectorConfig = new OracleConnectionConfiguration(JdbcConfiguration.adapt(testConnectionConfig));
-        OracleConnection connection = new OracleConnection(connectorConfig);
+        Configuration connectionConfiguration = getTestConnectionConfiguration(config);
+        final JdbcConfiguration jdbcConfig = JdbcConfiguration.adapt(connectionConfiguration);
+        OracleConnection connection = new OracleConnection(new OracleConnectionConfiguration(jdbcConfig));
         try {
             connection.setAutoCommit(autoCommit);
             return connection;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -28,6 +28,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnection.OracleConnectionConfiguration;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
 import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningBufferType;
@@ -353,7 +354,7 @@ public class TestHelper {
      * @return the connection
      */
     private static OracleConnection createConnection(Configuration config, JdbcConfiguration jdbcConfig, boolean autoCommit) {
-        OracleConnection connection = new OracleConnection(jdbcConfig);
+        OracleConnection connection = new OracleConnection(new OracleConnectionConfiguration(jdbcConfig));
         try {
             connection.setAutoCommit(autoCommit);
 
@@ -373,7 +374,7 @@ public class TestHelper {
         Configuration config = adminConfig().build();
         Configuration jdbcConfig = config.subset(DATABASE_PREFIX, true);
 
-        try (OracleConnection jdbcConnection = new OracleConnection(JdbcConfiguration.adapt(jdbcConfig))) {
+        try (OracleConnection jdbcConnection = new OracleConnection(new OracleConnectionConfiguration(JdbcConfiguration.adapt(jdbcConfig)))) {
             if ((new OracleConnectorConfig(defaultConfig().build())).getPdbName() != null) {
                 jdbcConnection.resetSessionToCdb();
             }
@@ -388,7 +389,7 @@ public class TestHelper {
         Configuration config = adminConfig().build();
         Configuration jdbcConfig = config.subset(DATABASE_PREFIX, true);
 
-        try (OracleConnection jdbcConnection = new OracleConnection(JdbcConfiguration.adapt(jdbcConfig))) {
+        try (OracleConnection jdbcConnection = new OracleConnection(new OracleConnectionConfiguration(JdbcConfiguration.adapt(jdbcConfig)))) {
             if ((new OracleConnectorConfig(defaultConfig().build())).getPdbName() != null) {
                 jdbcConnection.resetSessionToCdb();
             }
@@ -680,7 +681,7 @@ public class TestHelper {
      * @throws SQLException if a database error occurred
      */
     public static Scn getCurrentScn() throws SQLException {
-        try (OracleConnection admin = new OracleConnection(adminJdbcConfig(), false)) {
+        try (OracleConnection admin = new OracleConnection(new OracleConnectionConfiguration(adminJdbcConfig()), false)) {
             // Force the connection to the CDB$ROOT if we're operating w/a PDB
             if (isUsingPdb()) {
                 admin.resetSessionToCdb();
@@ -705,8 +706,9 @@ public class TestHelper {
 
     // expects user passed in the config to be any local user account on the Oracle DB instance
     private static OracleConnection createConnection(ConnectorConfiguration config, boolean autoCommit) {
-        Configuration connectionConfiguration = getTestConnectionConfiguration(config);
-        OracleConnection connection = new OracleConnection(JdbcConfiguration.adapt(connectionConfiguration));
+        Configuration testConnectionConfig = getTestConnectionConfiguration(config);
+        OracleConnectionConfiguration connectorConfig = new OracleConnectionConfiguration(JdbcConfiguration.adapt(testConnectionConfig));
+        OracleConnection connection = new OracleConnection(connectorConfig);
         try {
             connection.setAutoCommit(autoCommit);
             return connection;

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
@@ -253,7 +253,7 @@ public class EndToEndPerf {
         }
 
         private OracleConnection getTestConnection() {
-            OracleConnection connection = new OracleConnection(testJdbcConfig());
+            OracleConnection connection = new OracleConnection(new OracleConnection.OracleConnectionConfiguration(testJdbcConfig()));
             try {
                 connection.setAutoCommit(false);
             }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -244,6 +244,7 @@ ahazourli,Ahmed Rachid Hazourli
 sherpa003,Jiri Kulhanek
 slknijnenburg,Sebastiaan Knijnenburg
 baabgai,baabgai
+shybovycha,Artem Shubovych
 methodmissing,Lourens Naudé
 Prabhu19,Pavithrananda Prabhu
 Lourens Naude,Lourens Naudé


### PR DESCRIPTION
Oracle 23 introduced a new column type, `JSON`.

In order to properly support it, Oracle JDBC driver requires a [`oracle.jdbc.jsonDefaultGetObjectType`](https://docs.oracle.com/en//database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_JSON_DEFAULT_GET_OBJECT_TYPE) property to be set to one of the allowed values (Java classes).

I followed the same pattern as `MySqlConnection` and added an extra `driver`-level connector configuration option to allow users to change the `jsonDefaultGetObjectType` value.

Once the property is set, `JSON` columns can use the `Json` schema to be parsed by Debezium, which requires the proper `jdbcType` value to be set and handled by `OracleValueConverters#schemaBuilder` and `OracleValueConverters#converter` methods.

This proved to be a bit tricky, since by default the `Column#jdbcType` and `Column#nativeType` are set to generic values: `jdbcType = oracle.jdbc.OracleTypes.OTHER (1111)` and `nativeType = -1`. Hence had to set those based on the `Column#typeName` in `OracleConnection#overrideColumn` instead of `resolveJdbcType` or `resolveNativeType`, since that is the only method (among the three) which has access to an entire `Column` object (giving access to `typeName` value).