### PR TITLE
DBZ-7758 Initial implementation of EhCache buffer

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>infinispan-core-jakarta</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod-jakarta</artifactId>
         </dependency>

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -36,6 +36,7 @@ import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.logminer.logwriter.LogWriterFlushStrategy;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
+import io.debezium.connector.oracle.logminer.processor.ehcache.EhcacheLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.infinispan.EmbeddedInfinispanLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.infinispan.RemoteInfinispanLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.memory.MemoryLogMinerEventProcessor;
@@ -373,7 +374,9 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     System.lineSeparator() +
                     "infinispan_embedded - This option uses an embedded Infinispan cache to buffer transaction data and persist it to disk." + System.lineSeparator() +
                     System.lineSeparator() +
-                    "infinispan_remote - This option uses a remote Infinispan cluster to buffer transaction data and persist it to disk.");
+                    "infinispan_remote - This option uses a remote Infinispan cluster to buffer transaction data and persist it to disk." + System.lineSeparator() +
+                    System.lineSeparator() +
+                    "ehcache - This option uses an embedded Ehcache cache to buffer transaction data and persist it to disk.");
 
     public static final Field LOG_MINING_BUFFER_TRANSACTION_EVENTS_THRESHOLD = Field.create("log.mining.buffer.transaction.events.threshold")
             .withDisplayName("The maximum number of events a transaction can have before being discarded.")
@@ -430,6 +433,38 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 26))
             .withValidation(OracleConnectorConfig::validateLogMiningInfinispanCacheConfiguration)
             .withDescription("Specifies the XML configuration for the Infinispan 'schema-changes' cache");
+
+    public static final Field LOG_MINING_BUFFER_EHCACHE_CACHE_PATH = Field.create("log.mining.buffer.ehcache.path")
+            .withDisplayName("Ehcache storage path configuration")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.LOW)
+            .withValidation(OracleConnectorConfig::validateLogMiningEhcacheCacheConfiguration)
+            .withDescription("Ehcache storage path configuration");
+
+    public static final Field LOG_MINING_BUFFER_EHCACHE_CACHE_TRANSACTION_SIZE_GB = Field.create("log.mining.buffer.ehcache.cache.transaction.size.gb")
+            .withDisplayName("Ehcache Transaction Cache size on disk tier in GB")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Ehcache Transaction Cache size on disk tier in GB");
+
+    public static final Field LOG_MINING_BUFFER_EHCACHE_CACHE_RECENTTRANSACTIONS_SIZE_MB = Field.create("log.mining.buffer.ehcache.cache.recenttransaction.size.mb")
+            .withDisplayName("Ehcache Recently Processed Transactions Cache size on disk tier in MB")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Ehcache Recently Processed Transactions Cache size on disk tier in MB");
+
+    public static final Field LOG_MINING_BUFFER_EHCACHE_CACHE_SCHEMACHANGES_SIZE_MB = Field.create("log.mining.buffer.ehcache.cache.schemachanges.size.mb")
+            .withDisplayName("Ehcache Schema Changes Cache size on disk tier in MB")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Ehcache Schema Changes Cache size on disk tier in MB");
 
     public static final Field LOG_MINING_BUFFER_DROP_ON_STOP = Field.create("log.mining.buffer.drop.on.stop")
             .withDisplayName("Controls whether the buffer cache is dropped when connector is stopped")
@@ -681,6 +716,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_EVENTS,
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_PROCESSED_TRANSACTIONS,
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_SCHEMA_CHANGES,
+                    LOG_MINING_BUFFER_EHCACHE_CACHE_PATH,
+                    LOG_MINING_BUFFER_EHCACHE_CACHE_TRANSACTION_SIZE_GB,
+                    LOG_MINING_BUFFER_EHCACHE_CACHE_RECENTTRANSACTIONS_SIZE_MB,
+                    LOG_MINING_BUFFER_EHCACHE_CACHE_SCHEMACHANGES_SIZE_MB,
                     LOG_MINING_BUFFER_TRANSACTION_EVENTS_THRESHOLD,
                     LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS,
                     LOG_MINING_SCN_GAP_DETECTION_GAP_SIZE_MIN,
@@ -1423,6 +1462,21 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             }
         },
 
+        EHCACHE("ehcache") {
+            @Override
+            public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
+                                                          OracleConnectorConfig connectorConfig,
+                                                          OracleConnection connection,
+                                                          EventDispatcher<OraclePartition, TableId> dispatcher,
+                                                          OraclePartition partition,
+                                                          OracleOffsetContext offsetContext,
+                                                          OracleDatabaseSchema schema,
+                                                          LogMinerStreamingChangeEventSourceMetrics metrics) {
+                return new EhcacheLogMinerEventProcessor(context, connectorConfig, connection, dispatcher, partition,
+                        offsetContext, schema, metrics);
+            }
+        },
+
         INFINISPAN_EMBEDDED("infinispan_embedded") {
             @Override
             public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
@@ -1474,7 +1528,11 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         }
 
         public boolean isInfinispan() {
-            return !MEMORY.equals(this);
+            return INFINISPAN_EMBEDDED.equals(this) || INFINISPAN_REMOTE.equals(this);
+        }
+
+        public boolean isEhcache() {
+            return EHCACHE.equals(this);
         }
 
         public boolean isInfinispanEmbedded() {
@@ -2057,6 +2115,15 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             return 0;
         }
         return Field.isRequired(config, field, problems);
