### PR TITLE
DBZ-6387 Addding new isostring, microseconds, nanoseconds TemporalPrecisionModes

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -279,7 +279,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
                 logger.warn("Using UTF-8 charset by default for column without charset: {}", column);
                 return (data) -> convertString(column, fieldDefn, StandardCharsets.UTF_8, data);
             case Types.TIME:
-                if (adaptiveTimeMicrosecondsPrecisionMode) {
+                if (temporalPrecisionMode == TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS) {
                     return data -> convertDurationToMicroseconds(column, fieldDefn, data);
                 }
             case Types.TIMESTAMP:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -267,7 +267,10 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.BOOL_ARRAY:
                 return SchemaBuilder.array(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
             case PgOid.DATE_ARRAY:
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
+                if (adaptiveTimeIsoString) {
+                    return SchemaBuilder.array(io.debezium.time.IsoDate.builder().optional().build());
+                }
+                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode || adaptiveTimeMicroseconds || adaptiveTimeNanoseconds) {
                     return SchemaBuilder.array(io.debezium.time.Date.builder().optional().build());
                 }
                 return SchemaBuilder.array(org.apache.kafka.connect.data.Date.builder().optional().build());
@@ -277,10 +280,28 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.JSON_ARRAY:
                 return SchemaBuilder.array(Json.builder().optional().build());
             case PgOid.TIME_ARRAY:
+                if (adaptiveTimeIsoString) {
+                    return SchemaBuilder.array(io.debezium.time.IsoTime.builder().optional().build());
+                }
+                if (adaptiveTimeMicroseconds) {
+                    return SchemaBuilder.array(io.debezium.time.MicroTime.builder().optional().build());
+                }
+                if (adaptiveTimeNanoseconds) {
+                    return SchemaBuilder.array(io.debezium.time.NanoTime.builder().optional().build());
+                }
                 return SchemaBuilder.array(MicroTime.builder().optional().build());
             case PgOid.TIMETZ_ARRAY:
                 return SchemaBuilder.array(ZonedTime.builder().optional().build());
             case PgOid.TIMESTAMP_ARRAY:
+                if (adaptiveTimeIsoString) {
+                    return SchemaBuilder.array(io.debezium.time.IsoTimestamp.builder().optional().build());
+                }
+                if (adaptiveTimeMicroseconds) {
+                    return SchemaBuilder.array(io.debezium.time.MicroTimestamp.builder().optional().build());
+                }
+                if (adaptiveTimeNanoseconds) {
+                    return SchemaBuilder.array(io.debezium.time.NanoTimestamp.builder().optional().build());
+                }
                 if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
                     if (getTimePrecision(column) <= 3) {
                         return SchemaBuilder.array(io.debezium.time.Timestamp.builder().optional().build());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -74,9 +74,6 @@ import io.debezium.relational.ValueConverter;
 import io.debezium.time.Conversions;
 import io.debezium.time.Interval;
 import io.debezium.time.MicroDuration;
-import io.debezium.time.MicroTime;
-import io.debezium.time.MicroTimestamp;
-import io.debezium.time.NanoTime;
 import io.debezium.time.ZonedTime;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.NumberConversions;
@@ -267,51 +264,18 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.BOOL_ARRAY:
                 return SchemaBuilder.array(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
             case PgOid.DATE_ARRAY:
-                if (adaptiveTimeIsoString) {
-                    return SchemaBuilder.array(io.debezium.time.IsoDate.builder().optional().build());
-                }
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode || adaptiveTimeMicroseconds || adaptiveTimeNanoseconds) {
-                    return SchemaBuilder.array(io.debezium.time.Date.builder().optional().build());
-                }
-                return SchemaBuilder.array(org.apache.kafka.connect.data.Date.builder().optional().build());
+                return SchemaBuilder.array(temporalPrecisionMode.getDateBuilder().optional().build());
             case PgOid.UUID_ARRAY:
                 return SchemaBuilder.array(Uuid.builder().optional().build());
             case PgOid.JSONB_ARRAY:
             case PgOid.JSON_ARRAY:
                 return SchemaBuilder.array(Json.builder().optional().build());
             case PgOid.TIME_ARRAY:
-                if (adaptiveTimeIsoString) {
-                    return SchemaBuilder.array(io.debezium.time.IsoTime.builder().optional().build());
-                }
-                if (adaptiveTimeMicroseconds) {
-                    return SchemaBuilder.array(io.debezium.time.MicroTime.builder().optional().build());
-                }
-                if (adaptiveTimeNanoseconds) {
-                    return SchemaBuilder.array(io.debezium.time.NanoTime.builder().optional().build());
-                }
-                return SchemaBuilder.array(MicroTime.builder().optional().build());
+                return SchemaBuilder.array(temporalPrecisionMode.getTimeBuilder(getTimePrecision(column)).optional().build());
             case PgOid.TIMETZ_ARRAY:
                 return SchemaBuilder.array(ZonedTime.builder().optional().build());
             case PgOid.TIMESTAMP_ARRAY:
-                if (adaptiveTimeIsoString) {
-                    return SchemaBuilder.array(io.debezium.time.IsoTimestamp.builder().optional().build());
-                }
-                if (adaptiveTimeMicroseconds) {
-                    return SchemaBuilder.array(io.debezium.time.MicroTimestamp.builder().optional().build());
-                }
-                if (adaptiveTimeNanoseconds) {
-                    return SchemaBuilder.array(io.debezium.time.NanoTimestamp.builder().optional().build());
-                }
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
-                    if (getTimePrecision(column) <= 3) {
-                        return SchemaBuilder.array(io.debezium.time.Timestamp.builder().optional().build());
-                    }
-                    if (getTimePrecision(column) <= 6) {
-                        return SchemaBuilder.array(MicroTimestamp.builder().optional().build());
-                    }
-                    return SchemaBuilder.array(NanoTime.builder().optional().build());
-                }
-                return SchemaBuilder.array(org.apache.kafka.connect.data.Timestamp.builder().optional().build());
+                return SchemaBuilder.array(temporalPrecisionMode.getTimestampBuilder(getTimePrecision(column)).optional().build());
             case PgOid.TIMESTAMPTZ_ARRAY:
                 return SchemaBuilder.array(ZonedTimestamp.builder().optional().build());
             case PgOid.BYTEA_ARRAY:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
@@ -20,8 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
@@ -35,7 +33,6 @@ import io.debezium.util.Testing;
  * @author Ismail Simsek
  */
 public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConnectorTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresTemporalPrecisionHandlingIT.class);
 
     static String TOPIC_NAME = topicName("temporaltype.test_data_types");
 
@@ -172,10 +169,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(TOPIC_NAME, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
         after = getAfter(insertRecord);
-        LOGGER.error("KEY:{}", insertRecord.key());
-        LOGGER.error("RECORD:{}", insertRecord);
-        LOGGER.error("AFTER:{}", after);
-        //
+        // validate right record received
         assertEquals(after.get("c_id"), 3);
         stopConnector();
     }
@@ -230,7 +224,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
 
         assertEquals(after.get("c_id"), 2);
         // '2017-09-15'::DATE
-        // assertEquals(after.get("c_date"), "2017-09-15Z");
+        assertEquals(after.get("c_date"), 17424);
         // '2019-07-09 02:28:57+01' ,
         assertEquals(after.get("c_timestamp0"), 1562639337000000L);
         // '2019-07-09 02:28:57.1+01'
@@ -260,10 +254,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(TOPIC_NAME, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
         after = getAfter(insertRecord);
-        LOGGER.error("KEY:{}", insertRecord.key());
-        LOGGER.error("RECORD:{}", insertRecord);
-        LOGGER.error("AFTER:{}", after);
-        //
+        // validate right record received
         assertEquals(after.get("c_id"), 3);
         stopConnector();
     }
@@ -274,7 +265,6 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "temporaltype")
-                // .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                 .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.NANOSECONDS)
                 .build());
         start(PostgresConnector.class, config.getConfig());
@@ -318,7 +308,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
 
         assertEquals(after.get("c_id"), 2);
         // '2017-09-15'::DATE
-        // assertEquals(after.get("c_date"), "2017-09-15Z");
+        assertEquals(after.get("c_date"), 17424);
         // '2019-07-09 02:28:57+01' ,
         assertEquals(after.get("c_timestamp0"), 1562639337000000000L);
         // '2019-07-09 02:28:57.1+01'
