### PR TITLE
Dbz 7815 fix doc anchor id collisions

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -145,8 +145,10 @@ You can find more information about snapshots in the following sections:
 
 endif::product[]
 
-[[debezium-db2-default-workflow-for-performing-an-initial-snapshot]]
-.Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
+// Type: concept
+// ModuleID: default-workflow-that-the-db2-connector-uses-to-perform-an-initial-snapshot
+[[default-workflow-for-performing-an-initial-snapshot]]
+==== Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
 
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:db2-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -147,7 +147,7 @@ endif::product[]
 
 // Type: concept
 // ModuleID: default-workflow-that-the-db2-connector-uses-to-perform-an-initial-snapshot
-[[default-workflow-for-performing-an-initial-snapshot]]
+[[db2-default-workflow-for-performing-an-initial-snapshot]]
 ==== Default workflow that the {prodname} Db2 connector uses to perform an initial snapshot
 
 The following workflow lists the steps that {prodname} takes to create a snapshot.
@@ -219,7 +219,7 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 |`initial`
-|The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
+|The connector performs a database snapshot as described in the xref:db2-default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 |`initial_only`
@@ -230,7 +230,7 @@ After the snapshot completes, the connector stops, and does not stream event rec
 |Deprecated, see `no_data`.
 
 |`no_data`
-|The connector captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+|The connector captures the structure of all relevant tables, performing all the steps described in the xref:db2-default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
 
 |`recovery`
 |Set this option to restore a database schema history topic that is lost or corrupted.
@@ -2653,6 +2653,7 @@ For `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as 
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
+// Title: Advanced {prodname} Db2 connector configuration properties
 [id="db2-advanced-configuration-properties"]
 ==== Advanced connector configuration properties
 
@@ -2695,7 +2696,7 @@ The snapshot includes the structure and data of the captured tables.
 Specify this value to populate topics with a complete representation of the data from the captured tables every time that the connector starts.
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
-`initial`:: The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
+`initial`:: The connector performs a database snapshot as described in the xref:db2-default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 `initial_only`:: The connector performs a database a snapshot only when no offsets have been recorded for the logical server name.
@@ -2704,7 +2705,7 @@ It does not transition to streaming event records for subsequent database change
 
 `schema_only`:: Deprecated, see `no_data`.
 
-`no_data`:: The connector runs a snapshot that captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+`no_data`:: The connector runs a snapshot that captures the structure of all relevant tables, performing all the steps described in the xref:db2-default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
 
 `recovery`:: Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1854,6 +1854,7 @@ See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more de
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
 
+// Title: Advanced {prodname} MongoDB connector configuration properties
 [id="debezium-mongodb-connector-advanced-configuration-properties"]
 .{prodname} MongoDB connector advanced configuration properties
 [cols="30%a,25%a,45%a",options="header"]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -303,9 +303,8 @@ endif::product[]
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 |`initial`
-|The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
-After the snapshot completes, the connector begins to stream event records for subsequent database changes.
-
+|After the connector starts, it performs an initial database snapshot.
+//as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 |`initial_only`
 |The connector performs a database snapshot.
 After the snapshot completes, the connector stops, and does not stream event records for subsequent database changes.
@@ -314,7 +313,10 @@ After the snapshot completes, the connector stops, and does not stream event rec
 |Deprecated, see `no_data`.
 
 |`no_data`
-|The connector captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+|The connector captures the structure of all relevant tables,
+//performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow],
+but it does not create `READ` events to represent the data set at the point of the connector's start-up.
+//(Step 7.b).
 
 |`when_needed`
 |After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
@@ -1993,7 +1995,8 @@ The snapshot includes the structure and data of the captured tables.
 Specify this value to populate topics with a complete representation of the data from the captured tables every time that the connector starts.
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
-`initial`:: The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
+`initial`:: When the connector starts, it performs an initial database snapshot.
+//as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 `initial_only`:: The connector performs a database a snapshot only when no offsets have been recorded for the logical server name.
@@ -2002,7 +2005,10 @@ It does not transition to streaming event records for subsequent database change
 
 `never`:: Deprecated, see `no_data`.
 
-`no_data`:: The connector runs a snapshot that captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+`no_data`:: The connector runs a snapshot that captures the structure of all relevant tables,
+//, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that
+but it does not create `READ` events to represent the data set at the point of the connector's start-up.
+// (Step 7.b).
 
 `when_needed`:: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3423,6 +3423,7 @@ However, it's best to use the minimum number that are required to specify a uniq
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
+// Title: Advanced {prodname} MySQL connector configuration properties
 [id="mysql-advanced-connector-configuration-properties"]
 ==== Advanced MySQL connector configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -108,9 +108,11 @@ You can find more information about snapshots in the following sections:
 * xref:debezium-oracle-incremental-snapshots[]
 endif::product[]
 
-
+// Type: concept
+// ModuleID: default-workflow-that-the-oracle-connector-uses-to-perform-an-initial-snapshot
 [[default-workflow-for-performing-an-initial-snapshot]]
-.Default workflow that the Oracle connector uses to perform an initial snapshot
+==== Default workflow that the Oracle connector uses to perform an initial snapshot
+
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`]  configuration property is set to its default value, which is `initial`.
 You can customize the way that the connector creates snapshots by changing the value of the `snapshot.mode` property.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3261,6 +3261,7 @@ For information about the structure of _message_ events and about their ordering
 
 |===
 
+// Title: Advanced {prodname} PostgreSQL connector configuration properties
 [id="postgresql-advanced-configuration-properties"]
 The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -134,8 +134,10 @@ You can find more information about snapshots in the following sections:
 * xref:debezium-sqlserver-incremental-snapshots[]
 endif::product[]
 
