### PR TITLE
DBZ-8063 Add documentation for webhook auth config

### DIFF
--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -798,7 +798,13 @@ optional https://en.wikipedia.org/wiki/JSON_Web_Token[JSON Web Token (JWT) authe
 
 |[[httpclient-authentication-type]]<<httpclient-authentication-type, `debezium.sink.http.authentication.type` >>
 |
-|Specifies the authentication type to use.  If missing, no authentication is used.  Currently, only JSON Web Token (JWT) authentication (indicated by the value `jwt`) is supported.
+|Specifies the type of authentication the HTTP client sink uses when connecting to an HTTP server.  
+Supports one of the following options:
+
+`jwt`:: JSON Web Token (JWT) authentication.
+`standard-webhooks`:: link:https://www.standardwebhooks.com/[Standard Webhooks].
+
+If you omit this property, the HTTP client sink does not use authentication headers for the connection
 
 |[[httpclient-authentication-jwt-username]]<<httpclient-authentication-jwt-username, `debezium.sink.http.authentication.jwt.username` >>
 |
@@ -819,6 +825,13 @@ optional https://en.wikipedia.org/wiki/JSON_Web_Token[JSON Web Token (JWT) authe
 |[[httpclient-authentication-jwt-refresh-token-expiration]]<<httpclient-authentication-jwt-refresh-token-expiration, `debezium.sink.http.authentication.jwt.refresh_token_expiration` >>
 |
 |Requested duration (in minutes) before the refresh token expires.
+
+|[[httpclient-authentication-webhook-secret]]<<httpclient-authentication-webhook-secret, `debezium.sink.http.authentication.webhook.secret` >>
+|
+|The webhooks signing secret that {prodname} uses to generate HMAC-SHA256 signatures for the webhook request. 
+The secret must be Base64-encoded, with a size from 24 bytes to 64 bytes (192–512 bits).
+Optionally, you can add the prefix `whsec_` to the secret to help distinguish it from other types of keys or tokens.
+For more information about implementing or validating webhook signatures, see the link:https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md[Standard Webhooks specification]. 
 
 
 |===


### PR DESCRIPTION
Update documentation of config options for Standard Webhooks authentication.

Main PR: https://github.com/debezium/debezium-server/pull/108