### PR TITLE
DBZ-7421 Improve incremental snapshot performance with increasing number of collections to snapshot

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -348,7 +348,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 + Arrays.toString(maximumKey) + "]";
     }
 
-    public static class SnapshotDataCollection<T> extends LinkedList<DataCollection<T>> {
+    private static class SnapshotDataCollection<T> extends LinkedList<DataCollection<T>> {
 
         public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY = INCREMENTAL_SNAPSHOT_KEY + "_collections";
 
@@ -365,15 +365,15 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         private final Queue<DataCollection<T>> dataCollectionsToSnapshot = new LinkedList<>();
         private String dataCollectionsToSnapshotJson;
 
-        public SnapshotDataCollection() {
+        SnapshotDataCollection() {
         }
 
-        public void add(List<DataCollection<T>> dataCollectionIds) {
+        void add(List<DataCollection<T>> dataCollectionIds) {
             this.dataCollectionsToSnapshot.addAll(dataCollectionIds);
             this.dataCollectionsToSnapshotJson = jsonString();
         }
 
-        public DataCollection<T> getNext() {
+        DataCollection<T> getNext() {
             DataCollection<T> nextDataCollection = this.dataCollectionsToSnapshot.poll();
             this.dataCollectionsToSnapshotJson = jsonString();
             return nextDataCollection;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -51,22 +51,14 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     // TODO Consider which (if any) information should be exposed in source info
     public static final String INCREMENTAL_SNAPSHOT_KEY = "incremental_snapshot";
-    public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY = INCREMENTAL_SNAPSHOT_KEY + "_collections";
-
-    public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID = DATA_COLLECTIONS_TO_SNAPSHOT_KEY + "_id";
-
-    public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
-            + "_additional_condition";
-
-    public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
-            + "_surrogate_key";
 
     public static final String EVENT_PRIMARY_KEY = INCREMENTAL_SNAPSHOT_KEY + "_primary_key";
     public static final String TABLE_MAXIMUM_KEY = INCREMENTAL_SNAPSHOT_KEY + "_maximum_key";
     public static final String CORRELATION_ID = INCREMENTAL_SNAPSHOT_KEY + "_correlation_id";
+    private final SnapshotDataCollection<T> snapshotDataCollection = new SnapshotDataCollection<>();
 
     /**
-     * @code(true) if window is opened and deduplication should be executed
+     * {@code true} if window is opened and deduplication should be executed
      */
     protected boolean windowOpened = false;
 
@@ -78,7 +70,6 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     // TODO After extracting add into source info optional block
     // incrementalSnapshotWindow{String from, String to}
     // State to be stored and recovered from offsets
-    private final Queue<DataCollection<T>> dataCollectionsToSnapshot = new LinkedList<>();
 
     private final boolean useCatalogBeforeSchema;
     /**
@@ -104,11 +95,6 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
      * Determines if the incremental snapshot was paused or not.
      */
     private final AtomicBoolean paused = new AtomicBoolean(false);
-    private final ObjectMapper mapper = new ObjectMapper();
-    private String dataCollectionsToSnapshotJson;
-
-    private final TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
-    };
 
     public AbstractIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
@@ -185,49 +171,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         }
     }
 
-    private String dataCollectionsToSnapshotAsString() {
-        // TODO Handle non-standard table ids containing dots, commas etc.
-
-        if (!Strings.isNullOrEmpty(dataCollectionsToSnapshotJson)) {
-            // A cached value to improve performance since this method is called in the "store"
-            // that is called during events processing
-            return dataCollectionsToSnapshotJson;
-        }
-
-        try {
-            List<LinkedHashMap<String, String>> dataCollectionsMap = dataCollectionsToSnapshot.stream()
-                    .map(x -> {
-                        LinkedHashMap<String, String> map = new LinkedHashMap<>();
-                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, x.getId().toString());
-                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
-                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
-                        return map;
-                    })
-                    .collect(Collectors.toList());
-            return mapper.writeValueAsString(dataCollectionsMap);
-        }
-        catch (JsonProcessingException e) {
-            throw new DebeziumException("Cannot serialize dataCollectionsToSnapshot information");
-        }
-    }
-
-    private List<DataCollection<T>> stringToDataCollections(String dataCollectionsStr) {
-        try {
-            List<LinkedHashMap<String, String>> dataCollections = mapper.readValue(dataCollectionsStr, mapperTypeRef);
-            List<DataCollection<T>> dataCollectionsList = dataCollections.stream()
-                    .map(x -> new DataCollection<T>((T) TableId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID), useCatalogBeforeSchema),
-                            Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)).orElse(""),
-                            Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY)).orElse("")))
-                    .collect(Collectors.toList());
-            return dataCollectionsList;
-        }
-        catch (JsonProcessingException e) {
-            throw new DebeziumException("Cannot de-serialize dataCollectionsToSnapshot information");
-        }
-    }
-
     public boolean snapshotRunning() {
-        return !dataCollectionsToSnapshot.isEmpty();
+        return !snapshotDataCollection.isEmpty();
     }
 
     public Map<String, Object> store(Map<String, Object> offset) {
@@ -236,14 +181,13 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         }
         offset.put(EVENT_PRIMARY_KEY, arrayToSerializedString(lastEventKeySent));
         offset.put(TABLE_MAXIMUM_KEY, arrayToSerializedString(maximumKey));
