### PR TITLE
DBZ-8325 Remove converters from mysql parsers

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
@@ -70,13 +70,13 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     private TableSchemaBuilder tableSchemaBuilder;
     private Properties properties;
 
-    protected abstract P getParser(SimpleDdlParserListener listener, V converters);
+    protected abstract P getParser(SimpleDdlParserListener listener);
 
-    protected abstract P getParser(SimpleDdlParserListener listener, V converters, boolean includeViews);
+    protected abstract P getParser(SimpleDdlParserListener listener, boolean includeViews);
 
-    protected abstract P getParser(SimpleDdlParserListener listener, V converters, TableFilter tableFilter);
+    protected abstract P getParser(SimpleDdlParserListener listener, TableFilter tableFilter);
 
-    protected abstract P getParser(SimpleDdlParserListener listener, V converters, boolean includeViews, boolean includeComments);
+    protected abstract P getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments);
 
     protected abstract V getValueConverters();
 
@@ -86,7 +86,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     public void beforeEach() {
         listener = new SimpleDdlParserListener();
         converters = getValueConverters();
-        parser = getParser(listener, converters);
+        parser = getParser(listener);
         tables = new Tables();
         tableSchemaBuilder = new TableSchemaBuilder(
                 converters,
@@ -370,7 +370,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     @Test
     @FixFor("DBZ-4000")
     public void shouldProcessCommentForTable() {
-        parser = getParser(listener, converters, false, true);
+        parser = getParser(listener, false, true);
         parser.parse("CREATE TABLE table1(\n"
                 + "id INT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE PRIMARY KEY COMMENT 'pk',\n"
                 + "bin_volume DECIMAL(20, 4) COMMENT 'decimal column'\n"
@@ -1364,7 +1364,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "); " + System.lineSeparator();
         String ddl2 = "CREATE VIEW fooView AS (SELECT * FROM foo)" + System.lineSeparator();
 
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         parser.parse(ddl2, tables);
         assertThat(tables.size()).isEqualTo(2);
@@ -1384,7 +1384,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "); " + System.lineSeparator();
         String ddl2 = "CREATE VIEW fooView AS (SELECT * FROM foo)" + System.lineSeparator();
         String ddl3 = "DROP VIEW fooView";
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         parser.parse(ddl2, tables);
         parser.parse(ddl3, tables);
@@ -1400,7 +1400,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "CREATE TABLE db.t1 (ID INTEGER PRIMARY KEY);"
                 + "ALTER TABLE `t1` RENAME TO `t2`;"
                 + "ALTER TABLE `db`.`t2` RENAME TO `db`.`t3`;";
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(1);
         final Table table = tables.forTable(new TableId(null, "db", "t3"));
@@ -1416,7 +1416,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "); " + System.lineSeparator();
         String ddl2 = "CREATE VIEW fooView(w1) AS (SELECT c2 as w1 FROM foo)" + System.lineSeparator();
 
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         parser.parse(ddl2, tables);
         assertThat(tables.size()).isEqualTo(2);
@@ -1435,7 +1435,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "); " + System.lineSeparator();
         String ddl2 = "CREATE VIEW fooView(w1) AS (SELECT foo2.c2 as w1 FROM (SELECT c1 as c2 FROM foo) AS foo2)" + System.lineSeparator();
 
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         parser.parse(ddl2, tables);
         assertThat(tables.size()).isEqualTo(2);
@@ -1454,7 +1454,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "); " + System.lineSeparator();
         String ddl2 = "CREATE VIEW fooView(w1) AS (SELECT foo2.c2 as w1 FROM (SELECT c1 as c2 FROM foo) AS foo2)" + System.lineSeparator();
         String ddl3 = "ALTER VIEW fooView AS (SELECT c2 FROM foo)";
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         parser.parse(ddl2, tables);
         parser.parse(ddl3, tables);
@@ -1469,7 +1469,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
 
     @Test
     public void shouldUseFiltersForAlterTable() {
-        parser = getParser(listener, converters, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
+        parser = getParser(listener, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
 
         final String ddl = "CREATE TABLE ok (id int primary key, val smallint);" + System.lineSeparator()
                 + "ALTER TABLE ignored ADD COLUMN(x tinyint)" + System.lineSeparator()
@@ -1495,7 +1495,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     @Test
     @FixFor("DBZ-903")
     public void shouldParseFunctionNamedDatabase() {
-        parser = getParser(listener, converters, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
+        parser = getParser(listener, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
 
         final String ddl = "SELECT `table_name` FROM `information_schema`.`TABLES` WHERE `table_schema` = DATABASE()";
         parser.parse(ddl, tables);
@@ -1504,7 +1504,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     @Test
     @FixFor("DBZ-910")
     public void shouldParseConstraintCheck() {
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
 
         final String ddl = "CREATE TABLE t1 (c1 INTEGER NOT NULL,c2 VARCHAR(22),CHECK (c2 IN ('A', 'B', 'C')));"
                 + "CREATE TABLE t2 (c1 INTEGER NOT NULL,c2 VARCHAR(22),CONSTRAINT c1 CHECK (c2 IN ('A', 'B', 'C')));"
@@ -1543,7 +1543,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
     @Test
     @FixFor("DBZ-780")
     public void shouldRenameColumnWithoutDefinition() {
-        parser = getParser(listener, converters, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
+        parser = getParser(listener, TableFilter.fromPredicate(x -> !x.table().contains("ignored")));
 
         final String ddl = "CREATE TABLE foo (id int primary key, old INT);" + System.lineSeparator()
                 + "ALTER TABLE foo RENAME COLUMN old to new ";
@@ -2675,7 +2675,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         final String ddl = "USE db;"
                 + "CREATE TABLE db.t1 (ID INTEGER PRIMARY KEY, val INTEGER, INDEX myidx(val));"
                 + "ALTER TABLE db.t1 RENAME INDEX myidx to myidx2;";
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(1);
         final Table table = tables.forTable(new TableId(null, "db", "t1"));
@@ -2690,7 +2690,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
                 + "CREATE TABLE db.t1 (ID INTEGER PRIMARY KEY, val INTEGER, INDEX myidx(val));";
         final String ddl2 = "USE db;"
                 + "CREATE OR REPLACE INDEX myidx on db.t1(val);";
-        parser = getParser(listener, converters, true);
+        parser = getParser(listener, true);
         parser.parse(ddl1, tables);
         assertThat(tables.size()).isEqualTo(1);
         final Table table = tables.forTable(new TableId(null, "db", "t1"));

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
@@ -40,7 +40,6 @@ public class MariaDbDatabaseSchema extends BinlogDatabaseSchema<MariaDbPartition
                 true,
                 false,
                 connectorConfig.isSchemaChangesHistoryEnabled(),
-                valueConverter,
                 getTableFilter(),
                 connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
     }

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -25,7 +25,6 @@ import io.debezium.antlr.DataTypeResolver;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mariadb.antlr.listener.MariaDbAntlrDdlParserListener;
-import io.debezium.connector.mariadb.jdbc.MariaDbValueConverters;
 import io.debezium.ddl.parser.mariadb.generated.MariaDBLexer;
 import io.debezium.ddl.parser.mariadb.generated.MariaDBParser;
 import io.debezium.ddl.parser.mariadb.generated.MariaDBParser.CharsetNameContext;
@@ -47,30 +46,23 @@ import io.debezium.relational.Tables;
 public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBParser> {
 
     private final ConcurrentHashMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
-    private final MariaDbValueConverters converters;
     private final Tables.TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
 
     @VisibleForTesting
     public MariaDbAntlrDdlParser() {
-        this(null, Tables.TableFilter.includeAll());
+        this(Tables.TableFilter.includeAll());
     }
 
     @VisibleForTesting
-    public MariaDbAntlrDdlParser(MariaDbValueConverters valueConverters) {
-        this(valueConverters, Tables.TableFilter.includeAll());
-    }
-
-    @VisibleForTesting
-    public MariaDbAntlrDdlParser(MariaDbValueConverters valueConverters, Tables.TableFilter tableFilter) {
-        this(true, false, true, valueConverters, tableFilter, null);
+    public MariaDbAntlrDdlParser(Tables.TableFilter tableFilter) {
+        this(true, false, true, tableFilter, null);
     }
 
     public MariaDbAntlrDdlParser(boolean throwWerrorsFromTreeWalk, boolean includeViews, boolean includeComments,
-                                 MariaDbValueConverters valueConverters, Tables.TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+                                 Tables.TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
         super(throwWerrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
-        this.converters = valueConverters;
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
     }
@@ -451,10 +443,6 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
         // Replace backlash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
         return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
-    }
-
-    public MariaDbValueConverters getConverters() {
-        return converters;
     }
 
     public Tables.TableFilter getTableFilter() {

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/DefaultValueTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/DefaultValueTest.java
@@ -25,7 +25,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 public class DefaultValueTest extends BinlogDefaultValueTest<MariaDbValueConverters, MariaDbAntlrDdlParser> {
     @Override
     protected MariaDbAntlrDdlParser getDdlParser(MariaDbValueConverters valueConverters) {
-        return new MariaDbAntlrDdlParser(valueConverters);
+        return new MariaDbAntlrDdlParser();
     }
 
     @Override

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbAntlrDdlParserTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbAntlrDdlParserTest.java
@@ -26,23 +26,23 @@ import io.debezium.relational.ddl.SimpleDdlParserListener;
  */
 public class MariaDbAntlrDdlParserTest extends BinlogAntlrDdlParserTest<MariaDbValueConverters, MariaDbDefaultValueConverter, MariaDbAntlrDdlParser> {
     @Override
-    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, MariaDbValueConverters converters) {
-        return new MariaDbDdlParserWithSimpleTestListener(listener, converters);
+    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener) {
+        return new MariaDbDdlParserWithSimpleTestListener(listener);
     }
 
     @Override
-    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, MariaDbValueConverters converters, boolean includeViews) {
-        return new MariaDbDdlParserWithSimpleTestListener(listener, includeViews, converters);
+    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews) {
+        return new MariaDbDdlParserWithSimpleTestListener(listener, includeViews);
     }
 
     @Override
-    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, MariaDbValueConverters converters, Tables.TableFilter tableFilter) {
-        return new MariaDbDdlParserWithSimpleTestListener(listener, tableFilter, converters);
+    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, Tables.TableFilter tableFilter) {
+        return new MariaDbDdlParserWithSimpleTestListener(listener, tableFilter);
     }
 
     @Override
-    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, MariaDbValueConverters converters, boolean includeViews, boolean includeComments) {
-        return new MariaDbDdlParserWithSimpleTestListener(listener, includeViews, includeComments, converters);
+    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments) {
+        return new MariaDbDdlParserWithSimpleTestListener(listener, includeViews, includeComments);
     }
 
     @Override
@@ -66,25 +66,24 @@ public class MariaDbAntlrDdlParserTest extends BinlogAntlrDdlParserTest<MariaDbV
     }
 
     public static class MariaDbDdlParserWithSimpleTestListener extends MariaDbAntlrDdlParser {
-        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, MariaDbValueConverters converters) {
-            this(listener, false, converters);
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener) {
+            this(listener, false);
         }
 
-        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, Tables.TableFilter tableFilter, MariaDbValueConverters converters) {
-            this(listener, false, false, tableFilter, converters);
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, Tables.TableFilter tableFilter) {
+            this(listener, false, false, tableFilter);
         }
 
-        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, MariaDbValueConverters converters) {
-            this(listener, includeViews, false, Tables.TableFilter.includeAll(), converters);
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews) {
+            this(listener, includeViews, false, Tables.TableFilter.includeAll());
         }
 
-        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments, MariaDbValueConverters converters) {
-            this(listener, includeViews, includeComments, Tables.TableFilter.includeAll(), converters);
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments) {
+            this(listener, includeViews, includeComments, Tables.TableFilter.includeAll());
         }
 
-        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments, Tables.TableFilter tableFilter,
-                                                      MariaDbValueConverters converters) {
-            super(false, includeViews, includeComments, converters, tableFilter, new MariaDbCharsetRegistry());
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments, Tables.TableFilter tableFilter) {
+            super(false, includeViews, includeComments, tableFilter, new MariaDbCharsetRegistry());
             this.ddlChanges = listener;
         }
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -52,7 +52,6 @@ public class MySqlDatabaseSchema extends BinlogDatabaseSchema<MySqlPartition, My
                 true,
                 false,
                 connectorConfig.isSchemaCommentsHistoryEnabled(),
-                valueConverter,
                 getTableFilter(),
                 connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -27,7 +27,6 @@ import io.debezium.antlr.DataTypeResolver.DataTypeEntry;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mysql.antlr.listener.MySqlAntlrDdlParserListener;
-import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
 import io.debezium.ddl.parser.mysql.generated.MySqlLexer;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser.CharsetNameContext;
@@ -49,30 +48,23 @@ import io.debezium.relational.Tables.TableFilter;
 public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser> {
 
     private final ConcurrentMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
-    private final MySqlValueConverters converters;
     private final TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
 
     @VisibleForTesting
     public MySqlAntlrDdlParser() {
-        this(null, TableFilter.includeAll());
+        this(TableFilter.includeAll());
     }
 
     @VisibleForTesting
-    public MySqlAntlrDdlParser(MySqlValueConverters converters) {
-        this(converters, TableFilter.includeAll());
-    }
-
-    @VisibleForTesting
-    public MySqlAntlrDdlParser(MySqlValueConverters converters, TableFilter tableFilter) {
-        this(true, false, false, converters, tableFilter, null);
+    public MySqlAntlrDdlParser(TableFilter tableFilter) {
+        this(true, false, false, tableFilter, null);
     }
 
     public MySqlAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
-                               MySqlValueConverters converters, TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+                               TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
         super(throwErrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
-        this.converters = converters;
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
     }
@@ -439,10 +431,6 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
         // Replace backlash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
         return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
-    }
-
-    public MySqlValueConverters getConverters() {
-        return converters;
     }
 
     public TableFilter getTableFilter() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -31,23 +31,23 @@ public class MySqlAntlrDdlParserTest
         extends BinlogAntlrDdlParserTest<MySqlValueConverters, MySqlDefaultValueConverter, MySqlAntlrDdlParser>
         implements MySqlCommon {
     @Override
-    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, MySqlValueConverters converters) {
-        return new MySqlDdlParserWithSimpleTestListener(listener, converters);
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener) {
+        return new MySqlDdlParserWithSimpleTestListener(listener);
     }
 
     @Override
-    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, MySqlValueConverters converters, boolean includeViews) {
-        return new MySqlDdlParserWithSimpleTestListener(listener, includeViews, converters);
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews) {
+        return new MySqlDdlParserWithSimpleTestListener(listener, includeViews);
     }
 
     @Override
-    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, MySqlValueConverters converters, TableFilter tableFilter) {
-        return new MySqlDdlParserWithSimpleTestListener(listener, tableFilter, converters);
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, TableFilter tableFilter) {
+        return new MySqlDdlParserWithSimpleTestListener(listener, tableFilter);
     }
 
     @Override
-    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, MySqlValueConverters converters, boolean includeViews, boolean includeComments) {
-        return new MySqlDdlParserWithSimpleTestListener(listener, includeViews, includeComments, converters);
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments) {
+        return new MySqlDdlParserWithSimpleTestListener(listener, includeViews, includeComments);
     }
 
     @Override
@@ -71,25 +71,24 @@ public class MySqlAntlrDdlParserTest
     }
 
     public static class MySqlDdlParserWithSimpleTestListener extends MySqlAntlrDdlParser {
-        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, MySqlValueConverters converters) {
-            this(changesListener, false, converters);
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener) {
+            this(changesListener, false);
         }
 
-        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, TableFilter tableFilter, MySqlValueConverters converters) {
-            this(changesListener, false, false, tableFilter, converters);
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, TableFilter tableFilter) {
+            this(changesListener, false, false, tableFilter);
         }
 
-        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, MySqlValueConverters converters) {
-            this(changesListener, includeViews, false, TableFilter.includeAll(), converters);
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews) {
+            this(changesListener, includeViews, false, TableFilter.includeAll());
         }
 
-        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, MySqlValueConverters converters) {
-            this(changesListener, includeViews, includeComments, TableFilter.includeAll(), converters);
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments) {
+            this(changesListener, includeViews, includeComments, TableFilter.includeAll());
         }
 
-        private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter,
-                                                     MySqlValueConverters converters) {
-            super(false, includeViews, includeComments, converters, tableFilter, new MySqlCharsetRegistry());
+        private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter) {
+            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry());
             this.ddlChanges = changesListener;
         }
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -24,7 +24,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 public class MySqlDefaultValueTest extends BinlogDefaultValueTest<MySqlValueConverters, MySqlAntlrDdlParser> {
     @Override
     protected MySqlAntlrDdlParser getDdlParser(MySqlValueConverters valueConverter) {
-        return new MySqlAntlrDdlParser(valueConverter);
+        return new MySqlAntlrDdlParser();
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1015,7 +1015,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         /**
          * Perform a snapshot of the schema but no data upon initial startup of a connector.
          *
-         * @deprecated to be removed in Debezium 3.0, replaced by {{@link #NO_DATA}}
+         * @deprecated to be removed in Debezium 3.0, replaced by {{@link #no_data}}
          */
         SCHEMA_ONLY("schema_only"),
 


### PR DESCRIPTION
Remove converters from mysql parsers. 

A refactor to make https://github.com/debezium/debezium-connector-vitess/pull/210 possible.

I tried moving more language specific DDL parsers (eg mariadb, mysql, oracle) to the debezium-ddl-parser package but they are quite inter-tangled with other parts of the mariadb/mysql connectors (eg converters, charset registry). Additionally, the test modules (eg MySqlAntlrDdlParserTest) rely on BinlongAntlrDdlParserTest which relies on specific TableSchemaBuilders (eg MySqlTableSchemaBuilder) and others. It seems difficult to do a proper refactor without circular dependencies. I could move the AntlrDdlParsers and not their tests but it seems odd to have a class in one package and its unit tests located in another package. Based on this, I am just having the vitess-connector import the MySqlConnector. Let me know if there are other ideas for how to structure this.