### PR TITLE
DBZ-7443 Correct debezium.sink.pubsub.flowcontrol variables

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -581,3 +581,4 @@ Pavithrananda Prabhu
 Peter Hamer
 Artem Shubovych
 leoloel
+Clifford Cheefoon

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -620,15 +620,15 @@ This is not supported by Pub/Sub so a surrogate key must be used.
 |`10000000L`
 |Once the number of bytes in the batched request reaches this threshold, send all of the messages in a single call, even if neither the delay or message count thresholds have been exceeded yet.
 
-|[[flowControl-enabled]]<<flowControl-enabled, `debezium.sink.pubsub.flowControl.enabled`>>
+|[[flowcontrol-enabled]]<<flowcontrol-enabled, `debezium.sink.pubsub.flowcontrol.enabled`>>
 |`false`
 |When enabled, configures your publisher client with flow control to limit the rate of publish requests.
 
-|[[flowControl-max-outstanding-messages]]<<flowControl-max-outstanding-messages, `debezium.sink.pubsub.flowControl.max.outstanding.messages`>>
+|[[flowcontrol-max-outstanding-messages]]<<flowcontrol-max-outstanding-messages, `debezium.sink.pubsub.flowcontrol.max.outstanding.messages`>>
 |`Long.MAX_VALUE`
 |(Optional) If flow control enabled, the maxmium number of messages before messages are blocked from being published
 
-|[[flowControl-max-outstanding-bytes]]<<flowControl-max-outstanding-bytes, `debezium.sink.pubsub.flowControl.max.outstanding.bytes`>>
+|[[flowcontrol-max-outstanding-bytes]]<<flowcontrol-max-outstanding-bytes, `debezium.sink.pubsub.flowcontrol.max.outstanding.bytes`>>
 |`Long.MAX_VALUE`
 |(Optional) If flow control enabled, the maxmium number of bytes before messages are blocked from being published
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -251,3 +251,4 @@ wukachn,Peter Hamer
 shybovycha,Artem Shubovych
 Liaoyuxing,leoloel
 iankko,Jan Lieskovsky
+CliffordCheefoon,Clifford Cheefoon


### PR DESCRIPTION
Correct case discrepancy for configuration variables between docs and pubsub sink connector https://github.com/debezium/debezium-server/blob/df953233220e5250129135fabf1d97212d77ea40/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java#L98C3-L98C88

[DBZ-7443](https://issues.redhat.com/browse/DBZ-7443)