### PR TITLE
DBZ-7420 [MariaDb] Allow tablename. prefix for drop foreign key syntax

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -724,7 +724,7 @@ alterSpecification
         | SET (VISIBLE | INVISIBLE)
         | DROP DEFAULT)                                             #alterByAlterColumnDefault
     | ALTER INDEX uid (VISIBLE | INVISIBLE)                         #alterByAlterIndexVisibility
-    | DROP FOREIGN KEY ifExists? uid                                #alterByDropForeignKey // here ifExists is MariaDB-specific only
+    | DROP FOREIGN KEY ifExists? (uid | fullId)                     #alterByDropForeignKey // here ifExists is MariaDB-specific only. fullId is mariadb only
     | DISABLE KEYS                                                  #alterByDisableKeys
     | ENABLE KEYS                                                   #alterByEnableKeys
     | RENAME renameFormat=(TO | AS)? (uid | fullId)                 #alterByRename
@@ -2240,6 +2240,7 @@ uid
     //| REVERSE_QUOTE_ID
     | CHARSET_REVERSE_QOUTE_STRING
     | STRING_LITERAL
+    | CHARSET_REVERSE_QOUTE_ID_LITERAL
     ;
 
 simpleId

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
@@ -14,6 +14,7 @@ alter table childtable drop index fk_idParent_parentTable;
 alter table t2 drop primary key;
 alter table t3 rename to table3column;
 alter table childtable add constraint `fk1` foreign key (idParent) references parenttable(id) on delete restrict on update cascade;
+alter table `table_name` drop foreign key `table_name`.`foreign_key_column`;
 alter table table3column default character set = cp1251;
 alter table `test` change `id` `id` varchar(10) character set utf8mb4 collate utf8mb4_bin not null;
 alter table `test` change `id` `id` varchar(10) character set utf8mb4 binary not null;


### PR DESCRIPTION
The following statement should be parsed successfully for mariadb -

```mysql
'alter table `table_name` drop foreign key `table_name`.`fk_column`';
```

This is a valid statement in mariadb.

```mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 8
Server version: 10.3.39-MariaDB-1:10.3.39+maria~ubu2004 mariadb.org binary distributionCopyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.


MariaDB [mysql]> create table mysql.parent (`id` int not null, primary key (`id`));
Query OK, 0 rows affected (0.013 sec) 

MariaDB [mysql]> create table mysql.child (`id` int not null, primary key (`id`), parent_id int, foreign key (parent_id) references mysql.parent(id));
Query OK, 0 rows affected (0.007 sec)

-- constraint name is child_ibfk_1
MariaDB [mysql]> alter table `child` drop foreign key `child`.`child_ibfk_1`;
Query OK, 0 rows affected (0.005 sec)
Records: 0  Duplicates: 0  Warnings: 0
```

Although not valid in mysql. 

```mysql
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 8
Server version: 8.3.0 MySQL Community Server - GPLCopyright (c) 2000, 2024, Oracle and/or its affiliates.Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

mysql> create table mysql.parent (`id` int not null, primary key (`id`));
Query OK, 0 rows affected (0.04 sec)

mysql> create table mysql.child (`id` int not null, primary key (`id`), parent_id int, foreign key (parent_id) references mysql.parent(id));
Query OK, 0 rows affected (0.02 sec)

-- constraint name is child_ibfk_1
mysql> alter table `child` drop foreign key `child`.`child_ibfk_1`;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.`child_ibfk_1`' at line 1
```

So, this change is target for mariadb users of this plugin.