### PR TITLE
V2.7.0.final with jdbc flags

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -550,6 +550,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
 
+    public static final Field JDBC_CONNECTION_FLAGS = RelationalDatabaseConnectorConfig.JDBC_CONNECTION_FLAGS;
     public static final Field PLUGIN_NAME = Field.create("plugin.name")
             .withDisplayName("Plugin")
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_REPLICATION, 0))
@@ -1014,6 +1015,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getInteger(PORT);
     }
 
+    public String jdbcConnectionFlags() {
+        return getConfig().getString(JDBC_CONNECTION_FLAGS);
+    }
+
     public String databaseName() {
         return getConfig().getString(DATABASE_NAME);
     }
@@ -1142,6 +1147,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     USER,
                     PASSWORD,
                     DATABASE_NAME,
+                    JDBC_CONNECTION_FLAGS,
                     QUERY_TIMEOUT_MS,
                     PLUGIN_NAME,
                     SLOT_NAME,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -78,10 +78,11 @@ public class PostgresConnection extends JdbcConnection {
     private static Logger LOGGER = LoggerFactory.getLogger(PostgresConnection.class);
 
     private static final String URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}:${"
-            + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}";
+            + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}${" + JdbcConfiguration.JDBC_CONNECTION_FLAGS + "}";
     protected static final ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(URL_PATTERN,
             org.postgresql.Driver.class.getName(),
-            PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
+            PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()),
+            JdbcConfiguration.JDBC_CONNECTION_FLAGS);
 
     /**
      * Obtaining a replication slot may fail if there's a pending transaction. We're retrying to get a slot for 30 min.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -283,7 +283,8 @@ public final class TestHelper {
                 .withDefault(JdbcConfiguration.HOSTNAME, hostname)
                 .withDefault(JdbcConfiguration.PORT, port)
                 .withDefault(JdbcConfiguration.USER, "postgres")
-                .withDefault(JdbcConfiguration.PASSWORD, "postgres");
+                .withDefault(JdbcConfiguration.PASSWORD, "postgres")
+                .withDefault(JdbcConfiguration.JDBC_CONNECTION_FLAGS, "");
     }
 
     public static JdbcConfiguration defaultJdbcConfig() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -80,6 +80,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
                 .with("transforms.timescaledb.database.user", "postgres")
                 .with("transforms.timescaledb.database.password", "postgres")
                 .with("transforms.timescaledb.database.dbname", "postgres")
+                .with("transforms.timescaledb.database.jdbc.connection.flags", "")
                 .build();
     }
 

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
@@ -53,8 +53,10 @@ public interface JdbcConfiguration extends Configuration {
     Field PORT = Field.create("port", "Port of the database");
 
     /**
-    * This line will be supplemented with the database connection URL
-    */
+     * Specifies custom flags to be appended to the PostgreSQL JDBC connection string.
+     * This allows for fine-tuning of the connection parameters to address specific use cases and requirements.
+     * For example, disabling prepared statements by setting '?prepareThreshold=0'.
+     */
     Field JDBC_CONNECTION_FLAGS = Field.create("jdbc.connection.flags")
             .withDisplayName("This line will be supplemented with the database connection URL")
             .withType(Type.STRING)

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
@@ -53,6 +53,15 @@ public interface JdbcConfiguration extends Configuration {
     Field PORT = Field.create("port", "Port of the database");
 
     /**
+    * This line will be supplemented with the database connection URL
+    */
+    Field JDBC_CONNECTION_FLAGS = Field.create("jdbc.connection.flags")
+            .withDisplayName("This line will be supplemented with the database connection URL")
+            .withType(Type.STRING)
+            .withDefault("")
+            .withValidation(Field::isOptional);
+
+    /**
      * A semicolon separated list of SQL statements to be executed when the connection to database is established.
      * Typical use-case is setting of session parameters. There is no default value.
      */
@@ -85,7 +94,7 @@ public interface JdbcConfiguration extends Configuration {
      * {@link #PASSWORD}, {@link #HOSTNAME}, and {@link #PORT}.
      */
     Set<String> ALL_KNOWN_FIELDS = Collect.unmodifiableSet(Field::name, DATABASE, USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS,
-            CONNECTION_FACTORY_CLASS, CONNECTION_TIMEOUT_MS, QUERY_TIMEOUT_MS);
+            JDBC_CONNECTION_FLAGS, CONNECTION_FACTORY_CLASS, CONNECTION_TIMEOUT_MS, QUERY_TIMEOUT_MS);
 
     /**
      * Obtain a {@link JdbcConfiguration} adapter for the given {@link Configuration}.
@@ -184,6 +193,16 @@ public interface JdbcConfiguration extends Configuration {
          */
         default Builder withConnectionFactoryClass(String connectionFactoryClass) {
             return with(CONNECTION_FACTORY_CLASS, connectionFactoryClass);
+        }
+
+        /**
+         * Use the given connection factory class in the resulting configuration.
+         *
+         * @param jdbcConnectionFlags connection string
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withJdbcConnectionFlags(String jdbcConnectionFlags) {
+            return with(JDBC_CONNECTION_FLAGS, jdbcConnectionFlags);
         }
 
         /**
@@ -401,6 +420,15 @@ public interface JdbcConfiguration extends Configuration {
      */
     default String getConnectionFactoryClassName() {
         return getString(CONNECTION_FACTORY_CLASS);
+    }
+
+    /**
+     * Get the connection string property from the configuration.
+     *
+     * @return the specified value, or null if there is none.
+     */
+    default String getJdbcConnectionFlags() {
+        return getString(JDBC_CONNECTION_FLAGS);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -185,7 +185,8 @@ public class JdbcConnection implements AutoCloseable {
                     JdbcConfiguration.PORT,
                     JdbcConfiguration.USER,
                     JdbcConfiguration.PASSWORD,
-                    JdbcConfiguration.DATABASE);
+                    JdbcConfiguration.DATABASE,
+                    JdbcConfiguration.JDBC_CONNECTION_FLAGS);
             String url = findAndReplace(urlPattern, props, varsWithDefaults);
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Props: {}", propsWithMaskedPassword(props));
@@ -229,7 +230,8 @@ public class JdbcConnection implements AutoCloseable {
                     JdbcConfiguration.PORT,
                     JdbcConfiguration.USER,
                     JdbcConfiguration.PASSWORD,
-                    JdbcConfiguration.DATABASE);
+                    JdbcConfiguration.DATABASE,
+                    JdbcConfiguration.JDBC_CONNECTION_FLAGS);
             String url = findAndReplace(urlPattern, props, varsWithDefaults);
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Props: {}", propsWithMaskedPassword(props));
@@ -1097,7 +1099,7 @@ public class JdbcConnection implements AutoCloseable {
     public String connectionString(String urlPattern) {
         Properties props = config.asProperties();
         return findAndReplace(urlPattern, props, JdbcConfiguration.DATABASE, JdbcConfiguration.HOSTNAME, JdbcConfiguration.PORT,
-                JdbcConfiguration.USER, JdbcConfiguration.PASSWORD);
+                JdbcConfiguration.USER, JdbcConfiguration.PASSWORD, JdbcConfiguration.JDBC_CONNECTION_FLAGS);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -229,7 +229,9 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 34))
             .withWidth(Width.LONG)
             .withImportance(Importance.HIGH)