-        offset.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY, dataCollectionsToSnapshotAsString());
+        offset.put(SnapshotDataCollection.DATA_COLLECTIONS_TO_SNAPSHOT_KEY, snapshotDataCollection.dataCollectionsAsJsonString());
         offset.put(CORRELATION_ID, correlationId);
         return offset;
     }
 
     private void addTablesIdsToSnapshot(List<DataCollection<T>> dataCollectionIds) {
-        dataCollectionsToSnapshot.addAll(dataCollectionIds);
-        dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
+        snapshotDataCollection.add(dataCollectionIds);
     }
 
     @SuppressWarnings("unchecked")
@@ -272,8 +216,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     @Override
     public void stopSnapshot() {
-        this.dataCollectionsToSnapshot.clear();
-        this.dataCollectionsToSnapshotJson = null;
+        this.snapshotDataCollection.clear();
         this.correlationId = null;
     }
 
@@ -281,14 +224,12 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @SuppressWarnings("unchecked")
     public boolean removeDataCollectionFromSnapshot(String dataCollectionId) {
         final T collectionId = (T) TableId.parse(dataCollectionId, useCatalogBeforeSchema);
-        boolean removed = dataCollectionsToSnapshot.removeAll(Arrays.asList(new DataCollection<T>(collectionId)));
-        this.dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
-        return removed;
+        return snapshotDataCollection.remove(List.of(new DataCollection<>(collectionId)));
     }
 
     @Override
     public List<DataCollection<T>> getDataCollections() {
-        return new ArrayList<>(dataCollectionsToSnapshot);
+        return new ArrayList<>(snapshotDataCollection.getDataCollectionsToSnapshot());
     }
 
     @Override
@@ -310,11 +251,10 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         final String maximumKeyStr = (String) offsets.get(TABLE_MAXIMUM_KEY);
         context.maximumKey = (maximumKeyStr != null) ? context.serializedStringToArray(TABLE_MAXIMUM_KEY, maximumKeyStr)
                 : null;
-        final String dataCollectionsStr = (String) offsets.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY);
-        context.dataCollectionsToSnapshot.clear();
-        context.dataCollectionsToSnapshotJson = null;
+        final String dataCollectionsStr = (String) offsets.get(SnapshotDataCollection.DATA_COLLECTIONS_TO_SNAPSHOT_KEY);
+        context.snapshotDataCollection.clear();
         if (dataCollectionsStr != null) {
-            context.addTablesIdsToSnapshot(context.stringToDataCollections(dataCollectionsStr));
+            context.addTablesIdsToSnapshot(context.snapshotDataCollection.stringToDataCollections(dataCollectionsStr, context.useCatalogBeforeSchema));
         }
         context.correlationId = (String) offsets.get(CORRELATION_ID);
         return context;
