### PR TITLE
DBZ-8472 connector configuration logging improvement

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -242,10 +242,12 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             }
 
             if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("Starting {} with configuration:", getClass().getSimpleName());
+                StringBuilder configLogBuilder = new StringBuilder("Starting " + getClass().getSimpleName() + " with configuration:");
                 withMaskedSensitiveOptions(config).forEach((propName, propValue) -> {
-                    LOGGER.info("   {} = {}", propName, propValue);
+                    configLogBuilder.append("\n   ").append(propName).append(" = ").append(propValue);
                 });
+                configLogBuilder.append("\n");
+                LOGGER.info(configLogBuilder.toString());
             }
             try {
                 this.coordinator = start(config);


### PR DESCRIPTION
[DBZ-8472](https://issues.redhat.com/browse/DBZ-8472)

Use `StringBuilder` to build a consolidated connector configuration log message.