+// Type: concept
+// ModuleID: default-workflow-that-the-sqlserver-connector-uses-to-perform-an-initial-snapshot
 [[default-workflow-for-performing-an-initial-snapshot]]
-.Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
+==== Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
 
 The following workflow lists the steps that {prodname} takes to create a snapshot.
 These steps describe the process for a snapshot when the xref:{context}-property-snapshot-mode[`snapshot.mode`] configuration property is set to its default value, which is `initial`.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -136,7 +136,7 @@ endif::product[]
 
 // Type: concept
 // ModuleID: default-workflow-that-the-sqlserver-connector-uses-to-perform-an-initial-snapshot
-[[default-workflow-for-performing-an-initial-snapshot]]
+[[sqlserver-default-workflow-for-performing-an-initial-snapshot]]
 ==== Default workflow that the {prodname} SQL Server connector uses to perform an initial snapshot
 
 The following workflow lists the steps that {prodname} takes to create a snapshot.
@@ -203,7 +203,7 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 |`initial`
-|The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
+|The connector performs a database snapshot as described in the xref:sqlserver-default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 |`initial_only`
@@ -213,7 +213,7 @@ After the snapshot completes, the connector begins to stream event records for s
 |Deprecated, see `no_data`.
 
 |`no_data`
-|The connector captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+|The connector captures the structure of all relevant tables, performing all the steps described in the xref:sqlserver-default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
 
 |`recovery`
 |Set this option to restore a database schema history topic that is lost or corrupted.
@@ -2823,6 +2823,7 @@ For more information, see {link-prefix}:{link-avro-serialization}#avro-naming[Av
 
 |===
 
+// Title: Advanced {prodname} SQL Server connector configuration properties
 [id="sqlserver-advanced-connector-configuration-properties"]
 ==== Advanced SQL Server connector configuration properties
 
@@ -2867,14 +2868,14 @@ The following values are supported:
 `always`:: Perform snapshot on each connector start.
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
-`initial`:: The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
+`initial`:: The connector performs a database snapshot as described in the xref:sqlserver-default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
 `initial_only`:: The connector performs a database snapshot and stops before streaming any change event records, not allowing any subsequent change events to be captured.
 
 `schema_only`:: Deprecated, see `no_data`.
 
-`no_data`:: The connector captures the structure of all relevant tables, performing all the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
+`no_data`:: The connector captures the structure of all relevant tables, performing all the steps described in the xref:sqlserver-default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 7.b).
 
 `recovery`:: Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -46,7 +46,7 @@ The following topics provide details:
 * xref:outbox-table-structure-expected-by-debezium-outbox-event-router-smt[]
 * xref:basic-debezium-outbox-event-router-smt-configuration[]
 * xref:options-for-applying-the-outbox-event-router-transformation-selectively[]
-* xref:using-avro-as-the-payload-format-in-debezium-outbox-messages[]
+* xref:outbox-event-router-using-avro-as-the-payload-format-in-debezium-outbox-messages[]
 * xref:emitting-additional-fields-in-debezium-outbox-messages[]
 * xref:expanding-escaped-json-string-as-json[]
 * xref:options-for-configuring-outbox-event-router-transformation[]
@@ -212,8 +212,8 @@ You can use one of the following methods to configure the connector to apply the
 // ModuleID: outbox-event-router-payload-serialization-format
 == Payload serialization format
 
-The outbox event router SMT supports arbitrary payload formats. 
-The SMT passes on `payload` column values that it reads from the outbox table without modification. 
+The outbox event router SMT supports arbitrary payload formats.
+The SMT passes on `payload` column values that it reads from the outbox table without modification.
 The way that the SMT converts these column values into Kafka message fields depends on how you configure the SMT.
 Common payload formats for serializing data are JSON and Avro.
 
@@ -224,7 +224,7 @@ Common payload formats for serializing data are JSON and Avro.
 [[using-json-payload-format]]
 === Using JSON as the payload format
 
-The default serialization format for the outbox event router SMT is JSON. 
+The default serialization format for the outbox event router SMT is JSON.
 To use this format, the data type of the source column must be JSON (for example, `jsonb` in PostgreSQL).
 
 // Type: concept
@@ -246,7 +246,7 @@ When a {prodname} outbox message represents the `payload` as a JSON String, the 
 }
 ----
 
-The outbox event router enables you to expand the message content to "real" JSON, deducing the companion schema from the JSON document. 
+The outbox event router enables you to expand the message content to "real" JSON, deducing the companion schema from the JSON document.
 The resulting Kafka message is formatted as in the following example:
 
 [source,javascript,indent=0]
@@ -276,7 +276,7 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 [[avro-as-payload-format]]
 === Using Apache Avro as the payload format
 
-Apache Avro is a common framework for serializing data. 
+Apache Avro is a common framework for serializing data.
 Using Avro can be beneficial for message format governance and for ensuring that outbox event schemas evolve in a backwards-compatible way.
 
 How a source application produces Avro formatted content for outbox message payloads is out of the scope of this documentation.
@@ -291,7 +291,7 @@ transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
 value.converter=io.debezium.converters.BinaryDataConverter
 ----
 
-By default, the `payload` column value (the Avro data) is the only message value. 
+By default, the `payload` column value (the Avro data) is the only message value.
 When data is stored in Avro format, the column format must be set to a binary data type, such as `bytea` in PostgreSQL.
 The value converter for the SMT must also be set to `BinaryDataConverter`, so that it propagates the binary value of the `payload` column as-is into the Kafka message value.
 


### PR DESCRIPTION
[DBZ-7815](https://issues.redhat.com/browse/DBZ-7815)

Ensures uniqueness of anchor IDs in connector docs and makes other corrections to fix build errors in downstream documentation.

Tested in local Antora and downstream builds.

This changes requires a backport to 2.7.

