### PR TITLE
Call commit after running DDL statements

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -413,6 +413,7 @@ Peter Junos
 Peter Larsson
 Peter Urbanetz
 Philip Sanetra
+Piotr Piastucki
 Plugaru Tudor
 Poonam Meghnani
 Pradeep Mamillapalli

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
@@ -263,6 +263,7 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                         ps.execute();
                         LOG.info("Created table in given database...");
                     }
+                    conn.commit();
                 }
             }, "initialize storage", false);
         }

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStore.java
@@ -105,6 +105,7 @@ public class JdbcOffsetBackingStore implements OffsetBackingStore {
             try (var ps = conn.prepareStatement(config.getTableCreate())) {
                 ps.execute();
             }
+            conn.commit();
         }, "checking / creating table", false);
     }
 


### PR DESCRIPTION
PostgreSQL does not auto-commit DDL statements so, currently, other clients trying to execute DDL statements might get stuck until commit is invoked in storeRecord for instance.