### PR TITLE
DBZ-7224 Switched to centralised JDK version control for Quarkus Outbox

### DIFF
--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -10,6 +10,19 @@
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- JDK version is controlled by Debezium Parent, do not change! -->
+        <!--    the compiler setting may be different from the parent -->
+        <!--    thus the setting must be here and use the referenced properties -->
+        <!--    e.g. different setting may be required due to quarkus version -->
+        <maven.compiler.source>${debezium.java.source}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
+        <maven.compiler.release>${debezium.java.specific.target}</maven.compiler.release>
+        <maven.compiler.testSource>${debezium.java.source}</maven.compiler.testSource>
+        <maven.compiler.testTarget>${debezium.java.specific.target}</maven.compiler.testTarget>
+        <maven.compiler.testRelease>${debezium.java.specific.target}</maven.compiler.testRelease>
+    </properties>
+
     <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
     <name>Debezium Quarkus :: Outbox :: Common</name>
     <packaging>pom</packaging>

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -15,9 +15,16 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- Quarkus has moved to Java 17 as baseline -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <!-- JDK version is controlled by Debezium Parent, do not change! -->
+        <!--    the compiler setting may be different from the parent -->
+        <!--    thus the setting must be here and use the referenced properties -->
+        <!--    e.g. different setting may be required due to quarkus version -->
+        <maven.compiler.source>${debezium.java.source}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
+        <maven.compiler.release>${debezium.java.specific.target}</maven.compiler.release>
+        <maven.compiler.testSource>${debezium.java.source}</maven.compiler.testSource>
+        <maven.compiler.testTarget>${debezium.java.specific.target}</maven.compiler.testTarget>
+        <maven.compiler.testRelease>${debezium.java.specific.target}</maven.compiler.testRelease>
     </properties>
 
     <dependencyManagement>

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -14,6 +14,19 @@
     <name>Debezium Quarkus :: Outbox</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- JDK version is controlled by Debezium Parent, do not change! -->
+        <!--    the compiler setting may be different from the parent -->
+        <!--    thus the setting must be here and use the referenced properties -->
+        <!--    e.g. different setting may be required due to quarkus version -->
+        <maven.compiler.source>${debezium.java.source}</maven.compiler.source>
+        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
+        <maven.compiler.release>${debezium.java.specific.target}</maven.compiler.release>
+        <maven.compiler.testSource>${debezium.java.source}</maven.compiler.testSource>
+        <maven.compiler.testTarget>${debezium.java.specific.target}</maven.compiler.testTarget>
+        <maven.compiler.testRelease>${debezium.java.specific.target}</maven.compiler.testRelease>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7224

Follows on https://github.com/debezium/debezium/pull/5654

replaces https://github.com/debezium/debezium/pull/5659