### PR TITLE
DBZ-8090 Cherry-pick from main to 2.7

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -65,6 +65,8 @@ For example, `signal.data.collection = inventory.debezium_signals`. +
 The format for the fully-qualified name of the signaling collection depends on the connector. +
 The following example shows the naming formats to use for each connector:
 
+.Fully qualified {data-collection} names
+[id="format-for-specifying-fully-qualified-names-for-data-collections"]
 Db2:: `_<schemaName>_._<tableName>_`
 MongoDB:: `_<databaseName>_._<collectionName>_`
 MySQL:: `_<databaseName>_._<tableName>_`
@@ -199,9 +201,8 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 
 |`data-collections`
 |_N/A_
-| An array of comma-separated regular expressions that match the fully-qualified names of the data collections to include in the snapshot. +
-Specify the names by using the same format as is required for the `signal.data.collection` configuration option.
-
+| An array of comma-separated regular expressions that match the fully qualified names of the data collections to include in the snapshot. +
+The xref:format-for-specifying-fully-qualified-names-for-data-collections[naming format] depends on the database.
 
 |`additional-conditions`
 |_N/A_

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -11,6 +11,7 @@
 :connector-class: Db2Connector
 :connector-name: Db2
 :include-list-example: public.inventory
+:collection-container: schema
 ifdef::community[]
 
 :toc:
