### PR TITLE
DBZ-8303 Fix race condition in stop snapshot

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -146,8 +146,8 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     }
 
     @Override
-    public void stopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds) {
-        super.stopSnapshot(partition, offsetContext, additionalData, dataCollectionIds);
+    public void requestStopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds) {
+        super.requestStopSnapshot(partition, offsetContext, additionalData, dataCollectionIds);
         getContext().setSignalOffset((Long) additionalData.get(KafkaSignalChannel.CHANNEL_OFFSET));
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mongodb;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -111,5 +112,9 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
     @Override
     public boolean isHistorized() {
         return false;
+    }
+
+    public Set<CollectionId> collections() {
+        return collections.keySet();
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
@@ -612,7 +612,7 @@ public class IncrementalSnapshotIT extends AbstractMongoConnectorIT {
         // Consume any residual left-over events after stopping incremental snapshots such as open/close
         // and wait for the stop message in the connector logs
         assertThat(consumeAnyRemainingIncrementalSnapshotEventsAndCheckForStopMessage(
-                interceptor, "Stopping incremental snapshot")).isTrue();
+                interceptor, "Removed collections from incremental snapshot: ")).isTrue();
 
         // stop the connector
         stopConnector((r) -> interceptor.clear());

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/StopSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/StopSnapshot.java
@@ -49,7 +49,7 @@ public class StopSnapshot<P extends Partition> extends AbstractSnapshotSignal<P>
         switch (type) {
             case INCREMENTAL:
                 dispatcher.getIncrementalSnapshotChangeEventSource()
-                        .stopSnapshot(signalPayload.partition, signalPayload.offsetContext, signalPayload.additionalData, dataCollections);
+                        .requestStopSnapshot(signalPayload.partition, signalPayload.offsetContext, signalPayload.additionalData, dataCollections);
                 break;
         }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -36,7 +36,7 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
     void addDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration)
             throws InterruptedException;
 
-    void stopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds);
+    void requestStopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds);
 
     default void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -65,7 +65,7 @@ public interface IncrementalSnapshotContext<T> {
 
     void setSchemaVerificationPassed(boolean schemaVerificationPassed);
 
-    void stopSnapshot();
+    void requestSnapshotStop(List<String> dataCollectionIds);
 
     boolean removeDataCollectionFromSnapshot(String dataCollectionId);
 
@@ -74,5 +74,7 @@ public interface IncrementalSnapshotContext<T> {
     void unsetCorrelationId();
 
     String getCorrelationId();
+
+    List<String> getDataCollectionsToStop();
 
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/DBZ-8303
[Conversation](https://groups.google.com/g/debezium/c/4Ir18BzYTiE/m/PeEzHa_cAQAJ)

### Problem: 

The `AbstractIncrementalSnapshotContext` is accessed by two threads—the main binlog thread and the `SignalProcessor` thread. A race condition occurs when the `SignalProcessor` thread calls `stopSnapshot()` while the main thread is executing `readChunk()`. This can lead to inconsistencies, causing exceptions during snapshot processing.

### Solution:

- Instead of immediately modifying the snapshot state in `stopSnapshot()`, a queue (`dataCollectionsToStop`, a `LinkedBlockingQueue<String>`) is used to manage the list of collections to stop. This queue can contain collection names or regex patterns. ".*" is used to stop all collections' snapshots.
- The method `stopSnapshot()` has been renamed to `requestSnapshotStop()` to reflect that it only queues the collections for stopping, rather than stopping the snapshot immediately.
- The `readChunk()` method has been updated to check the queue (`dataCollectionsToStop`) for any collections that should be stopped using a helper method `checkAndProcessStopFlag()`
- The method `expandAndDedupeDataCollectionIds()` for `MongoDB` has been updated to handle cases where all snapshots need to be stopped. It ensures that snapshots are stopped properly when ".*" is passed

### Edge Case:

A potential edge case exists where the stop snapshot signal might be lost if Debezium is stopped between receiving the signal and executing `readChunk()` plus one event after `readChunk()`. (One event after `readChunk()` is necessary to trigger an offset commit with the updated list of `incremental_snapshot_collections`)