### PR TITLE
DBZ-8241 Use pre-defined builder factory when none is specified 

### DIFF
--- a/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
+++ b/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
@@ -16,8 +16,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
-import org.slf4j.LoggerFactory;
-
 import io.debezium.DebeziumException;
 import io.debezium.common.annotation.Incubating;
 import io.debezium.engine.format.ChangeEventFormat;
@@ -370,17 +368,7 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
     }
 
     private static BuilderFactory determineBuilderFactory() {
-        final ServiceLoader<BuilderFactory> loader = ServiceLoader.load(BuilderFactory.class);
-        final Iterator<BuilderFactory> iterator = loader.iterator();
-        if (!iterator.hasNext()) {
-            throw new DebeziumException("No implementation of Debezium engine builder was found");
-        }
-        final BuilderFactory builder = iterator.next();
-        if (iterator.hasNext()) {
-            LoggerFactory.getLogger(Builder.class)
-                    .warn("More than one Debezium engine builder implementation was found, using {} (in Debezium 2.6 you can ignore this warning)", builder.getClass());
-        }
-        return builder;
+        return determineBuilderFactory("io.debezium.embedded.ConvertingEngineBuilderFactory");
     }
 
     private static BuilderFactory determineBuilderFactory(String builderFactory) {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
@@ -40,10 +40,13 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.simple.SimpleSourceConnector;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.embedded.Connect;
+import io.debezium.embedded.ConvertingEngineBuilder;
 import io.debezium.embedded.DebeziumEngineTestUtils;
 import io.debezium.embedded.EmbeddedEngineChangeEvent;
 import io.debezium.embedded.EmbeddedEngineConfig;
 import io.debezium.embedded.EmbeddedEngineHeader;
+import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.format.KeyValueHeaderChangeEventFormat;
@@ -711,6 +714,50 @@ public class AsyncEmbeddedEngineTest {
         completionCallbackLatch.await(AbstractConnectorTest.waitTimeForEngine(), TimeUnit.SECONDS);
         assertThat(completionCallbackLatch.getCount()).isEqualTo(0);
         assertThat(connectorCallbackCalled.get()).isTrue();
+    }
+
+    @Test
+    @FixFor("DBZ-8241")
+    public void testDefaultBuilderFactory() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty(ConnectorConfig.NAME_CONFIG, "debezium-engine");
+        props.setProperty(ConnectorConfig.TASKS_MAX_CONFIG, "1");
+        props.setProperty(ConnectorConfig.CONNECTOR_CLASS_CONFIG, FileStreamSourceConnector.class.getName());
+        props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, OFFSET_STORE_PATH.toAbsolutePath().toString());
+        props.setProperty(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, "0");
+        props.setProperty(FileStreamSourceConnector.FILE_CONFIG, TEST_FILE_PATH.toAbsolutePath().toString());
+        props.setProperty(FileStreamSourceConnector.TOPIC_CONFIG, "testTopic");
+
+        DebeziumEngine.Builder<ChangeEvent<SourceRecord, SourceRecord>> builder = DebeziumEngine.create(Connect.class);
+
+        // Until EmbeddedEngine is removed, the default is EmbeddedEngine.
+        assertThat(builder).isInstanceOf(ConvertingEngineBuilder.class);
+
+        // Verify that engine created by default builder factory works.
+        appendLinesToSource(NUMBER_OF_LINES);
+        CountDownLatch recordsLatch = new CountDownLatch(NUMBER_OF_LINES);
+
+        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = builder
+                .using(props)
+                .using(new TestEngineConnectorCallback())
+                .notifying((records, committer) -> {
+                    assertThat(records.size()).isGreaterThanOrEqualTo(NUMBER_OF_LINES);
+                    for (int i = 0; i < records.size(); i++) {
+                        assertThat(records.get(i).value()).isInstanceOf(SourceRecord.class);
+                        recordsLatch.countDown();
+                    }
+                    committer.markBatchFinished();
+                }).build();
+
+        engineExecSrv.submit(() -> {
+            LoggingContext.forConnector(getClass().getSimpleName(), "", "engine");
+            engine.run();
+        });
+
+        recordsLatch.await(AbstractConnectorTest.waitTimeForEngine(), TimeUnit.SECONDS);
+        assertThat(recordsLatch.getCount()).isEqualTo(0);
+
+        engine.close();
     }
 
     private void runEngineBasicLifecycleWithConsumer(final Properties props) throws IOException, InterruptedException {


### PR DESCRIPTION
Order of loading classes via SPI is not guaranteed. As DebeziumEngine.create() method is defined in debezium-api module which we don't want to depends on embedded module, possibly the only how to prevend loading async engine builder via SPI is to remove it from SPI.

https://issues.redhat.com/browse/DBZ-8241