### PR TITLE
Add upstream sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,6 +17,6 @@ jobs:
       with:
         github_actor: "${GITHUB_ACTOR}"
         github_repository: "${GITHUB_REPOSITORY}"
-        github_token: "${GITHUB_TOKEN}"
+        github_token: ${{ secrets.WORKFLOW_TOKEN }}
         upstream_repo: debezium/debezium
         major_version: "1"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,22 @@
+name: Sync upstream
+# This runs every day on 1000 UTC
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  # Allows manual workflow run
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+ build:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Create upstream version tag
+      uses: DataDog/sync-upstream-release-tag@main
+      with:
+        github_actor: "${GITHUB_ACTOR}"
+        github_repository: "${GITHUB_REPOSITORY}"
+        github_token: "${GITHUB_TOKEN}"
+        upstream_repo: debezium/debezium
+        major_version: "1"


### PR DESCRIPTION
Add a GitHub workflow that syncs (rebase) with the upstream repo.

Based on https://github.com/DataDog/sync-upstream-release-tag