### PR TITLE
DBZ-8302: Treat oracle negative timestamp values as -infinity.

### DIFF
--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -202,6 +202,7 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc11</artifactId>
+            <version>23.6.0.24.10</version>
         </dependency>
     </dependencies>
 

--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -202,7 +202,6 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc11</artifactId>
-            <version>23.6.0.24.10</version>
         </dependency>
     </dependencies>
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -62,6 +62,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String USE_REDUCTION_BUFFER = "use.reduction.buffer";
     public static final String FLUSH_MAX_RETRIES = "flush.max.retries";
     public static final String FLUSH_RETRY_DELAY_MS = "flush.retry.delay.ms";
+    public static final String ORACLE_INFINITY_CONVERTER_ENABLE = "oracle.infinity.converter.enable";
 
     // todo add support for the ValueConverter contract
 
@@ -264,6 +265,15 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     FLUSH_RETRY_DELAY_MS_FIELD)
             .create();
 
+    public static final Field ORACLE_INFINITY_CONVERTER_ENABLE_FIELD = Field.create(ORACLE_INFINITY_CONVERTER_ENABLE)
+            .withDisplayName("Enable Oracle Infinity Converter")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 9))
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(false)
+            .withDescription("Enable Oracle Infinity Converter");
+
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
@@ -374,6 +384,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final FieldNameFilter fieldsFilter;
     private final int batchSize;
     private final boolean useReductionBuffer;
+    private final boolean oracleInfinityConverterEnable;
 
     public JdbcSinkConnectorConfig(Map<String, String> props) {
         config = Configuration.from(props);
@@ -395,6 +406,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         this.useReductionBuffer = config.getBoolean(USE_REDUCTION_BUFFER_FIELD);
         this.flushMaxRetries = config.getInteger(FLUSH_MAX_RETRIES_FIELD);
         this.flushRetryDelayMs = config.getLong(FLUSH_RETRY_DELAY_MS_FIELD);
+        this.oracleInfinityConverterEnable = config.getBoolean(ORACLE_INFINITY_CONVERTER_ENABLE_FIELD);
 
         String fieldIncludeList = config.getString(FIELD_INCLUDE_LIST_FIELD);
         String fieldExcludeList = config.getString(FIELD_EXCLUDE_LIST_FIELD);
@@ -500,6 +512,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     public long getFlushRetryDelayMs() {
         return flushRetryDelayMs;
+    }
+
+    public boolean isOracleInfinityConverterEnable() {
+        return oracleInfinityConverterEnable;
     }
 
     /** makes {@link org.hibernate.cfg.Configuration} from connector config

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/ZonedTimestampType.java
@@ -6,10 +6,17 @@
 package io.debezium.connector.jdbc.dialect.mysql;
 
 import java.sql.Types;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.type.Type;
 import io.debezium.connector.jdbc.type.debezium.DebeziumZonedTimestampType;
 import io.debezium.time.ZonedTimestamp;
+
+import static com.fasterxml.jackson.databind.type.LogicalType.DateTime;
+import static io.debezium.connector.jdbc.dialect.oracle.ZonedTimestampType.MINIMUM_TIMESTAMP;
 
 /**
  * An implementation of {@link Type} for {@link ZonedTimestamp} values.
@@ -19,9 +26,30 @@ import io.debezium.time.ZonedTimestamp;
 public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     public static final ZonedTimestampType INSTANCE = new ZonedTimestampType();
+//    TODO: Should the new config value be carried down through call stack or be directly accessible in the file
+//    private final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig();
+    public static final String MINIMUM_TIMESTAMP = "1970-01-01T00:00:01+00:00";
+    public static final String MAXIMUM_TIMESTAMP = "2038-01-19T03:14:07+00:00";
 
     @Override
     protected int getJdbcBindType() {
         return Types.TIMESTAMP; // TIMESTAMP_WITH_TIMEZONE not supported
+    }
+
+    @Override
+    protected Object convertInfinityTimestampValue(Object value) {
+//        if (config. ORACLE_INFINITY_CONVERTER_ENABLE) {
+//            return value;
+//        }
+
+        final ZonedDateTime zdt;
+        zdt = ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER).withZoneSameInstant(ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+
+        if (ZonedDateTime.parse(io.debezium.connector.jdbc.dialect.oracle.ZonedTimestampType.MINIMUM_TIMESTAMP).equals(zdt)) {
+            return ZonedDateTime.parse(MINIMUM_TIMESTAMP, ZonedTimestamp.FORMATTER).withZoneSameInstant(ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+        } else if (ZonedDateTime.parse(io.debezium.connector.jdbc.dialect.oracle.ZonedTimestampType.MINIMUM_TIMESTAMP).equals(zdt)) {
+            return ZonedDateTime.parse(MAXIMUM_TIMESTAMP, ZonedTimestamp.FORMATTER).withZoneSameInstant(ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+        }
+        return value;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/ZonedTimestampType.java
@@ -21,6 +21,8 @@ import io.debezium.time.ZonedTimestamp;
 public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     public static final ZonedTimestampType INSTANCE = new ZonedTimestampType();
+    public static final String MINIMUM_TIMESTAMP = "-4712-01-01T00:00:00+00:00";
+    public static final String MAXIMUM_TIMESTAMP = "9999-12-31T23:59:59+00:00";
 
     protected List<ValueBindDescriptor> infinityTimestampValue(int index, Object value) {
         final ZonedDateTime zdt;

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/DebeziumZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/DebeziumZonedTimestampType.java
@@ -39,9 +39,11 @@ public class DebeziumZonedTimestampType extends AbstractTimestampType {
         return dialect.getFormattedTimestampWithTimeZone((String) value);
     }
 
-    @Override
-    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+    protected Object convertInfinityTimestampValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
 
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value, boolean oracleInifinityConverterEnable) {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
@@ -51,11 +53,18 @@ public class DebeziumZonedTimestampType extends AbstractTimestampType {
                 return infinityTimestampValue(index, value);
             }
 
+            convertInfinityTimestampValue(value);
+
             return normalTimestampValue(index, value);
         }
 
         throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
                 value, value.getClass().getName()));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        return bind(index, schema, value, false);
     }
 
     protected List<ValueBindDescriptor> infinityTimestampValue(int index, Object value) {


### PR DESCRIPTION
We were hoping to create a PR on this issue but found that the repo is archived.
Below is the PR that we attempted to create.
 
We want to refer to config from ZonedTimestampType.
But it takes a lot of depth to reach config from this class.
So we would you to provide some advice on this issue pls.
https://github.com/dongwook-chan/debezium-connector-jdbc/blob/2e2aa669c2a4f50ba85196d5cf8f4115a5155c28/src/main/java/io/debezium/connector/jdbc/dialect/mysql/ZonedTimestampType.java#L37-L39

We tried to run integration test on jdbc sink connector but failed.
So if you have any instructions on this please provide.
