### PR TITLE
DBZ-7142 Improved Outbox Event Router SMT to handle whitespaces inside of fields.additional.placement setting

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -328,9 +328,9 @@ public class EventRouterConfigDefinition {
         if (extraFieldsMapping != null) {
             for (String field : extraFieldsMapping.split(",")) {
                 final String[] parts = field.split(":");
-                final String fieldName = parts[0];
-                AdditionalFieldPlacement placement = AdditionalFieldPlacement.parse(parts[1]);
-                final AdditionalField addField = new AdditionalField(placement, fieldName, parts.length == 3 ? parts[2] : fieldName);
+                final String fieldName = parts[0].trim();
+                AdditionalFieldPlacement placement = AdditionalFieldPlacement.parse(parts[1].trim());
+                final AdditionalField addField = new AdditionalField(placement, fieldName, parts.length == 3 ? parts[2].trim() : fieldName);
                 additionalFields.add(addField);
             }
         }

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -651,7 +651,7 @@ public class EventRouterTest {
         final Map<String, String> config = new HashMap<>();
         config.put(
                 EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(),
-                "type:envelope:payloadType,aggregateid:envelope:payloadId,type:header:payloadType");
+                "type:envelope:payloadType, aggregateid:envelope:payloadId,type:header:payloadType");
         router.configure(config);
 
         final SourceRecord eventRecord = createEventRecord();


### PR DESCRIPTION
Guys, I do understand that it is not a major improvement to the codebase, but believe me - it will significantly improve life of many people (those who use different UIs to manage connectors).
Two minor points here:
- technically there is no sense in adding ".trim()" to a "AdditionalFieldPlacement placement = AdditionalFieldPlacement.parse(parts[1]);" line (line 332) as AdditionalFieldPlacement.parse() function does call trim() under the hood. But I still decided to add it to keep the consistent for all 3 parts and not to confuse any of its future readers
- there already exists a test for this functionality, so I just slightly modified it