### PR TITLE
DBZ-6964 Temporary fix schema for MySQL "Geometry" types conflicting with Avro schema registries (Confluent, Apicurio).

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -163,6 +163,11 @@
                 <artifactId>apicurio-registry-utils-converter</artifactId>
                 <version>${version.apicurio}</version>
             </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-client</artifactId>
+                <version>${version.apicurio}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.antlr</groupId>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -123,6 +123,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -211,7 +211,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
                 || matches(typeName, "MULTILINESTRING")
                 || matches(typeName, "MULTIPOLYGON")
                 || isGeometryCollection(typeName)) {
-            return io.debezium.data.geometry.Geometry.builder();
+            return io.debezium.data.geometry.Geometry.builder(column.name());
         }
         if (matches(typeName, "YEAR")) {
             return Year.builder();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/JdbcSinkDataTypesConverter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/JdbcSinkDataTypesConverter.java
@@ -169,7 +169,7 @@ public class JdbcSinkDataTypesConverter implements CustomConverter<SchemaBuilder
                     return null;
                 }
                 else if (field.hasDefaultValue()) {
-                    return (String) field.defaultValue();
+                    return field.defaultValue();
                 }
                 return "";
             }
@@ -177,10 +177,10 @@ public class JdbcSinkDataTypesConverter implements CustomConverter<SchemaBuilder
                 return new String((byte[]) value, StandardCharsets.UTF_8);
             }
             else if (value instanceof Number) {
-                return ((Number) value).toString();
+                return value.toString();
             }
             else if (value instanceof String) {
-                return (String) value;
+                return value;
             }
             LOGGER.warn("Cannot convert '{}' to STRING", value.getClass());
             return "";

--- a/debezium-connector-mysql/src/test/resources/ddl/geometry_test_5.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/geometry_test_5.sql
@@ -31,3 +31,16 @@ CREATE TABLE dbz_507_geometry (
 );
 INSERT INTO dbz_507_geometry VALUES (1, ST_GeomFromText('POINT(1 1)', 4326), ST_GeomFromText('LINESTRING(0 0, 1 1)', 3187), ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 0))'), ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1), LINESTRING(0 0, 1 1))', 4326));
 INSERT INTO dbz_507_geometry VALUES (2, ST_GeomFromText('LINESTRING(0 0, 1 1)'), NULL, NULL, NULL);
+
+CREATE TABLE dbz_6964_geometry (
+    id INT NOT NULL,
+    geom GEOMETRY,
+    geom2 GEOMETRY,
+    linestring LINESTRING,
+    polygon POLYGON,
+    collection GEOMETRYCOLLECTION,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO dbz_6964_geometry VALUES (1, ST_GeomFromText('POINT(1 1)', 4326), ST_GeomFromText('POINT(2 2)', 4326), ST_GeomFromText('LINESTRING(0 0, 1 1)', 3187), ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 0))'), ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1), LINESTRING(0 0, 1 1))', 4326));
+INSERT INTO dbz_6964_geometry VALUES (2, ST_GeomFromText('LINESTRING(0 0, 1 1)'), ST_GeomFromText('LINESTRING(1 1, 2 2)'), NULL, NULL, NULL);

--- a/debezium-connector-mysql/src/test/resources/ddl/geometry_test_8.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/geometry_test_8.sql
@@ -30,3 +30,16 @@ CREATE TABLE dbz_507_geometry (
 );
 INSERT INTO dbz_507_geometry VALUES (1, ST_GeomFromText('POINT(1 1)', 4326), ST_GeomFromText('LINESTRING(0 0, 1 1)', 3187), ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 0))'), ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1), LINESTRING(0 0, 1 1))', 4326));
 INSERT INTO dbz_507_geometry VALUES (2, ST_GeomFromText('LINESTRING(0 0, 1 1)'), NULL, NULL, NULL);
