### PR TITLE
Support MySQL 8 high resolution replication timestamps from GTID events

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -299,6 +299,7 @@ Liu Hanlin
 Liu Lang Wa
 Liz Chatman
 Lokesh Sanapalli
+Lourens Naudé
 Luca Scannapieco
 Luis Garcés-Erice
 Lukas Krejci

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -195,18 +195,6 @@ public final class SourceInfo extends BaseSourceInfo {
         this.serverId = serverId;
     }
 
-    /**
-     * Set the number of <em>seconds</em> since Unix epoch (January 1, 1970) as found within the MySQL binary log file.
-     * Note that the value in the binlog events is in seconds, but the library we use returns the value in milliseconds
-     * (with only second precision and therefore all fractions of a second are zero). We capture this as seconds
-     * since that is the precision that MySQL uses.
-     *
-     * @param timestampInSeconds the timestamp in <em>seconds</em> found within the binary log file
-     */
-    public void setBinlogTimestampSeconds(long timestampInSeconds) {
-        this.sourceTime = Instant.ofEpochSecond(timestampInSeconds);
-    }
-
     public void setSourceTime(Instant timestamp) {
         sourceTime = timestamp;
     }
@@ -270,10 +258,6 @@ public final class SourceInfo extends BaseSourceInfo {
 
     long getCurrentBinlogPosition() {
         return currentBinlogPosition;
-    }
-
-    long getBinlogTimestampSeconds() {
-        return (sourceTime == null) ? 0 : sourceTime.getEpochSecond();
     }
 
     int getCurrentRowNumber() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.mysql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -625,7 +626,7 @@ public class SourceInfoTest {
     @Test
     public void shouldHaveTimestamp() {
         sourceWith(offset(100, 5, true));
-        source.setBinlogTimestampSeconds(1_024);
+        source.setSourceTime(Instant.ofEpochSecond(1_024, 0));
         source.databaseEvent("mysql");
         assertThat(source.struct().get("ts_ms")).isEqualTo(1_024_000L);
     }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -242,3 +242,4 @@ ahmedrachid,Ahmed Rachid Hazourli
 sherpa003,Jiri Kulhanek
 slknijnenburg,Sebastiaan Knijnenburg
 baabgai,baabgai
+methodmissing,Lourens Naudé

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.6.0</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
-        <version.mysql.binlog>0.28.3</version.mysql.binlog>
+        <version.mysql.binlog>0.29.0</version.mysql.binlog>
         <version.mongo.driver>4.11.0</version.mongo.driver>
         <version.sqlserver.driver>12.4.2.jre8</version.sqlserver.driver>
         <version.oracle.driver>21.6.0.0</version.oracle.driver>


### PR DESCRIPTION
References and depends on https://github.com/osheroff/mysql-binlog-connector-java/pull/130

## Gist of the changes

More accurate metrics and also `source.ts_ms` for `MySQL >= 8.0.1` with `GTID` replication mode enabled. At Shopify we're doubling down on lower latency business use cases for CDC and we're aware of the second resolution (int4) timestamp constraint in binlog event headers for some time.

This issue and Github pull requests to the binlog client and Debezium is an attempt to engage with the community to report higher resolution metrics and `source.ts_ms` in a backwards compatible way.

Some example graphs from a lower environment connecting to MySQL 8 writers where the higher resolution timestamps are rendered - a lot easier to spot trends and variance for the writer -> binlog client hop.

<img width="1193" alt="Screenshot 2023-11-26 at 00 23 13" src="https://github.com/debezium/debezium/assets/379/15d0f73f-1bfa-4c94-9198-12eab88b7a9a">

<img width="1196" alt="Screenshot 2023-11-26 at 00 23 32" src="https://github.com/debezium/debezium/assets/379/d9eba92e-b506-41be-9871-4904a04c2607">

### Dead code removals

I could not find any references to these methods anymore:

* `SourceInfo::setBinlogTimestampSeconds`
* `SourceInfo::getBinlogTimestampSeconds`

### Alignment of event time extraction in onEvent and handleEvent

I preferred to handle event timestamp extraction in `MySqlStreamingChangeEventSource::onEvent` as both handlers are called in order by the binlog client event listeners feature. That way emitted metrics values and `source.ts_ms` key off the same `Instant` instance. 

### Event timestamp logic

MySQL 8.0.1 introduced [2 new microsecond resolution timestamps](https://webyog.com/blog/monyog/replication-performance-enhancements-mysql-8/) on GTID events to track replication lag more accurately:

* [immediate_commit_timestamp](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1005-L1009), microsecond resolution timestamp from the immediate master (or equal to original_commit_timestamp if connecting to master) since MySQL 8.0.1
* [original_commit_timestamp](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1005-L1009), microsecond resolution timestamp of the commit on the originating master (or equal to original_commit_timestamp if connecting to master) since MySQL 8.0.1

`original_commit_timestamp` is representative of the original commit time on the MySQL writer.

The order of precedence is:

* IF GTID mode is enabled and `GtidEventData::getOriginalCommitTimestamp` returns a non-zero value (MySQL >= 8.0.1), use the high resolution timestamp as set by the writer
* Otherwise fallback to the second resolution timestamps

### Other due diligence checks

* Snapshots set the current time in milliseconds for `source.ts_ms` already, I did not find any timestamp resolution issues with aligning on millisecond resolution for the streaming path as well

Jira issue: https://issues.redhat.com/projects/DBZ/issues/DBZ-7183