### PR TITLE
[docs] Update downstream annotations to remove suggestion of support …

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2508,7 +2508,8 @@ Without these grants, the connector cannot operate.
 |===
 
 // Type: concept
-// Title: Support for Oracle standby databases
+// Title: Running the connector with an Oracle standby database
+// ModuleID: running-the-connector-with-an-oracle-standby-database
 [id="support-for-oracle-standby-databases"]
 === Standby databases
 ifdef::product[]


### PR DESCRIPTION
…for DP feature

Update the downstream title annotation and add a new ModuleID annotation comment to remove use of the term `support` from the title and ID of the topic about using the connector with Oracle standby databases

(cherry picked from commit a92bca5004798e5939da4e90e9a45ca3177fd934)