### PR TITLE
Dbz 8293 formatting chars render literally in docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -245,8 +245,8 @@ After the snapshot completes, the connector stops, and does not stream event rec
 |`recovery`
 |Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.
-You can also set the property to periodically prune a database schema history topic that experiences unexpected growth. +
-+
+You can also set the property to periodically prune a database schema history topic that experiences unexpected growth.
+
 WARNING: Do not use this mode to perform a snapshot if schema changes were committed to the database after the last connector shutdown.
 
 |`when_needed`

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1059,8 +1059,8 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 |3
 |`before`
 |Contains the JSON string representation of the actual MongoDB document before change.
-+
-An _update_ event value does not contain an `before` field if the capture mode is not set to one of the `*_with_preimage` options.
+
+An _update_ event value does not contain a `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
 |4
 |`after`
@@ -1147,8 +1147,8 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 |3
 |`before`
 |Contains the JSON string representation of the actual MongoDB document before change.
-+
-An _update_ event value does not contain an `before` field if the capture mode is not set to one of the `*_with_preimage` options.
+
+An _update_ event value does not contain a `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
 |4
 |`source`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3472,14 +3472,14 @@ endif::community[]
 
 |[[postgresql-property-snapshot-locking-mode]]<<postgresql-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |`none`
-|Specifies how the connector holds locks on tables while performing a schema snapshot: +
+|Specifies how the connector holds locks on tables while performing a schema snapshot. +
 Set one of the following options:
- +
+
 `shared`:: The connector holds a table lock that prevents exclusive table access during the initial portion phase of the snapshot in which database schemas and other metadata are read.
 After the initial phase, the snapshot no longer requires table locks.
- +
-`none`:: The connector avoids locks entirely. +
-+
+
+`none`:: The connector avoids locks entirely.
+
 [WARNING]
 ====
 Do not use this mode if schema changes might occur during the snapshot.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1009,7 +1009,7 @@ The value of a change event for an update in the sample `customers` table has th
 |1
 |`before`
 |An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
-+
+
 For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
 |2

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3074,11 +3074,11 @@ Disabled by default.
 |[[sqlserver-property-heartbeat-action-query]]<<sqlserver-property-heartbeat-action-query, `+heartbeat.action.query+`>>
 |No default
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
-+
+ +
 This is useful for keeping offsets from becoming stale when capturing changes from a low-traffic database. Create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
-+
+ +
 `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')` +
-+
+ +
 This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents offsets from become stale.
 
 |[[sqlserver-property-snapshot-delay-ms]]<<sqlserver-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>

--- a/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
@@ -127,15 +127,19 @@ The following table lists the configuration options that you can set for the Res
 |[[reselect-columns-post-processor-property-reselect-columns-include-list]]<<reselect-columns-post-processor-property-reselect-columns-include-list, `+reselect.columns.include.list+`>>
 |No default
 |Comma-separated list of column names to reselect from the source database.
-Use the following format to specify column names: + `_<schema>_._<table>_:_<column>_`  +
- +
+Use the following format to specify column names: +
+
+`__<schema>__.__<table>__:__<column>__`
+
 Do not set this property if you set the `reselect.columns.exclude.list` property.
 
 |[[reselect-columns-post-processor-property-reselect-columns-exclude-list]]<<reselect-columns-post-processor-property-reselect-columns-exclude-list, `+reselect.columns.exclude.list+`>>
 |No default
 |Comma-separated list of column names in the source database to exclude from reselection.
-Use the following format to specify column names: + `_<schema>_._<table>_:_<column>_` +
- +
+Use the following format to specify column names: +
+
+`__<schema>__.__<table>__:__<column>__`
+
 Do not set this property if you set the `reselect.columns.include.list` property.
 
 |[[reselect-columns-post-processor-property-reselect-unavailable-values]]<<reselect-columns-post-processor-property-reselect-unavailable-values, `+reselect.unavailable.values+`>>

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -421,17 +421,20 @@ For an example, see the xref:mongodb-outbox-route-by-field-example[description o
 |[[mongodb-outbox-event-router-property-route-topic-regex]]<<mongodb-outbox-event-router-property-route-topic-regex, `route.topic.regex`>>
 |`(?<routedByValue>.*)`
 |Router
-|Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox collection documents. This regular expression is part of the setting of the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
-+
-The default behavior is that the SMT replaces the default `pass:[${routedByValue}]` variable in the setting of the `route.topic.replacement` SMT option with the setting of the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] outbox SMT option.
+|Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox collection documents.
+This regular expression is part of the setting of the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
+ +
+When this property is set to the default `Router` value, the SMT replaces the default `pass:[${routedByValue}]` variable that is set in the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] property with the value that is specified for the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] property.
 
 |[[mongodb-outbox-event-router-property-route-topic-replacement]]<<mongodb-outbox-event-router-property-route-topic-replacement, `route.topic.replacement`>>
 |`outbox.event{zwsp}.pass:[${routedByValue}]`
 |Router
 a|Specifies the name of the topic to which the connector emits outbox messages.
