### PR TITLE
Fix MySQL 8 event timestamp resolution logic error where fallback to seconds occurs erroneously for non-GTID events

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -229,16 +229,22 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     private void setEventTimestamp(Event event, long eventTs) {
         // Prefer higher resolution replication timestamps from MySQL 8 GTID events, if possible
         if (isGtidModeEnabled) {
-            if (event.getHeader().getEventType() == EventType.GTID) {
-                GtidEventData gtidEvent = unwrapData(event);
-                final long gtidEventTs = gtidEvent.getOriginalCommitTimestamp();
-                if (gtidEventTs != 0) {
-                    // >= MySQL 8.0.1, prefer the higher resolution replication timestamp
-                    eventTimestamp = Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
-                }
-                else {
-                    // Fallback to second resolution event timestamps
-                    eventTimestamp = Instant.ofEpochMilli(eventTs);
+            if (connection.isMariaDb()) {
+                // Fallback to second resolution event timestamps
+                eventTimestamp = Instant.ofEpochMilli(eventTs);
+            }
+            else {
+                if (event.getHeader().getEventType() == EventType.GTID) {
+                    GtidEventData gtidEvent = unwrapData(event);
+                    final long gtidEventTs = gtidEvent.getOriginalCommitTimestamp();
+                    if (gtidEventTs != 0) {
+                        // >= MySQL 8.0.1, prefer the higher resolution replication timestamp
+                        eventTimestamp = Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
+                    }
+                    else {
+                        // Fallback to second resolution event timestamps
+                        eventTimestamp = Instant.ofEpochMilli(eventTs);
+                    }
                 }
             }
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -227,30 +227,22 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     private void setEventTimestamp(Event event, long eventTs) {
-        // Prefer higher resolution replication timestamps from MySQL 8 GTID events, if possible
-        if (isGtidModeEnabled) {
-            if (connection.isMariaDb()) {
+        if (connection.isMariaDb() || !isGtidModeEnabled) {
+            // Fallback to second resolution event timestamps
+            eventTimestamp = Instant.ofEpochMilli(eventTs);
+        }
+        else if (event.getHeader().getEventType() == EventType.GTID) {
+            // Prefer higher resolution replication timestamps from MySQL 8 GTID events, if possible
+            GtidEventData gtidEvent = unwrapData(event);
+            final long gtidEventTs = gtidEvent.getOriginalCommitTimestamp();
+            if (gtidEventTs != 0) {
+                // >= MySQL 8.0.1, prefer the higher resolution replication timestamp
+                eventTimestamp = Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
+            }
+            else {
                 // Fallback to second resolution event timestamps
                 eventTimestamp = Instant.ofEpochMilli(eventTs);
             }
-            else {
-                if (event.getHeader().getEventType() == EventType.GTID) {
-                    GtidEventData gtidEvent = unwrapData(event);
-                    final long gtidEventTs = gtidEvent.getOriginalCommitTimestamp();
-                    if (gtidEventTs != 0) {
-                        // >= MySQL 8.0.1, prefer the higher resolution replication timestamp
-                        eventTimestamp = Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
-                    }
-                    else {
-                        // Fallback to second resolution event timestamps
-                        eventTimestamp = Instant.ofEpochMilli(eventTs);
-                    }
-                }
-            }
-        }
-        else {
-            // Fallback to second resolution event timestamps
-            eventTimestamp = Instant.ofEpochMilli(eventTs);
         }
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -219,14 +219,14 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             return;
         }
 
-        eventTimestamp = getEventTimestamp(event, eventTs);
+        setEventTimestamp(event, eventTs);
 
         ts = clock.currentTimeInMillis() - eventTimestamp.toEpochMilli();
         LOGGER.trace("Current milliseconds behind source: {} ms", ts);
         metrics.setMilliSecondsBehindSource(ts);
     }
 
-    private Instant getEventTimestamp(Event event, long eventTs) {
+    private void setEventTimestamp(Event event, long eventTs) {
         // Prefer higher resolution replication timestamps from MySQL 8 GTID events, if possible
         if (isGtidModeEnabled) {
             if (event.getHeader().getEventType() == EventType.GTID) {
@@ -234,13 +234,18 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                 final long gtidEventTs = gtidEvent.getOriginalCommitTimestamp();
                 if (gtidEventTs != 0) {
                     // >= MySQL 8.0.1, prefer the higher resolution replication timestamp
-                    return Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
+                    eventTimestamp = Instant.EPOCH.plus(gtidEventTs, ChronoUnit.MICROS);
+                }
+                else {
+                    // Fallback to second resolution event timestamps
+                    eventTimestamp = Instant.ofEpochMilli(eventTs);
                 }
             }
         }
-
-        // Fallback to second resolution event timestamps
-        return Instant.ofEpochMilli(eventTs);
+        else {
+            // Fallback to second resolution event timestamps
+            eventTimestamp = Instant.ofEpochMilli(eventTs);
+        }
     }
 
     protected void ignoreEvent(MySqlOffsetContext offsetContext, Event event) {


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/DBZ-7500

Fixes: https://github.com/debezium/debezium/pull/5036

Applied to a MySQL 8 connector:

<img width="623" alt="Screenshot 2024-02-16 at 23 41 22" src="https://github.com/debezium/debezium/assets/379/aff02b9d-2618-45b1-8e1c-b4feb0f87ef9">


Proof of millisecond resolution `source.ts_ms`:

```json
"source": {
    "query": "REDACTED",
    "thread": 3683566,
    "server_id": 12844,
    "version": "2.6.0-SNAPSHOT",
    "sequence": "",
    "file": "binlog.726557",
    "connector": "mysql",
    "pos": 59658237,
    "name": "REDACTED",
    "gtid": "6aafb3ca-9b99-11ee-a237-4201f300802c:187141265",
    "row": 0,
    "ts_ms": 1708126035867,
    "snapshot": "false",
    "db": "REDACTED",
    "table": "products"
  },
```