### PR TITLE
DBZ-7099 Provide default value for PeriodicCommitOffsetPolicy

### DIFF
--- a/debezium-api/src/main/java/io/debezium/engine/spi/OffsetCommitPolicy.java
+++ b/debezium-api/src/main/java/io/debezium/engine/spi/OffsetCommitPolicy.java
@@ -40,7 +40,10 @@ public interface OffsetCommitPolicy {
         private final Duration minimumTime;
 
         public PeriodicCommitOffsetPolicy(Properties config) {
-            minimumTime = Duration.ofMillis(Long.valueOf(config.getProperty(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP)));
+            final long interval = config.containsKey(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP)
+                    ? Long.valueOf(config.getProperty(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP))
+                    : 60000L;
+            minimumTime = Duration.ofMillis(interval);
         }
 
         @Override

--- a/debezium-api/src/main/java/io/debezium/engine/spi/OffsetCommitPolicy.java
+++ b/debezium-api/src/main/java/io/debezium/engine/spi/OffsetCommitPolicy.java
@@ -37,13 +37,13 @@ public interface OffsetCommitPolicy {
      */
     class PeriodicCommitOffsetPolicy implements OffsetCommitPolicy {
 
+        private static final Duration DEFAULT_COMMIT_OFFSET_INTERVAL = Duration.ofMinutes(1);
         private final Duration minimumTime;
 
         public PeriodicCommitOffsetPolicy(Properties config) {
-            final long interval = config.containsKey(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP)
-                    ? Long.valueOf(config.getProperty(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP))
-                    : 60000L;
-            minimumTime = Duration.ofMillis(interval);
+            minimumTime = config.containsKey(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP)
+                    ? Duration.ofMillis(Long.valueOf(config.getProperty(DebeziumEngine.OFFSET_FLUSH_INTERVAL_MS_PROP)))
+                    : DEFAULT_COMMIT_OFFSET_INTERVAL;
         }
 
         @Override


### PR DESCRIPTION
In 7b4cf1901 deprecated `io.debezium.embedded.spi.OffsetCommitPolicy`, which provided also constructor for `Configuration`, was removed. This constructor was actually used for creating `OffsetCommitPolicy`. `Configuration` provides default values for options which are not explicitly set, while `Properties` based constructor cannot do that and therefore with this switch the default value for `offset.flush.interval.ms` is now missing.

As debezium-api package has no knowledge about `Configuration` interface, which is part of debezium-core, and thus about the default values, specify default value direcly in the `PeriodicCommitOffsetPolicy` class.

https://issues.redhat.com/browse/DBZ-7099