### PR TITLE
Dbz 7418 convert callout description lists to tables

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -566,21 +566,51 @@ The following example shows a JSON request for registering an instance of the {p
     }
 }
 ----
-<1> The name that is assigned to the connector when you register it with Kafka Connect service.
-<2> The name of the JDBC sink connector class.
-<3> The maximum number of tasks to create for this connector.
-<4> The JDBC URL that the connector uses to connect to the sink database that it writes to.
-<5> The name of the database user used for authentication.
-<6> The password of the database user used for authentication.
-<7> The xref:jdbc-property-insert-mode[insert.mode] that the connector uses.
-<8> Enables the deletion of records in the database.
+Descriptions of JDBC connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name that is assigned to the connector when you register it with Kafka Connect service.
+
+|2
+|The name of the JDBC sink connector class.
+
+|3
+|The maximum number of tasks to create for this connector.
+
+|4
+|The JDBC URL that the connector uses to connect to the sink database that it writes to.
+
+|5
+|The name of the database user that is used for authentication.
+
+|6
+|The password of the database user used for authentication.
+
+|7
+|The xref:jdbc-property-insert-mode[insert.mode] that the connector uses.
+
+|8
+|Enables the deletion of records in the database.
 For more information, see the xref:jdbc-property-delete-enabled[delete.enabled] configuration property.
-<9> Specifies the method used to resolve primary key columns.
+
+|9
+|Specifies the method used to resolve primary key columns.
 For more information, see the xref:jdbc-property-primary-key-mode[primary.key.mode] configuration property.
-<10> Enables the connector to evolve the destination database's schema.
+
+|10
+|Enables the connector to evolve the destination database's schema.
 For more information, see the xref:jdbc-property-schema-evolution[schema.evolution] configuration property.
-<11> Specifies the timezone used when writing temporal field types.
-<12> List of topics to consume, separated by commas.
+
+|11
+|Specifies the timezone used when writing temporal field types.
+
+|12
+|List of topics to consume, separated by commas.
+
+|===
 
 For a complete list of configuration properties that you can set for the {prodname} JDBC connector, see xref:jdbc-connector-properties[JDBC connector properties].
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1365,11 +1365,28 @@ apiVersion: {KafkaConnectApiVersion}
      topic.prefix: inventory-connector-{context} // <4>
      collection.include.list: inventory[.]* // <5>
 ----
-<1> The name that is used to register the connector with Kafka Connect.
-<2> The name of the MongoDB connector class.
-<3> The host addresses to use to connect to the MongoDB replica set.
-<4> The _logical name_ of the MongoDB replica set, which forms a namespace for generated events and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<5> An optional list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored.
+.Descriptions of settings in the MongoDB `inventory-connector.yaml` example
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name that is used to register the connector with Kafka Connect.
+
+|2
+|The name of the MongoDB connector class.
+
+|3
+|The host addresses to use to connect to the MongoDB replica set.
+
+|4
+|The _logical name_ of the MongoDB replica set.
+The logical name forms a namespace for generated events, and is used in the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+
+|5
+|An optional list of regular expressions that match the collection namespaces (for example, __<dbName>.<collectionName>__) of all collections to be monitored.
+
+|===
 
 . Create your connector instance with Kafka Connect.
 For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1348,8 +1348,9 @@ Optionally, you can set properties that filter out collections that are not need
 +
 The following example configures a {prodname} connector that connects to a MongoDB replica set `rs0` at port `27017` on `192.168.99.100`,
 and captures changes that occur in the `inventory` collection.
-`inventory-connector-{context}` is the logical name of the replica set.
+`inventory-connector-{context}` is the logical name of the replica set. +
 +
