### PR TITLE
DBZ-8160 Update engine's signal API

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SignalsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SignalsIT.java
@@ -31,8 +31,8 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.connector.postgresql.spi.CustomActionProvider;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.engine.DebeziumEngine;
 import io.debezium.junit.logging.LogInterceptor;
-import io.debezium.pipeline.signal.SignalRecord;
 import io.debezium.pipeline.signal.actions.Log;
 
 public class SignalsIT extends AbstractAsyncEngineConnectorTest {
@@ -114,7 +114,7 @@ public class SignalsIT extends AbstractAsyncEngineConnectorTest {
         }
         else {
             expectedNumRecords = 1;
-            signaler.signal(new SignalRecord("1", "log", "{\"message\": \"Signal message at offset ''{}''\"}", null));
+            getSignaler().signal(new DebeziumEngine.Signal("1", "log", "{\"message\": \"Signal message at offset ''{}''\"}", null));
         }
 
         waitForAvailableRecords(800, TimeUnit.MILLISECONDS);

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -40,6 +40,7 @@ import io.debezium.function.LogPositionValidator;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.notification.channels.NotificationChannel;
 import io.debezium.pipeline.signal.channels.SignalChannelReader;
+import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.pipeline.spi.Partition;
@@ -277,16 +278,14 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     }
 
     /**
-     * Returns the first available signal channel of the given type.
+     * Returns the first available signal channel writer
      *
-     * @param type the type of the signal channel
-     * @param <T> the type of the signal channel
-     * @return the first available signal channel of the given type or empty optional if not available
+     * @return the first available signal channel writer empty optional if not available
      */
