### PR TITLE
DBZ-8187 Don't close transformations in EmbeddedEngine

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -483,15 +483,6 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
                 finally {
                     // Close the offset storage and finally the connector ...
                     stopOffsetStoreAndConnector(connector, connectorClassName, offsetStore, connectorCallback);
-                    // Close the transformation chain.
-                    if (transformations != null) {
-                        try {
-                            transformations.close();
-                        }
-                        catch (IOException e) {
-                            fail("Failed to close transformations: ", e);
-                        }
-                    }
                 }
             }
             catch (EmbeddedEngineRuntimeException e) {


### PR DESCRIPTION
`EmbeddedEngine` can be stopped and started again. Closing the transfomation chain may cause the issue when engine is started again and already closed transformations are applied to stream of data.

Restore original behavior of `EmbeddedEngine` and don't close the transformation chain in this engine.

https://issues.redhat.com/browse/DBZ-8187