### PR TITLE
DBZ -7301 Implement Snapshotter SPI MySQL/MariaDB

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -23,6 +23,7 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
@@ -42,11 +43,12 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     private final MongoDbTaskContext taskContext;
     private final MongoDbSchema schema;
     private final MongoDbStreamingChangeEventSourceMetrics streamingMetrics;
+    private final SnapshotterService snapshotterService;
 
     public MongoDbChangeEventSourceFactory(MongoDbConnectorConfig configuration, ErrorHandler errorHandler,
                                            EventDispatcher<MongoDbPartition, CollectionId> dispatcher, Clock clock,
                                            MongoDbTaskContext taskContext, MongoDbSchema schema,
-                                           MongoDbStreamingChangeEventSourceMetrics streamingMetrics) {
+                                           MongoDbStreamingChangeEventSourceMetrics streamingMetrics, SnapshotterService snapshotterService) {
         this.configuration = configuration;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
@@ -54,6 +56,7 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
         this.taskContext = taskContext;
         this.schema = schema;
         this.streamingMetrics = streamingMetrics;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override
@@ -66,7 +69,8 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
                 clock,
                 snapshotProgressListener,
                 errorHandler,
-                notificationService);
+                notificationService,
+                snapshotterService);
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -38,6 +38,7 @@ import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext.PreviousContext;
 
@@ -133,6 +134,8 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
 
             MongoDbChangeEventSourceMetricsFactory metricsFactory = new MongoDbChangeEventSourceMetricsFactory();
 
+            SnapshotterService snapshotterService = null; // TODO with DBZ-7304
+
             ChangeEventSourceCoordinator<MongoDbPartition, MongoDbOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                     previousOffset,
                     errorHandler,
@@ -145,12 +148,13 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
                             clock,
                             taskContext,
                             schema,
-                            metricsFactory.getStreamingMetrics(taskContext, queue, metadataProvider)),
+                            metricsFactory.getStreamingMetrics(taskContext, queue, metadataProvider),
+                            snapshotterService),
                     metricsFactory,
                     dispatcher,
                     schema,
                     signalProcessor,
-                    notificationService);
+                    notificationService, snapshotterService);
 
             coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -51,6 +51,7 @@ import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -71,11 +72,12 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     private final Clock clock;
     private final SnapshotProgressListener<MongoDbPartition> snapshotProgressListener;
     private final ErrorHandler errorHandler;
