### PR TITLE
Dbz 7800 enhance docs about using tags to customize mbean names

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -145,7 +145,7 @@ You can find more information about snapshots in the following sections:
 
 endif::product[]
 
-[[default-workflow-for-performing-an-initial-snapshot]]
+[[debezium-db2-default-workflow-for-performing-an-initial-snapshot]]
 .Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
 
 The following workflow lists the steps that {prodname} takes to create a snapshot.
@@ -3029,7 +3029,15 @@ endif::product[]
 
 |[[db2-property-custom-metric-tags]]<<db2-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[db2-property-errors-max-retires]]<<db2-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -3084,6 +3092,13 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 * xref:db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-db2-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-db2-databases

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -2635,14 +2635,15 @@ endif::community[]
 
 |[[informix-property-custom-metric-tags]]<<informix-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|Defines tags for customizing MBean object names by adding metadata that provides contextual information that enables you to organize and categorize metrics data.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
 Specify a comma-separated list of key-value pairs.
 Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
 `k1=v1,k2=v2`
 
 The connector appends the specified tags to the base MBean object name.
-
+Tags can help you to organize and categorize metrics data.
 You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[informix-property-errors-max-retires]]<<informix-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -2688,6 +2689,13 @@ The {prodname} Informix connector provides three types of metrics that are in ad
 * xref:informix-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-informix-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-informix-databases

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2213,7 +2213,15 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[mongodb-property-custom-metric-tags]]<<mongodb-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[mongodb-property-errors-max-retires]]<<mongodb-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -2252,6 +2260,13 @@ The {prodname} MongoDB connector has two metric types in addition to the built-i
 * xref:mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
 The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-mongodb-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-mongodb-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3897,7 +3897,15 @@ Specify one of the following options:
 
 |[[mysql-property-custom-metric-tags]]<<mysql-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[mysql-property-errors-max-retires]]<<mysql-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -3960,6 +3968,13 @@ The {prodname} MySQL connector provides three types of metrics that are in addit
 * xref:mysql-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-mysql-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-mysql-databases

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4154,7 +4154,15 @@ By default, no additional retries will be performed.
 
 |[[oracle-property-custom-metric-tags]]<<oracle-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[oracle-property-errors-max-retires]]<<oracle-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -4206,6 +4214,13 @@ The {prodname} Oracle connector provides three metric types in addition to the b
 * xref:oracle-schema-history-metrics[schema history metrics]; for monitoring the status of the connector's schema history
 
 Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-oracle-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: debezium-oracle-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3681,7 +3681,15 @@ endif::product[]
 
 |[[postgresql-property-custom-metric-tags]]<<postgresql-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[postgresql-property-errors-max-retires]]<<postgresql-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -3730,6 +3738,13 @@ The {prodname} PostgreSQL connector provides two types of metrics that are in ad
 * xref:postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+/ Type: concept
+// ModuleID: monitoring-debezium-postgresql-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-postgresql-databases

--- a/documentation/modules/ROOT/pages/connectors/spanner.adoc
+++ b/documentation/modules/ROOT/pages/connectors/spanner.adoc
@@ -950,6 +950,13 @@ The {prodname} Spanner connector provides only one type of metric in addition to
 
 xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
+// Type: concept
+// ModuleID: monitoring-debezium-spanner-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
+
 // Type: reference
 // ModuleID: monitoring-debezium-spanner-connector-record-streaming
 // Title: Monitoring {prodname} Spanner connector record streaming
@@ -1243,7 +1250,15 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[spanner-property-custom-metric-tags]]<<spanner-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[spanner-property-errors-max-retires]]<<spanner-property-errors-max-retires, `errors.max.retries`>>
 |`-1`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3247,7 +3247,15 @@ endif::product[]
 
 |[[sqlserver-property-custom-metric-tags]]<<sqlserver-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
-|The custom metric tags will accept key-value pairs to customize the MBean object name which should be appended the end of regular name, each key would represent a tag for the MBean object name, and the corresponding value would be the value of that tag the key is. For example: `k1=v1,k2=v2`.
+|Defines tags that customize MBean object names by adding metadata that provides contextual information.
+Specify a comma-separated list of key-value pairs.
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+`k1=v1,k2=v2`
+
+The connector appends the specified tags to the base MBean object name.
+Tags can help you to organize and categorize metrics data.
+You can define tags to identify particular application instances, environments, regions, versions, and so forth.
+For more information, see xref:customized-mbean-names[Customized MBean names].
 
 |[[sqlserver-property-errors-max-retires]]<<sqlserver-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
