### PR TITLE
Dbz 8254 fix conditionalization in shared mariadb mysql files

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2068,7 +2068,7 @@ For information about how to obtain the driver, see xref:obtaining-the-db2-jdbc-
 
 .Additional resources
 
-* xref:descriptions-of-debezium-db2-connector-configuration-properties[]
+* xref:descriptions-of-debezium-db2-connector-configuration-properties[Db2 connector configuration properties]
 
 // Type: procedure
 [id="obtaining-the-db2-jdbc-driver"]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1275,7 +1275,7 @@ This is the preferred method.
 
 .Additional resources
 
-* xref:mongodb-connector-properties[]
+* xref:mongodb-connector-properties[MongoDB connector configuration properties]
 
 // Type: concept
 [id="openshift-streams-mongodb-connector-deployment"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2833,7 +2833,7 @@ For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Or
 
 .Additional resources
 
-* xref:descriptions-of-debezium-oracle-connector-configuration-properties[]
+* xref:descriptions-of-debezium-oracle-connector-configuration-properties[Oracle connector configuration properties]
 
 // Type: procedure
 [id="obtaining-the-oracle-jdbc-driver"]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2523,7 +2523,7 @@ This is the preferred method.
 
 .Additional resources
 
-* xref:descriptions-of-debezium-postgresql-connector-configuration-properties[]
+* xref:descriptions-of-debezium-postgresql-connector-configuration-properties[PostgreSQL connector configuration properties]
 
 // Type: concept
 [id="openshift-streams-postgresql-connector-deployment"]
@@ -3239,7 +3239,7 @@ If the connector cannot find the publication, the connector throws an exception 
  +
 `filtered` - If a publication does not exist, the connector creates one by running a SQL command in the following format: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, tbl3>`. +
 
-The resulting publication includes tables that match the current filter configuration, as specified by the `schema.include.list`, `schema.exclude.list`, `table.include.list`, and `table.exclude.list` connector configuration properties. 
+The resulting publication includes tables that match the current filter configuration, as specified by the `schema.include.list`, `schema.exclude.list`, `table.include.list`, and `table.exclude.list` connector configuration properties.
 
 If the publication exists, the connector updates the publication for tables that match the current filter configuration by running a SQL command in the following format: `ALTER PUBLICATION <publication_name> SET TABLE <tbl1, tbl2, tbl3>`. +
  +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2178,7 +2178,7 @@ This is the preferred method.
 
 .Additional resources
 
-* xref:descriptions-of-debezium-sqlserver-connector-configuration-properties[]
+* xref:descriptions-of-debezium-sqlserver-connector-configuration-properties[SQL Server connector configuration properties]
 
 // Type: concept
 [id="openshift-streams-sqlserver-connector-deployment"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -50,17 +50,11 @@ If you later decide to capture changes from tables that you did not originally d
 If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
-|
-ifdef::MARIADB,MYSQL[]
-`true`
-endif::[]
-ifndef::MARIADB,MYSQL[]
-`false`
-endif::[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=schema-hist-prop-store-only-cap-db-ddl-boolean]
 |A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance. +
 Specify one of the following values:
 
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
-`false`:: The connector records schema structures for all logical databases. +
+`false`:: The connector records schema structures for all logical databases.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -392,14 +392,9 @@ That is, the specified expression is matched against the entire name string of t
 [id="{context}-property-snapshot-lock-timeout-ms"]
 xref:{context}-property-snapshot-lock-timeout-ms[`snapshot.lock.timeout.ms`]::
 Default value: `10000` +
-Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails.
-For more information, see
-ifdef::MYSQL[]
-xref:mysql-snapshots[how {connector-name} connectors perform database snapshots].
-endif::MYSQL[]
-ifdef::MARIADB[]
-xref:mariadb-snapshots[how {connector-name} connectors perform database snapshots].
-endif::MARIADB[]
+Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
+If the connector cannot acquire table locks in this time interval, the snapshot fails.
+For more information, see the documentation that describes xref:{context}-snapshots[how {connector-name} connectors perform database snapshots].
 
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -43,14 +43,9 @@ The {prodname} {connector-name} connector supports the following {connector-name
 
 Standalone::
 When a single {connector-name} server is used, the server must have the binlog enabled so the {prodname} {connector-name} connector can monitor the server.
-This is often acceptable, since the binary log can also be used as an incremental
-ifdef::MARIADB[]
-link:https://mariadb.com/kb/en/backup-and-restore-overview/
-endif::MARIADB[]
-ifdef::MYSQL[]
-link:https://dev.mysql.com/doc/refman/{mysql-version}/en/backup-methods.html
-endif::MYSQL[]
-[backup].
+ +
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-standalone-backupdoc]
+ +
 In this case, the {connector-name} connector always connects to and follows this standalone {connector-name} server instance.
 
 Primary and replica::
@@ -62,35 +57,11 @@ Therefore, the connector must follow just one {connector-name} server instance.
 If that server fails, that server must be restarted or recovered before the connector can continue.
 
 High available clusters::
-A variety of
-ifdef::MARIADB[]
-link:https://mariadb.com/docs/server/architecture/use-cases/high-availability/
-endif::MARIADB[]
-ifdef::MYSQL[]
-https://dev.mysql.com/doc/mysql-ha-scalability/en/
-endif::MYSQL[]
-[high availability] solutions exist for {connector-name}, and they make it significantly easier to tolerate and almost immediately recover from problems and failures.
-Because
-ifdef::MYSQL[]
-most
-endif::MYSQL[]
-HA {connector-name} clusters use GTIDs, replicas are able to track all of the changes that occur on any primary server.
-
-
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-ha]
 
 Multi-primary::
-ifdef::MYSQL[]
-link:https://dev.mysql.com/doc/refman/{mysql-version}/en/mysql-cluster-replication-multi-source.html[Network Database (NDB) cluster replication]
-endif::MYSQL[]
-ifdef::MARIADB[]
-link:https://mariadb.com/kb/en/galera-cluster/[Galera cluster replication]
-endif::MARIADB[]
-uses one or more {connector-name} replica nodes that each replicate from multiple primary servers.
-Cluster replication provides a powerful way to aggregate the replication of multiple {connector-name} clusters.
-ifdef::MYSQL[]
-This topology requires the use of GTIDs.
-endif::MYSQL[]
-+
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-multi-primary]
+ +
 A {prodname} {connector-name} connector can use these multi-primary {connector-name} replicas as sources, and can fail over to different multi-primary {connector-name} replicas as long as the new replica is caught up to the old replica.
 That is, the new replica has all transactions that were seen on the first replica.
 This works even if the connector is using only a subset of databases and/or tables, because the connector can be configured to include or exclude specific GTID sources when attempting to reconnect to a new multi-primary {connector-name} replica and find the correct position in the binlog.
@@ -105,7 +76,7 @@ end::supported-topos[]
 
 
 
-== How the connector works
+=== How the connector works
 
 tag::how-connector-works-intro[]
 
@@ -482,12 +453,7 @@ The snapshot itself does not prevent other clients from applying DDL that might 
 The connector retains the global read lock while it reads the binlog position, and releases the lock as described in a later step.
 
 |4
-ifdef::MYSQL[]
-a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_. +
-endif::MYSQL[]
-ifdef::MARIADB[]
-a|Start a transaction with link:https://mariadb.com/kb/en/set-transaction/#repeatable-read[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_. +
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=snapshots-default-workflow-repeatable-read-semantics]
  +
 [NOTE]
 ====
@@ -580,12 +546,7 @@ To have the connector capture a subset of tables or table elements, you can set 
 |Obtain table-level locks.
 
 |4
-ifdef::MYSQL[]
-a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
-endif::MYSQL[]
-ifdef::MARIADB[]
-a|Start a transaction with link:https://mariadb.com/kb/en/set-transaction/#repeatable-read[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=snapshots-default-workflow-repeatable-read-semantics]
 
 |5
 a|Read the current binlog position.
@@ -1476,10 +1437,7 @@ This field contains information that you can use to compare this event with othe
 * {connector-name} server ID (if available)
 * Timestamp for when the change was made in the database
 
-ifdef::MARIADB[]
-If the xref:enable-query-log-events[`binlog_annotate_row_events`] MariaDB configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
-endif::MARIADB[]
-
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=create-event-values-table-source-entry]
 |===
 end::create-events[]
 
@@ -1563,9 +1521,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * {connector-name} server ID (if available)
 * Timestamp for when the change was made in the database
 
-ifdef::MARIADB[]
-If the xref:enable-query-log-events[`binlog_annotate_row_events`] MariaDB configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=create-event-values-table-source-entry]
 
 |4
 |`op`
@@ -1687,9 +1643,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * {connector-name} server ID (if available)
 * Timestamp for when the change was made in the database
 
-ifdef::MARIADB[]
-If the xref:enable-query-log-events[`binlog_annotate_row_events`] MariaDB configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=create-event-values-table-source-entry]
 
 |4
 |`op`
@@ -1921,11 +1875,7 @@ a|The precision is used only to determine storage size.
 A precision `P` from 0 to 23 results in a 4-byte single-precision `FLOAT32` column.
 A precision `P` from 24 to 53 results in an 8-byte double-precision `FLOAT64` column.
 
-ifdef::MARIADB[]
-|`FLOAT(M,D)`
-|`FLOAT64`
-a|_n/a_
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=basic-data-type-descriptions-float-m-d]
 
 |`DOUBLE[(M,D)]`
 |`FLOAT64`
@@ -2054,12 +2004,9 @@ It is converted by {connector-name} from the server (or session’s) current tim
 Such columns are converted into an equivalent `io.debezium.time.ZonedTimestamp` in UTC based on the server (or session’s) current time zone.
 The time zone will be queried from the server by default.
 
-ifdef::MARIADB[]
-If this fails, it must be specified explicitly by the database `timezone` {connector-name} configuration option.
-For example, if the database’s time zone (either globally or configured for the connector by means of the `timezone` option) is "America/Los_Angeles", the TIMESTAMP value "2018-06-20 06:37:03" is represented by a `ZonedTimestamp` with the value "2018-06-20T13:37:03Z".
-endif::MARIADB[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=temporal-data-type-timezone-conversions]
 
-The time zone of the JVM running Kafka Connect and {prodname} does not affect these conversions.
+The time zone setting for the JVM that runs Kafka Connect and {prodname} does not affect these conversions.
 
 More details about properties related to temporal values are in the documentation for xref:{context}-connector-properties[{connector-name} connector configuration properties].
 
@@ -2453,23 +2400,8 @@ The binary logs record transaction updates in a way that enables replicas to pro
 
 . Check whether the `log-bin` option is enabled:
 +
-ifdef::MARIADB[]
-[source,SQL]
-----
-mariadb> SHOW VARIABLES LIKE '%log_bin%';
-----
-endif::MARIADB[]
-ifdef::MYSQL[]
-[source,SQL]
-----
-// for MySQL 5.x
-mysql> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-FROM information_schema.global_variables WHERE variable_name='log_bin';
-// for MySQL 8.x
-mysql> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-FROM performance_schema.global_variables WHERE variable_name='log_bin';
-----
-endif::MYSQL[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=setting-up-the-db-enabling-binlog]
+
 . If the binlog is `OFF`, add the properties in the following table to the configuration file for the {connector-name} server:
 +
 [source,properties,subs="+attributes"]
@@ -2483,23 +2415,8 @@ binlog_expire_logs_seconds  = 864000
 
 . Confirm your changes by checking the binlog status once more:
 +
-ifdef::MARIADB[]
-[source,SQL,subs="+attributes"]
-----
-{context}> SHOW VARIABLES LIKE '%log_bin%';
-----
-endif::MARIADB[]
-ifdef::MYSQL[]
-[source,SQL]
-----
-// for MySQL 5.x
-{context}> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-FROM information_schema.global_variables WHERE variable_name='log_bin';
-// for MySQL 8.x
-{context}> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-FROM performance_schema.global_variables WHERE variable_name='log_bin';
-----
-endif::MYSQL[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=setting-up-the-db-enabling-binlog]
+
 . If you run {connector-name} on Amazon RDS, you must enable automated backups for your database instance for binary logging to occur.
 If the database instance is not configured to perform automated backups, the binlog is disabled, even if you apply the settings described in the previous steps.
 
@@ -2571,21 +2488,7 @@ You can prevent this behavior by configuring `interactive_timeout` and `wait_tim
 
 |`interactive_timeout`
 a|The number of seconds the server waits for activity on an interactive connection before closing it.
-For more information see the:
-ifdef::MARIADB[]
-link:https://mariadb.com/kb/en/server-system-variables/#interactive_timeout[MariaDB documentation].
-endif::MARIADB[]
-ifdef::MYSQL[]
-link:https://dev.mysql.com/doc/refman/{mysql-version}/en/server-system-variables.html#sysvar_interactive_timeout[MySQL documentation].
-endif::MYSQL[]
-|`wait_timeout`
-a|The number of seconds that the server waits for activity on a non-interactive connection before closing it.
-ifdef::MARIADB[]
-For more information, see the link:https://mariadb.com/kb/en/server-system-variables/#wait_timeout[MariaDB documentation].
-endif::MARIADB[]
-ifdef::MYSQL[]
-For more information, see the link:https://dev.mysql.com/doc/refman/{mysql-version}/en/server-system-variables.html#sysvar_interactive_timeout[MySQL documentation].
-endif::MYSQL[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=session-timeout-options-descriptions]
 |===
 end::cfg-session-timeouts[]
 
@@ -2637,7 +2540,7 @@ end::validate-binlog-row-options[]
 
 
 
-== Deployment
+=== Deployment
 
 tag::deployment[]
 ifdef::community[]
@@ -2685,7 +2588,7 @@ This is the preferred method.
 
 .Additional resources
 
-* xref:{context}-connector-properties[]
+* xref:{context}-connector-properties[{connector-name} connector configuration properties]
 endif::product[]
 end::deployment[]
 
@@ -3008,7 +2911,8 @@ end::add-connector-cfg[]
 tag::connector-props-intro[]
 The {prodname} {connector-name} connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
 Many properties have default values.
-Information about the properties is organized as follows:
+
+Information about {connector-name} connector configuration properties is organized as follows:
 
 * xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
 * xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
@@ -3019,7 +2923,6 @@ Information about the properties is organized as follows:
 ** xref:debezium-{context}-connector-pass-through-signals-kafka-consumer-client-configuration-properties[Pass-through Kafka signals consumer client configuration properties]
 ** xref:debezium-{context}-connector-pass-through-kafka-sink-notification-configuration-properties[Pass-through sink notification configuration properties]
 ** xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver configuration properties]
