### PR TITLE
DBZ-8170 Error caused by database name containing regular keywords

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -634,3 +634,4 @@ Gaurav Miglani
 张展业
 Ashish Binu
 Mohamed El Shaer
+Shiwanming

--- a/debezium-core/src/main/java/io/debezium/function/Predicates.java
+++ b/debezium-core/src/main/java/io/debezium/function/Predicates.java
@@ -15,6 +15,7 @@ import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -227,12 +228,12 @@ public class Predicates {
      * @throws PatternSyntaxException if the string includes an invalid regular expression
      */
     public static <T> Predicate<T> includes(String regexPatterns, Function<T, String> conversion) {
-        Set<Pattern> patterns = Strings.setOfRegex(regexPatterns, Pattern.CASE_INSENSITIVE);
+        Set<Pattern> patterns = Strings.setOfRegex(regexPatterns != null ? Matcher.quoteReplacement(regexPatterns) : null, Pattern.CASE_INSENSITIVE);
         return includedInPatterns(patterns, conversion);
     }
 
     public static <T, U> BiPredicate<T, U> includes(String regexPatterns, BiFunction<T, U, String> conversion) {
-        Set<Pattern> patterns = Strings.setOfRegex(regexPatterns, Pattern.CASE_INSENSITIVE);
+        Set<Pattern> patterns = Strings.setOfRegex(regexPatterns != null ? Matcher.quoteReplacement(regexPatterns) : null, Pattern.CASE_INSENSITIVE);
         return includedInPatterns(patterns, conversion);
     }
 

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
@@ -314,7 +315,7 @@ public class JdbcConnection implements AutoCloseable {
 
                 if (value != null) {
                     // And replace the variable ...
-                    url = url.replaceAll("\\$\\{" + name + "\\}", value);
+                    url = url.replaceAll("\\$\\{" + name + "\\}", Matcher.quoteReplacement(value));
                 }
             }
         }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -281,3 +281,4 @@ wltmlx,Lukas Langegger
 GitHubSergei,Sergey Kazakov
 shaer,Mohamed El Shaer
 SylvainMarty,Sylvain Marty
+jw-itq,Shiwanming


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8170

Error caused by database name containing regular keywords, such as database name: test$user