+    }
+
+    public static int validateLogMiningEhcacheCacheConfiguration(Configuration config, Field field, ValidationOutput problems) {
+        final LogMiningBufferType bufferType = LogMiningBufferType.parse(config.getString(LOG_MINING_BUFFER_TYPE));
+        int errors = 0;
+        if (bufferType.isEhcache()) {
+            errors = Field.isRequired(config, field, problems);
+        }
+        return errors;
     }
 
     public static int validateUsernameExcludeList(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle;
 
+import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Objects;
 
@@ -13,7 +14,9 @@ import java.util.Objects;
  *
  * @author Chris Cranford
  */
-public class Scn implements Comparable<Scn> {
+public class Scn implements Comparable<Scn>, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /**
      * Represents an Scn that implies the maximum possible value of an SCN, useful as a placeholder.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/EventType.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/EventType.java
@@ -5,12 +5,14 @@
  */
 package io.debezium.connector.oracle.logminer.events;
 
+import java.io.Serializable;
+
 /**
  * Represents all supported event types that are loaded from Oracle LogMiner.
  *
  * @author Chris Cranford
  */
-public enum EventType {
+public enum EventType implements Serializable {
     INSERT(1),
     DELETE(2),
     UPDATE(3),
@@ -35,6 +37,8 @@ public enum EventType {
             types[option.getValue()] = option;
         }
     }
+
+    private static final long serialVersionUID = 1L;
 
     private int value;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle.logminer.events;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -16,7 +17,9 @@ import io.debezium.relational.TableId;
  *
  * @author Chris Cranford
  */
-public class LogMinerEvent {
+public class LogMinerEvent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final EventType eventType;
     private final Scn scn;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlEntryImpl.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlEntryImpl.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle.logminer.parser;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -15,11 +16,13 @@ import io.debezium.connector.oracle.logminer.processor.infinispan.marshalling.Vi
  * This class holds one parsed DML LogMiner record details
  *
  */
-public class LogMinerDmlEntryImpl implements LogMinerDmlEntry {
+public class LogMinerDmlEntryImpl implements LogMinerDmlEntry, Serializable {
 
-    private final EventType eventType;
-    private final Object[] newValues;
-    private final Object[] oldValues;
+    private static final long serialVersionUID = 1L;
+
+    private EventType eventType;
+    private Object[] newValues;
+    private Object[] oldValues;
     private String objectOwner;
     private String objectName;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractTransaction.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle.logminer.processor;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -15,7 +16,9 @@ import io.debezium.connector.oracle.Scn;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractTransaction implements Transaction {
+public abstract class AbstractTransaction implements Transaction, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private static final String UNKNOWN = "UNKNOWN";
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/ehcache/EhcacheLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/ehcache/EhcacheLogMinerEventProcessor.java
@@ -3,23 +3,39 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.oracle.logminer.processor.memory;
+package io.debezium.connector.oracle.logminer.processor.ehcache;
+
+import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_PATH;
+import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_RECENTTRANSACTIONS_SIZE_MB;
+import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_SCHEMACHANGES_SIZE_MB;
+import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_TRANSACTION_SIZE_GB;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
+import org.ehcache.Cache;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.CacheManagerConfiguration;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.statistics.CacheStatistics;
+import org.ehcache.core.statistics.DefaultStatisticsService;
+import org.ehcache.core.statistics.TierStatistics;
+import org.ehcache.expiry.ExpiryPolicy;
 import org.infinispan.commons.util.CloseableIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,87 +57,146 @@ import io.debezium.relational.TableId;
 import io.debezium.util.Loggings;
 
 /**
- * A {@link LogMinerEventProcessor} that uses the JVM heap to store events as they're being
+ * A {@link LogMinerEventProcessor} that uses Ehcache to store events as they're being
  * processed and emitted from Oracle LogMiner.
  *
- * @author Chris Cranford
  */
-public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor<MemoryTransaction> {
+public class EhcacheLogMinerEventProcessor extends AbstractLogMinerEventProcessor<EhcacheTransaction> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MemoryLogMinerEventProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheLogMinerEventProcessor.class);
     private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final OraclePartition partition;
     private final OracleOffsetContext offsetContext;
     private final LogMinerStreamingChangeEventSourceMetrics metrics;
+    private final StatisticsService transactionCacheStats;
+    private final PersistentCacheManager cacheManager;
 
     /**
      * Cache of transactions, keyed based on the transaction's unique identifier
      */
-    private final Map<String, MemoryTransaction> transactionCache = new HashMap<>();
+    private final Cache<String, EhcacheTransaction> transactionCache;
+
     /**
      * Cache of processed transactions (committed or rolled back), keyed based on the transaction's unique identifier.
      */
-    private final Map<String, Scn> recentlyProcessedTransactionsCache = new HashMap<>();
-    private final Set<Scn> schemaChangesCache = new HashSet<>();
+    private final Cache<String, Scn> recentlyProcessedTransactionsCache;
+    private final Cache<Scn, String> schemaChangesCache;
 
-    public MemoryLogMinerEventProcessor(ChangeEventSourceContext context,
-                                        OracleConnectorConfig connectorConfig,
-                                        OracleConnection jdbcConnection,
-                                        EventDispatcher<OraclePartition, TableId> dispatcher,
-                                        OraclePartition partition,
-                                        OracleOffsetContext offsetContext,
-                                        OracleDatabaseSchema schema,
-                                        LogMinerStreamingChangeEventSourceMetrics metrics) {
+    public EhcacheLogMinerEventProcessor(ChangeEventSourceContext context,
+                                         OracleConnectorConfig connectorConfig,
+                                         OracleConnection jdbcConnection,
+                                         EventDispatcher<OraclePartition, TableId> dispatcher,
+                                         OraclePartition partition,
+                                         OracleOffsetContext offsetContext,
+                                         OracleDatabaseSchema schema,
+                                         LogMinerStreamingChangeEventSourceMetrics metrics) {
         super(context, connectorConfig, schema, partition, offsetContext, dispatcher, metrics, jdbcConnection);
         this.dispatcher = dispatcher;
         this.partition = partition;
         this.offsetContext = offsetContext;
         this.metrics = (LogMinerStreamingChangeEventSourceMetrics) metrics;
+
+        this.transactionCacheStats = new DefaultStatisticsService();
+
+        final int transactionCacheSizeGb = connectorConfig.getConfig().getInteger(LOG_MINING_BUFFER_EHCACHE_CACHE_TRANSACTION_SIZE_GB);
+        final int recentTransactionsCacheSizeMb = connectorConfig.getConfig().getInteger(LOG_MINING_BUFFER_EHCACHE_CACHE_RECENTTRANSACTIONS_SIZE_MB);
+        final int schemaChangesCacheSizeMb = connectorConfig.getConfig().getInteger(LOG_MINING_BUFFER_EHCACHE_CACHE_SCHEMACHANGES_SIZE_MB);
+
+        final CacheConfiguration<String, EhcacheTransaction> transactionCacheConfig = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(String.class, EhcacheTransaction.class,
+                        ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                .disk(transactionCacheSizeGb, MemoryUnit.GB, false))
+                .withExpiry(ExpiryPolicy.NO_EXPIRY)
+                .build();
+
+        final CacheConfiguration<String, Scn> recentlyProcessedTransactionsCacheConfig = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, Scn.class,
+                ResourcePoolsBuilder.newResourcePoolsBuilder()
+                        .disk(recentTransactionsCacheSizeMb, MemoryUnit.MB, false))
+                .withExpiry(ExpiryPolicy.NO_EXPIRY)
+                .build();
+
+        final CacheConfiguration<Scn, String> schemaChangesCacheConfig = CacheConfigurationBuilder.newCacheConfigurationBuilder(Scn.class, String.class,
+                ResourcePoolsBuilder.newResourcePoolsBuilder()
+                        .disk(schemaChangesCacheSizeMb, MemoryUnit.MB, false))
+                .withExpiry(ExpiryPolicy.NO_EXPIRY)
+                .build();
+
+        final CacheManagerConfiguration cacheManagerConf = CacheManagerBuilder.persistence(connectorConfig.getConfig().getString(LOG_MINING_BUFFER_EHCACHE_CACHE_PATH));
+
+        this.cacheManager = (PersistentCacheManager) CacheManagerBuilder.newCacheManagerBuilder()
+                .with(cacheManagerConf)
+                .withCache("transactionCache", transactionCacheConfig)
+                .withCache("recentlyProcessedTransactionsCache", recentlyProcessedTransactionsCacheConfig)
+                .withCache("schemaChangesCache", schemaChangesCacheConfig)
+                .using(transactionCacheStats)
+                .build(true);
+
+        this.recentlyProcessedTransactionsCache = cacheManager.getCache("recentlyProcessedTransactionsCache", String.class, Scn.class);
+        this.schemaChangesCache = cacheManager.getCache("schemaChangesCache", Scn.class, String.class);
+        this.transactionCache = cacheManager.getCache("transactionCache", String.class, EhcacheTransaction.class);
     }
 
     @Override
-    protected Collection<MemoryTransaction> transactionCacheValues() {
-        return transactionCache.values();
+    protected Collection<EhcacheTransaction> transactionCacheValues() {
+        return StreamSupport.stream(transactionCache.spliterator(), false)
+                .map(t -> t.getValue())
+                .collect(Collectors.toList());
     }
 
     @Override
-    protected MemoryTransaction transactionCacheGet(String key) {
-        return transactionCache.get(key);
+    protected EhcacheTransaction transactionCacheGet(String key) {
+        return (key == null) ? null : transactionCache.get(key);
     }
 
     @Override
-    protected void transactionCachePut(String key, MemoryTransaction value) {
-        transactionCache.put(key, value);
+    protected void transactionCachePut(String key, EhcacheTransaction value) {
+        if (key != null && value != null) {
+            transactionCache.put(key, value);
+        }
+    }
+
+    private void transactionCacheReplace(String key, EhcacheTransaction value) {
+        if (key != null && value != null) {
+            transactionCache.replace(key, value);
+        }
     }
 
     @Override
     protected int transactionCacheSize() {
-        return transactionCache.size();
+        CacheStatistics statistics = transactionCacheStats.getCacheStatistics("transactionCache");
+        return Long.valueOf(
+                statistics.getTierStatistics().values().stream().mapToLong(TierStatistics::getMappings).sum())
+                .intValue();
     }
 
     @Override
     protected boolean transactionCacheContainsKey(String key) {
+        if (key == null) {
+            return false;
+        }
         return transactionCache.containsKey(key);
     }
 
     @Override
     protected Set<String> transactionCacheKeys() {
-        return transactionCache.keySet();
+        return StreamSupport.stream(transactionCache.spliterator(), false)
+                .map(t -> t.getKey())
+                .collect(Collectors.toSet());
     }
 
     @Override
     protected Iterator transactionCacheIterator() {
-        return transactionCache.entrySet().iterator();
+        return transactionCache.iterator();
     }
 
     @Override
-    protected MemoryTransaction createTransaction(LogMinerEventRow row) {
-        return new MemoryTransaction(row.getTransactionId(), row.getScn(), row.getChangeTime(), row.getUserName(), row.getThread());
+    protected EhcacheTransaction createTransaction(LogMinerEventRow row) {
+        return new EhcacheTransaction(row.getTransactionId(), row.getScn(), row.getChangeTime(), row.getUserName(), row.getThread());
     }
 
     @Override
     protected void removeEventWithRowId(LogMinerEventRow row) {
-        MemoryTransaction transaction = transactionCacheGet(row.getTransactionId());
+        EhcacheTransaction transaction = transactionCacheGet(row.getTransactionId());
         if (transaction == null) {
             if (isTransactionIdWithNoSequence(row.getTransactionId())) {
                 // This means that Oracle LogMiner found an event that should be undone but its corresponding
@@ -130,12 +205,15 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                 final String transactionPrefix = getTransactionIdPrefix(row.getTransactionId());
                 LOGGER.debug("Undo change refers to a transaction that has no explicit sequence, '{}'", row.getTransactionId());
                 LOGGER.debug("Checking all transactions with prefix '{}'", transactionPrefix);
-                for (String transactionKey : transactionCacheKeys()) {
+                Iterator it = transactionCacheIterator();
+                while (it.hasNext()) {
+                    final String transactionKey = ((Cache.Entry<String, EhcacheTransaction>) it.next()).getKey();
                     if (transactionKey.startsWith(transactionPrefix)) {
                         transaction = transactionCacheGet(transactionKey);
                         if (transaction != null && transaction.removeEventWithRowId(row.getRowId())) {
                             // We successfully found a transaction with the same XISUSN and XIDSLT and that
                             // transaction included a change for the specified row id.
+                            transactionCacheReplace(transactionKey, transaction);
                             Loggings.logDebugAndTraceRecord(LOGGER, row, "Undo change on table '{}' was applied to transaction '{}'", row.getTableId(), transactionKey);
                             return;
                         }
@@ -159,26 +237,31 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
 
     @Override
     public void close() throws Exception {
-        // close any resources used here
+        this.cacheManager.close();
     }
 
     @Override
     protected boolean isRecentlyProcessed(String transactionId) {
-        return recentlyProcessedTransactionsCache.containsKey(transactionId);
+        return (transactionId == null) ? false : recentlyProcessedTransactionsCache.containsKey(transactionId);
     }
 
     @Override
     protected boolean hasSchemaChangeBeenSeen(LogMinerEventRow row) {
-        return schemaChangesCache.contains(row.getScn());
+        return (row == null) ? false : schemaChangesCache.containsKey(row.getScn());
     }
 
     @Override
-    protected MemoryTransaction getAndRemoveTransactionFromCache(String transactionId) {
-        return transactionCache.remove(transactionId);
+    protected EhcacheTransaction getAndRemoveTransactionFromCache(String transactionId) {
+        if (transactionId == null) {
+            return null;
+        }
+        var transaction = transactionCache.get(transactionId);
+        transactionCache.remove(transactionId);
+        return transaction;
     }
 
     @Override
-    protected Iterator<LogMinerEvent> getTransactionEventIterator(MemoryTransaction transaction) {
+    protected Iterator<LogMinerEvent> getTransactionEventIterator(EhcacheTransaction transaction) {
         return transaction.getEvents().iterator();
     }
 
@@ -202,15 +285,15 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
 
     @Override
     protected String getFirstActiveTransactionKey() {
-        final Iterator<String> keyIterator = transactionCache.keySet().iterator();
-        return keyIterator.hasNext() ? keyIterator.next() : null;
+        Iterator<Cache.Entry<String, EhcacheTransaction>> it = transactionCache.iterator();
+        return it.hasNext() ? it.next().getKey() : null;
     }
 
     @Override
     protected void handleSchemaChange(LogMinerEventRow row) throws InterruptedException {
         super.handleSchemaChange(row);
         if (row.getTableName() != null && getConfig().isLobEnabled()) {
-            schemaChangesCache.add(row.getScn());
+            schemaChangesCache.put(row.getScn(), null);
         }
     }
 
@@ -221,7 +304,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
             return;
         }
         if (!isRecentlyProcessed(transactionId)) {
-            MemoryTransaction transaction = transactionCacheGet(transactionId);
+            EhcacheTransaction transaction = transactionCacheGet(transactionId);
             if (transaction == null) {
                 LOGGER.trace("Transaction {} not in cache for DML, creating.", transactionId);
                 transaction = createTransaction(row);
@@ -238,10 +321,13 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                 // Add new event at eventId offset
                 LOGGER.trace("Transaction {}, adding event reference at index {}", transactionId, eventId);
                 transaction.getEvents().add(eventSupplier.get());
+                transactionCacheReplace(transactionId, transaction);
                 metrics.calculateLagFromSource(row.getChangeTime());
             }
 
-            metrics.setActiveTransactionCount(transactionCacheSize());
+            CacheStatistics statistics = transactionCacheStats.getCacheStatistics("transactionCache");
+            long transactionsCount = statistics.getTierStatistics().values().stream().mapToLong(TierStatistics::getMappings).sum();
+            metrics.setActiveTransactionCount(transactionsCount);
         }
         else if (!getConfig().isLobEnabled()) {
             // Explicitly only log this warning when LobEnabled is false because its commonplace for a
@@ -252,7 +338,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     }
 
     @Override
-    protected int getTransactionEventCount(MemoryTransaction transaction) {
+    protected int getTransactionEventCount(EhcacheTransaction transaction) {
         return transaction.getEvents().size();
     }
 
@@ -267,7 +353,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     @Override
     protected Scn calculateNewStartScn(Scn endScn, Scn maxCommittedScn) throws InterruptedException {
         if (getConfig().isLobEnabled()) {
-            if (transactionCache.isEmpty() && !maxCommittedScn.isNull()) {
+            if (!transactionCache.iterator().hasNext() && !maxCommittedScn.isNull()) {
                 offsetContext.setScn(maxCommittedScn);
                 dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
             }
@@ -275,8 +361,14 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                 abandonTransactions(getConfig().getLogMiningTransactionRetention());
                 final Scn minStartScn = getTransactionCacheMinimumScn();
                 if (!minStartScn.isNull()) {
-                    recentlyProcessedTransactionsCache.entrySet().removeIf(entry -> entry.getValue().compareTo(minStartScn) < 0);
-                    schemaChangesCache.removeIf(scn -> scn.compareTo(minStartScn) < 0);
+                    StreamSupport.stream(recentlyProcessedTransactionsCache.spliterator(), false)
+                            .filter(e -> e.getValue().compareTo(minStartScn) < 0)
+                            .forEach(f -> recentlyProcessedTransactionsCache.remove(f.getKey()));
+
+                    StreamSupport.stream(schemaChangesCache.spliterator(), false)
+                            .filter(e -> e.getKey().compareTo(minStartScn) < 0)
+                            .forEach(f -> schemaChangesCache.remove(f.getKey()));
+
                     offsetContext.setScn(minStartScn.subtract(Scn.valueOf(1)));
                     dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                 }
@@ -290,7 +382,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                 endScn = getLastProcessedScn();
             }
 
-            if (transactionCache.isEmpty()) {
+            if (!transactionCache.iterator().hasNext()) {
                 offsetContext.setScn(endScn);
                 dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
             }
@@ -307,6 +399,39 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     }
 
     @Override
+    protected Scn getTransactionCacheMinimumScn() {
+        return StreamSupport.stream(transactionCache.spliterator(), false)
+                .map(c -> c.getValue().getStartScn())
+                .min(Scn::compareTo)
+                .orElse(Scn.NULL);
+    }
+
+    @Override
+    protected Optional<EhcacheTransaction> getOldestTransactionInCache() {
+        EhcacheTransaction transaction = null;
+        if (transactionCache.iterator().hasNext()) {
+            // Seed with the first element
+            transaction = transactionCache.iterator().next().getValue();
+            var it = transactionCache.iterator();
+            while (it.hasNext()) {
+                EhcacheTransaction entry = it.next().getValue();
+                int comparison = entry.getStartScn().compareTo(transaction.getStartScn());
+                if (comparison < 0) {
+                    // if entry has a smaller scn, it came before.
+                    transaction = entry;
+                }
+                else if (comparison == 0) {
+                    // if entry has an equal scn, compare the change times.
+                    if (entry.getChangeTime().isBefore(transaction.getChangeTime())) {
+                        transaction = entry;
+                    }
+                }
+            }
+        }
+        return Optional.ofNullable(transaction);
+    }
+
+    @Override
     public void abandonTransactions(Duration retention) throws InterruptedException {
         if (!Duration.ZERO.equals(retention)) {
             Optional<Scn> lastScnToAbandonTransactions = getLastScnToAbandon(jdbcConnection, retention);
@@ -315,15 +440,15 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                 Scn smallestScn = getTransactionCacheMinimumScn();
                 if (!smallestScn.isNull() && thresholdScn.compareTo(smallestScn) >= 0) {
                     boolean first = true;
-                    Iterator<Map.Entry<String, MemoryTransaction>> iterator = transactionCache.entrySet().iterator();
+                    Iterator<Cache.Entry<String, EhcacheTransaction>> iterator = transactionCache.iterator();
                     try {
                         while (iterator.hasNext()) {
-                            Map.Entry<String, MemoryTransaction> entry = iterator.next();
+                            Cache.Entry<String, EhcacheTransaction> entry = iterator.next();
                             if (entry.getValue().getStartScn().compareTo(thresholdScn) <= 0) {
                                 if (first) {
                                     LOGGER.warn("All transactions with SCN <= {} will be abandoned.", thresholdScn);
                                     if (LOGGER.isDebugEnabled()) {
-                                        try (Stream<String> s = transactionCache.keySet().stream()) {
+                                        try (Stream<String> s = transactionCacheKeys().stream()) {
                                             LOGGER.debug("List of transactions in the cache before transactions being abandoned: [{}]",
                                                     s.collect(Collectors.joining(",")));
                                         }
@@ -344,7 +469,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                     }
                     finally {
                         if (iterator instanceof CloseableIterator) {
-                            ((CloseableIterator<Map.Entry<String, MemoryTransaction>>) iterator).close();
+                            ((CloseableIterator<Cache.Entry<String, EhcacheTransaction>>) iterator).close();
                         }
                     }
                     if (LOGGER.isDebugEnabled()) {
@@ -355,9 +480,9 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
                     }
 
                     // Update the oldest scn metric are transaction abandonment
-                    final Optional<MemoryTransaction> oldestTransaction = getOldestTransactionInCache();
+                    final Optional<EhcacheTransaction> oldestTransaction = getOldestTransactionInCache();
                     if (oldestTransaction.isPresent()) {
-                        final MemoryTransaction transaction = oldestTransaction.get();
+                        final EhcacheTransaction transaction = oldestTransaction.get();
                         metrics.setOldestScnDetails(transaction.getStartScn(), transaction.getChangeTime());
                     }
                     else {
@@ -370,36 +495,4 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
             }
         }
     }
-
-    @Override
-    protected Scn getTransactionCacheMinimumScn() {
-        return transactionCache.values().stream()
-                .map(MemoryTransaction::getStartScn)
-                .min(Scn::compareTo)
-                .orElse(Scn.NULL);
-    }
-
-    @Override
-    protected Optional<MemoryTransaction> getOldestTransactionInCache() {
-        MemoryTransaction transaction = null;
-        if (!transactionCache.isEmpty()) {
-            // Seed with the first element
-            transaction = transactionCache.values().iterator().next();
-            for (MemoryTransaction entry : transactionCache.values()) {
-                int comparison = entry.getStartScn().compareTo(transaction.getStartScn());
-                if (comparison < 0) {
-                    // if entry has a smaller scn, it came before.
-                    transaction = entry;
-                }
-                else if (comparison == 0) {
-                    // if entry has an equal scn, compare the change times.
-                    if (entry.getChangeTime().isBefore(transaction.getChangeTime())) {
-                        transaction = entry;
-                    }
-                }
-            }
-        }
-        return Optional.ofNullable(transaction);
-    }
-
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/ehcache/EhcacheTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/ehcache/EhcacheTransaction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.processor.ehcache;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.processor.AbstractTransaction;
+
+/**
+ * A concrete implementation of a {@link AbstractTransaction} for the Ehcache processor.
+ */
+public class EhcacheTransaction extends AbstractTransaction implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheTransaction.class);
+
+    private int numberOfEvents;
+    private List<LogMinerEvent> events;
+
+    public EhcacheTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThreadId) {
+        super(transactionId, startScn, changeTime, userName, redoThreadId);
+        this.events = new ArrayList<>();
+        start();
+    }
+
+    @Override
+    public int getNumberOfEvents() {
+        return numberOfEvents;
+    }
+
+    @Override
+    public int getNextEventId() {
+        return numberOfEvents++;
+    }
+
+    @Override
+    public void start() {
+        numberOfEvents = 0;
+    }
+
+    public List<LogMinerEvent> getEvents() {
+        return events;
+    }
+
+    public boolean removeEventWithRowId(String rowId) {
+        // Should always iterate from the back of the event queue and remove the last that matches row-id.
+        for (int i = events.size() - 1; i >= 0; i--) {
+            final LogMinerEvent event = events.get(i);
+            if (event.getRowId().equals(rowId)) {
+                events.remove(i);
+                LOGGER.trace("Undo applied for event {}.", event);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "EhcacheTransaction{" +
+                "numberOfEvents=" + numberOfEvents +
+                "} " + super.toString();
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/EmbeddedInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/EmbeddedInfinispanLogMinerEventProcessor.java
@@ -10,9 +10,12 @@ import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFF
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_INFINISPAN_CACHE_SCHEMA_CHANGES;
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_INFINISPAN_CACHE_TRANSACTIONS;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.api.BasicCache;
@@ -109,6 +112,41 @@ public class EmbeddedInfinispanLogMinerEventProcessor extends AbstractInfinispan
     @Override
     public BasicCache<String, InfinispanTransaction> getTransactionCache() {
         return transactionCache;
+    }
+
+    @Override
+    protected Collection<InfinispanTransaction> transactionCacheValues() {
+        return transactionCache.values();
+    }
+
+    @Override
+    protected InfinispanTransaction transactionCacheGet(String key) {
+        return transactionCache.get(key);
+    }
+
+    @Override
+    protected void transactionCachePut(String key, InfinispanTransaction value) {
+        transactionCache.put(key, value);
+    }
+
+    @Override
+    protected int transactionCacheSize() {
+        return transactionCache.size();
+    }
+
+    @Override
+    protected boolean transactionCacheContainsKey(String key) {
+        return transactionCache.containsKey(key);
+    }
+
+    @Override
+    protected Set<String> transactionCacheKeys() {
+        return transactionCache.keySet();
+    }
+
+    @Override
+    protected Iterator transactionCacheIterator() {
+        return transactionCache.entrySet().iterator();
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/RemoteInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/RemoteInfinispanLogMinerEventProcessor.java
@@ -10,10 +10,13 @@ import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFF
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_INFINISPAN_CACHE_SCHEMA_CHANGES;
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFFER_INFINISPAN_CACHE_TRANSACTIONS;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import org.checkerframework.checker.units.qual.C;
 import org.infinispan.client.hotrod.RemoteCache;
@@ -181,6 +184,41 @@ public class RemoteInfinispanLogMinerEventProcessor extends AbstractInfinispanLo
             }
         }
         return Optional.ofNullable(transaction);
+    }
+
+    @Override
+    protected Collection<InfinispanTransaction> transactionCacheValues() {
+        return transactionCache.values();
+    }
+
+    @Override
+    protected InfinispanTransaction transactionCacheGet(String key) {
+        return transactionCache.get(key);
+    }
+
+    @Override
+    protected void transactionCachePut(String key, InfinispanTransaction value) {
+        transactionCache.put(key, value);
+    }
+
+    @Override
+    protected int transactionCacheSize() {
+        return transactionCache.size();
+    }
+
+    @Override
+    protected boolean transactionCacheContainsKey(String key) {
+        return transactionCache.containsKey(key);
+    }
+
+    @Override
+    protected Set<String> transactionCacheKeys() {
+        return transactionCache.keySet();
+    }
+
+    @Override
+    protected Iterator transactionCacheIterator() {
+        return transactionCache.entrySet().iterator();
     }
 
     @Override

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
@@ -122,7 +122,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
     public void testCacheIsEmpty() throws Exception {
         final OracleConnectorConfig config = new OracleConnectorConfig(getConfig().build());
         try (T processor = getProcessor(config)) {
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -132,7 +132,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
         try (T processor = getProcessor(config)) {
             processor.handleStart(getStartLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
         }
     }
 
@@ -142,7 +142,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
         final OracleConnectorConfig config = new OracleConnectorConfig(getConfig().build());
         try (T processor = getProcessor(config)) {
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
         }
     }
 
@@ -155,7 +155,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleStart(getStartLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleDataEvent(insertRow);
             processor.handleCommit(partition, getCommitLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -167,7 +167,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
         try (T processor = getProcessor(config)) {
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleCommit(partition, getCommitLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -178,7 +178,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleStart(getStartLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -189,7 +189,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
         try (T processor = getProcessor(config)) {
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -202,7 +202,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleStart(getStartLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_2));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(4L), TRANSACTION_ID_2));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(5L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_1)).isTrue();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_2)).isFalse();
         }
@@ -216,7 +216,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_2));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_1));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_1)).isTrue();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_2)).isFalse();
         }
@@ -231,7 +231,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleStart(getStartLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_2));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(4L), TRANSACTION_ID_2));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(5L), TRANSACTION_ID_2));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_2)).isTrue();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_1)).isFalse();
         }
@@ -245,7 +245,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(1L), TRANSACTION_ID_1));
             processor.handleDataEvent(getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_2));
             processor.handleRollback(getRollbackLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_2));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_2)).isTrue();
             assertThat(metrics.getRolledBackTransactionIds().contains(TRANSACTION_ID_1)).isFalse();
         }