+=====================================================================
 .MongoDB `inventory-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
 ----
@@ -1365,6 +1366,8 @@ apiVersion: {KafkaConnectApiVersion}
      topic.prefix: inventory-connector-{context} // <4>
      collection.include.list: inventory[.]* // <5>
 ----
+=====================================================================
++
 .Descriptions of settings in the MongoDB `inventory-connector.yaml` example
 [cols="1,7",options="header",subs="+attributes"]
 |===

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2312,9 +2312,21 @@ local   replication     <youruser>                          trust   // <1>
 host    replication     <youruser>  127.0.0.1/32            trust   // <2>
 host    replication     <youruser>  ::1/128                 trust   // <3>
 ----
-<1> Instructs the server to allow replication for `<youruser>` locally, that is, on the server machine.
-<2> Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV4`.
-<3> Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV6`.
+.Descriptions of `pg_hba.conf` settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|Instructs the server to allow replication for `<youruser>` locally, that is, on the server machine.
+
+|2
+|Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV4`.
+
+|3
+|Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV6`.
+
+|===
 
 [NOTE]
 ====

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2715,22 +2715,42 @@ apiVersion: {KafkaConnectorApiVersion}
 
       ...
 ----
-<1> The name of the connector.
-<2> Only one task should operate at any one time.
-Because the PostgreSQL connector reads the PostgreSQL server’s `binlog`,
-using a single connector task ensures proper order and event handling.
-The Kafka Connect service uses connectors to start one or more tasks that do the work,
+.Descriptions of settings in the PostgreSQL `inventory-connector.yaml` example
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name that is used to register the connector with Kafka Connect.
+
+|2
+|The maximum number of tasks to create for this connector.
+Because the PostgreSQL connector uses a single connector task read the PostgreSQL server `binlog`, to ensure proper order and event handling, only one task should operate at a time.
+The Kafka Connect service uses connectors to start one or more tasks to perform the work,
 and it automatically distributes the running tasks across the cluster of Kafka Connect services.
-If any of the services stop or crash,
-those tasks will be redistributed to running services.
-<3> The connector’s configuration.
-<4> The name of the database host that is running the PostgreSQL server. In this example, the database host name is `192.168.99.100`.
-<5> A unique topic prefix.
-The server name is the logical identifier for the PostgreSQL server or cluster of servers.
-This name is used as the prefix for all Kafka topics that receive change event records.
-<6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose.
+If any services stop or crash, tasks are redistributed to running services.
+
+|3
+|The connector’s configuration.
+
+|4
+|The name of the database host that runs the PostgreSQL server.
+In this example, the database host name is `192.168.99.100`.
+
+|5
+|A unique topic prefix.
+The topic prefix is the logical identifier for the PostgreSQL server or cluster of servers.
+This string is prefixed to the names of all Kafka topics that receive change event records from the connector.
+
+|6
+|The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose.
 For more information, see xref:postgresql-property-table-include-list[`table.include.list`].
-<7> The name of the PostgreSQL xref:postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
+
+|7
+|The name of the PostgreSQL xref:postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
+Although the connector only supports use of the `pgoutput` plugin, you must explicitly set `plugin.name` to `pgoutput`.
+
+|===
 
 . Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:
 +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2312,6 +2312,7 @@ local   replication     <youruser>                          trust   // <1>
 host    replication     <youruser>  127.0.0.1/32            trust   // <2>
 host    replication     <youruser>  ::1/128                 trust   // <3>
 ----
++
 .Descriptions of `pg_hba.conf` settings
 [cols="1,7",options="header",subs="+attributes"]
 |===

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2690,9 +2690,10 @@ The connector configuration might instruct {prodname} to produce events for a su
 For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see xref:descriptions-of-debezium-postgresql-connector-configuration-properties[PostgreSQL connector properties].
 +
 The following example shows an excerpt from a custom resource that configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`.
-This host has a database named `sampledb`, a schema named `public`, and `inventory-connector-{context}` is the server's logical name.
+This host has a database named `sampledb`, a schema named `public`, and `inventory-connector-{context}` is the server's logical name. +
 +
