### PR TITLE
DBZ-8231 Fixes broken link from logging doc to Streams doc

### DIFF
--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -326,7 +326,7 @@ ifdef::product[]
 == {prodname} logging on OpenShift
 
 If you are using {prodname} on OpenShift, you can use the Kafka Connect loggers to configure the {prodname} loggers and logging levels.
-For more information about configuring logging properties in a Kafka Connect schema, see link:{LinkStreamsOpenShift}#type-KafkaConnectSpec-schema-reference[{NameStreamsOpenShift}].
+For more information about configuring logging properties in a Kafka Connect schema, see link:{LinkDeployManageStreamsOpenShift}#external-logging_str[{NameDeployManageStreamsOpenShift}].
 
 endif::product[]
 


### PR DESCRIPTION
[DBZ-8231](https://issues.redhat.com/browse/DBZ-8231)

Applies change  from `main` that fixes link  in` logging.adoc` that targets to obsolete destination in Streams doc.

(cherry picked from commit 4aee13e973cc9dfd693059980a306f71d00843ca)