### PR TITLE
DBZ-8279 Edit & conditionalize architecture.adoc text for DBZ Server DP

### DIFF
--- a/documentation/modules/ROOT/pages/architecture.adoc
+++ b/documentation/modules/ROOT/pages/architecture.adoc
@@ -38,7 +38,7 @@ If needed, you can adjust the destination topic name by configuring {prodname}'s
 After change event records are in Apache Kafka, different connectors in the Kafka Connect ecosystem can stream the records to other systems and databases such as Elasticsearch, data warehouses and analytics systems, or caches such as Infinispan.
 Depending on the chosen sink connector, you might need to configure the {prodname} {link-prefix}:{link-event-flattening}#new-record-state-extraction[new record state extraction] transformation.
 This Kafka Connect SMT propagates the `after` structure from a {prodname} change event to the sink connector.
-This is in place of the verbose change event record that is propagated by default.
+The modified change event record replaces the original, more verbose record that is propagated by default.
 
 == {prodname} Server
 

--- a/documentation/modules/ROOT/pages/architecture.adoc
+++ b/documentation/modules/ROOT/pages/architecture.adoc
@@ -35,21 +35,45 @@ If needed, you can adjust the destination topic name by configuring {prodname}'s
 * Route records to a topic whose name is different from the table's name
 * Stream change event records for multiple tables into a single topic
 
-After change event records are in Apache Kafka, different connectors in the Kafka Connect eco-system can stream the records to other systems and databases such as Elasticsearch, data warehouses and analytics systems, or caches such as Infinispan.
-Depending on the chosen sink connector, you might need to configure {prodname}'s {link-prefix}:{link-event-flattening}#new-record-state-extraction[new record state extraction] transformation. This Kafka Connect SMT propagates the `after` structure from {prodname}'s change event to the sink connector. This is in place of the verbose change event record that is propagated by default.
+After change event records are in Apache Kafka, different connectors in the Kafka Connect ecosystem can stream the records to other systems and databases such as Elasticsearch, data warehouses and analytics systems, or caches such as Infinispan.
+Depending on the chosen sink connector, you might need to configure the {prodname} {link-prefix}:{link-event-flattening}#new-record-state-extraction[new record state extraction] transformation.
+This Kafka Connect SMT propagates the `after` structure from a {prodname} change event to the sink connector.
+This is in place of the verbose change event record that is propagated by default.
 
-ifdef::community[]
 == {prodname} Server
 
-Another way to deploy {prodname} is using the xref:operations/debezium-server.adoc[{prodname} server].
+ifdef::product[]
+You can also deploy {prodname} by using the xref:debezium-server[{prodname} Server].
+endif::product[]
+ifdef::community[]
+Another way to deploy {prodname} is by using the xref:operations/debezium-server.adoc[{prodname} server].
+endif::community[]
 The {prodname} server is a configurable, ready-to-use application that streams change events from a source database to a variety of messaging infrastructures.
+ifdef::product[]
+[IMPORTANT]
+====
+{prodname} Server is Developer Preview software only.
+Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready.
+Do not use Developer Preview software for production or business-critical workloads.
+Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering.
+Customers can use this software to test functionality and provide feedback during the development process.
+This software might not have any documentation, is subject to change or removal at any time, and has received limited testing.
+Red{nbsp}Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
 
-The following image shows the architecture of a change data capture pipeline that uses the {prodname} server:
+For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+====
+endif::product[]
+The following image shows the architecture of a change data capture pipeline that uses the {prodname} Server:
 
 image::debezium-server-architecture.png[{prodname} Architecture]
 
-The {prodname} server is configured to use one of the {prodname} source connectors to capture changes from the source database.
-Change events can be serialized to different formats like JSON or Apache Avro and then will be sent to one of a variety of messaging infrastructures such as Amazon Kinesis, Google Cloud Pub/Sub, or Apache Pulsar.
+You can configure {prodname} server to use one of the {prodname} source connectors to capture changes from a source database.
+Change events can be serialized to different formats like JSON or Apache Avro and then will be sent to one of a variety of messaging infrastructures such as
+ifdef::product[]
+Apache Kafka or Redis Streams.
+endif::product[]
+ifdef::community[]
+Amazon Kinesis, Google Cloud Pub/Sub, or Apache Pulsar.
 
 == Debezium Engine
 


### PR DESCRIPTION
[DBZ-8279](https://issues.redhat.com/browse/DBZ-8279)

To support the downstream DP release of Debezium Server, this change conditionalizes text in the architecture topic of the documentation to expose references to the component and to adjust content based on the release context. I also made a few other minor edits, such as removing the use of the possessive when referring to Debezium artifacts. 

Tested in local Antora and downstream releases.
The changes are evident only in the productized version of the documentation; no changes are visible in the community edition. 