-.`inventory-connector.yaml`
+=====================================================================
+.PostgreSQL `inventory-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
 ----
 apiVersion: {KafkaConnectorApiVersion}
@@ -2716,6 +2717,8 @@ apiVersion: {KafkaConnectorApiVersion}
 
       ...
 ----
+=====================================================================
++
 .Descriptions of settings in the PostgreSQL `inventory-connector.yaml` example
 [cols="1,7",options="header",subs="+attributes"]
 |===

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -45,8 +45,11 @@ The CloudEvents specification defines:
 
 To configure a {prodname} connector to emit change event records that conform to the CloudEvents specification, {prodname} provides the `io.debezium.converters.CloudEventsConverter`, which is a Kafka Connect message converter.
 
-Currently, only structured mapping mode is supported. The CloudEvents change event envelope can be JSON or Avro and each envelope type supports JSON or Avro as the `data` format. It is expected that a future {prodname} release will support binary mapping mode.
-
+Currently, only structured mapping mode can be used.
+The CloudEvents change event envelope can be JSON or Avro, and you can use JSON or Avro as the `data` format for each envelope type.
+ifdef::community[]
+It is expected that a future {prodname} release will support binary mapping mode.
+endif::community[]
 ifdef::product[]
 Information about emitting change events in CloudEvents format is organized as follows:
 

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -60,7 +60,8 @@ For information about using Avro, see:
 // Title: Example {prodname} change event records in CloudEvents format
 == Example event format
 
-The following example shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like. In this example, the PostgreSQL connector is configured to use JSON as the CloudEvents format envelope and also as the `data` format.
+The following example shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like.
+In this example, the PostgreSQL connector is configured to use JSON as the CloudEvents format envelope and also as the `data` format.
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -94,6 +95,50 @@ The following example shows what a CloudEvents change event record emitted by a 
   }
 }
 ----
+.Descriptions of fields in a CloudEvents change event record
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|Unique ID that the connector generates for the change event based on the change event's content.
+
+|2
+|The source of the event, which is the logical name of the database as specified by the `topic.prefix` property in the connector's configuration.
+
+|3
+|The CloudEvents specification version.
+
+|4
+|Connector type that generated the change event.
+The format of this field is `io.debezium._CONNECTOR_TYPE_.datachangeevent`.
+The value of `_CONNECTOR_TYPE_` is `mongodb`, `mysql`, `postgresql`, or `sqlserver`.
+
+|5
+|Time of the change in the source database.
+
+|6
+|Describes the content type of the `data` attribute.
+Possible values are `json`, as in this example, or `avro`.
+
+|7
+|An operation identifier.
+Possible values are `r` for read, `c` for create, `u` for update, or `d` for delete.
+
+|8
+|All `source` attributes that are known from {prodname} change events are mapped to CloudEvents extension attributes by using the `iodebezium` prefix for the attribute name.
+
+|9
+|When enabled in the connector, each `transaction` attribute that is known from {prodname} change events is mapped to a CloudEvents extension attribute by using the `iodebeziumtx` prefix for the attribute name.
+
+|10
+|The actual data change.
+Depending on the operation and the connector, the data might contain `before`, `after`, or `patch` fields.
+
+|===
+
+
+
 <1> Unique ID that the connector generates for the change event based on the change event's content.
 <2> The source of the event, which is the logical name of the database as specified by the `topic.prefix` property in the connector's configuration.
 <3> The CloudEvents specification version.
@@ -180,12 +225,12 @@ By default, the `metadata.source` property consists of three parts, as seen in t
 "value,id:generate,type:generate,dataSchemaName:generate"
 ----
 
-The first part specifies the source for retrieving a record's metadata; the permitted values are `value` and `header`. 
-The next parts specify how the converter populates values for the following metadata fields: 
+The first part specifies the source for retrieving a record's metadata; the permitted values are `value` and `header`.
+The next parts specify how the converter populates values for the following metadata fields:
 
 * `id`
 * `type`
-* `dataSchemaName` (the name under which the schema is registered in the Schema Registry)  
+* `dataSchemaName` (the name under which the schema is registered in the Schema Registry)
 
 The converter can use one of the following methods to populate each field:
 
@@ -195,7 +240,7 @@ The converter can use one of the following methods to populate each field:
 === Obtaining record metadata
 
 To construct a CloudEvent, the converter requires source, operation, and transaction metadata.
-Generally, the converter can retrieve the metadata from a record's value. 
+Generally, the converter can retrieve the metadata from a record's value.
 But in some cases, before the converter receives a record, the record might be processed in such a way that metadata is not present in its value, for example, after the record is processed by the Outbox Event Router SMT.
 To preserve the required metadata, you can use the following approach to pass the metadata in the record headers.
 
@@ -304,25 +349,25 @@ The value can be `json` or `avro`.
 |[[cloud-events-converter-schema-cloudevents-name]]xref:cloud-events-converter-schema-cloudevents-name[`schema.cloudevents.name`]
 |none
 |Specifies CloudEvents schema name under which the schema is registered in a Schema Registry. The setting is ignored when `serializer.type` is `json` in
-which case a record's value is schemaless. 
+which case a record's value is schemaless.
 If this property is not specified, the default algorithm is used to generate the
 schema name: `pass:[${serverName}.${databaseName}].CloudEvents.Envelope`.
 
 |[[cloud-events-converter-schema-data-name-source-header-enable]]xref:cloud-events-converter-schema-data-name-source-header-enable[`schema.data.name.source.header.enable`]
 |false
-|Specifies whether the converter can retrieve the schema name of the CloudEvents `data` field from a header. 
+|Specifies whether the converter can retrieve the schema name of the CloudEvents `data` field from a header.
 The schema name is obtained from the `dataSchemaName` parameter that is specified in the xref:cloud-events-converter-metadata-source[`metadata.source`] property.
 
 |[[cloud-events-converter-extension-attributes-enable]]xref:cloud-events-converter-extension-attributes-enable[`extension.attributes.enable`]
 |`true`
-|Specifies whether the converter includes extension attributes when it generates a cloud event. 
+|Specifies whether the converter includes extension attributes when it generates a cloud event.
 The value can be `true` or `false`.
 
 |[[cloud-events-converter-metadata-source]]xref:cloud-events-converter-metadata-source[`metadata.source`]
 |`value,id:generate,type:generate,dataSchemaName:generate`
 |A comma-separated list that specifies the sources from which the converter retrieves metadata values (source, operation, transaction) for CloudEvent `id` and `type` fields,
 and for the `dataSchemaName` parameter, which specifies the name under which the schema is registered in a Schema Registry.
-The first element in the list is a global setting that specifies the source of the metadata.  
+The first element in the list is a global setting that specifies the source of the metadata.
 The source of metadata can be `value` or `header`.
 The global setting is followed by a set of pairs.
 The first element in each pair specifies the name of a CloudEvent field (`id` or `type`), or the name of a data schema (`dataSchemaName`).

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -137,20 +137,6 @@ Depending on the operation and the connector, the data might contain `before`, `
 
 |===
 
