### PR TITLE
[docs] Specify that custom converters require relational DB connector

### DIFF
--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -221,8 +221,8 @@ To use a custom converter with a connector, you deploy the converter JAR file al
 
 [IMPORTANT]
 ====
-Custom converters are designed to modify messages emitted by {prodname} source connectors.
-You cannot configure the {prodname} JDBC sink connector to use a custom converter.
+Custom converters are designed to modify messages emitted by {prodname} relational database source connectors.
+You cannot configure either the {prodname} MongoDB connector, or the {prodname} JDBC sink connector to use a custom converter.
 ====
 
 // Type: procedure
@@ -251,7 +251,7 @@ If the converter requires further information to customize the formats of specif
 .Prerequisites
 
 * You xref:implementing-a-custom-converter[created] and xref:deploying-a-debezium-custom-converter[deployed a custom converter].
-* A {prodname} source connector is deployed.
+* A {prodname} relational database source connector is deployed.
 
 .Procedure
 


### PR DESCRIPTION
In the custom converters documentation, the introductory topic includes a note that specifies that these converters are for use only with relational database source connectors. DBZ-8031 added information to explicitly state that custom converters are not intended for use with sink connectors, such as the Debezium JDBC sink connector.

However,  later in the document, the _Configuring and Using Converters_ and _Configuring a custom connector_ topics do not mention anything about the requirement to use a relational database connector. To remove any ambiguity and reinforce the message that you cannot configure a custom converter for the MongoDB connector, this change adds information to explicitly state that you can only configure a custom converter  for a  relational database connector.