### PR TITLE
DBZ-7811 Reduce logging level for invalid timestamp/date values, fix edge case

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -76,6 +76,7 @@ import io.debezium.util.Strings;
 public abstract class BinlogValueConverters extends JdbcValueConverters {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BinlogValueConverters.class);
+    private static final Logger INVALID_VALUE_LOGGER = LoggerFactory.getLogger(BinlogValueConverters.class.getName() + ".invalid_value");
 
     /**
      * Used to parse values of TIME columns. Format: 000:00:00.000000.
@@ -901,7 +902,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
         final int day = Integer.parseInt(matcher.group(3));
 
         if (month == 0 || day == 0) {
-            LOGGER.debug("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
+            INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
                     dateString, column.name(), table.id());
             return null;
         }
@@ -928,7 +929,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
         final int day = Integer.parseInt(matcher.group(3));
 
         if (month == 0 || day == 0) {
-            LOGGER.debug("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
+            INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
                     timestampString, column.name(), table.id());
             return true;
         }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -900,8 +900,8 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
         final int month = Integer.parseInt(matcher.group(2));
         final int day = Integer.parseInt(matcher.group(3));
 
-        if (year == 0 || month == 0 || day == 0) {
-            LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
+        if (month == 0 || day == 0) {
+            LOGGER.debug("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
                     dateString, column.name(), table.id());
             return null;
         }
@@ -927,8 +927,8 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
         final int month = Integer.parseInt(matcher.group(2));
         final int day = Integer.parseInt(matcher.group(3));
 
-        if (year == 0 || month == 0 || day == 0) {
-            LOGGER.warn("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
+        if (month == 0 || day == 0) {
+            LOGGER.debug("Invalid value '{}' stored in column '{}' of table '{}' converted to empty value",
                     timestampString, column.name(), table.id());
             return true;
         }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
@@ -269,7 +269,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
 
     @Test
     public void testInvalidLocalDate() {
-        LogInterceptor interceptor = new LogInterceptor(BinlogValueConverters.class);
+        LogInterceptor interceptorInvalid = new LogInterceptor(BinlogValueConverters.class.getName() + ".invalid_value");
         String dateTable = "DATE_TABLE";
         String sql = "CREATE TABLE " + dateTable + " (A DATE NOT NULL);";
 
@@ -291,7 +291,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
         LocalDate actual = BinlogValueConverters.stringToLocalDate("0000-00-00", colA, table);
         assertThat(actual).isNull();
 
-        assertThat(interceptor.containsWarnMessage("Invalid value")).isFalse();
+        assertThat(interceptorInvalid.containsWarnMessage("Invalid value")).isTrue();
     }
 
     @Test
@@ -320,7 +320,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
 
     @Test
     public void testInvalidTimestamp() {
-        LogInterceptor interceptor = new LogInterceptor(BinlogValueConverters.class);
+        LogInterceptor interceptorInvalid = new LogInterceptor(BinlogValueConverters.class.getName() + ".invalid_value");
         String dateTable = "TIMESTAMP_TABLE";
         String sql = "CREATE TABLE " + dateTable + " (A TIMESTAMP(3) NOT NULL);";
 
@@ -348,7 +348,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
         Boolean actual = BinlogValueConverters.containsZeroValuesInDatePart(timestampString, colA, table);
         assertThat(actual).isTrue();
 
-        assertThat(interceptor.containsWarnMessage("Invalid value")).isFalse();
+        assertThat(interceptorInvalid.containsWarnMessage("Invalid value")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
That warn message could happen for every event processed in the worst case so change to debug.

Also there's an edge case with the year zero value that can still be valid.

https://issues.redhat.com/browse/DBZ-7811