@@ -348,10 +338,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(TOPIC_NAME, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
         after = getAfter(insertRecord);
-        LOGGER.error("KEY:{}", insertRecord.key());
-        LOGGER.error("RECORD:{}", insertRecord);
-        LOGGER.error("AFTER:{}", after);
-        //
+
         assertEquals(after.get("c_id"), 3);
         stopConnector();
     }
@@ -373,7 +360,6 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         SourceRecord insertRecord = records.recordsForTopic("test_server.public.time_table").get(0);
         VerifyRecord.isValidRead(insertRecord, "pk", 1);
         Struct after = getAfter(insertRecord);
-        LOGGER.error("{}", after);
         // somehow on github pipeline it gets +292278994-08-16Z vs +292278994-08-17Z
         assertTrue(after.get("date_pinf").toString().contains("+292278994-08-"));
         // somehow on github pipeline it fails expected:<+292269055-12-02Z> but was:<+292269055-12-03Z>
@@ -405,7 +391,6 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         Struct after = getAfter(insertRecord);
         assertEquals(after.get("tsrange_array").toString(), "[[\"2019-03-31 15:30:00\",infinity), [\"2019-03-31 15:30:00\",\"2019-04-30 15:30:00\"]]");
         assertEquals(after.get("daterange_array").toString(), "[[2019-03-31,infinity), [2019-03-31,2019-04-30)]");
