### PR TITLE
[docs] Remove unordered record processing from sever docs

### DIFF
--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -502,22 +502,6 @@ To use all available cores on given machine, set the placeholder value, `AVAILAB
 |1000
 |Maximum time, in milliseconds, that the engine allows for processing pending records after a task shutdown is called.
 
-|[[debezium-server-property-record-processing-order]]<<debezium-server-property-record-processing-order, `+record.processing.order+`>>
-|`ORDERED`
-|Specifies whether the engine processes records sequentially.
-Set one of the following options:
-
-`ORDERED`:: Records are processed sequentially; that is, they are produced in the order in which they were obtained from the database.
-`UNORDERED`:: Records are processed non-sequentially; that is, they can be produced in an different order than in the source database.
-
-The non-sequential processing of the `UNORDERED` option results in better throughput, because records are produced immediately after any SMT processing and message serialization is complete, without waiting for other records.
-This option has no effect if xref:debezium-server-property-record-processing-with-serial-consumer[record.processing.with.serial.consumer] is set to `ChangeConsumer`.
-
-|[[debezium-server-property-record-processing-with-serial-consumer]]<<debezium-server-property-record-processing-with-serial-consumer, `+record.processing.with.serial.consumer+`>>
-|`false`
-|Specifies whether the default `ChangeConsumer` should be created from the provided `Consumer`, resulting in serial `Consumer` processing.
-This option has no effect if you specified the `ChangeConsumer` interface when you used the API to create the engine.
-
 |[[debezium-server-property-task-management-timeout.ms]]<<debezium-server-property-task-management-timeout.ms, `+task.management.timeout.ms+`>>
 |180,000 (3 min)
 |Time, in milliseconds, that the engine waits for a task's lifecycle management operations (starting and stopping) to complete.


### PR DESCRIPTION
Currently Debezium server allows to use only sinks which implements `ChangeConsumer` interface, which excludes these options. Listing these properties may be confusing for users. Remove them until we actually allow to use them in the Debezium sever.