@@ -425,7 +425,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.processRow(partition, getStartLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1, changeTime));
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_1, changeTime));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -444,7 +444,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             Instant changeTime = Instant.now().minus(24, ChronoUnit.HOURS);
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1, changeTime));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isTrue();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isTrue();
         }
     }
 
@@ -465,9 +465,9 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.processRow(partition, getStartLogMinerEventRow(Scn.valueOf(4L), TRANSACTION_ID_2));
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(5L), TRANSACTION_ID_2));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_1)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_2)).isNotNull();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_1)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_2)).isNotNull();
         }
     }
 
@@ -487,9 +487,9 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(2L), TRANSACTION_ID_1, changeTime));
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_2));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_1)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_2)).isNotNull();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_1)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_2)).isNotNull();
         }
     }
 
@@ -521,10 +521,10 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.processRow(partition, getStartLogMinerEventRow(Scn.valueOf(6L), TRANSACTION_ID_3));
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(7L), TRANSACTION_ID_3));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_1)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_2)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_3)).isNotNull();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_1)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_2)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_3)).isNotNull();
         }
     }
 
@@ -553,10 +553,10 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(3L), TRANSACTION_ID_2, changeTime2));
             processor.processRow(partition, getInsertLogMinerEventRow(Scn.valueOf(4L), TRANSACTION_ID_3));
             processor.abandonTransactions(Duration.ofHours(1L));
