### PR TITLE
DBZ-8371 bump protobuf dependencies to avoid vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,9 +160,9 @@
         <version.cassandra5>5.0.2</version.cassandra5>
 
         <!-- Required in protoc plug-in config, too; can't be in BOM therefore -->
-        <version.com.google.protobuf>3.25.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
         <!-- The version is separate so different protoc can be used in product -->
-        <version.com.google.protobuf.protoc>3.25.2</version.com.google.protobuf.protoc>
+        <version.com.google.protobuf.protoc>3.25.5</version.com.google.protobuf.protoc>
 
         <!-- Infinispan version for Oracle and Debezium Server sink -->
         <version.infinispan>15.0.8.Final</version.infinispan>


### PR DESCRIPTION
The current version of the protobuf libraries (3.25.2) is affected by [SNYK-JAVA-COMGOOGLEPROTOBUF-8055227](https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-8055227).

The recommended fix is to upgrade to 3.25.5, which should be safe as it's just a patch fix.