### PR TITLE
[ci] Speed up the "Update dependencies" stage on CI

### DIFF
--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -216,7 +216,16 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
-          restore-keys: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          # Caches should be restored based on a logical order to minimize the build and test
+          # execution time. Here the logic is as follows:
+          #   1. Restore this PR's cache if the PR has previously been built
+          #   2. Restore the latest main cache if the core pom has not changed
+          #   3. Restore the latest main cache available
+          # This should minimize the download time required for updating dependencies
+          restore-keys: |
+            maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+            maven-debezium-test-push-build-${{ hashFiles('core/**/pom.xml') }}
+            maven-debezium-test-push-build-
 
       # This step is responsible for pulling down artifacts
       # Unfortunately due to the nature of how some of the maven workflows work, the only reliable way


### PR DESCRIPTION
### Previous Way
- Runtime: ~30 minutes
	* Core dependencies update ~17m
	* Debezium Server update ~9m

### New Way
- Runtime: ~3m 30 seconds
	* Core dependencies update ~2m
	* Debezium Server update ~1m

This should help get pull requests running the tests significantly faster without sacrificing any stability in the checks by electing to try and reuse the caches based on this precedence:

1. Uses the PR's previously executed cache if it exists
2. Fallback to push to target branch cache where the hash of core pom.xml files hasn't changed (no deps changed)
3. Fallback to the most recent push to target branch cache, overlaying this PR's dep changes as needed

Options (2) and (3) get the PR up and testing faster, while storing the cache using this PR's metadata so that on future pushes to the PR, it will attempt to use (1) as long as the cache has not aged out of the Github cache archive.  In which case, the fallbacks to (2) and (3) again fall in place and speed up time to get to CI testing.