### PR TITLE
[docs] Declare attributes outside of `community`-conditionalized blocks

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -11,13 +11,13 @@
 :connector-class: MariaDb
 :connector-name: MariaDB
 :include-list-example: inventory.*
+:MARIADB:
 ifdef::community[]
 :toc:
 :toc-placement: macro
 :linkattrs:
 :icons: font
 :source-highlighter: highlight.js
-:MARIADB:
 
 toc::[]
 endif::community[]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -11,13 +11,13 @@
 :connector-class: MySql
 :connector-name: MySQL
 :include-list-example: inventory.*
+:MYSQL:
 ifdef::community[]
 :toc:
 :toc-placement: macro
 :linkattrs:
 :icons: font
 :source-highlighter: highlight.js
-:MYSQL:
 toc::[]
 endif::community[]
 


### PR DESCRIPTION
This change relocates the  `MARIADB` and `MYSQL` attributes that are declared at the head of the `mariadb.adoc` and `mysql.adoc` files so that they are not listed with a conditionalized block.

Because the files that provide shared content for the MariaDB and MySQL connectors contain a subset information that is not common to both, the files use `ifdef` statements with the `MARIADB` and `MYSQL` attributes to identify connector-specific content. After building a downstream version of the documentation, I found that the content inside the `ifdef` directive was not rendered correctly. During troubleshooting, I realized that I mistakenly declared the attributes in a block that is conditionalized for `community` use.      
