### PR TITLE
DBZ-3658 Oracle JDBC driver JDK8 to JDK11 (ojdbc11) 21.15.0.0

### DIFF
--- a/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution-no-infinispan.xml
+++ b/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution-no-infinispan.xml
@@ -36,6 +36,7 @@
 
               <!-- Exclude Oracle JDBC driver libraries -->
               <exclude>com.oracle.database.jdbc:ojdbc8:*</exclude>
+              <exclude>com.oracle.database.jdbc:ojdbc11:*</exclude>
               <exclude>com.oracle.database.nls:orai18n:*</exclude>
 
               <!-- Exclude dependencies with incorrect scope -->

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -230,7 +230,7 @@
             <!-- Oracle JDBC driver, XML support, Oracle XStream -->
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc8</artifactId>
+                <artifactId>ojdbc11</artifactId>
                 <version>${version.oracle.driver}</version>
             </dependency>
             <dependency>

--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -197,7 +197,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
+            <artifactId>ojdbc11</artifactId>
         </dependency>
     </dependencies>
 

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
+            <artifactId>ojdbc11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
+            <artifactId>ojdbc11</artifactId>
         </dependency>
     </dependencies>
 

--- a/debezium-testing/debezium-testing-system/README.md
+++ b/debezium-testing/debezium-testing-system/README.md
@@ -31,13 +31,19 @@ mkdir -p ${ORACLE_ARTIFACT_DIR}
 cd ${ORACLE_ARTIFACT_DIR}
 ```
 
-Download [Oracle Instant Client package](https://www.oracle.com/database/technologies/instant-client/downloads.html), unpack it and place `ojdbc8.jar` and `xstreams.jar` to `${ORACLE_ARTIFACT_DIR}` folder.
+Download [Oracle Instant Client package](https://www.oracle.com/database/technologies/instant-client/downloads.html), unpack it and place `ojdbc8.jar` or `ojdbc11.jar` along with `xstreams.jar` to `${ORACLE_ARTIFACT_DIR}` folder.
 The downloaded Oracle Instant Client version has to be the same as `ORACLE_ARTIFACT_VERSION`. 
 
 ```bash
+# Used by older versions of Debezium
 mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc8 \
     -Dversion=${ORACLE_ARTIFACT_VERSION} -Dpackaging=jar -Dfile=ojdbc8.jar \
     -Dmaven.repo.local=${MAVEN_REPO}
+# Used by newer versions of Debezium    
+mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc11 \
+    -Dversion=${ORACLE_ARTIFACT_VERSION} -Dpackaging=jar -Dfile=ojdbc11.jar \
+    -Dmaven.repo.local=${MAVEN_REPO}
+# Used by both older/newer Debezium versions    
 mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=xstreams \
     -Dversion=${ORACLE_INSTANTCLIENT_ARTIFACT_VERSION} -Dpackaging=jar -Dfile=xstreams.jar \
     -Dmaven.repo.local=${MAVEN_REPO}

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -504,7 +504,7 @@
       <dependencies>
         <dependency>
           <groupId>com.oracle.database.jdbc</groupId>
-          <artifactId>ojdbc8</artifactId>
+          <artifactId>ojdbc11</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaConnectBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaConnectBuilder.java
@@ -100,7 +100,7 @@ public class FabricKafkaConnectBuilder extends
 
         if (ConfigProperties.DATABASE_ORACLE) {
             plugins.add(
-                    artifactServer.createDebeziumPlugin("oracle", List.of("jdbc/ojdbc8")));
+                    artifactServer.createDebeziumPlugin("oracle", List.of("jdbc/ojdbc11")));
         }
 
         return withBuild(plugins);

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -19,7 +19,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '2.6.2.Final'
     db2-version: '11.5.0.0'
-    ojdbc8-version: '21.11.0.0'
+    ojdbc11-version: '21.11.0.0'
     informix-jdbc-version: '4.50.11'
     ifx-changestream-version: '1.1.3'
     community: true

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -19,7 +19,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '2.6.2.Final'
     db2-version: '11.5.0.0'
-    ojdbc11-version: '21.15.0.0'
+    ojdbc-version: '21.15.0.0'
     informix-jdbc-version: '4.50.11'
     ifx-changestream-version: '1.1.3'
     community: true

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -19,7 +19,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '2.6.2.Final'
     db2-version: '11.5.0.0'
