### PR TITLE
DBZ-8384 Commit pause signal to connector offset

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/PauseIncrementalSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/PauseIncrementalSnapshot.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.pipeline.signal.actions.snapshotting;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.AbstractSnapshotSignal;
@@ -12,6 +15,8 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.spi.schema.DataCollectionId;
 
 public class PauseIncrementalSnapshot<P extends Partition> extends AbstractSnapshotSignal<P> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PauseIncrementalSnapshot.class);
 
     public static final String NAME = "pause-snapshot";
 
@@ -23,6 +28,7 @@ public class PauseIncrementalSnapshot<P extends Partition> extends AbstractSnaps
 
     @Override
     public boolean arrived(SignalPayload<P> signalPayload) throws InterruptedException {
+        LOGGER.info("Request to pause incremental snapshot");
         dispatcher.getIncrementalSnapshotChangeEventSource().pauseSnapshot(signalPayload.partition, signalPayload.offsetContext);
         return true;
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ResumeIncrementalSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ResumeIncrementalSnapshot.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.pipeline.signal.actions.snapshotting;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.AbstractSnapshotSignal;
@@ -12,6 +15,8 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.spi.schema.DataCollectionId;
 
 public class ResumeIncrementalSnapshot<P extends Partition> extends AbstractSnapshotSignal<P> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResumeIncrementalSnapshot.class);
 
     public static final String NAME = "resume-snapshot";
 
