### PR TITLE
DBZ-7697 When new tables are added to MSSQL, its schema must be not captured.

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -598,3 +598,4 @@ Fr0z3Nn
 Xianming Zhou
 Akula
 Nick Golubev
+Punsak Incham

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -261,3 +261,4 @@ VWagen1989,Sean Wu
 ArthurLR,Arthur Le Ray
 Lars M Johansson,Lars M. Johansson
 nivolg,Nick Golubev
+Mon-MFEC,Punsak Incham


### PR DESCRIPTION
The current Debezium captured the schema of newly added tables on MSSQL after initial deployment. This pull request will make that if a new tables are added on MSSQL, its schema must be not captured which be a follow the behavior as documented.