### PR TITLE
DBZ-1252 Allow configuring the postgres snapshot isolation level

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -265,6 +265,77 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     /**
+     * The set of predefined snapshot isolation mode options.
+     */
+    public enum SnapshotIsolationMode implements EnumeratedValue {
+
+        /**
+         * This mode uses SERIALIZABLE isolation level.
+         */
+        SERIALIZABLE("serializable"),
+
+        /**
+         * This mode uses REPEATABLE READ isolation level.
+         */
+        REPEATABLE_READ("repeatable_read"),
+
+        /**
+         * This mode uses READ COMMITTED isolation level.
+         */
+        READ_COMMITTED("read_committed"),
+
+        /**
+         * This mode uses READ UNCOMMITTED isolation level.
+         */
+        READ_UNCOMMITTED("read_uncommitted");
+
+        private final String value;
+
+        SnapshotIsolationMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static SnapshotIsolationMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (SnapshotIsolationMode option : SnapshotIsolationMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value        the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static SnapshotIsolationMode parse(String value, String defaultValue) {
+            SnapshotIsolationMode mode = parse(value);
+            if (mode == null && defaultValue != null) {
+                mode = parse(defaultValue);
+            }
+            return mode;
+        }
+    }
+
+    /**
      * The set of predefined SecureConnectionMode options or aliases.
      */
     public enum SecureConnectionMode implements EnumeratedValue {
@@ -826,6 +897,22 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "'exported': This option is deprecated; use 'initial' instead.; "
                     + "'custom': The connector loads a custom class  to specify how the connector performs snapshots. For more information, see Custom snapshotter SPI in the PostgreSQL connector documentation.");
 
+    public static final Field SNAPSHOT_ISOLATION_MODE = Field.create("snapshot.isolation.mode")
+            .withDisplayName("Snapshot isolation mode")
+            .withEnum(SnapshotIsolationMode.class, SnapshotIsolationMode.SERIALIZABLE)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 1))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Controls which transaction isolation level is used. "
+                    + "The default is '" + SnapshotIsolationMode.SERIALIZABLE.getValue()
+                    + "', which means that serializable isolation level is used. "
+                    + "When '" + SnapshotIsolationMode.REPEATABLE_READ.getValue()
+                    + "' is specified, connector runs the initial snapshot in REPEATABLE READ isolation level. "
+                    + "When '" + SnapshotIsolationMode.READ_COMMITTED.getValue()
+                    + "' is specified, connector runs the initial snapshot in READ COMMITTED isolation level. "
+                    + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue()
+                    + "' is specified, connector runs the initial snapshot in READ UNCOMMITTED isolation level.");
+
     public static final Field SNAPSHOT_LOCKING_MODE = Field.create("snapshot.locking.mode")
             .withDisplayName("Snapshot locking mode")
             .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.NONE)
@@ -992,6 +1079,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     private final ReplicaIdentityMapper replicaIdentityMapper;
 
     private final SnapshotMode snapshotMode;
+    private final SnapshotIsolationMode snapshotIsolationMode;
     private final SnapshotLockingMode snapshotLockingMode;
     private final boolean readOnlyConnection;
 
@@ -1014,6 +1102,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         final var replicaIdentityMapping = config.getString(REPLICA_IDENTITY_AUTOSET_VALUES);
         this.replicaIdentityMapper = (replicaIdentityMapping != null) ? new ReplicaIdentityMapper(replicaIdentityMapping) : null;
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());
+        this.snapshotIsolationMode = SnapshotIsolationMode.parse(config.getString(SNAPSHOT_ISOLATION_MODE), SNAPSHOT_ISOLATION_MODE.defaultValueAsString());
         this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
         this.readOnlyConnection = config.getBoolean(READ_ONLY_CONNECTION);
     }
@@ -1128,6 +1217,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return this.snapshotMode;
     }
 
+    public SnapshotIsolationMode getSnapshotIsolationMode() {
+        return this.snapshotIsolationMode;
+    }
+
     @Override
     public Optional<SnapshotLockingMode> getSnapshotLockingMode() {
         return Optional.of(this.snapshotLockingMode);
@@ -1186,6 +1279,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     SOURCE_INFO_STRUCT_MAKER)
             .connector(
                     SNAPSHOT_MODE,
+                    SNAPSHOT_ISOLATION_MODE,
                     SNAPSHOT_QUERY_MODE,
                     SNAPSHOT_QUERY_MODE_CUSTOM_NAME,
                     SNAPSHOT_LOCKING_MODE_CUSTOM_NAME,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -285,23 +285,19 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             return "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; \n" + snapSet;
         }
 