-The default topic name is `outbox.event.` followed by the `aggregatetype` field value in the outbox collection document. For example, if the `aggregatetype` value is `customers`, the topic name is `outbox.event.customers`. +
-+
-To change the topic name, you can: +
+The default topic name is prefixed by the string `outbox.event.`, followed by the value of the `aggregatetype` field that is assigned to the outbox collection document. +
+ +
+For example, if the `aggregatetype` value is `customers`, then connector emits outbox messages to the topic `outbox.event.customers`. +
+ +
+To change the default name of the destination topic, perform one of the following actions:
 
 * Set the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] option to a different field.
 * Set the xref:mongodb-outbox-event-router-property-route-topic-regex[`route.topic.regex`] option to a different regular expression.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -27,9 +27,8 @@ INSERT INTO _<signalTable>_ (id, type, data) values (_'<id>'_, 'stop-snapshot', 
 For example,
 +
 include::{snippetsdir}/{context}-frag-signaling-fq-table-formats.adoc[leveloffset=+1,tags=stopping-incremental-snapshot-example]
-+
-The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
-+
+
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}]. +
 The following table describes the parameters in the example:
 +
 .Descriptions of fields in a SQL command for sending a stop incremental snapshot signal to the signaling {data-collection}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -33,9 +33,8 @@ INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'
 For example,
 +
 include::{snippetsdir}/{context}-frag-signaling-fq-table-formats.adoc[leveloffset=+1,tags=snapshot-signal-example]
-+
-The values of the `id`,`type`, and `data` parameters in the command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
-+
+
+The values of the `id`,`type`, and `data` parameters in the command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}]. +
 The following table describes the parameters in the example:
 +
 .Descriptions of fields in a SQL command for sending an incremental snapshot signal to the signaling {data-collection}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -14,6 +14,7 @@ The `data-collections` array for an incremental snapshot signal has no default v
 If the `data-collections` array is empty, {prodname} interprets the empty array to mean that no action is required, and it does not perform a snapshot.
 
 include::{snippetsdir}/{context}-frag-signaling-fq-table-formats.adoc[leveloffset=+1,tags=fq-table-name-format-note]
+
 .Prerequisites
 
 * {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled]. +

--- a/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
@@ -100,6 +100,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO myschema.debezium_signal (id, type, data) // <1>
@@ -108,6 +109,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["schema1.table1", "schema1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
@@ -21,6 +21,7 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO myschema.debezium_signal (id, type, data) // <1>
@@ -30,6 +31,8 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "schema1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
@@ -101,6 +101,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.debezium_signal (id, type, data) // <1>
@@ -109,6 +110,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["db1.table1", "db1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 === Stopping an incremental snapshot using the Kafka signaling channel

--- a/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
@@ -22,6 +22,7 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.debezium_signal (id, type, data) // <1>
@@ -31,6 +32,8 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "db1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
@@ -100,6 +100,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.debezium_signal (id, type, data) // <1>
@@ -108,6 +109,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["db1.table1", "db1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 === Stopping an incremental snapshot using the Kafka signaling channel

--- a/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
@@ -21,6 +21,7 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.debezium_signal (id, type, data) // <1>
@@ -30,6 +31,8 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "db1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
@@ -21,6 +21,7 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.myschema.debezium_signal (id, type, data) // <1>
@@ -30,6 +31,8 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "db1.schema1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
@@ -100,6 +100,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.myschema.debezium_signal (id, type, data) // <1>
@@ -108,6 +109,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["db1.schema1.table1", "db1.schema1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
@@ -100,6 +100,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO myschema.debezium_signal (id, type, data) // <1>
@@ -108,6 +109,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["schema1.table1", "schema1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
@@ -22,6 +22,7 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO myschema.debezium_signal (id, type, data) // <1>
@@ -31,6 +32,8 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "schema1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
@@ -22,8 +22,8 @@ end::fq-table-name-format-note[]
 // Example in Step 1 of procedure
 
 tag::snapshot-signal-example[]
-[source,sql,indent=0,subs="+attributes"]
 ====
+[source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.myschema.debezium_signal (id, type, data) // <1>
 values ('ad-hoc-1',   // <2>
@@ -33,6 +33,7 @@ values ('ad-hoc-1',   // <2>
     "additional-conditions":[{"data-collection": "db1.schema1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
 ====
++
 end::snapshot-signal-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
@@ -101,6 +101,7 @@ end::triggering-incremental-snapshot-kafka-multi-addtl-cond-example[]
 === Stopping an incremental snapshot
 
 tag::stopping-incremental-snapshot-example[]
+====
 [source,sql,indent=0,subs="+attributes"]
 ----
 INSERT INTO db1.myschema.debezium_signal (id, type, data) // <1>
@@ -109,6 +110,8 @@ values ('ad-hoc-1',   // <2>
     '{"data-collections": ["db1.schema1.table1", "db1.schema1.table2"], // <4>
     "type":"incremental"}'); // <5>
 ----
+====
++
 end::stopping-incremental-snapshot-example[]
 
 

--- a/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
@@ -23,6 +23,7 @@ end::fq-table-name-format-note[]
 
 tag::snapshot-signal-example[]
 [source,sql,indent=0,subs="+attributes"]
+====
 ----
 INSERT INTO db1.myschema.debezium_signal (id, type, data) // <1>
 values ('ad-hoc-1',   // <2>
@@ -31,6 +32,7 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental", // <5>
     "additional-conditions":[{"data-collection": "db1.schema1.table1" ,"filter":"color=\'blue\'"}]}'); // <6>
 ----
+====
 end::snapshot-signal-example[]
 
 


### PR DESCRIPTION
[DBZ-8293](https://issues.redhat.com/browse/DBZ-8293)

Fixes formatting errors that caused in list continuation characters and other formatting artifacts to render in the built documentation.

Tested in local Antora and downstream builds.

Please backport to 2.7.