### PR TITLE
DBZ-7508 Exit from readChunk after createDataEventsForTable if snapshot is not running anymore

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
@@ -342,7 +342,6 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
                     return logInterceptor.containsMessage(tableRemoveMessage);
                 });
 
-        stopConnector();
     }
 
     @Test

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -388,7 +388,12 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                                 context.maximumKey().orElse(new Object[0]));
                     }
                 }
+
                 if (createDataEventsForTable(partition)) {
+
+                    if (!context.snapshotRunning()) { // A stop signal has been processed and window cleared.
+                        return;
+                    }
 
                     if (window.isEmpty()) {
                         LOGGER.info("No data returned by the query, incremental snapshotting of table '{}' finished",


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-7508