### PR TITLE
DBZ-7479 PreparedStatement leak in Oracle ReselectColumnsProcessor

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -12,6 +12,7 @@ import java.sql.SQLRecoverableException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -579,16 +580,25 @@ public class OracleConnection extends JdbcConnection {
             return super.buildReselectColumnQuery(oracleTableId, columns, keyColumns, source);
         }
 
-        return String.format("SELECT %s FROM (SELECT * FROM %s AS OF SCN %s) WHERE %s",
+        return String.format("SELECT %s FROM (SELECT * FROM %s AS OF SCN ?) WHERE %s",
                 columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
                 quotedTableIdString(oracleTableId),
-                commitScn,
                 keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
     }
 
     @Override
-    public Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues) throws SQLException {
-        return optionallyDoInContainer(() -> super.reselectColumns(query, tableId, columns, bindValues));
+    public Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues, Struct source) throws SQLException {
+        final String commitScn = source.getString(SourceInfo.COMMIT_SCN_KEY);
+        final List<Object> values;
+        if (Strings.isNullOrEmpty(commitScn)) {
+            values = bindValues;
+        }
+        else {
+            values = new ArrayList<>(bindValues.size() + 1);
+            values.add(commitScn);
+            values.addAll(bindValues);
+        }
+        return optionallyDoInContainer(() -> super.reselectColumns(query, tableId, columns, values, source));
     }
 
     private <T> T optionallyDoInContainer(ContainerWork<T> work) throws SQLException {

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1605,7 +1605,7 @@ public class JdbcConnection implements AutoCloseable {
                 keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
     }
 
-    public Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues) throws SQLException {
+    public Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues, Struct source) throws SQLException {
         final Map<String, Object> results = new HashMap<>();
         prepareQuery(query, bindValues, (params, rs) -> {
             if (!rs.next()) {

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1598,14 +1598,16 @@ public class JdbcConnection implements AutoCloseable {
         return tableId.schema() + "." + tableId.table();
     }
 
-    public String buildReselectColumnQuery(TableId tableId, List<String> columns, List<String> keyColumns, Struct source) {
-        return String.format("SELECT %s FROM %s WHERE %s",
+    public Map<String, Object> reselectColumns(TableId tableId, List<String> columns, List<String> keyColumns, List<Object> keyValues, Struct source)
+            throws SQLException {
+        final String query = String.format("SELECT %s FROM %s WHERE %s",
                 columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
                 quotedTableIdString(tableId),
                 keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
+        return reselectColumns(query, tableId, columns, keyValues);
     }
 
-    public Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues, Struct source) throws SQLException {
+    protected Map<String, Object> reselectColumns(String query, TableId tableId, List<String> columns, List<Object> bindValues) throws SQLException {
         final Map<String, Object> results = new HashMap<>();
         prepareQuery(query, bindValues, (params, rs) -> {
             if (!rs.next()) {

--- a/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -143,10 +143,9 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             }
         }
 
-        Map<String, Object> selections;
+        final Map<String, Object> selections;
         try {
-            final String reselectQuery = jdbcConnection.buildReselectColumnQuery(tableId, requiredColumnSelections, keyColumns, source);
-            selections = jdbcConnection.reselectColumns(reselectQuery, tableId, requiredColumnSelections, keyValues, source);
+            selections = jdbcConnection.reselectColumns(tableId, requiredColumnSelections, keyColumns, keyValues, source);
             if (selections.isEmpty()) {
                 LOGGER.warn("Failed to find row in table {} with key {}.", tableId, key);
                 return;

--- a/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -146,7 +146,7 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
         Map<String, Object> selections;
         try {
             final String reselectQuery = jdbcConnection.buildReselectColumnQuery(tableId, requiredColumnSelections, keyColumns, source);
-            selections = jdbcConnection.reselectColumns(reselectQuery, tableId, requiredColumnSelections, keyValues);
+            selections = jdbcConnection.reselectColumns(reselectQuery, tableId, requiredColumnSelections, keyValues, source);
             if (selections.isEmpty()) {
                 LOGGER.warn("Failed to find row in table {} with key {}.", tableId, key);
                 return;


### PR DESCRIPTION
Each time, Oracle connector creates a new instance of PreparedStatement because value of commit SCN is added directly to SQL query to reselect column values.

https://issues.redhat.com/browse/DBZ-7479