### PR TITLE
DBZ-8103 Add SMT to decode binary content of a logical decoding message

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -61,6 +61,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchemaFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchemaFactory.java
@@ -29,14 +29,14 @@ public class PostgresSchemaFactory extends SchemaFactory {
     /*
      * Postgres LogicalDecodingMessageMonitor schema
      */
+    public static final String POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_VALUE_SCHEMA_NAME = "io.debezium.connector.postgresql.MessageValue";
+    private static final int POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_VALUE_SCHEMA_VERSION = 1;
+
     private static final String POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_KEY_SCHEMA_NAME = "io.debezium.connector.postgresql.MessageKey";
     private static final int POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_KEY_SCHEMA_VERSION = 1;
 
     private static final String POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_BLOCK_SCHEMA_NAME = "io.debezium.connector.postgresql.Message";
     private static final int POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_BLOCK_SCHEMA_VERSION = 1;
-
-    private static final String POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_VALUE_SCHEMA_NAME = "io.debezium.connector.postgresql.MessageValue";
-    private static final int POSTGRES_LOGICAL_DECODING_MESSAGE_MONITOR_VALUE_SCHEMA_VERSION = 1;
 
     public Schema logicalDecodingMessageMonitorKeySchema(SchemaNameAdjuster adjuster) {
         return SchemaBuilder.struct()

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContent.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContent.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.transforms;
+
+import static io.debezium.connector.postgresql.LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_CONTENT_KEY;
+import static io.debezium.connector.postgresql.LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_KEY;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.ReplaceField;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.Module;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
+import io.debezium.schema.FieldNameSelector;
+import io.debezium.transforms.ConnectRecordUtil;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition;
+import io.debezium.transforms.outbox.JsonSchemaData;
+import io.debezium.util.BoundedConcurrentHashMap;
+
+/**
+ * The transform converts binary content of a logical decoding message to a structured form.
+ * One of the possible usages is to apply the transform before {@link io.debezium.transforms.outbox.EventRouter} so that the transform
+ * will produce a record suitable for the Outbox SMT.
+ *
+ * @author Roman Kudryashov
+ */
+public class DecodeLogicalDecodingMessageContent<R extends ConnectRecord<R>> implements Transformation<R>, Versioned {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecodeLogicalDecodingMessageContent.class);
+
+    private static final String POSTGRES_LOGICAL_DECODING_MESSAGE_SCHEMA_NAME = "io.debezium.connector.postgresql.MessageValue";
+
+    private BoundedConcurrentHashMap<Schema, Schema> logicalDecodingMessageContentSchemaCache;
+    private ObjectMapper objectMapper;
+    private JsonSchemaData jsonSchemaData;
+
+    @Override
+    public ConfigDef config() {
+        final ConfigDef config = new ConfigDef();
+        return config;
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final Configuration config = Configuration.from(configs);
+
+        objectMapper = new ObjectMapper();
+        CommonConnectorConfig.FieldNameAdjustmentMode fieldNameAdjustmentMode = CommonConnectorConfig.FieldNameAdjustmentMode.parse(
+                config.getString(CommonConnectorConfig.FIELD_NAME_ADJUSTMENT_MODE));
+        jsonSchemaData = new JsonSchemaData(EventRouterConfigDefinition.JsonPayloadNullFieldBehavior.IGNORE,
+                FieldNameSelector.defaultNonRelationalSelector(fieldNameAdjustmentMode.createAdjuster()));
+        logicalDecodingMessageContentSchemaCache = new BoundedConcurrentHashMap<>(10000, 10, BoundedConcurrentHashMap.Eviction.LRU);
+    }
+
+    @Override
+    public R apply(final R record) {
+        // ignore all messages that are not logical decoding messages
+        if (!Objects.equals(record.valueSchema().name(), POSTGRES_LOGICAL_DECODING_MESSAGE_SCHEMA_NAME)) {
+            LOGGER.debug("Ignore not a logical decoding message. Message key: \"{}\"", record.key());
+            return record;
+        }
+
+        Struct originalValue = requireStruct(record.value(), "Retrieve a record value");
+        Struct logicalDecodingMessageContent = getLogicalDecodingMessageContent(originalValue);
+        R recordWithoutMessageField = removeLogicalDecodingMessageContentField(record);
+
+        final Schema updatedValueSchema = getUpdatedValueSchema(logicalDecodingMessageContent.schema(), recordWithoutMessageField.valueSchema());
+        final Struct updatedValue = getUpdatedValue(updatedValueSchema, originalValue, logicalDecodingMessageContent);
+
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                null,
+                // clear prefix of a logical decoding message
+                null,
+                updatedValueSchema,
+                updatedValue,
+                record.timestamp(),
+                record.headers());
+    }
+
+    private Struct getLogicalDecodingMessageContent(Struct valueStruct) {
+        Struct logicalDecodingMessageStruct = requireStruct(valueStruct.get(DEBEZIUM_LOGICAL_DECODING_MESSAGE_KEY),
+                "Retrieve content of a logical decoding message");
+
+        if (logicalDecodingMessageStruct.schema().field(DEBEZIUM_LOGICAL_DECODING_MESSAGE_CONTENT_KEY).schema().type() != Schema.Type.BYTES) {
+            throw new DataException("The content of a logical decoding message is non-binary");
+        }
+
+        byte[] logicalDecodingMessageContentBytes = logicalDecodingMessageStruct.getBytes(DEBEZIUM_LOGICAL_DECODING_MESSAGE_CONTENT_KEY);
+        return convertLogicalDecodingMessageContentBytesToStruct(logicalDecodingMessageContentBytes);
+    }
+
+    private Struct convertLogicalDecodingMessageContentBytesToStruct(byte[] logicalDecodingMessageContent) {
+        final String logicalDecodingMessageContentString = new String(logicalDecodingMessageContent);
+        try {
+            // parse and get Jackson JsonNode
+            final JsonNode logicalDecodingMessageContentJson = parseLogicalDecodingMessageContentJsonString(logicalDecodingMessageContentString);
+            // get schema of a logical decoding message content
+            Schema logicalDecodingMessageContentSchema = jsonSchemaData.toConnectSchema(null, logicalDecodingMessageContentJson);
+            // get Struct of a logical decoding message content
+            return (Struct) jsonSchemaData.toConnectData(logicalDecodingMessageContentJson, logicalDecodingMessageContentSchema);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Conversion of logical decoding message content failed", e);
+            throw new DataException("Conversion of logical decoding message content failed");
+        }
+    }
+
+    private JsonNode parseLogicalDecodingMessageContentJsonString(String logicalDecodingMessageContentJsonString) throws Exception {
+        if (logicalDecodingMessageContentJsonString.startsWith("{") || logicalDecodingMessageContentJsonString.startsWith("[")) {
+            return objectMapper.readTree(logicalDecodingMessageContentJsonString);
+        }
+        throw new Exception("Unable to parse logical decoding message content JSON string starting with '" + logicalDecodingMessageContentJsonString.charAt(0) + "'");
+    }
+
+    private R removeLogicalDecodingMessageContentField(R record) {
+        final ReplaceField<R> dropFieldDelegate = ConnectRecordUtil.dropFieldFromValueDelegate(DEBEZIUM_LOGICAL_DECODING_MESSAGE_KEY);
+        return dropFieldDelegate.apply(record);
+    }
+
+    private Schema getUpdatedValueSchema(Schema logicalDecodingMessageContentSchema, Schema debeziumEventSchema) {
+        Schema valueSchema = logicalDecodingMessageContentSchemaCache.get(logicalDecodingMessageContentSchema);
+        if (valueSchema == null) {
+            valueSchema = getSchemaBuilder(logicalDecodingMessageContentSchema, debeziumEventSchema).build();
+            logicalDecodingMessageContentSchemaCache.put(logicalDecodingMessageContentSchema, valueSchema);
+        }
+
+        return valueSchema;
+    }
+
+    private SchemaBuilder getSchemaBuilder(Schema logicalDecodingMessageContentSchema, Schema debeziumEventSchema) {
+        // a schema name ending with such a suffix makes the record processable by Outbox SMT
+        String schemaName = debeziumEventSchema.name() + Envelope.SCHEMA_NAME_SUFFIX;
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(schemaName);
+
+        for (Field originalSchemaField : debeziumEventSchema.fields()) {
+            schemaBuilder.field(originalSchemaField.name(), originalSchemaField.schema());
+        }
+
+        schemaBuilder.field(Envelope.FieldName.AFTER, logicalDecodingMessageContentSchema);
+
+        return schemaBuilder;
+    }
+
+    private Struct getUpdatedValue(Schema updatedValueSchema, Struct originalValue, Struct logicalDecodingMessageContent) {
+        final Struct updatedValue = new Struct(updatedValueSchema);
+
+        for (Field field : updatedValueSchema.fields()) {
+            Object fieldValue;
+            switch (field.name()) {
+                case Envelope.FieldName.AFTER:
+                    fieldValue = logicalDecodingMessageContent;
+                    break;
+                case Envelope.FieldName.OPERATION:
+                    // replace the original operation so that a record will look as INSERT event
+                    fieldValue = Envelope.Operation.CREATE.code();
+                    break;
+                default:
+                    fieldValue = originalValue.get(field);
+                    break;
+            }
+            updatedValue.put(field, fieldValue);
+        }
+        return updatedValue;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
@@ -6,14 +6,33 @@
 
 package io.debezium.connector.postgresql;
 
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.HeaderFrom;
 import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
+import io.debezium.connector.postgresql.transforms.DecodeLogicalDecodingMessageContent;
 import io.debezium.converters.AbstractCloudEventsConverterTest;
+import io.debezium.converters.CloudEventsConverterTest;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.SkipWhenDatabaseVersion;
+import io.debezium.transforms.outbox.EventRouter;
 
 /**
  * Integration test for {@link io.debezium.converters.CloudEventsConverter} with {@link PostgresConnector}
@@ -89,6 +108,10 @@ public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<Pos
         return TestHelper.topicName("outboxsmtit.outbox");
     }
 
+    protected String topicNameMessage() {
+        return TestHelper.topicName("message");
+    }
+
     @Override
     protected void createTable() throws Exception {
         TestHelper.execute(SETUP_SCHEMA);
@@ -138,8 +161,86 @@ public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<Pos
         return insert.toString();
     }
 
+    protected String createStatementToCallInsertToWalFunction(String eventId,
+                                                              String eventType,
+                                                              String aggregateType,
+                                                              String aggregateId,
+                                                              String payloadJson) {
+        StringBuilder statement = new StringBuilder();
+        statement.append("SELECT pg_logical_emit_message(true, 'foo', '");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode rootNode = mapper.createObjectNode();
+        rootNode.put("id", eventId);
+        rootNode.put("type", eventType);
+        rootNode.put("aggregateType", aggregateType);
+        rootNode.put("aggregateId", aggregateId);
+        rootNode.put("payload", payloadJson);
+
+        statement.append(rootNode).append("');");
+
+        return statement.toString();
+    }
+
     @Override
     protected void waitForStreamingStarted() throws InterruptedException {
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+    }
+
+    @Test
+    @FixFor("DBZ-8103")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Only supported on PgOutput")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, minor = 0, reason = "Message not supported for PG version < 14")
+    public void shouldConvertToCloudEventsInJsonWithDataAsJsonAndAllMetadataInHeadersAfterOutboxEventRouterAppliedToLogicalDecodingMessage() throws Exception {
+        HeaderFrom<SourceRecord> headerFrom = new HeaderFrom.Value<>();
+        Map<String, String> headerFromConfig = new LinkedHashMap<>();
+        headerFromConfig.put("fields", "source,op");
+        headerFromConfig.put("headers", "source,op");
+        headerFromConfig.put("operation", "copy");
+        headerFromConfig.put("header.converter.schemas.enable", "true");
+        headerFrom.configure(headerFromConfig);
+
+        DecodeLogicalDecodingMessageContent<SourceRecord> decodeLogicalDecodingMessageContent = new DecodeLogicalDecodingMessageContent<>();
+        Map<String, String> smtConfig = new LinkedHashMap<>();
+        decodeLogicalDecodingMessageContent.configure(smtConfig);
+
+        EventRouter<SourceRecord> outboxEventRouter = new EventRouter<>();
+        Map<String, String> outboxEventRouterConfig = new LinkedHashMap<>();
+        outboxEventRouterConfig.put("table.expand.json.payload", "true");
+        outboxEventRouterConfig.put("table.field.event.key", "aggregateId");
+        // this adds `type` header with value from the DB column. `id` header is added by Outbox Event Router by default
+        outboxEventRouterConfig.put("table.fields.additional.placement", "type:header");
+        outboxEventRouterConfig.put("route.by.field", "aggregateType");
+        outboxEventRouter.configure(outboxEventRouterConfig);
+
+        // emit non transactional logical decoding message
+        TestHelper.execute(createStatementToCallInsertToWalFunction("59a42efd-b015-44a9-9dde-cb36d9002425",
+                "UserCreated",
+                "User",
+                "10711fa5",
+                "{" +
+                        "\"someField1\": \"some value 1\"," +
+                        "\"someField2\": 7005" +
+                        "}"));
+
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        assertThat(streamingRecords.allRecordsInOrder()).hasSize(1);
+
+        SourceRecord record = streamingRecords.recordsForTopic(topicNameMessage()).get(0);
+        SourceRecord recordWithMetadataHeaders = headerFrom.apply(record);
+        SourceRecord recordWithDecodedLogicalDecodingMessageContent = decodeLogicalDecodingMessageContent.apply(recordWithMetadataHeaders);
+        SourceRecord routedEvent = outboxEventRouter.apply(recordWithDecodedLogicalDecodingMessageContent);
+
+        assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
+        assertThat(routedEvent.keySchema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(routedEvent.key()).isEqualTo("10711fa5");
+        assertThat(routedEvent.value()).isInstanceOf(Struct.class);
+
+        CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithMetadataAndIdAndTypeInHeaders(routedEvent, getConnectorName(), getServerName());
+
+        headerFrom.close();
+        decodeLogicalDecodingMessageContent.close();
+        outboxEventRouter.close();
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -323,7 +323,7 @@ public final class TestHelper {
         }
     }
 
-    protected static String topicName(String suffix) {
+    public static String topicName(String suffix) {
         return TestHelper.TEST_SERVER + "." + suffix;
     }
 
@@ -365,7 +365,7 @@ public final class TestHelper {
         }
     }
 
-    protected static void dropDefaultReplicationSlot() {
+    public static void dropDefaultReplicationSlot() {
         try {
             execute("SELECT pg_drop_replication_slot('" + ReplicationConnection.Builder.DEFAULT_SLOT_NAME + "')");
         }
@@ -376,7 +376,7 @@ public final class TestHelper {
         }
     }
 
-    protected static void dropPublication() {
+    public static void dropPublication() {
         dropPublication(ReplicationConnection.Builder.DEFAULT_PUBLICATION_NAME);
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContentTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContentTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -27,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.SourceInfo;
@@ -87,9 +87,9 @@ public class DecodeLogicalDecodingMessageContentTest extends AbstractConnectorTe
         List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("message"));
         assertThat(recordsForTopic).hasSize(1);
 
-        Exception exception = assertThrows(DataException.class, () -> decodeLogicalDecodingMessageContent.apply(recordsForTopic.get(0)));
+        Exception exception = assertThrows(DebeziumException.class, () -> decodeLogicalDecodingMessageContent.apply(recordsForTopic.get(0)));
 
-        assertThat(exception.getMessage()).isEqualTo("Conversion of logical decoding message content failed");
+        assertThat(exception.getMessage()).isEqualTo("Unable to parse logical decoding message content JSON string ''");
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContentTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/DecodeLogicalDecodingMessageContentTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.transforms;
+
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnector;
+import io.debezium.connector.postgresql.SourceInfo;
+import io.debezium.connector.postgresql.TestHelper;
+import io.debezium.connector.postgresql.junit.SkipTestDependingOnDecoderPluginNameRule;
+import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.junit.SkipWhenDatabaseVersion;
+
+/**
+ * Tests for {@link io.debezium.connector.postgresql.transforms.DecodeLogicalDecodingMessageContent} SMT.
+ *
+ * @author Roman Kudryashov
+ */
+public class DecodeLogicalDecodingMessageContentTest extends AbstractConnectorTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecodeLogicalDecodingMessageContentTest.class);
+
+    @Rule
+    public final TestRule skipName = new SkipTestDependingOnDecoderPluginNameRule();
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        TestHelper.dropAllSchemas();
+    }
+
+    @Before
+    public void before() {
+        initializeConnectorTestFramework();
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Test
+    @FixFor("DBZ-8103")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Only supported on PgOutput")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, minor = 0, reason = "Message not supported for PG version < 14")
+    public void shouldFailWhenLogicalDecodingMessageContentIsEmptyString() throws Exception {
+        DecodeLogicalDecodingMessageContent<SourceRecord> decodeLogicalDecodingMessageContent = new DecodeLogicalDecodingMessageContent<>();
+        Map<String, String> smtConfig = new LinkedHashMap<>();
+        decodeLogicalDecodingMessageContent.configure(smtConfig);
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig();
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        // emit non transactional logical decoding message
+        TestHelper.execute("SELECT pg_logical_emit_message(false, 'foo', '');");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("message"));
+        assertThat(recordsForTopic).hasSize(1);
+
+        Exception exception = assertThrows(DataException.class, () -> decodeLogicalDecodingMessageContent.apply(recordsForTopic.get(0)));
+
+        assertThat(exception.getMessage()).isEqualTo("Conversion of logical decoding message content failed");
+
+        decodeLogicalDecodingMessageContent.close();
+        stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-8103")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Only supported on PgOutput")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, minor = 0, reason = "Message not supported for PG version < 14")
+    public void shouldConvertRecordWithNonTransactionalLogicalDecodingMessageWithEmptyContent() throws Exception {
+        DecodeLogicalDecodingMessageContent<SourceRecord> decodeLogicalDecodingMessageContent = new DecodeLogicalDecodingMessageContent<>();
+        Map<String, String> smtConfig = new LinkedHashMap<>();
+        decodeLogicalDecodingMessageContent.configure(smtConfig);
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig();
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        // emit non transactional logical decoding message
+        TestHelper.execute("SELECT pg_logical_emit_message(false, 'foo', '{}');");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("message"));
+        assertThat(recordsForTopic).hasSize(1);
+
+        SourceRecord transformedRecord = decodeLogicalDecodingMessageContent.apply(recordsForTopic.get(0));
+        assertThat(transformedRecord).isNotNull();
+
+        Struct value = (Struct) transformedRecord.value();
+        String op = value.getString(Envelope.FieldName.OPERATION);
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        Struct after = value.getStruct(Envelope.FieldName.AFTER);
+
+        assertNull(source.getInt64(SourceInfo.TXID_KEY));
+        assertNotNull(source.getInt64(SourceInfo.TIMESTAMP_KEY));
+        assertNotNull(source.getInt64(SourceInfo.LSN_KEY));
+        assertEquals("", source.getString(SourceInfo.TABLE_NAME_KEY));
+        assertEquals("", source.getString(SourceInfo.SCHEMA_NAME_KEY));
+
+        assertEquals(Envelope.Operation.CREATE.code(), op);
+        assertEquals(0, after.schema().fields().size());
+        List<Field> recordValueSchemaFields = value.schema().fields();
+        assertTrue(recordValueSchemaFields.stream().noneMatch(f -> f.name().equals("message")));
+
+        decodeLogicalDecodingMessageContent.close();
+        stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-8103")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Only supported on PgOutput")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, minor = 0, reason = "Message not supported for PG version < 14")
+    public void shouldConvertRecordWithTransactionalLogicalDecodingMessageWithContent() throws Exception {
+        DecodeLogicalDecodingMessageContent<SourceRecord> decodeLogicalDecodingMessageContent = new DecodeLogicalDecodingMessageContent<>();
+        Map<String, String> smtConfig = new LinkedHashMap<>();
+        decodeLogicalDecodingMessageContent.configure(smtConfig);
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig();
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        // emit transactional logical decoding message
+        TestHelper.execute("SELECT pg_logical_emit_message(true, 'foo', '{\"bar\": \"baz\", \"qux\": 9703}');");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("message"));
+        assertThat(recordsForTopic).hasSize(1);
+
+        SourceRecord transformedRecord = decodeLogicalDecodingMessageContent.apply(recordsForTopic.get(0));
+        assertThat(transformedRecord).isNotNull();
+
+        Struct value = (Struct) transformedRecord.value();
+        String op = value.getString(Envelope.FieldName.OPERATION);
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        Struct after = value.getStruct(Envelope.FieldName.AFTER);
+
+        assertNotNull(source.getInt64(SourceInfo.TXID_KEY));
+        assertNotNull(source.getInt64(SourceInfo.TIMESTAMP_KEY));
+        assertNotNull(source.getInt64(SourceInfo.LSN_KEY));
+        assertEquals("", source.getString(SourceInfo.TABLE_NAME_KEY));
+        assertEquals("", source.getString(SourceInfo.SCHEMA_NAME_KEY));
+
+        assertEquals(Envelope.Operation.CREATE.code(), op);
+        assertEquals(2, after.schema().fields().size());
+        assertEquals("baz", after.get("bar"));
+        assertEquals(9703, after.get("qux"));
+        List<Field> recordValueSchemaFields = value.schema().fields();
+        assertTrue(recordValueSchemaFields.stream().noneMatch(f -> f.name().equals("message")));
+
+        decodeLogicalDecodingMessageContent.close();
+        stopConnector();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
@@ -15,6 +15,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 
+import io.debezium.DebeziumException;
 import io.debezium.converters.CloudEventsConverterConfig.MetadataSource;
 import io.debezium.converters.CloudEventsConverterConfig.MetadataSourceValue;
 import io.debezium.converters.spi.CloudEventsMaker;
