### PR TITLE
DBZ-8194 Always set binlog client GTID when GTID is enabled

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -253,7 +253,18 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                 // We've not yet seen any GTIDs, so that means we have to start reading the binlog from the beginning ...
                 client.setBinlogFilename(effectiveOffsetContext.getSource().binlogFilename());
                 client.setBinlogPosition(effectiveOffsetContext.getSource().binlogPosition());
-                initializeGtidSet("");
+                if (purgedServerGtidSet == null || purgedServerGtidSet.isEmpty()) {
+                    LOGGER.info("No GTID stored in the offset, registering binlog reader with empty GTID set.");
+                    client.setGtidSet("");
+                    initializeGtidSet("");
+                }
+                else {
+                    LOGGER.info("No GTID stored in the offset, but there is non-empty purged GTID set. Registering binlog reader with purged GTID set: '{}'",
+                            purgedServerGtidSet.toString());
+                    client.setGtidSet(purgedServerGtidSet.toString());
+                    // We don't have stored any GTID in the offset, so start from empty GTID set.
+                    initializeGtidSet("");
+                }
             }
         }
         else {


### PR DESCRIPTION
When GTID is enabled, binlog client tracks GTID and eventually resumes from the last GTID position. However, to enable GTID on the client, client has to set initial GTID position (can be empty). When GTID is enbled in the connector, always enable GTID also on the binlog client to make sure that it tracks GTID and its keep alive thread eventually resumes from the right position.

https://issues.redhat.com/browse/DBZ-8194