### PR TITLE
[docs] remove unnecessary `context` attribute that prefixes xref target

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3184,7 +3184,7 @@ For example, to define a `selector` parameter that specifies the subset of colum
 |[[mysql-property-database-ssl-keystore-password]]<<mysql-property-database-ssl-keystore-password, `+database.ssl.keystore.password+`>>
 |No defaults
 |The password for the key store file.
- This is optional and only needed if xref:{context}-mysql-property-database-ssl-keystore[`database.ssl.keystore`] is configured.
+ This is optional and only needed if xref:mysql-property-database-ssl-keystore[`database.ssl.keystore`] is configured.
 |[[mysql-property-database-ssl-truststore]]<<mysql-property-database-ssl-truststore, `+database.ssl.truststore+`>>
 |No defaults
 |The location of the trust store file for the server certificate verification.


### PR DESCRIPTION
In the description of the `database.ssl.keystore.password` property, the xref to the `database.ssl.keystore` property is incorrectly prefixed with the `{context}` attribute

(cherry picked from commit 13703c74577af767f002235557b70b456d4a7dcb)