### PR TITLE
DBZ-8081 Conditionalize default value field of schema.history.internal.store.only.captured.databases.ddl property 

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -50,14 +50,18 @@ If you later decide to capture changes from tables that you did not originally d
 If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
-|`false`
+|
+ifdef::MARIADB,MYSQL[]
+`true`
+endif::[]
+ifndef::MARIADB,MYSQL[]
+`false`
+endif::[]
 |A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance. +
 Specify one of the following values:
 
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
 `false`:: The connector records schema structures for all logical databases. +
-
-NOTE: The default value is `true` for MySQL Connector +
 
 |===
 


### PR DESCRIPTION
[DBZ-8081](https://issues.redhat.com/browse/DBZ-8081)

This change conditionalizes the default value field of the `schema.history.internal.store.only.captured.databases.ddl` property  in the shared `ref-connector-configuration-database-history-properties.adoc` file to render the value `true` for the MariaDB and MySQL connectors, and `false` in all other contexts.

Tested in a local Antora build.