### PR TITLE
DBZ-7189 Parsing MySQL indexes for JSON field fails, when casting is used with types double and float

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2362,9 +2362,9 @@ collectionOption
 convertedDataType
     :
     (
-      typeName=(BINARY| NCHAR) lengthOneDimension?
+      typeName=(BINARY | NCHAR | FLOAT) lengthOneDimension?
       | typeName=CHAR lengthOneDimension? (charSet charsetName)?
-      | typeName=(DATE | DATETIME | TIME | JSON | INT | INTEGER)
+      | typeName=(DATE | DATETIME | TIME | YEAR | JSON | INT | INTEGER | DOUBLE)
       | typeName=(DECIMAL | DEC) lengthTwoOptionalDimension?
       | (SIGNED | UNSIGNED) (INTEGER | INT)?
     ) ARRAY?

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
@@ -29,6 +29,8 @@ alter table add_test add column if not exists col1 varchar(255);
 alter table add_test add column if not exists col4 varchar(255);
 alter table add_test add index if not exists ix_add_test_col1 using btree (col1) comment 'test index';
 alter table add_test add index if not exists ix_add_test_col4 using btree (col4) comment 'test index';
+ALTER TABLE `deals` ADD INDEX `idx_custom_field_30c4f4a7c529ccf0825b2fac732bebfd843ed764` ((cast(json_unquote(json_extract(`custom_fields`,_utf8mb4'$."30c4f4a7c529ccf0825b2fac732bebfd843ed764".value')) as DOUBLE)));
+ALTER TABLE `deals` ADD INDEX `idx_custom_field_30c4f4a7c529ccf0825b2fac732bebfd843ed764` ((cast(json_unquote(json_extract(`custom_fields`,_utf8mb4'$."30c4f4a7c529ccf0825b2fac732bebfd843ed764".value')) as FLOAT)));
 alter table add_test alter index ix_add_test_col1 invisible;
 alter table add_test alter index ix_add_test_col1 visible;
 alter table add_test change column if exists col8 col9 tinyint;

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -272,6 +272,8 @@ create index ix_add_test_col1 on add_test(col1) comment 'test index' using btree
 #begin
 create index myindex on t1(col1) comment 'test index' comment 'some test' using btree;
 create or replace index myindex on t1(col1) comment 'test index' comment 'some test' using btree;
+CREATE INDEX `idx_custom_field_30c4f4a7c529ccf0825b2fac732bebfd843ed764` ON `deals` ((cast(json_unquote(json_extract(`custom_fields`,_utf8mb4'$."30c4f4a7c529ccf0825b2fac732bebfd843ed764".value')) as double)));
+CREATE INDEX `idx_custom_field_d3bb7ad91ba729aaa20df0af037cb7ed8ce3ffc8` ON `deals` ((cast(json_unquote(json_extract(`custom_fields`,_utf8mb4'$."d3bb7ad91ba729aaa20df0af037cb7ed8ce3ffc8".value')) as float)));
 #end
 #begin
 -- Create logfile group


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7189