### PR TITLE
DBZ-2386 Notify errorHandler on Postgres errors

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -217,7 +217,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
         }
     }
 
-    private boolean hasStreamingStoppingLsn(PostgresOffsetContext offsetContext, Lsn lastCompletelyProcessedLsn) {
+    private boolean haveNotReceivedStreamingStoppingLsn(PostgresOffsetContext offsetContext, Lsn lastCompletelyProcessedLsn) {
         return offsetContext.getStreamingStoppingLsn() == null ||
                 (lastCompletelyProcessedLsn.compareTo(offsetContext.getStreamingStoppingLsn()) < 0);
     }
@@ -227,7 +227,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
         LOGGER.info("Processing messages");
         int noMessageIterations = 0;
         while (context.isRunning()
-                && !hasStreamingStoppingLsn(offsetContext, lastCompletelyProcessedLsn)
+                && haveNotReceivedStreamingStoppingLsn(offsetContext, lastCompletelyProcessedLsn)
                 && !commitOffsetFailure) {
             boolean receivedMessage = stream.readPending(message -> processReplicationMessages(partition, offsetContext, stream, message));
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -439,7 +439,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             }
         }
         catch (SQLException e) {
-            errorHandler.setProducerThrowable(e);
             throw new ConnectException(e);
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -439,6 +439,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             }
         }
         catch (SQLException e) {
+            errorHandler.setProducerThrowable(e);
             throw new ConnectException(e);
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -454,11 +454,9 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             }
         }
         catch (SQLException e) {
-            throw new ConnectException(e);
-        }
-        finally {
             commitOffsetFailure = true;
             cleanUpStreamingOnStop(null);
+            throw new ConnectException(e);
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -341,8 +341,13 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
     }
 
     public void commitOffset(Map<String, ?> partition, Map<String, ?> offset) {
-        if (!commitOffsetLock.isLocked() && streamingSource != null && offset != null) {
-            streamingSource.commitOffset(partition, offset);
+        try {
+            if (!commitOffsetLock.isLocked() && streamingSource != null && offset != null) {
+                streamingSource.commitOffset(partition, offset);
+            }
+        }
+        catch (Throwable e) {
+            errorHandler.setProducerThrowable(e);
         }
     }
 


### PR DESCRIPTION
During certain scenarios, especially during RDS reboots (planned or unplanned), Postgres becomes available in such a way that Debezium is not aware that Postgres went away.  In many cases, this can result in connectors thinking they are healthy (with all statuses returning RUNNING), but are not actually reading from the replication slots.

By notifying the errorHandler when these occur, we are able to have the in-built retry mechanism reconnect after these failures.

Due to the inconsistent nature of how this happens - not every reboot will cause a connector to get stuck - we are catching erros happening in both the PostgresStreamingChangeEventSource, and the core ChangeEventSourceCoordinator.  In my testing, I have seen only some types of events get caught by the error handler in the ChangeEventSourceCoordinator.