### PR TITLE
DBZ-7446 Reduce string creation during SQL_REDO column read

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
@@ -195,7 +195,7 @@ public class LogMinerEventRowTest {
 
         row = LogMinerEventRow.fromResultSet(resultSet, CATALOG_NAME, true);
         assertThat(row.getRedoSql()).isNull();
-        verify(resultSet, times(13)).getInt(6);
+        verify(resultSet, times(14)).getInt(6);
         verify(resultSet, times(14)).getString(2);
 
         when(resultSet.getInt(6)).thenReturn(0);
@@ -203,7 +203,7 @@ public class LogMinerEventRowTest {
 
         assertThrows(resultSet, SQLException.class);
 
-        verify(resultSet, times(13)).getInt(6);
+        verify(resultSet, times(15)).getInt(6);
         verify(resultSet, times(15)).getString(2);
     }
 


### PR DESCRIPTION
Oracle Connector can create a new string when reading SQL_REDO column only if CSF column value is 1.

https://issues.redhat.com/browse/DBZ-7446