-            .withDescription("This line will be supplemented with the database connection URL.");
+            .withDescription("Specifies custom flags to be appended to the PostgreSQL JDBC connection string. " +
+                    "This allows for fine-tuning of the connection parameters to address specific use cases and requirements. " +
+                    "For example, disabling prepared statements by setting '?prepareThreshold=0'.");
 
     public static final Field USER = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.USER)
             .withDisplayName("User")

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -223,6 +223,14 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withValidation(Field::isInteger)
             .withDescription("Port of the database server.");
 
+    public static final Field JDBC_CONNECTION_FLAGS = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.JDBC_CONNECTION_FLAGS)
+            .withDisplayName("JDBC connection flags")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 34))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.HIGH)
+            .withDescription("This line will be supplemented with the database connection URL.");
+
     public static final Field USER = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.USER)
             .withDisplayName("User")
             .withType(Type.STRING)

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -228,7 +228,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 34))
             .withWidth(Width.LONG)
-            .withImportance(Importance.HIGH)
+            .withImportance(Importance.LOW)
             .withDescription("Specifies custom flags to be appended to the PostgreSQL JDBC connection string. " +
                     "This allows for fine-tuning of the connection parameters to address specific use cases and requirements. " +
                     "For example, disabling prepared statements by setting '?prepareThreshold=0'.");


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request adds the ability to specify additional flags in the PostgreSQL connector configuration for Debezium. These flags will be appended to the connection string, allowing for greater flexibility and customization of the database connection.

#### Changes
- Introduced a new configuration property: database.jdbc.connection.flags.
- This property allows users to specify additional flags for the JDBC connection string. For example, it can be used as follows:
 
  "database.jdbc.connection.flags": "?targetServerType=master&tcpKeepAlive=true&prepareThreshold=0"
  
#### Rationale
In my company, it is crucial to set the prepareThreshold=0 flag in the PostgreSQL connection string. Without this flag, it is impossible to create a transaction with a “prepared statement.” This enhancement provides the necessary flexibility to accommodate such specific requirements, ensuring that Debezium can be used effectively in environments with similar constraints.

#### Example Usage
"database.jdbc.connection.flags": "?targetServerType=master&tcpKeepAlive=true&prepareThreshold=0"
This will result in a connection string that includes the specified flags, allowing the connector to operate as required by the user's environment.

### Testing
- Conducted integration tests to ensure that the connector works seamlessly with the specified flags.
