### PR TITLE
[ci] Bump tj-actions/changed-files from v43.0.1 to v44

### DIFF
--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -42,11 +42,12 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Get modified files (Common)
         id: changed-files-common
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             support/checkstyle/**
@@ -68,42 +69,42 @@ jobs:
 
       - name: Get modified files (MongoDB)
         id: changed-files-mongodb
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connector-mongodb/**
 
       - name: Get modified files (MySQL)
         id: changed-files-mysql
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connector-mysql/**
 
       - name: Get modified files (PostgreSQL)
         id: changed-files-postgresql
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connector-postgres/**
 
       - name: Get modified files (Oracle)
         id: changed-files-oracle
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connector-oracle/**
 
       - name: Get modified files (SQL Server)
         id: changed-files-sqlserver
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connector-sqlserver/**
 
       - name: Get modified files (Quarkus Outbox)
         id: changed-files-outbox
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-quarkus-outbox/**
@@ -112,35 +113,35 @@ jobs:
 
       - name: Get modified files (REST Extension)
         id: changed-files-rest-extension
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-connect-rest-extension/**
 
       - name: Get modified files (Schema Generator)
         id: changed-files-schema-generator
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-schema-generator/**
 
       - name: Get modified files (Debezium Testing)
         id: changed-files-debezium-testing
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-testing/**
 
       - name: Get modified files (Debezium Testing MongoDB)
         id: changed-files-debezium-testing-mongodb
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-testing/**/MongoDb*.java
 
       - name: Get modified files (MySQL DDL parser)
         id: changed-files-mysql-ddl-parser
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/**
@@ -149,7 +150,7 @@ jobs:
 
       - name: Get modified files (Oracle DDL parser)
         id: changed-files-oracle-ddl-parser
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/oracle/**
@@ -159,14 +160,14 @@ jobs:
 
       - name: Get modified files (Documentation)
         id: changed-files-documentation
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             documentation/**
 
       - name: Get modified files (Storage)
         id: changed-files-storage
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             debezium-storage/**


### PR DESCRIPTION
### Changes
In addition, modified the repository checkout to be based on the PR branch. This has the benefit that if there are file changes in the upstream target repository which changed, additional steps won't be tested as the changed files will now solely be based on the commit file changes in the PR.