### PR TITLE
DBZ-8107 Remove references to `additional-condition` signal paramter

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -202,14 +202,6 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 | An array of comma-separated regular expressions that match the fully-qualified names of the data collections to include in the snapshot. +
 Specify the names by using the same format as is required for the `signal.data.collection` configuration option.
 
-|`[.line-through]#additional-condition#`
-|_N/A_
-| An optional string that specifies a condition that the connector evaluates to designate a subset of records to include in a snapshot. +
- +
-[NOTE]
-====
-This property is deprecated and should be replaced by the `additional-conditions` property.
-====
 
 |`additional-conditions`
 |_N/A_
@@ -272,15 +264,6 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 |_N/A_
 | An array of comma-separated regular expressions that match the fully-qualified names of the tables to include in the snapshot. +
 Specify the names by using the same format as is required for the xref:{context}-property-signal-data-collection[signal.data.collection] configuration option.
-
-|`[.line-through]#additional-condition#`
-|_N/A_
-| An optional string that specifies a condition that the connector evaluates to designate a subset of records to include in a snapshot. +
-
-[NOTE]
-====
-This property is deprecated and should be replaced by the `additional-conditions` property.
-====
 
 |`additional-conditions`
 |_N/A_

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -44,17 +44,6 @@ Currently, you can request `incremental` or `blocking` snapshots.
 The format of the names is the same as for the `signal.data.collection` configuration option.
 
 ifeval::['{context}' != 'mongodb']
-|`[.line-through]#additional-condition#`
-|_N/A_
-| An optional string, which specifies a condition based on the column(s) of the {data-collection}(s), to capture a
-subset of the contents of the {data-collection}(s). +
-
-[NOTE]
-====
-This property is deprecated.
-To specify criteria for defining the subset of data that you want the snapshot to capture, use the `additional-conditions` parameter.
-====
-
 |`additional-conditions`
 |_N/A_
 |An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
@@ -66,7 +55,6 @@ You can apply different filters to each {data-collection}.
 `filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
  +
 The values that you assign to the `filter` parameter are the same types of values that you might specify in the `WHERE` clause of `SELECT` statements when you set the `snapshot.select.statement.overrides` property for a blocking snapshot.
-In earlier {prodname} releases, an explicit `filter` parameter was not defined for snapshot signals; instead, filter criteria were implied by the values that were specified for the now deprecated  `additional-condition` parameter.
 endif::[]
 
 ifeval::['{context}' != 'mongodb']

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
@@ -22,15 +22,6 @@ See the next section for more details.
 | An array of comma-separated regular expressions that match the fully-qualified names of tables to include in the snapshot. +
 Specify the names by using the same format as is required for the xref:{context}-property-signal-data-collection[signal.data.collection] configuration option.
 
-|`[.line-through]#additional-condition#`
-|_N/A_
-| An optional string that specifies a condition that the connector evaluates to designate a subset of records to include in a snapshot. +
-
-[NOTE]
-====
-This property is deprecated and should be replaced by the `additional-conditions` property.
-====
-
 |`additional-conditions`
 |_N/A_
 | An optional array of additional conditions that specifies criteria that the connector evaluates to designate a subset of records to include in a snapshot. +
@@ -41,7 +32,6 @@ You can apply different filters to each {data-collection}.
 `filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
  +
 The values that you assign to the `filter` parameter are the same types of values that you might specify in the `WHERE` clause of `SELECT` statements when you set the `snapshot.select.statement.overrides` property for a blocking snapshot.
-In earlier {prodname} releases, an explicit `filter` parameter was not defined for snapshot signals; instead, filter criteria were implied by the values that were specified for the now deprecated `additional-condition` parameter.
 |===
 
 An example of the execute-snapshot Kafka message:


### PR DESCRIPTION
[DBZ-8107](https://issues.redhat.com/browse/DBZ-8107)

Removes entries for the `additional-condition` parameter from snapshot and signal tables that describe the fields in signal records.
Please backport to 2.7.