+        final PostgresConnectorConfig.SnapshotIsolationMode isolationMode = connectorConfig.getSnapshotIsolationMode();
+        if (isolationMode == PostgresConnectorConfig.SnapshotIsolationMode.REPEATABLE_READ) {
+            return "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY;";
+        }
+        if (isolationMode == PostgresConnectorConfig.SnapshotIsolationMode.READ_COMMITTED) {
+            return "SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY;";
+        }
+        if (isolationMode == PostgresConnectorConfig.SnapshotIsolationMode.READ_UNCOMMITTED) {
+            return "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED, READ ONLY;";
+        }
         // DEFERRABLE only takes affect for READY ONLY and SERIALIZABLE
         // https://www.postgresql.org/docs/current/sql-set-transaction.html
-        String transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
-        switch (connectorConfig.getSnapshotIsolationMode()) {
-            case REPEATABLE_READ:
-                transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY;";
-                break;
-            case READ_COMMITTED:
-                transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY;";
-                break;
-            case READ_UNCOMMITTED:
-                transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED, READ ONLY;";
-                break;
-            default:
-                break;
-        }
-        return transactionIsolationLevelStatement;
+        return "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
     }
 
     /**

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ package io.debezium.connector.postgresql;
+
+ import static io.debezium.connector.postgresql.TestHelper.topicName;
+ import static org.assertj.core.api.Assertions.assertThat;
+ import static org.junit.Assert.assertNull;
+ 
+ import java.sql.SQLException;
+ import java.util.List;
+ 
+ import org.apache.kafka.connect.data.Schema;
+ import org.apache.kafka.connect.data.Struct;
+ import org.apache.kafka.connect.source.SourceRecord;
+ import org.junit.After;
+ import org.junit.Before;
+ import org.junit.BeforeClass;
+ import org.junit.Test;
+ 
+ import io.debezium.config.Configuration;
+ import io.debezium.data.SchemaAndValueField;
+ import io.debezium.embedded.AbstractConnectorTest;
+ 
+ /**
+  * Integration test for {@link io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE}
+  */
+ public class SnapshotIsolationIT extends AbstractConnectorTest {
+ 
+     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
+             "INSERT INTO s2.a (aa) VALUES (2);" +
+             "INSERT INTO s1.a (aa) VALUES (3);" +
+             "INSERT INTO s2.a (aa) VALUES (4);";
+     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+             "DROP SCHEMA IF EXISTS s2 CASCADE;" +
+             "CREATE SCHEMA s1; " +
+             "CREATE SCHEMA s2; " +
+             "CREATE TABLE s1.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);" +
+             "CREATE TABLE s2.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);";
+     private static final String SETUP_TABLES_STMT = CREATE_TABLES_STMT + INSERT_STMT;
+ 
+     @BeforeClass
+     public static void beforeClass() throws SQLException {
+         TestHelper.dropAllSchemas();
+     }
+ 
+     @Before
+     public void before() {
+         initializeConnectorTestFramework();
+     }
+ 
+     @After
+     public void after() {
+         stopConnector();
+         TestHelper.dropDefaultReplicationSlot();
+         TestHelper.dropPublication();
+     }
+ 
+     @Test
+     public void takeSnapshotInSerializableMode() throws Exception {
+         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.SERIALIZABLE);
+     }
+ 
+     @Test
+     public void takeSnapshotInRepeatableReadMode() throws Exception {
+         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.REPEATABLE_READ);
+     }
+ 
+     @Test
+     public void takeSnapshotInReadCommittedMode() throws Exception {
+         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_COMMITTED);
+     }
+ 
+     @Test
+     public void takeSnapshotInReadUncommittedMode() throws Exception {
+         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_UNCOMMITTED);
+     }
+ 
+     private void takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode lockingMode) throws Exception {
+         TestHelper.execute(SETUP_TABLES_STMT);
+ 
+         final Configuration config = TestHelper.defaultConfig()
+                 .with(PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())
+                 .build();
+ 
+         start(PostgresConnector.class, config);
+         assertConnectorIsRunning();
+ 
+         final SourceRecords records = consumeRecordsByTopic(4);
+ 
+         final List<SourceRecord> table1 = records.recordsForTopic(topicName("s1.a"));
+         assertThat(table1).hasSize(2);
+ 
+         final List<SourceRecord> table2 = records.recordsForTopic(topicName("s2.a"));
+         assertThat(table2).hasSize(2);
+ 
+         final List<SourceRecord> tables = List.of(
+                 table1.get(0),
+                 table2.get(0),
+                 table1.get(1),
+                 table2.get(1));
+ 
+         for (int i = 0; i < 4; i++) {
+             final SourceRecord record1 = tables.get(i);
+ 
+             final List<SchemaAndValueField> expectedKey1 = List.of(
+                     new SchemaAndValueField("pk", Schema.INT32_SCHEMA, i / 2 + 1));
+             final List<SchemaAndValueField> expectedRow1 = List.of(
+                     new SchemaAndValueField("pk", Schema.INT32_SCHEMA, i / 2 + 1),
+                     new SchemaAndValueField("aa", Schema.OPTIONAL_INT32_SCHEMA, i + 1));
+ 
+             final Struct key1 = (Struct) record1.key();
+             final Struct value1 = (Struct) record1.value();
+             assertRecord(key1, expectedKey1);
+             assertRecord((Struct) value1.get("after"), expectedRow1);
+             assertThat(record1.sourceOffset())
+                     .extracting("snapshot").containsExactly(true);
+             assertThat(record1.sourceOffset())
+                     .extracting("snapshot_completed").containsExactly(i == 4 - 1);
+             assertNull(value1.get("before"));
+         }
+     }
+ 
+     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
+         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
+     }
+ }
+ 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
@@ -131,4 +131,3 @@ public class SnapshotIsolationIT extends AbstractConnectorTest {
         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
     }
 }
