### PR TITLE
DBZ-7925 Expand truncate support to byte arrays in addition to strings

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/mapping/ColumnMappers.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/ColumnMappers.java
@@ -175,7 +175,7 @@ public class ColumnMappers {
          * @return this object so that methods can be chained together; never null
          */
         public Builder truncateStrings(String fullyQualifiedColumnNames, int maxLength) {
-            return map(fullyQualifiedColumnNames, new TruncateStrings(maxLength));
+            return map(fullyQualifiedColumnNames, new TruncateColumn(maxLength));
         }
 
         /**

--- a/debezium-core/src/main/java/io/debezium/relational/mapping/MaskStrings.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/MaskStrings.java
@@ -61,7 +61,7 @@ public class MaskStrings implements ColumnMapper {
         this.converterFromColumn = column -> {
             final HashValueConverter hashValueConverter = new HashValueConverter(salt, hashAlgorithm, hashingByteArrayStrategy);
             if (column.length() > 0) {
-                return hashValueConverter.and(new TruncateStrings.TruncatingValueConverter(column.length()));
+                return hashValueConverter.and(new TruncateColumn.TruncatingValueConverter(column.length()));
             }
             else {
                 return hashValueConverter;

--- a/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateColumn.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateColumn.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.relational.mapping;
 
+import java.nio.ByteBuffer;
+
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.annotation.Immutable;
@@ -12,21 +14,21 @@ import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
 
 /**
- * A {@link ColumnMapper} implementation that ensures that string values longer than a specified length will be truncated.
+ * A {@link ColumnMapper} implementation that ensures that column values longer than a specified length will be truncated.
  *
  * @author Randall Hauch
  */
-public class TruncateStrings implements ColumnMapper {
+public class TruncateColumn implements ColumnMapper {
 
     private final TruncatingValueConverter converter;
 
     /**
-     * Create a {@link ColumnMapper} that truncates string values to a maximum length.
+     * Create a {@link ColumnMapper} that truncates column values to a maximum length.
      *
      * @param maxLength the maximum number of characters allowed in values
      * @throws IllegalArgumentException if the {@code maxLength} is not positive
      */
-    public TruncateStrings(int maxLength) {
+    public TruncateColumn(int maxLength) {
         if (maxLength <= 0) {
             throw new IllegalArgumentException("Maximum length must be positive");
         }
@@ -65,6 +67,13 @@ public class TruncateStrings implements ColumnMapper {
                 String str = (String) value;
                 if (str.length() > maxLength) {
                     return str.substring(0, maxLength);
+                }
+            }
+            else if (value instanceof ByteBuffer) {
+                ByteBuffer buffer = (ByteBuffer) value;
+                if (buffer.limit() > maxLength) {
+                    buffer.limit(maxLength);
+                    return buffer.slice();
                 }
             }
             return value;

--- a/debezium-core/src/test/java/io/debezium/relational/mapping/TruncateColumnTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/mapping/TruncateColumnTest.java
@@ -7,6 +7,8 @@ package io.debezium.relational.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
+
 import org.junit.Test;
 
 import io.debezium.relational.Column;
@@ -16,14 +18,14 @@ import io.debezium.relational.ValueConverter;
  * @author Randall Hauch
  *
  */
-public class TruncateStringsTest {
+public class TruncateColumnTest {
 
     private final Column column = Column.editor().name("col").create();
     private ValueConverter converter;
 
     @Test
     public void shouldTruncateStrings() {
-        converter = new TruncateStrings(5).create(column);
+        converter = new TruncateColumn(5).create(column);
         assertThat(converter.convert("1234567890").toString()).isEqualTo("12345");
         assertThat(converter.convert("123456").toString()).isEqualTo("12345");
         assertThat(converter.convert("12345").toString()).isEqualTo("12345");
@@ -32,6 +34,31 @@ public class TruncateStringsTest {
         assertThat(converter.convert("12").toString()).isEqualTo("12");
         assertThat(converter.convert("1").toString()).isEqualTo("1");
         assertThat(converter.convert(null)).isNull();
+    }
+
+    @Test
+    public void shouldTruncateByteBuffer() {
+        converter = new TruncateColumn(3).create(column);
+        ByteBuffer buffer5 = createBuffer(5);
+        ByteBuffer buffer4 = createBuffer(4);
+        ByteBuffer buffer3 = createBuffer(3);
+        ByteBuffer buffer2 = createBuffer(2);
+        ByteBuffer buffer1 = createBuffer(1);
+        assertThat(converter.convert(buffer5)).isEqualTo(buffer3);
+        assertThat(converter.convert(buffer4)).isEqualTo(buffer3);
+        assertThat(converter.convert(buffer3)).isEqualTo(buffer3);
+        assertThat(converter.convert(buffer2)).isEqualTo(buffer2);
+        assertThat(converter.convert(buffer1)).isEqualTo(buffer1);
+        assertThat(converter.convert(null)).isNull();
+    }
+
+    private ByteBuffer createBuffer(int size) {
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        for (int i = 0; i < size; i++) {
+            buffer.put((byte) i);
+        }
+        buffer.position(0);
+        return buffer;
     }
 
 }


### PR DESCRIPTION
Expand truncate strings to also work for byte buffers (e.g., for mysq/vitess blob types).

Rename class from TruncateStrings to TruncateColumn to be more generically named, and we can expand to include any other types that we want to truncate going forward.

We added an itest in vitess-connector repo that is passing locally with these changes https://github.com/debezium/debezium-connector-vitess/pull/198