### PR TITLE
DBZ-7463: SQL Server queries with special characters fail after applying DBZ-7273

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -349,7 +349,8 @@ public class SqlServerConnection extends JdbcConnection {
 
         int idx = 0;
         for (SqlServerChangeTable changeTable : changeTables) {
-            String capturedColumns = String.join(", ", changeTable.getCapturedColumns());
+            String capturedColumns = changeTable.getCapturedColumns().stream().map(c -> "[" + c + "]")
+                    .collect(Collectors.joining(", "));
             String source = changeTable.getCaptureInstance();
             if (config.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT) {
                 source = changeTable.getChangeTableId().table();


### PR DESCRIPTION
Enclose column names in square brackets to account for spaces and special characters.