### PR TITLE
DBZ-7441 Postpone SignalProcessor start after streaming is initialized

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -147,9 +147,6 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     streamingConnected(false);
                 }
             });
-
-            getSignalProcessor(previousOffsets).ifPresent(signalProcessor -> registerSignalActionsAndStartProcessor(signalProcessor,
-                    eventDispatcher, this, connectorConfig));
         }
         finally {
             if (previousLogContext.get() != null) {
@@ -268,6 +265,8 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
 
     protected void streamEvents(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException {
         initStreamEvents(partition, offsetContext);
+        getSignalProcessor(previousOffsets).ifPresent(signalProcessor -> registerSignalActionsAndStartProcessor(signalProcessor,
+                eventDispatcher, this, connectorConfig));
         LOGGER.info("Starting streaming");
         streamingSource.execute(context, partition, offsetContext);
         LOGGER.info("Finished streaming");

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
@@ -205,6 +205,7 @@ public class KafkaSignalChannel implements SignalChannelReader {
 
     @Override
     public void close() {
+        signalsConsumer.commitSync();
         signalsConsumer.close();
     }
 }


### PR DESCRIPTION
This will avoid, for channels that not depends on the event streaming like the 'source' channel, to start processing signals before the IncrementalSnapshotChangeEventSource is initialized.

closes: https://issues.redhat.com/browse/DBZ-7441