+
+CREATE TABLE dbz_6964_geometry (
+    id INT NOT NULL,
+    geom GEOMETRY,
+    geom2 GEOMETRY,
+    linestring LINESTRING,
+    polygon POLYGON,
+    collection GEOMETRYCOLLECTION,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO dbz_6964_geometry VALUES (1, ST_GeomFromText('POINT(1 1)', 4326), ST_GeomFromText('POINT(2 2)', 4326), ST_GeomFromText('LINESTRING(0 0, 1 1)', 3187), ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 0))'), ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1), LINESTRING(0 0, 1 1))', 4326));
+INSERT INTO dbz_6964_geometry VALUES (2, ST_GeomFromText('LINESTRING(0 0, 1 1)'), ST_GeomFromText('LINESTRING(1 1, 2 2)'), NULL, NULL, NULL);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -537,7 +537,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
-    protected static final String DATABASE_CONFIG_PREFIX = "database.";
     protected static final int DEFAULT_PORT = 5_432;
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final int DEFAULT_MAX_RETRIES = 6;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -304,7 +304,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
             default:
                 if (oidValue == typeRegistry.geometryOid()) {
-                    return Geometry.builder();
+                    return Geometry.builder(column.name());
                 }
                 else if (oidValue == typeRegistry.geographyOid()) {
                     return Geography.builder();
@@ -313,7 +313,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                     return SchemaBuilder.string();
                 }
                 else if (oidValue == typeRegistry.geometryArrayOid()) {
-                    return SchemaBuilder.array(Geometry.builder().optional().build());
+                    return SchemaBuilder.array(Geometry.builder(column.name()).optional().build());
                 }
                 else if (oidValue == typeRegistry.hstoreOid()) {
                     return hstoreSchema();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -881,7 +881,7 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForPostgisTypes() {
-        Schema geomSchema = Geometry.builder().optional().build();
+        Schema geomSchema = Geometry.builder("p").optional().build();
         Schema geogSchema = Geography.builder().optional().build();
         return Arrays.asList(
                 // geometries are encoded here as HexEWKB
@@ -895,21 +895,33 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForPostgisArrayTypes() {
-        Schema geomSchema = Geometry.builder()
+        Schema gaSchema = Geometry.builder("ga")
+                .optional()
+                .build();
+        Schema gaanSchema = Geometry.builder("gaan")
                 .optional()
                 .build();
 
-        List<Struct> values = Arrays.asList(
+        List<Struct> gaValues = Arrays.asList(
                 // 'GEOMETRYCOLLECTION EMPTY'::postgis.geometry
-                Geometry.createValue(geomSchema, DatatypeConverter.parseHexBinary("010700000000000000"), null),
+                Geometry.createValue(gaSchema, DatatypeConverter.parseHexBinary("010700000000000000"), null),
                 // 'POLYGON((166.51 -46.64, 178.52 -46.64, 178.52 -34.45, 166.51 -34.45, 166.51 -46.64))'::postgis.geometry
-                Geometry.createValue(geomSchema, DatatypeConverter.parseHexBinary(
+                Geometry.createValue(gaSchema, DatatypeConverter.parseHexBinary(
                         "01030000000100000005000000B81E85EB51D0644052B81E85EB5147C0713D0AD7A350664052B81E85EB5147C0713D0AD7A35066409A999999993941C0B81E85EB51D064409A999999993941C0B81E85EB51D0644052B81E85EB5147C0"),
                         null));
+
+        List<Struct> gaanValues = Arrays.asList(
+                // 'GEOMETRYCOLLECTION EMPTY'::postgis.geometry
+                Geometry.createValue(gaSchema, DatatypeConverter.parseHexBinary("010700000000000000"), null),
+                // 'POLYGON((166.51 -46.64, 178.52 -46.64, 178.52 -34.45, 166.51 -34.45, 166.51 -46.64))'::postgis.geometry
+                Geometry.createValue(gaSchema, DatatypeConverter.parseHexBinary(
+                        "01030000000100000005000000B81E85EB51D0644052B81E85EB5147C0713D0AD7A350664052B81E85EB5147C0713D0AD7A35066409A999999993941C0B81E85EB51D064409A999999993941C0B81E85EB51D0644052B81E85EB5147C0"),
+                        null));
+
         return Arrays.asList(
                 // geometries are encoded here as HexEWKB
-                new SchemaAndValueField("ga", SchemaBuilder.array(geomSchema).optional().build(), values),
-                new SchemaAndValueField("gann", SchemaBuilder.array(geomSchema).build(), values));
+                new SchemaAndValueField("ga", SchemaBuilder.array(gaSchema).optional().build(), gaValues),
+                new SchemaAndValueField("gann", SchemaBuilder.array(gaanSchema).build(), gaanValues));
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForQuotedTypes() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -190,7 +190,7 @@ public class PostgresSchemaIT {
             Arrays.stream(testTables).forEach(tableId -> assertKeySchema(tableId, "pk", SchemaBuilder.int32().defaultValue(0).build()));
 
             assertTableSchema("public.postgis_table", "p, ml",
-                    Geometry.builder().optional().build(), Geography.builder().optional().build());
+                    Geometry.builder("p").optional().build(), Geography.builder().optional().build());
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -267,7 +267,7 @@ public final class TestHelper {
     }
 
     public static JdbcConfiguration.Builder defaultJdbcConfigBuilder(String hostname, int port) {
-        return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
+        return JdbcConfiguration.copy(Configuration.fromSystemProperties(CommonConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .with(CommonConnectorConfig.TOPIC_PREFIX, "dbserver1")
                 .withDefault(JdbcConfiguration.DATABASE, "postgres")
                 .withDefault(JdbcConfiguration.HOSTNAME, hostname)

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -177,6 +177,9 @@ public class SchemaUtil {
                         break;
                     default:
                 }
+                if (schema.parameters() != null) {
+                    appendAdditional("parameters", schema.parameters());
+                }
                 sb.append('}');
             }
             else if (obj instanceof Struct) {

--- a/debezium-core/src/main/java/io/debezium/data/geometry/Geometry.java
+++ b/debezium-core/src/main/java/io/debezium/data/geometry/Geometry.java
@@ -33,9 +33,9 @@ public class Geometry {
      *
      * @return the schema builder
      */
-    public static SchemaBuilder builder() {
+    public static SchemaBuilder builder(String columnName) {
         return SchemaBuilder.struct()
-                .name(LOGICAL_NAME)
+                .name(LOGICAL_NAME + "__" + columnName) // temporary fix for DBZ-6964
                 .version(1)
                 .doc("Geometry")
                 .optional()
@@ -47,10 +47,10 @@ public class Geometry {
      * Returns a {@link SchemaBuilder} for a Geometry field, with all other default Schema settings.
      *
      * @return the schema
-     * @see #builder()
+     * @see #builder(String columnName)
      */
-    public static Schema schema() {
-        return builder().build();
+    public static Schema schema(String columnName) {
+        return builder(columnName).build();
     }
 
     /**


### PR DESCRIPTION
It seems that schema registries don't incorporate schema parameters correctly leading to that only the first row of a Geometry type is used as schema reference. If a single topic/table has multiple fields/rows of a geo type than only one schema is referenced for all fields, even when the real schema of those fields differ.