@@ -98,7 +99,7 @@ public class RecordAndMetadataHeaderImpl extends RecordAndMetadataBaseImpl imple
                 return SchemaAndValue.NULL;
             }
             else {
-                throw new RuntimeException("Header `" + headerName + "` was not provided");
+                throw new DebeziumException("Header `" + headerName + "` was not provided");
             }
         }
         return jsonHeaderConverter.toConnectData(null, header.value());

--- a/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
+++ b/debezium-core/src/main/java/io/debezium/converters/recordandmetadata/RecordAndMetadataHeaderImpl.java
@@ -93,8 +93,13 @@ public class RecordAndMetadataHeaderImpl extends RecordAndMetadataBaseImpl imple
 
     private SchemaAndValue getHeaderSchemaAndValue(Headers headers, String headerName, boolean isOptional) {
         Header header = headers.lastHeader(headerName);
-        if (header == null && !isOptional) {
-            throw new RuntimeException("Header `" + headerName + "` was not provided");
+        if (header == null) {
+            if (isOptional) {
+                return SchemaAndValue.NULL;
+            }
+            else {
+                throw new RuntimeException("Header `" + headerName + "` was not provided");
+            }
         }
         return jsonHeaderConverter.toConnectData(null, header.value());
     }

--- a/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
@@ -15,6 +15,7 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Flatten;
 import org.apache.kafka.connect.transforms.InsertField;
+import org.apache.kafka.connect.transforms.ReplaceField;
 
 /**
  * A set of utilities for more easily creating various kinds of transformations.
@@ -58,6 +59,14 @@ public class ConnectRecordUtil {
         delegateConfig.put("static.value", value);
         insertDelegate.configure(delegateConfig);
         return insertDelegate;
+    }
+
+    public static <R extends ConnectRecord<R>> ReplaceField<R> dropFieldFromValueDelegate(String field) {
+        ReplaceField<R> dropFieldDelegate = new ReplaceField.Value<>();
+        Map<String, String> delegateConfig = new HashMap<>();
+        delegateConfig.put("exclude", field);
+        dropFieldDelegate.configure(delegateConfig);
+        return dropFieldDelegate;
     }
 
     public static <R extends ConnectRecord<R>> Flatten<R> flattenValueDelegate(String delimiter) {

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
@@ -30,6 +30,7 @@ import io.debezium.schema.FieldNameSelector;
 import io.debezium.schema.FieldNameSelector.FieldNamer;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadNullFieldBehavior;
+import io.debezium.util.Strings;
 
 public class JsonSchemaData {
     private final JsonPayloadNullFieldBehavior jsonPayloadNullFieldBehavior;
@@ -69,7 +70,8 @@ public class JsonSchemaData {
                 final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(key).optional();
                 node.fields().forEachRemaining(entry -> {
                     final String fieldName = fieldNamer.fieldNameFor(entry.getKey());
-                    final Schema fieldSchema = toConnectSchema(key + "." + fieldName, entry.getValue());
+                    final String fieldKey = (Strings.isNullOrBlank(key) ? "" : key + ".") + fieldName;
+                    final Schema fieldSchema = toConnectSchema(fieldKey, entry.getValue());
                     if (fieldSchema != null && !hasField(schemaBuilder, fieldName)) {
                         schemaBuilder.field(fieldName, fieldSchema);
                     }


### PR DESCRIPTION
The transform:
1) puts the encoded binary data (only `BYTES` case) to `after` field and replaces `op` field value with `c` that makes a record suitable for Outbox SMT
2) supposes that a logical decoding messages contains data in JSON form
3) is not tested with non-Postgres logical decoding messages