### PR TITLE
DBZ-7512 Support arbitrary payloads with outbox event router on debezium server

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -587,3 +587,4 @@ leoloel
 Clifford Cheefoon
 Fr0z3Nn
 Xianming Zhou
+Akula

--- a/debezium-api/src/main/java/io/debezium/engine/format/Binary.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Binary.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+/**
+ * A {@link SerializationFormat} defining the binary format serialized as byte[].
+ */
+public class Binary implements SerializationFormat<Object> {
+}

--- a/debezium-api/src/main/java/io/debezium/engine/format/SimpleString.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/SimpleString.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+/**
+ * A {@link SerializationFormat} defining the string format serialized as String
+ */
+public class SimpleString implements SerializationFormat<String> {
+}

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -379,7 +379,7 @@ By default the output is in JSON format but an arbitrary implementation of Kafka
 
 |[[debezium-format-key]]<<debezium-format-key, `debezium.format.key`>>
 |`json`
-|The name of the output format for key, one of `json`/`jsonbytearray`/`avro`/`protobuf`.
+|The name of the output format for key, one of `json`/`jsonbytearray`/`avro`/`protobuf`/`simplestring`/`binary`.
 
 |[[debezium-format-key-props]]<<debezium-format-key-props, `debezium.format.key.*`>>
 |
@@ -387,7 +387,7 @@ By default the output is in JSON format but an arbitrary implementation of Kafka
 
 |[[debezium-format-value]]<<debezium-format-value, `debezium.format.value`>>
 |`json`
-|The name of the output format for value, one of `json`/`jsonbytearray`/`avro`/`protobuf`/`cloudevents`.
+|The name of the output format for value, one of `json`/`jsonbytearray`/`avro`/`protobuf`/`cloudevents`/`simplestring`/`binary`.
 
 |[[debezium-format-value-props]]<<debezium-format-value-props, `debezium.format.value.*`>>
 |

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -256,3 +256,4 @@ CliffordCheefoon,Clifford Cheefoon
 Fr0z3Nn,Ivanov Sergey Vasilevich
 Bue-Von-Hun,Bue Von Hun
 nrkeli,Emil Lindström
+akulapid,Akula


### PR DESCRIPTION
Outbox event router supports arbitrary payload formats with BinaryDataConverter as the value.converter which passes payload transparently. However this is  currently not supported with the embedded engine which handles message conversion using value.format to specify the format.

In addition, when we want to pass payload transparently, it makes sense to also pass aggregateid i.e. the event key transparently. The default outbox table configuration specifies aggregateid as a varchar which is also not supported by embedded engine.

Propose to introduce the following change to support the above use cases.

1. Support for string and binary serialization formats on debezium api.
2. Allow configuring separate key and value formats on embedded engine.