### PR TITLE
DBZ-4903 Allow schema retrieval when schema is missing during incremental snapshot

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -76,4 +76,12 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
             throw new DebeziumException("Failed to close snapshot connection", e);
         }
     }
+
+    @Override
+    protected String getTableDDL(TableId dataCollectionId) throws SQLException {
+        this.connection.setAutoCommit(false);
+        String ddlString = this.connection.getTableMetadataDdl(dataCollectionId);
+        this.connection.setAutoCommit(true);
+        return ddlString;
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4903

Hi there!  I wanted to take a stab at this, so I resurrected my extremely old ticket, hopefully that's okay?  I believe there are other tickets as well that deal with a similar idea.

What I'm trying to do is retrieve the schema when currentTable == null in the isTableInvalid.  My thinking was that it could be similar to the process to create the schema when transactions are done on a table whose schema hasn't been captured yet.

I tested in mysql and oracle and seems to do the job, but definitely need someone to look over it and let me know if I'm on completely the wrong track or not.  I could only find Oracle examples where the DDL is included in the schemaChangeEvent