+    private final SnapshotterService snapshotterService;
 
     public MongoDbSnapshotChangeEventSource(MongoDbConnectorConfig connectorConfig, MongoDbTaskContext taskContext,
                                             EventDispatcher<MongoDbPartition, CollectionId> dispatcher, Clock clock,
                                             SnapshotProgressListener<MongoDbPartition> snapshotProgressListener, ErrorHandler errorHandler,
-                                            NotificationService<MongoDbPartition, MongoDbOffsetContext> notificationService) {
+                                            NotificationService<MongoDbPartition, MongoDbOffsetContext> notificationService, SnapshotterService snapshotterService) {
         super(connectorConfig, snapshotProgressListener, notificationService);
         this.connectorConfig = connectorConfig;
         this.taskContext = taskContext;
@@ -83,6 +85,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
         this.clock = clock;
         this.snapshotProgressListener = snapshotProgressListener;
         this.errorHandler = errorHandler;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -25,6 +25,7 @@ import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -45,10 +46,12 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
     // but in the core shared code.
     private final ChangeEventQueue<DataChangeEvent> queue;
 
+    private final SnapshotterService snapshotterService;
+
     public MySqlChangeEventSourceFactory(MySqlConnectorConfig configuration, MainConnectionProvidingConnectionFactory<AbstractConnectorConnection> connectionFactory,
                                          ErrorHandler errorHandler, EventDispatcher<MySqlPartition, TableId> dispatcher, Clock clock, MySqlDatabaseSchema schema,
                                          MySqlTaskContext taskContext, MySqlStreamingChangeEventSourceMetrics streamingMetrics,
-                                         ChangeEventQueue<DataChangeEvent> queue) {
+                                         ChangeEventQueue<DataChangeEvent> queue, SnapshotterService snapshotterService) {
         this.configuration = configuration;
         this.connectionFactory = connectionFactory;
         this.errorHandler = errorHandler;
@@ -58,13 +61,23 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
         this.streamingMetrics = streamingMetrics;
         this.queue = queue;
         this.schema = schema;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override
     public SnapshotChangeEventSource<MySqlPartition, MySqlOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<MySqlPartition> snapshotProgressListener,
                                                                                                       NotificationService<MySqlPartition, MySqlOffsetContext> notificationService) {
-        return new MySqlSnapshotChangeEventSource(configuration, connectionFactory, taskContext.getSchema(), dispatcher, clock,
-                (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener, this::modifyAndFlushLastRecord, this::preSnapshot, notificationService);
+        return new MySqlSnapshotChangeEventSource(
+                configuration,
+                connectionFactory,
+                taskContext.getSchema(),
+                dispatcher,
+                clock,
+                (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener,
+                this::modifyAndFlushLastRecord,
+                this::preSnapshot,
+                notificationService,
+                snapshotterService);
     }
 
     private void preSnapshot() {
@@ -78,6 +91,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
 
     @Override
     public StreamingChangeEventSource<MySqlPartition, MySqlOffsetContext> getStreamingChangeEventSource() {
+
         queue.disableBuffering();
         return new MySqlStreamingChangeEventSource(
                 configuration,
@@ -86,7 +100,8 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
                 errorHandler,
                 clock,
                 taskContext,
-                streamingMetrics);
+                streamingMetrics,
+                snapshotterService);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -136,19 +136,19 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         /**
          * Perform a snapshot when it is needed.
          */
-        WHEN_NEEDED("when_needed", true, true, true, false, true),
+        WHEN_NEEDED("when_needed"),
 
         /**
          * Perform a snapshot only upon initial startup of a connector.
          */
-        INITIAL("initial", true, true, true, false, false),
+        INITIAL("initial"),
 
         /**
          * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog.
          * This should be used with care, but it is very useful when the change event consumers need only the changes
          * from the point in time the snapshot is made (and doesn't care about any state or changes prior to this point).
          */
-        SCHEMA_ONLY("schema_only", true, false, true, false, false),
+        SCHEMA_ONLY("schema_only"),
 
         /**
          * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog at the current binlog position.
@@ -156,82 +156,28 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
          * This recovery option should be used with care as it assumes there have been no schema changes since the connector last stopped,
          * otherwise some events during the gap may be processed with an incorrect schema and corrupted.
          */
-        SCHEMA_ONLY_RECOVERY("schema_only_recovery", true, false, true, true, false),
+        SCHEMA_ONLY_RECOVERY("schema_only_recovery"),
 
         /**
          * Never perform a snapshot and only read the binlog. This assumes the binlog contains all the history of those
          * databases and tables that will be captured.
          */
-        NEVER("never", false, false, true, false, false),
+        NEVER("never"),
 
         /**
          * Perform a snapshot and then stop before attempting to read the binlog.
          */
-        INITIAL_ONLY("initial_only", true, true, false, false, false);
+        INITIAL_ONLY("initial_only");
 
         private final String value;
-        private final boolean includeSchema;
-        private final boolean includeData;
-        private final boolean shouldStream;
-        private final boolean shouldSnapshotOnSchemaError;
-        private final boolean shouldSnapshotOnDataError;
 
-        SnapshotMode(String value, boolean includeSchema, boolean includeData, boolean shouldStream, boolean shouldSnapshotOnSchemaError,
-                     boolean shouldSnapshotOnDataError) {
+        SnapshotMode(String value) {
             this.value = value;
-            this.includeSchema = includeSchema;
-            this.includeData = includeData;
-            this.shouldStream = shouldStream;
-            this.shouldSnapshotOnSchemaError = shouldSnapshotOnSchemaError;
-            this.shouldSnapshotOnDataError = shouldSnapshotOnDataError;
         }
 
         @Override
         public String getValue() {
             return value;
-        }
-
-        /**
-         * Whether this snapshotting mode should include the schema.
-         */
-        public boolean includeSchema() {
-            return includeSchema;
-        }
-
-        /**
-         * Whether this snapshotting mode should include the actual data or just the
-         * schema of captured tables.
-         */
-        public boolean includeData() {
-            return includeData;
-        }
-
-        /**
-         * Whether the snapshot mode is followed by streaming.
-         */
-        public boolean shouldStream() {
-            return shouldStream;
-        }
-
-        /**
-         * Whether the schema can be recovered if database schema history is corrupted.
-         */
-        public boolean shouldSnapshotOnSchemaError() {
-            return shouldSnapshotOnSchemaError;
-        }
-
-        /**
-         * Whether the snapshot should be re-executed when there is a gap in data stream.
-         */
-        public boolean shouldSnapshotOnDataError() {
-            return shouldSnapshotOnDataError;
-        }
-
-        /**
-         * Whether the snapshot should be executed.
-         */
-        public boolean shouldSnapshot() {
-            return includeSchema || includeData;
         }
 
         /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -22,6 +22,7 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
 import io.debezium.connector.mysql.MySqlConnectorConfig.BigIntUnsignedHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.snapshot.MySqlSnapshotLockProvider;
 import io.debezium.connector.mysql.snapshot.MySqlSnapshotQueryProvider;
 import io.debezium.connector.mysql.snapshot.MySqlSnapshotterServiceProvider;
 import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
@@ -247,7 +248,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
     protected void registerServiceProviders(ServiceRegistry serviceRegistry) {
 
         super.registerServiceProviders(serviceRegistry);
-        // serviceRegistry.registerServiceProvider(new SnapshotLockProvider());
+        serviceRegistry.registerServiceProvider(new MySqlSnapshotLockProvider());
         serviceRegistry.registerServiceProvider(new MySqlSnapshotQueryProvider());
         serviceRegistry.registerServiceProvider(new MySqlSnapshotterServiceProvider());
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -22,6 +22,7 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
 import io.debezium.connector.mysql.MySqlConnectorConfig.BigIntUnsignedHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.snapshot.MySqlSnapshotQueryProvider;
 import io.debezium.connector.mysql.snapshot.MySqlSnapshotterServiceProvider;
 import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
 import io.debezium.connector.mysql.strategy.ConnectorAdapter;
@@ -247,7 +248,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
 
         super.registerServiceProviders(serviceRegistry);
         // serviceRegistry.registerServiceProvider(new SnapshotLockProvider());
-        // serviceRegistry.registerServiceProvider(new SnapshotQueryProvider());
+        serviceRegistry.registerServiceProvider(new MySqlSnapshotQueryProvider());
         serviceRegistry.registerServiceProvider(new MySqlSnapshotterServiceProvider());
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -102,7 +102,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
                 .collect(Collectors.toMap(e -> e.getKey().identifier(), Map.Entry::getValue));
 
         // found a previous offset and the earlier snapshot has completed
-        if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
+        if (previousOffset != null && !previousOffset.isSnapshotRunning()) { // TODO DBZ-7308 check if this should be removed fort example for AlwaysSnapshotter
 
             if (databaseSchema.isStorageInitializationExecuted()) {
                 LOGGER.info(

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -301,7 +301,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
         ctx.offset = offsetContext;
 
         connectorConfig.getConnectorAdapter()
-                .setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(offsetContext, connection);
+                .setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(offsetContext, connection, snapshotterService);
 
         tryStartingSnapshot(ctx);
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotLockProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotLockProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot;
+
+import static io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode.CUSTOM;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+import io.debezium.DebeziumException;
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.bean.spi.BeanRegistryAware;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode;
+import io.debezium.service.spi.ServiceProvider;
+import io.debezium.service.spi.ServiceRegistry;
+import io.debezium.snapshot.spi.SnapshotLock;
+
+/**
+ * An implementation of the {@link ServiceProvider} contract for the {@link SnapshotLock}.
+ *
+ * @author Mario Fiore Vitale
+ */
+public class MySqlSnapshotLockProvider implements ServiceProvider<SnapshotLock> {
+
+    @Override
+    public SnapshotLock createService(Configuration configuration, ServiceRegistry serviceRegistry) {
+
+        BeanRegistry beanRegistry = serviceRegistry.tryGetService(BeanRegistry.class);
+        MySqlConnectorConfig mySqlConnectorConfig = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+
+        final SnapshotLockingMode configuredSnapshotQueryMode = mySqlConnectorConfig.getSnapshotLockingMode();
+        final String snapshotLockingModeCustomName = mySqlConnectorConfig.snapshotLockingModeCustomName();
+
+        String snapshotQueryMode;
+        if (CUSTOM.equals(configuredSnapshotQueryMode) && !snapshotLockingModeCustomName.isEmpty()) {
+            snapshotQueryMode = snapshotLockingModeCustomName;
+        }
+        else {
+            snapshotQueryMode = configuredSnapshotQueryMode.getValue();
+        }
+
+        Optional<SnapshotLock> snapshotLock = StreamSupport.stream(ServiceLoader.load(SnapshotLock.class).spliterator(), false)
+                .filter(s -> s.name().equals(snapshotQueryMode))
+                .findAny();
+
+        return snapshotLock.map(s -> {
+            s.configure(configuration.asMap());
+            if (s instanceof BeanRegistryAware) {
+                ((BeanRegistryAware) s).injectBeanRegistry(beanRegistry);
+            }
+            return s;
+        })
+                .orElseThrow(() -> new DebeziumException(String.format("Unable to find %s snapshot query mode. Please check your configuration.", snapshotQueryMode)));
+
+    }
+
+    @Override
+    public Class<SnapshotLock> getServiceClass() {
+        return SnapshotLock.class;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotQueryProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotQueryProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot;
+
+import static io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotQueryMode.CUSTOM;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+import io.debezium.DebeziumException;
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.bean.spi.BeanRegistryAware;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotQueryMode;
+import io.debezium.service.spi.ServiceProvider;
+import io.debezium.service.spi.ServiceRegistry;
+import io.debezium.snapshot.spi.SnapshotQuery;
+
+/**
+ * An implementation of the {@link ServiceProvider} contract for the {@link SnapshotQuery}.
+ *
+ * @author Mario Fiore Vitale
+ */
+public class MySqlSnapshotQueryProvider implements ServiceProvider<SnapshotQuery> {
+
+    @Override
+    public SnapshotQuery createService(Configuration configuration, ServiceRegistry serviceRegistry) {
+
+        BeanRegistry beanRegistry = serviceRegistry.tryGetService(BeanRegistry.class);
+        MySqlConnectorConfig postgresConnectorConfig = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+
+        final SnapshotQueryMode configuredSnapshotQueryMode = postgresConnectorConfig.snapshotQueryMode();
+        final String snapshotQueryModeCustomName = postgresConnectorConfig.snapshotQueryModeCustomName();
+
+        String snapshotQueryMode;
+        if (CUSTOM.equals(configuredSnapshotQueryMode) && !snapshotQueryModeCustomName.isEmpty()) {
+            snapshotQueryMode = snapshotQueryModeCustomName;
+        }
+        else {
+            snapshotQueryMode = configuredSnapshotQueryMode.getValue();
+        }
+
+        Optional<SnapshotQuery> snapshotQuery = StreamSupport.stream(ServiceLoader.load(SnapshotQuery.class).spliterator(), false)
+                .filter(s -> s.name().equals(snapshotQueryMode))
+                .findAny();
+
+        return snapshotQuery.map(s -> {
+            s.configure(configuration.asMap());
+            if (s instanceof BeanRegistryAware) {
+                ((BeanRegistryAware) s).injectBeanRegistry(beanRegistry);
+            }
+            return s;
+        })
+                .orElseThrow(() -> new DebeziumException(String.format("Unable to find %s snapshot query mode. Please check your configuration.", snapshotQueryMode)));
+
+    }
+
+    @Override
+    public Class<SnapshotQuery> getServiceClass() {
+        return SnapshotQuery.class;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotterServiceProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/MySqlSnapshotterServiceProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot;
+
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.snapshot.SnapshotterServiceProvider;
+
+public class MySqlSnapshotterServiceProvider extends SnapshotterServiceProvider {
+
+    @Override
+    public String snapshotMode(BeanRegistry beanRegistry) {
+
+        MySqlConnectorConfig mySqlConnectorConfig = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+
+        return mySqlConnectorConfig.getSnapshotMode().getValue();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/DefaultSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/DefaultSnapshotLock.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.lock;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+public abstract class DefaultSnapshotLock {
+    public Optional<String> tableLockingStatement(Duration lockTimeout, Set<String> tableIds) {
+        return Optional.of("FLUSH TABLES WITH READ LOCK");
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/ExtendedSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/ExtendedSnapshotLock.java
@@ -10,11 +10,11 @@ import java.util.Map;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.snapshot.spi.SnapshotLock;
 
-public class MinimalSnapshotLock extends DefaultSnapshotLock implements SnapshotLock {
+public class ExtendedSnapshotLock extends DefaultSnapshotLock implements SnapshotLock {
 
     @Override
     public String name() {
-        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL.getValue();
+        return MySqlConnectorConfig.SnapshotLockingMode.EXTENDED.getValue();
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalPerconaSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalPerconaSnapshotLock.java
@@ -5,20 +5,28 @@
  */
 package io.debezium.connector.mysql.snapshot.lock;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.snapshot.spi.SnapshotLock;
 
-public class MinimalSnapshotLock extends DefaultSnapshotLock implements SnapshotLock {
+public class MinimalPerconaSnapshotLock implements SnapshotLock {
 
     @Override
     public String name() {
-        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL.getValue();
+        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL_PERCONA.getValue();
     }
 
     @Override
     public void configure(Map<String, ?> properties) {
 
+    }
+
+    @Override
+    public Optional<String> tableLockingStatement(Duration lockTimeout, Set<String> tableIds) {
+        return Optional.of("LOCK TABLES FOR BACKUP");
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalSnapshotLock.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.lock;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.snapshot.spi.SnapshotLock;
+
+public class MinimalSnapshotLock implements SnapshotLock {
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public Optional<String> tableLockingStatement(Duration lockTimeout, Set<String> tableIds) {
+        return Optional.empty();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/NoneSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/NoneSnapshotLock.java
@@ -5,20 +5,28 @@
  */
 package io.debezium.connector.mysql.snapshot.lock;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.snapshot.spi.SnapshotLock;
 
-public class MinimalSnapshotLock extends DefaultSnapshotLock implements SnapshotLock {
+public class NoneSnapshotLock implements SnapshotLock {
 
     @Override
     public String name() {
-        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL.getValue();
+        return MySqlConnectorConfig.SnapshotLockingMode.NONE.getValue();
     }
 
     @Override
     public void configure(Map<String, ?> properties) {
 
+    }
+
+    @Override
+    public Optional<String> tableLockingStatement(Duration lockTimeout, Set<String> tableIds) {
+        return Optional.empty();
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/BeanAwareSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/BeanAwareSnapshotter.java
@@ -7,6 +7,11 @@ package io.debezium.connector.mysql.snapshot.mode;
 
 import io.debezium.bean.spi.BeanRegistry;
 import io.debezium.bean.spi.BeanRegistryAware;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
+import io.debezium.connector.mysql.strategy.mariadb.MariaDbConnection;
+import io.debezium.connector.mysql.strategy.mariadb.MariaDbConnectorAdapter;
+import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
 
 public class BeanAwareSnapshotter implements BeanRegistryAware {
     protected BeanRegistry beanRegistry;
@@ -14,5 +19,15 @@ public class BeanAwareSnapshotter implements BeanRegistryAware {
     @Override
     public void injectBeanRegistry(BeanRegistry beanRegistry) {
         this.beanRegistry = beanRegistry;
+    }
+
+    protected Class<? extends AbstractConnectorConnection> getConnectionClass(MySqlConnectorConfig config) {
+        // TODO review this when MariaDB becomes a first class connector
+        if (config.getConnectorAdapter() instanceof MariaDbConnectorAdapter) {
+            return MariaDbConnection.class;
+        }
+        else {
+            return MySqlConnection.class;
+        }
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/BeanAwareSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/BeanAwareSnapshotter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.bean.spi.BeanRegistryAware;
+
+public class BeanAwareSnapshotter implements BeanRegistryAware {
+    protected BeanRegistry beanRegistry;
+
+    @Override
+    public void injectBeanRegistry(BeanRegistry beanRegistry) {
+        this.beanRegistry = beanRegistry;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialOnlySnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialOnlySnapshotter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+
+public class InitialOnlySnapshotter extends InitialSnapshotter {
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.INITIAL_ONLY.getValue();
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return false;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialSnapshotter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+public class InitialSnapshotter extends BeanAwareSnapshotter implements Snapshotter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InitialSnapshotter.class);
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.INITIAL.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
+
+        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
+        final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
+        final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
+
+        if (offset != null && !offset.isSnapshotRunning()) {
+            // Check to see if the server still has those binlog coordinates ...
+            if (!connection.isBinlogPositionAvailable(config, offset.gtidSet(), offset.getSource().binlogFilename())) {
+                throw new DebeziumException("The connector is trying to read binlog starting at " + offset.getSource() + ", but this is no longer "
+                        + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+
+            }
+        }
+
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return false;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/InitialSnapshotter.java
@@ -15,7 +15,7 @@ import io.debezium.bean.StandardBeanNames;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.connector.mysql.MySqlPartition;
-import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.spi.snapshot.Snapshotter;
 
@@ -36,8 +36,8 @@ public class InitialSnapshotter extends BeanAwareSnapshotter implements Snapshot
     @Override
     public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
 
-        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
         final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final AbstractConnectorConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, getConnectionClass(config));
         final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
         final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/NeverSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/NeverSnapshotter.java
@@ -15,7 +15,7 @@ import io.debezium.bean.StandardBeanNames;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.connector.mysql.MySqlPartition;
-import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.spi.snapshot.Snapshotter;
 
@@ -36,8 +36,8 @@ public class NeverSnapshotter extends BeanAwareSnapshotter implements Snapshotte
     @Override
     public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
 
-        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
         final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final AbstractConnectorConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, getConnectionClass(config));
         final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
         final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/NeverSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/NeverSnapshotter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+public class NeverSnapshotter extends BeanAwareSnapshotter implements Snapshotter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NeverSnapshotter.class);
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.NEVER.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
+
+        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
+        final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
+        final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
+
+        if (offsetContextExists) {
+            if (isSnapshotInProgress) {
+                // The last offset was an incomplete snapshot and now the snapshot was disabled
+                throw new DebeziumException("The connector previously stopped while taking a snapshot, but now the connector is configured "
+                        + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.");
+            }
+            else {
+                // But check to see if the server still has those binlog coordinates ...
+                if (!connection.isBinlogPositionAvailable(config, offset.gtidSet(), offset.getSource().binlogFilename())) {
+                    throw new DebeziumException("The connector is trying to read binlog starting at " + offset.getSource() + ", but this is no longer "
+                            + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+
+                }
+            }
+        }
+
+        // Look to see what the first available binlog file is called, and whether it looks like binlog files have
+        // been purged. If so, then output a warning ...
+        String earliestBinlogFilename = connection.earliestBinlogFilename();
+        if (earliestBinlogFilename == null) {
+            LOGGER.warn("No binlog appears to be available. Ensure that the MySQL row-level binlog is enabled.");
+        }
+        else if (!earliestBinlogFilename.endsWith("00001")) {
+            LOGGER.warn("It is possible the server has purged some binlogs. If this is the case, then using snapshot mode may be required.");
+        }
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return false;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlyRecoverySnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlyRecoverySnapshotter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+
+public class SchemaOnlyRecoverySnapshotter extends SchemaOnlySnapshotter {
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.SCHEMA_ONLY_RECOVERY.getValue();
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return true;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlySnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlySnapshotter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+public class SchemaOnlySnapshotter extends BeanAwareSnapshotter implements Snapshotter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaOnlySnapshotter.class);
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.SCHEMA_ONLY.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
+
+        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
+        final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
+        final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
+
+        if (offset != null && !offset.isSnapshotRunning()) {
+            // Check to see if the server still has those binlog coordinates ...
+            if (!connection.isBinlogPositionAvailable(config, offset.gtidSet(), offset.getSource().binlogFilename())) {
+                throw new DebeziumException("The connector is trying to read binlog starting at " + offset.getSource() + ", but this is no longer "
+                        + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+
+            }
+        }
+
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return false;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlySnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/SchemaOnlySnapshotter.java
@@ -15,7 +15,7 @@ import io.debezium.bean.StandardBeanNames;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.connector.mysql.MySqlPartition;
-import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.spi.snapshot.Snapshotter;
 
@@ -36,8 +36,8 @@ public class SchemaOnlySnapshotter extends BeanAwareSnapshotter implements Snaps
     @Override
     public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
 
-        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
         final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final AbstractConnectorConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, getConnectionClass(config));
         final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
         final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/WhenNeededSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/WhenNeededSnapshotter.java
@@ -11,20 +11,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.bean.StandardBeanNames;
-import io.debezium.bean.spi.BeanRegistry;
-import io.debezium.bean.spi.BeanRegistryAware;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.connector.mysql.MySqlPartition;
-import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.connector.mysql.strategy.AbstractConnectorConnection;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.spi.snapshot.Snapshotter;
 
-public class WhenNeededSnapshotter implements Snapshotter, BeanRegistryAware {
+public class WhenNeededSnapshotter extends BeanAwareSnapshotter implements Snapshotter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WhenNeededSnapshotter.class);
-
-    private BeanRegistry beanRegistry;
 
     @Override
     public String name() {
@@ -37,15 +33,10 @@ public class WhenNeededSnapshotter implements Snapshotter, BeanRegistryAware {
     }
 
     @Override
-    public void injectBeanRegistry(BeanRegistry beanRegistry) {
-        this.beanRegistry = beanRegistry;
-    }
-
-    @Override
     public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
 
-        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
         final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final AbstractConnectorConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, getConnectionClass(config));
         final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
         final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/WhenNeededSnapshotter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/mode/WhenNeededSnapshotter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.mode;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.bean.spi.BeanRegistryAware;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.connector.mysql.strategy.mysql.MySqlConnection;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+public class WhenNeededSnapshotter implements Snapshotter, BeanRegistryAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WhenNeededSnapshotter.class);
+
+    private BeanRegistry beanRegistry;
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotMode.WHEN_NEEDED.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public void injectBeanRegistry(BeanRegistry beanRegistry) {
+        this.beanRegistry = beanRegistry;
+    }
+
+    @Override
+    public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
+
+        final MySqlConnection connection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, MySqlConnection.class);
+        final MySqlConnectorConfig config = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, MySqlConnectorConfig.class);
+        final Offsets<MySqlPartition, MySqlOffsetContext> mySqloffsets = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
+        final MySqlOffsetContext offset = mySqloffsets.getTheOnlyOffset();
+
+        if (offset != null && !offset.isSnapshotRunning()) {
+            // Check to see if the server still has those binlog coordinates ...
+            if (!connection.isBinlogPositionAvailable(config, offset.gtidSet(), offset.getSource().binlogFilename())) {
+                LOGGER.warn(
+                        "The connector is trying to read binlog starting at '{}', but this is no longer available on the server. Forcing the snapshot execution as it is allowed by the configuration.",
+                        offset.getSource());
+                mySqloffsets.resetOffset(mySqloffsets.getTheOnlyPartition());
+
+            }
+        }
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return true;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/query/SelectAllSnapshotQuery.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/query/SelectAllSnapshotQuery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.query;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.snapshot.spi.SnapshotQuery;
+
+public class SelectAllSnapshotQuery implements SnapshotQuery {
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotQueryMode.SELECT_ALL.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public Optional<String> snapshotQuery(String tableId, List<String> snapshotSelectColumns) {
+
+        return Optional.of(snapshotSelectColumns.stream()
+                .collect(Collectors.joining(", ", "SELECT ", " FROM " + tableId)));
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/ConnectorAdapter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/ConnectorAdapter.java
@@ -20,6 +20,7 @@ import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChang
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
@@ -46,7 +47,8 @@ public interface ConnectorAdapter {
      * @throws Exception if an exception is thrown
      */
     void setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(MySqlOffsetContext offsetContext,
-                                                                 AbstractConnectorConnection connection)
+                                                                 AbstractConnectorConnection connection,
+                                                                 SnapshotterService snapshotterService)
             throws Exception;
 
     // todo: should we consider splitting value converters, it may prove useful in the future

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/mariadb/MariaDbConnectorAdapter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/mariadb/MariaDbConnectorAdapter.java
@@ -33,6 +33,7 @@ import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSn
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -68,7 +69,8 @@ public class MariaDbConnectorAdapter implements ConnectorAdapter {
 
     @Override
     public void setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(MySqlOffsetContext offsetContext,
-                                                                        AbstractConnectorConnection connection)
+                                                                        AbstractConnectorConnection connection,
+                                                                        SnapshotterService snapshotterService)
             throws Exception {
         LOGGER.info("Read binlog position of MariaDB primary server");
         final String showMasterStmt = "SHOW MASTER STATUS";
@@ -89,7 +91,7 @@ public class MariaDbConnectorAdapter implements ConnectorAdapter {
                     }
                 });
             }
-            else if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            else if (!snapshotterService.getSnapshotter().shouldStream()) {
                 LOGGER.warn("Failed retrieving binlog position, continuing as streaming CDC wasn't requested");
             }
             else {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/mysql/MySqlConnectorAdapter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/strategy/mysql/MySqlConnectorAdapter.java
@@ -34,6 +34,7 @@ import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSn
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
@@ -68,7 +69,8 @@ public class MySqlConnectorAdapter implements ConnectorAdapter {
 
     @Override
     public void setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(MySqlOffsetContext offsetContext,
-                                                                        AbstractConnectorConnection connection)
+                                                                        AbstractConnectorConnection connection,
+                                                                        SnapshotterService snapshotterService)
             throws Exception {
         LOGGER.info("Read binlog position of MySQL primary server");
         final String showMasterStmt = "SHOW MASTER STATUS";
@@ -85,7 +87,7 @@ public class MySqlConnectorAdapter implements ConnectorAdapter {
                             gtidSet);
                 }
             }
-            else if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            else if (!snapshotterService.getSnapshotter().shouldStream()) {
                 LOGGER.warn("Failed retrieving binlog position, continuing as streaming CDC wasn't requested");
             }
             else {

--- a/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
+++ b/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
@@ -1,0 +1,4 @@
+io.debezium.connector.mysql.snapshot.lock.ExtendedSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalPerconaSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.NoneSnapshotLock

--- a/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
+++ b/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
@@ -1,0 +1,1 @@
+io.debezium.connector.mysql.snapshot.query.SelectAllSnapshotQuery

--- a/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -1,0 +1,6 @@
+io.debezium.connector.mysql.snapshot.mode.InitialSnapshotter
+io.debezium.connector.mysql.snapshot.mode.InitialOnlySnapshotter
+io.debezium.connector.mysql.snapshot.mode.SchemaOnlySnapshotter
+io.debezium.connector.mysql.snapshot.mode.SchemaOnlyRecoverySnapshotter
+io.debezium.connector.mysql.snapshot.mode.WhenNeededSnapshotter
+io.debezium.connector.mysql.snapshot.mode.NeverSnapshotter

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/CustomTestSnapshot.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/CustomTestSnapshot.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.bean.spi.BeanRegistryAware;
+import io.debezium.connector.mysql.snapshot.query.SelectAllSnapshotQuery;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+/**
+ * This is a small class used in PostgresConnectorIT to test a custom snapshot
+ *
+ * It is tightly coupled to the test there, but needs to be placed here in order
+ * to allow for class loading to work
+ */
+public class CustomTestSnapshot extends SelectAllSnapshotQuery implements Snapshotter, BeanRegistryAware {
+
+    private boolean hasState;
+
+    @Override
+    public String name() {
+        return CustomTestSnapshot.class.getName();
+    }
+
+    @Override
+    public void injectBeanRegistry(BeanRegistry beanRegistry) {
+
+        Offsets<MySqlPartition, MySqlOffsetContext> mySqlOffsetContext = beanRegistry.lookupByName(StandardBeanNames.OFFSETS, Offsets.class);
+        hasState = mySqlOffsetContext.getTheOnlyOffset() != null;
+    }
+
+    @Override
+    public void validate(boolean offsetContextExists, boolean isSnapshotInProgress) {
+        hasState = offsetContextExists;
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return false;
+    }
+
+    @Override
+    public Optional<String> snapshotQuery(String tableId, List<String> snapshotSelectColumns) {
+
+        if (!hasState && tableId.contains("`b`")) {
+            return Optional.empty();
+        }
+        else {
+            String query = snapshotSelectColumns.stream()
+                    .collect(Collectors.joining(", ", "SELECT ", " FROM " + tableId));
+
+            return Optional.of(query);
+        }
+    }
+}

--- a/debezium-connector-mysql/src/test/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
+++ b/debezium-connector-mysql/src/test/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
@@ -1,0 +1,1 @@
+io.debezium.connector.mysql.CustomTestSnapshot

--- a/debezium-connector-mysql/src/test/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/debezium-connector-mysql/src/test/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -1,0 +1,1 @@
+io.debezium.connector.mysql.CustomTestSnapshot

--- a/debezium-connector-mysql/src/test/resources/ddl/custom_snapshot.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/custom_snapshot.sql
@@ -1,0 +1,10 @@
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  custom_snapshot
+-- ----------------------------------------------------------------------------------------------------------------
+
+
+CREATE TABLE a (pk INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, aa integer) AUTO_INCREMENT=1;
+CREATE TABLE b (pk INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, aa integer) AUTO_INCREMENT=1;
+
+INSERT INTO a (aa) VALUES (1);
+INSERT INTO b (aa) VALUES (1);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -19,6 +19,7 @@ import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -34,11 +35,12 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     private final Configuration jdbcConfig;
     private final OracleTaskContext taskContext;
     private final AbstractOracleStreamingChangeEventSourceMetrics streamingMetrics;
+    private final SnapshotterService snapshotterService;
 
     public OracleChangeEventSourceFactory(OracleConnectorConfig configuration, MainConnectionProvidingConnectionFactory<OracleConnection> connectionFactory,
                                           ErrorHandler errorHandler, EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock, OracleDatabaseSchema schema,
                                           Configuration jdbcConfig, OracleTaskContext taskContext,
-                                          AbstractOracleStreamingChangeEventSourceMetrics streamingMetrics) {
+                                          AbstractOracleStreamingChangeEventSourceMetrics streamingMetrics, SnapshotterService snapshotterService) {
         this.configuration = configuration;
         this.connectionFactory = connectionFactory;
         this.errorHandler = errorHandler;
@@ -48,12 +50,14 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
         this.jdbcConfig = jdbcConfig;
         this.taskContext = taskContext;
         this.streamingMetrics = streamingMetrics;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override
     public SnapshotChangeEventSource<OraclePartition, OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<OraclePartition> snapshotProgressListener,
                                                                                                         NotificationService<OraclePartition, OracleOffsetContext> notificationService) {
-        return new OracleSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService);
+        return new OracleSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService,
+                snapshotterService);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -36,6 +36,7 @@ import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -143,17 +144,18 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
         NotificationService<OraclePartition, OracleOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
                 connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
 
+        SnapshotterService snapshotterService = null; // TODO with DBZ-7302
         ChangeEventSourceCoordinator<OraclePartition, OracleOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffsets,
                 errorHandler,
                 OracleConnector.class,
                 connectorConfig,
                 new OracleChangeEventSourceFactory(connectorConfig, connectionFactory, errorHandler, dispatcher, clock, schema, jdbcConfig, taskContext,
-                        streamingMetrics),
+                        streamingMetrics, snapshotterService),
                 new OracleChangeEventSourceMetricsFactory(streamingMetrics),
                 dispatcher,
                 schema, signalProcessor,
-                notificationService);
+                notificationService, snapshotterService);
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -34,6 +34,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 
@@ -53,8 +54,8 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     public OracleSnapshotChangeEventSource(OracleConnectorConfig connectorConfig, MainConnectionProvidingConnectionFactory<OracleConnection> connectionFactory,
                                            OracleDatabaseSchema schema, EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
                                            SnapshotProgressListener<OraclePartition> snapshotProgressListener,
-                                           NotificationService<OraclePartition, OracleOffsetContext> notificationService) {
-        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService);
+                                           NotificationService<OraclePartition, OracleOffsetContext> notificationService, SnapshotterService snapshotterService) {
+        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = connectionFactory.mainConnection();
         this.databaseSchema = schema;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
@@ -49,7 +49,7 @@ public class PostgresChangeEventSourceCoordinator extends ChangeEventSourceCoord
                                                 SignalProcessor<PostgresPartition, PostgresOffsetContext> signalProcessor,
                                                 NotificationService<PostgresPartition, PostgresOffsetContext> notificationService) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
-                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor, notificationService);
+                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor, notificationService, snapshotterService);
         this.snapshotterService = snapshotterService;
         this.slotInfo = slotInfo;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -857,7 +857,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.NONE)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 12))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 13))
             .withDescription("Controls how the connector holds locks on tables while performing the schema snapshot. The 'shared' "
                     + "which means the connector will hold a table lock that prevents exclusive table access for just the initial portion of the snapshot "
                     + "while the database schemas and other metadata are being read. The remaining work in a snapshot involves selecting all rows from "
@@ -868,7 +868,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field SNAPSHOT_LOCKING_MODE_CUSTOM_NAME = Field.create("snapshot.locking.mode.custom.name")
             .withDisplayName("Snapshot Locking Mode Custom Name")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 13))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 14))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withValidation((config, field, output) -> {
@@ -887,13 +887,13 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withEnum(SnapshotQueryMode.class, SnapshotQueryMode.SELECT_ALL)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 14))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 15))
             .withDescription("Controls query used during the snapshot");
 
     public static final Field SNAPSHOT_QUERY_MODE_CUSTOM_NAME = Field.create("snapshot.query.mode.custom.name")
             .withDisplayName("Snapshot Query Mode Custom Name")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 15))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 16))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withValidation((config, field, output) -> {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -857,7 +857,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.NONE)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 13))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 12))
             .withDescription("Controls how the connector holds locks on tables while performing the schema snapshot. The 'shared' "
                     + "which means the connector will hold a table lock that prevents exclusive table access for just the initial portion of the snapshot "
                     + "while the database schemas and other metadata are being read. The remaining work in a snapshot involves selecting all rows from "
@@ -868,7 +868,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field SNAPSHOT_LOCKING_MODE_CUSTOM_NAME = Field.create("snapshot.locking.mode.custom.name")
             .withDisplayName("Snapshot Locking Mode Custom Name")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 14))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 13))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withValidation((config, field, output) -> {
@@ -879,7 +879,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             })
             .withDescription(
-                    "When 'snapshot.locking.mode' is set as custom, this setting must be set to specify the name of the custom implementation provided in the 'name()' method. "
+                    "When 'snapshot.locking.mode' is set as custom, this setting must be set to specify a the name of the custom implementation provided in the 'name()' method. "
                             + "The implementations must implement the 'SnapshotterLocking' interface and is called to determine how to lock tables during schema snapshot.");
 
     public static final Field SNAPSHOT_QUERY_MODE = Field.create("snapshot.query.mode")
@@ -887,13 +887,13 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withEnum(SnapshotQueryMode.class, SnapshotQueryMode.SELECT_ALL)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 15))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 14))
             .withDescription("Controls query used during the snapshot");
 
     public static final Field SNAPSHOT_QUERY_MODE_CUSTOM_NAME = Field.create("snapshot.query.mode.custom.name")
             .withDisplayName("Snapshot Query Mode Custom Name")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 16))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 15))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withValidation((config, field, output) -> {
@@ -904,7 +904,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             })
             .withDescription(
-                    "When 'snapshot.query.mode' is set as custom, this setting must be set to specify the name of the custom implementation provided in the 'name()' method. "
+                    "When 'snapshot.query.mode' is set as custom, this setting must be set to specify a the name of the custom implementation provided in the 'name()' method. "
                             + "The implementations must implement the 'SnapshotterQuery' interface and is called to determine how to build queries during snapshot.");
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.PostgresOffsetContext.Loader;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
-import io.debezium.connector.postgresql.snapshot.mode.AlwaysSnapshotter;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
@@ -33,7 +32,6 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.snapshot.SnapshotterService;
-import io.debezium.spi.snapshot.Snapshotter;
 import io.debezium.util.Clock;
 
 public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> {
@@ -43,8 +41,6 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     private final PostgresConnectorConfig connectorConfig;
     private final PostgresConnection jdbcConnection;
     private final PostgresSchema schema;
-    private final SnapshotterService snapshotterService;
-    private final Snapshotter blockingSnapshotter;
     private final SlotCreationResult slotCreatedInfo;
     private final SlotState startingSlotInfo;
 
@@ -53,14 +49,12 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
                                              EventDispatcher<PostgresPartition, TableId> dispatcher, Clock clock,
                                              SnapshotProgressListener<PostgresPartition> snapshotProgressListener, SlotCreationResult slotCreatedInfo,
                                              SlotState startingSlotInfo, NotificationService<PostgresPartition, PostgresOffsetContext> notificationService) {
-        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService);
+        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = connectionFactory.mainConnection();
         this.schema = schema;
