### PR TITLE
DBZ-7159 Fail fast during deserialization if a value is not a CloudEvent

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
@@ -193,6 +193,48 @@ public class CloudEventsConverterIT extends AbstractMongoConnectorIT {
         insertHeader.close();
     }
 
+    @Test
+    @FixFor({ "DBZ-7159" })
+    public void shouldThrowExceptionWhenDeserializingNotCloudEventJson() throws Exception {
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME)
+                    .insertOne(new Document()
+                            .append("pk", 1)
+                            .append("aa", 1));
+        }
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic("mongo1.dbA.c1").get(0);
+
+        assertThat(record).isNotNull();
+        assertThat(record.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldThrowExceptionWhenDeserializingNotCloudEventJson(record);
+    }
+
+    @Test
+    @FixFor({ "DBZ-7159" })
+    public void shouldThrowExceptionWhenDeserializingNotCloudEventAvro() throws Exception {
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME)
+                    .insertOne(new Document()
+                            .append("pk", 1)
+                            .append("aa", 1));
+        }
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic("mongo1.dbA.c1").get(0);
+
+        assertThat(record).isNotNull();
+        assertThat(record.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldThrowExceptionWhenDeserializingNotCloudEventAvro(record);
+    }
+
     private Configuration getConfiguration() {
         return TestHelper.getConfiguration(mongo)
                 .edit()

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
@@ -41,9 +41,6 @@ public class CloudEventsConverterConfig extends ConverterConfig {
             + "'avro' replaces the characters that cannot be used in the Avro type name with underscore (default)"
             + "'none' does not apply any adjustment";
 
-    @Deprecated
-    public static final String CLOUDEVENTS_METADATA_LOCATION_CONFIG = "metadata.location";
-
     public static final String CLOUDEVENTS_METADATA_SOURCE_CONFIG = "metadata.source";
     public static final String CLOUDEVENTS_METADATA_SOURCE_DEFAULT = "value,id:generate,type:generate";
     private static final String CLOUDEVENTS_METADATA_SOURCE_DOC = "Specify from where to retrieve metadata";

--- a/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsValidator.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsValidator.java
@@ -46,7 +46,7 @@ public class CloudEventsValidator {
             case AVRO:
                 return schemaAndValue.schema().name().endsWith(CLOUD_EVENTS_SCHEMA_NAME_SUFFIX) && schemaAndValue.value() instanceof Struct;
             default:
-                throw new DataException("No such serializer for \"" + serializerType + "\" format");
+                throw new DataException("Can't check whether a record is a CloudEvent for serializer type \"" + serializerType + "\"");
         }
     }
 
@@ -61,7 +61,7 @@ public class CloudEventsValidator {
                 fieldNames = ((Struct) value).schema().fields().stream().map(Field::name).collect(Collectors.toList());
                 break;
             default:
-                throw new DataException("No such serializer for \"" + serializerType + "\" format");
+                throw new DataException("Can't check whether a record is a CloudEvent for serializer type \"" + serializerType + "\"");
         }
 
         return fieldNames.size() >= 4 && fieldNames.containsAll(cloudEventsSpecRequiredFields);

--- a/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
@@ -166,6 +166,42 @@ public abstract class AbstractCloudEventsConverterTest<T extends SourceConnector
         insertHeader.close();
     }
 
+    @Test
+    @FixFor({ "DBZ-7159" })
+    public void shouldThrowExceptionWhenDeserializingNotCloudEventJson() throws Exception {
+        createTable();
+
+        databaseConnection().execute(createInsert());
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic(topicName()).get(0);
+
+        assertThat(record).isNotNull();
+        assertThat(record.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldThrowExceptionWhenDeserializingNotCloudEventJson(record);
+    }
+
+    @Test
+    @FixFor({ "DBZ-7159" })
+    public void shouldThrowExceptionWhenDeserializingNotCloudEventAvro() throws Exception {
+        createTable();
+
+        databaseConnection().execute(createInsert());
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic(topicName()).get(0);
+
+        assertThat(record).isNotNull();
+        assertThat(record.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldThrowExceptionWhenDeserializingNotCloudEventAvro(record);
+    }
+
     private void startConnector() throws Exception {
         Configuration.Builder configBuilder = getConfigurationBuilder();
         start(getConnectorClass(), configBuilder.build());


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7159

A new validator will also be used by [`ConvertCloudEventToSaveableForm`](https://github.com/debezium/debezium-connector-jdbc/blob/main/src/main/java/io/debezium/connector/jdbc/transforms/ConvertCloudEventToSaveableForm.java#L156)