### PR TITLE
DBZ-8423 Resolved the issue that the debezium_offset_storage table is locked after storage initialization

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStore.java
@@ -152,6 +152,8 @@ public class JdbcOffsetBackingStore implements OffsetBackingStore {
                     }
                 }
                 data = tmpData;
+                // The commit will release the lock of the debezium_offset_storage table
+                conn.commit();
             }, "loading offset data", false);
         }
         catch (SQLException e) {


### PR DESCRIPTION
During the load function, a SELECT operation is performed on the debezium_offset_storage table. This operation locks the table, and the lock is not released after the offset storage initialization. We added a commit of the connection to the load function. This ensures, that the lock on the debezium_offset_storage table is released, when no longer needed.