### PR TITLE
DBZ-7879 Retry to connect to Redis on failure in RedisOffsetBackingStore

### DIFF
--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -435,7 +435,7 @@ jobs:
     name: "Storage Module"
     needs: [ check_style, file_changes ]
     runs-on: ubuntu-latest
-    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.mysql-changed == 'true' || needs.file_changes.outputs.mysql-ddl-parser-changed == 'true' || needs.file_changes.outputs.storage-changed == 'true' }}
+    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.mysql-changed == 'true' || needs.file_changes.outputs.mysql-ddl-parser-changed == 'true' || needs.file_changes.outputs.storage-only-changed == 'true' }}
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ The Docker Maven Plugin will resolve the docker host by checking the following e
 
 These can be set automatically if using Docker Machine or something similar.
 
+#### Colima
+In order to run testcontainers against [colima](https://github.com/abiosoft/colima) the env vars below should be set (assume we use `default` profile of colima)
+
+    colima start
+    export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+    export TESTCONTAINERS_HOST_OVERRIDE="0.0.0.0"
+    export DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock"
+
+
 ### Building the code
 
 First obtain the code by cloning the Git repository:

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.VisibleForTesting;
 import io.debezium.config.Configuration;
 import io.debezium.storage.redis.RedisClient;
-import io.debezium.storage.redis.RedisClientConnectionException;
 import io.debezium.storage.redis.RedisConnection;
 import io.smallrye.mutiny.Uni;
 
@@ -107,9 +106,6 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
                         f -> {
                             LOGGER.warn("Reading from Redis offset store failed with " + f);
                             LOGGER.warn("Will retry");
-                        })
-                .onFailure(RedisClientConnectionException.class).invoke(
-                        f -> {
                             LOGGER.warn("Attempting to reconnect to Redis");
                             this.connect();
                         })
@@ -150,9 +146,6 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
                             f -> {
                                 LOGGER.warn("Writing to Redis offset store failed with " + f);
                                 LOGGER.warn("Will retry");
-                            })
-                    .onFailure(RedisClientConnectionException.class).invoke(
-                            f -> {
                                 LOGGER.warn("Attempting to reconnect to Redis");
                                 this.connect();
                             })


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7879
> Redis timeout occured when storing offset and then it got stuck in a crash loop of NullPointerException

I noticed the similar issue (Debezium 2.7) when testing locally with `docker compose`. Stop `redis` container and start it again put us in endless loop, until the debezium-server is manually restarted.

This PR attempts to fix that issue by `connect()` on every failure instead of just `RedisClientConnectionException`
`connect()` calls `closeClient()` (Related https://github.com/debezium/debezium/commit/84ab7f7b8adc9b9c437ea5c5829ee83b86d3a761) which has `null` guard so I believe this is safe but I may miss something.

- I updated the tests and documentation so this can be tested quite easily with `mvn test`.
- I can also try to add my example to https://github.com/debezium/debezium-examples/ as well so we can test this further if needed.