-
 end::connector-props-intro[]
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2542,6 +2542,9 @@ end::validate-binlog-row-options[]
 
 === Deployment
 
+// Retaining the conditional statements in the following section, because they only apply to the upstream content,
+// so there's no problem with them not yielding the expected results as there would be if used downstream.
+
 tag::deployment[]
 ifdef::community[]
 To deploy a {prodname} {connector-name} connector, you install the {prodname} {connector-name} connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
@@ -3023,10 +3026,7 @@ Each change event message includes source-specific information that you can use 
 * Event origin
 * {connector-name} server's event time
 * The binlog file name and position
-* GTIDs
-ifdef::MYSQL[]
-(if used)
-endif::MYSQL[]
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=kc-process-crash-gtid-in-change-event-msg]
 
 [id="debezium-{context}-kafka-process-becomes-unavailable"]
 Kafka becomes unavailable::

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-db2-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-db2-props-snippets.adoc
@@ -1,0 +1,13 @@
+= Db2 snippets
+
+== Database history properties
+
+// Boolean value for Db2 `schema-history-cfg-store-only-captured-dbs-ddl` config property.
+// // Used in `ref-connector-configuration-database-history-properties.adoc`.
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|
+`false`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-informix-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-informix-props-snippets.adoc
@@ -1,0 +1,13 @@
+= Informix snippets
+
+== Database history properties
+
+// Boolean value for Informix `schema-history-cfg-store-only-captured-dbs-ddl` config property
+// Used in `ref-connector-configuration-database-history-properties.adoc`.
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|
+`false`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
@@ -90,3 +90,29 @@ For more information see the link:https://mariadb.com/kb/en/server-system-variab
 a|The number of seconds that the server waits for activity on a non-interactive connection before closing it.
 For more information, see the link:https://mariadb.com/kb/en/server-system-variables/#wait_timeout[MariaDB documentation].
 end::session-timeout-options-descriptions[]
