### PR TITLE
DBZ-8189 Return new byte array/buffer when truncating

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateColumn.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateColumn.java
@@ -6,6 +6,7 @@
 package io.debezium.relational.mapping;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.apache.kafka.connect.data.SchemaBuilder;
 
@@ -72,8 +73,7 @@ public class TruncateColumn implements ColumnMapper {
             else if (value instanceof ByteBuffer) {
                 ByteBuffer buffer = (ByteBuffer) value;
                 if (buffer.limit() > maxLength) {
-                    buffer.limit(maxLength);
-                    return buffer.slice();
+                    return ByteBuffer.wrap(Arrays.copyOfRange(buffer.array(), 0, maxLength));
                 }
             }
             return value;

--- a/debezium-core/src/test/java/io/debezium/relational/mapping/TruncateColumnTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/mapping/TruncateColumnTest.java
@@ -48,7 +48,7 @@ public class TruncateColumnTest {
     }
 
     @Test
-    public void shouldTruncateByteBuffer() {
+    public void shouldTruncateByteBufferToPositiveLength() {
         converter = new TruncateColumn(3).create(column);
         ByteBuffer buffer5 = createBuffer(5);
         ByteBuffer buffer4 = createBuffer(4);
@@ -56,20 +56,41 @@ public class TruncateColumnTest {
         ByteBuffer buffer2 = createBuffer(2);
         ByteBuffer buffer1 = createBuffer(1);
         assertThat(converter.convert(buffer5)).isEqualTo(buffer3);
+        assertThat(((ByteBuffer) converter.convert(buffer5)).array()).isEqualTo(buffer3.array());
         assertThat(converter.convert(buffer4)).isEqualTo(buffer3);
+        assertThat(((ByteBuffer) converter.convert(buffer4)).array()).isEqualTo(buffer3.array());
         assertThat(converter.convert(buffer3)).isEqualTo(buffer3);
+        assertThat(((ByteBuffer) converter.convert(buffer3)).array()).isEqualTo(buffer3.array());
         assertThat(converter.convert(buffer2)).isEqualTo(buffer2);
+        assertThat(((ByteBuffer) converter.convert(buffer2)).array()).isEqualTo(buffer2.array());
         assertThat(converter.convert(buffer1)).isEqualTo(buffer1);
+        assertThat(((ByteBuffer) converter.convert(buffer1)).array()).isEqualTo(buffer1.array());
         assertThat(converter.convert(null)).isNull();
+    }
+
+    @Test
+    public void shouldTruncateByteBufferToZero() {
+        converter = new TruncateColumn(3).create(column);
+        ByteBuffer buffer5 = createBuffer(5);
+        ByteBuffer buffer4 = createBuffer(4);
+        ByteBuffer buffer3 = createBuffer(3);
+        ByteBuffer buffer2 = createBuffer(2);
+        ByteBuffer buffer1 = createBuffer(1);
 
         converter = new TruncateColumn(0).create(column);
         ByteBuffer buffer0 = createBuffer(0);
         assertThat(converter.convert(buffer5)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer5)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(buffer4)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer4)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(buffer3)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer3)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(buffer2)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer2)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(buffer1)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer1)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(buffer0)).isEqualTo(buffer0);
+        assertThat(((ByteBuffer) converter.convert(buffer0)).array()).isEqualTo(buffer0.array());
         assertThat(converter.convert(null)).isNull();
     }
 


### PR DESCRIPTION
### Description

[DBZ-8189](https://issues.redhat.com/browse/DBZ-8189)
For some converters they properly only look at the byte buffer slice. However for Kafka Connect's [default json converter](https://github.com/apache/kafka/blob/3.8.0/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java#L631) it gets the underlying array which undoes the truncate logic. So we fix that here by returning a new byte buffer & new byte array that way no subsequent converter can access the original untruncated byte array.

### Verification

Add unit test to reproduce the error with the call to get the underlying array that the slice view is referencing.

We also had a case where a connector we were running ran into this issue & RecordTooLargeException and deploying this change fixed it.