### PR TITLE
DBZ-7497 Add a configuration based snapshot modes configurable via connector properties

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -99,7 +99,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         WHEN_NEEDED("when_needed"),
 
         /**
-         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         * Allows control over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
          */
         CONFIGURATION_BASED("configuration_based"),
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -99,6 +99,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         WHEN_NEEDED("when_needed"),
 
         /**
+         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         */
+        CONFIGURATION_BASED("configuration_based"),
+
+        /**
          * Inject a custom snapshotter, which allows for more control over snapshots.
          */
         CUSTOM("custom");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -195,7 +195,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         INITIAL_ONLY("initial_only"),
 
         /**
-         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         * Allows control over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
          */
         CONFIGURATION_BASED("configuration_based"),
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -195,6 +195,11 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         INITIAL_ONLY("initial_only"),
 
         /**
+         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         */
+        CONFIGURATION_BASED("configuration_based"),
+
+        /**
          * Inject a custom snapshotter, which allows for more control over snapshots.
          */
         CUSTOM("custom");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1040,6 +1040,11 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         WHEN_NEEDED("when_needed"),
 
         /**
+         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         */
+        CONFIGURATION_BASED("configuration_based"),
+
+        /**
          * Inject a custom snapshotter, which allows for more control over snapshots.
          */
         CUSTOM("custom");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1040,7 +1040,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         WHEN_NEEDED("when_needed"),
 
         /**
-         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         * Allows control over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
          */
         CONFIGURATION_BASED("configuration_based"),
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -208,7 +208,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         WHEN_NEEDED("when_needed"),
 
         /**
-         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         * Allows control over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
          */
         CONFIGURATION_BASED("configuration_based"),
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -208,6 +208,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         WHEN_NEEDED("when_needed"),
 
         /**
+         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         */
+        CONFIGURATION_BASED("configuration_based"),
+
+        /**
          * Inject a custom snapshotter, which allows for more control over snapshots.
          */
         CUSTOM("custom");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomSnapshotterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomSnapshotterIT.java
@@ -129,7 +129,7 @@ public class CustomSnapshotterIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.CONFIGURATION_BASED)
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, false)
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA, false)
-                .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM, true)
+                .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM, true)
                 .with(PostgresConnectorConfig.SNAPSHOT_QUERY_MODE_CUSTOM_NAME, CustomTestSnapshot.class.getName())
                 .build();
 
@@ -162,7 +162,7 @@ public class CustomSnapshotterIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.CONFIGURATION_BASED)
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, false)
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA, false)
-                .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM, false)
+                .with(CommonConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM, false)
                 .with(PostgresConnectorConfig.SNAPSHOT_QUERY_MODE_CUSTOM_NAME, CustomTestSnapshot.class.getName())
                 .build();
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -97,6 +97,11 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         WHEN_NEEDED("when_needed"),
 
         /**
+         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         */
+        CONFIGURATION_BASED("configuration_based"),
+
+        /**
          * Inject a custom snapshotter, which allows for more control over snapshots.
          */
         CUSTOM("custom");

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -97,7 +97,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         WHEN_NEEDED("when_needed"),
 
         /**
-         * Allows over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
+         * Allows control over snapshots by setting connectors properties prefixed with 'snapshot.mode.configuration.based'.
          */
         CONFIGURATION_BASED("configuration_based"),
 

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -991,84 +991,57 @@ public abstract class CommonConnectorConfig {
     public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA = Field.create("snapshot.mode.configuration.based.snapshot.data")
             .withDisplayName("Snapshot mode property based snapshot data")
             .withType(Type.BOOLEAN)
+            .withDefault(false)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 17))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "", "snapshot.mode.configuration.based.snapshot.data cannot be empty when snapshot.mode 'configuration_based' is defined");
-                    return 1;
-                }
-                return 0;
-            })
+            .optional()
             .withDescription(
-                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the data should be snapshotted or not.");
+                    "When 'snapshot.mode' is set as configuration_based, this setting permits to specify whenever the data should be snapshotted or not.");
 
     public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA = Field.create("snapshot.mode.configuration.based.snapshot.schema")
             .withDisplayName("Snapshot mode property based snapshot schema")
             .withType(Type.BOOLEAN)
+            .withDefault(false)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 18))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "", "snapshot.mode.configuration.based.snapshot.schema cannot be empty when snapshot.mode 'configuration_based' is defined");
-                    return 1;
-                }
-                return 0;
-            })
+            .optional()
             .withDescription(
-                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the schema should be snapshotted or not.");
+                    "When 'snapshot.mode' is set as configuration_based, this setting permits to specify whenever the schema should be snapshotted or not.");
 