@@ -325,11 +265,11 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     }
 
     public DataCollection<T> currentDataCollectionId() {
-        return dataCollectionsToSnapshot.peek();
+        return snapshotDataCollection.peek();
     }
 
     public int dataCollectionsToBeSnapshottedCount() {
-        return dataCollectionsToSnapshot.size();
+        return snapshotDataCollection.size();
     }
 
     public void nextChunkPosition(Object[] end) {
@@ -359,9 +299,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     public DataCollection<T> nextDataCollection() {
         resetChunk();
-        DataCollection<T> nextDataCollection = dataCollectionsToSnapshot.poll();
-        this.dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
-        return nextDataCollection;
+        return snapshotDataCollection.getNext();
     }
 
     public void startNewChunk() {
@@ -405,8 +343,112 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @Override
     public String toString() {
         return "IncrementalSnapshotContext [windowOpened=" + windowOpened + ", chunkEndPosition="
-                + Arrays.toString(chunkEndPosition) + ", dataCollectionsToSnapshot=" + dataCollectionsToSnapshot
+                + Arrays.toString(chunkEndPosition) + ", dataCollectionsToSnapshot=" + snapshotDataCollection.getDataCollectionsToSnapshot()
                 + ", lastEventKeySent=" + Arrays.toString(lastEventKeySent) + ", maximumKey="
                 + Arrays.toString(maximumKey) + "]";
+    }
+
+    public static class SnapshotDataCollection<T> extends LinkedList<DataCollection<T>> {
+
+        public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY = INCREMENTAL_SNAPSHOT_KEY + "_collections";
+
+        public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID = DATA_COLLECTIONS_TO_SNAPSHOT_KEY + "_id";
+
+        public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
+                + "_additional_condition";
+
+        public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
+                + "_surrogate_key";
+        private final ObjectMapper mapper = new ObjectMapper();
+        private final TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
+        };
+        private final Queue<DataCollection<T>> dataCollectionsToSnapshot = new LinkedList<>();
+        private String dataCollectionsToSnapshotJson;
+
+        public SnapshotDataCollection() {
+        }
+
+        public void add(List<DataCollection<T>> dataCollectionIds) {
+            this.dataCollectionsToSnapshot.addAll(dataCollectionIds);
+            this.dataCollectionsToSnapshotJson = jsonString();
+        }
+
+        public DataCollection<T> getNext() {
+            DataCollection<T> nextDataCollection = this.dataCollectionsToSnapshot.poll();
+            this.dataCollectionsToSnapshotJson = jsonString();
+            return nextDataCollection;
+        }
+
+        public DataCollection<T> peek() {
+            return this.dataCollectionsToSnapshot.peek();
+        }
+
+        public int size() {
+            return this.dataCollectionsToSnapshot.size();
+        }
+
+        public void clear() {
+            this.dataCollectionsToSnapshot.clear();
+            this.dataCollectionsToSnapshotJson = null;
+        }
+
+        public boolean isEmpty() {
+            return this.dataCollectionsToSnapshot.isEmpty();
+        }
+
+        public boolean remove(List<DataCollection<T>> toRemove) {
+            boolean removed = this.dataCollectionsToSnapshot.removeAll(toRemove);
+            this.dataCollectionsToSnapshotJson = jsonString();
+            return removed;
+        }
+
+        public String dataCollectionsAsJsonString() {
+            return this.dataCollectionsToSnapshotJson;
+        }
+
+        public Queue<DataCollection<T>> getDataCollectionsToSnapshot() {
+            return this.dataCollectionsToSnapshot;
+        }
+
+        private String jsonString() {
+            // TODO Handle non-standard table ids containing dots, commas etc.
+
+            if (!Strings.isNullOrEmpty(dataCollectionsToSnapshotJson)) {
+                // A cached value to improve performance since this method is called in the "store"
+                // that is called during events processing
+                return dataCollectionsToSnapshotJson;
+            }
+
+            try {
+                List<LinkedHashMap<String, String>> dataCollectionsMap = dataCollectionsToSnapshot.stream()
+                        .map(x -> {
+                            LinkedHashMap<String, String> map = new LinkedHashMap<>();
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, x.getId().toString());
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
+                            return map;
+                        })
+                        .collect(Collectors.toList());
+
+                return mapper.writeValueAsString(dataCollectionsMap);
+            }
+            catch (JsonProcessingException e) {
+                throw new DebeziumException("Cannot serialize dataCollectionsToSnapshot information");
+            }
+        }
+
+        private List<DataCollection<T>> stringToDataCollections(String dataCollectionsStr, boolean useCatalogBeforeSchema) {
+            try {
+                List<LinkedHashMap<String, String>> dataCollections = mapper.readValue(dataCollectionsStr, mapperTypeRef);
+                return dataCollections.stream()
+                        .map(x -> new DataCollection<>((T) TableId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID), useCatalogBeforeSchema),
+                                Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)).orElse(""),
+                                Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY)).orElse("")))
+                        .collect(Collectors.toList());
+            }
+            catch (JsonProcessingException e) {
+                throw new DebeziumException("Cannot de-serialize dataCollectionsToSnapshot information");
+            }
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -36,6 +36,7 @@ import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
+import io.debezium.util.Strings;
 
 /**
  * A class describing current state of incremental snapshot
@@ -102,10 +103,11 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     /**
      * Determines if the incremental snapshot was paused or not.
      */