-
-
-<1> Unique ID that the connector generates for the change event based on the change event's content.
-<2> The source of the event, which is the logical name of the database as specified by the `topic.prefix` property in the connector's configuration.
-<3> The CloudEvents specification version.
-<4> Connector type that generated the change event. The format of this field is `io.debezium._CONNECTOR_TYPE_.datachangeevent`. The value of `_CONNECTOR_TYPE_` is `mongodb`, `mysql`, `postgresql`, or `sqlserver`.
-<5> Time of the change in the source database.
-<6> Describes the content type of the `data` attribute, which is JSON in this example.
-The only alternative is Avro.
-<7> An operation identifier. Possible values are `r` for read, `c` for create, `u` for update, or `d` for delete.
-<8> All `source` attributes that are known from {prodname} change events are mapped to CloudEvents extension attributes by using the `iodebezium` prefix for the attribute name.
-<9> When enabled in the connector, each `transaction` attribute that is known from {prodname} change events is mapped to a CloudEvents extension attribute by using the `iodebeziumtx` prefix for the attribute name.
-<10> The actual data change itself. Depending on the operation and the connector, the data might contain `before`, `after` and/or `patch` fields.
-
 The following example also shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like. In this example, the PostgreSQL connector is again configured to use JSON as the CloudEvents format envelope, but this time the connector is configured to use Avro for the `data` format.
 
 [source,json,indent=0,subs="+attributes"]

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -13,7 +13,13 @@
 
 toc::[]
 
-link:https://cloudevents.io/[CloudEvents] is a specification for describing event data in a common way. Its aim is to provide interoperability across services, platforms and systems. {prodname} enables you to configure a MongoDB, MySQL, PostgreSQL, or SQL Server connector to emit change event records that conform to the CloudEvents specification.
+link:https://cloudevents.io/[CloudEvents] is a specification for describing event data in a common way.
+Its aim is to provide interoperability across services, platforms and systems.
+{prodname} enables you to configure a Db2,
+ifdef::community[]
+Informix,
+endif::community[]
+MongoDB, MySQL, Oracle, PostgreSQL, or SQL Server connector to emit change event records that conform to the CloudEvents specification.
 
 ifdef::community[]
 [NOTE]
