### PR TITLE
DBZ-7437: ReselectColumnsPostProcessor filter not use exclude predicate.

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -582,3 +582,4 @@ Peter Hamer
 Artem Shubovych
 leoloel
 Clifford Cheefoon
+Fr0z3Nn

--- a/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -252,7 +252,9 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             if (columnNames == null || columnNames.trim().isEmpty()) {
                 reselectColumnInclusions = null;
             }
-            reselectColumnInclusions = Predicates.includes(columnNames, Pattern.CASE_INSENSITIVE);
+            else {
+                reselectColumnInclusions = Predicates.includes(columnNames, Pattern.CASE_INSENSITIVE);
+            }
             return this;
         }
 
@@ -260,13 +262,20 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             if (columnNames == null || columnNames.trim().isEmpty()) {
                 reselectColumnExclusions = null;
             }
-            reselectColumnExclusions = Predicates.excludes(columnNames, Pattern.CASE_INSENSITIVE);
+            else {
+                reselectColumnExclusions = Predicates.excludes(columnNames, Pattern.CASE_INSENSITIVE);
+            }
             return this;
         }
 
         public Predicate<String> build() {
-            Predicate<String> filter = reselectColumnInclusions != null ? reselectColumnInclusions : reselectColumnExclusions;
-            return filter != null ? filter : (x) -> true;
+            if (reselectColumnInclusions != null) {
+                return reselectColumnInclusions;
+            }
+            if (reselectColumnExclusions != null) {
+                return reselectColumnExclusions;
+            }
+            return (x) -> true;
         }
     }
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -252,3 +252,4 @@ shybovycha,Artem Shubovych
 Liaoyuxing,leoloel
 iankko,Jan Lieskovsky
 CliffordCheefoon,Clifford Cheefoon
+Fr0z3Nn,Ivanov Sergey Vasilevich


### PR DESCRIPTION
The "reselect.columns.exclude.list" property is not applied when configuring the connector. Configuration without exclude+include do not processed (all passed values ignoring).
Reason:
The reselectColumnInclusions predicate never becomes null.
Build filter condition is always true.