### PR TITLE
DBZ-7657 Use SQL Server 2022 instead of 2019

### DIFF
--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -20,7 +20,7 @@
         <sqlserver.user>sa</sqlserver.user>
         <sqlserver.password>Password!</sqlserver.password>
         <sqlserver.dbname>testDB</sqlserver.dbname>
-        <docker.db>mcr.microsoft.com/mssql/server:2019-latest</docker.db>
+        <docker.db>mcr.microsoft.com/mssql/server:2022-latest</docker.db>
         <docker.filter>${docker.db}</docker.filter>
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7657

As a result of the discussion about Linux kernel compatibility: https://github.com/microsoft/mssql-docker/issues/868