### PR TITLE
DBZ-8386 Consume all records before starting actual snapshot test

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -344,14 +344,13 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void updatesWithRestart() throws Exception {
         // Testing.Print.enable();
 
-        populateTable();
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
+        waitForStreamingRunning(connector(), server());
 
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        populateTable();
+        consumeRecords(ROW_COUNT);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignal();
 
@@ -414,14 +413,13 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotOnlyWithRestart() throws Exception {
         // Testing.Print.enable();
 
-        populateTable();
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
+        waitForStreamingRunning(connector(), server());
 
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        populateTable();
+        consumeRecords(ROW_COUNT);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignal();
 
@@ -449,16 +447,15 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void whenSnapshotMultipleTablesAndConnectorRestartsThenOnlyNotAlreadyProcessedTableMustBeProcessed() throws Exception {
         // Testing.Print.enable();
 
-        populateTables();
         final Configuration config = config()
                 .with(CommonConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 200)
                 .build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
+        waitForStreamingRunning(connector(), server());
 
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        populateTables();
+        consumeRecords(ROW_COUNT * 2);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignal(tableDataCollectionIds().toArray(new String[0]));
 
@@ -861,13 +858,12 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
     @Test
     public void testPauseDuringSnapshot() throws Exception {
-        populateTable();
         startConnector(x -> x.with(CommonConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 50));
-        waitForConnectorToStart();
+        waitForStreamingRunning(connector(), server());
 
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        populateTable();
+        consumeRecords(ROW_COUNT);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignal();
 
@@ -903,17 +899,16 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotWithAdditionalCondition() throws Exception {
         // Testing.Print.enable();
 
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForStreamingRunning(connector(), server());
+
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
         populateTableWithSpecificValue(2000, expectedCount, expectedValue);
         waitForCdcTransactionPropagation(3);
-        final Configuration config = config().build();
-        startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
-
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        consumeRecords(ROW_COUNT + expectedCount);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(Map.of(tableDataCollectionId(), String.format("aa = %s", expectedValue)), "",
                 tableDataCollectionId());
@@ -929,17 +924,16 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotWithNewAdditionalConditionsField() throws Exception {
         // Testing.Print.enable();
 
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForStreamingRunning(connector(), server());
+
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
         populateTableWithSpecificValue(2000, expectedCount, expectedValue);
         waitForCdcTransactionPropagation(3);
-        final Configuration config = config().build();
-        startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
-
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        consumeRecords(ROW_COUNT + expectedCount);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(Map.of(tableDataCollectionId(), String.format("aa = %s", expectedValue)), "",
                 tableDataCollectionId());
@@ -971,17 +965,16 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotWithAdditionalConditionWithRestart() throws Exception {
         // Testing.Print.enable();
 
-        int expectedCount = 1000, expectedValue = 12345678;
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForStreamingRunning(connector(), server());
+
+        int expectedCount = 10, expectedValue = 12345678;
         populateTable();
         populateTableWithSpecificValue(2000, expectedCount, expectedValue);
         waitForCdcTransactionPropagation(3);
-        final Configuration config = config().build();
-        startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
-
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        consumeRecords(ROW_COUNT + expectedCount);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(Map.of(tableDataCollectionId(), String.format("aa = %s", expectedValue)), "",
                 tableDataCollectionId());
@@ -1023,17 +1016,16 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotWithAdditionalConditionWithSurrogateKey() throws Exception {
         // Testing.Print.enable();
 
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForStreamingRunning(connector(), server());
+
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
         populateTableWithSpecificValue(2000, expectedCount, expectedValue);
         waitForCdcTransactionPropagation(3);
-        final Configuration config = config().build();
-        startAndConsumeTillEnd(connectorClass(), config);
-        waitForConnectorToStart();
-
-        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
-        // there shouldn't be any snapshot records
-        assertNoRecordsToConsume();
+        consumeRecords(ROW_COUNT + expectedCount);
+        consumedLines.clear();
 
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(Map.of(tableDataCollectionId(), String.format("aa = %s", expectedValue)), "\"aa\"",
                 tableDataCollectionId());

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         populateTable();
         consumeRecords(ROW_COUNT);
@@ -415,7 +415,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         populateTable();
         consumeRecords(ROW_COUNT);
@@ -451,7 +451,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
                 .with(CommonConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 200)
                 .build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         populateTables();
         consumeRecords(ROW_COUNT * 2);
@@ -859,7 +859,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     @Test
     public void testPauseDuringSnapshot() throws Exception {
         startConnector(x -> x.with(CommonConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 50));
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         populateTable();
         consumeRecords(ROW_COUNT);
@@ -901,7 +901,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
@@ -926,7 +926,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
@@ -967,7 +967,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();
@@ -1018,7 +1018,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
-        waitForStreamingRunning(connector(), server());
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
         int expectedCount = 10, expectedValue = 12345678;
         populateTable();


### PR DESCRIPTION
This seems to be more reliable then waiting more or less random time and assuming that all transaction were already processed by the database.

https://issues.redhat.com/browse/DBZ-8386