-    private AtomicBoolean paused = new AtomicBoolean(false);
-    private ObjectMapper mapper = new ObjectMapper();
+    private final AtomicBoolean paused = new AtomicBoolean(false);
+    private final ObjectMapper mapper = new ObjectMapper();
+    private String dataCollectionsToSnapshotJson;
 
-    private TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
+    private final TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
     };
 
     public AbstractIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
@@ -185,14 +187,20 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     private String dataCollectionsToSnapshotAsString() {
         // TODO Handle non-standard table ids containing dots, commas etc.
+
+        if (!Strings.isNullOrEmpty(dataCollectionsToSnapshotJson)) {
+            // A cached value to improve performance since this method is called in the "store"
+            // that is called during events processing
+            return dataCollectionsToSnapshotJson;
+        }
+
         try {
             List<LinkedHashMap<String, String>> dataCollectionsMap = dataCollectionsToSnapshot.stream()
                     .map(x -> {
                         LinkedHashMap<String, String> map = new LinkedHashMap<>();
                         map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, x.getId().toString());
-                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION,
-                                x.getAdditionalCondition().isEmpty() ? null : x.getAdditionalCondition().orElse(null));
-                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().isEmpty() ? null : x.getSurrogateKey().orElse(null));
+                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
+                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
                         return map;
                     })
                     .collect(Collectors.toList());
@@ -235,6 +243,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     private void addTablesIdsToSnapshot(List<DataCollection<T>> dataCollectionIds) {
         dataCollectionsToSnapshot.addAll(dataCollectionIds);
+        dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
     }
 
     @SuppressWarnings("unchecked")
@@ -264,6 +273,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @Override
     public void stopSnapshot() {
         this.dataCollectionsToSnapshot.clear();
+        this.dataCollectionsToSnapshotJson = null;
         this.correlationId = null;
     }
 
@@ -271,7 +281,9 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @SuppressWarnings("unchecked")
     public boolean removeDataCollectionFromSnapshot(String dataCollectionId) {
         final T collectionId = (T) TableId.parse(dataCollectionId, useCatalogBeforeSchema);
-        return dataCollectionsToSnapshot.removeAll(Arrays.asList(new DataCollection<T>(collectionId)));
+        boolean removed = dataCollectionsToSnapshot.removeAll(Arrays.asList(new DataCollection<T>(collectionId)));
+        this.dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
+        return removed;
     }
 
     @Override
@@ -300,6 +312,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 : null;
         final String dataCollectionsStr = (String) offsets.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY);
         context.dataCollectionsToSnapshot.clear();
+        context.dataCollectionsToSnapshotJson = null;
         if (dataCollectionsStr != null) {
             context.addTablesIdsToSnapshot(context.stringToDataCollections(dataCollectionsStr));
         }
