### PR TITLE
DBZ-7418 Removes duplicate callout annotation from example

### DIFF
--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -157,7 +157,7 @@ log4j.logger.io.debezium.connector.mysql=DEBUG, stdout  // <1>
 log4j.logger.io.debezium.relational.history=DEBUG, stdout  // <2>
 
 log4j.additivity.io.debezium.connector.mysql=false  // <3>
-log4j.additivity.io.debezium.storage.kafka.history=false  // <3>
+log4j.additivity.io.debezium.storage.kafka.history=false
 ...
 ----
 +
@@ -173,8 +173,8 @@ log4j.additivity.io.debezium.storage.kafka.history=false  // <3>
 |Configures the logger named `io.debezium.relational.history` to send `DEBUG`, `INFO`, `WARN`, and `ERROR` messages to the `stdout` appender.
 
 |3
-|Turns off _additivity_, which results in log messages not being sent to the appenders of parent loggers.
-If you use multiple appenders, set `additivity` values to `false` to prevent duplicate log messages.
+|This pair of `log4j.additivity.io` entries disable https://logging.apache.org/log4j/2.x/manual/configuration.html#additivity[additivity].
+If you use multiple appenders, set `additivity` values to `false` to prevent duplicate log messages from being sent to the appenders of the parent loggers.
 
 |===
 


### PR DESCRIPTION
Follows up on [DBZ-7418](https://issues/redhat.com/browse/DBZ-7418) changes.
This change removes the second `<3>` callout annotation from the `log4j.properties` example In `logging.adoc` and rewords the callout description to make it clear that it applies to two entries in the example.

In Step 2 of  `Setting the logging level by configuring loggers`, the example repeats the `<3>` callout annotation for each of the two `additivity.io.debezium` entries.  
In the published upstream documentation, this works, because the annotations for the two instances both show the expected `3`, which collates to the related callout description in the table that follows the example. However, in the downstream customer portal, the value of the second annotation renders as `4`, which has no related entry in the related _Descriptions of `log4j.properties` settings_  table.

Tested in local Antora and downstream documentation builds.