### PR TITLE
DBZ-8078 Standard Webhooks auth secret config value is not marked as PASSWORD_PATTERN

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -515,6 +515,7 @@ Thomas Thornton
 Tim Loes
 tisonkun
 Timo Roeseler
+Timo Wilhelm
 Tin Nguyen
 Tom Bentley
 Tom Billiet

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -64,7 +64,7 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
+    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
             Pattern.CASE_INSENSITIVE);
 
     /**

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -275,3 +275,4 @@ chungeun-choi,Chungeun Choi
 ashwinmk,Ashwin Murali Krishnan
 ganesh-bankar,Ganesh Bankar
 HenkvanDyk,Henk van Dyk
+TimoWilhelm,Timo Wilhelm


### PR DESCRIPTION
In https://github.com/debezium/debezium-server/pull/108 a new configuration value `debezium.sink.http.authentication.webhook.secret` has been introduced. This value is currently not marked as a password and will be logged during initialization.