### PR TITLE
Dbz 7614 Catch exceptions during validation

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -508,12 +508,12 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
     private Map<String, String> getConnectorConfig(final SourceConnector connector, final String connectorClassName) throws EmbeddedEngineRuntimeException {
         Map<String, String> connectorConfig = workerConfig.originalsStrings();
         Config validatedConnectorConfig = null;
-        try{
-          validatedConnectorConfig = connector.validate(connectorConfig);
+        try {
+            validatedConnectorConfig = connector.validate(connectorConfig);
         }
-        catch (java.lang.NoClassDefFoundError ex){
-          String msg = "Connector configuration is not valid: "+ex.getMessage();
-          failAndThrow(msg, ex);
+        catch (java.lang.NoClassDefFoundError ex) {
+            String msg = "Connector configuration is not valid: " + ex.getMessage();
+            failAndThrow(msg, ex);
         }
         ConfigInfos configInfos = AbstractHerder.generateResult(connectorClassName, Collections.emptyMap(), validatedConnectorConfig.configValues(),
                 connector.config().groups());

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -507,7 +507,14 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
 
     private Map<String, String> getConnectorConfig(final SourceConnector connector, final String connectorClassName) throws EmbeddedEngineRuntimeException {
         Map<String, String> connectorConfig = workerConfig.originalsStrings();
-        Config validatedConnectorConfig = connector.validate(connectorConfig);
+        Config validatedConnectorConfig = null;
+        try{
+          validatedConnectorConfig = connector.validate(connectorConfig);
+        }
+        catch (java.lang.NoClassDefFoundError ex){
+          String msg = "Connector configuration is not valid: "+ex.getMessage();
+          failAndThrow(msg, ex);
+        }
         ConfigInfos configInfos = AbstractHerder.generateResult(connectorClassName, Collections.emptyMap(), validatedConnectorConfig.configValues(),
                 connector.config().groups());
         if (configInfos.errorCount() > 0) {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -511,7 +511,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
         try {
             validatedConnectorConfig = connector.validate(connectorConfig);
         }
-        catch (java.lang.NoClassDefFoundError ex) {
+        catch (Exception ex) {
             String msg = "Connector configuration is not valid: " + ex.getMessage();
             failAndThrow(msg, ex);
         }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DBZ-7614
Adds a try-catch block around the `validate` call, which means that we can catch NoClassDef exceptions when a jar file is missing from the plugin directory