-            assertThat(processor.getTransactionCache().isEmpty()).isFalse();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_1)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_2)).isNull();
-            assertThat(processor.getTransactionCache().get(TRANSACTION_ID_3)).isNotNull();
+            assertThat(processor.transactionCacheKeys().isEmpty()).isFalse();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_1)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_2)).isNull();
+            assertThat(processor.transactionCacheGet(TRANSACTION_ID_3)).isNotNull();
         }
 
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/EhcacheProcessorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/EhcacheProcessorIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.processor;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningBufferType;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.util.Testing;
+import org.junit.Before;
+
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applicable for LogMiner")
+public class EhcacheProcessorIT extends AbstractProcessorTest {
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+
+        // Before each test make sure to clear all Ehcache caches
+        Testing.Files.delete(Testing.Files.createTestingPath("data/transactions.dat").toAbsolutePath());
+        Testing.Files.delete(Testing.Files.createTestingPath("data/committed-transactions.dat").toAbsolutePath());
+        Testing.Files.delete(Testing.Files.createTestingPath("data/rollback-transactions.dat").toAbsolutePath());
+        Testing.Files.delete(Testing.Files.createTestingPath("data/schema-changes.dat").toAbsolutePath());
+    }
+
+    @Override
+    protected Configuration.Builder getBufferImplementationConfig() {
+        return TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE, LogMiningBufferType.EHCACHE);
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/EhcacheProcessorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/EhcacheProcessorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningBufferType;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.logminer.processor.ehcache.EhcacheLogMinerEventProcessor;
+import io.debezium.connector.oracle.util.TestHelper;
+
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applicable for LogMiner")
+public class EhcacheProcessorTest extends AbstractProcessorUnitTest<EhcacheLogMinerEventProcessor> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheProcessorTest.class);
+
+    @Override
+    protected Configuration.Builder getConfig() {
+        return TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE, LogMiningBufferType.EHCACHE)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_PATH, "/ehcachedata")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_RECENTTRANSACTIONS_SIZE_MB, 1)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_TRANSACTION_SIZE_GB, 1)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_EHCACHE_CACHE_SCHEMACHANGES_SIZE_MB, 1)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DROP_ON_STOP, true);
+    }
+
+    @Override
+    protected EhcacheLogMinerEventProcessor getProcessor(OracleConnectorConfig connectorConfig) {
+        assertThat(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error)).isTrue();
+        return new EhcacheLogMinerEventProcessor(context,
+                connectorConfig,
+                connection,
+                dispatcher,
+                partition,
+                offsetContext,
+                schema,
+                metrics);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.relational;
 