-        this.snapshotterService = snapshotterService;
         this.slotCreatedInfo = slotCreatedInfo;
         this.startingSlotInfo = startingSlotInfo;
-        this.blockingSnapshotter = new AlwaysSnapshotter();
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
@@ -30,6 +30,7 @@ import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext;
 import io.debezium.util.Metronome;
@@ -55,9 +56,10 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
                                                  DatabaseSchema<?> schema,
                                                  Clock clock,
                                                  SignalProcessor<SqlServerPartition, SqlServerOffsetContext> signalProcessor,
-                                                 NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
+                                                 NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService,
+                                                 SnapshotterService snapshotterService) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
-                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor, notificationService);
+                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor, notificationService, snapshotterService);
         this.clock = clock;
         this.pollInterval = connectorConfig.getPollInterval();
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -19,6 +19,7 @@ import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
@@ -33,11 +34,12 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
     private final NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService;
+    private final SnapshotterService snapshotterService;
 
     public SqlServerChangeEventSourceFactory(SqlServerConnectorConfig configuration, MainConnectionProvidingConnectionFactory<SqlServerConnection> connectionFactory,
                                              SqlServerConnection metadataConnection, ErrorHandler errorHandler, EventDispatcher<SqlServerPartition, TableId> dispatcher,
                                              Clock clock, SqlServerDatabaseSchema schema,
-                                             NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
+                                             NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService, SnapshotterService snapshotterService) {
         this.configuration = configuration;
         this.connectionFactory = connectionFactory;
         this.metadataConnection = metadataConnection;
@@ -46,12 +48,14 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
         this.clock = clock;
         this.schema = schema;
         this.notificationService = notificationService;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override
     public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
                                                                                                               NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
-        return new SqlServerSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService);
+        return new SqlServerSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService,
+                snapshotterService);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -33,6 +33,7 @@ import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
 
