### PR TITLE
[docs] Fix typo found in each of the source connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1145,7 +1145,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2570,7 +2570,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -2158,7 +2158,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3144,7 +3144,7 @@ The following table describes xref:mysql-advanced-connector-configuration-proper
 For example, `boolean`. +
 This property is required to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2937,7 +2937,7 @@ The following configuration properties are _required_ unless a default value is 
 For example, `boolean`. +
 This property is required to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3254,7 +3254,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2730,7 +2730,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1424,7 +1424,7 @@ For example, +
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
 The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +


### PR DESCRIPTION
Missing `i` in `qualified` 