### PR TITLE
DBZ-7276 Grant DELETE on signalling table in the incremental snapshot…

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotCaseSensitiveIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotCaseSensitiveIT.java
@@ -47,7 +47,7 @@ public class IncrementalSnapshotCaseSensitiveIT extends AbstractIncrementalSnaps
         // todo: creates signal table in the PDB, do we want it to be in the CDB?
         TestHelper.dropTable(connection, "debezium_signal");
         connection.execute("CREATE TABLE debezium_signal (id varchar2(64), type varchar2(32), data varchar2(2048))");
-        connection.execute("GRANT INSERT on debezium_signal to " + TestHelper.getConnectorUserName());
+        connection.execute("GRANT INSERT, DELETE on debezium_signal to " + TestHelper.getConnectorUserName());
         TestHelper.streamTable(connection, "debezium_signal");
 
         setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);


### PR DESCRIPTION
… tests

Delete is needed for `insert_delete` watermarking strategy.

https://issues.redhat.com/browse/DBZ-7276