### PR TITLE
Dbz 7440 fix broken links to obsolete streams guide

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2001,7 +2001,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 * Db2 is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-db2-to-run-a-debezium-connector[set up Db2 to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
+For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1998,7 +1998,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 
 .Prerequisites
 
-* Db2 is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-db2-to-run-a-debezium-connector[set up Db2 to work with a {prodname} connector].
+* Db2 is running and you completed the steps to xref:setting-up-db2-to-run-a-debezium-connector[set up Db2 to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
 For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1220,10 +1220,10 @@ You then create two custom resources (CRs):
 
 .Prerequisites
 
-* MongoDB is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-mongodb[set up MongoDB to work with a {prodname} connector].
+* MongoDB is running and you completed the steps to xref:setting-up-mongodb-to-work-with-debezium[set up MongoDB to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
+  For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2452,7 +2452,7 @@ You then need to create the following custom resources (CRs):
 * MySQL is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-mysql-to-run-a-debezium-connector[set up MySQL to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
+For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2449,7 +2449,7 @@ You then need to create the following custom resources (CRs):
 
 .Prerequisites
 
-* MySQL is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-mysql-to-run-a-debezium-connector[set up MySQL to work with a {prodname} connector].
+* MySQL is running and you completed the steps to xref:setting-up-mysql-to-run-a-debezium-connector[set up MySQL to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
 For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2544,7 +2544,7 @@ You then need to create the following custom resources (CRs):
 
 .Prerequisites
 
-* Oracle Database is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-oracle-to-work-with-debezium[set up Oracle to work with a {prodname} connector].
+* Oracle Database is running and you completed the steps to xref:setting-up-oracle-to-work-with-debezium[set up Oracle to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
   For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2544,10 +2544,10 @@ You then need to create the following custom resources (CRs):
 
 .Prerequisites
 
-* Oracle Database is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-oracle-for-use-with-the-debezium-oracle-connector[set up Oracle to work with a {prodname} connector].
+* Oracle Database is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-oracle-to-work-with-debezium[set up Oracle to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}]
+  For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}]
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2551,7 +2551,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 
 .Prerequisites
 
-* PostgreSQL is running and you performed the steps to {LinkDebeziumUserGuide}#setting-up-postgresql-to-run-a-debezium-connector[set up PostgreSQL to run a {prodname} connector].
+* PostgreSQL is running and you performed the steps to xref:setting-up-postgresql-to-run-a-debezium-connector[set up PostgreSQL to run a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
   For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -185,8 +185,8 @@ If the connector fails, is rebalanced, or stops after Step 1 begins but before S
 
 ifdef::community[]
 |`custom`
-|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.spi.snapshot.Snapshotter` interface. 
-Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation, as specified on the classpath of your Kafka Connect cluster, or included in the connector JAR file, if using the `EmbeddedEngine`. 
+|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
+Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation, as specified on the classpath of your Kafka Connect cluster, or included in the connector JAR file, if using the `EmbeddedEngine`.
 For more information, see xref:postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
@@ -263,10 +263,10 @@ For more advanced uses, you can fine-tune control the snapshot by implementing o
  * - Whether to snapshot data or schema following an error.
  * <p>
  * Although {prodname} provides many default snapshot modes,
- * to provide more advanced functionality, such as partial snapshots, 
+ * to provide more advanced functionality, such as partial snapshots,
  * you can customize implementation of the interface.
  * For more information, see the documentation.
- 
+
  *
  *
  * @author Mario Fiore Vitale
@@ -318,7 +318,7 @@ public interface Snapshotter extends Configurable {
     /**
      *
      * @return {@code true} if streaming should resume from the start of the snapshot
-     * transaction, or {@code false} if following a restart, the connector  
+     * transaction, or {@code false} if following a restart, the connector
      * should take a snapshot, and then resume streaming from the last offset.
      */
     default boolean shouldStreamEventsStartingFromSnapshot() {
@@ -2554,7 +2554,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 * PostgreSQL is running and you performed the steps to {LinkDebeziumUserGuide}#setting-up-postgresql-to-run-a-debezium-connector[set up PostgreSQL to run a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
+  For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}].
 
 * Podman or Docker is installed.
 
@@ -3354,7 +3354,7 @@ ifdef::community[]
 |[[postgresql-property-snapshot-mode-custom-name]]<<postgresql-property-snapshot-mode-custom-name, `+snapshot.mode.custom.name+`>>
 |No default
 | When `snapshot.mode` is set as `custom`, use this setting to specify the name of the custom implementation provided in the `name()` method that is defined by the 'io.debezium.spi.snapshot.Snapshotter' interface.
-The provided implementation is called after a connector restart to determine whether to perform a snapshot. 
+The provided implementation is called after a connector restart to determine whether to perform a snapshot.
 For more information, see xref:postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
@@ -3363,16 +3363,16 @@ endif::community[]
 |Specifies how the connector holds locks on tables while performing a schema snapshot: +
 Set one of the following options:
  +
-`shared`:: The connector holds a table lock that prevents exclusive table access during the initial portion phase of the snapshot in which database schemas and other metadata are read. 
-After the initial phase, the snapshot no longer requires table locks. 
+`shared`:: The connector holds a table lock that prevents exclusive table access during the initial portion phase of the snapshot in which database schemas and other metadata are read.
+After the initial phase, the snapshot no longer requires table locks.
  +
 `none`:: The connector avoids locks entirely. +
 +
 [WARNING]
 ====
-Do not use this mode if schema changes might occur during the snapshot. 
+Do not use this mode if schema changes might occur during the snapshot.
 ====
- 
+
 ifdef::community[]
 `custom`:: The connector performs a snapshot according to the implementation specified by the xref:postgresql-property-snapshot-locking-mode-custom-name[`snapshot.locking.mode.custom.name`] property, which is a custom implementation of the `io.debezium.spi.snapshot.SnapshotLock` interface.
 endif::community[]
@@ -3389,7 +3389,7 @@ endif::community[]
 |Specifies how the connector queries data while performing a snapshot. +
 Set one of the following options:
 
-`select_all`:: The connector performs a `select all` query. 
+`select_all`:: The connector performs a `select all` query.
 
 ifdef::community[]
 `custom`:: The connector performs a snapshot query according to the implementation specified by the xref:postgresql-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface. +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2095,7 +2095,7 @@ You then need to create the following custom resources (CRs):
 
 .Prerequisites
 
-* SQL Server is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to work with a {prodname} connector].
+* SQL Server is running and you completed the steps to xref:setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
   For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2098,7 +2098,7 @@ You then need to create the following custom resources (CRs):
 * SQL Server is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}]
+  For more information, see link:{LinkDeployManageStreamsOpenShift}[{NameDeployManageStreamsOpenShift}]
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -138,10 +138,10 @@ ifdef::product[]
 == Monitoring {prodname} on OpenShift
 
 If you are using {prodname} on OpenShift, you can obtain JMX metrics by opening a JMX port on `9999`.
-For more information, see link:{LinkStreamsOpenShift}#assembly-jmx-options-deployment-configuration-kafka[JMX Options] in {NameStreamsOpenShift}.
+For information about configuring JMX connection options, see the link:{LinkStreamsOpenShift}#type-KafkaJmxOptions-reference[KafkaJmxOptions schema reference] in the {NameStreamsAPIReference}.
 
 In addition, you can use Prometheus and Grafana to monitor the JMX metrics.
-For more information, see _Monitoring_ in link:{LinkStreamsOpenShiftOverview}#metrics-overview_str[{NameDeployStreamsOpenShift}] and _Setting up metrics and dashboards_ in link:{LinkDeployManageStreamsOpenShift}#assembly-metrics-str[{NameDeployManageStreamsOpenShift}] .
+For more information, see _Monitoring_ in link:{LinkStreamsOpenShiftOverview}#metrics-overview_str[{NameStreamsOpenShiftOverview}] and _Setting up metrics and dashboards_ in link:{LinkDeployManageStreamsOpenShift}#assembly-metrics-str[{NameDeployManageStreamsOpenShift}] .
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -141,7 +141,7 @@ If you are using {prodname} on OpenShift, you can obtain JMX metrics by opening 
 For more information, see link:{LinkStreamsOpenShift}#assembly-jmx-options-deployment-configuration-kafka[JMX Options] in {NameStreamsOpenShift}.
 
 In addition, you can use Prometheus and Grafana to monitor the JMX metrics.
-For more information, see link:{LinkDeployStreamsOpenShift}/#assembly-metrics-str[Introducing Metrics to Kafka], in {NameDeployStreamsOpenShift}.
+For more information, see _Monitoring_ in link:{LinkStreamsOpenShiftOverview}#metrics-overview_str[{NameDeployStreamsOpenShift}] and _Setting up metrics and dashboards_ in link:{LinkDeployManageStreamsOpenShift}#assembly-metrics-str[{NameDeployManageStreamsOpenShift}] .
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -138,7 +138,7 @@ ifdef::product[]
 == Monitoring {prodname} on OpenShift
 
 If you are using {prodname} on OpenShift, you can obtain JMX metrics by opening a JMX port on `9999`.
-For information about configuring JMX connection options, see the link:{LinkStreamsOpenShift}#type-KafkaJmxOptions-reference[KafkaJmxOptions schema reference] in the {NameStreamsAPIReference}.
+For information about configuring JMX connection options, see the link:{LinkStreamsAPIReference}#type-KafkaJmxOptions-reference[KafkaJmxOptions schema reference] in the {NameStreamsAPIReference}.
 
 In addition, you can use Prometheus and Grafana to monitor the JMX metrics.
 For more information, see _Monitoring_ in link:{LinkStreamsOpenShiftOverview}#metrics-overview_str[{NameStreamsOpenShiftOverview}] and _Setting up metrics and dashboards_ in link:{LinkDeployManageStreamsOpenShift}#assembly-metrics-str[{NameDeployManageStreamsOpenShift}] .

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -23,4 +23,4 @@ You can still use the REST API to retrieve information.
 .Additional resources
 
 * link:{LinkDeployManageStreamsOpenShift}#con-kafka-connect-config-str[Configuring Kafka Connect] in {NameDeployManageStreamsOpenShift}.
-* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically in {NameDeployManageStreamsOpenShift}.
+* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically] in {NameDeployManageStreamsOpenShift}.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -22,5 +22,5 @@ You can still use the REST API to retrieve information.
 
 .Additional resources
 
-* link:{LinkConfiguringStreamsOpenShift}#proc-kafka-connect-config-str[Configuring Kafka Connect] in {NameStreamsOpenShift}.
-* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically] in {NameDeployManageStreamsOpenShift}].
+* link:{LinkDeployManageStreamsOpenShift}#con-kafka-connect-config-str[Configuring Kafka Connect] in {NameDeployManageStreamsOpenShift}.
+* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically] in {NameDeployManageStreamsOpenShift}.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -23,4 +23,4 @@ You can still use the REST API to retrieve information.
 .Additional resources
 
 * link:{LinkDeployManageStreamsOpenShift}#con-kafka-connect-config-str[Configuring Kafka Connect] in {NameDeployManageStreamsOpenShift}.
-* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically] in {NameDeployManageStreamsOpenShift}.
+* link:{LinkDeployManageStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Building a new container image automatically in {NameDeployManageStreamsOpenShift}.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
@@ -10,8 +10,8 @@ After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` 
 .Prerequisites
 * You have access to an OpenShift cluster on which the cluster Operator is installed.
 * The {StreamsName} Operator is running.
-* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
-* link:{LinkDeployStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployManageStreamsOpenShift}#kafka-cluster-str[{NameDeployManageStreamsOpenShift}].
+* link:{LinkDeployManageStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
 * You have a {prodnamefull} license.
 * The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html-single/cli_tools/index#installing-openshift-cli[OpenShift `oc` CLI] client is installed or you have access to the OpenShift Container Platform web console.
 * Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -10,8 +10,8 @@ After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` 
 .Prerequisites
 * You have access to an OpenShift cluster on which the cluster Operator is installed.
 * The {StreamsName} Operator is running.
-* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
-* link:{LinkDeployStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployManageStreamsOpenShift}#kafka-cluster-str[{NameDeployManageStreamsOpenShift}].
+* link:{LinkDeployManageStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
 * You have a {prodnamefull} license.
 * The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html-single/cli_tools/index#installing-openshift-cli[OpenShift `oc` CLI] client is installed or you have access to the OpenShift Container Platform web console.
 * Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:


### PR DESCRIPTION
[DBZ-7440](https://issues.redhat.com/browse/DBZ-7440)

Fixed multiple broken links across the docs. Most of these targeted content in the AMQ Streams docs, which underwent some structural changes that moved content such that previous URLs are no longer present. In the future, I'll reconsider whether it makes sense to include direct hyperlinks vs. general cross-references to the Streams docs. 

Tested in a downstream build.
These changes affect the downstream documentation only and are not visible in the community version.