### PR TITLE
DBZ-7567 Fix null event timestamp possible from FORMAT_DESCRIPTION and PREVIOUS_GTIDS events in MySqlStreamingChangeEventSource::setEventTimestamp

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -227,7 +227,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     private void setEventTimestamp(Event event, long eventTs) {
-        if (connection.isMariaDb() || !isGtidModeEnabled) {
+        if (eventTimestamp == null || connection.isMariaDb() || !isGtidModeEnabled) {
             // Fallback to second resolution event timestamps
             eventTimestamp = Instant.ofEpochMilli(eventTs);
         }


### PR DESCRIPTION
References https://issues.redhat.com/browse/DBZ-7567 and a null value edge case introduced in https://github.com/debezium/debezium/pull/5281 for the `FORMAT_DESCRIPTION` and `PREVIOUS_GTIDS` events which the MySQL connector does not directly handle.

I stumbled on them by logs from the `choked` event logger:

```
Feb 26, 2024 11:22:00 PM com.github.shyiko.mysql.binlog.BinaryLogClient notifyEventListeners
WARNING: io.debezium.connector.mysql.MySqlStreamingChangeEventSource$$Lambda$1860/0x00000008016a7b80@78ecf20b choked on Event{header=EventHeaderV4{timestamp=1708989435000, eventType=FORMAT_DESCRIPTION, serverId=6656, headerLength=19, dataLength=103, nextPosition=126, flags=0}, data=FormatDescriptionEventData{binlogVersion=4, serverVersion='8.0.34-26', headerLength=19, dataLength=98, checksumType=CRC32}}
java.lang.NullPointerException: Cannot invoke "java.time.Instant.toEpochMilli()" because "this.eventTimestamp" is null
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.onEvent(MySqlStreamingChangeEventSource.java:224)
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.lambda$execute$32(MySqlStreamingChangeEventSource.java:893)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.notifyEventListeners(BinaryLogClient.java:1263)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:1089)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:648)
	at com.github.shyiko.mysql.binlog.BinaryLogClient$7.run(BinaryLogClient.java:949)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

```
WARNING: io.debezium.connector.mysql.MySqlStreamingChangeEventSource$$Lambda$1860/0x00000008016a7b80@78ecf20b choked on Event{header=EventHeaderV4{timestamp=1708989435000, eventType=PREVIOUS_GTIDS, serverId=6656, headerLength=19, dataLength=4292, nextPosition=4437, flags=128}, data=PreviousGtidSetEventData {gtidSet='0254e8f3-f493-11eb-a11f-42010ae7000e:1-12549722,02c13318-eda9-11ec-804d-4201f3008081:1-22524564,05f5019d-ef69-11e9-8406-beb2ce0dddee:1-3978775,0a82948f-7325-11eb-b698-42010aef00f2:1-302662,0a8c9096-7da6-11ee-9b0b-4201f300437f:1-104755639,0ab9b8d1-5097-11e9-82f6-b6e13127893d:1-57958,0c4bfc0f-e4e5-11eb-abdd-42010aef0004:1-44879148,0dd15adf-1aab-11e9-9038-42010aef0009:1-5443962,0e0ac63f-581e-11ea-aa7e-0aed1095e00d:1-3455991,0f1650eb-8cdd-11eb-a71c-42010ae70028:1-272673650,10764e7b-0b73-11ec-a986-4201f3004187:1-141697409,13b88c6b-5c3e-11ec-9739-4201f3008081:1-6133449,1b38007e-d046-11ea-bf9e-42010ae70151:1-2321250,1b3c9deb-beff-11eb-9652-42010aef009b:1-32229895,1d672888-5bc6-11e9-9523-42010aef0026:1-184425624,23ec7159-22c3-11eb-9c75-42010aef008b:1-54825288,265eceaf-7324-11eb-8dbe-42010aef00fd:1-51630897,26929eb5-22c5-11eb-ac80-42010ae70123:1-15186259,2996037f-eba8-11e9-9307-beb2ce0dddee:1-414647,2c18238d-7bb2-11eb-aaee-42010aef0118:1-241560923,30477377-e71d-11ea-8157-42010aef004f:1-581118795,331be06a-e1cc-11ec-853c-4201f30080b1:1-304623013,3411dc19-fb92-11eb-9434-42010aef005e:1-11478819,37b95fac-f7da-11ec-b1f3-4201f300819c:1-1,3990d04c-7bb2-11eb-96a5-42010ae70010:1-212125760,3bfd3ba2-5c44-11ec-90ac-4201f300809b:1-19839326,3ceb51f1-7bb2-11eb-8daa-42010ae70081:1-75739812,421a78b9-ace1-11ea-8103-42010aef0014:1-970293,444f79e3-22c6-11eb-9396-42010ae701f2:1-822513320,46f5b740-78cd-11ee-a0f8-4201f30043c9:1-189354,4a3cb5f3-d933-11eb-b1cf-42010aef000b:1-71025170,4f9f000c-eba9-11e9-8553-36b1b6d70072:1-42137920,4fd7d783-af51-11eb-af7c-42010aef0067:1-185426350,5072f2dc-d794-11ec-bec7-4201f3004002:1-243752319,53832795-78d5-11ee-ae91-4201f30043cc:1-18084434,5429370b-e7af-11ea-9cda-42010aef0059:1-197134554,5aeae05e-9122-11ed-a308-4201f3004226:1-321758072,5bb4f2be-cc31-11ea-99ea-42010ae700ed:1-495696445,6975dfd6-8ceb-11eb-800e-42010ae7002a:1-997030,6aafb3ca-9b99-11ee-a237-4201f300802c:1-228172473,6e16572b-f48f-11eb-a08b-42010aef0032:1-73982050,7763fe1a-55be-11eb-948e-42010ae7000d:1-4853142,77823b93-6f73-11ea-8cc2-126d05c5767f:1-40388,785ba861-581c-11ea-afd4-424417d05558:1-9043397,7879d2ac-5acd-11ed-be62-4201f300434a:1-210017595,875eb1f8-97b1-11eb-954c-42010ae7005d:1-82552,87fcd6f6-d25b-11ed-a16a-4201f3004052:1-71681801,92b202ba-22c4-11eb-bc0e-42010aef020a:1-1803865771,9581c8d0-38fc-11ec-9613-4201f3004288:1-203933877,982bbbc3-81c3-11e8-89b4-42010aef0013:207918146-540563558,9973d598-b4e7-11ec-9cef-4201f30040b9:1-361357343,9b449697-b4e7-11ec-907b-4201f30040a8:1-143284781,9b5e7097-38fc-11ec-be57-4201f300827c:1-186722248,9d8c7e9d-09ea-11ec-8da3-4201f3004009:1-7041538,9ff56ea6-e212-11e8-9a5b-42010ae7002d:28783165-179463255,a1c00011-7ef0-11e8-9cd0-42010aef0026:165851671-167079555,a29898e8-9125-11ed-b145-4201f300423c:1-100597632,a4737dfc-a2d5-11eb-bbca-42010aef005f:1-189199911,a4901b2c-09ea-11ec-91a3-4201f300400a:1-31518661,ac55cfe2-eb0b-11eb-b9d1-42010ae70009:1-54058304,b17f08d6-1efa-11ed-9e0f-4201f3020018:1-236788212,b20c1c6e-7c08-11e8-96ca-42010ae7000a:185031395-187343467,b42f66e1-b4e7-11ec-90be-4201f30040cc:1-41380164,b51a90e3-09c7-11eb-be3d-42010ae7008a:1-63646107,b8bbbca3-1955-11eb-9c11-42010ae70086:1-44199839,ba7e0b25-6f75-11ea-9e58-ae9b9eaff5e4:1-214236247,bf054a28-faea-11eb-8cc4-42010aef008d:1-41597192,c160dc8b-5c43-11ec-9f03-4201f300407a:1-323433043,c34ce625-09ea-11ec-b4fa-4201f300800b:1-100019149,c6ab4448-9122-11ed-92fa-4201f300824f:1-309301731,c7f99dec-b4e7-11ec-9cf0-4201f300825e:1-7782421,c8a8d2d3-c374-11e9-a874-42010aef0082:1-70073100,cb8a2afa-09ea-11ec-9daf-4201f300800e:1-101787003,ccd970c2-a2cc-11eb-8c9c-42010ae70062:1-158489849,cd7e085b-22c3-11eb-84a6-42010aef015b:1-25521,cea19b6f-b6b9-11ec-94c8-4201f300809c:1-164515158,d03450ee-09ea-11ec-a4b8-4201f300800d:1-67627691,d176e17f-9ebe-11eb-8b37-42010aef0058:1-77679006,d36c21e6-911a-11ed-84b3-4201f30041ae:1-108001451,d38bf4c4-b4e7-11ec-ada6-4201f3008272:1-110540,d623110c-78d0-11ee-95af-4201f30083c0:1-9923918,d669a7fa-ec18-11e8-830f-42010ae70016:51920339-464544601,d8722146-f5d5-11e9-a1a0-42010aef00dd:1-1259173633,d8dc5f40-46cc-11ea-9c37-96e9c93c7a09:1-47689990,db0d6f10-ca90-11ed-96e4-4201f300814a:1-47263829,dbb9cd60-69ec-11ea-9276-0ee6bb426b5b:1-6063375,dbd2b430-3fff-11ed-8ab5-4201f3040025:1-53034150,de2532e5-7ac5-11eb-ab87-42010aef010a:1-9219692,e0057403-b4e7-11ec-a441-4201f3008269:1-5331063,e1907e42-7ac5-11eb-985b-42010aef0047:1-40908,e1bbc17d-5c39-11ec-8c2d-4201f300807a:1-555861393,e1d166b1-7ac5-11eb-8e3d-42010ae700a8:1-1350905,e2868d91-9b97-11ee-b964-4201f30040b1:1-230547813,e30c68e5-2515-11eb-b06a-42010aef00c2:1-6098,e46c10ae-c95c-11eb-a4c6-42010aef0064:1-257809,e55aec00-97c9-11eb-b377-42010ae7005f:1-188988989,eb535de8-7323-11eb-9b77-42010ae70112:1-109707008,ee960e96-59d0-11eb-ac2d-42010ae70082:1-62033114,ef5df7b2-bdcc-11ed-9a58-4201f3004184:1-392927416,f2a16087-7324-11eb-9779-42010aef00e7:1-55112005,f3de802d-317a-11ea-91a0-c292dd3b7259:1-6125534,f63d0efc-b4e7-11ec-a139-4201f3008270:1-25767,f78430b6-f1e2-11ea-bfe3-42010ae700c2:1-63307107,f89046e1-7da6-11ee-80c5-4201f30083a3:1-118064714,f890ba36-a8b8-11ed-b694-4201f30080a1:1-747395894,f8d74ba3-5ac7-11ed-bce1-4201f3008117:1-296081621,f9076d4e-e621-11ea-9012-42010ae7001b:1-2077697'}}
java.lang.NullPointerException: Cannot invoke "java.time.Instant.toEpochMilli()" because "this.eventTimestamp" is null
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.onEvent(MySqlStreamingChangeEventSource.java:224)
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.lambda$execute$32(MySqlStreamingChangeEventSource.java:893)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.notifyEventListeners(BinaryLogClient.java:1263)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:1089)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:648)
```

```
WARNING: io.debezium.connector.mysql.MySqlStreamingChangeEventSource$$Lambda$1860/0x00000008016a7b80@2fe28984 choked on Event{header=EventHeaderV4{timestamp=1708989637000, eventType=PREVIOUS_GTIDS, serverId=64249, headerLength=19, dataLength=772, nextPosition=917, flags=128}, data=PreviousGtidSetEventData {gtidSet='1159f990-01de-11eb-83a6-42010ae7017d:1-107203748,19992277-440d-11ec-82bf-4201f30040f4:1-314981770,225b68d0-7cbc-11ee-9129-4201f3004270:1-979720445,2815fca4-01de-11eb-93a7-42010aef01a4:1-204102399,335523e0-7e05-11eb-b361-42010ae7ff2b:1-3439694596,38c6bf68-b9bc-11ec-8e37-4201f300409d:1-3039332855,413e5ac9-0aa6-11ec-9e30-4201f30080a0:1-266002682,6dadcd5d-23b4-11eb-b820-42010ae702b0:1-1803423602,75d63b9e-9241-11ed-bc34-4201f300413c:1-2757216064,767604d9-9626-11ee-b8b6-4201f3004390:1-1670728428,7ff3abb5-5ed1-11ed-a184-4201f3008218:1-49591093,91131c4a-b9bd-11ec-a9ef-4201f30080f7:1-723095240,97e34857-0aa5-11ec-9c98-4201f300808f:1-38520866,b5cb5c8d-0aa6-11ec-9293-4201f300409c:1-1556671893,bd9bbcdd-440c-11ec-8061-4201f3008256:1-144310183,cbbab159-82b8-11ec-ac89-4201f300431e:1-805223419,e5806f77-9243-11ed-897d-4201f3008146:1-2491036638,e6503b55-5ed3-11ed-b83d-4201f30042b7:1-1467585675,ed07f9fb-5790-11ec-af2e-4201f30041ec:1-1319667664'}}
java.lang.NullPointerException: Cannot invoke "java.time.Instant.toEpochMilli()" because "this.eventTimestamp" is null
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.onEvent(MySqlStreamingChangeEventSource.java:224)
	at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.lambda$execute$32(MySqlStreamingChangeEventSource.java:893)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.notifyEventListeners(BinaryLogClient.java:1263)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:1089)
	at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:648)
```