### PR TITLE
DBZ-8393 ExtractNewRecordState transform: move processing of headers after envelope has been checked

### DIFF
--- a/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import io.debezium.connector.AbstractSourceInfo;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -150,6 +151,31 @@ public abstract class AbstractExtractStateTest {
                 .build();
         final Struct payload = envelope.create(after, source, Instant.now());
         return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", envelope.schema(), payload);
+    }
+
+    protected SourceRecord createHeartbeatRecord() {
+        Schema valueSchema = SchemaBuilder.struct()
+            .name("io.debezium.connector.common.Heartbeat")
+            .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
+            .build();
+
+        Struct value = new Struct(valueSchema);
+
+        Schema keySchema = SchemaBuilder.struct()
+            .name("op.with.heartbeat.Key")
+            .field("id", Schema.STRING_SCHEMA)
+            .build();
+
+        Struct key = new Struct(keySchema).put("id", "123");
+
+        return new SourceRecord(
+            new HashMap<>(),
+            new HashMap<>(),
+            "op.with.heartbeat",
+            keySchema,
+            key,
+            valueSchema,
+            value);
     }
 
     protected SourceRecord createCreateRecordWithOptionalNull() {

--- a/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
@@ -15,13 +15,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import io.debezium.connector.AbstractSourceInfo;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.util.Collect;
@@ -155,27 +155,27 @@ public abstract class AbstractExtractStateTest {
 
     protected SourceRecord createHeartbeatRecord() {
         Schema valueSchema = SchemaBuilder.struct()
-            .name("io.debezium.connector.common.Heartbeat")
-            .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
-            .build();
+                .name("io.debezium.connector.common.Heartbeat")
+                .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
+                .build();
 
         Struct value = new Struct(valueSchema);
 
         Schema keySchema = SchemaBuilder.struct()
-            .name("op.with.heartbeat.Key")
-            .field("id", Schema.STRING_SCHEMA)
-            .build();
+                .name("op.with.heartbeat.Key")
+                .field("id", Schema.STRING_SCHEMA)
+                .build();
 
         Struct key = new Struct(keySchema).put("id", "123");
 
         return new SourceRecord(
-            new HashMap<>(),
-            new HashMap<>(),
-            "op.with.heartbeat",
-            keySchema,
-            key,
-            valueSchema,
-            value);
+                new HashMap<>(),
+                new HashMap<>(),
+                "op.with.heartbeat",
+                keySchema,
+                key,
+                valueSchema,
+                value);
     }
 
     protected SourceRecord createCreateRecordWithOptionalNull() {

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -945,4 +945,18 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
         }
     }
 
+
+    @Test
+    @FixFor("DBZ-8393")
+    public void testAddHeadersForNonEnvelopeRecord() {
+        try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(ADD_HEADERS, "op,source.lsn");
+            transform.configure(props);
+
+            final SourceRecord heartbeatRecord = createHeartbeatRecord();
+            final SourceRecord unwrapped = transform.apply(heartbeatRecord);
+            assertThat(unwrapped).isEqualTo(heartbeatRecord);
+        }
+    }
 }

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -945,7 +945,6 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
         }
     }
 
-
     @Test
     @FixFor("DBZ-8393")
     public void testAddHeadersForNonEnvelopeRecord() {


### PR DESCRIPTION
 This is to avoid NPE for non-envelope rerords.