@@ -450,6 +451,14 @@ The {prodname} connector for Db2 does not support schema changes while an increm
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
+
+// Type: procedure
+// ModuleID: debezium-db2-running-an-incremental-snapshot-with-additional-conditions
+[id="db2-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
 
 // Type: procedure
 // ModuleID: debezium-db2-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
@@ -2900,7 +2909,7 @@ Heartbeat messages are useful when there are many updates in a database that is 
 |[[db2-property-streaming-delay-ms]]<<db2-property-streaming-delay-ms, `+streaming.delay.ms+`>>
 |0
 |Specifies the time, in milliseconds, that the connector delays the start of the streaming process after it completes a snapshot.
-Setting a delay interval helps to prevent the connector from restarting snapshots in the event that a failure occurs immediately after the snapshot completes, but before the streaming process begins. 
+Setting a delay interval helps to prevent the connector from restarting snapshots in the event that a failure occurs immediately after the snapshot completes, but before the streaming process begins.
 Set a delay value that is higher than the value of the {link-kafka-docs}/#connectconfigs_offset.flush.interval.ms[`offset.flush.interval.ms`] property that is set for the Kafka Connect worker.
 
 |[[db2-property-snapshot-include-collection-list]]<<db2-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -379,6 +379,12 @@ The {prodname} connector for Informix does not support schema changes while an i
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
+[id="informix-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
+
 // Type: procedure
 // ModuleID: debezium-informix-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="informix-triggering-an-incremental-snapshot-kafka"]

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -12,6 +12,8 @@
 :connector-name: MariaDB
 :include-list-example: inventory.*
 :MARIADB:
+:collection-container: database
+
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -116,6 +118,12 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
+
+[id="mariadb-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
 
 // Type: procedure
 // ModuleID: debezium-mariadb-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -10,6 +10,7 @@
 :connector-class: MongoDb
 :connector-name: MongoDB
 :include-list-example: public.inventory
+:collection-container:  database
 ifdef::community[]
 
 :toc:
@@ -1793,7 +1794,7 @@ endif::product[]
 [WARNING]
 ====
 Setting the value of the `capture.scope` property to `collection` prevents the connector from using the default `source` {link-prefix}:{link-signalling}[signaling] channel.
-Because the `source` channel must be enabled to permit connectors to process incremental snapshot signals -- even for signals are sent over the Kafka, JMX, or File channels -- the connector cannot perform incremental snapshots when `capture-scope` is set to `collection`. 
+Because the `source` channel must be enabled to permit connectors to process incremental snapshot signals -- even for signals are sent over the Kafka, JMX, or File channels -- the connector cannot perform incremental snapshots when `capture-scope` is set to `collection`.
 ====
 
 |[[mongodb-property-capture-target]]<<mongodb-property-capture-target, `+capture.target+`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -12,6 +12,8 @@
 :connector-name: MySQL
 :include-list-example: inventory.*
 :MYSQL:
+:collection-container: database
+
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -115,6 +117,13 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
+
+// Type: procedure
+// ModuleID: debezium-mysql-running-an-incremental-snapshot-with-additional-conditions
+[id="mysql-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
 
 // Type: procedure
 // ModuleID: debezium-mysql-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -11,6 +11,8 @@
 :connector-file: {context}
 :connector-name: Oracle
 :include-list-example: PUBLIC.INVENTORY
+:collection-container: database.schema
+
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -379,6 +381,14 @@ The {prodname} connector for Oracle does not support schema changes while an inc
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
+
+// Type: procedure
+// ModuleID: debezium-oracle-running-an-incremental-snapshot-with-additional-conditions
+[id="oracle-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
 
 // Type: procedure
 // ModuleID:debezium-oracle-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -11,6 +11,8 @@
 :connector-class: Postgres
 :connector-name: PostgreSQL
 :include-list-example: public.inventory
+:collection-container: schema
+
 ifdef::community[]
 
 :toc:
@@ -85,7 +87,7 @@ The connector relies on and reflects the PostgreSQL logical decoding feature, wh
 
 * Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
 * Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector.
-* Because logical decoding replication slots publish changes during commit -- and not post commit -- undesirable side-effects can occur. There are two main scenarios when clients can observe inconsistent states. First, publishing uncommitted changes when the master dies before replication completes. Second, publishing changes that cannot be read (i.e., read-after-write consistency) temporarily because they are being replicated. For example, an EmbeddedEngine consumer receives a notification of a row that was created but it cannot be read by a transaction. 
+* Because logical decoding replication slots publish changes during commit -- and not post commit -- undesirable side-effects can occur. There are two main scenarios when clients can observe inconsistent states. First, publishing uncommitted changes when the master dies before replication completes. Second, publishing changes that cannot be read (i.e., read-after-write consistency) temporarily because they are being replicated. For example, an EmbeddedEngine consumer receives a notification of a row that was created but it cannot be read by a transaction.
 
 
 Additionally, the `pgoutput` logical decoding output plug-in does not capture values for generated columns, resulting in missing data for these columns in the connector's output.
@@ -239,6 +241,14 @@ If a schema change is performed _before_ the incremental snapshot start but _aft
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
+
+// Type: procedure
+// ModuleID: debezium-postgresql-running-an-incremental-snapshot-with-additional-conditions
+[id="postgresql-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
 
 // Type: procedure
 // ModuleID: debezium-postgresql-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -12,6 +12,8 @@
 :connector-class: SqlServer
 :connector-name: SQL Server
 :include-list-example: dbo.customers
+:collection-container: database.schema
+
 ifdef::community[]
 
 :toc:
@@ -436,6 +438,14 @@ The {prodname} connector for SQL Server does not support schema changes while an
 ==== Triggering an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+1]
+
+// Type: procedure
+// ModuleID: debezium-sqlserver-running-an-incremental-snapshot-with-additional-conditions
+[id="sqlserver-incremental-snapshots-additional-conditions"]
+==== Running an ad hoc incremental snapshots with `additional-conditions`
+
+include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc[leveloffset=+1]
+
 
 // Type: procedure
 // ModuleID: debezium-sqlserver-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -54,3 +54,8 @@ After the snapshot window for the chunk closes, the buffer contains only `READ` 
 {prodname} emits these remaining `READ` events to the {data-collection}'s Kafka topic.
 
 The connector repeats the process for each snapshot chunk.
+
+Currently, you can use one of the following methods to initiate an incremental snapshot:
+
+* xref:{context}-triggering-an-incremental-snapshot[Send an ad hoc snapshot signal to the signaling {data-collection} on the source database].
+* xref:{context}-triggering-an-incremental-snapshot-kafka[Send a message to a configured Kafka signaling topic].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc
@@ -1,0 +1,81 @@
+If you want a snapshot to include only a subset of the content in a {data-collection}, you can modify the signal request by appending an `additional-conditions` parameter to the snapshot signal.
+
+The SQL query for a typical snapshot takes the following form:
+
+[source,sql,subs="+attributes,+quotes"]
+----
+SELECT * FROM _<tableName>_ ....
+----
+
+By adding an `additional-conditions` parameter, you append a `WHERE` condition to the SQL query, as in the following example:
+
+[source,sql,subs="+attributes,+quotes"]
+----
+SELECT * FROM _<data-collection>_ WHERE _<filter>_ ....
+----
+
+The following example shows a SQL query to send an ad hoc incremental snapshot request with an additional condition to the signaling {data-collection}:
+[source,sql,indent=0,subs="+attributes,+quotes"]
+----
+INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-conditions":[{"data-collection": "_<tableName>_", "filter": "_<additional-condition>_"}]}');
+----
+
+For example, suppose you have a `products` {data-collection} that contains the following columns:
+
+* `id` (primary key)
+* `color`
+* `quantity`
+
+If you want an incremental snapshot of the `products` {data-collection} to include only the data items where `color=blue`, you can use the following SQL statement to trigger the snapshot:
+
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-conditions":[{"data-collection": "schema1.products", "filter": "color=blue"}]}');
+----
+
+The `additional-conditions` parameter also enables you to pass conditions that are based on more than one column.
+For example, using the `products` {data-collection} from the previous example, you can submit a query that triggers an incremental snapshot that includes the data of only those items for which `color=blue` and `quantity>10`:
+
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-conditions":[{"data-collection": "schema1.products", "filter": "color=blue AND quantity>10"}]}');
+----
+
+The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
+
+.Example: Incremental snapshot event message
+[source,json,index=0]
+----
+{
+    "before":null,
+    "after": {
+        "pk":"1",
+        "value":"New data"
+    },
+    "source": {
+        ...
+        "snapshot":"incremental" <1>
+    },
+    "op":"r", <2>
+    "ts_ms":"1620393591654",
+    "ts_us":"1620393591654547",
+    "ts_ns":"1620393591654547920",
+    "transaction":null
+}
+----
+[cols="1,1,4",options="header"]
+|===
+|Item |Field name |Description
+|1
+|`snapshot`
+|Specifies the type of snapshot operation to run. +
+Currently, the only valid options are `blocking` and `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+
+|2
+|`op`
+|Specifies the event type. +
+The value for snapshot events is `r`, signifying a `READ` operation.
+
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
@@ -19,8 +19,8 @@ See the next section for more details.
 
 |`data-collections`
 |_N/A_
-| An optional array of comma-separated regular expressions that match the fully-qualified names of the tables to include in the snapshot. +
-Specify the names by using the same format as is required for the xref:{context}-property-signal-data-collection[signal.data.collection] configuration option.
+| An optional array of comma-separated regular expressions that match the fully-qualified names of the tables an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+Specify {data-collection} names by using the format `{container}.{data-collection}`.
 
 |===
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
@@ -58,8 +58,9 @@ Use this string to identify logging messages to entries in the signaling {data-c
 |4
 |`data-collections`
 |An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
-The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
-If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
+The array lists regular expressions that match {data-collection}s by their fully-qualified names in the format `database.collection`.
+
+If you omit the `data-collections` array from the `data` field, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -41,7 +41,7 @@ The following table describes the parameters in the example:
 |Item|Value |Description
 
 |1
-|`myschema.debezium_signal`
+|`{container}.debezium_signal`
 |Specifies the fully-qualified name of the signaling {data-collection} on the source database.
 
 |2
@@ -57,8 +57,9 @@ Use this string to identify logging messages to entries in the signaling {data-c
 |4
 |`data-collections`
 |An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
-The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
-If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
+The array lists regular expressions which match {data-collection}s by their fully-qualified names in the format `{container}.table`
+
+If you omit this component from the `data` field, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -1,18 +1,17 @@
-Currently, the only way to initiate an incremental snapshot is to send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
-
-You submit a signal to the signaling {data-collection} as SQL `INSERT` queries.
+To initiate an incremental snapshot, you can send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+You submit snapshot signals as SQL `INSERT` queries.
 
 After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
 
 The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
-Currently supports the `incremental` and `blocking` types.
+{prodname} currently supports the `incremental` and `blocking` snapshot types.
 
-To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s, or an array of regular expressions used to match {data-collection}s, for example, +
 
 `{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}` +
 
 The `data-collections` array for an incremental snapshot signal has no default value.
-If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
+If the `data-collections` array is empty, {prodname} interprets the empty array to mean that no action is required, and it does not perform a snapshot.
 
 [NOTE]
 ====
@@ -75,104 +74,20 @@ Rather, during the snapshot, {prodname} generates its own `id` string as a water
 |4
 |`data-collections`
 |A required component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to include in the snapshot. +
-The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+The array lists regular expressions that use the format `{container}.table` to match the fully-qualified names of {data-collection}s.
+This format is the same as the one that you use to specify the name of the connector's xref:{context}-property-signal-data-collection[signaling {data-collection}].
 
 |5
 |`incremental`
 |An optional `type` component of the `data` field of a signal that specifies the type of snapshot operation to run. +
-Currently supports the `incremental` and `blocking` types. +
+Valid values are `incremental` and `blocking`. +
 If you do not specify a value, the connector runs an incremental snapshot.
 
 |6
 |`additional-conditions`
 | An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
-Each additional condition is an object with `data-collection` and `filter` properties. 
+Each additional condition is an object with `data-collection` and `filter` properties.
 You can specify different filters for each data collection. +
-* The `data-collection` property is the fully-qualified name of the data collection for which the filter will be applied.
+* The `data-collection` property is the fully-qualified name of the data collection that the filter applies to.
 For more information about the `additional-conditions` parameter, see xref:{context}-incremental-snapshots-additional-conditions[].
-|===
-
-[id="{context}-incremental-snapshots-additional-conditions"]
-.Ad hoc incremental snapshots with `additional-conditions`
-
-If you want a snapshot to include only a subset of the content in a {data-collection}, you can modify the signal request by appending an `additional-conditions` parameter to the snapshot signal.
-
-The SQL query for a typical snapshot takes the following form:
-
-[source,sql,subs="+attributes,+quotes"]
-----
-SELECT * FROM _<tableName>_ ....
-----
-
-By adding an `additional-conditions` parameter, you append a `WHERE` condition to the SQL query, as in the following example:
-
-[source,sql,subs="+attributes,+quotes"]
-----
-SELECT * FROM _<data-collection>_ WHERE _<filter>_ ....
-----
-
-The following example shows a SQL query to send an ad hoc incremental snapshot request with an additional condition to the signaling {data-collection}:
-[source,sql,indent=0,subs="+attributes,+quotes"]
-----
-INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-conditions":[{"data-collection": "_<tableName>_", "filter": "_<additional-condition>_"}]}');
-----
-
-For example, suppose you have a `products` {data-collection} that contains the following columns:
-
-* `id` (primary key)
-* `color`
-* `quantity`
-
-If you want an incremental snapshot of the `products` {data-collection} to include only the data items where `color=blue`, you can use the following SQL statement to trigger the snapshot:
-
-[source,sql,indent=0,subs="+attributes"]
-----
-INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-conditions":[{"data-collection": "schema1.products", "filter": "color=blue"}]}');
-----
-
-The `additional-conditions` parameter also enables you to pass conditions that are based on more than one column.
-For example, using the `products` {data-collection} from the previous example, you can submit a query that triggers an incremental snapshot that includes the data of only those items for which `color=blue` and `quantity>10`:
-
-[source,sql,indent=0,subs="+attributes"]
-----
-INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-conditions":[{"data-collection": "schema1.products", "filter": "color=blue AND quantity>10"}]}');
-----
-
-The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
-
-.Example: Incremental snapshot event message
-[source,json,index=0]
-----
-{
-    "before":null,
-    "after": {
-        "pk":"1",
-        "value":"New data"
-    },
-    "source": {
-        ...
-        "snapshot":"incremental" <1>
-    },
-    "op":"r", <2>
-    "ts_ms":"1620393591654",
-    "ts_us":"1620393591654547",
-    "ts_ns":"1620393591654547920",
-    "transaction":null
-}
-----
-[cols="1,1,4",options="header"]
-|===
-|Item |Field name |Description
-|1
-|`snapshot`
-|Specifies the type of snapshot operation to run. +
-Currently, the only valid options are `blocking` and `incremental`. +
-Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
-If you do not specify a value, the connector runs an incremental snapshot.
-
-|2
-|`op`
-|Specifies the event type. +
-The value for snapshot events is `r`, signifying a `READ` operation.
-
 |===


### PR DESCRIPTION
Cherry-picks multiple changes from `main` to `2.7` 

[DBZ-8090](https://issues.redhat.com/browse/DBZ-8090)

Updates the incremental snapshot documentation to correct the format for specifying fully qualified table names in snapshot signals. A relatively simple content change that's made complex due to the many moving parts. This PR includes the following changes:

-     Refactors the existing shared files to reference new snippet files that host examples with the appropriate FQ names for each context.
-     Edits content to clarify the use of multiple signaling channels and place information about the proper naming formats in-line vs. relying on cross-references to descriptions in configuration properties.
-     Defines new attribute collection-container to identify the container used to form the FQ collection name for each DB.
-     Adds missing connector-name attributes for Spanner and Vitess connectors to eliminate bothersome build errors that resulted from unresolved attributes.
-     Removes {context} attributes from signaling.adoc where value cannot be resolved.
-     Moves content from shared files in the partials directory into the file proc-running-an-ad-hoc-snapshot-with-additional-conditions.adoc to eliminate headings and anchor IDs that are invalid for use in shared files.
-     Add description of why a user might want to stop an incremental snapshot.
-     Edit the note about how to list table names that include a dot (.) to improve clarity.
-     Remove the embedded topic Pass-through database schema history properties for configuring producer and consumer clients from the upstream ref-connector-pass-through-database-driver-configuration-properties.adoc file and add the content to the new file, rec-connector-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients.
-     Add heading for the Add heading for topic "Pass-through database schema history properties for configuring producer and consumer clients topic to configuration properties section for each connector
-     Apply consistent order to subheadings in the configuration properties sections and to the "mini TOC" bulleted list of configuration properties that begins each section.
-     Edits description of kafka.consumer.offset.commit.enabled property introduced in DBZ-7164.