### PR TITLE
DBZ-7639 Bump org.postgresql:postgresql to 42.3.9 in version 1.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.apicurio>2.1.5.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.3.5</version.postgresql.driver>
+        <version.postgresql.driver>42.3.9</version.postgresql.driver>
         <version.mysql.driver>8.0.28</version.mysql.driver>
         <version.mysql.binlog>0.27.2</version.mysql.binlog>
         <version.mongo.driver>4.3.3</version.mongo.driver>


### PR DESCRIPTION
Version 42.3.5 to 42.3.8 have reported vulnerabilities, using latest minor version.

We are depending on debezium version 1.9 in one of our products [1].
I'm unsure if this is the correct / regular way to push changes to previous versions of the code, please let me know if should do something else.

[1] https://github.com/RedHatInsights/playbook-dispatcher/blob/888da7f0b6806964f79769f47c08f5dcfaf6cf48/event-streams/Dockerfile#L6