@@ -346,7 +359,9 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     public DataCollection<T> nextDataCollection() {
         resetChunk();
-        return dataCollectionsToSnapshot.poll();
+        DataCollection<T> nextDataCollection = dataCollectionsToSnapshot.poll();
+        this.dataCollectionsToSnapshotJson = dataCollectionsToSnapshotAsString();
+        return nextDataCollection;
     }
 
     public void startNewChunk() {

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/core/IncrementalSnapshotContextPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/core/IncrementalSnapshotContextPerf.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.core;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
+import io.debezium.relational.TableId;
+
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 2, time = 5)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode({ Mode.Throughput })
+public class IncrementalSnapshotContextPerf {
+
+    private SignalBasedIncrementalSnapshotContext<TableId> snapshotContext;
+
+    @Param({ "1", "5", "10", "50", "100" })
+    private int numberOfTableToSnapshot;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        snapshotContext = new SignalBasedIncrementalSnapshotContext<>(false);
+        List<String> dataCollectionIds = generateDataCollectionIds(numberOfTableToSnapshot);
+        snapshotContext.addDataCollectionNamesToSnapshot("1",
+                dataCollectionIds,
+                dataCollectionIds.stream().map(id -> AdditionalCondition.AdditionalConditionBuilder.builder()
+                        .dataCollection(Pattern.compile(id))
+                        .filter("color='blue'")
+                        .build()).collect(Collectors.toList()),
+                "");
+    }
+
+    private List<String> generateDataCollectionIds(int number) {
+
+        return IntStream.rangeClosed(1, number)
+                .mapToObj(i -> IntStream.rangeClosed(1, number)
+                        .mapToObj(j -> String.format("%s.%s", "db" + i, "table" + j))
+                        .collect(Collectors.toList()))
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
+
+    @Benchmark
+    public void store() {
+        Map<String, Object> offset = new HashMap<>();
+        snapshotContext.store(offset);
+    }
+}


### PR DESCRIPTION
a possibile solution for https://issues.redhat.com/browse/DBZ-7421

Before
```
Benchmark                             (numberOfTableToSnapshot)   Mode  Cnt       Score   Error  Units
IncrementalSnapshotContextPerf.store                          1  thrpt    2  962999.691          ops/s
IncrementalSnapshotContextPerf.store                          5  thrpt    2  118903.880          ops/s
IncrementalSnapshotContextPerf.store                         10  thrpt    2   31712.744          ops/s
IncrementalSnapshotContextPerf.store                         50  thrpt    2     786.632          ops/s
IncrementalSnapshotContextPerf.store                        100  thrpt    2     195.274          ops/s
```

After some code optimization
```
Benchmark                             (numberOfTableToSnapshot)   Mode  Cnt       Score   Error  Units
IncrementalSnapshotContextPerf.store                          1  thrpt    2  926594.940          ops/s
IncrementalSnapshotContextPerf.store                          5  thrpt    2  130743.643          ops/s
IncrementalSnapshotContextPerf.store                         10  thrpt    2   30547.231          ops/s
IncrementalSnapshotContextPerf.store                         50  thrpt    2     873.143          ops/s
IncrementalSnapshotContextPerf.store                        100  thrpt    2     222.739          ops/s
```

With the cache
```
Benchmark                             (numberOfTableToSnapshot)   Mode  Cnt        Score   Error  Units
IncrementalSnapshotContextPerf.store                          1  thrpt    2  1794620.143          ops/s
IncrementalSnapshotContextPerf.store                          5  thrpt    2  1984367.094          ops/s
IncrementalSnapshotContextPerf.store                         10  thrpt    2  1792400.614          ops/s
IncrementalSnapshotContextPerf.store                         50  thrpt    2  1985691.291          ops/s
IncrementalSnapshotContextPerf.store                        100  thrpt    2  1911970.545          ops/s
```

Even if improving the code that serializes the data collections to JSON, the performance was not good. Adding a cache seems the best approach here. 
With this implementation the serialize code will not affect the `store` method that is called during the event `IncrementalSnapshotChangeRecordReceiver` but will affect the methods that modify the `dataCollectionsToSnapshot` variable, but the impact in this case is limited to the number of data collections to snapshot and not at every events. 

@Naros, @jpechane @vjuranek @jcechace  WDYT?  