### PR TITLE
Dbz 7094 ExtractNewRecordState value of optional null field which has default value

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -651,3 +651,4 @@ Gaurav Miglani
 Ashish Binu
 Mohamed El Shaer
 Artyom Dubinin
+Giovanni Panice

--- a/debezium-core/src/main/java/io/debezium/transforms/AbstractExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/AbstractExtractNewRecordState.java
@@ -14,7 +14,15 @@ import static io.debezium.data.Envelope.FieldName.TRANSACTION;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.*;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_FIELDS;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_FIELDS_PREFIX;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_DELETES;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_TOMBSTONE_DELETES;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.REPLACE_NULL_WITH_DEFAULT;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/debezium-core/src/main/java/io/debezium/transforms/AbstractExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/AbstractExtractNewRecordState.java
@@ -14,14 +14,7 @@ import static io.debezium.data.Envelope.FieldName.TRANSACTION;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY;
 import static io.debezium.pipeline.txmetadata.TransactionStructMaker.DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_FIELDS;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_FIELDS_PREFIX;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_DELETES;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_TOMBSTONE_DELETES;
-import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -100,13 +93,13 @@ public abstract class AbstractExtractNewRecordState<R extends ConnectRecord<R>> 
         // handle deleted records
         if (!Strings.isNullOrBlank(config.getString(HANDLE_TOMBSTONE_DELETES))) {
             DeleteTombstoneHandling deleteTombstoneHandling = DeleteTombstoneHandling.parse(config.getString(HANDLE_TOMBSTONE_DELETES));
-            extractRecordStrategy = new DefaultDeleteHandlingStrategy<>(deleteTombstoneHandling);
+            extractRecordStrategy = new DefaultDeleteHandlingStrategy<>(deleteTombstoneHandling, config.getBoolean(REPLACE_NULL_WITH_DEFAULT));
         }
         else {
             // will be removed in further release
             boolean dropTombstones = config.getBoolean(DROP_TOMBSTONES);
             DeleteHandling handleDeletes = DeleteHandling.parse(config.getString(HANDLE_DELETES));
-            extractRecordStrategy = new LegacyDeleteHandlingStrategy<>(handleDeletes, dropTombstones);
+            extractRecordStrategy = new LegacyDeleteHandlingStrategy<>(handleDeletes, dropTombstones, config.getBoolean(REPLACE_NULL_WITH_DEFAULT));
             LOGGER.warn(
                     "The deleted record handling configs \"drop.tombstones\" and \"delete.handling.mode\" have been deprecated, " +
                             "please use \"delete.tombstone.handling.mode\" instead.");

--- a/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
@@ -57,6 +57,7 @@ public class ConnectRecordUtil {
         Map<String, String> delegateConfig = new HashMap<>();
         delegateConfig.put("static.field", field);
         delegateConfig.put("static.value", value);
+        delegateConfig.put("replace.null.with.default", "false");
         insertDelegate.configure(delegateConfig);
         return insertDelegate;
     }

--- a/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ConnectRecordUtil.java
@@ -52,12 +52,12 @@ public class ConnectRecordUtil {
         return extractField;
     }
 
-    public static <R extends ConnectRecord<R>> InsertField<R> insertStaticValueDelegate(String field, String value) {
+    public static <R extends ConnectRecord<R>> InsertField<R> insertStaticValueDelegate(String field, String value, boolean replaceNullWithDefault) {
         InsertField<R> insertDelegate = new InsertField.Value<>();
         Map<String, String> delegateConfig = new HashMap<>();
         delegateConfig.put("static.field", field);
         delegateConfig.put("static.value", value);
-        delegateConfig.put("replace.null.with.default", "false");
+        delegateConfig.put("replace.null.with.default", replaceNullWithDefault ? "true" : "false");
         insertDelegate.configure(delegateConfig);
         return insertDelegate;
     }

--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
@@ -202,6 +202,15 @@ public class ExtractNewRecordStateConfigDefinition {
                     + "Optionally one can also map new field name like version:VERSION,connector:CONNECTOR,source.ts_ms:EVENT_TIMESTAMP."
                     + "Please note that the new field name is case-sensitive.");
 
+    public static final Field REPLACE_NULL_WITH_DEFAULT = Field.create("replace.null.with.default")
+            .withDisplayName("replace null field value with default")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(true)
+            .optional()
+            .withDescription("When this option is enabled, null field values are replaced by source-defined defaults when rewriting the record.");
+
     public static final Field.Set CONFIG_FIELDS = Field.setOf(
             DROP_TOMBSTONES, HANDLE_DELETES, ROUTE_BY_FIELD, ADD_FIELDS_PREFIX, ADD_FIELDS, ADD_HEADERS_PREFIX, ADD_HEADERS);
 }

--- a/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/AbstractExtractRecordStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/AbstractExtractRecordStrategy.java
@@ -30,15 +30,11 @@ public abstract class AbstractExtractRecordStrategy<R extends ConnectRecord<R>> 
     // for mongodb
     protected ExtractField<R> updateDescriptionDelegate;
 
-    public AbstractExtractRecordStrategy() {
-        init();
-    }
-
-    private void init() {
+    public AbstractExtractRecordStrategy(boolean replaceNullWithDefault) {
         afterDelegate = ConnectRecordUtil.extractAfterDelegate();
         beforeDelegate = ConnectRecordUtil.extractBeforeDelegate();
-        removedDelegate = ConnectRecordUtil.insertStaticValueDelegate(DELETED_FIELD, "true");
-        updatedDelegate = ConnectRecordUtil.insertStaticValueDelegate(DELETED_FIELD, "false");
+        removedDelegate = ConnectRecordUtil.insertStaticValueDelegate(DELETED_FIELD, "true", replaceNullWithDefault);
+        updatedDelegate = ConnectRecordUtil.insertStaticValueDelegate(DELETED_FIELD, "false", replaceNullWithDefault);
         updateDescriptionDelegate = ConnectRecordUtil.extractUpdateDescriptionDelegate();
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/DefaultDeleteHandlingStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/DefaultDeleteHandlingStrategy.java
@@ -23,7 +23,8 @@ public class DefaultDeleteHandlingStrategy<R extends ConnectRecord<R>> extends A
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDeleteHandlingStrategy.class);
     private final DeleteTombstoneHandling deleteTombstoneHandling;
 
-    public DefaultDeleteHandlingStrategy(DeleteTombstoneHandling deleteTombstoneHandling) {
+    public DefaultDeleteHandlingStrategy(DeleteTombstoneHandling deleteTombstoneHandling, boolean replaceNullWithDefault) {
+        super(replaceNullWithDefault);
         this.deleteTombstoneHandling = deleteTombstoneHandling;
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/LegacyDeleteHandlingStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/extractnewstate/LegacyDeleteHandlingStrategy.java
@@ -25,7 +25,8 @@ public class LegacyDeleteHandlingStrategy<R extends ConnectRecord<R>> extends Ab
     private final DeleteHandling deleteHandling;
     private final boolean dropTombstones;
 
-    public LegacyDeleteHandlingStrategy(DeleteHandling deleteHandling, boolean dropTombstones) {
+    public LegacyDeleteHandlingStrategy(DeleteHandling deleteHandling, boolean dropTombstones, boolean replaceNullWithDefault) {
+        super(replaceNullWithDefault);
         this.deleteHandling = deleteHandling;
         this.dropTombstones = dropTombstones;
     }

--- a/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/AbstractExtractStateTest.java
@@ -45,6 +45,7 @@ public abstract class AbstractExtractStateTest {
     protected static final String DROP_FIELDS_HEADER_NAME = "drop.fields.header.name";
     protected static final String DROP_FIELDS_FROM_KEY = "drop.fields.from.key";
     protected static final String DROP_FIELDS_KEEP_SCHEMA_COMPATIBLE = "drop.fields.keep.schema.compatible";
+    protected static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     Schema idSchema = SchemaBuilder
             .int8()

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -973,4 +973,19 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
             assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
         }
     }
+
+    @Test
+    @FixFor("DBZ-7094")
+    public void testUnwrapCreateRecordRewriteWithOptionalDefaultValueAndNullReplaceWithDefault() {
+        try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(HANDLE_TOMBSTONE_DELETES, "rewrite");
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecordWithOptionalNull();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo("default_str");
+        }
+    }
 }

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -958,4 +958,19 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
             assertThat(unwrapped).isEqualTo(heartbeatRecord);
         }
     }
