### PR TITLE
[docs] Remove redundant --rm flag

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-command-line-client.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-command-line-client.adoc
@@ -18,7 +18,7 @@ and defines a shell command to run the MySQL command line client with the correc
 
 [source,shell,options="nowrap"]
 ----
-$ docker run -it --rm --name mysqlterm --link mysql --rm mysql:8.2 sh -c 'exec mysql -h"$MYSQL_PORT_3306_TCP_ADDR" -P"$MYSQL_PORT_3306_TCP_PORT" -uroot -p"$MYSQL_ENV_MYSQL_ROOT_PASSWORD"'
+$ docker run -it --rm --name mysqlterm --link mysql mysql:8.2 sh -c 'exec mysql -h"$MYSQL_PORT_3306_TCP_ADDR" -P"$MYSQL_PORT_3306_TCP_PORT" -uroot -p"$MYSQL_ENV_MYSQL_ROOT_PASSWORD"'
 ----
 
 `-it`:: The container is interactive,
@@ -34,7 +34,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name mysqlterm --pod dbz --rm mysql:8.2 sh -c 'exec mysql -h 0.0.0.0 -uroot -pdebezium'
+$ sudo podman run -it --rm --name mysqlterm --pod dbz mysql:8.2 sh -c 'exec mysql -h 0.0.0.0 -uroot -pdebezium'
 ----
 ====
 endif::community[]


### PR DESCRIPTION
Deleted the extra --rm flag in Docker and Podman commands.