@@ -138,19 +139,22 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
                 connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
 
+        SnapshotterService snapshotterService = null; // TODO with DBZ-7303
+
         ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator = new SqlServerChangeEventSourceCoordinator(
                 offsets,
                 errorHandler,
                 SqlServerConnector.class,
                 connectorConfig,
                 new SqlServerChangeEventSourceFactory(connectorConfig, connectionFactory, metadataConnection, errorHandler, dispatcher, clock, schema,
-                        notificationService),
+                        notificationService, snapshotterService),
                 new SqlServerMetricsFactory(offsets.getPartitions()),
                 dispatcher,
                 schema,
                 clock,
                 signalProcessor,
-                notificationService);
+                notificationService,
+                snapshotterService);
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -33,6 +33,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
 
 public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> {
@@ -52,8 +53,9 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     public SqlServerSnapshotChangeEventSource(SqlServerConnectorConfig connectorConfig, MainConnectionProvidingConnectionFactory<SqlServerConnection> connectionFactory,
                                               SqlServerDatabaseSchema schema, EventDispatcher<SqlServerPartition, TableId> dispatcher, Clock clock,
                                               SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
-                                              NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
-        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService);
+                                              NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService,
+                                              SnapshotterService snapshotterService) {
+        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = connectionFactory.mainConnection();
         this.sqlServerDatabaseSchema = schema;

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -843,6 +843,23 @@ public abstract class CommonConnectorConfig {
                     + "'insert_insert' both open and close signal is written into signal data collection (default); "
                     + "'insert_delete' only open signal is written on signal data collection, the close will delete the relative open signal;");
 
+    public static final Field SNAPSHOT_MODE_CUSTOM_NAME = Field.create("snapshot.mode.custom.name")
+            .withDisplayName("Snapshot Mode Custom Name")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 11))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("custom".equalsIgnoreCase(config.getString("snapshot.mode")) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "", "snapshot.mode.custom.name cannot be empty when snapshot.mode 'custom' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as custom, this setting must be set to specify a the name of the custom implementation provided in the 'name()' method. "
+                            + "The implementations must implement the 'Snapshotter' interface and is called on each app boot to determine whether to do a snapshot.");
+
     public static final Field EVENT_CONVERTING_FAILURE_HANDLING_MODE = Field.create("event.converting.failure.handling.mode")
             .withDisplayName("Event converting failure handling mode")
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 26))

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -846,7 +846,7 @@ public abstract class CommonConnectorConfig {
     public static final Field SNAPSHOT_MODE_CUSTOM_NAME = Field.create("snapshot.mode.custom.name")
             .withDisplayName("Snapshot Mode Custom Name")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 11))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 12))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withValidation((config, field, output) -> {
@@ -870,23 +870,6 @@ public abstract class CommonConnectorConfig {
                     + "'fail' throw an exception that the column of event conversion is failed with unmatched schema type, causing the connector to be stopped. it could need schema recovery to covert successfully; "
                     + "'warn' (the default) the value of column of event that conversion failed will be null and be logged with warn level; "
                     + "'skip' the value of column of event that conversion failed will be null and be logged with debug level.");
-
-    public static final Field SNAPSHOT_MODE_CUSTOM_NAME = Field.create("snapshot.mode.custom.name")
-            .withDisplayName("Snapshot Mode Custom Name")
-            .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 12))
-            .withWidth(Width.MEDIUM)
-            .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("custom".equalsIgnoreCase(config.getString("snapshot.mode")) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "", "snapshot.mode.custom.name cannot be empty when snapshot.mode 'custom' is defined");
-                    return 1;
-                }
-                return 0;
-            })
-            .withDescription(
-                    "When 'snapshot.mode' is set as custom, this setting must be set to specify a the name of the custom implementation provided in the 'name()' method. "
-                            + "The implementations must implement the 'Snapshotter' interface and is called on each app boot to determine whether to do a snapshot.");
 
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -49,6 +49,7 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.pipeline.spi.SnapshotResult.SnapshotResultStatus;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.LoggingContext;
 import io.debezium.util.Threads;
