### PR TITLE
DBZ-7501 Remove incubating from Debezium documentation

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/index.adoc
+++ b/documentation/modules/ROOT/pages/connectors/index.adoc
@@ -12,7 +12,7 @@ We currently have the following connectors:
 * xref:connectors/db2.adoc[Db2]
 * xref:connectors/cassandra.adoc[Cassandra]
 * xref:connectors/vitess.adoc[Vitess] (Incubating)
-* xref:connectors/spanner.adoc[Spanner] (Incubating)
+* xref:connectors/spanner.adoc[Spanner]
 * xref:connectors/jdbc.adoc[JDBC] (Incubating)
 * xref:connectors/informix.adoc[Informix] (Incubating)
 

--- a/documentation/modules/ROOT/pages/connectors/spanner.adoc
+++ b/documentation/modules/ROOT/pages/connectors/spanner.adoc
@@ -12,11 +12,6 @@
 
 toc::[]
 
-[NOTE]
-====
-This connector is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive. Please let us know if you encounter any problems.
-====
-
 {prodname}'s Cloud Spanner connector consumes and outputs Spanner change streams data into a Kafka topic.
 
 A Spanner link:https://cloud.google.com/spanner/docs/change-streams[change stream] watches and streams out a Spanner database's data changes - inserts, updates, deletes - in near-real-time. The Spanner connector abstracts away the details of querying the Spanner change streams. With this connector, you don't have to manage the change streams partition lifecycle, which is necessary when you link:https://cloud.devsite.corp.google.com/spanner/docs/change-streams/details#query[use the Spanner API directly].

--- a/documentation/modules/ROOT/pages/install.adoc
+++ b/documentation/modules/ROOT/pages/install.adoc
@@ -36,7 +36,7 @@ ifeval::['{page-version}' == 'master']
 * {link-cassandra-3-plugin-snapshot}[Cassandra 3.x plugin archive]
 * {link-cassandra-4-plugin-snapshot}[Cassandra 4.x plugin archive]
 * {link-vitess-plugin-snapshot}[Vitess plugin archive] (incubating)
-* {link-spanner-plugin-snapshot}[Spanner plugin archive] (incubating)
+* {link-spanner-plugin-snapshot}[Spanner plugin archive]
 * {link-jdbc-plugin-snapshot}[JDBC sink plugin archive] (incubating)
 * {link-informix-plugin-snapshot}[Informix plugin archive] (incubating)
 


### PR DESCRIPTION
Remove incubating from Debezium documentation since the connector has been launched for quite some time now.