### PR TITLE
DBZ-8082: Pass Headers to Key/Value Converters

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/FixedValueHeader.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/FixedValueHeader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.embedded.async;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.Transformation;
+
+public class FixedValueHeader<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    @Override
+    public R apply(R record) {
+        Headers headers = new ConnectHeaders();
+        headers.add("fixed-key", 2, Schema.INT32_SCHEMA);
+        headers.forEach(h -> record.headers().add(h));
+
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                record.valueSchema(),
+                record.value(),
+                record.timestamp(),
+                headers);
+    }
+
+    @Override
+    public ConfigDef config() {
+        return null;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/DBZ-8082

We want to be able to use headers in the key/value converter. When a configuration is set, the headers will be passed through to the converters.

My gut reaction to the increased complexity this configuration adds would be to keep the code clean and change the default behaviour. Converters by default call the current method if you pass the Headers so I think we don't need a configuration. I understand the extra `cast` will be slower - but I'm curious if that really warrants the extra complexity.

```
    /**
     * Convert a Kafka Connect data object to a native object for serialization,
     * potentially using the supplied topic and headers in the record as necessary.
     *
     * <p>Connect uses this method directly, and for backward compatibility reasons this method
     * by default will call the {@link #fromConnectData(String, Schema, Object)} method.
     * Override this method to make use of the supplied headers.</p>
     * @param topic the topic associated with the data
     * @param headers the headers associated with the data; any changes done to the headers
     *        are applied to the message sent to the broker
     * @param schema the schema for the value
     * @param value the value to convert
     * @return the serialized value
     */
    default byte[] fromConnectData(String topic, Headers headers, Schema schema, Object value) {
        return fromConnectData(topic, schema, value);
    }
```

I still need to add some testing but I'd love a first pass at the general structure.