- 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
@@ -4,128 +4,131 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
- package io.debezium.connector.postgresql;
+package io.debezium.connector.postgresql;
 
- import static io.debezium.connector.postgresql.TestHelper.topicName;
- import static org.assertj.core.api.Assertions.assertThat;
- import static org.junit.Assert.assertNull;
- 
- import java.sql.SQLException;
- import java.util.List;
- 
- import org.apache.kafka.connect.data.Schema;
- import org.apache.kafka.connect.data.Struct;
- import org.apache.kafka.connect.source.SourceRecord;
- import org.junit.After;
- import org.junit.Before;
- import org.junit.BeforeClass;
- import org.junit.Test;
- 
- import io.debezium.config.Configuration;
- import io.debezium.data.SchemaAndValueField;
- import io.debezium.embedded.AbstractConnectorTest;
- 
- /**
-  * Integration test for {@link io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE}
-  */
- public class SnapshotIsolationIT extends AbstractConnectorTest {
- 
-     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
-             "INSERT INTO s2.a (aa) VALUES (2);" +
-             "INSERT INTO s1.a (aa) VALUES (3);" +
-             "INSERT INTO s2.a (aa) VALUES (4);";
-     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
-             "DROP SCHEMA IF EXISTS s2 CASCADE;" +
-             "CREATE SCHEMA s1; " +
-             "CREATE SCHEMA s2; " +
-             "CREATE TABLE s1.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);" +
-             "CREATE TABLE s2.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);";
-     private static final String SETUP_TABLES_STMT = CREATE_TABLES_STMT + INSERT_STMT;
- 
-     @BeforeClass
-     public static void beforeClass() throws SQLException {
-         TestHelper.dropAllSchemas();
-     }
- 
-     @Before
-     public void before() {
-         initializeConnectorTestFramework();
-     }
- 
-     @After
-     public void after() {
-         stopConnector();
-         TestHelper.dropDefaultReplicationSlot();
-         TestHelper.dropPublication();
-     }
- 
-     @Test
-     public void takeSnapshotInSerializableMode() throws Exception {
-         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.SERIALIZABLE);
-     }
- 
-     @Test
-     public void takeSnapshotInRepeatableReadMode() throws Exception {
-         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.REPEATABLE_READ);
-     }
- 
-     @Test
-     public void takeSnapshotInReadCommittedMode() throws Exception {
-         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_COMMITTED);
-     }
- 
-     @Test
-     public void takeSnapshotInReadUncommittedMode() throws Exception {
-         takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_UNCOMMITTED);
-     }
- 
-     private void takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode lockingMode) throws Exception {
-         TestHelper.execute(SETUP_TABLES_STMT);
- 
-         final Configuration config = TestHelper.defaultConfig()
-                 .with(PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())
-                 .build();
- 
-         start(PostgresConnector.class, config);
-         assertConnectorIsRunning();
- 
-         final SourceRecords records = consumeRecordsByTopic(4);
- 
-         final List<SourceRecord> table1 = records.recordsForTopic(topicName("s1.a"));
-         assertThat(table1).hasSize(2);
- 
-         final List<SourceRecord> table2 = records.recordsForTopic(topicName("s2.a"));
-         assertThat(table2).hasSize(2);
- 
-         final List<SourceRecord> tables = List.of(
-                 table1.get(0),
-                 table2.get(0),
-                 table1.get(1),
-                 table2.get(1));
- 
-         for (int i = 0; i < 4; i++) {
-             final SourceRecord record1 = tables.get(i);
- 
-             final List<SchemaAndValueField> expectedKey1 = List.of(
-                     new SchemaAndValueField("pk", Schema.INT32_SCHEMA, i / 2 + 1));
-             final List<SchemaAndValueField> expectedRow1 = List.of(
-                     new SchemaAndValueField("pk", Schema.INT32_SCHEMA, i / 2 + 1),
-                     new SchemaAndValueField("aa", Schema.OPTIONAL_INT32_SCHEMA, i + 1));
- 
-             final Struct key1 = (Struct) record1.key();
-             final Struct value1 = (Struct) record1.value();
-             assertRecord(key1, expectedKey1);
-             assertRecord((Struct) value1.get("after"), expectedRow1);
-             assertThat(record1.sourceOffset())
-                     .extracting("snapshot").containsExactly(true);
-             assertThat(record1.sourceOffset())
-                     .extracting("snapshot_completed").containsExactly(i == 4 - 1);
-             assertNull(value1.get("before"));
-         }
-     }
- 
-     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
-         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
-     }
- }
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.data.SchemaAndValueField;
+import io.debezium.embedded.AbstractConnectorTest;
+
+/**
+ * Integration test for {@link io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE}
+ */
+public class SnapshotIsolationIT extends AbstractConnectorTest {
+
+    private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
+            "INSERT INTO s2.a (aa) VALUES (2);" +
+            "INSERT INTO s1.a (aa) VALUES (3);" +
+            "INSERT INTO s2.a (aa) VALUES (4);";
+    private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+            "DROP SCHEMA IF EXISTS s2 CASCADE;" +
+            "CREATE SCHEMA s1; " +
+            "CREATE SCHEMA s2; " +
+            "CREATE TABLE s1.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);" +
+            "CREATE TABLE s2.a (pk SERIAL NOT NULL PRIMARY KEY, aa integer);";
+    private static final String SETUP_TABLES_STMT = CREATE_TABLES_STMT + INSERT_STMT;
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        TestHelper.dropAllSchemas();
+    }
+
+    @Before
+    public void before() {
+        initializeConnectorTestFramework();
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Test
+    public void takeSnapshotInSerializableMode() throws Exception {
+        takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.SERIALIZABLE);
+    }
+
+    @Test
+    public void takeSnapshotInRepeatableReadMode() throws Exception {
+        takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.REPEATABLE_READ);
+    }
+
+    @Test
+    public void takeSnapshotInReadCommittedMode() throws Exception {
+        takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_COMMITTED);
+    }
+
+    @Test
+    public void takeSnapshotInReadUncommittedMode() throws Exception {
+        takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode.READ_UNCOMMITTED);
+    }
+
+    private void takeSnapshot(PostgresConnectorConfig.SnapshotIsolationMode lockingMode) throws Exception {
+        TestHelper.execute(SETUP_TABLES_STMT);
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+
+        final SourceRecords records = consumeRecordsByTopic(4);
+
+        final List<SourceRecord> table1 = records.recordsForTopic(topicName("s1.a"));
+        assertThat(table1).hasSize(2);
+
+        final List<SourceRecord> table2 = records.recordsForTopic(topicName("s2.a"));
+        assertThat(table2).hasSize(2);
+
+        final List<SourceRecord> tables = List.of(
+                table1.get(0),
+                table2.get(0),
+                table1.get(1),
+                table2.get(1));
+
+        final Schema pkSchema = SchemaBuilder.int32().defaultValue(0).build();
+
+        for (int i = 0; i < 4; i++) {
+            final SourceRecord record1 = tables.get(i);
+
+            final List<SchemaAndValueField> expectedKey1 = List.of(
+                    new SchemaAndValueField("pk", pkSchema, i / 2 + 1));
+            final List<SchemaAndValueField> expectedRow1 = List.of(
+                    new SchemaAndValueField("pk", pkSchema, i / 2 + 1),
+                    new SchemaAndValueField("aa", Schema.OPTIONAL_INT32_SCHEMA, i + 1));
+
+            final Struct key1 = (Struct) record1.key();
+            final Struct value1 = (Struct) record1.value();
+            assertRecord(key1, expectedKey1);
+            assertRecord((Struct) value1.get("after"), expectedRow1);
+            assertThat(record1.sourceOffset())
+                    .extracting("snapshot").containsExactly(true);
+            assertThat(record1.sourceOffset())
+                    .extracting("snapshot_completed").containsExactly(i == 4 - 1);
+            assertNull(value1.get("before"));
+        }
+    }
+
+    private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
+        expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
+    }
+}
  

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotIsolationIT.java
@@ -122,7 +122,7 @@ public class SnapshotIsolationIT extends AbstractConnectorTest {
             assertThat(record1.sourceOffset())
                     .extracting("snapshot").containsExactly(true);
             assertThat(record1.sourceOffset())
-                    .extracting("snapshot_completed").containsExactly(i == 4 - 1);
+                    .extracting("last_snapshot_record").containsExactly(i == 4 - 1);
             assertNull(value1.get("before"));
         }
     }


### PR DESCRIPTION
This change allows users to define the desired transaction isolation for the postgres snapshot.

This will allow for running the initial snapshot with a reader instance that doesn't support SERIALIZABLE.