### PR TITLE
DBZ-6116 Rewrite to comply with style guidelines

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -356,9 +356,11 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 
 [WARNING]
 ====
-Incremental snapshots requires the primary key to be stably ordered. However, `String` may not guarantees stable ordering as encodings and special characters
-can lead to unexpected behaviour (https://www.mongodb.com/docs/manual/reference/bson-types/#ref-sort-string-internationalization-id3/[Mongo sort `String`]).
-Please consider using other types for the primary key when performing incremental snapshots.
+Incremental snapshots require that the primary key for each table is stably ordered.
+Because `String` fields can include special characters, and are subject to different encodings, string-based primary keys do not lend themselves to sorting in a consistent and predictable order.
+When performing incremental snapshots, it's best to set the primary key to a data type other than `String`.
+
+For more information about BSON string types in MongoDB, see the https://www.mongodb.com/docs/manual/reference/bson-types/#string/[MongoDB documentation]).
 ====
 
 .Incremental snapshots for sharded clusters


### PR DESCRIPTION
[DBZ-6116](https://issues.redhat.com/browse/DBZ-6116)

This documentation was previously merged, but never received my review/approval. 
Per style guidelines, `please` is not for use in _"technical information or in instructions. Terms of politeness are superfluous, convey the wrong tone for technical material, and are not regarded the same way in all cultures. "_
Also, updated the reference to the database to refer to its correct trade name, and made other edits intended to enhance clarify.