### PR TITLE
DBZ-7571: Bump of PostgreSQL driver to 42.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.apicurio>2.4.3.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.6.0</version.postgresql.driver>
+        <version.postgresql.driver>42.6.1</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
         <version.mysql.binlog>0.29.0</version.mysql.binlog>
         <version.mongo.driver>4.11.0</version.mongo.driver>


### PR DESCRIPTION
The current version is affected by [SNYK-JAVA-ORGPOSTGRESQL-6252740](https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-6252740)

The vulnerability fix is the only change in the [changelog](https://github.com/pgjdbc/pgjdbc/compare/REL42.6.0...REL42.6.1)

Jira [DBZ-7571](https://issues.redhat.com/browse/DBZ-7571)