### PR TITLE
[docs] incremental snapshot: blocking snapshot are also supported

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
@@ -63,7 +63,7 @@ If this component of the `data` field is omitted, the signal stops the entire in
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
 Currently, the only valid option is `incremental`. +
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -62,7 +62,7 @@ If this component of the `data` field is omitted, the signal stops the entire in
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
 Currently, the only valid option is `incremental`. +
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
@@ -90,7 +90,7 @@ If this component of the `data` field is omitted, the signal stops the entire in
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
 Currently, the only valid option is `incremental`. +
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===
@@ -125,7 +125,7 @@ If this component of the `data` field is omitted, the signal stops the entire in
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
 Currently, the only valid option is `incremental`. +
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
@@ -14,7 +14,7 @@ The signal type is `execute-snapshot`, and the `data` field must have the follow
 |`type`
 |`incremental`
 | The type of the snapshot to be executed.
-Currently {prodname} supports only the `incremental` type.  +
+Currently {prodname} supports the `incremental` and `blocking` types. +
 See the next section for more details.
 
 |`data-collections`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
@@ -4,8 +4,8 @@ You submit a signal to the signaling {data-collection} by using the MongoDB `ins
 
 After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
 
-The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
-Currently, the only valid option for snapshots operations is the default value, `incremental`.
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
+Currently, the only valid options for snapshots operations are `incremental`and `blocking`.
 
 To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
 `{"data-collections": ["public.Collection1", "public.Collection2"]}` +
@@ -80,8 +80,8 @@ The array lists regular expressions which match {data-collection}s by their full
 
 |5
 |`incremental`
-|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+|An optional `type` component of the `data` field of a signal that specifies the type of snapshot operation to run. +
+Currently supports the `incremental` and `blocking` types. +
 If you do not specify a value, the connector runs an incremental snapshot.
 |===
 
@@ -111,7 +111,7 @@ The following example, shows the JSON for an incremental snapshot event that is 
 |1
 |`snapshot`
 |Specifies the type of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+Currently, the only valid options are `blocking` and `incremental`. +
 Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
 If you do not specify a value, the connector runs an incremental snapshot.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -4,8 +4,8 @@ You submit a signal to the signaling {data-collection} as SQL `INSERT` queries.
 
 After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
 
-The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
-Currently, the only valid option for snapshots operations is the default value, `incremental`.
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
+Currently supports the `incremental` and `blocking` types.
 
 To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
 
@@ -79,8 +79,8 @@ The array lists regular expressions which match {data-collection}s by their full
 
 |5
 |`incremental`
-|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+|An optional `type` component of the `data` field of a signal that specifies the type of snapshot operation to run. +
+Currently supports the `incremental` and `blocking` types. +
 If you do not specify a value, the connector runs an incremental snapshot.
 
 |6
@@ -164,7 +164,7 @@ The following example, shows the JSON for an incremental snapshot event that is 
 |1
 |`snapshot`
 |Specifies the type of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+Currently, the only valid options are `blocking` and `incremental`. +
 Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
 If you do not specify a value, the connector runs an incremental snapshot.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
@@ -8,8 +8,8 @@ end::nosql-based-snapshot[]
 
 After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
 
-The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
-Currently, the only valid option for snapshots operations is the default value, `incremental`.
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
+Currently, the only valid options for snapshots operations are `incremental` and `blocking`.
 
 To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
 tag::sql-based-snapshot[]
@@ -120,8 +120,8 @@ The array lists regular expressions which match {data-collection}s by their full
 
 |5
 |`incremental`
-|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+|An optional `type` component of the `data` field of a signal that specifies the type of snapshot operation to run. +
+Currently supports the `incremental` and `blocking` types. +
 If you do not specify a value, the connector runs an incremental snapshot.
 
 |6
@@ -214,8 +214,8 @@ Rather, during the snapshot, {prodname} generates its own `id` string as a water
 The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
 
 |`incremental`
-|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+|An optional `type` component of the `data` field of a signal that specifies the type of snapshot operation to run. +
+Currently supports the `incremental` and `blocking` types. +
 If you do not specify a value, the connector runs an incremental snapshot.
 |===
 
@@ -247,7 +247,7 @@ The following example, shows the JSON for an incremental snapshot event that is 
 |1
 |`snapshot`
 |Specifies the type of snapshot operation to run. +
-Currently, the only valid option is the default value, `incremental`. +
+Currently, the only valid options are `blocking` and `incremental`. +
 Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
 If you do not specify a value, the connector runs an incremental snapshot.
 


### PR DESCRIPTION
PR https://github.com/debezium/debezium/pull/4721 documented blocking snapshot added in [DBZ-6566](https://issues.redhat.com/browse/DBZ-6566). But it missed a
few spots.

Also, for consistency use "snapshot type" instead of "snapshot kind".