### PR TITLE
DBZ-8250 Move engine running check to avoid premature exit

### DIFF
--- a/.github/actions/build-debezium-db2/action.yml
+++ b/.github/actions/build-debezium-db2/action.yml
@@ -41,4 +41,5 @@ runs:
         -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
         -Dmaven.wagon.http.pool=false
         -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        -Ddebezium.test.records.waittime=5 
         -DfailFlakyTests=false

--- a/.github/workflows/jdk-outreach-workflow.yml
+++ b/.github/workflows/jdk-outreach-workflow.yml
@@ -289,6 +289,7 @@ jobs:
           -Dhttp.keepAlive=false 
           -Dmaven.wagon.http.pool=false 
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 
+          -Ddebezium.test.records.waittime=5 
           -DfailFlakyTests=false
           ${{ matrix.feature.extra }}
   spanner:

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -549,7 +549,7 @@ public abstract class AbstractConnectorTest implements Testing {
         int recordsConsumed = 0;
         int nullReturn = 0;
         boolean isLastRecord = false;
-        while (!isLastRecord && isEngineRunning.get()) {
+        while (!isLastRecord) {
             SourceRecord record = consumedLines.poll(pollTimeoutInMs, TimeUnit.MILLISECONDS);
             if (record != null) {
                 nullReturn = 0;
@@ -573,6 +573,9 @@ public abstract class AbstractConnectorTest implements Testing {
             else {
                 if (++nullReturn >= breakAfterNulls) {
                     return recordsConsumed;
+                }
+                if (!isEngineRunning.get()) {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8250

@jpechane as requested, this should continue to satisfy the original logic but avoid the premature loop exits when data still needs to be consumed that hasn't yet been drained from the queue. I tested this with the Db2ConnectorIT method you referred me to and it now passes on the first execution :tada: 