### PR TITLE
DBZ-8040: Custom Converter Support

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/ClientProvided.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ClientProvided.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.embedded;
+
+import io.debezium.engine.format.SerializationFormat;
+
+public class ClientProvided implements SerializationFormat<Object> {
+}

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConverterBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConverterBuilder.java
@@ -149,7 +149,7 @@ public class ConverterBuilder<R> {
     }
 
     private List<Header<byte[]>> convertHeaders(
-            SourceRecord record, String topicName, HeaderConverter headerConverter) {
+                                                SourceRecord record, String topicName, HeaderConverter headerConverter) {
         List<Header<byte[]>> headers = new ArrayList<>();
 
         for (org.apache.kafka.connect.header.Header header : record.headers()) {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConverterBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConverterBuilder.java
@@ -149,7 +149,7 @@ public class ConverterBuilder<R> {
     }
 
     private List<Header<byte[]>> convertHeaders(
-                                                SourceRecord record, String topicName, HeaderConverter headerConverter) {
+            SourceRecord record, String topicName, HeaderConverter headerConverter) {
         List<Header<byte[]>> headers = new ArrayList<>();
 
         for (org.apache.kafka.connect.header.Header header : record.headers()) {
@@ -170,6 +170,12 @@ public class ConverterBuilder<R> {
 
         if (isFormat(format, Json.class) || isFormat(format, JsonByteArray.class)) {
             converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "org.apache.kafka.connect.json.JsonConverter").build();
+        }
+        else if (isFormat(format, ClientProvided.class)) {
+            if (converterConfig.getString(FIELD_CLASS) == null) {
+                throw new DebeziumException(
+                        "`" + ClientProvided.class.getSimpleName().toLowerCase() + "`" + " header converter requires a '" + FIELD_CLASS + "' configuration");
+            }
         }
         else {
             throw new DebeziumException("Header Converter '" + format.getSimpleName() + "' is not supported");
@@ -217,6 +223,13 @@ public class ConverterBuilder<R> {
         }
         else if (isFormat(format, SimpleString.class)) {
             converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "org.apache.kafka.connect.storage.StringConverter").build();
+        }
+        else if (isFormat(format, ClientProvided.class)) {
+            if (converterConfig.getString(FIELD_CLASS) == null) {
+                throw new DebeziumException(
+                        "`" + ClientProvided.class.getSimpleName().toLowerCase() + "`" + (key ? " key" : " value") + " converter requires a '" + FIELD_CLASS
+                                + "' configuration");
+            }
         }
         else {
             throw new DebeziumException("Converter '" + format.getSimpleName() + "' is not supported");


### PR DESCRIPTION
This PR in combination with a PR from Debezium Server supports the ability to do custom converters. Internally we have multiple custom converters and needed to build our own modules and hardcore our class names.

Now we can do the following: (operator spec)
```
      type: clientprovided
      config:
        class: com.shopify.cdc.transforms.ByteArrayHeaderConverter
```

If you don't provide the config

```
java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.debezium.server.Main.main(Main.java:15)
Caused by: io.debezium.DebeziumException: `clientprovided` value converter requires a 'class' configuration
	at io.debezium.embedded.ConverterBuilder.createConverter(ConverterBuilder.java:229)
	at io.debezium.embedded.ConverterBuilder.toFormat(ConverterBuilder.java:96)
	at io.debezium.embedded.async.AsyncEmbeddedEngine$AsyncEngineBuilder.build(AsyncEmbeddedEngine.java:922)
	at io.debezium.server.DebeziumServer.start(DebeziumServer.java:176)
	at io.debezium.server.DebeziumServer_Bean.doCreate(Unknown Source)
	at io.debezium.server.DebeziumServer_Bean.create(Unknown Source)
	at io.debezium.server.DebeziumServer_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:113)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:37)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:34)
	at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
	at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:34)
	at io.quarkus.arc.impl.ClientProxies.getApplicationScopedDelegate(ClientProxies.java:21)
	at io.debezium.server.DebeziumServer_ClientProxy.arc$delegate(Unknown Source)
	at io.debezium.server.DebeziumServer_ClientProxy.arc_contextualInstance(Unknown Source)
	at io.debezium.server.DebeziumServer_Observer_Synthetic_f28a48f6bdce4326db44aec92fdb5c84d535b5d9.notify(Unknown Source)
	at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:346)
	at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:328)
	at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:82)
	at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:155)
	at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:106)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
	... 7 more
```

Related Issue: https://issues.redhat.com/browse/DBZ-8040