### PR TITLE
DBZ-7859: reduce enum array allocation

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -454,6 +454,7 @@ Saulius Valatka
 Sayed Mohammad Hossein Torabi
 Scofield Xu
 Sara Fonseca
+Sean C. Sullivan
 Sean Rooney
 Sean Wu
 Sebastiaan Knijnenburg

--- a/debezium-core/src/main/java/io/debezium/data/Envelope.java
+++ b/debezium-core/src/main/java/io/debezium/data/Envelope.java
@@ -8,7 +8,10 @@ package io.debezium.data;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -32,6 +35,7 @@ public final class Envelope {
      * The constants for the values for the {@link FieldName#OPERATION operation} field in the message envelope.
      */
     public enum Operation {
+
         /**
          * The operation that read the current state of a record, most typically during snapshots.
          */
@@ -57,6 +61,11 @@ public final class Envelope {
          */
         MESSAGE("m");
 
+        // Enum .values() returns a new array upon each invocation
+        // Reference: https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
+        private static final Map<String, Operation> CODE_LOOKUP = Stream.of(Operation.values()).collect(
+                Collectors.toMap(Operation::code, op -> op));
+
         private final String code;
 
         Operation(String code) {
@@ -64,12 +73,10 @@ public final class Envelope {
         }
 
         public static Operation forCode(String code) {
-            for (Operation op : Operation.values()) {
-                if (op.code().equalsIgnoreCase(code)) {
-                    return op;
-                }
+            if (code == null) {
+                return null;
             }
-            return null;
+            return CODE_LOOKUP.get(code.toLowerCase());
         }
 
         public String code() {

--- a/debezium-core/src/test/java/io/debezium/data/EnvelopeTest.java
+++ b/debezium-core/src/test/java/io/debezium/data/EnvelopeTest.java
@@ -57,6 +57,18 @@ public class EnvelopeTest {
         assertRequiredField(env, Envelope.FieldName.TRANSACTION, SchemaBuilder.STRING_SCHEMA);
     }
 
+    @Test
+    public void envelopeOperationLookupByCode() {
+        assertThat(Envelope.Operation.forCode(null)).isNull();
+        assertThat(Envelope.Operation.forCode("")).isNull();
+        assertThat(Envelope.Operation.forCode("bogus")).isNull();
+        for (Envelope.Operation operation : Envelope.Operation.values()) {
+            assertThat(Envelope.Operation.forCode(operation.code().toLowerCase())).isEqualTo(operation);
+            assertThat(Envelope.Operation.forCode(operation.code().toUpperCase())).isEqualTo(operation);
+            assertThat(Envelope.Operation.forCode(operation.name())).isNull();
+        }
+    }
+
     protected void assertRequiredField(Envelope env, String fieldName, Schema expectedSchema) {
         assertField(env.schema().field(fieldName), fieldName, expectedSchema, false);
     }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -265,3 +265,4 @@ zeldanerd24,Kevin Rothenberger
 PradeepNain,Pradeep Nain
 DLT1412,Duc Le Tu
 gaurav7261,Gaurav Miglani
+sullis,Sean C. Sullivan


### PR DESCRIPTION
reduce Java enum array allocation by caching the result of .values() method.

Reference:
https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/

https://issues.redhat.com/projects/DBZ/issues/DBZ-7859

