### PR TITLE
DBZ-8441 Make AbstractConnectorTest#createEngine method abstract

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -124,6 +124,17 @@ public abstract class AbstractConnectorTest implements Testing {
     @Rule
     public TestRule logTestName = new TestLogger(logger);
 
+    /**
+     * Creates instance of {@link DebeziumEngine} which should be used for testing across the testsuite.
+     */
+    protected abstract TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder);
+
+    /**
+     * Creates instance of {@link DebeziumEngine.Builder} which corresponds to the {@link DebeziumEngine} provided
+     * by the {@link #createEngine(DebeziumEngine.Builder)} method.
+     */
+    protected abstract DebeziumEngine.Builder<SourceRecord> createEngineBuilder();
+
     @Before
     public final void initializeConnectorTestFramework() {
         LoggingContext.forConnector(getClass().getSimpleName(), "", "test");
@@ -452,14 +463,6 @@ public abstract class AbstractConnectorTest implements Testing {
                 fail("Interrupted while waiting for engine startup");
             }
         }
-    }
-
-    protected DebeziumEngine.Builder<SourceRecord> createEngineBuilder() {
-        return new EmbeddedEngine.EngineBuilder();
-    }
-
-    protected TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder) {
-        return new TestingEmbeddedEngine((EmbeddedEngine) builder.build());
     }
 
     protected Consumer<SourceRecord> getConsumer(Predicate<SourceRecord> isStopRecord, Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop) {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
@@ -118,6 +118,14 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
         }
     }
 
+    protected DebeziumEngine.Builder<SourceRecord> createEngineBuilder() {
+        return new EmbeddedEngine.EngineBuilder();
+    }
+
+    protected TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder) {
+        return new TestingEmbeddedEngine((EmbeddedEngine) builder.build());
+    }
+
     @Before
     public void beforeEach() throws Exception {
         nextConsumedLineNumber = 1;


### PR DESCRIPTION
With this change, all `EmbeddedEngine` stuff which is used in the tests should be localted only in `EmbeddedEngineTest` and `TestingEmbeddedEngine` classes, i.e. used only for running tests for `EmbeddedEngine` itself.

https://issues.redhat.com/browse/DBZ-8441