### PR TITLE
DBZ-7729 Fix shouldNotStreamWhenUsingSnapshotModeInitialOnly test assertion due to log message change

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2446,7 +2446,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         // should be no more records
         assertNoRecordsToConsume();
 
-        final String message = "Streaming is not enabled in current configuration";
+        final String message = "Streaming is disabled for snapshot mode initial_only";
         stopConnector(value -> assertThat(logInterceptor.containsMessage(message)).isTrue());
     }
 


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-7729