### PR TITLE
DBZ 3720 Error with debezium.sink.pulsar.client.serviceUrl and debezium-server version 1.6

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.text.ParsingException;
@@ -1098,4 +1099,25 @@ public final class Strings {
             tokens.addToken(input.position(tokenStart), tokenStart, input.index() + 1);
         }
     }
+
+    /**
+     * Converts a given string to camel case format.
+     * The input string can use '.' or '_' as delimiters to separate words.
+     * The method capitalizes the first letter of each word after the first
+     * delimiter and removes the delimiters.
+     * Examples:
+     * - "example.string.input" becomes "ExampleStringInput"
+     * - "another_example_input" becomes "AnotherExampleInput"
+     *
+     * @param input the input string to be converted, containing words separated by '.' or '_'.
+     * @return the converted string in camel case format.
+     *
+     * @throws NullPointerException if the input string is null.
+     */
+    public static String convertToCamelCase(String input) {
+        return Arrays.stream(input.split("[._]"))
+                .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                .collect(Collectors.joining());
+    }
+
 }

--- a/debezium-server/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
+++ b/debezium-server/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
@@ -31,6 +31,7 @@ import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.DebeziumEngine.RecordCommitter;
 import io.debezium.server.BaseChangeConsumer;
+import io.debezium.util.Strings;
 
 /**
  * Implementation of the consumer that delivers the messages into a Pulsar destination.
@@ -63,8 +64,12 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
     void connect() {
         final Config config = ConfigProvider.getConfig();
         try {
+            Map<String, Object> pulsarClientConfig = getConfigSubset(config, PROP_CLIENT_PREFIX);
+            Map<String, Object> camelCaseConfig = new HashMap<>();
+            pulsarClientConfig.forEach((key, value) -> camelCaseConfig.put(Strings.convertToCamelCase(key), value));
+
             pulsarClient = PulsarClient.builder()
-                    .loadConf(getConfigSubset(config, PROP_CLIENT_PREFIX))
+                    .loadConf(camelCaseConfig)
                     .build();
         }
         catch (PulsarClientException e) {


### PR DESCRIPTION
Add camel case conversion for Pulsar client configuration keys

Introduced a utility method `convertToCamelCase` in `Strings` to transform configuration keys. Updated `PulsarChangeConsumer` to apply this conversion for Pulsar client settings, ensuring compatibility with expected key format.