### PR TITLE
DBZ-7046 Backport formatting and link fixes to 2.3

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -79,10 +79,11 @@ The following example shows a typical notification that provides the status of a
 {
     "id": "5563ae14-49f8-4579-9641-c1bbc2d76f99",
     "aggregate_type": "Initial Snapshot",
-    "type": "COMPLETED" <1>
+    "type": "COMPLETED", // <1>
 }
 ----
-<1> The type field can contain one of the following values:
+
+<1> The `type` field can contain one of the following values:
 
 * `COMPLETED`
 * `ABORTED`
@@ -181,13 +182,17 @@ a|[source, json]
    }
 }
 ----
-<1> The possible values are:
-* EMPTY - table is empty
-* NO_PRIMARY_KEY - table has no primary key necessary for snapshot
-* SKIPPED - snapshot for this kind of table is not supported, check logs for details
-* SQL_EXCEPTION - SQL exception caught while processing a snapshot
-* SUCCEEDED - snapshot completed successfully
-* UNKNOWN_SCHEMA - schema not found for table, check logs for the list of known tables
+In the preceding example, the `additional_data.status` field can contain one of the following values:
+
+`EMPTY`:: The table contains no values.
+`NO_PRIMARY_KEY`:: Cannot complete snapshot; table has no primary key.
+`SKIPPED`:: Cannot complete a snapshots for this type of table.
+Refer to the logs for details.
+`SQL_EXCEPTION`:: A SQL exception occurred while performing the snapshot.
+`SUCCEEDED`:: The snapshot completed successfully.
+`UNKNOWN_SCHEMA`:: Could not find a schema for the table.
+Check the logs for the list of known tables.
+
 |Completed
 a|[source, json]
 ----

--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -178,7 +178,7 @@ a|[source, json]
       "data_collection":"table1, table2",
       "scanned_collection":"table1",
       "total_rows_scanned":"100",
-      "status":"SUCCEEDED" // <1>
+      "status":"SUCCEEDED"
    }
 }
 ----

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -306,7 +306,7 @@ You can add the schema by running a new schema snapshot, or by running an initia
 Initial snapshot captured the schema for all tables (`store.only.captured.tables.ddl` was set to `false`)::
 1. Edit the xref:{context}-property-table-include-list[`table.include.list`] property to specify the tables that you want to capture.
 2. Restart the connector.
-3. Initiate an xref:{context}-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
+3. Initiate an xref:debezium-db2-incremental-snapshots[incremental snapshot] if you want to capture existing data from the newly added tables.
 
 Initial snapshot did not capture the schema for all tables (`store.only.captured.tables.ddl` was set to `true`)::
 If the initial snapshot did not save the schema of the table that you want to capture, complete one of the following procedures:

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -222,8 +222,8 @@ To provide for the greatest control, run a separate Kafka Connect cluster for ea
 ifdef::product[]
 You can find more information about snapshots in the following sections:
 
-* xref:debezium-postgresql-ad-hoc-snapshots[]
-* xref:debezium-postgresql-incremental-snapshots[]
+* xref:debezium-mongodb-ad-hoc-snapshots[]
+* xref:debezium-mongodb-incremental-snapshots[]
 endif::product[]
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -693,7 +693,7 @@ This operation is potentially destructive, and should be performed only as a las
 6. Restart the connector.
 The connector takes a full database snapshot.
 After the snapshot completes, the connector transitions to streaming.
-7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:mysql-incremental-snapshots[incremental snapshot].
+7. (Optional) To capture any data that changed while the connector was off-line, initiate an xref:debezium-mysql-incremental-snapshots[incremental snapshot].
 
 // Type: concept
 // ModuleID: debezium-mysql-ad-hoc-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -500,7 +500,7 @@ For the connector to perform a snapshot that uses table-level locks, the databas
 
 .Default workflow that the {prodname} MySQL connector uses to perform an initial snapshot with table-level locks
 The following workflow lists the steps that {prodname} takes to create a snapshot with table-level read locks.
-For information about the snapshot process in environments that do not permit global read locks, see the xref:default-snapshot-workflow-with-global-read-lock[snapshot workflow for global read locks].
+For information about the snapshot process in environments that do not permit global read locks, see the xref:initial-snapshot-workflow-with-global-read-lock[snapshot workflow for global read locks].
 
 [id="snapshot-workflow-with-table-level-locks"]
 [cols="1,9",options="header",subs="+attributes"]
@@ -589,7 +589,7 @@ This can be useful when you want to reduce the time required to complete a snaps
 Or when {prodname} connects to the database instance through a user account that has access to multiple logical databases, but you want the connector to capture changes only from tables in a specific logic database.
 
 .Additional information
-* xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot[Capturing data from tables not captured by the initial snapshot (no schema change)]
+* xref:{context}-capturing-data-from-tables-not-captured-by-the-initial-snapshot-no-schema-change[Capturing data from tables not captured by the initial snapshot (no schema change)]
 * xref:{context}-capturing-data-from-new-tables-with-schema-changes[Capturing data from tables not captured by the initial snapshot (schema change)]
 * Setting the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] property to specify the tables from which to capture schema information.
 * Setting the xref:{context}-property-database-history-store-only-captured-databases-ddl[`schema.history.internal.store.only.captured.databases.ddl`] property to specify the logical databases from which to capture schema changes.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -339,10 +339,10 @@ The {prodname} connector for Oracle does not support schema changes while an inc
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
-
+// ModuleID: debezium-oracle-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="oracle-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
-// ModuleID: debezium-oracle-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
+
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -176,7 +176,7 @@ transforms.unwrap.add.fields=table,lsn
 
 .Customizing the configuration
 The connector might emit many types of event messages (heartbeat messages, tombstone messages, or metadata messages about transactions or schema changes).
-To apply the transformation to a subset of events, you can define xref:applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
+To apply the transformation to a subset of events, you can define xref:applying-the-event-flattening-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
 
 // Type: concept
 // ModuleID: example-of-adding-debezium-metadata-to-the-kafka-record

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -66,7 +66,7 @@ The snapshot process reads the first and last primary key values and uses those 
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
 Currently, the `execute-snapshot` action type triggers {link-prefix}:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
-For more information, see xref:{context}-incremental-snapshots[Incremental snapshots].
+For more information, see xref:debezium-{context}-incremental-snapshots[Incremental snapshots].
 ////
 .Prerequisites
 


### PR DESCRIPTION
[DBZ-6997](https://issues.redhat.com/browse/DBZ-6997)
[DBZ-7039](https://issues.redhat.com/browse/DBZ-7039)
[DBZ-7046](https://issues.redhat.com/browse/DBZ-7046)

This change fixes formatting and link errors that result in downstream build failures.

These changes were previously applied downstream for the 2.3.4 release and were applied upstream to `main`, but not backported to `2.3`.