### PR TITLE
Bump the MySQL binlog client version to 0.29.1 (fixes a bug when deserializing a large gtid transaction's length)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.6.1</version.postgresql.driver>
         <version.mysql.driver>8.3.0</version.mysql.driver>
-        <version.mysql.binlog>0.29.0</version.mysql.binlog>
+        <version.mysql.binlog>0.29.1</version.mysql.binlog>
         <version.mongo.driver>4.11.0</version.mongo.driver>
         <version.sqlserver.driver>12.4.2.jre8</version.sqlserver.driver>
         <version.db2.driver>11.5.0.0</version.db2.driver>


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/DBZ-7757

Applies https://github.com/osheroff/mysql-binlog-connector-java/pull/141 which addresses a bug that manifests like this for very large transactions:

```
io.debezium.DebeziumException: Failed to deserialize data of EventHeaderV4
{timestamp=1709171907000, eventType=GTID, serverId=28775006, headerLength=19, dataLength=62, nextPosition=80207890, flags=0}
at io.debezium.connector.mysql.MySqlStreamingChangeEventSource.wrap(MySqlStreamingChangeEventSource.java:1091)
at io.debezium.connector.mysql.MySqlStreamingChangeEventSource$ReaderThreadLifecycleListener.onEventDeserializationFailure(MySqlStreamingChangeEventSource.java:1144)
at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:1081)
at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:648)
at com.github.shyiko.mysql.binlog.BinaryLogClient$7.run(BinaryLogClient.java:949)
at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializationException: Failed to deserialize data of EventHeaderV4{timestamp=1709171907000, eventType=GTID, serverId=28775006, headerLength=19, dataLength=62, nextPosition=80207890, flags=0}
at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.deserializeEventData(EventDeserializer.java:343)
at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.nextEvent(EventDeserializer.java:246)
at io.debezium.connector.mysql.strategy.AbstractBinaryLogClientConfigurator$1.nextEvent(AbstractBinaryLogClientConfigurator.java:110)
at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:1068)
... 3 more
Caused by: java.io.IOException: Stumbled upon long even though int expected
at com.github.shyiko.mysql.binlog.io.ByteArrayInputStream.readPackedInteger(ByteArrayInputStream.java:157)
at com.github.shyiko.mysql.binlog.event.deserialization.GtidEventDataDeserializer.deserialize(GtidEventDataDeserializer.java:90)
at com.github.shyiko.mysql.binlog.event.deserialization.GtidEventDataDeserializer.deserialize(GtidEventDataDeserializer.java:27)
at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.deserializeEventData(EventDeserializer.java:337)
... 6 more
```

More details here https://github.com/osheroff/mysql-binlog-connector-java/issues/140

New upstream version commit: https://github.com/osheroff/mysql-binlog-connector-java/commit/0f38e4362895452717e9a27db2abc0a736ef2b18

I contributed the code with the bug to the binlog client, my responsibility to bring it back full circle and bump the 0.29 -> 0.29.1 version here as well.