@@ -3487,6 +3495,14 @@ The connector provides the following metrics:
 * xref:sqlserver-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
 For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation].
+
+// Type: concept
+// ModuleID: monitoring-debezium-sqlserver-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+[id="customized-mbean-names"]
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
 // Type: reference
 // ModuleID: debezium-sqlserver-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1321,6 +1321,13 @@ The {prodname} Vitess connector provides only one type of metrics that are in ad
 
 xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
+// Type: concept
+// ModuleID: monitoring-debezium-vitess-connectors-customized-mbean-names
+// Title: Customized names for Db2 connector snapshot and streaming MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
+
 // Type: reference
 // ModuleID: monitoring-debezium-vitess-connector-record-streaming
 // Title: Monitoring {prodname} Vitess connector record streaming

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -26,3 +26,51 @@ end::sqlserver-snapshot[]
 tag::sqlserver-streaming[]
 The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<topic.prefix>_,task=_<task.id>_,context=streaming`.
 end::sqlserver-streaming[]
+
+
+// Shared
+tag::mbeans-shared[]
+{prodname} connectors expose metrics via the MBean name for the connector.
+These metrics, which are specific to each connector instance, provide data about the behavior of the connector's snapshot, streaming, and schema history processes.
+
+By default, when you deploy a correctly configured connector, {prodname} generates a unique MBean name for each of the different connector metrics.
+To view the metrics for a connector process, you configure your observability stack to monitor its MBean.
+But these default MBean names depend on the connector configuration; configuration changes can result in changes to the MBean names.
+A change to the MBean name breaks the linkage between the connector instance and the MBean, disrupting monitoring activity.
+In this scenario, you must reconfigure the observability stack to use the new MBean name if you want to resume monitoring.
+
+To prevent monitoring disruptions that result from MBean name changes, you can configure custom metrics tags.
+You configure custom metrics by adding the `custom.metric.tags` property to the connector configuration.
+The property accepts key-value pairs in which each key represents a tag for the MBean object name, and the corresponding value represents the value of that tag.
+For example: `k1=v1,k2=v2`.
+{prodname} appends the specified tags to the MBean name of the connector.
+
+After you configure the `custom.metric.tags` property for a connector, you can configure the observability stack to retrieve metrics associated with the specified tags.
+The observability stack then uses the specified tags, rather than the mutable MBean names to uniquely identify connectors.
+Later, if {prodname} redefines how it constructs MBean names, or if the `topic.prefix` in the connector configuration changes, metrics collection is uninterrupted,
+because the metrics scrape task uses the specified tag patterns to identify the connector.
+
+A further benefit of using custom tags, is that you can use tags that reflect the architecture of your data pipeline, so that metrics are organized in a way that suits you operational needs.
+For example, you might specify tags with values that declare the type of connector activity, the application context, or the data source, for example, `db1-streaming-for-application-abc`.
+If you specify multiple key-value pairs, all of the specified pairs are appended to the connector's MBean name.
+
+The following example illustrates how tags modify the default MBean name.
+
+.How custom tags modify the connector MBean name
+=======
+By default, the {connector-name} connector uses the following MBean name for streaming metrics:
+ +
+[source,subs="attributes+,quotes"]
+----
+debezium.{context}:type=connector-metrics,context=streaming,server=_<topic.prefix>_
+----
+
+If you set the value of `custom.metric.tags` to `database=salesdb-streaming,table=inventory`, {prodname} generates the following custom MBean name:
+
+[source,subs="attributes+,quotes"]
+----
+debezium.{context}:type=connector-metrics,context=streaming,server=_<topic.prefix>_,database=salesdb-streaming,table=inventory
+----
+=======
+
+end::mbeans-shared[]


### PR DESCRIPTION
[DBZ-7800](https://issues.redhat.com/browse/DBZ-7800)

This change includes the following updates:

- Adds a shared topic to describe how you can customize the default MBean names that Debezium uses for connector metrics. 
- Updates descriptions for the `custom.metric.tags` property in the documentation for each connector.
- Inserts a _Customized MBean names_ topic heading in the documentation file for each connector,  and adds an `include` directive that pulls in the shared topic.

Tested in a local Antora build.
During downstream testing, I discovered that changes implemented in [DBZ-7304](https://issues.redhat.com/browse/DBZ-7304) resulted in ID collisions because the same anchor ID is used multiple times in the upstream files.  I opened [DBZ-7815](https://issues.redhat.com/browse/DBZ-7815) to address that issue.