### PR TITLE
[docs] Update downstream annotations to remove suggestion of support …

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2420,7 +2420,8 @@ Without these grants, the connector cannot operate.
 |===
 
 // Type: concept
-// Title: Support for Oracle standby databases
+// Title: Running the connector with an Oracle standby database
+// ModuleID: running-the-connector-with-an-oracle-standby-database
 [id="support-for-oracle-standby-databases"]
 === Standby databases
 ifdef::product[]


### PR DESCRIPTION
…for DP feature

Update the downstream title annotation and add a new ModuleID annotation comment to remove use of the term `support` from the title and ID of the topic about using the connector with Oracle standby databases.

This change does not affect the community documentation and renders only in the downstream version of the documentation.