### PR TITLE
Adaptions for Informix integration tests (DBZ-8114)

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -340,7 +340,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -410,7 +410,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -447,7 +447,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -838,7 +838,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startConnector(x -> x.with(CommonConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 50));
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -884,7 +884,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -910,7 +910,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -952,7 +952,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -1004,7 +1004,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         startAndConsumeTillEnd(connectorClass(), config);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 
@@ -1029,7 +1029,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         waitForConnectorToStart();
 
-        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
 
         waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -277,7 +277,7 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
         start(connectorClass(), config, callback);
         waitForConnectorToStart();
 
-        waitForAvailableRecords(5, TimeUnit.SECONDS);
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         if (expectNoRecords) {
             // there shouldn't be any snapshot records
             assertNoRecordsToConsume();

--- a/debezium-embedded/src/test/java/io/debezium/transforms/outbox/AbstractEventRouterTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/transforms/outbox/AbstractEventRouterTest.java
@@ -211,7 +211,6 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
     @Test
     @FixFor({ "DBZ-1169", "DBZ-3940" })
     public void shouldSupportAllFeatures() throws Exception {
-        startConnectorWithNoSnapshot();
 
         final StringBuilder placements = new StringBuilder();
         placements.append(envelope(getFieldSchemaVersion(), "eventVersion")).append(",");
@@ -227,6 +226,8 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
         outboxEventRouter.configure(config);
 
         alterTableWithExtra4Fields();
+
+        startConnectorWithNoSnapshot();
 
         databaseConnection().execute(createInsert(
                 "f9171eb6-19f3-4579-9206-0e179d2ebad7",
@@ -282,7 +283,6 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
     @Test
     @FixFor({ "DBZ-1707", "DBZ-3940" })
     public void shouldConvertMicrosecondsTimestampToMilliseconds() throws Exception {
-        startConnectorWithNoSnapshot();
 
         outboxEventRouter = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
@@ -290,6 +290,8 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
         outboxEventRouter.configure(config);
 
         alterTableWithTimestampField();
+
+        startConnectorWithNoSnapshot();
 
         databaseConnection().execute(createInsert(
                 "f9171eb6-19f3-4579-9206-0e179d2ebad7",
@@ -314,7 +316,6 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
     @Test
     @FixFor({ "DBZ-1320", "DBZ-3940" })
     public void shouldNotProduceTombstoneEventForNullPayload() throws Exception {
-        startConnectorWithNoSnapshot();
 
         final StringBuilder placements = new StringBuilder();
         placements.append(envelope(getFieldSchemaVersion(), "eventVersion")).append(",");
@@ -331,6 +332,8 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
         outboxEventRouter.configure(config);
 
         alterTableWithExtra4Fields();
+
+        startConnectorWithNoSnapshot();
 
         databaseConnection().execute(createInsert(
                 "a9d76f78-bda6-48d3-97ed-13a146163218",
@@ -374,7 +377,6 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
     @Test
     @FixFor({ "DBZ-1320", "DBZ-3940" })
     public void shouldProduceTombstoneEventForNullPayload() throws Exception {
-        startConnectorWithNoSnapshot();
 
         final StringBuilder placements = new StringBuilder();
         placements.append(envelope(getFieldSchemaVersion(), "eventVersion")).append(",");
@@ -392,6 +394,8 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
         outboxEventRouter.configure(config);
 
         alterTableWithExtra4Fields();
+
+        startConnectorWithNoSnapshot();
 
         databaseConnection().execute(createInsert(
                 "a9d76f78-bda6-48d3-97ed-13a146163218",
@@ -433,7 +437,6 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
     @Test
     @FixFor({ "DBZ-1320", "DBZ-3940" })
     public void shouldProduceTombstoneEventForEmptyPayload() throws Exception {
-        startConnectorWithNoSnapshot();
 
         outboxEventRouter = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
@@ -441,6 +444,9 @@ public abstract class AbstractEventRouterTest<T extends SourceConnector> extends
         outboxEventRouter.configure(config);
 
         alterTableModifyPayload();
+
+        startConnectorWithNoSnapshot();
+
         databaseConnection().execute(createInsert(
                 "a9d76f78-bda6-48d3-97ed-13a146163218",
                 "UserUpdated",

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -1599,12 +1599,13 @@ To populate values in these fields from the source columns, the connector uses a
 The connector provides default mappings for the following Informix data types:
 
 * xref:informix-basic-types[Basic types]
-* xref:informix-temportal-types[Temporal types]
+* xref:informix-temporal-types[Temporal types]
 * xref:informix-timestamp-types[Timestamp types]
 * xref:informix-decimal-types[Decimal types]
+
 If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
 
-[id="informix-basic-types"]
+[[informix-basic-types]]
 === Basic types
 
 The following table describes how the connector maps each Informix data type to a _literal type_ and a _semantic type_ in event fields.
@@ -1778,6 +1779,9 @@ Represents the number of milliseconds since the epoch, and does not include time
 
 |===
 
+.INTERVAL
+The `INTERVAL` type is not supported by the Informix Change Stream client.
+
 [[informix-timestamp-types]]
 === Timestamp types
 
@@ -1804,7 +1808,7 @@ The `connect.decimal.precision` schema parameter contains an integer that repres
 |`DECIMAL[(P[,S])]`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal` +
-+
+ +
 The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 


### PR DESCRIPTION
In AbstractEventRouterTest, start connector after altering schema to avoid having to stop and start it again for Informix (which does not permit altering schema during capture)