### PR TITLE
DBZ-8370 Revert migration Oracle testsuite to async engine

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
@@ -41,7 +41,7 @@ import io.debezium.data.SchemaAndValueField;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.time.MicroDuration;
@@ -56,7 +56,7 @@ import io.debezium.util.Testing;
  *
  * @author Jiri Pechanec
  */
-public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineConnectorTest {
+public abstract class AbstractOracleDatatypesTest extends AbstractConnectorTest {
 
     /**
      * Key for schema parameter used to store DECIMAL/NUMERIC columns' precision.

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CustomSnapshotterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CustomSnapshotterIT.java
@@ -21,10 +21,10 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
-public class CustomSnapshotterIT extends AbstractAsyncEngineConnectorTest {
+public class CustomSnapshotterIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBinaryModeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBinaryModeIT.java
@@ -26,14 +26,14 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnStrategyRule;
 import io.debezium.connector.oracle.junit.SkipWhenLogMiningStrategyIs;
 import io.debezium.connector.oracle.util.TestHelper;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
  * @author Chris Cranford
  */
 @SkipWhenLogMiningStrategyIs(value = SkipWhenLogMiningStrategyIs.Strategy.HYBRID, reason = "Hybrid does not support BLOB")
-public class OracleBinaryModeIT extends AbstractAsyncEngineConnectorTest {
+public class OracleBinaryModeIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipStrategyRule = new SkipTestDependingOnStrategyRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -40,7 +40,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.util.IoUtil;
 import io.debezium.util.Testing;
@@ -53,7 +53,7 @@ import ch.qos.logback.classic.Level;
  * @author Chris Cranford
  */
 @SkipWhenLogMiningStrategyIs(value = SkipWhenLogMiningStrategyIs.Strategy.HYBRID, reason = "BLOB not supported by this mine mode")
-public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
+public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
     private static final byte[] BIN_DATA = readBinaryData("data/test_lob_data.json");
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -41,7 +41,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.util.Testing;
 
@@ -53,7 +53,7 @@ import ch.qos.logback.classic.Level;
  * @author Chris Cranford
  */
 @SkipWhenLogMiningStrategyIs(value = SkipWhenLogMiningStrategyIs.Strategy.HYBRID, reason = "Hybrid does not support CLOB")
-public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
+public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
     private static final String JSON_DATA = Testing.Files.readResourceAsString("data/test_lob_data.json");
     private static final String JSON_DATA2 = Testing.Files.readResourceAsString("data/test_lob_data2.json");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
@@ -33,7 +33,7 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -41,7 +41,7 @@ import io.debezium.util.Testing;
  *
  * @author Gunnar Morling
  */
-public class OracleConnectorFilterIT extends AbstractAsyncEngineConnectorTest {
+public class OracleConnectorFilterIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
     private static OracleConnection adminConnection;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -92,8 +92,8 @@ import io.debezium.data.SchemaAndValueField;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.embedded.EmbeddedEngineConfig;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.heartbeat.DatabaseHeartbeatImpl;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConnection;
@@ -111,7 +111,7 @@ import ch.qos.logback.classic.Level;
  *
  * @author Gunnar Morling
  */
-public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
+public class OracleConnectorIT extends AbstractConnectorTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorIT.class);
 
     private static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDefaultValueIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDefaultValueIT.java
@@ -27,7 +27,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.time.Interval;
 import io.debezium.time.MicroDuration;
@@ -39,7 +39,7 @@ import io.debezium.util.Testing;
  *
  * @author Chris Cranford
  */
-public class OracleDefaultValueIT extends AbstractAsyncEngineConnectorTest {
+public class OracleDefaultValueIT extends AbstractConnectorTest {
 
     private OracleConnection connection;
     private Consumer<Configuration.Builder> configUpdater;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleExtendedStringIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleExtendedStringIT.java
@@ -27,7 +27,7 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnDatabaseParameterRu
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -36,7 +36,7 @@ import io.debezium.util.Testing;
  * @author Chris Cranford
  */
 @SkipOnDatabaseParameter(parameterName = "max_string_size", value = "EXTENDED", matches = false, reason = "Requires max_string_size set to EXTENDED")
-public class OracleExtendedStringIT extends AbstractAsyncEngineConnectorTest {
+public class OracleExtendedStringIT extends AbstractConnectorTest {
 
     @Rule
     public TestRule skipOnDatabaseParameter = new SkipTestDependingOnDatabaseParameterRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleNumberNegativeScaleIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleNumberNegativeScaleIT.java
@@ -28,7 +28,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.SchemaAndValueField;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -36,7 +36,7 @@ import io.debezium.util.Testing;
  *
  * @author vjuranek
  */
-public class OracleNumberNegativeScaleIT extends AbstractAsyncEngineConnectorTest {
+public class OracleNumberNegativeScaleIT extends AbstractConnectorTest {
 
     private static final String PRECISION_PARAMETER_KEY = "connect.decimal.precision";
     private static final Schema NUMBER_SCHEMA = Decimal.builder(0).optional().parameter(PRECISION_PARAMETER_KEY, "38").build();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleNumberOneIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleNumberOneIT.java
@@ -23,7 +23,7 @@ import io.debezium.connector.oracle.converters.NumberOneToBooleanConverter;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope.FieldName;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -31,7 +31,7 @@ import io.debezium.util.Testing;
  *
  * @author Chris Cranford
  */
-public class OracleNumberOneIT extends AbstractAsyncEngineConnectorTest {
+public class OracleNumberOneIT extends AbstractConnectorTest {
 
     private OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OraclePrimaryKeyLobReselectIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OraclePrimaryKeyLobReselectIT.java
@@ -27,7 +27,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 
 /**
  * Integration tests when LOB is enabled and the primary key changes, to re-select LOB columns
@@ -35,7 +35,7 @@ import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
  *
  * @author Chris Cranford
  */
-public class OraclePrimaryKeyLobReselectIT extends AbstractAsyncEngineConnectorTest {
+public class OraclePrimaryKeyLobReselectIT extends AbstractConnectorTest {
 
     @Rule
     public TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRawDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRawDataTypeIT.java
@@ -28,14 +28,14 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 
 /**
  * Integration tests for RAW data type support.
  *
  * @author Chris Cranford
  */
-public class OracleRawDataTypeIT extends AbstractAsyncEngineConnectorTest {
+public class OracleRawDataTypeIT extends AbstractConnectorTest {
 
     private static final int RAW_LENGTH = 2000;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRawToStringIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRawToStringIT.java
@@ -23,7 +23,7 @@ import io.debezium.connector.oracle.converters.RawToStringConverter;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -31,7 +31,7 @@ import io.debezium.util.Testing;
  *
  * @author Chris Cranford
  */
-public class OracleRawToStringIT extends AbstractAsyncEngineConnectorTest {
+public class OracleRawToStringIT extends AbstractConnectorTest {
 
     private OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRowIdDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleRowIdDataTypeIT.java
@@ -25,14 +25,14 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Other adapters do not support ROWID data types")
-public class OracleRowIdDataTypeIT extends AbstractAsyncEngineConnectorTest {
+public class OracleRowIdDataTypeIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaMigrationIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaMigrationIT.java
@@ -33,7 +33,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope.FieldName;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
@@ -48,7 +48,7 @@ import ch.qos.logback.classic.Level;
  *
  * @author Chris Cranford
  */
-public class OracleSchemaMigrationIT extends AbstractAsyncEngineConnectorTest {
+public class OracleSchemaMigrationIT extends AbstractConnectorTest {
 
     private OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSkipMessagesWithoutChangeConfigIT.java
@@ -24,14 +24,14 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 
 /**
  * Integration tests for config skip.messages.without.change
  *
  * @author Ronak Jain
  */
-public class OracleSkipMessagesWithoutChangeConfigIT extends AbstractAsyncEngineConnectorTest {
+public class OracleSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleXmlDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleXmlDataTypesIT.java
@@ -36,7 +36,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.util.Testing;
 
@@ -50,7 +50,7 @@ import oracle.xml.parser.v2.XMLDocument;
  * @author Chris Cranford
  */
 @SkipWhenLogMiningStrategyIs(value = SkipWhenLogMiningStrategyIs.Strategy.HYBRID, reason = "Hybrid does not support XML")
-public class OracleXmlDataTypesIT extends AbstractAsyncEngineConnectorTest {
+public class OracleXmlDataTypesIT extends AbstractConnectorTest {
 
     // Short XML files
     private static final String XML_DATA = Testing.Files.readResourceAsString("data/test_xml_data_short.xml");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SchemaHistoryTopicIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SchemaHistoryTopicIT.java
@@ -23,7 +23,7 @@ import io.debezium.connector.SnapshotType;
 import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -34,7 +34,7 @@ import io.debezium.util.Testing;
  *
  * @author Jiri Pechanec
  */
-public class SchemaHistoryTopicIT extends AbstractAsyncEngineConnectorTest {
+public class SchemaHistoryTopicIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SignalsIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SignalsIT.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.connector.oracle.util.TestHelper;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.EqualityCheck;
 import io.debezium.junit.SkipTestRule;
 import io.debezium.junit.SkipWhenDatabaseVersion;
@@ -34,7 +34,7 @@ import io.debezium.util.Testing;
  * @author Jiri Pechanec
  */
 @SkipWhenDatabaseVersion(check = EqualityCheck.GREATER_THAN_OR_EQUAL, major = 21, reason = "Not compatible, schema changes cause unexpected 'COL#' columns")
-public class SignalsIT extends AbstractAsyncEngineConnectorTest {
+public class SignalsIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotSelectOverridesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotSelectOverridesIT.java
@@ -23,7 +23,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -31,7 +31,7 @@ import io.debezium.util.Testing;
  *
  * @author Chris Cranford
  */
-public class SnapshotSelectOverridesIT extends AbstractAsyncEngineConnectorTest {
+public class SnapshotSelectOverridesIT extends AbstractConnectorTest {
 
     private static final int INITIAL_RECORDS_PER_TABLE = 10;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
@@ -25,7 +25,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 
@@ -34,7 +34,7 @@ import io.debezium.util.Testing;
  *
  * @author Jiri Pechanec
  */
-public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
+public class TransactionMetadataIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
@@ -30,7 +30,7 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.logwriter.CommitLogWriterFlushStrategy;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.TableId;
 import io.debezium.util.Strings;
@@ -41,7 +41,7 @@ import io.debezium.util.Testing;
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Flush strategy only applies to LogMiner implementation")
 @SkipOnReadOnly(reason = "Test expects flush table, not applicable during read only.")
-public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
+public class FlushStrategyIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/HybridMiningStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/HybridMiningStrategyIT.java
@@ -51,9 +51,9 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.embedded.EmbeddedEngineConfig;
 import io.debezium.embedded.KafkaConnectUtil;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.SkipLongRunning;
 import io.debezium.junit.SkipTestRule;
@@ -76,7 +76,7 @@ import io.debezium.util.Testing;
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applies to LogMiner")
-public class HybridMiningStrategyIT extends AbstractAsyncEngineConnectorTest {
+public class HybridMiningStrategyIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipApicurioRule = new SkipTestWhenRunWithApicurioRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorIT.java
@@ -33,7 +33,7 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Strings;
 import io.debezium.util.Testing;
 
@@ -43,7 +43,7 @@ import io.debezium.util.Testing;
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "LogMiner specific")
-public class LogFileCollectorIT extends AbstractAsyncEngineConnectorTest {
+public class LogFileCollectorIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerSourceInfoRedoSqlIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerSourceInfoRedoSqlIT.java
@@ -31,7 +31,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Testing;
 
 /**
@@ -40,7 +40,7 @@ import io.debezium.util.Testing;
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Requires LogMiner")
-public class LogMinerSourceInfoRedoSqlIT extends AbstractAsyncEngineConnectorTest {
+public class LogMinerSourceInfoRedoSqlIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
@@ -28,14 +28,14 @@ import io.debezium.connector.oracle.junit.SkipWhenLogMiningStrategyIs;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 
 /**
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(SkipWhenAdapterNameIsNot.AdapterName.LOGMINER)
 @SkipWhenLogMiningStrategyIs(value = SkipWhenLogMiningStrategyIs.Strategy.HYBRID, reason = "Cannot use lob.enabled with Hybrid")
-public class TransactionCommitConsumerIT extends AbstractAsyncEngineConnectorTest {
+public class TransactionCommitConsumerIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorTest.java
@@ -27,7 +27,7 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.util.Testing;
 
@@ -37,7 +37,7 @@ import io.debezium.util.Testing;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractProcessorTest extends AbstractAsyncEngineConnectorTest {
+public abstract class AbstractProcessorTest extends AbstractConnectorTest {
 
     private OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
@@ -46,7 +46,7 @@ import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
-import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
@@ -64,7 +64,7 @@ import oracle.sql.CharacterSet;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventProcessor> extends AbstractAsyncEngineConnectorTest {
+public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventProcessor> extends AbstractConnectorTest {
 
     private static final String TRANSACTION_ID_1 = "1234567890";
     private static final String TRANSACTION_ID_2 = "9876543210";

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -124,17 +124,6 @@ public abstract class AbstractConnectorTest implements Testing {
     @Rule
     public TestRule logTestName = new TestLogger(logger);
 
-    /**
-     * Creates instance of {@link DebeziumEngine} which should be used for testing across the testsuite.
-     */
-    protected abstract TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder);
-
-    /**
-     * Creates instance of {@link DebeziumEngine.Builder} which corresponds to the {@link DebeziumEngine} provided
-     * by the {@link #createEngine(DebeziumEngine.Builder)} method.
-     */
-    protected abstract DebeziumEngine.Builder<SourceRecord> createEngineBuilder();
-
     @Before
     public final void initializeConnectorTestFramework() {
         LoggingContext.forConnector(getClass().getSimpleName(), "", "test");
@@ -463,6 +452,14 @@ public abstract class AbstractConnectorTest implements Testing {
                 fail("Interrupted while waiting for engine startup");
             }
         }
+    }
+
+    protected DebeziumEngine.Builder<SourceRecord> createEngineBuilder() {
+        return new EmbeddedEngine.EngineBuilder();
+    }
+
+    protected TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder) {
+        return new TestingEmbeddedEngine((EmbeddedEngine) builder.build());
     }
 
     protected Consumer<SourceRecord> getConsumer(Predicate<SourceRecord> isStopRecord, Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop) {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
@@ -118,14 +118,6 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
         }
     }
 
-    protected DebeziumEngine.Builder<SourceRecord> createEngineBuilder() {
-        return new EmbeddedEngine.EngineBuilder();
-    }
-
-    protected TestingDebeziumEngine<SourceRecord> createEngine(DebeziumEngine.Builder<SourceRecord> builder) {
-        return new TestingEmbeddedEngine((EmbeddedEngine) builder.build());
-    }
-
     @Before
     public void beforeEach() throws Exception {
         nextConsumedLineNumber = 1;


### PR DESCRIPTION
This reverts commit 43cdf502ed2f00f2ee54245f430477170e99abc8.
The PR is for verification is async engine is responsible for testsuite slow down or not.