### PR TITLE
DBZ-6573 Enhance description of errors.max.retries property

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1322,7 +1322,16 @@ See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[cassandra-property-errors-max-retires]]<<cassandra-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation fails with a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1330,7 +1330,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2992,7 +2992,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2719,13 +2719,13 @@ endif::community[]
 
 |[[db2-property-snapshot-locking-mode]]<<db2-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |_exclusive_
-a|Controls whether and for how long the connector holds a table lock. 
+a|Controls whether and for how long the connector holds a table lock.
 Table locks prevent other database clients from performing certain table operations during a snapshot.
 You can set the following values:
 
 `exclusive`:: Controls how the connector holds locks on tables while performing the schema snapshot when `snapshot.isolation.mode` is `REPEATABLE_READ` or `EXCLUSIVE`. +
 The connector holds a table lock that ensures exclusive table access during only the initial phase of the snapshot in which the connector reads the database schema and other metadata.
-In subsequent phases of the snapshot, the connector uses a flashback query, which requires no locks, to select all rows from each table. 
+In subsequent phases of the snapshot, the connector uses a flashback query, which requires no locks, to select all rows from each table.
 If you prefer snapshots to run without setting any locks, set the following option, `none`.
 
 `none`:: Prevents the connector from acquiring any table locks during the snapshot.
@@ -2984,7 +2984,16 @@ endif::product[]
 
 |[[db2-property-errors-max-retires]]<<db2-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2107,7 +2107,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2099,7 +2099,16 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[mongodb-property-errors-max-retires]]<<mongodb-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3743,7 +3743,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |[[mysql-property-event-converting-failure-handling-mode]]<<mysql-property-event-converting-failure-handling-mode, `event.converting.failure.handling.mode`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -657,7 +657,7 @@ After the snapshot completes, the connector stops, and does not stream event rec
 |The connector captures the structure of all relevant tables, performing all of the steps described in the xref:initial-snapshot-workflow-with-global-read-lock[default workflow for creating an initial snapshot], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 8.2).
 
 |`never`
-|When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes. 
+|When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes.
 This option is under consideration for future deprecation, in favor of the `no_data` option.
 
 |`schema_only_recovery`
@@ -672,14 +672,14 @@ WARNING: Do not use this mode to perform a snapshot if schema changes were commi
 
 |`when_needed`
 |After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
- 
+
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a log position that is not available on the server.
 
 ifdef::community[]
 |`custom`
 |The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
-Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation. 
+Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation.
 The name is specified on the classpath of your Kafka Connect cluster.
 If you use the `EmbeddedEngine`, the name is included in the connector JAR file.
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
@@ -3428,7 +3428,7 @@ It does not transition to streaming to read change events from the binlog.
 
 `schema_only`:: Deprecated, see `no_data`.
 
-`no_data`:: The connector runs a snapshot that captures only the schema, but not any table data. 
+`no_data`:: The connector runs a snapshot that captures only the schema, but not any table data.
 Set this option if you do not need the topics to contain a consistent snapshot of the data, but you want to capture any schema changes that were applied after the last connector restart.
 
 `schema_only_recovery`:: Deprecated, see `recovery`.
@@ -3439,11 +3439,11 @@ You can also set the property to periodically prune a database schema history to
  +
 WARNING: Do not use this mode to perform a snapshot if schema changes were committed to the database after the last connector shutdown.
 
-`never`:: When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes. 
+`never`:: When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes.
 This option is under consideration for future deprecation, in favor of the `no_data` option.
 
 `when_needed`:: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
- 
+
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a binlog position or GTID that is not available on the server.
 
@@ -3455,25 +3455,25 @@ endif::community[]
 |_minimal_
 a|Controls whether and how long the connector holds the global MySQL read lock, which prevents any updates to the database, while the connector is performing a snapshot. Possible settings are: +
 
-`minimal`:: The connector holds the global read lock for only the initial phase of the snapshot during which it reads the database schemas and other metadata. 
-During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table. 
-To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction. 
+`minimal`:: The connector holds the global read lock for only the initial phase of the snapshot during which it reads the database schemas and other metadata.
+During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table.
+To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction.
 Although the release of the global read lock permits other MySQL clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction. +
 
