### PR TITLE
DBZ-7740 Fix NOAUTH authentication required error while initializing Redis client

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -598,3 +598,4 @@ Fr0z3Nn
 Xianming Zhou
 Akula
 Nick Golubev
+Selman Genç

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -80,7 +80,7 @@ public class RedisConnection {
         Jedis client;
         try {
             client = new Jedis(address, DefaultJedisClientConfig.builder().database(this.dbIndex).connectionTimeoutMillis(this.connectionTimeout)
-                    .socketTimeoutMillis(this.socketTimeout).ssl(this.sslEnabled).build());
+                    .socketTimeoutMillis(this.socketTimeout).ssl(this.sslEnabled).user(this.user).password(this.password).build());
 
             if (!Strings.isNullOrEmpty(this.user)) {
                 client.auth(this.user, this.password);

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -261,3 +261,4 @@ VWagen1989,Sean Wu
 ArthurLR,Arthur Le Ray
 Lars M Johansson,Lars M. Johansson
 nivolg,Nick Golubev
+selman-genc-alg, Selman Genç


### PR DESCRIPTION
This PR aims to fix NOAUTH authentication required error thrown when redis database index property is specified in the configuration

You can see the details of the issue here:
https://issues.redhat.com/browse/DBZ-7740