### PR TITLE
DBZ-7798 Fix documentation for `header` variable in filters (part 2)

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -142,7 +142,7 @@ The following table lists the variables that {prodname} binds into the evaluatio
 |`valueSchema`|Schema of the message value.| `org.apache.kafka.connect{zwsp}.data{zwsp}.Schema`
 |`topic`|Name of the target topic.| String
 |`header`|A Java map of message headers. The key field is the header name.
-The `headers` variable exposes the following properties:
+The `header` variable exposes the following properties:
 
 * `value` (of type `Object`)
 * `schema` (of type `org.apache.kafka{zwsp}.connect{zwsp}.data{zwsp}.Schema`)


### PR DESCRIPTION
- Fixes DBZ-7798
- Refs https://github.com/debezium/debezium/pull/5500

The original PR missed another occurrence of `headers` vs. `header`.