@@ -23,6 +28,7 @@ public class ResumeIncrementalSnapshot<P extends Partition> extends AbstractSnap
 
     @Override
     public boolean arrived(SignalPayload<P> signalPayload) throws InterruptedException {
+        LOGGER.info("Request to resume incremental snapshot");
         dispatcher.getIncrementalSnapshotChangeEventSource().resumeSnapshot(
                 signalPayload.partition, signalPayload.offsetContext);
         return true;

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
@@ -185,7 +185,8 @@ public class KafkaSignalChannel implements SignalChannelReader {
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .collect(Collectors.toList());
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             LOGGER.error("Kafka signal consumer failed", e);
             throw e;
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
@@ -175,16 +175,20 @@ public class KafkaSignalChannel implements SignalChannelReader {
 
     @Override
     public List<SignalRecord> read() {
+        try {
+            LOGGER.info("Reading signal form kafka");
+            // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
+            ConsumerRecords<String, String> recoveredRecords = signalsConsumer.poll(pollTimeoutMs.toMillis());
 
-        LOGGER.debug("Reading signal form kafka");
-        // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
-        ConsumerRecords<String, String> recoveredRecords = signalsConsumer.poll(pollTimeoutMs.toMillis());
-
-        return StreamSupport.stream(recoveredRecords.spliterator(), false)
-                .map(this::processSignal)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toList());
+            return StreamSupport.stream(recoveredRecords.spliterator(), false)
+                    .map(this::processSignal)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOGGER.error("Kafka signal consumer failed", e);
+            throw e;
+        }
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -117,23 +117,22 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         readChunk(partition, offsetContext);
     }
 
+
     @Override
     public void pauseSnapshot(P partition, OffsetContext offsetContext) {
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
-        if (context.snapshotRunning() && !context.isSnapshotPaused()) {
-            context.pauseSnapshot();
-            progressListener.snapshotPaused(partition);
-            notificationService.incrementalSnapshotNotificationService().notifyPaused(context, partition, offsetContext);
-        }
+        context.pauseSnapshot();
+        progressListener.snapshotPaused(partition);
+        notificationService.incrementalSnapshotNotificationService().notifyPaused(context, partition, offsetContext);
     }
 
     @Override
     public void resumeSnapshot(P partition, OffsetContext offsetContext) throws InterruptedException {
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
-        if (context.snapshotRunning() && context.isSnapshotPaused()) {
-            context.resumeSnapshot();
-            progressListener.snapshotResumed(partition);
-            notificationService.incrementalSnapshotNotificationService().notifyResumed(context, partition, offsetContext);
+        context.resumeSnapshot();
+        progressListener.snapshotResumed(partition);
+        notificationService.incrementalSnapshotNotificationService().notifyResumed(context, partition, offsetContext);
+        if (context.snapshotRunning()) {
             readChunk(partition, offsetContext);
         }
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -117,7 +117,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         readChunk(partition, offsetContext);
     }
 
-
     @Override
     public void pauseSnapshot(P partition, OffsetContext offsetContext) {
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -56,6 +56,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     public static final String EVENT_PRIMARY_KEY = INCREMENTAL_SNAPSHOT_KEY + "_primary_key";
     public static final String TABLE_MAXIMUM_KEY = INCREMENTAL_SNAPSHOT_KEY + "_maximum_key";
     public static final String CORRELATION_ID = INCREMENTAL_SNAPSHOT_KEY + "_correlation_id";
+    public static final String PAUSED_KEY = INCREMENTAL_SNAPSHOT_KEY + "_paused";
     private final SnapshotDataCollection<T> snapshotDataCollection = new SnapshotDataCollection<>();
 
     /**
@@ -185,6 +186,9 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     }
 
     public Map<String, Object> store(Map<String, Object> offset) {
+        if (paused.get()) {
+            offset.put(PAUSED_KEY, true);
+        }
         if (!snapshotRunning()) {
             return offset;
         }
@@ -281,6 +285,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
             context.addTablesIdsToSnapshot(context.snapshotDataCollection.stringToDataCollections(dataCollectionsStr, context.useCatalogBeforeSchema));
         }
         context.correlationId = (String) offsets.get(CORRELATION_ID);
+        final Boolean snapshotPaused  = Boolean.parseBoolean((String) offsets.get(PAUSED_KEY));
+        context.paused.set(snapshotPaused);
         return context;
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -285,7 +285,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
             context.addTablesIdsToSnapshot(context.snapshotDataCollection.stringToDataCollections(dataCollectionsStr, context.useCatalogBeforeSchema));
         }
         context.correlationId = (String) offsets.get(CORRELATION_ID);
-        final Boolean snapshotPaused  = Boolean.parseBoolean((String) offsets.get(PAUSED_KEY));
+        final Boolean snapshotPaused = Boolean.parseBoolean((String) offsets.get(PAUSED_KEY));
         context.paused.set(snapshotPaused);
         return context;
     }

--- a/debezium-core/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/PauseIncrementalSnapshotTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/PauseIncrementalSnapshotTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.signal.actions.snapshotting;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class PauseIncrementalSnapshotTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPauseSnapshotSignal() throws InterruptedException {
+        EventDispatcher<Partition, DataCollectionId> dispatcher = mock(EventDispatcher.class);
+        IncrementalSnapshotChangeEventSource<Partition, DataCollectionId> snapshotSource = mock(IncrementalSnapshotChangeEventSource.class);
+        when(dispatcher.getIncrementalSnapshotChangeEventSource()).thenReturn(snapshotSource);
+
+        PauseIncrementalSnapshot<Partition> pauseIncrementalSnapshot = new PauseIncrementalSnapshot<>(dispatcher);
+
+        Partition partition = mock(Partition.class);
+        OffsetContext offsetContext = mock(OffsetContext.class);
+        SignalPayload<Partition> signalPayload = new SignalPayload<>(partition, null, null, null, offsetContext, null);
+
+        boolean result = pauseIncrementalSnapshot.arrived(signalPayload);
+
+        verify(snapshotSource).pauseSnapshot(partition, offsetContext);
+        assertTrue(result);
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/ResumeIncrementalSnapshotTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/ResumeIncrementalSnapshotTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.signal.actions.snapshotting;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class ResumeIncrementalSnapshotTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResumeSnapshotSignal() throws InterruptedException {
+        EventDispatcher<Partition, DataCollectionId> dispatcher = mock(EventDispatcher.class);
+        IncrementalSnapshotChangeEventSource<Partition, DataCollectionId> snapshotSource = mock(IncrementalSnapshotChangeEventSource.class);
+        when(dispatcher.getIncrementalSnapshotChangeEventSource()).thenReturn(snapshotSource);
+
+        ResumeIncrementalSnapshot<Partition> resumeIncrementalSnapshot = new ResumeIncrementalSnapshot<>(dispatcher);
+
+        Partition partition = mock(Partition.class);
+        OffsetContext offsetContext = mock(OffsetContext.class);
+        SignalPayload<Partition> signalPayload = new SignalPayload<>(partition, null, null, null, offsetContext, null);
+
+        boolean result = resumeIncrementalSnapshot.arrived(signalPayload);
+
+        verify(snapshotSource).resumeSnapshot(partition, offsetContext);
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/DBZ-8384

When Debezium receives a pause signal (or resume signal), the committed offset needs to have a flag set. Otherwise when Debezium (or Kafka Connect) restarts it will just resume the incremental-snapshot.

Some small details:
- Incremental-snapshots can be very short, it would be nice if the pause signal was accepted regardless of whether a snapshot is running
- The Kafka consumer of signals will silently crash and it's impossible to notice, so I added a simple try-catch around the consumer
- Some logs in the signals
