### PR TITLE
DBZ-8147 Add SchemaOnlyRecoverySnapshotter to SPI service implementation

### DIFF
--- a/debezium-core/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/debezium-core/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -6,4 +6,5 @@ io.debezium.snapshot.mode.RecoverySnapshotter
 io.debezium.snapshot.mode.WhenNeededSnapshotter
 io.debezium.snapshot.mode.NeverSnapshotter
 io.debezium.snapshot.mode.SchemaOnlySnapshotter
+io.debezium.snapshot.mode.SchemaOnlyRecoverySnapshotter
 io.debezium.snapshot.mode.ConfigurationBasedSnapshotter


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-8147