### PR TITLE
DBZ-8467 Emit traces even when no propagated trace context is found

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -30,6 +30,7 @@
 
         <!-- Tracing -->
         <version.opentelemetry>1.23.0</version.opentelemetry>
+        <version.opentelemetry.testing>2.10.0</version.opentelemetry.testing>
 
         <!-- HTTP client -->
         <version.okhttp>4.8.1</version.okhttp>
@@ -611,6 +612,18 @@
               <groupId>com.squareup.okhttp3</groupId>
               <artifactId>logging-interceptor</artifactId>
               <version>${version.okhttp}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.javaagent</groupId>
+                <artifactId>opentelemetry-testing-common</artifactId>
+                <version>${version.opentelemetry.testing}-alpha</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.javaagent</groupId>
+                <artifactId>opentelemetry-agent-for-testing</artifactId>
+                <version>${version.opentelemetry.testing}-alpha</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -87,6 +87,16 @@
             <artifactId>groovy-json</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-testing-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-agent-for-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Used for unit testing with Kafka -->
         <dependency>
@@ -144,6 +154,23 @@
                 <configuration>
                     <source>15</source>
                     <target>15</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${io.opentelemetry.javaagent:opentelemetry-agent-for-testing:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
@@ -116,20 +116,16 @@ public class ActivateTracingSpan<R extends ConnectRecord<R>> implements Transfor
             propagatedSpanContext = after.getString(spanContextField);
         }
 
