### PR TITLE
[docs] Update Podman commands in the tutorial

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-cleaning-up.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-cleaning-up.adoc
@@ -28,8 +28,8 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman pod kill dbz
-$ sudo podman pod rm dbz
+$ podman pod kill dbz
+$ podman pod rm dbz
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
@@ -38,7 +38,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name connect --pod dbz -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses quay.io/debezium/connect:{debezium-docker-label}
+$ podman run -it --rm --name connect --pod dbz -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses quay.io/debezium/connect:{debezium-docker-label}
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka.adoc
@@ -51,7 +51,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name kafka --pod dbz quay.io/debezium/kafka:{debezium-docker-label}
+$ podman run -it --rm --name kafka --pod dbz quay.io/debezium/kafka:{debezium-docker-label}
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-command-line-client.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-command-line-client.adoc
@@ -34,7 +34,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name mysqlterm --pod dbz mysql:8.2 sh -c 'exec mysql -h 0.0.0.0 -uroot -pdebezium'
+$ podman run -it --rm --name mysqlterm --pod dbz mysql:8.2 sh -c 'exec mysql -h 0.0.0.0 -uroot -pdebezium'
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-database.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-mysql-database.adoc
@@ -37,7 +37,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name mysql --pod dbz -e MYSQL_ROOT_PASSWORD=debezium -e MYSQL_USER=mysqluser -e MYSQL_PASSWORD=mysqlpw quay.io/debezium/example-mysql:{debezium-docker-label}
+$ podman run -it --rm --name mysql --pod dbz -e MYSQL_ROOT_PASSWORD=debezium -e MYSQL_USER=mysqluser -e MYSQL_PASSWORD=mysqlpw quay.io/debezium/example-mysql:{debezium-docker-label}
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-zookeeper.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-zookeeper.adoc
@@ -34,8 +34,8 @@ ifdef::community[]
 If you use Podman, run the following command:s
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman pod create --name=dbz --publish "9092,3306,8083"
-$ sudo podman run -it --rm --name zookeeper --pod dbz quay.io/debezium/zookeeper:{debezium-docker-label}
+$ podman pod create --name=dbz -p 8083:8083
+$ podman run -it --rm --name zookeeper --pod dbz quay.io/debezium/zookeeper:{debezium-docker-label}
 ----
 ====
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-viewing-create-event.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-viewing-create-event.adoc
@@ -34,7 +34,7 @@ In this case, this contains the row's primary key.
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ sudo podman run -it --rm --name watcher --pod dbz quay.io/debezium/kafka:{debezium-docker-label} watch-topic -a -k dbserver1.inventory.customers
+$ podman run -it --rm --name watcher --pod dbz quay.io/debezium/kafka:{debezium-docker-label} watch-topic -a -k dbserver1.inventory.customers
 ----
 ====
 


### PR DESCRIPTION
I removed the sudo prefix from the podman commands for the following reasons:
1. There's no need to run podman commands with sudo. It is unnecessary.
2. Pods created with sudo won't appear in Podman Desktop.
3. Maintain consistency with the Docker commands in the tutorial (they are not prefixed with sudo).

When `dbz` pod is created, only port 8083 will be published. This is because the host will only interact with Kafka Connect (8083) via curl. The host will not interact with Apache Zookeeper (9092) or MySQL (3306), thus opening these two ports in the pod is unnecessary.