### PR TITLE
DBZ-7230 MySQL BIT Type should have a default length 1

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -180,7 +180,8 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.NUMERIC, MySqlParser.NUMERIC)
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL)
                         .setDefaultLengthScaleDimension(10, 0),
-                new DataTypeEntry(Types.BIT, MySqlParser.BIT),
+                new DataTypeEntry(Types.BIT, MySqlParser.BIT)
+                        .setDefaultLengthDimension(1),
                 new DataTypeEntry(Types.TIME, MySqlParser.TIME),
                 new DataTypeEntry(Types.TIMESTAMP_WITH_TIMEZONE, MySqlParser.TIMESTAMP),
                 new DataTypeEntry(Types.TIMESTAMP, MySqlParser.DATETIME),

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -3476,6 +3476,19 @@ public class MySqlAntlrDdlParserTest {
         assertColumn(table, "c", "NATIONAL CHAR", Types.NCHAR, 1, "utf8", true);
     }
 
+    @FixFor("DBZ-7230")
+    @Test
+    public void shouldParseCreateTableWithBitDefaultLength() {
+        String ddl = "CREATE TABLE t ( c1 BIT NULL );";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.retrieveColumnNames()).containsExactly("c1");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "c1", "BIT", Types.BIT, 1, -1, true, false, false);
+    }
+
     private String toIsoString(String timestamp) {
         return ZonedTimestamp.toIsoString(Timestamp.valueOf(timestamp).toInstant().atZone(ZoneId.systemDefault()), null, null);
     }


### PR DESCRIPTION
MySQL BIT Type should have a default length 1

https://dev.mysql.com/doc/refman/8.0/en/bit-type.html