-    ojdbc11-version: '21.11.0.0'
+    ojdbc11-version: '21.15.0.0'
     informix-jdbc-version: '4.50.11'
     ifx-changestream-version: '1.1.3'
     community: true

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2802,11 +2802,11 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/{debezium-version}/debezium-connector-oracle-{debezium-version}-plugin.tar.gz[Oracle connector plug-in archive].
 . Extract the files into your Kafka Connect environment.
-. Download the link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar[JDBC driver for Oracle] from Maven Central and extract the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file.
+. Download the link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar[JDBC driver for Oracle] from Maven Central and extract the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file.
 +
 NOTE: If you use the {prodname} Oracle connector with Oracle XStream, obtain the JDBC driver as part of the Oracle Instant Client package.
 For more information, see xref:obtaining-oracle-jdbc-driver-and-xstreams-api-files[].
-. Download the link:https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/{ojdbc8-version}/xdb-{ojdbc8-version}.jar[XDB library for Oracle] from Maven Central and extract the downloaded file to the directory that contains the {prodname} Oracle connector JAR file.
+. Download the link:https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/{ojdbc11-version}/xdb-{ojdbc11-version}.jar[XDB library for Oracle] from Maven Central and extract the downloaded file to the directory that contains the {prodname} Oracle connector JAR file.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 . Restart your Kafka Connect process to pick up the new JAR files.
 
@@ -2909,7 +2909,7 @@ RUN cd /opt/kafka/plugins/debezium/ \
 && unzip debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip \
 && rm debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip
 RUN cd /opt/kafka/plugins/debezium/ \
-&& curl -O https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/21.1.0.0/ojdbc8-21.1.0.0.jar
+&& curl -O https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar
 USER 1001
 EOF
 ----
