### PR TITLE
DBZ-7964 (quickfix) Only reset error retry counter if poll() successfully produced records

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -182,7 +182,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
     }
 
     @Override
-    protected void resetErrorHandlerRetriesIfNeeded() {
+    protected void resetErrorHandlerRetriesIfNeeded(List<SourceRecord> records) {
         // Reset the retries if all partitions have streamed without exceptions at least once after a restart
         if (coordinator.getErrorHandler().getRetries() > 0 && ((SqlServerChangeEventSourceCoordinator) coordinator).firstStreamingIterationCompletedSuccessfully()) {
             coordinator.getErrorHandler().resetRetries();

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -289,7 +289,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             final List<SourceRecord> records = doPoll();
             logStatistics(records);
 
-            resetErrorHandlerRetriesIfNeeded();
+            resetErrorHandlerRetriesIfNeeded(records);
 
             return records;
         }
@@ -340,12 +340,12 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
      * Should be called to reset the error handler's retry counter upon a successful poll or when known
      * that the connector task has recovered from a previous failure state.
      */
-    protected void resetErrorHandlerRetriesIfNeeded() {
+    protected void resetErrorHandlerRetriesIfNeeded(List<SourceRecord> records) {
         // When a connector throws a retriable error, the task is not re-created and instead the previous
         // error handler is passed into the new error handler, propagating the retry count. This method
-        // allows resetting that counter when a successful poll iteration step happens so that when a
+        // allows resetting that counter when a successful poll iteration step contains new records  so that when a
         // future failure is thrown, the maximum retry count can be utilized.
-        if (coordinator.getErrorHandler().getRetries() > 0) {
+        if (!records.isEmpty() && coordinator.getErrorHandler().getRetries() > 0) {
             coordinator.getErrorHandler().resetRetries();
         }
     }

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -343,7 +343,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     protected void resetErrorHandlerRetriesIfNeeded(List<SourceRecord> records) {
         // When a connector throws a retriable error, the task is not re-created and instead the previous
         // error handler is passed into the new error handler, propagating the retry count. This method
-        // allows resetting that counter when a successful poll iteration step contains new records  so that when a
+        // allows resetting that counter when a successful poll iteration step contains new records so that when a
         // future failure is thrown, the maximum retry count can be utilized.
         if (!records.isEmpty() && coordinator.getErrorHandler().getRetries() > 0) {
             coordinator.getErrorHandler().resetRetries();

--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
@@ -267,7 +267,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         }
 
         @Override
-        protected void resetErrorHandlerRetriesIfNeeded() {
+        protected void resetErrorHandlerRetriesIfNeeded(List<SourceRecord> records) {
             // do nothing as we don't have a coordinator mocked
         }
 

--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -171,7 +171,7 @@ public class BaseSourceTaskTest {
         }
 
         @Override
-        protected void resetErrorHandlerRetriesIfNeeded() {
+        protected void resetErrorHandlerRetriesIfNeeded(List<SourceRecord> records) {
             // do nothing as we don't have a coordinator mocked
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7964