+
+    @Test
+    @FixFor("DBZ-7094")
+    public void testUnwrapCreateRecordRewriteWithOptionalDefaultValue() {
+        try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(HANDLE_TOMBSTONE_DELETES, "rewrite");
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecordWithOptionalNull();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
+        }
+    }
 }

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -965,6 +965,7 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
         try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
             final Map<String, String> props = new HashMap<>();
             props.put(HANDLE_TOMBSTONE_DELETES, "rewrite");
+            props.put(REPLACE_NULL_WITH_DEFAULT, "false");
             transform.configure(props);
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -970,7 +970,7 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+
             assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
         }
     }
@@ -985,7 +985,7 @@ public class ExtractNewRecordStateTest extends AbstractExtractStateTest {
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+
             assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo("default_str");
         }
     }

--- a/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
@@ -887,6 +887,7 @@ public class LegacyExtractNewRecordStateTest extends AbstractExtractStateTest {
         try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
             final Map<String, String> props = new HashMap<>();
             props.put(HANDLE_DELETES, "rewrite");
+            props.put(REPLACE_NULL_WITH_DEFAULT, "false");
             transform.configure(props);
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();

--- a/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
@@ -892,7 +892,7 @@ public class LegacyExtractNewRecordStateTest extends AbstractExtractStateTest {
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+
             assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
         }
     }
