### PR TITLE
DBZ-8252 Add a note about flush-retry properties for JDBC connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -901,7 +901,7 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 [NOTE]
 ====
 When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush-max-retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
-To prevent the connector from rebalancing, set the total retry time (flush-retry-delay-ms * flush-max-retries) to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
+To prevent the connector from rebalancing, set the total retry time (flush.retry.delay.ms * flush.max.retries) to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
 ====
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -898,7 +898,11 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 |[[jdbc-property-flush-retry-delay-ms]]<<jdbc-property-flush-retry-delay-ms, `+flush.retry.delay.ms+`>>
 |1000
 |Specifies the number of milliseconds that the connector waits to retry a flush operation that failed.
-
+[NOTE]
+====
+Please note that this property, when used in conjunction with the xref:jdbc-property-flush-max-retries[`flush-max-retries`] property , may affect the behavior of the link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms].
+To prevent a re-balance, ensure that the total retry delay is less than the `max.poll.interval.ms` value (default is 5 minutes).
+====
 |===
 
 [[jdbc-connector-properties-extendable]]

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -900,8 +900,8 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 |Specifies the number of milliseconds that the connector waits to retry a flush operation that failed.
 [NOTE]
 ====
-Please note that this property, when used in conjunction with the xref:jdbc-property-flush-max-retries[`flush-max-retries`] property , may affect the behavior of the link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms].
-To prevent a re-balance, ensure that the total retry delay is less than the `max.poll.interval.ms` value (default is 5 minutes).
+When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush-max-retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
+To prevent the connector from rebalancing, set `flush.retry.delay.ms` to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
 ====
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -901,7 +901,7 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 [NOTE]
 ====
 When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush-max-retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
-To prevent the connector from rebalancing, set `flush.retry.delay.ms` to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
+To prevent the connector from rebalancing, set the total retry time (flush-retry-delay-ms * flush-max-retries) to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
 ====
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -900,7 +900,7 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 |Specifies the number of milliseconds that the connector waits to retry a flush operation that failed.
 [NOTE]
 ====
-When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush-max-retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
+When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush.max.retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
 To prevent the connector from rebalancing, set the total retry time (flush.retry.delay.ms * flush.max.retries) to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
 ====
 |===


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-8252
improves docs from this https://github.com/debezium/debezium/pull/5854