### PR TITLE
DBZ-7351 Avoid child data snapshots from PostgreSQL parent tables

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -360,6 +360,7 @@ Naveen Kumar KR
 Nayana Hettiarachchi
 Nenad Stojanovikj
 Nick Murray
+Nicolas Payart
 Niels Pardon
 Nikhil Benesch
 Nils Hartmann

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/QueryingSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/QueryingSnapshotter.java
@@ -27,7 +27,7 @@ public abstract class QueryingSnapshotter implements Snapshotter {
     @Override
     public Optional<String> buildSnapshotQuery(TableId tableId, List<String> snapshotSelectColumns) {
         String query = snapshotSelectColumns.stream()
-                .collect(Collectors.joining(", ", "SELECT ", " FROM " + tableId.toDoubleQuotedString()));
+                .collect(Collectors.joining(", ", "SELECT ", " FROM ONLY " + tableId.toDoubleQuotedString()));
 
         return Optional.of(query);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
@@ -47,7 +47,7 @@ public class CustomTestSnapshot implements Snapshotter {
         }
         else {
             String query = snapshotSelectColumns.stream()
-                    .collect(Collectors.joining(", ", "SELECT ", " FROM " + tableId.toDoubleQuotedString()));
+                    .collect(Collectors.joining(", ", "SELECT ", " FROM ONLY " + tableId.toDoubleQuotedString()));
 
             return Optional.of(query);
         }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -247,3 +247,4 @@ methodmissing,Lourens Naudé
 Prabhu19,Pavithrananda Prabhu
 Lourens Naude,Lourens Naudé
 overwatcheddude,حمود سمبول
+koleo,Nicolas Payart


### PR DESCRIPTION
When PostgreSQL tables are configured with inheritance (INHERIT clause), data is streamed by Debezium from the table where the data resides (usually the child tables).

However, during the initial/incremental snapshot, Debezium selects all data from the parent tables, including child data, which pushes unexpected/duplicate data into the topics (all data from child tables).

Using a "SELECT ... FROM ONLY" retrieves only data from the current table and avoids retrieving data from child tables.