-    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM = Field.create("snapshot.mode.configuration.based.start.stream")
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM = Field.create("snapshot.mode.configuration.based.start.stream")
             .withDisplayName("Snapshot mode property based start stream")
             .withType(Type.BOOLEAN)
+            .withDefault(false)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 19))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "", "snapshot.mode.configuration.based.start.stream cannot be empty when snapshot.mode 'configuration_based' is defined");
-                    return 1;
-                }
-                return 0;
-            })
+            .optional()
             .withDescription(
-                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the stream should start or not after snapshot.");
+                    "When 'snapshot.mode' is set as configuration_based, this setting permits to specify whenever the stream should start or not after snapshot.");
 
     public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR = Field.create("snapshot.mode.configuration.based.snapshot.on.schema.error")
             .withDisplayName("Snapshot mode property based snapshot on schema error")
             .withType(Type.BOOLEAN)
+            .withDefault(false)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 20))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "",
-                            "snapshot.mode.configuration.based.snapshot.on.schema.error cannot be empty when snapshot.mode 'configuration_based' is defined");
-                    return 1;
-                }
-                return 0;
-            })
+            .optional()
             .withDescription(
-                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the schema should be snapshotted or not in case of error.");
+                    "When 'snapshot.mode' is set as configuration_based, this setting permits to specify whenever the schema should be snapshotted or not in case of error.");
 
     public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR = Field.create("snapshot.mode.configuration.based.snapshot.on.data.error")
             .withDisplayName("Snapshot mode property based snapshot on data error")
             .withType(Type.BOOLEAN)