-`minimal_percona`:: The connector holds link:https://www.percona.com/doc/percona-server/8.0/management/backup_locks.html[the global backup lock] for only the initial phase of the snapshot during which it reads the database schemas and other metadata. 
-During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table. 
-To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction. 
+`minimal_percona`:: The connector holds link:https://www.percona.com/doc/percona-server/8.0/management/backup_locks.html[the global backup lock] for only the initial phase of the snapshot during which it reads the database schemas and other metadata.
+During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table.
+To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction.
 
 Although the release of the global read lock permits other MySQL clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction. +
 This mode does not flush tables to disk, is not blocked by long-running reads, and is available only in Percona Server. +
 
-`extended`:: Blocks all write operations for the duration of the snapshot. 
+`extended`:: Blocks all write operations for the duration of the snapshot.
 Use this setting if clients submit concurrent operations that are incompatible with the REPEATABLE READ isolation level in MySQL. +
 
-`none`:: Prevents the connector from acquiring any table locks during the snapshot. 
-Although this option is allowed with all snapshot modes, it is safe to use _only_ if no schema changes occur while the snapshot is running. 
-Tables that are defined with the MyISAM engine always acquire a table lock. 
-As a result, such tables are locked even if you set this option. 
+`none`:: Prevents the connector from acquiring any table locks during the snapshot.
+Although this option is allowed with all snapshot modes, it is safe to use _only_ if no schema changes occur while the snapshot is running.
+Tables that are defined with the MyISAM engine always acquire a table lock.
+As a result, such tables are locked even if you set this option.
 This behavior differs from tables that are defined by the InnoDB engine, which acquire row-level locks.
 
 ifdef::community[]
@@ -3735,7 +3735,16 @@ Specify one of the following options:
 
 |[[mysql-property-errors-max-retires]]<<mysql-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |[[mysql-property-event-converting-failure-handling-mode]]<<mysql-property-event-converting-failure-handling-mode, `event.converting.failure.handling.mode`>>
 |`warn`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -208,7 +208,7 @@ WARNING: Do not use this mode to perform a snapshot if schema changes were commi
 ifdef::community[]
 |`custom`
 |The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
-Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation. 
+Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation.
 The name is specified on the classpath of your Kafka Connect cluster.
 If you use the {prodname} `EmbeddedEngine`, the name is included in the connector JAR file.
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
@@ -269,12 +269,12 @@ For information about capturing data from a new table that has undergone structu
 2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. In the connector configuration:
 .. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to `schema_only_recovery`.
-.. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false` to ensure that in the future the connector can readily capture data for tables that are not currently designated for capture. 
-Connectors can capture data from a table only if the table's schema history is present in the history topic. 
+.. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false` to ensure that in the future the connector can readily capture data for tables that are not currently designated for capture.
+Connectors can capture data from a table only if the table's schema history is present in the history topic.
 .. Add the tables that you want the connector to capture to `table.include.list`.
 4. Restart the connector.
 The snapshot recovery process rebuilds the schema history based on the current structure of the tables.
-5. (Optional) After the snapshot completes, initiate an xref:debezium-oracle-incremental-snapshots[incremental snapshot] on the newly added tables. 
+5. (Optional) After the snapshot completes, initiate an xref:debezium-oracle-incremental-snapshots[incremental snapshot] on the newly added tables.
 The incremental snapshot first streams the historical data of the newly added tables, and then resumes reading changes from the redo and archive logs for previously configured tables, including changes that occur while that connector was off-line.
 6. (Optional) Reset the `snapshot.mode` back to `schema_only` to prevent the connector from initiating recovery after a future restart.
 
@@ -3155,7 +3155,7 @@ Note this mode is only safe to be used when it is guaranteed that no schema chan
 After the snapshot is complete, the connector continues to read change events from the database's redo logs except when `snapshot.mode` is configured as `initial_only`.
 
 `when_needed`:: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
- 
+
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a log position that is not available on the server.
 
@@ -3976,7 +3976,16 @@ By default, no additional retries will be performed.
 
 |[[oracle-property-errors-max-retires]]<<oracle-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3984,7 +3984,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3653,7 +3653,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -178,11 +178,11 @@ If the connector fails, is rebalanced, or stops after Step 1 begins but before S
 |The connector performs a database snapshot and stops before streaming any change event records. If the connector had started but did not complete a snapshot before stopping, the connector restarts the snapshot process and stops when the snapshot completes.
 
 |`no_data`
-|The connector never performs snapshots. 
+|The connector never performs snapshots.
 When a connector is configured this way, after it starts, it behaves as follows:
 
