### PR TITLE
DBZ-7284 Provide config option to customize CloudEvents.data schema name

### DIFF
--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
@@ -276,8 +277,8 @@ public class CloudEventsConverter implements Converter {
         CloudEventsProvider provider = lookupCloudEventsProvider(source);
 
         RecordAndMetadata recordAndMetadata;
-        boolean useBaseImpl = metadataSource.global() != MetadataSourceValue.HEADER && metadataSource.id() != MetadataSourceValue.HEADER
-                && metadataSource.type() != MetadataSourceValue.HEADER;
+        final boolean useBaseImpl = Stream.of(metadataSource.global(), metadataSource.id(), metadataSource.type(), metadataSource.dataSchemaName())
+                .allMatch(metadataSource -> metadataSource != MetadataSourceValue.HEADER);
         if (useBaseImpl) {
             recordAndMetadata = new RecordAndMetadataBaseImpl(record, schema);
         }
@@ -365,7 +366,7 @@ public class CloudEventsConverter implements Converter {
 
     /**
      * Obtains the schema id from the given Avro record. They are prefixed by one magic byte,
-     * followed by an int for the schem id.
+     * followed by an int for the schema id.
      */
     private String getSchemaIdFromAvroMessage(byte[] serializedData) {
         return String.valueOf(ByteBuffer.wrap(serializedData, 1, 5).getInt());

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadata.java
@@ -31,5 +31,7 @@ public interface RecordAndMetadata {
 
     SchemaAndValue timestamp();
 
+    String dataSchemaName();
+
     Schema dataSchema(String... dataFields);
 }

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
@@ -26,8 +26,8 @@ public class RecordAndMetadataHeaderImpl extends RecordAndMetadataBaseImpl imple
     private final MetadataSource metadataSource;
     private final JsonConverter jsonHeaderConverter;
 
-    public RecordAndMetadataHeaderImpl(Struct record, Schema dataSchema, Headers headers, MetadataSource metadataSource, JsonConverter jsonHeaderConverter) {
-        super(record, dataSchema);
+    public RecordAndMetadataHeaderImpl(Struct record, Schema originalDataSchema, Headers headers, MetadataSource metadataSource, JsonConverter jsonHeaderConverter) {
+        super(record, originalDataSchema);
         this.headers = headers;
         this.metadataSource = metadataSource;
         this.jsonHeaderConverter = jsonHeaderConverter;
@@ -65,6 +65,11 @@ public class RecordAndMetadataHeaderImpl extends RecordAndMetadataBaseImpl imple
             Schema ts_msSchema = this.source().schema().field(Envelope.FieldName.TIMESTAMP).schema();
             return new SchemaAndValue(ts_msSchema, ts_ms);
         }, super::timestamp);
+    }
+
+    @Override
+    public String dataSchemaName() {
+        return getValueFromHeaderOrByDefault(metadataSource.dataSchemaName(), CloudEventsMaker.DATA_SCHEMA_NAME_PARAM, false, null, super::dataSchemaName);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsMaker.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsMaker.java
@@ -59,6 +59,7 @@ public abstract class CloudEventsMaker {
     }
 
     public static final String CLOUDEVENTS_SPECVERSION = "1.0";
+    public static final String DATA_SCHEMA_NAME_PARAM = "dataSchemaName";
     public static final String CLOUDEVENTS_SCHEMA_SUFFIX = "CloudEvents.Envelope";
 
     private final SerializerType dataContentType;

--- a/debezium-core/src/main/java/io/debezium/converters/spi/RecordParser.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/RecordParser.java
@@ -55,19 +55,6 @@ public abstract class RecordParser {
     }
 
     /**
-     * Get the value of the data field in the record; may not be null.
-     */
-    public Struct data() {
-        Struct data = new Struct(dataSchema());
-
-        for (Field field : dataSchema.fields()) {
-            data.put(field, record.get(field));
-        }
-
-        return data;
-    }
-
-    /**
      * Get id of a message
      *.
      * @return id of a message
@@ -144,6 +131,19 @@ public abstract class RecordParser {
      */
     public Schema dataSchema() {
         return dataSchema;
+    }
+
+    /**
+     * Get the value of the data field in the record; may not be null.
+     */
+    public Struct data() {
+        Struct data = new Struct(dataSchema());
+
+        for (Field field : dataSchema.fields()) {
+            data.put(field, record.get(field));
+        }
+
+        return data;
     }
 
     /**

--- a/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/converters/AbstractCloudEventsConverterTest.java
@@ -139,6 +139,56 @@ public abstract class AbstractCloudEventsConverterTest<T extends SourceConnector
     }
 
     @Test
+    @FixFor("DBZ-7284")
+    public void shouldConvertToCloudEventsInJsonWithDataAsAvroAndAllMetadataInHeadersAfterOutboxEventRouter() throws Exception {
+        HeaderFrom<SourceRecord> headerFrom = new HeaderFrom.Value<>();
+        Map<String, String> headerFromConfig = new LinkedHashMap<>();
+        headerFromConfig.put("fields", "source,op,transaction");
+        headerFromConfig.put("headers", "source,op,transaction");
+        headerFromConfig.put("operation", "copy");
+        headerFromConfig.put("header.converter.schemas.enable", "true");
+        headerFrom.configure(headerFromConfig);
+
+        EventRouter<SourceRecord> outboxEventRouter = new EventRouter<>();
+        Map<String, String> outboxEventRouterConfig = new LinkedHashMap<>();
+        outboxEventRouterConfig.put("table.expand.json.payload", "true");
+        // this adds `type` and `dataSchemaName` headers with values from the DB columns. `id` header is added by Outbox Event Router by default
+        outboxEventRouterConfig.put("table.fields.additional.placement", "event_type:header:type,aggregatetype:header:dataSchemaName");
+        outboxEventRouter.configure(outboxEventRouterConfig);
+
+        createOutboxTable();
+
+        databaseConnection().execute(createInsertToOutbox(
+                "59a42efd-b015-44a9-9dde-cb36d9002425",
+                "UserCreated",
+                "User",
+                "10711fa5",
+                "{" +
+                        "\"someField1\": \"some value 1\"," +
+                        "\"someField2\": 7005" +
+                        "}",
+                ""));
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic(topicNameOutbox()).get(0);
+        SourceRecord recordWithMetadataHeaders = headerFrom.apply(record);
+        SourceRecord routedEvent = outboxEventRouter.apply(recordWithMetadataHeaders);
+
+        assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
+        assertThat(routedEvent.keySchema()).isEqualTo(Schema.STRING_SCHEMA);
+        assertThat(routedEvent.key()).isEqualTo("10711fa5");
+        assertThat(routedEvent.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithDataAsAvroAndAllMetadataInHeaders(routedEvent, getConnectorName(), getServerName());
+
+        headerFrom.close();
+        outboxEventRouter.close();
+    }
+
+    @Test
     @FixFor({ "DBZ-7016" })
     public void shouldConvertToCloudEventsInJsonWithIdFromHeaderAndGeneratedType() throws Exception {
         InsertHeader<SourceRecord> insertHeader = new InsertHeader<>();


### PR DESCRIPTION
To actually retrieve data schema name from the `dataSchemaName` header, a user should specify two properties:

```
    "value.converter.metadata.source": "header",
    "value.converter.schema.data.name.source.header.enable": true,
```

The second property by default is `false` which provides backward compatibility

If it is Outbox SMT + CloudEventsConverter integration, the header can be added as follows:

```
    "transforms.outbox.table.fields.additional.placement": "type:header,aggregate_type:header:dataSchemaName",
```