### PR TITLE
Dbz 8220 add source and sink connectors sections to documentation nav

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -23,7 +23,8 @@
 ** xref:connectors/spanner.adoc[Spanner]
 ** xref:connectors/informix.adoc[Informix]
 * Sink Connectors
-** xref:connectors/jdbc.adoc[JDBC] 
+** xref:connectors/index-sink.adoc[Overview]
+** xref:connectors/jdbc.adoc[JDBC]
 * Transformations
 ** xref:transformations/index.adoc[Overview]
 ** xref:transformations/topic-routing.adoc[Topic Routing]

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -9,7 +9,7 @@
 ** xref:configuration/topic-auto-create-config.adoc[Customizing Topic Auto-Creation]
 ** xref:configuration/signalling.adoc[Sending Signals to Debezium]
 ** xref:configuration/notification.adoc[Receive notifications from Debezium]
-* Connectors
+* Source Connectors
 ** xref:connectors/index.adoc[Overview]
 ** xref:connectors/mysql.adoc[MySQL]
 ** xref:connectors/mariadb.adoc[MariaDB]
@@ -21,8 +21,9 @@
 ** xref:connectors/cassandra.adoc[Cassandra]
 ** xref:connectors/vitess.adoc[Vitess]
 ** xref:connectors/spanner.adoc[Spanner]
-** xref:connectors/jdbc.adoc[JDBC]
 ** xref:connectors/informix.adoc[Informix]
+* Sink Connectors
+** xref:connectors/jdbc.adoc[JDBC] 
 * Transformations
 ** xref:transformations/index.adoc[Overview]
 ** xref:transformations/topic-routing.adoc[Topic Routing]

--- a/documentation/modules/ROOT/pages/connectors/index-sink.adoc
+++ b/documentation/modules/ROOT/pages/connectors/index-sink.adoc
@@ -1,0 +1,11 @@
+= Sink Connectors
+
+{prodname} provides sink connectors that can consume events from sources such as Apache Kafka topics.
+A sink connector standardizes the format of the data, and then persists the event data to a configured sink repository.
+Other systems, applications, or users can then access the events from the data sink.
+
+Because the sink connector applies a consistent structure to the event data that it consumes, downstream applications that read from the data sink can more easily interpret and process that data.
+
+Currently, {prodname} provides the following sink connectors:
+
+* xref:connectors/jdbc.adoc[JDBC]

--- a/documentation/modules/ROOT/pages/connectors/index.adoc
+++ b/documentation/modules/ROOT/pages/connectors/index.adoc
@@ -1,6 +1,7 @@
-= Connectors
+= Source Connectors
 
-{prodname}'s goal is to build up a library of connectors that capture changes from a variety of database management systems and produce events with very similar structures, making it far easier for your applications to consume and respond to the events regardless of where the changes originated.
+{prodname} provides a growing library of source connectors that capture changes from a variety of database management systems.
+Each connector produces change events with very similar structures, making it easy for your applications to consume and respond to events, regardless of their origin.
 
 We currently have the following connectors:
 
@@ -13,7 +14,6 @@ We currently have the following connectors:
 * xref:connectors/cassandra.adoc[Cassandra]
 * xref:connectors/vitess.adoc[Vitess] (Incubating)
 * xref:connectors/spanner.adoc[Spanner]
-* xref:connectors/jdbc.adoc[JDBC] (Incubating)
 * xref:connectors/informix.adoc[Informix] (Incubating)
 
 [NOTE]


### PR DESCRIPTION
[DBZ-8220](https://issues.redhat.com/browse/DBZ-8220)

Add separate Sink connectors section to Navigation in community version of the docs.

Tested in a local Antora build.

This change should be backported to 2.7.

Because this change is not directly reflected in the product documentation repo, a separate MR applies a parallel change downstream: https://gitlab.cee.redhat.com/red-hat-integration-documentation/integration/-/merge_requests/1875