### PR TITLE
DBZ-8043 Document the support for spanner's FLOAT32 type

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -49,6 +49,7 @@ Ankur Gupta
 Ant Kutschera
 Anton Kondratev
 Anton Martynov
+Aravind Pedapudi
 Arik Cohen
 Aristofanis Lekkos
 Arkoprabho Chakraborti

--- a/documentation/modules/ROOT/pages/connectors/spanner.adoc
+++ b/documentation/modules/ROOT/pages/connectors/spanner.adoc
@@ -843,7 +843,10 @@ The Spanner connector represents changes to rows with events that are structured
 |`STRING`
 |`STRING`
 
+|`FLOAT32`
 |`FLOAT`
+
+|`FLOAT64`
 |`DOUBLE`
 
 |`NUMERIC`


### PR DESCRIPTION
The spanner connector is getting support for FLOAT32 type in https://github.com/debezium/debezium-connector-spanner/pull/92. This is documenting the data type mapping.

It uses the correct spanner type names (`s/FLOAT/FLOAT32`, `s/DOUBLE/FLOAT64`), and the earlier mapping of `FLOAT -> DOUBLE` to `FLOAT64 -> DOUBLE`