@@ -907,7 +907,7 @@ public class LegacyExtractNewRecordStateTest extends AbstractExtractStateTest {
 
             final SourceRecord createRecord = createCreateRecordWithOptionalNull();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+
             assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo("default_str");
         }
     }

--- a/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
@@ -895,4 +895,19 @@ public class LegacyExtractNewRecordStateTest extends AbstractExtractStateTest {
             assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
         }
     }
+
+    @Test
+    @FixFor("DBZ-7094")
+    public void testUnwrapCreateRecordRewriteWithOptionalDefaultValueAndNullReplaceWithDefault() {
+        try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(HANDLE_DELETES, "rewrite");
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecordWithOptionalNull();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo("default_str");
+        }
+    }
 }

--- a/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/LegacyExtractNewRecordStateTest.java
@@ -880,4 +880,19 @@ public class LegacyExtractNewRecordStateTest extends AbstractExtractStateTest {
             assertThat(((Struct) unwrapped.value()).get(fieldPrefix + "TOTAL_ORDER")).isEqualTo(42L);
         }
     }
+
+    @Test
+    @FixFor("DBZ-7094")
+    public void testUnwrapCreateRecordRewriteWithOptionalDefaultValue() {
+        try (ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(HANDLE_DELETES, "rewrite");
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecordWithOptionalNull();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isNull();
+        }
+    }
 }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -289,3 +289,4 @@ dongwook-chan,Dongwook Chan
 paumr,P. Aum
 yevhenii-lopatenko,Yevhenii Lopatenko
 kavyaramaiah1991,Kavya Ramaiah
+kmos, Giovanni Panice


### PR DESCRIPTION
## Context

A user reported an unexpected behavior when using the `ExtractNewRecordState` Single Message Transform (SMT). A table column defined with a default value in the source database is represented with that default value instead of `null` in the resulting event payload, even though the inserted record had `null` in that column.

This issue is not limited to PostgreSQL; it affects multiple RDBMS connectors (MySQL, PostgreSQL, etc.) when using the `ExtractNewRecordState` SMT. The root cause is how certain Kafka Connect transforms (`ExtractField`, `InsertField`) handle optional null fields and default values.

**Expected Behavior:**  
When a `null` value is inserted with a database-defined default value, Debezium’s change event should preserve that `null` in the final payload.

**Actual Behavior:**  
The final payload shows the column’s default value (e.g., `1.0`) instead of `null`, potentially causing downstream consumers to misinterpret the data.

## Changes

We add a configuration parameter `replace.null.with.default` that instruments `ExtractNewRecordState` and consequently the `InsertField` transformer in order to make the user decide the behavior of the extractor. This is possible thanks to the [KIP-1040](https://github.com/apache/kafka/pull/15756). In case the parameter is set to `true`, the behavior is to replace null value with the database-defined default. This behavior is the default one if the parameter is unset for backward compatibility.

closes https://issues.redhat.com/browse/DBZ-7094