### PR TITLE
DBZ-7931 Modify out_of_line_constraint clause

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/oracle/generated/PlSqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/oracle/generated/PlSqlParser.g4
@@ -1511,7 +1511,7 @@ out_of_line_ref_constraint
     ;
 
 out_of_line_constraint
-    : ( (CONSTRAINT constraint_name)?
+    : ( ((CONSTRAINT | CONSTRAINTS) constraint_name)?
           ( UNIQUE '(' column_name (',' column_name)* ')'
           | PRIMARY KEY '(' column_name (',' column_name)* ')'
           | foreign_key_clause

--- a/debezium-ddl-parser/src/test/resources/oracle/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/oracle/examples/ddl_create.sql
@@ -696,6 +696,13 @@ CREATE TABLE "interval_type_test" (
     "i1" INTERVAL YEAR(9) TO MONTH DEFAULT (INTERVAL '10-3' YEAR TO MONTH) NULL,
     "i2" INTERVAL DAY(6) TO SECOND (9) DEFAULT (INTERVAL '1 2:34:56.789' DAY TO SECOND) NOT NULL
 );
+CREATE TABLE T1 (
+ "NAME" VARCHAR(10) NOT NULL,
+ "ID" INT NOT NULL,
+ "ADDRESS" VARCHAR(255),
+ "SQ_NUMBER" NUMBER(10),
+ "PQ_NUMBER" NUMBER(10),
+ CONSTRAINTS UQ1 UNIQUE ("SQ_NUMBER", "PQ_NUMBER"));
 -- Create index (Oracle 23+)
 create index hr.name IF NOT EXISTS on hr.table (id,data) tablespace ts;
 -- Create user (Oracle 23+)


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7931

@Naros I think similar issues had come up regarding ordering of the constraints. In this particular issue, the DDL should be using the `out_of_line_constraint`, but it doesn't. Even if we did a reordering in the past for the `relational_property` so the preference would be given to `out_of_line_constraint` before using the `column_definition` clause, it didn't work as the definition of `out_of_line_constraint` goes by 
```
out_of_line_constraint
    : (CONSTRAINT constraint_name)?
```
But if DDL contains has `CONSTRAINTS`, it would go to the `column_definition` clause and end up near the `inline_clause` throwing an error. 
Adding the change in the PR works for corner cases. But it also makes me wonder why the DDL failed earlier near the `inline_clause` since it also doesn't have the `CONSTRAINTS` keyword. 🤔 

If you have any suggestions, we can discuss them.