### PR TITLE
Dbz 7192 ispn abandoned transactions

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -104,7 +104,6 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
     private Scn lastProcessedScn = Scn.NULL;
     private boolean sequenceUnavailable = false;
 
-
     private final Set<String> abandonedTransactionsCache = new HashSet<>();
 
     public AbstractLogMinerEventProcessor(ChangeEventSourceContext context,
@@ -134,7 +133,6 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
     protected Set<String> getAbandonedTransactionsCache() {
         return abandonedTransactionsCache;
     }
-
 
     protected OracleConnectorConfig getConfig() {
         return connectorConfig;
@@ -621,7 +619,8 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
     protected void cleanupAfterTransactionRemovedFromCache(T transaction, boolean isAbandoned) {
         if (isAbandoned) {
             abandonedTransactionsCache.remove(transaction.getTransactionId());
-        } else {
+        }
+        else {
             abandonedTransactionsCache.add(transaction.getTransactionId());
         }
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
@@ -7,7 +7,6 @@ package io.debezium.connector.oracle.logminer.processor;
 
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.Set;
 
 import io.debezium.connector.oracle.Scn;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
@@ -33,5 +33,4 @@ public interface LogMinerEventProcessor extends AutoCloseable {
      */
     void abandonTransactions(Duration retention) throws InterruptedException;
 
-    Set<String> getAbandonedTransactionsCache();
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
@@ -7,6 +7,7 @@ package io.debezium.connector.oracle.logminer.processor;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Set;
 
 import io.debezium.connector.oracle.Scn;
 
@@ -31,4 +32,6 @@ public interface LogMinerEventProcessor extends AutoCloseable {
      * @param retention the maximum duration in which long running transactions are allowed.
      */
     void abandonTransactions(Duration retention) throws InterruptedException;
+
+    Set<String> getAbandonedTransactionsCache();
 }


### PR DESCRIPTION
this closes the feature gap between memory and ISPN based processors.
It also fixes 2 bugs in existing ISPN processors impl (AFAIK): 
- the transactions abandonment was already implemented in ISPN version but the events were not removed from the event cache (it was staying there forever)
- if event came for abandoned transaction, it would be processed normally (not sure what would happen exactly, but not good situation anyway)

It also fixes dubious name `removeTransactionAndEventsFromCache` which was not doing what it says (e.g. in memory version it was not removing neither transaction nor events)