### PR TITLE
DBZ-8127: Use SQLState instead of error strings

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -538,8 +538,9 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                     break;
                 }
                 catch (SQLException ex) {
-                    // intercept the statement timeout error and retry
-                    if (ex.getMessage().contains("canceling statement due to user request")) {
+                    // intercept the statement timeout error (due to query_canceled or lock_not_available) and retry
+                    // ref: https://www.postgresql.org/docs/current/errcodes-appendix.html
+                    if (ex.getSQLState().equals("57014") || ex.getSQLState().equals("55P03")) {
                         String message = "Creation of replication slot failed; " +
                                 "query to create replication slot timed out, please make sure that there are no long running queries on the database.";
                         if (++tryCount > maxRetries) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
@@ -158,7 +158,7 @@ public class ReplicationConnectionIT {
         }
         catch (Exception e) {
             assertTrue(interceptor.containsWarnMessage("and retrying, attempt number"));
-            assertTrue(e.getCause().getMessage().contains("ERROR: canceling statement due to user request"));
+            assertTrue(((SQLException) e.getCause()).getSQLState().equals("57014"));
             assertTrue(e.getMessage().contains("query to create replication slot timed out"));
             throw e;
         }
@@ -185,7 +185,7 @@ public class ReplicationConnectionIT {
         }
         catch (Exception e) {
             assertTrue(interceptor.containsWarnMessage("and retrying, attempt number"));
-            assertTrue(e.getCause().getMessage().contains("ERROR: canceling statement due to user request"));
+            assertTrue(((SQLException) e.getCause()).getSQLState().equals("57014"));
             assertTrue(e.getMessage().contains("query to create replication slot timed out"));
         }
         finally {


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/DBZ-8127