### PR TITLE
Dbz 8227 add technology preview admonition for mariadb connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -24,6 +24,18 @@ ifdef::community[]
 toc::[]
 endif::community[]
 
+ifdef::product[]
+[IMPORTANT]
+====
+The {prodname} connector for MariaDB is a Technology Preview feature only.
+Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
+Red{nbsp}Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
+
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=mariadb-mysql-intro]
 
 // Type: assembly

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
@@ -1,4 +1,4 @@
-To initiate an incremental snapshot, you can send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+To initiate an incremental snapshot, you can send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-incremental-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
 
 You submit a signal to the signaling {data-collection} by using the MongoDB `insert()` method.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -1,4 +1,4 @@
-To initiate an incremental snapshot, you can send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+To initiate an incremental snapshot, you can send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-incremental-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
 You submit snapshot signals as SQL `INSERT` queries.
 
 After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.


### PR DESCRIPTION
[DBZ-8227](https://issues.redhat.com/browse/DBZ-8227)

Adds TP statement conditionalized for product use to the MariaDB connector docs. This change is not rendered in the community version of the documentation.

Tested in local Antora and downstream builds.

Also backporting the change to 2.7.