### PR TITLE
DBZ-7806 Skip search for WAL position when offset exist and is just after the initial snapshot

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotIT.java
@@ -9,9 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -54,7 +51,6 @@ public abstract class BinlogReadOnlyIncrementalSnapshotIT<C extends SourceConnec
     private static KafkaCluster kafka;
     private static final int PARTITION_NO = 0;
     public static final String EXCLUDED_TABLE = "b";
-    private final Path signalsFile = Paths.get("src", "test", "resources").resolve("debezium_signaling_file.txt");
 
     @Rule
     public ConditionalFail conditionalFail = new ConditionalFail();
@@ -349,16 +345,6 @@ public abstract class BinlogReadOnlyIncrementalSnapshotIT<C extends SourceConnec
     @Override
     public void insertDeleteWatermarkingStrategy() throws Exception {
         // test has not to be executed on read only
-    }
-
-    private void sendExecuteSnapshotFileSignal(String fullTableNames) throws IOException {
-
-        String signalValue = String.format(
-                "{\"id\":\"12345\",\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"%s\"], \"type\": \"INCREMENTAL\"}}",
-                fullTableNames);
-
-        java.nio.file.Files.write(signalsFile, signalValue.getBytes());
-
     }
 
     protected void populate4PkTable() throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -159,7 +159,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             this.lastCompletelyProcessedLsn = replicationStream.get().startLsn();
 
-            if (walPosition.searchingEnabled()) {
+            if (walPosition.searchingEnabled() && this.effectiveOffset.lastCompletelyProcessedLsn() != null) {
                 searchWalPosition(context, partition, this.effectiveOffset, stream, walPosition);
                 try {
                     if (!isInPreSnapshotCatchUpStreaming(this.effectiveOffset)) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -131,7 +131,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             if (hasStartLsnStoredInContext) {
                 // start streaming from the last recorded position in the offset
-                final Lsn lsn = this.effectiveOffset.lastCompletelyProcessedLsn() != null ? this.effectiveOffset.lastCompletelyProcessedLsn()
+                final Lsn lsn = this.effectiveOffset.hasCompletelyProcessedPosition() ? this.effectiveOffset.lastCompletelyProcessedLsn()
                         : this.effectiveOffset.lsn();
                 final Operation lastProcessedMessageType = this.effectiveOffset.lastProcessedMessageType();
                 LOGGER.info("Retrieved latest position from stored offset '{}'", lsn);
@@ -159,7 +159,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             this.lastCompletelyProcessedLsn = replicationStream.get().startLsn();
 
-            if (walPosition.searchingEnabled() && this.effectiveOffset.lastCompletelyProcessedLsn() != null) {
+            if (walPosition.searchingEnabled() && this.effectiveOffset.hasCompletelyProcessedPosition()) {
                 searchWalPosition(context, partition, this.effectiveOffset, stream, walPosition);
                 try {
                     if (!isInPreSnapshotCatchUpStreaming(this.effectiveOffset)) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
@@ -8,6 +8,8 @@ package io.debezium.connector.postgresql;
 
 import static io.debezium.pipeline.signal.actions.AbstractSnapshotSignal.SnapshotType.BLOCKING;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -21,6 +23,7 @@ import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.AbstractBlockingSnapshotTest;
+import io.debezium.pipeline.signal.channels.FileSignalChannel;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
 
 public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
@@ -32,6 +35,9 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
             "CREATE TABLE s1.a (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
             "CREATE TABLE s1.b (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
             "CREATE TABLE s1.debezium_signal (id varchar(64), type varchar(32), data varchar(2048))";
+
+    protected final Path signalsFile = Paths.get("src", "test", "resources")
+            .resolve("debezium_signaling_blocking_file.txt");
 
     @Before
     public void before() throws SQLException {
@@ -178,6 +184,33 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
         int signalingRecords = 1;
 
         assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT + signalingRecords, 10));
+
+        insertRecords(ROW_COUNT, ROW_COUNT * 2);
+
+        assertStreamingRecordsArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT, 10));
+
+    }
+
+    @Test
+    public void executeBlockingSnapshotJustAfterInitialSnapshotAndNoEventStreamedYet() throws Exception {
+        // Testing.Print.enable();
+
+        populateTable();
+
+        startConnectorWithSnapshot(x -> mutableConfig(false, false)
+                .with(FileSignalChannel.SIGNAL_FILE, signalsFile.toString())
+                .with(CommonConnectorConfig.SIGNAL_ENABLED_CHANNELS, "file"));
+
+        waitForSnapshotToBeCompleted(connector(), server(), task(), database());
+
+        SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT, 10);
+        assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT, consumedRecordsByTopic);
+
+        sendExecuteSnapshotFileSignal(tableDataCollectionId(), BLOCKING.name(), signalsFile);
+
+        waitForLogMessage("Snapshot completed", AbstractSnapshotChangeEventSource.class);
+
+        assertRecordsFromSnapshotAndStreamingArePresent((ROW_COUNT), consumeRecordsByTopic((ROW_COUNT), 10));
 
         insertRecords(ROW_COUNT, ROW_COUNT * 2);
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -7,7 +7,9 @@ package io.debezium.pipeline.source.snapshot.incremental;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +40,8 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
     protected static final int PARTITION_NO = 0;
     protected static final String SERVER_NAME = "test_server";
     private static final int MAXIMUM_NO_RECORDS_CONSUMES = 5;
+    protected final Path signalsFile = Paths.get("src", "test", "resources")
+            .resolve("debezium_signaling_file.txt");
 
     protected abstract Class<T> connectorClass();
 
@@ -299,6 +303,22 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
     @Override
     protected int getMaximumEnqueuedRecordCount() {
         return ROW_COUNT * 3;
+    }
+
+    protected void sendExecuteSnapshotFileSignal(String fullTableNames) throws IOException {
+
+        sendExecuteSnapshotFileSignal(fullTableNames, "INCREMENTAL", signalsFile);
+
+    }
+
+    protected void sendExecuteSnapshotFileSignal(String fullTableNames, String type, Path signalFile) throws IOException {
+
+        String signalValue = String.format(
+                "{\"id\":\"12345\",\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"%s\"], \"type\": \"%s\"}}",
+                fullTableNames, type);
+
+        java.nio.file.Files.write(signalFile, signalValue.getBytes());
+
     }
 
     protected void sendAdHocSnapshotSignal(String... dataCollectionIds) throws SQLException {


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-7806

@jpechane The intent here is to skip the search on the WAL when the connector has an offset that is the result of the initial snapshot. Not sure if there is a better way to check this condition. 