### PR TITLE
DBZ-7499 Fix deployment examples that expose attribute names vs values

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
@@ -106,7 +106,7 @@ oc create -n __<namespace>__ -f __<kafkaConnector>__.yaml
 +
 For example,
 +
-[source,shell,options="nowrap"]
+[source,shell,options="nowrap",subs="+attributes,+quotes"]
 ----
 oc create -n debezium -f {context}-inventory-connector.yaml
 ----

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -117,7 +117,7 @@ oc create -n __<namespace>__ -f __<kafkaConnector>__.yaml
 +
 For example,
 +
-[source,shell,options="nowrap"]
+[source,shell,options="nowrap",subs="+attributes,+quotes"]
 ----
 oc create -n debezium -f {context}-inventory-connector.yaml
 ----


### PR DESCRIPTION
[DBZ-7499](https://issues.redhat.com/browse/DBZ-7499)

In the downstream documentation the step to create the connector resource when using Streams to deploy a connector contained an attribute name (`{context}`), rather than displaying the attribute value.
This change corrects formatting of the related source blocks so that attribute values correctly display.

Tested in a local downstream build. 
This change appears in a part of the source file that is conditionalized for the `product` build and has no effect on the community version of the documentation. 