### PR TITLE
DBZ-7719 Make `GROWING_WAL_WARNING_LOG_INTERVAL` configurable

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -146,6 +146,7 @@ Dennis Persson
 Derek Moore
 Dhrubajyoti G
 Dominique Chanet
+Dongwook Chang
 Dou Pengwei
 Duc Le Tu
 Duncan Sands

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -972,6 +972,16 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(PostgresSourceInfoStructMaker.class.getName());
 
+    public static final Field GROWING_WAL_WARNING_LOG_INTERVAL = Field.create("wal.growing.warning.log.interval")
+            .withDisplayName("Interval between log messages about growing WAL")
+            .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 101))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Number of received events without sending anything to Kafka which will trigger a WAL backlog growing warning.")
+            .withDefault(10_000)
+            .withValidation(Field::isNonNegativeInteger);
+
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;
     private final HStoreHandlingMode hStoreHandlingMode;
     private final IntervalHandlingMode intervalHandlingMode;
@@ -1131,6 +1141,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     @Override
     protected SourceInfoStructMaker<? extends AbstractSourceInfo> getSourceInfoStructMaker(Version version) {
         return getSourceInfoStructMaker(SOURCE_INFO_STRUCT_MAKER, Module.name(), Module.version(), this);
+    }
+
+    protected int getGrowingWalWarningLogInterval() {
+        return getConfig().getInteger(GROWING_WAL_WARNING_LOG_INTERVAL);
     }
 
     private static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -43,12 +43,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
     private static final String KEEP_ALIVE_THREAD_NAME = "keep-alive";
 
-    /**
-     * Number of received events without sending anything to Kafka which will
-     * trigger a "WAL backlog growing" warning.
-     */
-    private static final int GROWING_WAL_WARNING_LOG_INTERVAL = 10_000;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresStreamingChangeEventSource.class);
 
     // PGOUTPUT decoder sends the messages with larger time gaps than other decoders
@@ -401,7 +395,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             numberOfEventsSinceLastEventSentOrWalGrowingWarning++;
         }
 
-        if (numberOfEventsSinceLastEventSentOrWalGrowingWarning > GROWING_WAL_WARNING_LOG_INTERVAL && !dispatcher.heartbeatsEnabled()) {
+        if (numberOfEventsSinceLastEventSentOrWalGrowingWarning > connectorConfig.getGrowingWalWarningLogInterval() && !dispatcher.heartbeatsEnabled()) {
             LOGGER.warn("Received {} events which were all filtered out, so no offset could be committed. "
                     + "This prevents the replication slot from acknowledging the processed WAL offsets, "
                     + "causing a growing backlog of non-removeable WAL segments on the database server. "

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -273,3 +273,4 @@ michal.kluz,Michal Pioun
 joontube,Seongjoon Jeong
 chungeun-choi,Chungeun Choi
 ashwinmk,Ashwin Murali Krishnan
+dongwook-chan,Dongwook Chang


### PR DESCRIPTION
Resolves [DBZ-7719](https://issues.redhat.com/browse/DBZ-7719)

After `GROWING_WAL_WARNING_LOG_INTERVAL` amount of skipped events,
a log is generated to warn the user about the growing WAL.

The issue suggests:
- Counting all events regardless of their types
- Making `GROWING_WAL_WARNING_LOG_INTERVAL` configurable

I have verified that the existing code indeed accounts for all events regardless of their types.
So I have made `GROWING_WAL_WARNING_LOG_INTERVAL` configurable as requested.