### PR TITLE
DBZ-8095 Bump Quarkus to 3.8.5 & Apicurio to 2.5.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <quarkus.version.runtime>3.8.5</quarkus.version.runtime>
 
         <!-- Apicurio -->
-        <version.apicurio>2.4.3.Final</version.apicurio>
+        <version.apicurio>2.5.8.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.6.1</version.postgresql.driver>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <!-- Version used in Debezium Server, Operator, etc., usually a LTS version -->
         <!-- Must be aligned with Apicurio version below -->
         <!-- Debezium Server Pravega must use the same Netty version as the one used by Quarkus -->
-        <quarkus.version.runtime>3.2.12.Final</quarkus.version.runtime>
+        <quarkus.version.runtime>3.8.5</quarkus.version.runtime>
 
         <!-- Apicurio -->
         <version.apicurio>2.4.3.Final</version.apicurio>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8095