+
+
+
+
+
+
+=== Configuration properties
+
+// Boolean value for MySQL/MariaDB `schema-history-cfg-store-only-captured-dbs-ddl` config property.
+// Used in `ref-connector-configuration-database-history-properties.adoc`
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|
+`true`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+
+
+
+=== Behavior when things go wrong
+
+
+tag::kc-process-crash-gtid-in-change-event-msg[]
+* GTIDs.
+end::kc-process-crash-gtid-in-change-event-msg[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
@@ -1,0 +1,92 @@
+= MariaDB snippets used in properties descriptions
+
+// This file is called from shared-mariadb-mysql.adoc to render content that is specific to one of the two databases.
+// Using this approach because the Nebel tool that is used to prepare the downstream docs does not process ifeval constructions,
+// and downstream builds also failed to conditionalize content based on the MARIADB or MYSQL attributes that I previously added.
+
+
+== Topologies
+
+=== Standalone
+
+tag::sup-topo-standalone-backupdoc[]
+This is often acceptable, since the binary log can also be used as an incremental link:https://mariadb.com/kb/en/backup-and-restore-overview/[backup].
+end::sup-topo-standalone-backupdoc[]
+
+=== High availability
+
+tag::sup-topo-ha[]
+A variety of link:https://mariadb.com/docs/server/architecture/use-cases/high-availability/[high availability] solutions exist for {connector-name}, and they make it significantly easier to tolerate and almost immediately recover from problems and failures.
+Because HA {connector-name} clusters use GTIDs, replicas are able to track all of the changes that occur on any primary server.
+end::sup-topo-ha[]
+
+=== Multi-primary
+
+tag::sup-topo-multi-primary[]
+link:https://mariadb.com/kb/en/galera-cluster/[Galera cluster replication] uses one or more {connector-name} replica nodes that each replicate from multiple primary servers.
+Cluster replication provides a powerful way to aggregate the replication of multiple {connector-name} clusters.
+end::sup-topo-multi-primary[]
+
+=== Snapshots
+
+==== Snapshot default flows (global/table read locks): repeatable read semantics
+
+tag::snapshots-default-workflow-repeatable-read-semantics[]
+a|Start a transaction with link:https://mariadb.com/kb/en/set-transaction/#repeatable-read[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_. +
+end::snapshots-default-workflow-repeatable-read-semantics[]
+
+
+
+=== Change events
+
+==== Event values: create, update, and delete events
+
+
+tag::create-event-values-table-source-entry[]
+If the xref:enable-mariadb-binlog[`binlog_annotate_row_events`] option is enabled in the MariaDB database configuration, and you enable the `include.query` property in the connector configuration, the `source` field also provides a `query` field, which contains the original SQL statement that caused the change event.
+end::create-event-values-table-source-entry[]
+
+
+
+=== Mapping data types
+
+
+==== Basic types
+
+tag::basic-data-type-descriptions-float-m-d[]
+|`FLOAT(M,D)`
+|`FLOAT64`
+a|_n/a_
+end::basic-data-type-descriptions-float-m-d[]
+
+==== Temporal types
+
+tag::temporal-data-type-timezone-conversions[]
+If this fails, it must be specified explicitly by the database `timezone` {connector-name} configuration option.
+For example, if the database’s time zone (either globally or configured for the connector by means of the `timezone` option) is "America/Los_Angeles", the TIMESTAMP value "2018-06-20 06:37:03" is represented by a `ZonedTimestamp` with the value "2018-06-20T13:37:03Z".
+end::temporal-data-type-timezone-conversions[]
+
+
+
+
+=== Setting up the database
+
+
+==== Enabling the binlog
+
+tag::setting-up-the-db-enabling-binlog[]
+[source,SQL]
+----
+mariadb> SHOW VARIABLES LIKE '%log_bin%';
+----
+end::setting-up-the-db-enabling-binlog[]
+
+
+==== Configuring session timeouts
+
+tag::session-timeout-options-descriptions[]
+For more information see the link:https://mariadb.com/kb/en/server-system-variables/#interactive_timeout[MariaDB documentation].
+|`wait_timeout`
+a|The number of seconds that the server waits for activity on a non-interactive connection before closing it.
+For more information, see the link:https://mariadb.com/kb/en/server-system-variables/#wait_timeout[MariaDB documentation].
+end::session-timeout-options-descriptions[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -1,0 +1,100 @@
+= MySQL snippets used in properties descriptions
+
+
+// This file is called from shared-mariadb-mysql.adoc to render content that is specific to one of the two databases.
+// Using this approach because the Nebel tool that is used to prepare the downstream docs does not process ifeval constructions,
+// and downstream builds also failed to conditionalize content based on the MARIADB or MYSQL attributes that I previously added.
+
+== Topologies
+
+=== Standalone
+
+tag::sup-topo-standalone-backupdoc[]
+This is often acceptable, since the binary log can also be used as an incremental link:https://dev.mysql.com/doc/refman/{mysql-version}/en/backup-methods.html[backup].
+end::sup-topo-standalone-backupdoc[]
+
+=== HA
+
+tag::sup-topo-ha[]
+You can use a variety of https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-switch.html[solutions to provide redundancy] for {connector-name}.
+Deploying redundant replica hosts makes it significantly easier to tolerate and almost immediately recover from problems and failures.
+Because most HA {connector-name} clusters use GTIDs, replicas are able to track all of the changes that occur on any primary server.
+end::sup-topo-ha[]
+
+=== Multi-primary
+
+tag::sup-topo-multi-primary[]
+link:https://dev.mysql.com/doc/refman/{mysql-version}/en/mysql-cluster-replication-multi-source.html[Network Database (NDB) cluster replication] uses one or more {connector-name} replica nodes that each replicate from multiple primary servers.
+Cluster replication provides a powerful way to aggregate the replication of multiple {connector-name} clusters.
+This topology requires the use of GTIDs.
+end::sup-topo-multi-primary[]
+
+
+=== Snapshots
+
+==== Snapshot default flows (global/table read locks): repeatable read semantics
+
+tag::snapshots-default-workflow-repeatable-read-semantics[]
+a|Start a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_. +
+end::snapshots-default-workflow-repeatable-read-semantics[]
+
+
+=== Change events
+
+==== Event values: create, update, and delete events
+
+// The value for the following region is intentionally null, because the content applies only to MariaDB
+
+tag::create-event-values-table-source-entry[]
+
+end::create-event-values-table-source-entry[]
+
+
+
+=== Mapping data types
+
+==== Basic types
+
+// The value for the following region is intentionally null, because the content applies only to MariaDB
+
+tag::basic-data-type-descriptions-float-m-d[]
+
+end::basic-data-type-descriptions-float-m-d[]
+
+
+==== Temporal types
+
+// The value for the following region is intentionally null, because the content applies only to MariaDB
+
+tag::temporal-data-type-timezone-conversions[]
+end::temporal-data-type-timezone-conversions[]
+
+
+=== Setting up the database
+
+
+==== Enabling the binlog
+
+tag::setting-up-the-db-enabling-binlog[]
+[source,SQL]
+----
+// for MySQL 5.x
+mysql> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+FROM information_schema.global_variables WHERE variable_name='log_bin';
+// for MySQL 8.x
+mysql> SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+FROM performance_schema.global_variables WHERE variable_name='log_bin';
+----
+end::setting-up-the-db-enabling-binlog[]
+
+
+
+
+==== Configuring session timeouts
+
+tag::session-timeout-options-descriptions[]
+For more information see the link:https://dev.mysql.com/doc/refman/{mysql-version}/en/server-system-variables.html#sysvar_interactive_timeout[MySQL documentation].
+|`wait_timeout`
+a|The number of seconds that the server waits for activity on a non-interactive connection before closing it.
+For more information, see the link:https://dev.mysql.com/doc/refman/{mysql-version}/en/server-system-variables.html#sysvar_interactive_timeout[MySQL documentation].
+end::session-timeout-options-descriptions[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -98,3 +98,25 @@ For more information see the link:https://dev.mysql.com/doc/refman/{mysql-versio
 a|The number of seconds that the server waits for activity on a non-interactive connection before closing it.
 For more information, see the link:https://dev.mysql.com/doc/refman/{mysql-version}/en/server-system-variables.html#sysvar_interactive_timeout[MySQL documentation].
 end::session-timeout-options-descriptions[]
+
+
+
+=== Configuration properties
+
+// Boolean value for MySQL/MariaDB `schema-history-cfg-store-only-captured-dbs-ddl` config property
+// Used in `ref-connector-configuration-database-history-properties.adoc`
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|`true`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+
+
+
+=== Behavior when things go wrong
+
+
+tag::kc-process-crash-gtid-in-change-event-msg[]
+* GTIDs, if used
+end::kc-process-crash-gtid-in-change-event-msg[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-oracle-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-oracle-props-snippets.adoc
@@ -1,0 +1,12 @@
+= Oracle snippets
+
+== Database history properties
+
+// Boolean value for Oracle `schema-history-cfg-store-only-captured-dbs-ddl` config property.
+// // Used in `ref-connector-configuration-database-history-properties.adoc`.
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|`false`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-sqlserver-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-sqlserver-props-snippets.adoc
@@ -1,0 +1,12 @@
+= SQL Server snippets
+
+== Database history properties
+
+// Boolean value for SQL Server `schema-history-cfg-store-only-captured-dbs-ddl` config property
+// Used in `ref-connector-configuration-database-history-properties.adoc`.
+// Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
+// Then include those files in the headers of each connector's main file.
+
+tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
+|`false`
+end::schema-hist-prop-store-only-cap-db-ddl-boolean[]


### PR DESCRIPTION
[DBZ-8254](https://issues.redhat.com/browse/DBZ-8254)

In DBZ-7786 we implemented content sharing between the MariaDB and MySQL connector documentation. One important goal of that original implementation was to preserve the few instances where content differed between the two connectors by assigning the conditional attributes, `MARIADB` and `MYSQL` to blocks that contained connector-specific content.
Unfortunately, while the conditionalization worked for the Antora-based content in the community documention, the distinctions were not preserved when content was processed for productization. 

This change refactors the previous conditionalization implementation by reusing the mechanism employed in DBZ-8090, creating shared snippet files to contain chunks of context-specific text within tagged regions. To insert the target content into a parent file, the file uses an `include` directive in which an attribute specifies the tag for a region. By setting up multiple files with names that are identical except for the connector `{context}` string, that is, `frag-{context}-props-snippets.adoc`, it's possible for a single include directive, such as `include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=schema-hist-prop-store-only-cap-db-ddl-boolean]` to fetch different versions of the content.         

Tested in local Antora and downstream builds.

This update leaves the community version of the documentation essentially unchanged, save for a few minor edits. But the product version now correctly renders content that is specific for MariaDB or MySQL. 

As I noted in the comments of the snippet files, in the long term, a cleaner implementation might be to assemble catalogs of  snippet values  for each connector,  and storing these values in connector-specific attribute files.
We could then use include statements in the headers of each connector file to make the snippet text available.
