### PR TITLE
DBZ-4967 If sink is Kafka and offset storage is Kafka topic, then reuse connection properties from sink to offset storage also.

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/KafkaConnectUtil.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/KafkaConnectUtil.java
@@ -10,6 +10,7 @@ import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -58,6 +59,15 @@ public class KafkaConnectUtil {
         final String clientId = "debezium-server";
         final Map<String, Object> adminProps = new HashMap<>(config);
         adminProps.put(CLIENT_ID_CONFIG, clientId + "shared-admin");
+
+        if (Objects.equals(config.get("name"), "kafka")) {
+            String PREFIX = "offset.storage.kafka.producer.";
+            adminProps.forEach((configName, value) -> {
+                if (configName.startsWith(PREFIX)) {
+                    adminProps.put(configName.substring(PREFIX.length()), value);
+                }
+            });
+        }
 
         Stream.of(
                 DistributedConfig.BOOTSTRAP_SERVERS_CONFIG,


### PR DESCRIPTION
Example:
`offset.storage.kafka.producer.bootstrap.servers` value will also be available under `bootstrap.servers`. This is because `KafkaOffsetBackingStore` is expecting these properties to be available at the top level.