### PR TITLE
DBZ-7740 Fixed NOAUTH authentication required error while initializing Redis connection

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -598,3 +598,4 @@ Fr0z3Nn
 Xianming Zhou
 Akula
 Nick Golubev
+Selman Genç


### PR DESCRIPTION
This PR aims to fix NOAUTH authentication required error thrown when redis database index property is specified in the configuration

You can see the details of the issue here:
https://issues.redhat.com/browse/DBZ-7740