@@ -98,7 +99,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                                         ChangeEventSourceFactory<P, O> changeEventSourceFactory,
                                         ChangeEventSourceMetricsFactory<P> changeEventSourceMetricsFactory, EventDispatcher<P, ?> eventDispatcher,
                                         DatabaseSchema<?> schema,
-                                        SignalProcessor<P, O> signalProcessor, NotificationService<P, O> notificationService) {
+                                        SignalProcessor<P, O> signalProcessor, NotificationService<P, O> notificationService, SnapshotterService snapshotterService) {
         this.previousOffsets = previousOffsets;
         this.errorHandler = errorHandler;
         this.changeEventSourceFactory = changeEventSourceFactory;

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -56,6 +56,7 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.SnapshotTablesRowCountOrder;
 import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.ColumnUtils;
@@ -85,12 +86,14 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     protected final EventDispatcher<P, TableId> dispatcher;
     protected final Clock clock;
     private final SnapshotProgressListener<P> snapshotProgressListener;
+    protected final SnapshotterService snapshotterService;
     protected Queue<JdbcConnection> connectionPool;
 
     public RelationalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig connectorConfig,
                                                MainConnectionProvidingConnectionFactory<? extends JdbcConnection> jdbcConnectionFactory,
                                                RelationalDatabaseSchema schema, EventDispatcher<P, TableId> dispatcher, Clock clock,
-                                               SnapshotProgressListener<P> snapshotProgressListener, NotificationService<P, O> notificationService) {
+                                               SnapshotProgressListener<P> snapshotProgressListener, NotificationService<P, O> notificationService,
+                                               SnapshotterService snapshotterService) {
         super(connectorConfig, snapshotProgressListener, notificationService);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnectionFactory.mainConnection();
@@ -99,6 +102,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         this.dispatcher = dispatcher;
         this.clock = clock;
         this.snapshotProgressListener = snapshotProgressListener;
+        this.snapshotterService = snapshotterService;
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/snapshot/SnapshotterServiceProvider.java
+++ b/debezium-core/src/main/java/io/debezium/snapshot/SnapshotterServiceProvider.java
@@ -52,15 +52,18 @@ public abstract class SnapshotterServiceProvider implements ServiceProvider<Snap
         final SnapshotQuery snapshotQueryService = serviceRegistry.tryGetService(SnapshotQuery.class);
         final SnapshotLock snapshotLockService = serviceRegistry.tryGetService(SnapshotLock.class);
 
-        return snapshotter.map(s -> {
-            s.configure(configuration.asMap());
-            if (s instanceof BeanRegistryAware) {
-                ((BeanRegistryAware) s).injectBeanRegistry(beanRegistry);
-            }
-            return new SnapshotterService(s, snapshotQueryService, snapshotLockService);
-        })
+        return snapshotter.map(s -> getSnapshotterService(configuration, s, beanRegistry, snapshotQueryService, snapshotLockService))
                 .orElseThrow(() -> new DebeziumException(String.format("Unable to find %s snapshotter. Please check your configuration.", snapshotMode)));
 
+    }
+
+    private static SnapshotterService getSnapshotterService(Configuration configuration, Snapshotter s, BeanRegistry beanRegistry, SnapshotQuery snapshotQueryService,
+                                                            SnapshotLock snapshotLockService) {
+        s.configure(configuration.asMap());
+        if (s instanceof BeanRegistryAware) {
+            ((BeanRegistryAware) s).injectBeanRegistry(beanRegistry);
+        }
+        return new SnapshotterService(s, snapshotQueryService, snapshotLockService);
     }
 
     @Override


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-7233

The PR is based on https://github.com/debezium/debezium/pull/5157, must be rebased after its merge. 

- [x] Implement the Snapshotter interface
- [x] Implement the SnapshotLock interface
- [x] Implement the SnapshotQuery interface 
- [x] Add test for a custom Snapshotter
- [x]  Provide PR for Db2, Spanner, Vitess to address new code change