### PR TITLE
DBZ-7169 - populating processed transaction cache only if lobs enabled

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -199,6 +199,7 @@ Jannik Steinmann
 Jason Schweier
 Jesse Ehrenzweig
 Jiabao Sun
+Jiri Kulhanek
 Juan Fiallo
 Jun Zhao
 Hady Willi

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -239,3 +239,4 @@ dtseiler,Don Seiler
 markducommun,Mark Ducommun
 Lars M Johansson,Lars M. Johansson
 ahmedrachid,Ahmed Rachid Hazourli
+sherpa003,Jiri Kulhanek


### PR DESCRIPTION
to be in sync with memory event processor

I tested that with this change the connector runs stable, finally ( for our case). However I'm struggling to make Docker based integration test working on my machine so I did not run those.