### PR TITLE
Dbz 7418 replace remaining callout description lists with tables

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -89,15 +89,19 @@ The following example shows a typical notification that provides the status of a
     "timestamp": "1695817046353"
 }
 ----
+[cols="1,7a",options="header",subs="+attributes"]
+|===
+|Item |Description
 
-<1> The `type` field can contain one of the following values:
+|1
+|The `type` field can contain one of the following values:
 
-* `STARTED`
-* `IN_PROGRESS`
-* `TABLE_SCAN_COMPLETED`
 * `COMPLETED`
 * `ABORTED`
 * `SKIPPED`
+
+|===
+
 
 The following table shows examples of the different payloads that might be present in notifications that report the status of initial snapshots:
 
@@ -400,13 +404,26 @@ public interface NotificationChannel {
     void close(); // <4>
 }
 ----
-<1> The name of the channel.
+[cols="1,7a",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the channel.
 To enable {prodname} to use the channel, specify this name in the connector's `notification.enabled.channels` property.
-<2> Initializes specific configuration, variables, or connections that the channel requires.
-<3> Sends the notification on the channel.
+
+|2
+|Initializes specific configuration, variables, or connections that the channel requires.
+
+|3
+|ends the notification on the channel.
 {prodname} calls this method to report its status.
-<4> Closes all allocated resources.
+
+|4
+|Closes all allocated resources.
 {prodname} calls this method when the connector is stopped.
+
+|===
 
 //   Type: concept
 [id="debezium-core-module-dependency"]
@@ -423,7 +440,14 @@ You must include these compile dependencies in your project's `pom.xml` file, as
     <version>${version.debezium}</version> // <1>
 </dependency>
 ----
-<1> `${version.debezium}` represents the version of the {prodname} connector.
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|`${version.debezium}` represents the version of the {prodname} connector.
+
+|===
 
 Declare your implementation in the `META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel` file.
 

--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -85,11 +85,25 @@ public interface CustomConverter<S, F extends ConvertedField> {
     void converterFor(F field, ConverterRegistration<S> registration); // <4>
 }
 ----
-<1> A function for converting data from one type to another.
-<2> Callback for registering a converter.
-<3> Registers the given schema and converter for the current field.
+.Descriptions of fields in a Java converter class that implements the `io.debezium.spi.converter.CustomConverter` interface
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|Converts data from one type to another.
+
+|2
+|Callback for registering a converter.
+
+|3
+|Registers the given schema and converter for the current field.
 Should not be invoked more than once for the same field.
-<4> Registers the customized value and schema converter for use with a specific field.
+
+|4
+|Registers the customized value and schema converter for use with a specific field.
+
+|===
 
 [id="debezium-custom-converter-methods"]
 === Custom converter methods
@@ -182,8 +196,19 @@ These compile dependencies must be included in your project's `pom.xml`, as show
     <version>${version.kafka}</version> <2>
 </dependency>
 ----
-<1> `${version.debezium}` represents the version of the {prodname} connector.
-<2> `${version.kafka}` represents the version of Apache Kafka in your environment.
+[cols="1,7",options="header",subs="+attributes"]
+.Descriptions of compile dependency versions in `pom.xml`
+|===
+|Item |Description
+
+|1
+|`${version.debezium}` represents the version of the {prodname} connector.
+
+|2
+|`${version.kafka}` represents the version of Apache Kafka in your environment.
+
+|===
+
 
 // Type: assembly
 // Title: Using custom converters with {prodname} connectors
@@ -225,9 +250,21 @@ If the converter requires further information to customize the formats of specif
 converters: _<converterSymbolicName>_ // <1>
 _<converterSymbolicName>_.type: _<fullyQualifiedConverterClassName>_ // <2>
 ----
-<1> The `converters` property is mandatory and enumerates a comma-separated list of symbolic names of the converter instances to use with the connector.
++
+[cols="1,7a",options="header",subs="+attributes"]
+.Description of connector configuration properties for enabling a converter
+|===
+|Item |Description
+
+|1
+|The mandatory `converters` property enumerates a comma-separated list of symbolic names of the converter instances to use with the connector.
 The values listed for this property serve as prefixes in the names of other properties that you specify for the converter.
-<2> The `_<converterSymbolicName>_.type` property is mandatory, and specifies the name of the class that implements the converter.
+
+|2
+|The mandatory `_<converterSymbolicName>_.type` property specifies the name of the class that implements the converter.
+
+|===
++
 For example, for the earlier xref:example-debezium-simple-custom-converter[custom converter example], you would add the following properties to the connector configuration:
 +
 ----

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -218,7 +218,15 @@ The following example shows how to configure the CloudEvents converter to emit c
 "value.converter.avro.schema.registry.url": "http://my-registry/schemas/ids/1"
 ...
 ----
-<1> Specifying the `serializer.type` is optional, because `json` is the default.
+[cols="1,7",options="header",subs="+attributes"]
+.Description of fields in CloudEvents converter configuration
+|===
+|Item |Description
+
+|1
+|Specifying the `serializer.type` is optional, because `json` is the default.
+
+|===
 
 The CloudEvents converter converts Kafka record values. In the same connector configuration, you can specify `key.converter` if you want to operate on record keys.
 For example, you might specify `StringConverter`, `LongConverter`, `JsonConverter`, or `AvroConverter`.


### PR DESCRIPTION
[DBZ-7418](https://issues.redhat.com/browse/DBZ-7418)

Addresses problem in downstream documentation portal where fixing the rendering a list of callout descriptions would cause rendering problems in the next instance. 
Proactively converts remaining description lists to tables in: 

- `configuration/notification.adoc`
- `development/converters.adoc`
- `integrations/cloudevents.adoc`