-If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. 
-If no LSN is stored, the connector starts streaming changes from the point at which the PostgreSQL logical replication slot was created on the server. 
+If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position.
+If no LSN is stored, the connector starts streaming changes from the point at which the PostgreSQL logical replication slot was created on the server.
 Use this snapshot mode only when you know that all data of interest is still reflected in the WAL.
 
 |[.line-through]`never`
@@ -190,14 +190,14 @@ Use this snapshot mode only when you know that all data of interest is still ref
 
 |`when_needed`
 |After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
- 
+
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a log position that is not available on the server.
 
 ifdef::community[]
 |`custom`
 |The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
-Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation. 
+Set the `snapshot.mode.custom.name` configuration property to the name provided by the `name()` method of your implementation.
 The name is specified on the classpath of your Kafka Connect cluster.
 If you use the `EmbeddedEngine`, the name is included in the connector JAR file.
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
@@ -3290,17 +3290,17 @@ After the snapshot completes, the connector begins to stream event records for s
 
 `initial_only`:: The connector performs an initial snapshot and then stops, without processing any subsequent changes.
 
-`no_data`:: The connector never performs snapshots. 
+`no_data`:: The connector never performs snapshots.
 When a connector is configured this way, after it starts, it behaves as follows:
 
 If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position.
-If no LSN is stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. 
+If no LSN is stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server.
 Use this snapshot mode only when you know all data of interest is still reflected in the WAL.
 
 `never`:: Deprecated see `no_data`.
 
 `when_needed`:: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
- 
+
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a log position that is not available on the server.
 
@@ -3645,7 +3645,16 @@ endif::product[]
 
 |[[postgresql-property-errors-max-retires]]<<postgresql-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/spanner.adoc
+++ b/documentation/modules/ROOT/pages/connectors/spanner.adoc
@@ -1255,7 +1255,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/spanner.adoc
+++ b/documentation/modules/ROOT/pages/connectors/spanner.adoc
@@ -24,7 +24,7 @@ The connector does not support the snapshot feature at the moment. The first tim
 [[spanner-overview]]
 == Overview
 
-To read and process database changes, the connector queries from a change stream. 
+To read and process database changes, the connector queries from a change stream.
 
 The connector produces a change event for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
@@ -129,7 +129,7 @@ The following skeleton JSON documents show the basic structure for the key and v
 
 |1
 |`schema`
-|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key. 
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key.
 
 |2
 |`payload`
@@ -246,7 +246,7 @@ PRIMARY KEY (id);
 [[spanner-create-events]]
 === _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `Users` table. If a Spanner column is marked is non-optional, its value is required for all mutations that insert a row. All primary key columns in Spanner will be marked as non-optional. Note that even if a non-key column is marked as non-optional in Spanner, it will be shown as optional in the schema. Only primary key columns are marked as non-optional in the schema. 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `Users` table. If a Spanner column is marked is non-optional, its value is required for all mutations that insert a row. All primary key columns in Spanner will be marked as non-optional. Note that even if a non-key column is marked as non-optional in Spanner, it will be shown as optional in the schema. Only primary key columns are marked as non-optional in the schema.
 
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
@@ -558,18 +558,18 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * The instance ID
 * The database ID
 * The change stream name
-* The transaction ID    
+* The transaction ID
 * The low watermark, which represents the timestamp at which all records with commit timestamp less than the low watermark timestamp have already been streamed out by the connector
 * The commit timestamp for when the change was made in the database
-* The timestamp at which the connnector processed the change 
-* The number of records in the originating transaction 
-* The transaction tag 
-* Whether or not the transaction was a system transaction 
-* The value capture type 
-* The originating partition token used to query this change event 
-* The mod number in the original data change event received from Spanner 
-* Whether or not the data change event was the last record in the transaction in the partition 
-* The total number of change stream partitions in the transaction 
+* The timestamp at which the connnector processed the change
+* The number of records in the originating transaction
+* The transaction tag
+* Whether or not the transaction was a system transaction
+* The value capture type
+* The originating partition token used to query this change event
+* The mod number in the original data change event received from Spanner
+* Whether or not the data change event was the last record in the transaction in the partition
+* The total number of change stream partitions in the transaction
 
 |9
 |`op`
@@ -672,18 +672,18 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * The instance ID
 * The database ID
 * The change stream name
-* The transaction ID    
+* The transaction ID
 * The low watermark, which represents the timestamp at which all records with commit timestamp less than the low watermark timestamp have already been streamed out by the connector
 * The commit timestamp for when the change was made in the database
