### PR TITLE
DBZ-8414 Catch exception from stopping the connector

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -336,7 +336,7 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
      */
     private void finishShutDown(Throwable exitError) {
         try {
-            shutDownLatch.await();
+            shutDownLatch.await(config.getLong(AsyncEngineConfig.TASK_MANAGEMENT_TIMEOUT_MS), TimeUnit.MILLISECONDS);
         }
         catch (InterruptedException e) {
             LOGGER.warn("Interrupted while waiting for shutdown to finish.");

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -282,7 +282,12 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
      * @param stateBeforeStop {@link State} of the engine when the shutdown was requested.
      */
     private void close(final State stateBeforeStop) {
-        stopConnector(tasks, stateBeforeStop);
+        try {
+            stopConnector(tasks, stateBeforeStop);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to stop connector properly: ", e);
+        }
         if (headerConverter != null) {
             try {
                 headerConverter.close();


### PR DESCRIPTION
Otherwise engine shutdown may get stuck as in such case the count down
of `shutDownLatch` would be skipped and engine would wait for `shutDownLatch` forever.

https://issues.redhat.com/browse/DBZ-8414