+import java.io.Serializable;
 import java.util.List;
 
-import io.debezium.annotation.Immutable;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
@@ -17,8 +17,9 @@ import io.debezium.util.Collect;
  *
  * @author Randall Hauch
  */
-@Immutable
-public final class TableId implements DataCollectionId, Comparable<TableId> {
+public class TableId implements DataCollectionId, Comparable<TableId>, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /**
      * Parse the supplied string, extracting up to the first 3 parts into a TableID.
@@ -117,10 +118,10 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
         return new TableId(parts[0], parts[1], parts[2]); // catalog, schema & table
     }
 
-    private final String catalogName;
-    private final String schemaName;
-    private final String tableName;
-    private final String id;
+    private String catalogName;
+    private String schemaName;
+    private String tableName;
+    private String id;
 
     /**
      * Create a new table identifier.
@@ -138,6 +139,9 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
         this.tableName = tableName;
         assert this.tableName != null;
         this.id = tableIdMapper == null ? tableId(this.catalogName, this.schemaName, this.tableName) : tableIdMapper.toString(this);
+    }
+
+    public TableId() {
     }
 
     /**


### PR DESCRIPTION
### Work that still needs/could to be done before merge
- [ ]  use explicit [Ehcache Serializers](https://www.ehcache.org/documentation/3.8/serializers-copiers.html) (instead of implementing native Java `Serializable` as of now) to avoid breaking immutable pattern on some data classes
- [ ] only disk tier from Ehcache tiering options is used, so may be good to allow to configure heap tier as well
-- Combination of heap and disk which we wanted for our use case turned out not to be working well, as the limit put on the heap was breached anyway (couldn't find out why) which led to OutOfMemoryError (we needed to limit the heap tier to less than 100 MB).
- [ ] upgrade Ehcache dependency to 3.10: I ended up using Ehcache version 3.8.1 (I've tried also the latest one: 3.10, but encountered problems with dependencies which I couldn't resolve after spending some time on it)

### FYI
- Some refactoring had to be done because up until the introduction of Ehcache, all the implementations were `Map`-based, while Ehcache's `Cache` interface doesn't provide some of `Map`'s methods.