-* The timestamp at which the connnector processed the change 
-* The number of records in the originating transaction 
-* The transaction tag 
-* Whether or not the transaction was a system transaction 
-* The value capture type 
-* The originating partition token used to query this change event 
-* The mod number in the original data change event received from Spanner 
-* Whether or not the data change event was the last record in the transaction in the partition 
-* The total number of change stream partitions in the transaction 
+* The timestamp at which the connnector processed the change
+* The number of records in the originating transaction
+* The transaction tag
+* Whether or not the transaction was a system transaction
+* The value capture type
+* The originating partition token used to query this change event
+* The mod number in the original data change event received from Spanner
+* Whether or not the data change event was the last record in the transaction in the partition
+* The total number of change stream partitions in the transaction
 
 |4
 |`op`
@@ -776,18 +776,18 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * The instance ID
 * The database ID
 * The change stream name
-* The transaction ID    
+* The transaction ID
 * The low watermark, which represents the timestamp at which all records with commit timestamp less than the low watermark timestamp have already been streamed out by the connector
 * The commit timestamp for when the change was made in the database
-* The timestamp at which the connnector processed the change 
-* The number of records in the originating transaction 
-* The transaction tag 
-* Whether or not the transaction was a system transaction 
-* The value capture type 
-* The originating partition token used to query this change event 
-* The mod number in the original data change event received from Spanner 
-* Whether or not the data change event was the last record in the transaction in the partition 
-* The total number of change stream partitions in the transaction 
+* The timestamp at which the connnector processed the change
+* The number of records in the originating transaction
+* The transaction tag
+* Whether or not the transaction was a system transaction
+* The value capture type
+* The originating partition token used to query this change event
+* The mod number in the original data change event received from Spanner
+* Whether or not the data change event was the last record in the transaction in the partition
+* The total number of change stream partitions in the transaction
 
 |4
 |`op`
@@ -866,7 +866,7 @@ The Spanner connector represents changes to rows with events that are structured
 * Make sure to provide a project ID, Spanner instance ID, Spanner database ID, and change stream name. See link:https://cloud.google.com/spanner/docs/change-streams/manage[documentation] on how to create change streams.
 * Make sure to create and configure a GCP service account with the proper credentials. The service account key will need to be provided in the connector configuration. See more link:https://cloud.google.com/iam/docs/service-accounts[information] about service accounts here.
 
-See the following section on how to configure a {prodname} Spanner connector. 
+See the following section on how to configure a {prodname} Spanner connector.
 
 // Type: assembly
 // ModuleID: deploying-and-managing-debezium-spanner-connectors
@@ -909,7 +909,7 @@ You can choose to produce events for a subset of the schemas and tables. Optiona
 <4> The GCP Project ID.
 <5> The Spanner Instance ID.
 <6> The Spanner Database ID.
-<7> The GCP service account key JSON. 
+<7> The GCP service account key JSON.
 <8> The maximum number of tasks.
 
 See the xref:spanner-connector-properties[complete list of Spanner connector properties] that can be specified in these configurations.
@@ -1247,7 +1247,16 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[spanner-property-errors-max-retires]]<<spanner-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3203,7 +3203,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |[[sqlserver-property-data-query-mode]]<<sqlserver-property-data-query-mode, `data.query.mode`>>

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3195,7 +3195,16 @@ endif::product[]
 
 |[[sqlserver-property-errors-max-retires]]<<sqlserver-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |[[sqlserver-property-data-query-mode]]<<sqlserver-property-data-query-mode, `data.query.mode`>>
 |`function`

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1597,7 +1597,7 @@ Set one of the following options:
 `0`:: Disabled. The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+`> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1589,7 +1589,16 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[vitess-property-errors-max-retires]]<<vitess-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|The maximum number of retries on retriable errors (e.g. connection errors) before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+Set one of the following options:
+
+`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+
+`0`:: Disabled. The connector fails immediately, and never retries the operation.
+User intervention is required to restart the connector.
+
+`> 0`:: The connector restarts automatically until it exceeds the specified value the maximum number of retries.
+After the next failure, the connector stops, and user intervention is required to restart it.
 
 |===
 


### PR DESCRIPTION
[DBZ-6573](https://issues.redhat.com/browse/DBZ-6573)

Follow up to the original issue to provide more detail in the description of the `errors.max.retries` connector configuration property.  
Tested in local Antora build.
Backport to 2.5 and 2.6.