+            .withDefault(false)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 21))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withValidation((config, field, output) -> {
-                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
-                    output.accept(field, "",
-                            "snapshot.mode.configuration.based.snapshot.on.data.error cannot be empty when snapshot.mode 'configuration_based' is defined");
-                    return 1;
-                }
-                return 0;
-            })
+            .optional()
             .withDescription(
-                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the data should be snapshotted or not in case of error.");
+                    "When 'snapshot.mode' is set as configuration_based, this setting permits to specify whenever the data should be snapshotted or not in case of error.");
 
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(
@@ -1084,6 +1057,11 @@ public abstract class CommonConnectorConfig {
                     SNAPSHOT_FETCH_SIZE,
                     SNAPSHOT_MAX_THREADS,
                     SNAPSHOT_MODE_CUSTOM_NAME,
+                    SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA,
+                    SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA,
+                    SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM,
+                    SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR,
+                    SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR,
                     RETRIABLE_RESTART_WAIT,
                     QUERY_FETCH_SIZE,
                     MAX_RETRIES_ON_ERROR,
@@ -1190,11 +1168,11 @@ public abstract class CommonConnectorConfig {
         this.snapshotLockingModeCustomName = config.getString(SNAPSHOT_LOCKING_MODE_CUSTOM_NAME, "");
         this.snapshotQueryMode = SnapshotQueryMode.parse(config.getString(SNAPSHOT_QUERY_MODE), SNAPSHOT_QUERY_MODE.defaultValueAsString());
         this.snapshotQueryModeCustomName = config.getString(SNAPSHOT_QUERY_MODE_CUSTOM_NAME, "");
-        this.snapshotModeConfigurationBasedSnapshotData = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, false);
-        this.snapshotModeConfigurationBasedSnapshotSchema = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA, false);
-        this.snapshotModeConfigurationBasedStream = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM, false);
-        this.snapshotModeConfigurationBasedSnapshotOnSchemaError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR, false);
-        this.snapshotModeConfigurationBasedSnapshotOnDataError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR, false);
+        this.snapshotModeConfigurationBasedSnapshotData = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA);
+        this.snapshotModeConfigurationBasedSnapshotSchema = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA);
+        this.snapshotModeConfigurationBasedStream = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM);
+        this.snapshotModeConfigurationBasedSnapshotOnSchemaError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR);
+        this.snapshotModeConfigurationBasedSnapshotOnDataError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR);
 
         this.signalingDataCollectionId = !Strings.isNullOrBlank(this.signalingDataCollection)
                 ? TableId.parse(this.signalingDataCollection)

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -74,6 +74,11 @@ public abstract class CommonConnectorConfig {
     protected SnapshotQueryMode snapshotQueryMode;
     protected String snapshotQueryModeCustomName;
     protected String snapshotLockingModeCustomName;
+    protected final boolean snapshotModeConfigurationBasedSnapshotData;
+    protected final boolean snapshotModeConfigurationBasedSnapshotSchema;
+    protected final boolean snapshotModeConfigurationBasedStream;
+    protected final boolean snapshotModeConfigurationBasedSnapshotOnSchemaError;
+    protected final boolean snapshotModeConfigurationBasedSnapshotOnDataError;
 
     /**
      * The set of predefined versions e.g. for source struct maker version
@@ -983,6 +988,88 @@ public abstract class CommonConnectorConfig {
                     "When 'snapshot.query.mode' is set as custom, this setting must be set to specify a the name of the custom implementation provided in the 'name()' method. "
                             + "The implementations must implement the 'SnapshotterQuery' interface and is called to determine how to build queries during snapshot.");
 
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA = Field.create("snapshot.mode.configuration.based.snapshot.data")
+            .withDisplayName("Snapshot mode property based snapshot data")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 17))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "", "snapshot.mode.configuration.based.snapshot.data cannot be empty when snapshot.mode 'configuration_based' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the data should be snapshotted or not.");
+
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA = Field.create("snapshot.mode.configuration.based.snapshot.schema")
+            .withDisplayName("Snapshot mode property based snapshot schema")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 18))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "", "snapshot.mode.configuration.based.snapshot.schema cannot be empty when snapshot.mode 'configuration_based' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the schema should be snapshotted or not.");
+
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM = Field.create("snapshot.mode.configuration.based.start.stream")
+            .withDisplayName("Snapshot mode property based start stream")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 19))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "", "snapshot.mode.configuration.based.start.stream cannot be empty when snapshot.mode 'configuration_based' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the stream should start or not after snapshot.");
+
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR = Field.create("snapshot.mode.configuration.based.snapshot.on.schema.error")
+            .withDisplayName("Snapshot mode property based snapshot on schema error")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 20))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "",
+                            "snapshot.mode.configuration.based.snapshot.on.schema.error cannot be empty when snapshot.mode 'configuration_based' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the schema should be snapshotted or not in case of error.");
+
+    public static final Field SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR = Field.create("snapshot.mode.configuration.based.snapshot.on.data.error")
+            .withDisplayName("Snapshot mode property based snapshot on data error")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 21))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withValidation((config, field, output) -> {
+                if ("configuration_based".equalsIgnoreCase(config.getString(SNAPSHOT_MODE_PROPERTY_NAME)) && config.getString(field, "").isEmpty()) {
+                    output.accept(field, "",
+                            "snapshot.mode.configuration.based.snapshot.on.data.error cannot be empty when snapshot.mode 'configuration_based' is defined");
+                    return 1;
+                }
+                return 0;
+            })
+            .withDescription(
+                    "When 'snapshot.mode' is set as configuration_based, this setting must be set to specify whenever the data should be snapshotted or not in case of error.");
+
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(
                     EVENT_PROCESSING_FAILURE_HANDLING_MODE,
@@ -1103,6 +1190,11 @@ public abstract class CommonConnectorConfig {
         this.snapshotLockingModeCustomName = config.getString(SNAPSHOT_LOCKING_MODE_CUSTOM_NAME, "");
         this.snapshotQueryMode = SnapshotQueryMode.parse(config.getString(SNAPSHOT_QUERY_MODE), SNAPSHOT_QUERY_MODE.defaultValueAsString());
         this.snapshotQueryModeCustomName = config.getString(SNAPSHOT_QUERY_MODE_CUSTOM_NAME, "");
+        this.snapshotModeConfigurationBasedSnapshotData = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, false);
+        this.snapshotModeConfigurationBasedSnapshotSchema = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA, false);
+        this.snapshotModeConfigurationBasedStream = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_STREAM, false);
+        this.snapshotModeConfigurationBasedSnapshotOnSchemaError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR, false);
+        this.snapshotModeConfigurationBasedSnapshotOnDataError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR, false);
 
         this.signalingDataCollectionId = !Strings.isNullOrBlank(this.signalingDataCollection)
                 ? TableId.parse(this.signalingDataCollection)
@@ -1436,6 +1528,26 @@ public abstract class CommonConnectorConfig {
 
     public String snapshotLockingModeCustomName() {
         return this.snapshotLockingModeCustomName;
+    }
+
+    public boolean snapshotModeConfigurationBasedSnapshotData() {
+        return this.snapshotModeConfigurationBasedSnapshotData;
+    }
+
+    public boolean snapshotModeConfigurationBasedSnapshotSchema() {
+        return this.snapshotModeConfigurationBasedSnapshotSchema;
+    }
+
+    public boolean snapshotModeConfigurationBasedStream() {
+        return this.snapshotModeConfigurationBasedStream;
+    }
+
+    public boolean snapshotModeConfigurationBasedSnapshotOnSchemaError() {
+        return this.snapshotModeConfigurationBasedSnapshotOnSchemaError;
+    }
+
+    public boolean snapshotModeConfigurationBasedSnapshotOnDataError() {
+        return this.snapshotModeConfigurationBasedSnapshotOnDataError;
     }
 
     public SnapshotQueryMode snapshotQueryMode() {

--- a/debezium-core/src/main/java/io/debezium/snapshot/SnapshotterServiceProvider.java
+++ b/debezium-core/src/main/java/io/debezium/snapshot/SnapshotterServiceProvider.java
@@ -65,13 +65,14 @@ public class SnapshotterServiceProvider implements ServiceProvider<SnapshotterSe
         return getSnapshotterService(configuration, snapshotter, beanRegistry, snapshotQueryService, snapshotLockService);
     }
 
-    private static SnapshotterService getSnapshotterService(Configuration configuration, Snapshotter s, BeanRegistry beanRegistry, SnapshotQuery snapshotQueryService,
+    private static SnapshotterService getSnapshotterService(Configuration configuration, Snapshotter snapshotter, BeanRegistry beanRegistry,
+                                                            SnapshotQuery snapshotQueryService,
                                                             SnapshotLock snapshotLockService) {
-        s.configure(configuration.asMap());
-        if (s instanceof BeanRegistryAware) {
-            ((BeanRegistryAware) s).injectBeanRegistry(beanRegistry);
+        if (snapshotter instanceof BeanRegistryAware) {
+            ((BeanRegistryAware) snapshotter).injectBeanRegistry(beanRegistry);
         }
-        return new SnapshotterService(s, snapshotQueryService, snapshotLockService);
+        snapshotter.configure(configuration.asMap());
+        return new SnapshotterService(snapshotter, snapshotQueryService, snapshotLockService);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/snapshot/mode/AlwaysSnapshotter.java
+++ b/debezium-core/src/main/java/io/debezium/snapshot/mode/AlwaysSnapshotter.java
@@ -28,7 +28,7 @@ public class AlwaysSnapshotter extends BeanAwareSnapshotter implements Snapshott
 
     @Override
     public boolean shouldSnapshotData(boolean offsetExists, boolean snapshotInProgress) {
-        // for ALWAYS snapshot mode don't use exiting offset to have up-to-date SCN
+
         LOGGER.info("Snapshot mode is set to ALWAYS, not checking exiting offset.");
         return true;
     }

--- a/debezium-core/src/main/java/io/debezium/snapshot/mode/ConfigurationBasedSnapshotter.java
+++ b/debezium-core/src/main/java/io/debezium/snapshot/mode/ConfigurationBasedSnapshotter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.snapshot.mode;
+
+import java.util.Map;
+
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.spi.snapshot.Snapshotter;
+
+public class ConfigurationBasedSnapshotter extends BeanAwareSnapshotter implements Snapshotter {
+    private boolean snapshotData;
+    private boolean snapshotSchema;
+    private boolean stream;
+    private boolean snapshotOnSchemaError;
+    private boolean snapshotOnDataError;
+
+    @Override
+    public String name() {
+        return "configuration_based";
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+        CommonConnectorConfig commonConnectorConfig = beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, CommonConnectorConfig.class);
+        this.snapshotData = commonConnectorConfig.snapshotModeConfigurationBasedSnapshotData();
+        this.snapshotSchema = commonConnectorConfig.snapshotModeConfigurationBasedSnapshotSchema();
+        this.stream = commonConnectorConfig.snapshotModeConfigurationBasedStream();
+        this.snapshotOnSchemaError = commonConnectorConfig.snapshotModeConfigurationBasedSnapshotOnSchemaError();
+        this.snapshotOnDataError = commonConnectorConfig.snapshotModeConfigurationBasedSnapshotOnDataError();
+    }
+
+    @Override
+    public boolean shouldSnapshotData(boolean offsetExists, boolean snapshotInProgress) {
+        return this.snapshotData;
+    }
+
+    @Override
+    public boolean shouldSnapshotSchema(boolean offsetExists, boolean snapshotInProgress) {
+        return this.snapshotSchema;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return this.stream;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnSchemaError() {
+        return this.snapshotOnSchemaError;
+    }
+
+    @Override
+    public boolean shouldSnapshotOnDataError() {
+        return this.snapshotOnDataError;
+    }
+}

--- a/debezium-core/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/debezium-core/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -6,3 +6,4 @@ io.debezium.snapshot.mode.RecoverySnapshotter
 io.debezium.snapshot.mode.WhenNeededSnapshotter
 io.debezium.snapshot.mode.NeverSnapshotter
 io.debezium.snapshot.mode.SchemaOnlySnapshotter
+io.debezium.snapshot.mode.ConfigurationBasedSnapshotter


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-7497

Provides an implementation of `Snapshotter` SPI that permits to configure it through connector configuration properties. 