### PR TITLE
[docs] JSON syntax fix in tutorial

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-deleting-record-database-viewing-delete-event.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-deleting-record-database-viewing-delete-event.adoc
@@ -49,7 +49,7 @@ Here are the details of the _key_ for the first new event (formatted for readabi
 {
   "schema": {
     "type": "struct",
-    "name": "dbserver1.inventory.customers.Key"
+    "name": "dbserver1.inventory.customers.Key",
     "optional": false,
     "fields": [
       {

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-updating-database-viewing-update-event.adoc
@@ -58,7 +58,7 @@ Here are the details of the _key_ for the _update_ event (formatted for readabil
   {
     "schema": {
       "type": "struct",
-      "name": "dbserver1.inventory.customers.Key"
+      "name": "dbserver1.inventory.customers.Key",
       "optional": false,
       "fields": [
         {


### PR DESCRIPTION
Added a comma after `"name": "dbserver1.inventory.customers.Key"` in JSON.