### PR TITLE
DBZ-6723 Expose partition in ChangeEvent interface

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -433,6 +433,7 @@ Sayed Mohammad Hossein Torabi
 Scofield Xu
 Sara Fonseca
 Sean Rooney
+Sebastiaan Knijnenburg
 Sebastian Bruckner
 Seo Jae-kwon
 Sergei Morozov

--- a/debezium-api/src/main/java/io/debezium/engine/ChangeEvent.java
+++ b/debezium-api/src/main/java/io/debezium/engine/ChangeEvent.java
@@ -28,4 +28,9 @@ public interface ChangeEvent<K, V> {
      * @return A name of the logical destination for which the event is intended
      */
     String destination();
+
+    /**
+     * @return The partition number for the event. Can be null.
+     */
+    Integer partition();
 }

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineChangeEvent.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineChangeEvent.java
@@ -53,6 +53,11 @@ class EmbeddedEngineChangeEvent<K, V, H> implements ChangeEvent<K, V>, RecordCha
         return sourceRecord.topic();
     }
 
+    @Override
+    public Integer partition() {
+        return sourceRecord.kafkaPartition();
+    }
+
     public SourceRecord sourceRecord() {
         return sourceRecord;
     }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -240,3 +240,4 @@ markducommun,Mark Ducommun
 Lars M Johansson,Lars M. Johansson
 ahmedrachid,Ahmed Rachid Hazourli
 sherpa003,Jiri Kulhanek
+slknijnenburg,Sebastiaan Knijnenburg

--- a/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
+++ b/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
@@ -9,6 +9,15 @@
             </item>
         </revapi.ignore>
     </version-1.5.0>
+    <version-2.5.0>
+        <revapi.ignore>
+            <item>
+              <code>java.method.addedToInterface</code>
+              <class>io.debezium.engine.ChangeEvent</class>
+              <justification>This interface is not supposed to be implemented by clients.</justification>
+            </item>
+        </revapi.ignore>
+    </version-2.5.0>
     <!-- No changes as of yet. This is just an example of how to tell Revapi to ignore intentional changes.
     <version-1.2.0>
         <revapi.ignore>


### PR DESCRIPTION
Link: https://issues.redhat.com/browse/DBZ-6723

Based on feedback in https://github.com/debezium/debezium-server/pull/33 this commit adds the `partition()` method to the ChangeEvent interface and implements it in the EmbeddedEngineChangeEvent. 

This allows reading the assigned partition for an event in downstream processors, for example in custom Sinks that need the assigned partition for routing purposes.

The change triggered a warning in the `revapi` checks, that I for now add to the ignores as I don't think there are any other implementations. Please let me know if this should be handled in a different way.