### PR TITLE
DBZ-7870 default value of -1 for connection error retries interpreted as no limit

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -350,6 +350,7 @@ Meng Qiu
 Melissa Winstanley
 Michael Cizmar
 Michael Wang
+Michal Augustyn
 Mickael Maison
 Mickaël Isaert
 Mike Graham

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -672,7 +672,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
                 startedSuccessfully = true;
             }
             catch (Exception ex) {
-                if (totalRetries >= maxRetries) {
+                if (maxRetries != EmbeddedEngineConfig.DEFAULT_ERROR_MAX_RETRIES && totalRetries >= maxRetries) {
                     LOGGER.error("Can't start the connector, max retries to connect exceeded; stopping connector...", ex);
                     return ex;
                 }


### PR DESCRIPTION
[The documentation](https://github.com/debezium/debezium/blob/main/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineConfig.java#L184) of `errors.max.retries` states that `-1` should mean _unlimited_, but the implementation doesn't handle it.

We discovered this because we have these two messages in the log (after Postgres update), and the Debezium wasn't processing any data then.
```
Retriable exception thrown, connector will be restarted; errors.max.retries=-1
Can't start the connector, max retries to connect exceeded; stopping connector...
```