### PR TITLE
DBZ-8231 Fixes broken link from logging doc to Streams doc

### DIFF
--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -326,7 +326,7 @@ ifdef::product[]
 == {prodname} logging on OpenShift
 
 If you are using {prodname} on OpenShift, you can use the Kafka Connect loggers to configure the {prodname} loggers and logging levels.
-For more information about configuring logging properties in a Kafka Connect schema, see link:{LinkStreamsOpenShift}#type-KafkaConnectSpec-schema-reference[{NameStreamsOpenShift}].
+For more information about configuring logging properties in a Kafka Connect schema, see link:{LinkDeployManageStreamsOpenShift}#external-logging_str[{NameDeployManageStreamsOpenShift}].
 
 endif::product[]
 


### PR DESCRIPTION
[DBZ-8231](https://issues.redhat.com/browse/DBZ-8231)

Revises the target of a link in `logging.adoc` to point to a new location in the Streams for Apache Kafka doc.   Both the attribute reference and the target ID in the original link were obsolete.

A related downstream change updates the value of the `LinkDeployManageStreamsOpenShift` and `NameDeployManageStreamsOpenShift` attributes.

Tested in a local downstream build. Because the content is located in a section that is conditionalized for product-only use, this change has no affect on the community version of the documentation.