@@ -110,9 +116,13 @@ In this example, the PostgreSQL connector is configured to use JSON as the Cloud
 |The CloudEvents specification version.
 
 |4
-|Connector type that generated the change event.
-The format of this field is `io.debezium._CONNECTOR_TYPE_.datachangeevent`.
-The value of `_CONNECTOR_TYPE_` is `mongodb`, `mysql`, `postgresql`, or `sqlserver`.
+a|Connector type that generated the change event.
+The format of this field is `io.debezium._<CONNECTOR_TYPE>_.datachangeevent`.
+Valid values for `_CONNECTOR_TYPE_` are `db2`,
+ifdef::community[]
+`informix`,
+endif::community[]
+`mongodb`, `mysql`, `oracle`, `postgresql`, or `sqlserver`.
 
 |5
 |Time of the change in the source database.

--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -83,7 +83,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout  // <3>
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n  // <4>
 ...
 ----
-.Descriptions of `.connect-log4j.properties` settings
+.Descriptions of `connect-log4j.properties` settings
 [cols="1,7",options="header",subs="+attributes"]
 |===
 |Property |Description

--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -83,12 +83,26 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout  // <3>
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n  // <4>
 ...
 ----
-<1> The root logger, which defines the default logger configuration.
+.Descriptions of `.connect-log4j.properties` settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Property |Description
+
+|1
+|The root logger, which defines the default logger configuration.
 By default, loggers include `INFO`, `WARN`, and `ERROR` messages.
 These log messages are written to the `stdout` appender.
-<2> The `stdout` appender writes log messages to the console (as opposed to a file).
-<3> The `stdout` appender uses a pattern matching algorithm to format the log messages.
-<4> The pattern for the `stdout` appender (see the https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html[Log4j documentation] for details).
+
+|2
+|Directs the `stdout` appender to write log messages to the console, as opposed to a file.
+
+|3
+|Specifies that the `stdout` appender uses a pattern matching algorithm to format log messages.
+
+|4
+|The pattern that the `stdout` appender uses (see the https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html[Log4j documentation] for details).
+
+|===
 
 Unless you configure other loggers,
 all of the loggers that {prodname} uses inherit the `rootLogger` configuration.

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
@@ -115,7 +115,7 @@ There are no changes in the `schema` section, so only the `payload` section is s
   }
 }
 ----
-.Descriptions of fields in the payload of a change event value
+.Descriptions of fields in the payload of an `update` event value
 [cols="1,7",options="header",subs="+attributes"]
 |===
 |Item |Description

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
@@ -115,15 +115,31 @@ There are no changes in the `schema` section, so only the `payload` section is s
   }
 }
 ----
-<1> The `before` field now has the state of the row with the values before the database commit.
-<2> The `after` field now has the updated state of the row,
-and the `first_name` value is now `Anne Marie`.
-<3> The `source` field structure has many of the same values as before,
+.Descriptions of fields in the payload of a change event value
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The `before` field shows the values present in the row before the database commit.
+The original `first_name` value is `Anne`.
+
+|2
+|The `after` field shows the state of the row after the change event.
+The `first_name` value is now `Anne Marie`.
+
+|3
+|The `source` field structure has many of the same values as before,
 except that the `ts_sec` and `pos` fields have changed
 (the `file` might have changed in other circumstances).
-<4> The `op` field value is now `u`,
-signifying that this row changed because of an update.
-<5> The `ts_ms` field shows the time stamp for when {prodname} processed this event.
+
+|4
+|The `op` field value is now `u`, signifying that this row changed because of an update.
+
+|5
+|The `ts_ms` field shows a timestamp that indicates when {prodname} processed this event.
+
+|===
 
 By viewing the `payload` section, you can learn several important things about the _update_ event:
 


### PR DESCRIPTION
[DBZ-7418](https://issues.redhat.com/browse/DBZ-7418)

For unknown reasons, callout description lists that render correctly in the community Antora documentation are not rendered correctly in the productized documentation. Instead, entries for each numbered description are repeated one or more times.
To  work around the issue, this change modifies the formatting in the sources to convert callout lists to tables.

Tested in a local Antora build and in a local downstream build.