### PR TITLE
DBZ-8237 Don't use unbounded number of processing threads in async engine

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -152,7 +154,7 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         taskService = Executors.newFixedThreadPool(this.config.getInteger(ConnectorConfig.TASKS_MAX_CONFIG, () -> 1));
         final String processingThreads = this.config.getString(AsyncEmbeddedEngine.RECORD_PROCESSING_THREADS);
         if (processingThreads == null || processingThreads.isBlank()) {
-            recordService = Executors.newCachedThreadPool();
+            recordService = new ThreadPoolExecutor(0, AsyncEngineConfig.AVAILABLE_CORES, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue());
         }
         else {
             recordService = Executors.newFixedThreadPool(computeRecordThreads(processingThreads));

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -527,10 +527,12 @@ The default is a periodic commity policy based upon time intervals.
 |Description
 
 |`record.processing.threads`
-|The number of available cores.
-|The number of threads to use for processing CDC records.
-If you want to use all available cores on given machine, you can use the `AVAILABLE_CORES` placeholder.
-If the value is not specified, threads are created as needed, using Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executors.html#newCachedThreadPool()[cached thread pool].
+|Threads allocated on demand, based on the workload and the number of available CPU cores.
+|The number of threads that are available to process change event records.
+If no value is specified (the default), the engine uses the Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html[ThreadPoolExecutor] to dynamically adjust the number of threads, based on the current workload.
+Maximum number of threads is number of CPU cores on given machine.
+If a value is specified, the engine uses the Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executors.html#newFixedThreadPool(int)[fixed thread pool] method to create a thread pool with the specified number of threads.
+To use all available cores on given machine, set the placeholder value, `AVAILABLE_CORES`.
 
 |`record.processing.shutdown.timeout.ms`
 |1000

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -491,9 +491,10 @@ You can configure the following options for the asynchronous embedded engine:
 |Description
 
 |[[debezium-server-property-record-processing-threads]]<<debezium-server-property-record-processing-threads, `+record.processing.threads+`>>
-|Threads allocated on demand, based on the workload and the number of available threads.
+|Threads allocated on demand, based on the workload and the number of available CPU cores.
 |The number of threads that are available to process change event records.
-If no value is specified (the default), the engine uses the Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executors.html#newCachedThreadPool()[cached thread pool] method to dynamically adjust the number of threads, based on the current workload.
+If no value is specified (the default), the engine uses the Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html[ThreadPoolExecutor] to dynamically adjust the number of threads, based on the current workload.
+Maximum number of threads is number of CPU cores on given machine.
 If a value is specified, the engine uses the Java https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executors.html#newFixedThreadPool(int)[fixed thread pool] method to create a thread pool with the specified number of threads.
 To use all available cores on given machine, set the placeholder value, `AVAILABLE_CORES`.
 


### PR DESCRIPTION
Before change:
```
Benchmark                                     (processingOrder)  (recordCount)  Mode  Cnt  Score   Error  Units
DebeziumEnginePerf.processRecordsAsyncEngine            ORDERED         100000    ss       0.511           s/op
DebeziumEnginePerf.processRecordsAsyncEngine            ORDERED        1000000    ss       4.026           s/op
DebeziumEnginePerf.processRecordsAsyncEngine          UNORDERED         100000    ss       0.495           s/op
DebeziumEnginePerf.processRecordsAsyncEngine          UNORDERED        1000000    ss       4.423           s/op
```

After change:
```
Benchmark                                     (processingOrder)  (recordCount)  Mode  Cnt  Score   Error  Units
DebeziumEnginePerf.processRecordsAsyncEngine            ORDERED         100000    ss       0.316           s/op
DebeziumEnginePerf.processRecordsAsyncEngine            ORDERED        1000000    ss       2.043           s/op
DebeziumEnginePerf.processRecordsAsyncEngine          UNORDERED         100000    ss       0.209           s/op
DebeziumEnginePerf.processRecordsAsyncEngine          UNORDERED        1000000    ss       2.038           s/op
```

https://issues.redhat.com/browse/DBZ-8237