### PR TITLE
DBZ-7777 Improve processing speed of async engine processors which use List#get()

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtAndConvertAsyncConsumerProcessor.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtAndConvertAsyncConsumerProcessor.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.embedded.async;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -41,18 +42,17 @@ public class ParallelSmtAndConvertAsyncConsumerProcessor<R> extends AbstractReco
         LOGGER.debug("Thread {} is submitting {} records for processing.", Thread.currentThread().getName(), records.size());
 
         final Future<Void>[] recordFutures = new Future[records.size()];
-        int i = 0;
-        for (SourceRecord r : records) {
-            recordFutures[i] = recordService.submit(new ProcessingCallables.TransformConvertConsumeRecord<>(r, transformations, convertor, consumer));
-            i++;
+        Iterator<SourceRecord> recordsIterator = records.iterator();
+        for (int i = 0; recordsIterator.hasNext(); i++) {
+            recordFutures[i] = recordService
+                    .submit(new ProcessingCallables.TransformConvertConsumeRecord<>(recordsIterator.next(), transformations, convertor, consumer));
         }
 
         LOGGER.trace("Waiting for the batch to finish processing.");
-        i = 0;
-        for (SourceRecord r : records) {
+        recordsIterator = records.iterator();
+        for (int i = 0; recordsIterator.hasNext(); i++) {
             recordFutures[i].get();
-            committer.markProcessed(r);
-            i++;
+            committer.markProcessed(recordsIterator.next());
         }
 
         LOGGER.trace("Marking batch as finished.");

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtAsyncConsumerProcessor.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtAsyncConsumerProcessor.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.embedded.async;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -37,13 +36,18 @@ public class ParallelSmtAsyncConsumerProcessor extends AbstractRecordProcessor<S
     @Override
     public void processRecords(final List<SourceRecord> records) throws Exception {
         LOGGER.debug("Thread {} is submitting {} records for processing.", Thread.currentThread().getName(), records.size());
-        final List<Future<Void>> recordFutures = new ArrayList<>(records.size());
-        records.stream().forEachOrdered(r -> recordFutures.add(recordService.submit(new ProcessingCallables.TransformAndConsumeRecord(r, transformations, consumer))));
+        final Future<Void>[] recordFutures = new Future[records.size()];
+        int i = 0;
+        for (SourceRecord r : records) {
+            recordFutures[i] = recordService.submit(new ProcessingCallables.TransformAndConsumeRecord(r, transformations, consumer));
+            i++;
+        }
 
         LOGGER.trace("Waiting for the batch to finish processing.");
-        for (int i = 0; i < records.size(); i++) {
-            recordFutures.get(i);
-            committer.markProcessed(records.get(i));
+        i = 0;
+        for (SourceRecord r : records) {
+            recordFutures[i].get();
+            committer.markProcessed(r);
         }
 
         LOGGER.trace("Marking batch as finished.");

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtConsumerProcessor.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtConsumerProcessor.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.embedded.async;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -37,18 +38,16 @@ public class ParallelSmtConsumerProcessor extends AbstractRecordProcessor<Source
     public void processRecords(final List<SourceRecord> records) throws Exception {
         LOGGER.debug("Thread {} is submitting {} records for processing.", Thread.currentThread().getName(), records.size());
         final Future<SourceRecord>[] recordFutures = new Future[records.size()];
-        int i = 0;
-        for (SourceRecord r : records) {
-            recordFutures[i] = recordService.submit(new ProcessingCallables.TransformRecord(r, transformations));
-            i++;
+        Iterator<SourceRecord> recordsIterator = records.iterator();
+        for (int i = 0; recordsIterator.hasNext(); i++) {
+            recordFutures[i] = recordService.submit(new ProcessingCallables.TransformRecord(recordsIterator.next(), transformations));
         }
 
         LOGGER.trace("Calling user consumer.");
-        i = 0;
-        for (SourceRecord r : records) {
+        recordsIterator = records.iterator();
+        for (int i = 0; recordsIterator.hasNext(); i++) {
             consumer.accept(recordFutures[i].get());
-            committer.markProcessed(r);
-            i++;
+            committer.markProcessed(recordsIterator.next());
         }
 
         LOGGER.trace("Marking batch as finished.");

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtConsumerProcessor.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/ParallelSmtConsumerProcessor.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.embedded.async;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -37,13 +36,19 @@ public class ParallelSmtConsumerProcessor extends AbstractRecordProcessor<Source
     @Override
     public void processRecords(final List<SourceRecord> records) throws Exception {
         LOGGER.debug("Thread {} is submitting {} records for processing.", Thread.currentThread().getName(), records.size());
-        final List<Future<SourceRecord>> recordFutures = new ArrayList<>(records.size());
-        records.stream().forEachOrdered(r -> recordFutures.add(recordService.submit(new ProcessingCallables.TransformRecord(r, transformations))));
+        final Future<SourceRecord>[] recordFutures = new Future[records.size()];
+        int i = 0;
+        for (SourceRecord r : records) {
+            recordFutures[i] = recordService.submit(new ProcessingCallables.TransformRecord(r, transformations));
+            i++;
+        }
 
         LOGGER.trace("Calling user consumer.");
-        for (int i = 0; i < records.size(); i++) {
-            consumer.accept(recordFutures.get(i).get());
-            committer.markProcessed(records.get(i));
+        i = 0;
+        for (SourceRecord r : records) {
+            consumer.accept(recordFutures[i].get());
+            committer.markProcessed(r);
+            i++;
         }
 
         LOGGER.trace("Marking batch as finished.");

--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/AbstractDebeziumEnginePerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/AbstractDebeziumEnginePerf.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.engine;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.util.IoUtil;
+
+/**
+ * Base class for JMH benchmark focused on speed of record processing of given {@link DebeziumEngine} implementation.
+ */
+@State(Scope.Thread)
+public abstract class AbstractDebeziumEnginePerf<R> {
+
+    protected static final String OFFSET_FILE_NAME = "offsets.txt";
+
+    private DebeziumEngine<R> engine;
+    private ExecutorService executors;
+    protected CountDownLatch finishLatch;
+
+    @Param({ "100000", "1000000" })
+    public int recordCount;
+
+    public abstract DebeziumEngine createEngine();
+
+    @Setup(Level.Iteration)
+    public void doSetup() throws InterruptedException {
+        delete(OFFSET_FILE_NAME);
+
+        finishLatch = new CountDownLatch(recordCount);
+        engine = createEngine();
+        executors = Executors.newFixedThreadPool(1);
+        executors.execute(engine);
+    }
+
+    @TearDown(Level.Iteration)
+    public void doCleanup() throws IOException {
+        try {
+            if (engine != null) {
+                engine.close();
+            }
+            if (executors != null) {
+                executors.shutdown();
+                try {
+                    executors.awaitTermination(60, TimeUnit.SECONDS);
+                }
+                catch (InterruptedException e) {
+                    executors.shutdownNow();
+                }
+            }
+        }
+        finally {
+            engine = null;
+            executors = null;
+        }
+    }
+
+    protected Consumer<R> getRecordConsumer() {
+        return record -> {
+            if (record != null) {
+                finishLatch.countDown();
+            }
+        };
+    }
+
+    protected Path getPath(String relativePath) {
+        return Paths.get(resolveDataDir(), relativePath).toAbsolutePath();
+    }
+
+    private void delete(String relativePath) {
+        Path history = getPath(relativePath).toAbsolutePath();
+        if (history != null) {
+            history = history.toAbsolutePath();
+            if (inTestDataDir(history)) {
+                try {
+                    IoUtil.delete(history);
+                }
+                catch (IOException e) {
+                    // ignored
+                }
+            }
+        }
+    }
+
+    private boolean inTestDataDir(Path path) {
+        Path target = FileSystems.getDefault().getPath(resolveDataDir()).toAbsolutePath();
+        return path.toAbsolutePath().startsWith(target);
+    }
+
+    private String resolveDataDir() {
+        String value = System.getProperty("dbz.test.data.dir");
+        if (value != null && (value = value.trim()).length() > 0) {
+            return value;
+        }
+
+        value = System.getenv("DBZ_TEST_DATA_DIR");
+        if (value != null && (value = value.trim()).length() > 0) {
+            return value;
+        }
+
+        return "/tmp";
+    }
+}

--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/DebeziumConvertingEnginePerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/DebeziumConvertingEnginePerf.java
@@ -5,29 +5,18 @@
  */
 package io.debezium.performance.engine;
 
-import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 import io.debezium.config.Configuration;
@@ -35,114 +24,19 @@ import io.debezium.embedded.ConvertingEngineBuilderFactory;
 import io.debezium.embedded.EmbeddedEngine;
 import io.debezium.embedded.async.AsyncEngineConfig;
 import io.debezium.embedded.async.ConvertingAsyncEngineBuilderFactory;
-import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.format.KeyValueChangeEventFormat;
 import io.debezium.performance.engine.connector.PreComputedRecordsSourceConnector;
-import io.debezium.util.IoUtil;
 
 /**
- * JMH benchmark focused on speed of record processing of given {@link DebeziumEngine} implementation.
+ * JMH benchmark focused on speed of record processing of given {@link DebeziumEngine} implementation using kay/value JSON converter.
  */
-public class DebeziumEnginePerf {
+public class DebeziumConvertingEnginePerf {
+    protected static final KeyValueChangeEventFormat KV_EVENT_FORMAT = KeyValueChangeEventFormat.of(Json.class, Json.class);
 
     @State(Scope.Thread)
-    public static abstract class DebeziumEnginePerfTest {
-
-        protected static final KeyValueChangeEventFormat KV_EVENT_FORMAT = KeyValueChangeEventFormat.of(Json.class, Json.class);
-        protected static final String OFFSET_FILE_NAME = "offsets.txt";
-
-        private DebeziumEngine<ChangeEvent<String, String>> engine;
-        private ExecutorService executors;
-        protected CountDownLatch finishLatch;
-
-        @Param({ "100000", "1000000" })
-        public int recordCount;
-
-        public abstract DebeziumEngine createEngine();
-
-        @Setup(Level.Iteration)
-        public void doSetup() throws InterruptedException {
-            delete(OFFSET_FILE_NAME);
-
-            finishLatch = new CountDownLatch(recordCount);
-            engine = createEngine();
-            executors = Executors.newFixedThreadPool(1);
-            executors.execute(engine);
-        }
-
-        @TearDown(Level.Iteration)
-        public void doCleanup() throws IOException {
-            try {
-                if (engine != null) {
-                    engine.close();
-                }
-                if (executors != null) {
-                    executors.shutdown();
-                    try {
-                        executors.awaitTermination(60, TimeUnit.SECONDS);
-                    }
-                    catch (InterruptedException e) {
-                        executors.shutdownNow();
-                    }
-                }
-            }
-            finally {
-                engine = null;
-                executors = null;
-            }
-        }
-
-        protected Consumer<ChangeEvent<String, String>> getRecordConsumer() {
-            return record -> {
-                if (record != null) {
-                    finishLatch.countDown();
-                }
-            };
-        }
-
-        protected Path getPath(String relativePath) {
-            return Paths.get(resolveDataDir(), relativePath).toAbsolutePath();
-        }
-
-        private void delete(String relativePath) {
-            Path history = getPath(relativePath).toAbsolutePath();
-            if (history != null) {
-                history = history.toAbsolutePath();
-                if (inTestDataDir(history)) {
-                    try {
-                        IoUtil.delete(history);
-                    }
-                    catch (IOException e) {
-                        // ignored
-                    }
-                }
-            }
-        }
-
-        private boolean inTestDataDir(Path path) {
-            Path target = FileSystems.getDefault().getPath(resolveDataDir()).toAbsolutePath();
-            return path.toAbsolutePath().startsWith(target);
-        }
-
-        private String resolveDataDir() {
-            String value = System.getProperty("dbz.test.data.dir");
-            if (value != null && (value = value.trim()).length() > 0) {
-                return value;
-            }
-
-            value = System.getenv("DBZ_TEST_DATA_DIR");
-            if (value != null && (value = value.trim()).length() > 0) {
-                return value;
-            }
-
-            return "/tmp";
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class AsyncEnginePerfTest extends DebeziumEnginePerfTest {
+    public static class AsyncEnginePerfTest extends AbstractDebeziumEnginePerf {
         @Param({ "1", "2", "4", "8", "16" })
         public int threadCount;
 
@@ -171,7 +65,7 @@ public class DebeziumEnginePerf {
     }
 
     @State(Scope.Thread)
-    public static class EmbeddedEnginePerfTest extends DebeziumEnginePerfTest {
+    public static class EmbeddedEnginePerfTest extends AbstractDebeziumEnginePerf {
 
         public DebeziumEngine createEngine() {
             Configuration config = Configuration.create()

--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/DebeziumEnginePerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/DebeziumEnginePerf.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.engine;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.debezium.config.Configuration;
+import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEngineConfig;
+import io.debezium.embedded.async.ConvertingAsyncEngineBuilderFactory;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.format.KeyValueHeaderChangeEventFormat;
+import io.debezium.performance.engine.connector.PreComputedRecordsSourceConnector;
+
+/**
+ * JMH benchmark focused on speed of record processing of given {@link DebeziumEngine} implementation not using any key/value converter.
+ */
+public class DebeziumEnginePerf {
+
+    @State(Scope.Thread)
+    public static class AsyncEnginePerfTest extends AbstractDebeziumEnginePerf {
+        @Param({ "1", "2", "4", "8", "16" })
+        public int threadCount;
+
+        @Param({ "ORDERED", "UNORDERED" })
+        public String processingOrder;
+
+        public DebeziumEngine createEngine() {
+            Configuration config = Configuration.create()
+                    .with(EmbeddedEngine.ENGINE_NAME, "async-engine")
+                    .with(EmbeddedEngine.CONNECTOR_CLASS, PreComputedRecordsSourceConnector.class)
+                    .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, getPath(OFFSET_FILE_NAME).toAbsolutePath())
+                    .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 3_600_000)
+                    .with(AsyncEngineConfig.RECORD_PROCESSING_SHUTDOWN_TIMEOUT_MS, 100)
+                    .with(AsyncEngineConfig.TASK_MANAGEMENT_TIMEOUT_MS, 100)
+                    .with(AsyncEngineConfig.RECORD_PROCESSING_THREADS, threadCount)
+                    .with(AsyncEngineConfig.RECORD_PROCESSING_ORDER, processingOrder)
+                    .build();
+
+            return new ConvertingAsyncEngineBuilderFactory()
+                    .builder((KeyValueHeaderChangeEventFormat) null)
+                    .using(config.asProperties())
+                    .notifying(getRecordConsumer())
+                    .using(this.getClass().getClassLoader())
+                    .build();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class EmbeddedEnginePerfTest extends AbstractDebeziumEnginePerf {
+
+        public DebeziumEngine createEngine() {
+            Configuration config = Configuration.create()
+                    .with(EmbeddedEngine.ENGINE_NAME, "embedded-engine")
+                    .with(EmbeddedEngine.CONNECTOR_CLASS, PreComputedRecordsSourceConnector.class)
+                    .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, getPath(OFFSET_FILE_NAME).toAbsolutePath())
+                    .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 3_600_000)
+                    .build();
+
+            return new EmbeddedEngine.EngineBuilder()
+                    .using(config.asProperties())
+                    .notifying(getRecordConsumer())
+                    .using(this.getClass().getClassLoader())
+                    .build();
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(value = 1)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 1, time = 1)
+    public void processRecordsAsyncEngine(AsyncEnginePerfTest test) throws InterruptedException {
+        test.finishLatch.await();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(value = 1)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 1, time = 1)
+    public void processRecordsEmbeddedEngine(EmbeddedEnginePerfTest test) throws InterruptedException {
+        test.finishLatch.await();
+    }
+}


### PR DESCRIPTION
ParallelSmtAndConvertConsumerProcessors:
    
Before the change:
    
        Benchmark                                        (processingOrder)  (recordCount)  (threadCount)  Mode  Cnt    Score   Error  Units
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              1    ss       295.353           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              2    ss       310.652           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              4    ss       305.956           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              8    ss       334.755           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000             16    ss       306.477           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              1    ss       257.661           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              2    ss        78.385           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              4    ss        75.899           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              8    ss        81.068           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000             16    ss        94.506           s/op
        DebeziumEnginePerf.processRecordsEmbeddedEngine                N/A         100000            N/A    ss         0.857           s/op
    
After the change:
    
        Benchmark                                        (processingOrder)  (recordCount)  (threadCount)  Mode  Cnt  Score   Error  Units
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              1    ss       0.738           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              2    ss       0.404           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              4    ss       0.524           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              8    ss       0.505           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000             16    ss       0.428           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              1    ss       0.685           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              2    ss       0.400           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              4    ss       0.357           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              8    ss       0.508           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000             16    ss       0.410           s/op
        DebeziumEnginePerf.processRecordsEmbeddedEngine                N/A         100000            N/A    ss       0.857           s/op

ParallelSmtAndConsumerProcessors:

Before the change:
    
        Benchmark                                        (processingOrder)  (recordCount)  (threadCount)  Mode  Cnt   Score   Error  Units
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              1    ss       88.006           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              2    ss       90.226           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              4    ss       83.129           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              8    ss       81.417           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000             16    ss       90.936           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              1    ss       83.645           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              2    ss       77.527           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              4    ss       88.495           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              8    ss       79.590           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000             16    ss       90.246           s/op
        DebeziumEnginePerf.processRecordsEmbeddedEngine                N/A         100000            N/A    ss        0.125           s/op
    
After the change:
    
        Benchmark                                        (processingOrder)  (recordCount)  (threadCount)  Mode  Cnt  Score   Error  Units
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              1    ss       0.514           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              2    ss       0.391           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              4    ss       0.467           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000              8    ss       0.393           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine               ORDERED         100000             16    ss       0.462           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              1    ss       0.410           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              2    ss       0.431           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              4    ss       0.460           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000              8    ss       0.419           s/op
        DebeziumEnginePerf.processRecordsAsyncEngine             UNORDERED         100000             16    ss       0.448           s/op
        DebeziumEnginePerf.processRecordsEmbeddedEngine                N/A         100000            N/A    ss       0.230           s/op

Here, as there is no SMT and also no converter involved, it's IMHO expected that async engine is slower because of thread management overhead.