@@ -5303,7 +5303,7 @@ The following configuration example adds the properties `database.connection.ada
 [id="obtaining-oracle-jdbc-driver-and-xstreams-api-files"]
 === Obtaining the Oracle JDBC driver and XStream API files
 
-The {prodname} Oracle connector requires the Oracle JDBC driver (`ojdbc8.jar`) to connect to Oracle databases.
+The {prodname} Oracle connector requires the Oracle JDBC driver (`ojdbc11.jar`) to connect to Oracle databases.
 If the connector uses XStream to access the database, you must also have the XStream API (`xstreams.jar`).
 Licensing requirements prohibit {prodname} from including these files in the Oracle connector archive.
 However, the required files are available for free download as part of the Oracle Instant Client.
@@ -5329,14 +5329,14 @@ instantclient_21_1/
 
 ...
 
-├── ojdbc8.jar
+├── ojdbc11.jar
 ├── ucp.jar
 ├── uidrvci
 └── xstreams.jar
 
 ----
 
-. Copy the `ojdbc8.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
+. Copy the `ojdbc11.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
 . Create an environment variable, `LD_LIBRARY_PATH`, and set its value to the path to the Instant Client directory, for example:
 +
 [source,bash,indent=0]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2802,11 +2802,11 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/{debezium-version}/debezium-connector-oracle-{debezium-version}-plugin.tar.gz[Oracle connector plug-in archive].
 . Extract the files into your Kafka Connect environment.
-. Download the link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar[JDBC driver for Oracle] from Maven Central and extract the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file.
+. Download the link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc-version}/ojdbc11-{ojdbc-version}.jar[JDBC driver for Oracle] from Maven Central and extract the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file.
 +
 NOTE: If you use the {prodname} Oracle connector with Oracle XStream, obtain the JDBC driver as part of the Oracle Instant Client package.
 For more information, see xref:obtaining-oracle-jdbc-driver-and-xstreams-api-files[].
-. Download the link:https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/{ojdbc11-version}/xdb-{ojdbc11-version}.jar[XDB library for Oracle] from Maven Central and extract the downloaded file to the directory that contains the {prodname} Oracle connector JAR file.
+. Download the link:https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/{ojdbc-version}/xdb-{ojdbc-version}.jar[XDB library for Oracle] from Maven Central and extract the downloaded file to the directory that contains the {prodname} Oracle connector JAR file.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 . Restart your Kafka Connect process to pick up the new JAR files.
 
@@ -2909,7 +2909,7 @@ RUN cd /opt/kafka/plugins/debezium/ \
 && unzip debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip \
 && rm debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip
 RUN cd /opt/kafka/plugins/debezium/ \
-&& curl -O https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar
+&& curl -O https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc11/{ojdbc-version}/ojdbc11-{ojdbc-version}.jar
 USER 1001
 EOF
 ----

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -38,7 +38,7 @@ spec:
           - type: jar
             url: https://repo1.maven.org/maven2/org/apache/groovy/groovy-json{groovy-version}/groovy-json-{groovy-version}.jar
           - type: jar          // <11>
-            url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar
+            url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -38,7 +38,7 @@ spec:
           - type: jar
             url: https://repo1.maven.org/maven2/org/apache/groovy/groovy-json{groovy-version}/groovy-json-{groovy-version}.jar
           - type: jar          // <11>
-            url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc11-version}/ojdbc11-{ojdbc11-version}.jar
+            url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/{ojdbc-version}/ojdbc11-{ojdbc-version}.jar
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
 

--- a/jenkins-jobs/pipelines/release/deploy_snapshots_pipeline.groovy
+++ b/jenkins-jobs/pipelines/release/deploy_snapshots_pipeline.groovy
@@ -48,7 +48,7 @@ node('Slave') {
             }
 
             dir(ORACLE_ARTIFACT_DIR) {
-                sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc8 -Dversion=$ORACLE_ARTIFACT_VERSION -Dpackaging=jar -Dfile=ojdbc8.jar"
+                sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc11 -Dversion=$ORACLE_ARTIFACT_VERSION -Dpackaging=jar -Dfile=ojdbc11.jar"
                 sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=xstreams -Dversion=$ORACLE_ARTIFACT_VERSION -Dpackaging=jar -Dfile=xstreams.jar"
             }
         }

--- a/jenkins-jobs/pipelines/release/release-pipeline.groovy
+++ b/jenkins-jobs/pipelines/release/release-pipeline.groovy
@@ -333,7 +333,7 @@ node('release-node') {
                 ORACLE_ARTIFACT_DIR = "$HOME_DIR/oracle-libs/${ORACLE_ARTIFACT_VERSION}.0"
             }
             dir(ORACLE_ARTIFACT_DIR) {
-                sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc8 -Dversion=$ORACLE_ARTIFACT_VERSION -Dpackaging=jar -Dfile=ojdbc8.jar"
+                sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=ojdbc11 -Dversion=$ORACLE_ARTIFACT_VERSION -Dpackaging=jar -Dfile=ojdbc11.jar"
                 sh "mvn install:install-file -DgroupId=com.oracle.instantclient -DartifactId=xstreams -Dversion=$ORACLE_INSTANTCLIENT_ARTIFACT_VERSION -Dpackaging=jar -Dfile=xstreams.jar"
             }
         }

--- a/jenkins-jobs/scripts/upstream-artifact-server-prepare.sh
+++ b/jenkins-jobs/scripts/upstream-artifact-server-prepare.sh
@@ -60,7 +60,7 @@ prefix=""
 if [ "${ORACLE}" = "false" ] ; then
   rm debezium-connector-oracle*.zip
 else
-  cp "$MAVEN_REPO"/com/oracle/database/jdbc/ojdbc8/*/ojdbc8-*.jar jdbc/
+  cp "$MAVEN_REPO"/com/oracle/database/jdbc/ojdbc11/*/ojdbc11-*.jar jdbc/
   echo "Changing quay organisation to private rh-integration since ORACLE connector is included"
   ORGANISATION="rh_integration"
   prefix="dbz-"

--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
         <version.mariadb.driver>3.2.0</version.mariadb.driver>
         <!-- These two should be aligned by major versions but minor could vary -->
         <!-- Oracle publishes the driver versions more frequently than the instant client -->
-        <version.oracle.driver>21.11.0.0</version.oracle.driver>
-        <version.oracle.instantclient>21.11.0.0</version.oracle.instantclient>
+        <version.oracle.driver>21.15.0.0</version.oracle.driver>
+        <version.oracle.instantclient>21.15.0.0</version.oracle.instantclient>
 
         <!-- Databases, should align with database drivers -->
         <version.mysql.server>8.2</version.mysql.server>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3658

@obabec your favorite task -- we'll need to align the testing farm to contain `ojdbc11` 21.11.0.0, when you have time :grinning: 

- [x] Check release bits and verify no changes needed for `ojdbc8` to `ojdbc11`.
- [x] Update driver reference used by the JDBC sink connector.