### PR TITLE
DBZ-7182: MongoDB : allow array with documents with optional fields

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -426,10 +426,11 @@ public class MongoDataConverter {
                 final SchemaBuilder documentSchemaBuilder = SchemaBuilder.struct().name(builder.name() + "." + key).optional();
                 final Map<String, BsonType> union = new HashMap<>();
                 if (value.isArray()) {
-                    value.asArray().forEach(f -> subSchema(documentSchemaBuilder, union, f.asDocument(), true));
-                    if (documentSchemaBuilder.fields().size() == 0) {
-                        value.asArray().forEach(f -> subSchema(documentSchemaBuilder, union, f.asDocument(), false));
-                    }
+                    value.asArray().forEach(f -> {
+                        if (documentSchemaBuilder.fields().size() < f.asDocument().size()) {
+                            subSchema(documentSchemaBuilder, union, f.asDocument(), false);
+                        }
+                    });
                 }
                 else {
                     subSchema(documentSchemaBuilder, union, value.asDocument(), false);


### PR DESCRIPTION
### Which use case/requirement will be addressed by the proposed feature?
I would like to use Debezium with MongoDB. But in our use case, some documents have arrays of documents of same types BUT with optional fields.

In current implementation, it is not allowed, and this is documented : 

> 
> array encoding
> 
> If array.encoding is set to array (the default), the SMT encodes uses the array datatype to encode arrays in the original message. To ensure correct processing, all elements in an array instance must be of the same type. This option is a restricting one, but it enables downstream clients to easily process arrays.

I was wondering if at least the schema could be generated based on the document with the maximum number of fields. The restriction is always true, but a little less strict... and might allow us to use debezium. Otherwise Debezium is not usable for us 