### PR TITLE
DBZ-7162 Removed duplicit source event count metric for MongoDB

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
@@ -68,33 +68,21 @@ public class MongoDbStreamingChangeEventSourceMetrics extends DefaultStreamingCh
     }
 
     @Override
-    public long getNumberOfSourceEvents() {
-        return numberOfSourceEvents.get();
-    }
-
-    @Override
     public long getNumberOfEmptyPolls() {
         return numberOfEmptyPolls.get();
     }
 
     public void onSourceEventPolled(ChangeStreamDocument<BsonDocument> event, Clock clock, Instant prePollTimestamp) {
         var now = clock.currentTimeAsInstant();
-
-        AtomicLong counter;
-        AtomicLong timer;
+        var duration = Duration.between(prePollTimestamp, now).toMillis();
 
         if (event == null) {
-            counter = numberOfEmptyPolls;
-            timer = lastEmptyPollTime;
+            lastEmptyPollTime.set(duration);
+            numberOfEmptyPolls.incrementAndGet();
         }
         else {
-            counter = numberOfSourceEvents;
-            timer = lastSourceEventPollTime;
+            lastSourceEventPollTime.set(duration);
         }
-
-        var duration = Duration.between(prePollTimestamp, now).toMillis();
-        timer.set(duration);
-        counter.incrementAndGet();
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetricsMBean.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetricsMBean.java
@@ -22,7 +22,5 @@ public interface MongoDbStreamingChangeEventSourceMetricsMBean extends Streaming
 
     long getLastEmptyPollTime();
 
-    long getNumberOfSourceEvents();
-
     long getNumberOfEmptyPolls();
 }


### PR DESCRIPTION
Removes the duplicit metric introduced in https://github.com/debezium/debezium/pull/5024