### PR TITLE
DBZ-8398 Order snapshot records to miss always the last one

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -301,7 +301,7 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_TABLES, String.join(",", tableDataCollectionIds())));
 
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(
-                Map.of(tableDataCollectionIds().get(0), String.format("SELECT * FROM %s", tableNames().get(0)),
+                Map.of(tableDataCollectionIds().get(0), String.format("SELECT * FROM %s ORDER BY PK ASC", tableNames().get(0)),
                         tableDataCollectionIds().get(1), "SELECT failing query"),
                 "", BLOCKING,
                 tableDataCollectionIds().get(0), tableDataCollectionIds().get(1));


### PR DESCRIPTION
As we may miss one record (the last one, see DBZ-8335) when Debezium hit some error while running blocking snapshot and records don't have to be ordered by the primary key, we may be missing any record, not only the record with highest PK.
Modify snapshot query to always return ordered records, so the eventually missed records is the last one.

https://issues.redhat.com/browse/DBZ-8398