### PR TITLE
DBZ-8169 Upgrade Adobe s3mock to 3.10.0

### DIFF
--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
 	<!-- S3 -->
-        <version.s3mock>2.4.14</version.s3mock>
+        <version.s3mock>3.10.0</version.s3mock>
 
     <!-- Azurite -->
         <version.azurite>3.22.0</version.azurite>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8169

upgrade to latest version of s3mock

https://github.com/adobe/S3Mock/releases


