### PR TITLE
DBZ-7706 added mongo-sharded-replicaset tag to system tests

### DIFF
--- a/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/tests/mongodb/sharded/OcpShardedReplicaMongoConnectorIT.java
+++ b/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/tests/mongodb/sharded/OcpShardedReplicaMongoConnectorIT.java
@@ -31,10 +31,7 @@ import fixture5.annotations.Fixture;
 import freemarker.template.TemplateException;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Tag("acceptance")
-@Tag("mongo")
-@Tag("openshift")
-@Tag("mongo-sharded")
+@Tag("mongo-sharded-replicaset")
 @Fixture(OcpClient.class)
 @Fixture(OcpStrimziOperator.class)
 @Fixture(OcpKafka.class)


### PR DESCRIPTION
for replicaset test added new tag and removed all others, so this test is ran only if explicitly specified
https://issues.redhat.com/browse/DBZ-7706