### PR TITLE
DBZ-8249 Adds caution about setting MySQL snapshot.fetch.size to 2.7 branch

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -50,6 +50,7 @@ If you later decide to capture changes from tables that you did not originally d
 If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
+|
 include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=schema-hist-prop-store-only-cap-db-ddl-boolean]
 |A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance. +
 Specify one of the following values:

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -371,14 +371,12 @@ An interval in milliseconds that the connector should wait before performing a s
 
 [id="{context}-property-snapshot-fetch-size"]
 xref:{context}-property-snapshot-fetch-size[`snapshot.fetch.size`]::
-Default value: No default +
-During a snapshot, the connector reads table content in batches of rows.
-This property specifies the maximum number of rows in a batch.
+Default value: Unset +
+By default, during a snapshot, the connector reads table content in batches of rows.
+Set this property to specify the maximum number of rows in a batch.
 
-[CAUTION]
-====
-Changing the default value can impair performance.
-====
+include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=snapshot-fetch-size-note]
+
 
 [id="{context}-property-snapshot-include-collection-list"]
 xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`]::

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-db2-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-db2-props-snippets.adoc
@@ -8,6 +8,5 @@
 // Then include those files in the headers of each connector's main file.
 
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|
 `false`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-informix-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-informix-props-snippets.adoc
@@ -8,6 +8,5 @@
 // Then include those files in the headers of each connector's main file.
 
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|
 `false`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
@@ -104,7 +104,6 @@ end::session-timeout-options-descriptions[]
 // Then include those files in the headers of each connector's main file.
 
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|
 `true`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mariadb-props-snippets.adoc
@@ -103,11 +103,17 @@ end::session-timeout-options-descriptions[]
 // Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
 // Then include those files in the headers of each connector's main file.
 
+==== schema.history.config-store.only.captured.database.ddl
+
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 `true`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 
 
+==== Advanced props snapshot.fetch.size
+
+tag::snapshot-fetch-size-note[]
+end::snapshot-fetch-size-note[]
 
 === Behavior when things go wrong
 

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -108,8 +108,10 @@ end::session-timeout-options-descriptions[]
 // Long term, for each connector, we could create a catalog of these snippet values and store them in connector-specific attribute files.
 // Then include those files in the headers of each connector's main file.
 
+==== schema.history.internal.store.only.captured.databases.ddl
+
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|`true`
+`true`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -119,9 +119,9 @@ end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 tag::snapshot-fetch-size-note[]
 [CAUTION]
 ====
-To maintain connector performance, it's best to leave this property at its unset default.
-The default configuration enables MySQL to stream the result set to {prodname} one row at a time.
-By contrast, if you set this property performance problems can result, because {prodname} attempts to fetch the entire result set into memory at once.
+To maintain connector performance, it's best to preserve the unset default of this property.
+This default configuration enables MySQL to stream the result set to {prodname} one row at a time.
+By contrast, if you set this property, performance problems can result, because {prodname} attempts to fetch the entire result set into memory at once.
 ====
 end::snapshot-fetch-size-note[]
 

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -114,7 +114,16 @@ tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 `true`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]
 
+==== Advanced props snapshot.fetch.size
 
+tag::snapshot-fetch-size-note[]
+[CAUTION]
+====
+To maintain connector performance, it's best to leave this property at its unset default.
+The default configuration enables MySQL to stream the result set to {prodname} one row at a time.
+By contrast, if you set this property performance problems can result, because {prodname} attempts to fetch the entire result set into memory at once.
+====
+end::snapshot-fetch-size-note[]
 
 === Behavior when things go wrong
 

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-oracle-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-oracle-props-snippets.adoc
@@ -8,5 +8,5 @@
 // Then include those files in the headers of each connector's main file.
 
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|`false`
+`false`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-sqlserver-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-sqlserver-props-snippets.adoc
@@ -8,5 +8,5 @@
 // Then include those files in the headers of each connector's main file.
 
 tag::schema-hist-prop-store-only-cap-db-ddl-boolean[]
-|`false`
+`false`
 end::schema-hist-prop-store-only-cap-db-ddl-boolean[]


### PR DESCRIPTION
[DBZ-8249](https://issues.redhat.com/browse/DBZ-8249)

Cherry-picked from `main` (#5887)
