### PR TITLE
[ci] Allow contributor check to pass when details are included in pull request

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -13,23 +13,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Checkout so that this contributor check passes if the contributor details are part of the pull request
+      # If we don't do this, then we are only
+      - name: Checkout Action
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Check if COPYRIGHT.txt has author name?
         id: check
         env:
           pull_request_number: ${{ github.event.pull_request.number }}
-        run: |
-          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/COPYRIGHT.txt >> COPYRIGHT.txt
-          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/jenkins-jobs/scripts/config/Aliases.txt >> ALIASES.txt
-          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/jenkins-jobs/scripts/config/FilteredNames.txt >> FILTEREDNAMES.txt
+        run: |        
+          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/COPYRIGHT.txt >> COPYRIGHT_MAIN.txt
+          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/jenkins-jobs/scripts/config/Aliases.txt >> ALIASES_MAIN.txt
+          curl -H 'Accept: application/vnd.github.v3.raw' https://raw.githubusercontent.com/debezium/debezium/main/jenkins-jobs/scripts/config/FilteredNames.txt >> FILTEREDNAMES_MAIN.txt
+          cat COPYRIGHT.txt COPYRIGHT_MAIN.txt | sort -u > COPYRIGHT_CHECK.txt
+          cat ALIASES_MAIN.txt jenkins-jobs/scripts/config/Aliases.txt | sort -u > ALIASES_CHECK.txt
+          cat FILTEREDNAMES_MAIN.txt jenkins-jobs/scripts/config/FilteredNames.txt | sort -u > FILTEREDNAMES_CHECK.txt
 
           curl --silent -X "GET" https://api.github.com/repos/debezium/debezium/pulls/$pull_request_number/commits | jq '.[] | {author: .commit.author.name}' | jq -r '.author' | uniq >> AUTHOR_NAME.txt
 
           while IFS=" " read -r AUTHOR;
           do
-            if ! grep -qi "$AUTHOR" COPYRIGHT.txt; then
-              if ! grep -qi "$AUTHOR" ALIASES.txt; then
-                if ! grep -qi "$AUTHOR" FILTEREDNAMES.txt; then
-                  echo "USER_NOT_FOUND=true" >> $GITHUB_OUTPUT
+            if ! grep -qi "$AUTHOR" COPYRIGHT_CHECK.txt; then
+              if ! grep -qi "$AUTHOR" ALIASES_CHECK.txt; then
+                if ! grep -qi "$AUTHOR" FILTEREDNAMES_CHECK.txt; then
+                  echo "USER_NOT_FOUND=true"
                 fi
               fi
             fi


### PR DESCRIPTION
If the PR included the contributor details, the contributor check would always fail due to the check only fetching the details from the `main` branch. This change will now take the contents from `main` and append any differences in this PR before performing the check, so it should pass.