-        LOGGER.error("ARRAY: {}", after);
     }
 
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import static io.debezium.connector.postgresql.AbstractRecordsProducerTest.INSERT_ARRAY_TYPES_STMT;
+import static io.debezium.connector.postgresql.AbstractRecordsProducerTest.INSERT_DATE_TIME_TYPES_STMT;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+import java.sql.SQLException;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.util.Testing;
+
+/**
+ * Integration test to test postgres with ISOSTRING {@link TemporalPrecisionMode}.
+ *
+ * @author Ismail Simsek
+ */
+public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConnectorTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresTemporalPrecisionHandlingIT.class);
+
+    static String TOPIC_NAME = topicName("temporaltype.test_data_types");
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        TestHelper.dropAllSchemas();
+    }
+
+    @Before
+    public void before() {
+        initializeConnectorTestFramework();
+        createTable();
+    }
+
+    @After
+    public void after() throws SQLException {
+        stopConnector();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    public void createTable() {
+        TestHelper.execute("DROP SCHEMA IF EXISTS temporaltype CASCADE;");
+        TestHelper.execute("CREATE SCHEMA IF NOT EXISTS temporaltype ;");
+        TestHelper.execute("""
+                              CREATE TABLE IF NOT EXISTS temporaltype.test_data_types
+                              (
+                                  c_id INTEGER             ,
+                                  c_json JSON              ,
+                                  c_jsonb JSONB            ,
+                                  c_date DATE              ,
+                                  c_timestamp0 TIMESTAMP(0),
+                                  c_timestamp1 TIMESTAMP(1),
+                                  c_timestamp2 TIMESTAMP(2),
+                                  c_timestamp3 TIMESTAMP(3),
+                                  c_timestamp4 TIMESTAMP(4),
+                                  c_timestamp5 TIMESTAMP(5),
+                                  c_timestamp6 TIMESTAMP(6),
+                                  c_timestamptz TIMESTAMPTZ,
+                                  c_time TIME WITH TIME ZONE,
+                                  c_time_whtz TIME WITHOUT TIME ZONE,
+                                  c_interval INTERVAL,
+                                  PRIMARY KEY(c_id)
+                              ) ;
+                          ALTER TABLE temporaltype.test_data_types REPLICA IDENTITY FULL;
+                """);
+    }
+
+    public Struct getAfter(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+    }
+
+    public Struct getBefore(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+    }
+
+    @Test
+    public void shouldConvertTemporalsToIsoString() throws Exception {
+        Testing.Print.disable();
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "temporaltype")
+                // .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ISOSTRING)
+                .build());
+        start(PostgresConnector.class, config.getConfig());
+        assertConnectorIsRunning();
+
+        // wait for snapshot completion
+        TestHelper.execute("""
+                INSERT INTO temporaltype.test_data_types
+                VALUES (1 , NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL );""");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        SourceRecord insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 1);
+        Struct after = getAfter(insertRecord);
+        assertEquals(after.get("c_id"), 1);
+        assertEquals(after.get("c_date"), null);
+        assertEquals(after.get("c_timestamp0"), null);
+        assertEquals(after.get("c_timestamp1"), null);
+        assertEquals(after.get("c_timestamp2"), null);
+        assertEquals(after.get("c_timestamp3"), null);
+        assertEquals(after.get("c_timestamp4"), null);
+        assertEquals(after.get("c_timestamp5"), null);
+        assertEquals(after.get("c_timestamp6"), null);
+        assertEquals(after.get("c_timestamptz"), null);
+        assertEquals(after.get("c_time"), null);
+        assertEquals(after.get("c_time_whtz"), null);
+        assertEquals(after.get("c_interval"), null);
+
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (2 , '{"jfield": 111}'::json , '{"jfield": 211}'::jsonb , '2017-09-15'::DATE , '2019-07-09 02:28:57+01' , '2019-07-09 02:28:57.1+01' , '2019-07-09 02:28:57.12+01' , '2019-07-09 02:28:57.123+01' , '2019-07-09 02:28:57.1234+01' , '2019-07-09 02:28:57.12345+01' , '2019-07-09 02:28:57.123456+01', '2019-07-09 02:28:10.123456+01', '04:05:11 PST', '04:05:11.789', INTERVAL '1' YEAR )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 2);
+        after = getAfter(insertRecord);
+
+        assertEquals(after.get("c_id"), 2);
+        // '2017-09-15'::DATE
+        assertEquals(after.get("c_date"), "2017-09-15Z");
+        // '2019-07-09 02:28:57+01' ,
+        assertEquals(after.get("c_timestamp0"), "2019-07-09T02:28:57Z");
+        // '2019-07-09 02:28:57.1+01'
+        assertEquals(after.get("c_timestamp1"), "2019-07-09T02:28:57.1Z");
+        // '2019-07-09 02:28:57.12+01' ,
+        assertEquals(after.get("c_timestamp2"), "2019-07-09T02:28:57.12Z");
+        assertEquals(after.get("c_timestamp3"), "2019-07-09T02:28:57.123Z");
+        assertEquals(after.get("c_timestamp4"), "2019-07-09T02:28:57.1234Z");
+        assertEquals(after.get("c_timestamp5"), "2019-07-09T02:28:57.12345Z");
+        assertEquals(after.get("c_timestamp6"), "2019-07-09T02:28:57.123456Z");
+        // '2019-07-09 02:28:10.123456+01' > TEST Hour changes to UTC!
+        assertEquals(after.get("c_timestamptz"), "2019-07-09T01:28:10.123456Z");
+        // '04:05:11 PST' (-8) Test Hour changes to UTC
+        assertEquals(after.get("c_time"), "12:05:11Z");
+        // '04:05:11.789'
+        assertEquals(after.get("c_time_whtz"), "04:05:11.789Z");
+        // INTERVAL '1' YEAR
+        assertEquals(after.get("c_interval"), 31557600000000L);
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (3 , '{"jfield": 222}'::json , '{"jfield": 222}'::jsonb , '2017-02-10'::DATE , '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:20.666666+01', '04:10:22', '04:05:22.789', INTERVAL '10' DAY )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
+        after = getAfter(insertRecord);
+        LOGGER.error("KEY:{}", insertRecord.key());
+        LOGGER.error("RECORD:{}", insertRecord);
+        LOGGER.error("AFTER:{}", after);
+        //
+        assertEquals(after.get("c_id"), 3);
+        stopConnector();
+    }
+
+    @Test
+    public void shouldConvertTemporalsMicroseconds() throws Exception {
+        Testing.Print.disable();
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "temporaltype")
+                // .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.MICROSECONDS)
+                .build());
+        start(PostgresConnector.class, config.getConfig());
+        assertConnectorIsRunning();
+
+        // wait for snapshot completion
+        TestHelper.execute("""
+                INSERT INTO temporaltype.test_data_types
+                VALUES (1 , NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL );""");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        SourceRecord insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 1);
+        Struct after = getAfter(insertRecord);
+        assertEquals(after.get("c_id"), 1);
+        assertEquals(after.get("c_date"), null);
+        assertEquals(after.get("c_timestamp0"), null);
+        assertEquals(after.get("c_timestamp1"), null);
+        assertEquals(after.get("c_timestamp2"), null);
+        assertEquals(after.get("c_timestamp3"), null);
+        assertEquals(after.get("c_timestamp4"), null);
+        assertEquals(after.get("c_timestamp5"), null);
+        assertEquals(after.get("c_timestamp6"), null);
+        assertEquals(after.get("c_timestamptz"), null);
+        assertEquals(after.get("c_time"), null);
+        assertEquals(after.get("c_time_whtz"), null);
+        assertEquals(after.get("c_interval"), null);
+
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (2 , '{"jfield": 111}'::json , '{"jfield": 211}'::jsonb , '2017-09-15'::DATE , '2019-07-09 02:28:57+01' , '2019-07-09 02:28:57.1+01' , '2019-07-09 02:28:57.12+01' , '2019-07-09 02:28:57.123+01' , '2019-07-09 02:28:57.1234+01' , '2019-07-09 02:28:57.12345+01' , '2019-07-09 02:28:57.123456+01', '2019-07-09 02:28:10.123456+01', '04:05:11 PST', '04:05:11.789', INTERVAL '1' YEAR )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 2);
+        after = getAfter(insertRecord);
+
+        assertEquals(after.get("c_id"), 2);
+        // '2017-09-15'::DATE
+        // assertEquals(after.get("c_date"), "2017-09-15Z");
+        // '2019-07-09 02:28:57+01' ,
+        assertEquals(after.get("c_timestamp0"), 1562639337000000L);
+        // '2019-07-09 02:28:57.1+01'
+        assertEquals(after.get("c_timestamp1"), 1562639337100000L);
+        // '2019-07-09 02:28:57.12+01' ,
+        assertEquals(after.get("c_timestamp2"), 1562639337120000L);
+        assertEquals(after.get("c_timestamp3"), 1562639337123000L);
+        assertEquals(after.get("c_timestamp4"), 1562639337123400L);
+        assertEquals(after.get("c_timestamp5"), 1562639337123450L);
+        assertEquals(after.get("c_timestamp6"), 1562639337123456L);
+        // '2019-07-09 02:28:10.123456+01' > TEST Hour changes to UTC!
+        assertEquals(after.get("c_timestamptz"), "2019-07-09T01:28:10.123456Z");
+        // '04:05:11 PST' (-8) Test Hour changes to UTC
+        assertEquals(after.get("c_time"), "12:05:11Z");
+        // '04:05:11.789'
+        assertEquals(after.get("c_time_whtz"), 14711789000L);
+        // INTERVAL '1' YEAR
+        assertEquals(after.get("c_interval"), 31557600000000L);
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (3 , '{"jfield": 222}'::json , '{"jfield": 222}'::jsonb , '2017-02-10'::DATE , '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:20.666666+01', '04:10:22', '04:05:22.789', INTERVAL '10' DAY )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
+        after = getAfter(insertRecord);
+        LOGGER.error("KEY:{}", insertRecord.key());
+        LOGGER.error("RECORD:{}", insertRecord);
+        LOGGER.error("AFTER:{}", after);
+        //
+        assertEquals(after.get("c_id"), 3);
+        stopConnector();
+    }
+
+    @Test
+    public void shouldConvertTemporalsNanoseconds() throws Exception {
+        Testing.Print.disable();
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "temporaltype")
+                // .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.NANOSECONDS)
+                .build());
+        start(PostgresConnector.class, config.getConfig());
+        assertConnectorIsRunning();
+
+        // wait for snapshot completion
+        TestHelper.execute("""
+                INSERT INTO temporaltype.test_data_types
+                VALUES (1 , NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL );""");
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        SourceRecord insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 1);
+        Struct after = getAfter(insertRecord);
+        assertEquals(after.get("c_id"), 1);
+        assertEquals(after.get("c_date"), null);
+        assertEquals(after.get("c_timestamp0"), null);
+        assertEquals(after.get("c_timestamp1"), null);
+        assertEquals(after.get("c_timestamp2"), null);
+        assertEquals(after.get("c_timestamp3"), null);
+        assertEquals(after.get("c_timestamp4"), null);
+        assertEquals(after.get("c_timestamp5"), null);
+        assertEquals(after.get("c_timestamp6"), null);
+        assertEquals(after.get("c_timestamptz"), null);
+        assertEquals(after.get("c_time"), null);
+        assertEquals(after.get("c_time_whtz"), null);
+        assertEquals(after.get("c_interval"), null);
+
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (2 , '{"jfield": 111}'::json , '{"jfield": 211}'::jsonb , '2017-09-15'::DATE , '2019-07-09 02:28:57+01' , '2019-07-09 02:28:57.1+01' , '2019-07-09 02:28:57.12+01' , '2019-07-09 02:28:57.123+01' , '2019-07-09 02:28:57.1234+01' , '2019-07-09 02:28:57.12345+01' , '2019-07-09 02:28:57.123456+01', '2019-07-09 02:28:10.123456+01', '04:05:11 PST', '04:05:11.789', INTERVAL '1' YEAR )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 2);
+        after = getAfter(insertRecord);
+
+        assertEquals(after.get("c_id"), 2);
+        // '2017-09-15'::DATE
+        // assertEquals(after.get("c_date"), "2017-09-15Z");
+        // '2019-07-09 02:28:57+01' ,
+        assertEquals(after.get("c_timestamp0"), 1562639337000000000L);
+        // '2019-07-09 02:28:57.1+01'
+        assertEquals(after.get("c_timestamp1"), 1562639337100000000L);
+        // '2019-07-09 02:28:57.12+01' ,
+        assertEquals(after.get("c_timestamp2"), 1562639337120000000L);
+        assertEquals(after.get("c_timestamp3"), 1562639337123000000L);
+        assertEquals(after.get("c_timestamp4"), 1562639337123400000L);
+        assertEquals(after.get("c_timestamp5"), 1562639337123450000L);
+        assertEquals(after.get("c_timestamp6"), 1562639337123456000L);
+        // '2019-07-09 02:28:10.123456+01' > TEST Hour changes to UTC!
+        assertEquals(after.get("c_timestamptz"), "2019-07-09T01:28:10.123456Z");
+        // '04:05:11 PST' (-8) Test Hour changes to UTC
+        assertEquals(after.get("c_time"), "12:05:11Z");
+        // '04:05:11.789'
+        assertEquals(after.get("c_time_whtz"), 14711789000000L);
+        // INTERVAL '1' YEAR
+        assertEquals(after.get("c_interval"), 31557600000000L);
+        TestHelper.execute(
+                """
+                        INSERT INTO temporaltype.test_data_types
+                        VALUES (3 , '{"jfield": 222}'::json , '{"jfield": 222}'::jsonb , '2017-02-10'::DATE , '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:57.666666+01', '2019-07-09 02:28:20.666666+01', '04:10:22', '04:05:22.789', INTERVAL '10' DAY )
+                        ;""");
+
+        records = consumeRecordsByTopic(1);
+        insertRecord = records.recordsForTopic(TOPIC_NAME).get(0);
+        assertEquals(TOPIC_NAME, insertRecord.topic());
+        VerifyRecord.isValidInsert(insertRecord, "c_id", 3);
+        after = getAfter(insertRecord);
+        LOGGER.error("KEY:{}", insertRecord.key());
+        LOGGER.error("RECORD:{}", insertRecord);
+        LOGGER.error("AFTER:{}", after);
+        //
+        assertEquals(after.get("c_id"), 3);
+        stopConnector();
+    }
+
+    @Test
+    public void shouldReceiveDeletesWithInfinityDate() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+        TestHelper.execute("ALTER TABLE time_table REPLICA IDENTITY FULL");
+        // insert data and time data
+        TestHelper.execute(INSERT_DATE_TIME_TYPES_STMT);
+
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ISOSTRING)
+                .build());
+        assertConnectorIsRunning();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        SourceRecord insertRecord = records.recordsForTopic("test_server.public.time_table").get(0);
+        VerifyRecord.isValidRead(insertRecord, "pk", 1);
+        Struct after = getAfter(insertRecord);
+        LOGGER.error("{}", after);
+        // somehow on github pipeline it gets +292278994-08-16Z vs +292278994-08-17Z
+        assertTrue(after.get("date_pinf").toString().contains("+292278994-08-"));
+        // somehow on github pipeline it fails expected:<+292269055-12-02Z> but was:<+292269055-12-03Z>
+        assertTrue(after.get("date_ninf").toString().contains("+292269055-12-"));
+        assertEquals(after.get("tz_max"), "+294247-01-01T23:59:59.999999Z");
+        assertEquals(after.get("tz_min"), "-4713-11-23T23:59:59.999999Z");
+        assertEquals(after.get("ts_pinf"), "+294247-01-10T04:00:25.2Z");
+        assertEquals(after.get("ts_ninf"), "-290308-12-21T19:59:27.6Z");
+        assertEquals(after.get("tz_pinf"), "infinity");
+        assertEquals(after.get("tz_ninf"), "-infinity");
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithArrayTypes() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+        TestHelper.execute("ALTER TABLE time_table REPLICA IDENTITY FULL");
+        // insert data and time data
+        TestHelper.execute(INSERT_ARRAY_TYPES_STMT);
+
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ISOSTRING)
+                .build());
+        assertConnectorIsRunning();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        SourceRecord insertRecord = records.recordsForTopic("test_server.public.array_table").get(0);
+        VerifyRecord.isValidRead(insertRecord, "pk", 1);
+        Struct after = getAfter(insertRecord);
+        assertEquals(after.get("tsrange_array").toString(), "[[\"2019-03-31 15:30:00\",infinity), [\"2019-03-31 15:30:00\",\"2019-04-30 15:30:00\"]]");
+        assertEquals(after.get("daterange_array").toString(), "[[2019-03-31,infinity), [2019-03-31,2019-04-30)]");
+        LOGGER.error("ARRAY: {}", after);
+    }
+
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -386,6 +386,21 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("DBZ-6387")
+    public void shouldProcessNotNullColumnsAdaptiveIsoStringTypes() throws Exception {
+        final Struct before = testProcessNotNullColumns(TemporalPrecisionMode.ISOSTRING);
+        if (before != null) {
+            assertThat(before.get("created_at")).isEqualTo("1970-01-01T00:00:00Z");
+            assertThat(before.get("created_at_tz")).isEqualTo("1970-01-01T00:00:00Z");
+            assertThat(before.get("ctime")).isEqualTo("1970-01-01Z");
+            assertThat(before.get("ctime_tz")).isEqualTo("00:00:00Z");
+            assertThat(before.get("cdate")).isEqualTo("00:00:00Z");
+            assertThat(before.get("cmoney")).isEqualTo(new BigDecimal("0.00"));
+            assertThat(before.get("cbits")).isEqualTo(new byte[0]);
+        }
+    }
+
+    @Test
     @FixFor("DBZ-1141")
     public void shouldProcessNotNullColumnsAdaptiveDateTypes() throws Exception {
         final Struct before = testProcessNotNullColumns(TemporalPrecisionMode.ADAPTIVE);

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -44,6 +44,9 @@ import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
 import io.debezium.relational.ValueConverterProvider;
 import io.debezium.time.Date;
+import io.debezium.time.IsoDate;
+import io.debezium.time.IsoTime;
+import io.debezium.time.IsoTimestamp;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
 import io.debezium.time.NanoTime;
@@ -97,6 +100,9 @@ public class JdbcValueConverters implements ValueConverterProvider {
     private final String fallbackTimeWithTimeZone;
     protected final boolean adaptiveTimePrecisionMode;
     protected final boolean adaptiveTimeMicrosecondsPrecisionMode;
+    protected final boolean adaptiveTimeIsoString;
+    protected final boolean adaptiveTimeMicroseconds;
+    protected final boolean adaptiveTimeNanoseconds;
     protected final DecimalMode decimalMode;
     protected final TemporalAdjuster adjuster;
     protected final BigIntUnsignedMode bigIntUnsignedMode;
@@ -132,6 +138,9 @@ public class JdbcValueConverters implements ValueConverterProvider {
         this.defaultOffset = defaultOffset != null ? defaultOffset : ZoneOffset.UTC;
         this.adaptiveTimePrecisionMode = temporalPrecisionMode.equals(TemporalPrecisionMode.ADAPTIVE);
         this.adaptiveTimeMicrosecondsPrecisionMode = temporalPrecisionMode.equals(TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
+        this.adaptiveTimeIsoString = temporalPrecisionMode.equals(TemporalPrecisionMode.ISOSTRING);
+        this.adaptiveTimeMicroseconds = temporalPrecisionMode.equals(TemporalPrecisionMode.MICROSECONDS);
+        this.adaptiveTimeNanoseconds = temporalPrecisionMode.equals(TemporalPrecisionMode.NANOSECONDS);
         this.decimalMode = decimalMode != null ? decimalMode : DecimalMode.PRECISE;
         this.adjuster = adjuster;
         this.bigIntUnsignedMode = bigIntUnsignedMode != null ? bigIntUnsignedMode : BigIntUnsignedMode.PRECISE;
@@ -218,8 +227,11 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 return Xml.builder();
             // Date and time values
             case Types.DATE:
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
+                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode || adaptiveTimeMicroseconds || adaptiveTimeNanoseconds) {
                     return Date.builder();
+                }
+                if (adaptiveTimeIsoString) {
+                    return IsoDate.builder();
                 }
                 return org.apache.kafka.connect.data.Date.builder();
             case Types.TIME:
@@ -235,6 +247,15 @@ public class JdbcValueConverters implements ValueConverterProvider {
                     }
                     return NanoTime.builder();
                 }
+                if (adaptiveTimeIsoString) {
+                    return IsoTime.builder();
+                }
+                if (adaptiveTimeMicroseconds) {
+                    return MicroTime.builder();
+                }
+                if (adaptiveTimeNanoseconds) {
+                    return NanoTime.builder();
+                }
                 return org.apache.kafka.connect.data.Time.builder();
             case Types.TIMESTAMP:
                 if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
@@ -244,6 +265,15 @@ public class JdbcValueConverters implements ValueConverterProvider {
                     if (getTimePrecision(column) <= 6) {
                         return MicroTimestamp.builder();
                     }
+                    return NanoTimestamp.builder();
+                }
+                if (adaptiveTimeIsoString) {
+                    return IsoTimestamp.builder();
+                }
+                if (adaptiveTimeMicroseconds) {
+                    return MicroTimestamp.builder();
+                }
+                if (adaptiveTimeNanoseconds) {
                     return NanoTimestamp.builder();
                 }
                 return org.apache.kafka.connect.data.Timestamp.builder();
@@ -325,23 +355,11 @@ public class JdbcValueConverters implements ValueConverterProvider {
 
             // Date and time values
             case Types.DATE:
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
-                    return (data) -> convertDateToEpochDays(column, fieldDefn, data);
-                }
-                return (data) -> convertDateToEpochDaysAsDate(column, fieldDefn, data);
+                return (data) -> convertDate(column, fieldDefn, data);
             case Types.TIME:
                 return (data) -> convertTime(column, fieldDefn, data);
             case Types.TIMESTAMP:
-                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
-                    if (getTimePrecision(column) <= 3) {
-                        return data -> convertTimestampToEpochMillis(column, fieldDefn, data);
-                    }
-                    if (getTimePrecision(column) <= 6) {
-                        return data -> convertTimestampToEpochMicros(column, fieldDefn, data);
-                    }
-                    return (data) -> convertTimestampToEpochNanos(column, fieldDefn, data);
-                }
-                return (data) -> convertTimestampToEpochMillisAsDate(column, fieldDefn, data);
+                return (data) -> convertTimestamp(column, fieldDefn, data);
             case Types.TIME_WITH_TIMEZONE:
                 return (data) -> convertTimeWithZone(column, fieldDefn, data);
             case Types.TIMESTAMP_WITH_TIMEZONE:
@@ -424,8 +442,30 @@ public class JdbcValueConverters implements ValueConverterProvider {
         });
     }
 
