### PR TITLE
DBZ-7287 Clarify comment about how we extract and serialize document ids

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/JsonSerialization.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/JsonSerialization.java
@@ -56,7 +56,11 @@ class JsonSerialization {
         if (document == null) {
             return null;
         }
-        // The serialized value is in format {"_": xxx} so we need to remove the starting dummy field name and closing brace
+        // Jackson can't serialize bson out of the box, so we have to use the bson
+        // .toJson() method. But .toJson() doesn't work on simple values like bson
+        // strings and bson numbers, only on bson objects. So we have to first nest
+        // the id in a bson object in the format {"_": xxx}, then serialize it using
+        // .toJson(), then remove the starting dummy field and closing brace.
         final String keyValue = new BasicDBObject("_", document.get(ID_FIELD_NAME)).toJson(SIMPLE_JSON_SETTINGS);
         final int start = 6;
         final int end = keyValue.length() - 1;


### PR DESCRIPTION
See [Jira ticket](https://issues.redhat.com/browse/DBZ-7287) and [Zulip discussion](https://debezium.zulipchat.com/#narrow/stream/348106-community-mongodb/topic/Raw.20string.20manipulation.20during.20extraction.20of.20document.20keys)

The code in the lines at  https://github.com/debezium/debezium/blob/main/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/JsonSerialization.java#L60-L66 seems at first to be a little convoluted – in order to get an id out of the document argument, it first extracts the id, then re-nests the id in a new document with a fieldname of fixed length, then serializes that, then extracts the id again, this time using raw string manipulation.

This seems odd but there's a good reason for it: it's tough to serialize scalar bson values and this is a good workaround, see the Zulip discussion above. 

Although necessary, this code is a little brittle and has possibly been involved in errors such as the one described in [DBZ-7157](https://issues.redhat.com/browse/DBZ-7157).

If we explain it a little more in a comment, these errors might be less likely to happen.