-        if (propagatedSpanContext == null) {
-            if (requireContextField) {
-                return connectRecord;
-            }
+        if (propagatedSpanContext == null && requireContextField) {
+            return connectRecord;
         }
-        else {
-            try {
-                return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
-            }
-            catch (NoClassDefFoundError e) {
-                throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
-            }
+
+        try {
+            return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
         }
-        return connectRecord;
+        catch (NoClassDefFoundError e) {
+            throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
+        }
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/TracingSpanUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/TracingSpanUtil.java
@@ -39,42 +39,58 @@ public class TracingSpanUtil {
 
     }
 
+    /**
+     * Create tracing spans representing the write operation in the database (the span timestamp is taken
+     * from the source event if available), as well as Debezium's processing operation (the span timestamp
+     * is taken from the envelope's timestamp).
+     * If a trace context is provided for propagation, it is set as the parent context of the
+     * created spans to enable distributed tracing.
+     * The resulting context is injected in the Kafka Connect Record headers for further propagation.
+     *
+     * @param <R> the subtype of {@link ConnectRecord} on which this transformation will operate
+     * @param connectRecord the Connect record that is to be enriched with tracing information
+     * @param envelope the envelope wrapped by the record
+     * @param source the source field of the envelope, or {@code null}
+     * @param propagatedSpanContext a String serialization of a {@link java.util.Properties} instance representing
+     *   the parent span context that should be used for trace propagation, or {@code null}
+     * @param operationName the operation name of the debezium processing span
+     * @return the connect record with message headers augmented with tracing information
+     */
     public static <R extends ConnectRecord<R>> R traceRecord(R connectRecord, Struct envelope, Struct source, String propagatedSpanContext, String operationName) {
+        SpanBuilder txLogSpanBuilder = tracer.spanBuilder(TX_LOG_WRITE_OPERATION_NAME)
+                .setSpanKind(SpanKind.INTERNAL);
 
         if (propagatedSpanContext != null) {
-
             Properties props = PropertiesGetter.extract(propagatedSpanContext);
 
             Context parentSpanContext = openTelemetry.getPropagators().getTextMapPropagator()
                     .extract(Context.current(), props, PropertiesGetter.INSTANCE);
 
-            SpanBuilder txLogSpanBuilder = tracer.spanBuilder(TX_LOG_WRITE_OPERATION_NAME)
-                    .setSpanKind(SpanKind.INTERNAL)
-                    .setParent(parentSpanContext);
+            txLogSpanBuilder.setParent(parentSpanContext);
+        }
 
+        if (source != null) {
+            Long eventTimestamp = source.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
+            if (eventTimestamp != null) {
+                txLogSpanBuilder.setStartTimestamp(eventTimestamp, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        Span txLogSpan = txLogSpanBuilder.startSpan();
+
+        try (Scope ignored = txLogSpan.makeCurrent()) {
             if (source != null) {
-                Long eventTimestamp = source.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
-                if (eventTimestamp != null) {
-                    txLogSpanBuilder.setStartTimestamp(eventTimestamp, TimeUnit.MILLISECONDS);
+                for (org.apache.kafka.connect.data.Field field : source.schema().fields()) {
+                    addFieldToSpan(txLogSpan, source, field.name(), DB_FIELDS_PREFIX);
                 }
             }
+            debeziumSpan(envelope, operationName);
 
-            Span txLogSpan = txLogSpanBuilder.startSpan();
-
-            try (Scope ignored = txLogSpan.makeCurrent()) {
-                if (source != null) {
-                    for (org.apache.kafka.connect.data.Field field : source.schema().fields()) {
-                        addFieldToSpan(txLogSpan, source, field.name(), DB_FIELDS_PREFIX);
-                    }
-                }
-                debeziumSpan(envelope, operationName);
-
-                TextMapPropagator textMapPropagator = openTelemetry.getPropagators().getTextMapPropagator();
-                textMapPropagator.inject(Context.current(), connectRecord.headers(), KafkaConnectHeadersSetter.INSTANCE);
-            }
-            finally {
-                txLogSpan.end();
-            }
+            TextMapPropagator textMapPropagator = openTelemetry.getPropagators().getTextMapPropagator();
+            textMapPropagator.inject(Context.current(), connectRecord.headers(), KafkaConnectHeadersSetter.INSTANCE);
+        }
+        finally {
+            txLogSpan.end();
         }
 
         return connectRecord;

--- a/debezium-core/src/test/java/io/debezium/transforms/ActivateTracingSpanTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ActivateTracingSpanTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.transforms.tracing.ActivateTracingSpan;
+import io.opentelemetry.javaagent.testing.common.AgentTestingExporterAccess;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+import scala.collection.mutable.StringBuilder;
+
+public class ActivateTracingSpanTest {
+    private final ActivateTracingSpan<SourceRecord> transform = new ActivateTracingSpan<>();
+    private final String tracingSpanContextFieldName = "tracingspancontext";
+    protected final Schema sourceSchema = SchemaBuilder.struct().optional()
+            .field("table", Schema.STRING_SCHEMA)
+            .field("lsn", Schema.INT32_SCHEMA)
+            .field("ts_ms", Schema.OPTIONAL_INT64_SCHEMA)
+            .build();
+    protected final SchemaBuilder recordSchemaBuilder = SchemaBuilder.struct().optional()
+            .field("id", Schema.INT8_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA);
+    protected final Schema recordSchema = recordSchemaBuilder.build();
+    protected final Schema recordSchemaWithTracingSpanContextField = recordSchemaBuilder.field(tracingSpanContextFieldName, Schema.STRING_SCHEMA).build();
+
+    @Test
+    public void whenPropagationContextIsProvidedATraceIsCreated() {
+        AgentTestingExporterAccess.reset();
+        // valid traceparent header from https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
+        final String propagatedTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"; // version-traceid-parentid-flags
+        final String propagatedParentId = "00f067aa0ba902b7"; // second to last part of propagatedTraceParent
+        final String propagatedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736"; // second part of propagatedTraceParent
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD.toString(), tracingSpanContextFieldName);
+        transform.configure(props);
+
+        final Schema myRecordSchema = SchemaBuilder.struct().optional()
+                .field("id", Schema.INT8_SCHEMA)
+                .field("name", Schema.STRING_SCHEMA)
+                .field(tracingSpanContextFieldName, Schema.STRING_SCHEMA)
+                .build();
+        final Struct after = new Struct(myRecordSchema);
+        final Struct source = new Struct(sourceSchema);
+        source.put("table", "mytable");
+        source.put("lsn", 1);
+        source.put("ts_ms", 1588252618953L);
+
+        after.put("id", (byte) 1);
+        after.put("name", "test");
+        // build the "tracingcontext" field which is expected to be a serialized representation
+        // of a java.util.Properties object (e.g. "prop1=val1\nprop2=val2\n")
+        final Map<String, String> tracingContext = new HashMap<>();
+        // example valid traceparent value taken from https://www.w3.org/TR/trace-context/#relationship-between-the-headers
+        tracingContext.put("traceparent", propagatedTraceParent);
+        final StringBuilder tracingContextSb = new StringBuilder();
+        for (var prop : tracingContext.entrySet()) {
+            tracingContextSb.append(prop.getKey())
+                    .append("=")
+                    .append(prop.getValue())
+                    .append("\n");
+        }
+        after.put(tracingSpanContextFieldName, tracingContextSb.toString());
+
+        final Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(myRecordSchema)
+                .withSource(sourceSchema)
+                .build();
+
+        final Struct payload = envelope.create(after, source, Instant.now());
+
+        SourceRecord record = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "db.server1.table1",
+                envelope.schema(),
+                payload);
+
+        VerifyRecord.isValid(record, true);
+        final SourceRecord transformedRecord = transform.apply(record);
+        VerifyRecord.isValid(transformedRecord, true);
+
+        final List<SpanData> spans = AgentTestingExporterAccess.getExportedSpans();
+        assertThat(spans.size()).isEqualTo(2);
+        assertThat(spans.get(0).getName()).isEqualTo("debezium-read");
+        assertThat(spans.get(1).getName()).isEqualTo("db-log-write");
+        // The "db-log-write" span should have the same parentId as the propagated trace
+        assertThat(spans.get(1).getParentSpanId()).isEqualTo(propagatedParentId);
+        // Spans should share the same trace id as the propagated trace
+        assertThat(spans.get(0).getTraceId()).isEqualTo(propagatedTraceId);
+        assertThat(spans.get(1).getTraceId()).isEqualTo(propagatedTraceId);
+
+        final Headers headers = transformedRecord.headers();
+        assertThat(headers).isNotEmpty();
+        // the produced Kafka record should have a traceparent header holding the propagated trace Id
+        assertThat(headers.lastWithName("traceparent").value().toString()).contains(propagatedTraceId);
+        // the produced Kafka record should have a traceparent header holding the "db-log-write" span Id as a parent
+        assertThat(headers.lastWithName("traceparent").value().toString()).contains(spans.get(1).getSpanId());
+    }
+
+    @Test
+    public void whenPropagationContextIsNotProvidedAndContextIsNotRequiredATraceIsCreated() {
+        AgentTestingExporterAccess.reset();
+        final Map<String, String> props = new HashMap<>();
+        transform.configure(props);
+
+        final Struct after = new Struct(recordSchema);
+        final Struct source = new Struct(sourceSchema);
+        source.put("table", "mytable");
+        source.put("lsn", 1);
+        source.put("ts_ms", 1588252618953L);
+
+        after.put("id", (byte) 1);
+        after.put("name", "test");
+
+        final Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+
+        final Struct payload = envelope.create(after, source, Instant.now());
+
+        SourceRecord record = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "db.server1.table1",
+                envelope.schema(),
+                payload);
+
+        VerifyRecord.isValid(record, true);
+        final SourceRecord transformedRecord = transform.apply(record);
+        VerifyRecord.isValid(transformedRecord, true);
+
+        final List<SpanData> spans = AgentTestingExporterAccess.getExportedSpans();
+        assertThat(spans.size()).isEqualTo(2);
+        assertThat(spans.get(0).getName()).isEqualTo("debezium-read");
+        assertThat(spans.get(1).getName()).isEqualTo("db-log-write");
+
+        final Headers headers = transformedRecord.headers();
+        assertThat(headers).isNotEmpty();
+        // the produced Kafka record should have a traceparent header holding the newly created trace Id
+        assertThat(headers.lastWithName("traceparent").value().toString()).contains(spans.get(1).getTraceId());
+        // the produced Kafka record should have a traceparent header holding the "db-log-write" span Id as a parent
+        assertThat(headers.lastWithName("traceparent").value().toString()).contains(spans.get(1).getSpanId());
+    }
+
+    @Test
+    public void whenPropagationContextIsNotProvidedAndContextIsRequiredNoTraceIsCreated() {
+        AgentTestingExporterAccess.reset();
+        final Map<String, String> props = new HashMap<>();
+        props.put(ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED.toString(), "true");
+        transform.configure(props);
+
+        final Struct after = new Struct(recordSchema);
+        final Struct source = new Struct(sourceSchema);
+        source.put("table", "mytable");
+        source.put("lsn", 1);
+        source.put("ts_ms", 1588252618953L);
+
+        after.put("id", (byte) 1);
+        after.put("name", "test");
+
+        final Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+
+        final Struct payload = envelope.create(after, source, Instant.now());
+
+        SourceRecord record = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "db.server1.table1",
+                envelope.schema(),
+                payload);
+
+        VerifyRecord.isValid(record, true);
+        final SourceRecord transformedRecord = transform.apply(record);
+        VerifyRecord.isValid(transformedRecord, true);
+
+        final List<SpanData> spans = AgentTestingExporterAccess.getExportedSpans();
+        assertThat(spans.size()).isEqualTo(0);
+
+        final Headers headers = transformedRecord.headers();
+        assertThat(headers).isEmpty();
+    }
+}


### PR DESCRIPTION
In the ActivateTracingSpan SMT, emitting traces when no propagated trace context is found is controlled by the `tracing.with.context.field.only` setting. However, the if/else condition was flawed, resulting in traces not being emitted event with this setting being set to `false`. This commit fixes the condition logic.

# Context

Debezium offers to create traces when processing records. The [documentation](https://debezium.io/documentation/reference/stable/integrations/tracing.html#_activatetracingspan_smt) states that when provided with a serialized upstream application tracing context (through a specific SQL table field), it will use this trace context as a parent trace context for its own spans. If it doesn't find any, it will create traces from scratch.

In reality, if no propagated trace context is found, Debezium skips emitting traces ([source](https://github.com/debezium/debezium/blob/v3.0.1.Final/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java#L119C1-L132C30))
```
if (propagatedSpanContext == null) {
    if (requireContextField) {
        return connectRecord;
    }
}
else {
    try {
        return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
    }
    catch (NoClassDefFoundError e) {
        throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
    }
}
return connectRecord;
```

The `requireContextField` parameter comes from a setting. It allows to specify whether we want to trace only records that provide a trace context.

So, [per the documentation](https://debezium.io/documentation/reference/stable/integrations/tracing.html#_activatetracingspan_smt), we have the following cases:

1. WHEN propagatedSpanContext is not null
   THEN create trace (and propagate span context as parent)
2. WHEN propagatedSpanContext is null AND requireContextField is true
   THEN skip trace creation
3. WHEN propagatedSpanContext is null AND requireContextField is false (default)
   THEN create trace

Case 3. is the one to be fixed here.

# Changes

Main diff in short:

* The SMT's `apply` method is modified to skip tracing when (and only when) `propagatedSpanContext == null && requireContextField`
* The `TracingSpanUtil.traceRecord` method is improved to always create a trace while still handling the case where its `propagatedSpanContext` parameter would be null.