+    protected Object convertDate(Column column, Field fieldDefn, Object data) {
+        if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
+            return convertDateToEpochDays(column, fieldDefn, data);
+        }
+        if (adaptiveTimeIsoString) {
+            return convertDateToUtcIsoString(column, fieldDefn, data);
+        }
+        return convertDateToEpochDaysAsDate(column, fieldDefn, data);
+    }
+
     protected Object convertTime(Column column, Field fieldDefn, Object data) {
+        if (adaptiveTimeIsoString) {
+            return convertTimeToUtcIsoString(column, fieldDefn, data);
+        }
+        if (adaptiveTimeMicroseconds) {
+            return convertTimeToMicrosPastMidnight(column, fieldDefn, data);
+        }
+        if (adaptiveTimeNanoseconds) {
+            return convertTimeToNanosPastMidnight(column, fieldDefn, data);
+        }
         if (adaptiveTimeMicrosecondsPrecisionMode) {
+            // @TODO ? THIS IS INCONSISTEND WITH Timestamp
+            // @TODO HERE ITS FIXED TO Micros! SHOULDN'T WE CHECK THE getTimePrecision()??
+            // @TODO FOR TIMESTAMP ITS NOT FIXED TO Micros, ITS ADAPTIVE!
             return convertTimeToMicrosPastMidnight(column, fieldDefn, data);
         }
         if (adaptiveTimePrecisionMode) {
@@ -441,6 +481,28 @@ public class JdbcValueConverters implements ValueConverterProvider {
         else {
             return convertTimeToMillisPastMidnightAsDate(column, fieldDefn, data);
         }
+    }
+
+    protected Object convertTimestamp(Column column, Field fieldDefn, Object data) {
+        if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
+            if (getTimePrecision(column) <= 3) {
+                return convertTimestampToEpochMillis(column, fieldDefn, data);
+            }
+            if (getTimePrecision(column) <= 6) {
+                return convertTimestampToEpochMicros(column, fieldDefn, data);
+            }
+            return convertTimestampToEpochNanos(column, fieldDefn, data);
+        }
+        if (adaptiveTimeIsoString) {
+            return convertTimestampToUtcIsoString(column, fieldDefn, data);
+        }
+        if (adaptiveTimeMicroseconds) {
+            return convertTimestampToEpochMicros(column, fieldDefn, data);
+        }
+        if (adaptiveTimeNanoseconds) {
+            return convertTimestampToEpochNanos(column, fieldDefn, data);
+        }
+        return convertTimestampToEpochMillisAsDate(column, fieldDefn, data);
     }
 
     /**
@@ -670,6 +732,78 @@ public class JdbcValueConverters implements ValueConverterProvider {
             catch (IllegalArgumentException e) {
                 logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
                         fieldDefn.schema(), data.getClass(), data);
+            }
+        });
+    }
+
+    /**
+     * Converts a value object of various date-related types to its representation as a UTC ISO 8601 string.
+     * <p>
+     * This method attempts to convert the provided data object, which can be of types like
+     * {@link java.sql.Date}, {@link java.util.Date}, {@link java.time.LocalDate}, or
+     * {@link java.time.LocalDateTime}, to a String representing the date in UTC ISO 8601 format (e.g., "2023-11-21Z").
+     *
+     * @param column the column definition describing the {@code data} value; never null
+     * @param fieldDefn the field definition; never null
+     * @param data the data object to be converted into a UTC ISO 8601 String; can be null
+     * @return the converted UTC ISO 8601 String representation of the date,
+     * or "1970-01-01Z", the fallback value, if the column is non-null and no default value is provided
+     * @throws IllegalArgumentException if the conversion fails and the column does not allow nulls
+     */
+    protected Object convertDateToUtcIsoString(Column column, Field fieldDefn, Object data) {
+        return convertValue(column, fieldDefn, data, "1970-01-01Z", (r) -> {
+            try {
+                r.deliver(IsoDate.toIsoString(data, adjuster));
+            }
+            catch (IllegalArgumentException e) {
+                logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
+                        fieldDefn.schema(), data.getClass(), data);
+            }
+        });
+    }
+
+    /**
+     * Converts a value object of various time-related types to its representation as a UTC ISO 8601 string.
+     * <p>
+     * This method handles conversion of time-related values such as {@link java.sql.Time},
+     * {@link java.util.Date}, {@link java.time.LocalTime}, and {@link java.time.LocalDateTime} to a
+     * UTC ISO 8601 string format (e.g., "00:00:00Z").
+
+     * @param column the column definition describing the data value; never null
+     * @param fieldDefn the field definition; never null
+     * @param data the data object to be converted; can be null
+     * @return the converted UTC ISO 8601 string representation of the time, or "00:00:00Z" if necessary
+     */
+    protected Object convertTimeToUtcIsoString(Column column, Field fieldDefn, Object data) {
+        // epoch is the fallback value
+        return convertValue(column, fieldDefn, data, "00:00:00Z", (r) -> {
+            try {
+                r.deliver(IsoTime.toIsoString(data, supportsLargeTimeValues()));
+            }
+            catch (IllegalArgumentException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    /**
+     * Converts a value object of various timestamp-related types to its representation as a UTC ISO 8601 string.
+     * <p>
+     * This method handles conversion of timestamp-related values such as {@link java.sql.Timestamp},
+     * {@link java.util.Date}, {@link java.time.LocalDateTime}, and {@link java.time.Instant} to a
+     * UTC ISO 8601 string format (e.g., "2023-11-21T12:34:56Z").
+
+     * @param column the column definition describing the data value; never null
+     * @param fieldDefn the field definition; never null
+     * @param data the data object to be converted; can be null
+     * @return the converted UTC ISO 8601 string representation of the timestamp, or "1970-01-01T00:00:00Z" if necessary
+     */
+    protected Object convertTimestampToUtcIsoString(Column column, Field fieldDefn, Object data) {
+        return convertValue(column, fieldDefn, data, "1970-01-01T00:00:00Z", (r) -> {
+            try {
+                r.deliver(IsoTimestamp.toIsoString(data, adjuster));
+            }
+            catch (IllegalArgumentException e) {
             }
         });
     }
@@ -1339,7 +1473,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
     }
 
     private boolean supportsLargeTimeValues() {
-        return adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode;
+        return adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode || adaptiveTimeNanoseconds || adaptiveTimeMicroseconds;
     }
 
     private byte[] toByteArray(char[] chars) {

--- a/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
@@ -25,10 +25,28 @@ public enum TemporalPrecisionMode implements EnumeratedValue {
     ADAPTIVE_TIME_MICROSECONDS("adaptive_time_microseconds"),
 
     /**
+     * Represent timestamp, datetime, date and time values as ISO 8601 string,
+     * using {@link io.debezium.time.IsoDate}, {@link io.debezium.time.IsoTime}, {@link io.debezium.time.IsoTimestamp} semantic types.
+     */
+    ISOSTRING("isostring"),
+
+    /**
      * Represent time and date values using Kafka Connect {@link org.apache.kafka.connect.data} logical types, which always
      * have millisecond precision.
      */
-    CONNECT("connect");
+    CONNECT("connect"),
+
+    /**
+     * Represent timestamp, datetime, time values using {@link io.debezium.time.MicroTime} semantic type,
+     * which always have microseconds precision
+     */
+    MICROSECONDS("microseconds"),
+
+    /**
+     * Represent timestamp, datetime, time values using {@link io.debezium.time.NanoTime} semantic type,
+     * which always have nanoseconds precision
+     */
+    NANOSECONDS("nanoseconds");
 
     private final String value;
 

--- a/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
@@ -5,7 +5,22 @@
  */
 package io.debezium.jdbc;
 
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+
 import io.debezium.config.EnumeratedValue;
+import io.debezium.time.Date;
+import io.debezium.time.IsoDate;
+import io.debezium.time.IsoTime;
+import io.debezium.time.IsoTimestamp;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.NanoTime;
+import io.debezium.time.NanoTimestamp;
+import io.debezium.time.Time;
+import io.debezium.time.Timestamp;
 
 /**
  * The set of predefined TemporalPrecisionMode options.
@@ -15,43 +30,56 @@ public enum TemporalPrecisionMode implements EnumeratedValue {
      * Represent time and date values based upon the resolution in the database, using {@link io.debezium.time} semantic
      * types.
      */
-    ADAPTIVE("adaptive"),
+    ADAPTIVE("adaptive", Date::builder,
+            x -> (x <= 3) ? Time.builder() : (x <= 6) ? MicroTime.builder() : NanoTime.builder(),
+            x -> (x <= 3) ? Timestamp.builder() : (x <= 6) ? MicroTimestamp.builder() : NanoTimestamp.builder()),
 
     /**
      * Represent timestamp, datetime and date values based upon the resolution in the database, using
      * {@link io.debezium.time} semantic types. TIME fields will always be represented as microseconds
      * in INT64 / {@link java.lang.Long} using {@link io.debezium.time.MicroTime}
      */
-    ADAPTIVE_TIME_MICROSECONDS("adaptive_time_microseconds"),
+    ADAPTIVE_TIME_MICROSECONDS("adaptive_time_microseconds", Date::builder,
+            x -> MicroTime.builder(),
+            x -> (x <= 3) ? Timestamp.builder() : (x <= 6) ? MicroTimestamp.builder() : NanoTimestamp.builder()),
 
     /**
      * Represent timestamp, datetime, date and time values as ISO 8601 string,
      * using {@link io.debezium.time.IsoDate}, {@link io.debezium.time.IsoTime}, {@link io.debezium.time.IsoTimestamp} semantic types.
      */
-    ISOSTRING("isostring"),
+    ISOSTRING("isostring", IsoDate::builder, x -> IsoTime.builder(), x -> IsoTimestamp.builder()),
 
     /**
      * Represent time and date values using Kafka Connect {@link org.apache.kafka.connect.data} logical types, which always
      * have millisecond precision.
      */
-    CONNECT("connect"),
+    CONNECT("connect", org.apache.kafka.connect.data.Date::builder,
+            x -> org.apache.kafka.connect.data.Time.builder(),
+            x -> org.apache.kafka.connect.data.Timestamp.builder()),
 
     /**
      * Represent timestamp, datetime, time values using {@link io.debezium.time.MicroTime} semantic type,
      * which always have microseconds precision
      */
-    MICROSECONDS("microseconds"),
+    MICROSECONDS("microseconds", Date::builder, x -> MicroTime.builder(), x -> MicroTimestamp.builder()),
 
     /**
      * Represent timestamp, datetime, time values using {@link io.debezium.time.NanoTime} semantic type,
      * which always have nanoseconds precision
      */
-    NANOSECONDS("nanoseconds");
+    NANOSECONDS("nanoseconds", Date::builder, x -> NanoTime.builder(), x -> NanoTimestamp.builder());
 
     private final String value;
+    private final Supplier<SchemaBuilder> dateBuilder;
+    private final Function<Integer, SchemaBuilder> timeBuilder;
+    private final Function<Integer, SchemaBuilder> timestampBuilder;
 
-    TemporalPrecisionMode(String value) {
+    TemporalPrecisionMode(String value, Supplier<SchemaBuilder> dateBuilder,
+                          Function<Integer, SchemaBuilder> timeBuilder, Function<Integer, SchemaBuilder> timestampBuilder) {
         this.value = value;
+        this.dateBuilder = dateBuilder;
+        this.timeBuilder = timeBuilder;
+        this.timestampBuilder = timestampBuilder;
     }
 
     @Override
@@ -91,5 +119,17 @@ public enum TemporalPrecisionMode implements EnumeratedValue {
             mode = parse(defaultValue);
         }
         return mode;
+    }
+
+    public SchemaBuilder getDateBuilder() {
+        return dateBuilder.get();
+    }
+
+    public SchemaBuilder getTimeBuilder(int precision) {
+        return timeBuilder.apply(precision);
+    }
+
+    public SchemaBuilder getTimestampBuilder(int precision) {
+        return timestampBuilder.apply(precision);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/time/IsoDate.java
+++ b/debezium-core/src/main/java/io/debezium/time/IsoDate.java
@@ -15,8 +15,6 @@ import java.time.temporal.TemporalAdjuster;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
-// Fixed javadoc descriptions!
-
 /**
  * A utility for converting various Java temporal object representations into a UTC ISO 8601 string representation,
  * specifically focusing on dates (without time or timezone information).

--- a/debezium-core/src/main/java/io/debezium/time/IsoDate.java
+++ b/debezium-core/src/main/java/io/debezium/time/IsoDate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.time;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjuster;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+// Fixed javadoc descriptions!
+
+/**
+ * A utility for converting various Java temporal object representations into a UTC ISO 8601 string representation,
+ * specifically focusing on dates (without time or timezone information).
+ * Additionally, it defines a Kafka Connect {@link Schema} for representing dates in this format.
+ *
+ * @author Ismail Simsek
+ * @see Timestamp
+ * @see ZonedTimestamp
+ */
+public class IsoDate {
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE;
+    public static final String SCHEMA_NAME = "io.debezium.time.IsoDate";
+
+    /**
+     * Returns a {@link SchemaBuilder} for a {@link IsoDate}. The builder will create a schema that describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#string() STRING} for the literal
+     * type storing the date in UTC ISO 8601 format (e.g., "2023-11-21").
+     * <p>
+     * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
+     * value, and documentation.
+     *
+     * @return the schema builder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.string()
+                .name(SCHEMA_NAME)
+                .version(1);
+    }
+
+    /**
+     * Returns a Schema for a {@link IsoDate} but with all other default Schema settings. The schema describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#string() STRING} for the literal
+     * type storing the date in UTC ISO 8601 format (e.g., "2023-11-21").
+     *
+     * @return the schema
+     * @see #builder()
+     */
+    public static Schema schema() {
+        return builder().build();
+    }
+
+    /**
+     * Converts a {@link java.time.LocalDateTime}, {@link LocalDate}, {@link LocalTime}, {@link java.util.Date},
+     * {@link java.sql.Date}, {@link java.sql.Time}, or {@link java.sql.Timestamp} to its UTC ISO 8601 string representation
+     * (e.g., "2023-11-21").
+     * <p>
+     * This method ignores time components of the input value. If an adjuster is provided, it's used to adjust the
+     * {@link LocalDate} before converting it to the string representation.
+     *
+     * @param value the local or SQL date, time, or timestamp value; may not be null
+     * @param adjuster the optional component that adjusts the local date value before obtaining the string representation;
+     * may be null if no adjustment is necessary
+     * @return the UTC ISO 8601 string representation of the date
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     */
+    public static String toIsoString(Object value, TemporalAdjuster adjuster) {
+        LocalDate date = Conversions.toLocalDate(value);
+        if (adjuster != null) {
+            date = date.with(adjuster);
+        }
+        ZonedDateTime zonedDate = ZonedDateTime.of(date, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        return zonedDate.format(FORMATTER);
+    }
+
+    private IsoDate() {
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/time/IsoTime.java
+++ b/debezium-core/src/main/java/io/debezium/time/IsoTime.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.time;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * A utility for converting various Java time representations into a UTC ISO 8601 string representation
+ * focusing on time (including fractional parts and offset from UTC), and for defining a Kafka Connect
+ * {@link Schema} for time values in this format.
+ * <p>
+ * The ISO 8601 time format includes the time (including fractional parts) and offset from UTC, such as '10:15:30Z'.
+ *
+ * @author Ismail Simsek
+ * @see Date
+ * @see Time
+ * @see Timestamp
+ * @see ZonedTimestamp
+ */
+public class IsoTime {
+
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_TIME;
+    public static final String SCHEMA_NAME = "io.debezium.time.IsoTime";
+    private static final Duration ONE_DAY = Duration.ofDays(1);
+
+    /**
+     * Returns a {@link SchemaBuilder} for a {@link IsoTime}. The builder will create a schema that describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#STRING() STRING} for the literal
+     * type storing the time in UTC ISO 8601 format (e.g., "10:15:30Z").
+     * <p>
+     * You can use the resulting SchemaBuilder to set additional schema settings such as required/optional, default value, and documentation.
+     *
+     * @return the schema builder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.string()
+                .name(SCHEMA_NAME)
+                .version(1);
+    }
+
+    /**
+     * Returns a Schema for a {@link IsoTime} but with all other default Schema settings. The schema describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#string() STRING} for the literal
+     * type storing the time in UTC ISO 8601 format (e.g., "10:15:30Z").
+     *
+     * @return the schema
+     * @see #builder()
+     */
+    public static Schema schema() {
+        return builder().build();
+    }
+
+    /**
+     * Converts a {@link Duration}, {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Time},
+     * or {@link java.sql.Timestamp} object to its UTC ISO 8601 string representation (e.g., "10:15:30Z").
+     * <p>
+     * This method handles both {@link Duration} values and time-related objects. For {@link Duration} values,
+     * it ensures the resulting time is within the valid range (between 00:00:00 and 24:00:00 inclusive)
+     * by throwing an {@link IllegalArgumentException} if the duration goes beyond this range and the `acceptLargeValues`
+     * parameter is set to false. For time-related objects, it converts them to {@link LocalTime} before formatting.
+     *
+     * @param value the time or duration value; may not be null
+     * @param acceptLargeValues whether to accept {@link Duration} values exceeding the valid range (00:00:00 - 24:00:00)
+     * @return the UTC ISO 8601 string representation of the time
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types, or if a
+     * {@link Duration} value exceeds the valid range and `acceptLargeValues` is false.
+     */
+    public static String toIsoString(Object value, boolean acceptLargeValues) {
+        if (value instanceof Duration) {
+            Duration duration = (Duration) value;
+            if (!acceptLargeValues && (duration.isNegative() || duration.compareTo(ONE_DAY) > 0)) {
+                throw new IllegalArgumentException("Time values must be between 00:00:00 and 24:00:00 (inclusive): " + duration);
+            }
+            // Base LocalTime (e.g., 0:00 AM)
+            // Calculate the new LocalTime by adding the duration to the base time
+            LocalTime localTime = LocalTime.of(0, 0).plus(duration);
+            return localTime.atOffset(ZoneOffset.UTC).format(FORMATTER);
+        }
+
+        LocalTime localTime = Conversions.toLocalTime(value);
+        return localTime.atOffset(ZoneOffset.UTC).format(FORMATTER);
+    }
+
+    private IsoTime() {
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/time/IsoTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/IsoTimestamp.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.time;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjuster;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * A utility for converting various Java timestamp representations into a UTC ISO 8601 string representation
+ * (including date, time, fractional parts, and offset from UTC), and for defining a Kafka Connect
+ * {@link Schema} for timestamp values in this format.
+ * <p>
+ * The ISO 8601 date-time format includes the date, time (including fractional parts), and offset from UTC, such as
+ * '2011-12-03T10:15:30Z'.
+ *
+ * @author Ismail Simsek
+ * @see Timestamp
+ * @see MicroTimestamp
+ * @see NanoTimestamp
+ * @see ZonedTime
+ */
+public class IsoTimestamp {
+
+    public static final String SCHEMA_NAME = "io.debezium.time.IsoTimestamp";
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    /**
+     * Returns a {@link SchemaBuilder} for a {@link IsoTimestamp}. The builder will create a schema that describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#string() STRING} for the literal
+     * type storing the timestamp in UTC ISO 8601 format (e.g., "2023-11-21T18:29:26Z").
+     * <p>
+     * You can use the resulting SchemaBuilder to set additional schema settings such as required/optional, default value, and documentation.
+     *
+     * @return the schema builder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.string()
+                .name(SCHEMA_NAME)
+                .version(1);
+    }
+
+    /**
+     * Returns a Schema for a {@link IsoTimestamp} but with all other default Schema settings. The schema describes a field
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#
+     * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#string() STRING} for the literal() STRING} for the literal
+     * type storing the timestamp in UTC ISO 8601 format (e.g., "2023-11-21T18:29:26Z").
+     *
+     * @return the schema
+     * @see #builder()
+     */
+    public static Schema schema() {
+        return builder().build();
+    }
+
+    /**
+     * Converts a {@link java.time.Instant} (represented as milliseconds since epoch), {@link java.time.LocalDateTime},
+     * {@link java.util.Date}, {@link java.sql.Timestamp}, or any other object convertible to a {@link LocalDateTime}
+     * to its UTC ISO 8601 string representation (e.g., "2011-12-03T10:15:30Z").
+     * <p>
+     * This method handles various timestamp-related objects. For {@link Instant}, it converts the milliseconds since
+     * epoch to a {@link LocalDateTime} in UTC. For other objects, it uses the {@link Conversions#toLocalDateTime(Object)}
+     * method for conversion. If an adjuster is provided, it's used to adjust the resulting {@link LocalDateTime} before
+     * formatting it to the string representation.
+     *
+     * @param value the timestamp value; may not be null
+     * @param adjuster the optional component that adjusts the local date-time value before obtaining the string representation;
+     * may be null if no adjustment is necessary
+     * @return the UTC ISO 8601 string representation of the timestamp
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     */
+    public static String toIsoString(Object value, TemporalAdjuster adjuster) {
+        LocalDateTime dateTime;
+        if (value instanceof Long) {
+            dateTime = Instant.ofEpochMilli((long) value).atOffset(ZoneOffset.UTC).toLocalDateTime();
+        }
+        else {
+            dateTime = Conversions.toLocalDateTime(value);
+        }
+
+        if (adjuster != null) {
+            dateTime = dateTime.with(adjuster);
+        }
+
+        return dateTime.atOffset(ZoneOffset.UTC).format(FORMATTER);
+    }
+
+    private IsoTimestamp() {
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
+++ b/debezium-core/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+
+/**
+ * Test to test temporal to ISO 8601 String conversions.
+ *
+ * @author Ismail Simsek
+ */
+public class JdbcValueConvertersTemporalPrecisionTest {
+    JdbcValueConverters converters = new JdbcValueConverters(null, TemporalPrecisionMode.ISOSTRING, ZoneOffset.UTC, null, null, null);
+    //
+    final Column dateCol = Column.editor().name("c1").type("DATE").optional(false).jdbcType(Types.DATE).create();
+    final Field dateField = new Field(dateCol.name(), -1, converters.schemaBuilder(dateCol).build());
+    final ValueConverter dateValConverter = converters.converter(dateCol, dateField);
+    //
+    final Column timeCol = Column.editor().name("c2").type("TIME").optional(false).jdbcType(Types.TIME).create();
+    //
+    final Column timestampCol = Column.editor().name("c2").type("TIMESTAMP").optional(false).jdbcType(Types.TIMESTAMP).create();
+
+    @Test
+    public void testSchemaBuilder() {
+        // test schema types are correct! set as ZonedDate
+        final Schema dateColSchema = converters.schemaBuilder(dateCol).schema();
+        assertThat(dateColSchema.type()).isEqualTo(Schema.Type.STRING);
+        assertThat(dateColSchema.name()).isEqualTo("io.debezium.time.IsoDate");
+        assertThat(dateColSchema.isOptional()).isEqualTo(false);
+        // test schema types are correct! set as ZonedTime
+        final Schema timeColSchema = converters.schemaBuilder(timeCol).schema();
+        assertThat(timeColSchema.type()).isEqualTo(Schema.Type.STRING);
+        assertThat(timeColSchema.name()).isEqualTo("io.debezium.time.IsoTime");
+        assertThat(dateColSchema.isOptional()).isEqualTo(false);
+        // test schema types are correct! set as ZonedTimestamp
+        final Schema tsColSchema = converters.schemaBuilder(timestampCol).schema();
+        assertThat(tsColSchema.type()).isEqualTo(Schema.Type.STRING);
+        assertThat(tsColSchema.name()).isEqualTo("io.debezium.time.IsoTimestamp");
+        assertThat(dateColSchema.isOptional()).isEqualTo(false);
+    }
+
+    @Test
+    public void testIsoDate() throws ParseException {
+        assertThat(dateCol.isOptional()).isEqualTo(false);
+
+        assertThat(dateValConverter.convert(null)).isEqualTo("1970-01-01Z");
+        //
+        Object val = dateValConverter.convert(LocalDate.parse("2005-05-12"));
+        assertThat(val).isEqualTo("2005-05-12Z");
+        // LocalDateTime
+        Object val2 = dateValConverter.convert(LocalDateTime.parse("2015-08-13T10:11:30"));
+        assertThat(val2).isEqualTo("2015-08-13Z");
+        // java.sql.Date
+        Object val3 = dateValConverter.convert(java.sql.Date.valueOf("2005-05-14"));
+        assertThat(val3).isEqualTo("2005-05-14Z");
+        // Date
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd"); // Specify your date format
+        Object val4 = dateValConverter.convert(formatter.parse("2005-05-15"));
+        assertThat(val4).isEqualTo("2005-05-15Z");
+        // LocalDate
+        assertThat(dateValConverter.convert(LocalDate.ofEpochDay(16321))).isEqualTo("2014-09-08Z");
+        assertThat(dateValConverter.convert(LocalDate.ofEpochDay(16321L))).isEqualTo("2014-09-08Z");
+    }
+
+    @Test
+    public void testIsoTime() {
+        Field timeField = new Field("tc1", -1, converters.schemaBuilder(timeCol).build());
+        ValueConverter timeValConverter = converters.converter(timeCol, timeField);
+        //
+        assertThat(timeCol.isOptional()).isEqualTo(false);
+        assertThat(timeValConverter.convert(null)).isEqualTo("00:00:00Z");
+        // java.util.Date
+        Object val = timeValConverter.convert(new java.util.Date(10, 30, 01, 3, 4, 5));
+        assertThat(val).isEqualTo("03:04:05Z");
+        // OffsetTime
+        val = timeValConverter.convert(new java.sql.Time(10, 30, 01));
+        assertThat(val).isEqualTo("10:30:01Z");
+        // Duration
+        Duration valDuration = Duration.ofHours(2).plusMinutes(30).plusNanos(5);
+        val = timeValConverter.convert(valDuration);
+        assertThat(val).isEqualTo("02:30:00.000000005Z");
+        // LocalTime
+        val = timeValConverter.convert(LocalTime.of(10, 30, 45, 123456789));
+        assertThat(val).isEqualTo("10:30:45.123456789Z");
+    }
+
+    @Test
+    public void testIsoTimestamp() {
+        Field tsField = new Field("tsc1", -1, converters.schemaBuilder(timestampCol).build());
+        ValueConverter tSValConverter = converters.converter(timestampCol, tsField);
+        //
+        assertThat(timestampCol.isOptional()).isEqualTo(false);
+        assertThat(tSValConverter.convert(null)).isEqualTo("1970-01-01T00:00:00Z");
+        // LocalDateTime
+        Object val = tSValConverter.convert(LocalDateTime.parse("2011-01-11T16:40:30.123456789"));
+        assertThat(val).isEqualTo("2011-01-11T16:40:30.123456789Z");
+        // long milliseconds
+        val = tSValConverter.convert(1732117483000L);
+        assertThat(val).isEqualTo("2024-11-20T15:44:43Z");
+    }
+
+    @Test
+    public void testMicroseconds() {
+        JdbcValueConverters convertersMicro = new JdbcValueConverters(null, TemporalPrecisionMode.MICROSECONDS, ZoneOffset.UTC, null, null, null);
+        JdbcValueConverters convertersNano = new JdbcValueConverters(null, TemporalPrecisionMode.NANOSECONDS, ZoneOffset.UTC, null, null, null);
+
+        final Column timeCol = Column.editor().name("c2").type("TIME").optional(false).jdbcType(Types.TIME).create();
+        Field timeField = new Field("time_col", -1, converters.schemaBuilder(timeCol).build());
+        ValueConverter timeMicroValConverter = convertersMicro.converter(timeCol, timeField);
+        ValueConverter timeNanoValConverter = convertersNano.converter(timeCol, timeField);
+        // null
+        assertThat(timeCol.isOptional()).isEqualTo(false);
+        assertThat(timeMicroValConverter.convert(null)).isEqualTo(0L);
+        assertThat(timeNanoValConverter.convert(null)).isEqualTo(0L);
+        // java.sql.Time
+        Object valMicro = timeMicroValConverter.convert(new java.sql.Time(10, 30, 01));
+        Object valNano = timeNanoValConverter.convert(new java.sql.Time(10, 30, 01));
+        assertThat(valMicro).isEqualTo(37801000000L);
+        assertThat(valNano).isEqualTo(37801000000000L);
+        // Duration
+        Duration valDuration = Duration.ofHours(2).plusMinutes(30).plusMillis(4).plusNanos(5);
+        assertThat(timeMicroValConverter.convert(valDuration)).isEqualTo(9000004000L);
+        assertThat(timeNanoValConverter.convert(valDuration)).isEqualTo(9000004000005L);
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
+++ b/debezium-core/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
@@ -30,13 +30,12 @@ import io.debezium.relational.ValueConverter;
  */
 public class JdbcValueConvertersTemporalPrecisionTest {
     JdbcValueConverters converters = new JdbcValueConverters(null, TemporalPrecisionMode.ISOSTRING, ZoneOffset.UTC, null, null, null);
-    //
     final Column dateCol = Column.editor().name("c1").type("DATE").optional(false).jdbcType(Types.DATE).create();
     final Field dateField = new Field(dateCol.name(), -1, converters.schemaBuilder(dateCol).build());
     final ValueConverter dateValConverter = converters.converter(dateCol, dateField);
-    //
+
     final Column timeCol = Column.editor().name("c2").type("TIME").optional(false).jdbcType(Types.TIME).create();
-    //
+
     final Column timestampCol = Column.editor().name("c2").type("TIMESTAMP").optional(false).jdbcType(Types.TIMESTAMP).create();
 
     @Test
@@ -62,8 +61,9 @@ public class JdbcValueConvertersTemporalPrecisionTest {
     public void testIsoDate() throws ParseException {
         assertThat(dateCol.isOptional()).isEqualTo(false);
 
+        // should return default value
         assertThat(dateValConverter.convert(null)).isEqualTo("1970-01-01Z");
-        //
+
         Object val = dateValConverter.convert(LocalDate.parse("2005-05-12"));
         assertThat(val).isEqualTo("2005-05-12Z");
         // LocalDateTime
@@ -85,7 +85,7 @@ public class JdbcValueConvertersTemporalPrecisionTest {
     public void testIsoTime() {
         Field timeField = new Field("tc1", -1, converters.schemaBuilder(timeCol).build());
         ValueConverter timeValConverter = converters.converter(timeCol, timeField);
-        //
+        // should return default value
         assertThat(timeCol.isOptional()).isEqualTo(false);
         assertThat(timeValConverter.convert(null)).isEqualTo("00:00:00Z");
         // java.util.Date
@@ -107,7 +107,7 @@ public class JdbcValueConvertersTemporalPrecisionTest {
     public void testIsoTimestamp() {
         Field tsField = new Field("tsc1", -1, converters.schemaBuilder(timestampCol).build());
         ValueConverter tSValConverter = converters.converter(timestampCol, tsField);
-        //
+        // should return default value
         assertThat(timestampCol.isOptional()).isEqualTo(false);
         assertThat(tSValConverter.convert(null)).isEqualTo("1970-01-01T00:00:00Z");
         // LocalDateTime
@@ -127,7 +127,7 @@ public class JdbcValueConvertersTemporalPrecisionTest {
         Field timeField = new Field("time_col", -1, converters.schemaBuilder(timeCol).build());
         ValueConverter timeMicroValConverter = convertersMicro.converter(timeCol, timeField);
         ValueConverter timeNanoValConverter = convertersNano.converter(timeCol, timeField);
-        // null
+        // should return default value
         assertThat(timeCol.isOptional()).isEqualTo(false);
         assertThat(timeMicroValConverter.convert(null)).isEqualTo(0L);
         assertThat(timeNanoValConverter.convert(null)).isEqualTo(0L);


### PR DESCRIPTION
Adding 3 new non **adaptive** temporal modes:
- `isostring`: converts to UTC ISO 8601
- `microseconds`: converts to int64, always with microseconds precision mode. not adaptive
- `nanoseconds`: converts to int64, always with nanoseconds precision mode. not adaptive

Implements [DBZ-6387](https://issues.redhat.com/browse/DBZ-6387)

remaining todos
- [x] update code comments
- [x] add it to postgresql array types as well

Requires https://github.com/debezium/debezium-connector-vitess/pull/219