### PR TITLE
[DBZ-7649] Add missing test annotation in PostgresConnectorIT

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -508,6 +508,7 @@ Troy Gaines
 Tudor Plugaru
 V K
 Vadzim Ramanenka
+Vaibhav Kushwaha
 Vasily Ulianko
 Vedit Firat Arig
 Vincenzo Santonastaso

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -3422,6 +3422,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertThat(message.get()).contains("snapshot.mode.custom.name cannot be empty when snapshot.mode 'custom' is defined");
     }
 
+    @Test
     @FixFor("DBZ-5917")
     public void shouldIncludeTableWithBackSlashInName() throws Exception {
         String setupStmt = "DROP SCHEMA IF EXISTS s1 CASCADE;" +


### PR DESCRIPTION
This PR adds the missing test annotation `@Test` from the file `PostgresConnectorIT.java`.