### PR TITLE
DBZ-8168 - Fix issue with reselecting JSONB fields in PostgreSQL

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -631,3 +631,4 @@ Pradeep Nain
 Gaurav Miglani
 张展业
 Ashish Binu
+Mohamed El Shaer

--- a/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -250,10 +250,8 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             case MAP:
                 return unavailableValuePlaceholderMap.equals(value);
             case STRING:
-                if (Json.LOGICAL_NAME.equals(schema.name())) {
-                    return unavailableValuePlaceholderJson.equals(value);
-                }
-                return unavailableValuePlaceholder.equals(value);
+                final boolean isJsonAndUnavailable = Json.LOGICAL_NAME.equals(schema.name()) && unavailableValuePlaceholderJson.equals(value);
+                return unavailableValuePlaceholder.equals(value) || isJsonAndUnavailable;
         }
         return false;
     }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -279,3 +279,4 @@ TimoWilhelm,Timo Wilhelm
 ashishbinu,Ashish Binu
 wltmlx,Lukas Langegger
 GitHubSergei,Sergey Kazakov
+shaer, Mohamed El Shaer


### PR DESCRIPTION
The `isUnavailableValueHolder` method checks if a field of type JSON matches the `unavailableValuePlaceholderJson`. However, the actual value was stored as `unavailableValuePlaceholder` using PostgreSQL's JSON/B fields.

I'm not entirely sure if this is the best approach, but I have modified the condition to always check for the `unavailableValuePlaceholder` string. Additionally, if the field is of JSON type, it will also check if the value matches `unavailableValuePlaceholderJson`.

A better approach would actually save the unavailable value correctly with JSON/JSONB fields, but since strings are also a valid JSON object I made it like that.

Reference:
https://issues.redhat.com/browse/DBZ-8168

https://debezium.zulipchat.com/#narrow/stream/348249-community-postgresql/topic/JSONB.20Fields.20are.20not.20supported.20with.20Reselect.20Post.20Processor