### PR TITLE
DBZ-7224 Use JDK 21 as build/runtime target for Outbox

### DIFF
--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -14,6 +14,14 @@
     <name>Debezium Quarkus :: Outbox :: Common</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- Java version used for Debezium specific components - Server, Operator, Outbox -->
+        <debezium.java.specific.target>21</debezium.java.specific.target>
+
+        <maven.compiler.source>${debezium.java.specific.target}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -15,9 +15,11 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- Quarkus has moved to Java 17 as baseline -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <!-- Java version used for Debezium specific components - Server, Operator, Outbox -->
+        <debezium.java.specific.target>21</debezium.java.specific.target>
+
+        <maven.compiler.source>${debezium.java.specific.target}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -14,6 +14,14 @@
     <name>Debezium Quarkus :: Outbox</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- Java version used for Debezium specific components - Server, Operator, Outbox -->
+        <debezium.java.specific.target>21</debezium.java.specific.target>
+
+        <maven.compiler.source>${debezium.java.specific.target}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7224

Follows on https://github.com/debezium/debezium/pull/5654