### PR TITLE
DBZ-8247 Truncate record ruins work in JDBC

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -638,3 +638,4 @@ Gaurav Miglani
 张展业
 Ashish Binu
 Mohamed El Shaer
+Artyom Dubinin

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -119,6 +119,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 catch (SQLException e) {
                     throw new ConnectException("Failed to process a sink record", e);
                 }
+                continue;
             }
 
             if (sinkRecordDescriptor.isDelete()) {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -283,3 +283,4 @@ shaer,Mohamed El Shaer
 SylvainMarty,Sylvain Marty
 m8719-github,Andrei Leibovski
 cwholmes,Cody Holmes
+ArtDu,Artyom Dubinin


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8247

Problem happens when evaluation of truncate record doesn't stops on truncating and go on with trying to use this record for update event also.