-    public <T extends SignalChannelReader> Optional<T> getSignalChannel(Class<T> type) {
+    public Optional<? extends SignalChannelWriter> getAvailableSignalChannelWriter() {
         return getAvailableSignalChannels().stream()
-                .filter(type::isInstance)
-                .map(type::cast)
+                .filter(SignalChannelWriter.class::isInstance)
+                .map(SignalChannelWriter.class::cast)
                 .findFirst();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalRecord.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalRecord.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.data.Envelope;
+import io.debezium.engine.DebeziumEngine;
 import io.debezium.pipeline.signal.actions.snapshotting.CloseIncrementalSnapshotWindow;
 
 /**
@@ -36,6 +37,10 @@ public class SignalRecord {
         this.type = type;
         this.data = data;
         this.additionalData = additionalData;
+    }
+
+    public SignalRecord(DebeziumEngine.Signal signal) {
+        this(signal.id(), signal.type(), signal.data(), signal.additionalData());
     }
 
     public static Optional<SignalRecord> buildSignalRecordFromChangeEventSource(Struct value, CommonConnectorConfig config) {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineSignaler.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineSignaler.java
@@ -12,9 +12,12 @@ import io.debezium.pipeline.signal.SignalRecord;
 import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 
 public class EmbeddedEngineSignaler implements DebeziumEngine.Signaler {
-    private final List<SignalChannelWriter> channels;
+    private final List<? extends SignalChannelWriter> channels;
 
-    public EmbeddedEngineSignaler(List<SignalChannelWriter> channels) {
+    public EmbeddedEngineSignaler(List<? extends SignalChannelWriter> channels) {
+        if (channels == null || channels.isEmpty()) {
+            throw new IllegalArgumentException("At least one channel must be provided");
+        }
         this.channels = channels;
     }
 

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineSignaler.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngineSignaler.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.embedded.async;
+package io.debezium.embedded;
 
 import java.util.List;
 
@@ -11,10 +11,10 @@ import io.debezium.engine.DebeziumEngine;
 import io.debezium.pipeline.signal.SignalRecord;
 import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 
-public class AsyncEngineSignaler implements DebeziumEngine.Signaler {
+public class EmbeddedEngineSignaler implements DebeziumEngine.Signaler {
     private final List<SignalChannelWriter> channels;
 
-    public AsyncEngineSignaler(List<SignalChannelWriter> channels) {
+    public EmbeddedEngineSignaler(List<SignalChannelWriter> channels) {
         this.channels = channels;
     }
 

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -78,8 +78,6 @@ import io.debezium.engine.source.EngineSourceConnectorContext;
 import io.debezium.engine.source.EngineSourceTask;
 import io.debezium.engine.source.EngineSourceTaskContext;
 import io.debezium.engine.spi.OffsetCommitPolicy;
-import io.debezium.pipeline.signal.channels.process.InProcessSignalChannel;
-import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 import io.debezium.util.DelayStrategy;
 
 /**
@@ -834,11 +832,8 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
     public Signaler getSignaler() {
         if (signaler == null) {
             var channels = tasks().stream()
-                    .map(EngineSourceTask::debeziumConnectTask)
+                    .map(EngineSourceTask::signalChannelWriter)
                     .flatMap(Optional::stream)
-                    .map(task -> task.getSignalChannel(InProcessSignalChannel.class))
-                    .flatMap(Optional::stream)
-                    .map(SignalChannelWriter.class::cast)
                     .toList();
 
             signaler = new EmbeddedEngineSignaler(channels);

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -63,6 +63,7 @@ import io.debezium.embedded.ConverterBuilder;
 import io.debezium.embedded.DebeziumEngineCommon;
 import io.debezium.embedded.EmbeddedEngineChangeEvent;
 import io.debezium.embedded.EmbeddedEngineConfig;
+import io.debezium.embedded.EmbeddedEngineSignaler;
 import io.debezium.embedded.EmbeddedWorkerConfig;
 import io.debezium.embedded.KafkaConnectUtil;
 import io.debezium.embedded.Transformations;
@@ -840,7 +841,7 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
                     .map(SignalChannelWriter.class::cast)
                     .toList();
 
-            signaler = new AsyncEngineSignaler(channels);
+            signaler = new EmbeddedEngineSignaler(channels);
         }
         return signaler;
     }

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEngineSignaler.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEngineSignaler.java
@@ -6,33 +6,20 @@
 package io.debezium.embedded.async;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
-import io.debezium.DebeziumException;
 import io.debezium.engine.DebeziumEngine;
-import io.debezium.engine.source.EngineSourceTask;
 import io.debezium.pipeline.signal.SignalRecord;
-import io.debezium.pipeline.signal.channels.process.InProcessSignalChannel;
+import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 
 public class AsyncEngineSignaler implements DebeziumEngine.Signaler {
-    private AsyncEmbeddedEngine<?> engine;
-    private List<InProcessSignalChannel> channels;
+    private final List<SignalChannelWriter> channels;
 
-    public AsyncEngineSignaler(AsyncEmbeddedEngine<?> engine) {
-        this.engine = Objects.requireNonNull(engine);
+    public AsyncEngineSignaler(List<SignalChannelWriter> channels) {
+        this.channels = channels;
     }
-    
+
     @Override
     public void signal(DebeziumEngine.Signal signal) {
-        if (channels == null) {
-            channels = engine.tasks().stream()
-                    .map(EngineSourceTask::debeziumConnectTask)
-                    .flatMap(Optional::stream)
-                    .map(task -> task.getSignalChannel(InProcessSignalChannel.class))
-                    .flatMap(Optional::stream)
-                    .toList();
-        }
         var sr = new SignalRecord(signal);
         channels.forEach(channel -> channel.signal(sr));
     }

--- a/debezium-embedded/src/main/java/io/debezium/engine/source/EngineSourceTask.java
+++ b/debezium-embedded/src/main/java/io/debezium/engine/source/EngineSourceTask.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import org.apache.kafka.connect.source.SourceTask;
 
 import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.pipeline.signal.channels.process.SignalChannelWriter;
 
 /**
  * Implementation of {@link DebeziumSourceTask} which currently serves only as a wrapper
@@ -37,9 +38,10 @@ public class EngineSourceTask implements DebeziumSourceTask {
     }
 
     @SuppressWarnings("unchecked")
-    public Optional<BaseSourceTask<?, ?>> debeziumConnectTask() {
+    public Optional<? extends SignalChannelWriter> signalChannelWriter() {
         return Optional.of(connectTask)
                 .filter(BaseSourceTask.class::isInstance)
-                .map(BaseSourceTask.class::cast);
+                .map(BaseSourceTask.class::cast)
+                .flatMap(BaseSourceTask::getAvailableSignalChannelWriter);
     }
 }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/AbstractAsyncEngineConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/AbstractAsyncEngineConnectorTest.java
@@ -8,7 +8,6 @@ package io.debezium.embedded.async;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.embedded.TestingDebeziumEngine;
 import io.debezium.engine.DebeziumEngine;
-import io.debezium.pipeline.signal.SignalRecord;
 
 /**
  * Base class for testing connectors using {@link AsyncEmbeddedEngine}.
@@ -17,18 +16,17 @@ import io.debezium.pipeline.signal.SignalRecord;
  */
 public class AbstractAsyncEngineConnectorTest extends AbstractConnectorTest {
 
-    protected DebeziumEngine.Signaler<SignalRecord> signaler;
-
     @Override
     protected DebeziumEngine.Builder createEngineBuilder() {
-        this.signaler = new AsyncEngineSignaler();
-
-        return new AsyncEmbeddedEngine.AsyncEngineBuilder()
-                .using(signaler);
+        return new AsyncEmbeddedEngine.AsyncEngineBuilder();
     }
 
     @Override
     protected TestingDebeziumEngine createEngine(DebeziumEngine.Builder builder) {
         return new TestingAsyncEmbeddedEngine((AsyncEmbeddedEngine) builder.build());
+    }
+
+    protected DebeziumEngine.Signaler getSignaler() {
+        return engine.getSignaler();
     }
 }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/TestingAsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/TestingAsyncEmbeddedEngine.java
@@ -36,4 +36,9 @@ public class TestingAsyncEmbeddedEngine implements TestingDebeziumEngine {
     public void runWithTask(Consumer consumer) {
         engine.runWithTask(consumer);
     }
+
+    @Override
+    public Signaler getSignaler() {
+        return engine.getSignaler();
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8160

THe original approach proved to be poorly usable as there was no way to ensure (or know) which implementation of signaler to use. This PR does the following


- Add Signal record to DebeziumEngine API
- Simplifies Signaler interface so that it always accepts Signal
- Moves the responsibility of creating Signaler to the engine implementations
- Exposes Signaler via DebeziumEngine API


this allows use as following 

```java
engine.getSignaler().signal(mySignal)
```