### PR TITLE
Dbz 8509 Container Tests are executed with -DskipITs

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseIT.java
@@ -29,9 +29,9 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
-public class TimescaleDbDatabaseTest extends AbstractAsyncEngineConnectorTest {
+public class TimescaleDbDatabaseIT extends AbstractAsyncEngineConnectorTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimescaleDbDatabaseTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimescaleDbDatabaseIT.class);
 
     private static final org.testcontainers.containers.Network network = org.testcontainers.containers.Network.newNetwork();
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxIT.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxIT.java
@@ -8,6 +8,6 @@ package io.debezium.outbox.reactive.quarkus.it;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class OutboxIT extends OutboxTest {
+class OutboxIT extends OutboxTestIT {
 
 }

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxTestIT.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxTestIT.java
@@ -33,7 +33,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
  */
 @QuarkusTest
 @TestProfile(OutboxProfiles.Default.class)
-public class OutboxTest extends AbstractOutboxTest {
+public class OutboxTestIT extends AbstractOutboxTest {
     @Inject
     MyService myService;
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxWithoutOpenTelemetryIT.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxWithoutOpenTelemetryIT.java
@@ -24,7 +24,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @TestProfile(OutboxProfiles.OpenTelemetryDisabled.class)
 @QuarkusTestResource(DatabaseTestResource.class)
-public class OutboxWithoutOpenTelemetryTest extends AbstractOutboxTest {
+public class OutboxWithoutOpenTelemetryIT extends AbstractOutboxTest {
 
     @Test
     public void testOutboxEntityMetamodelDoesntHaveTracingSpanColumn() throws Exception {

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxIT.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxIT.java
@@ -8,6 +8,6 @@ package io.debezium.outbox.quarkus.it;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class OutboxIT extends OutboxTest {
+class OutboxIT extends OutboxTestIT {
 
 }

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTestIT.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTestIT.java
@@ -27,7 +27,7 @@ import io.quarkus.test.junit.TestProfile;
  */
 @QuarkusTest
 @TestProfile(OutboxProfiles.Default.class)
-public class OutboxTest extends AbstractOutboxTest {
+public class OutboxTestIT extends AbstractOutboxTest {
 
     @Inject
     EntityManager entityManager;

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxWithoutOpenTelemetryIT.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxWithoutOpenTelemetryIT.java
@@ -25,7 +25,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @TestProfile(OutboxProfiles.OpenTelemetryDisabled.class)
 @QuarkusTestResource(DatabaseTestResource.class)
-public class OutboxWithoutOpenTelemetryTest extends AbstractOutboxTest {
+public class OutboxWithoutOpenTelemetryIT extends AbstractOutboxTest {
 
     @Test
     public void testOutboxEntityMetamodelDoesntHaveTracingSpanColumn() throws Exception {

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
@@ -28,7 +28,7 @@ import io.debezium.storage.redis.RedisClientConnectionException;
 import io.debezium.storage.redis.RedisConnection;
 
 @Testcontainers
-class RedisOffsetBackingStoreTest {
+class RedisOffsetBackingStoreIT {
     @Container
     public GenericContainer redis = new GenericContainer(DockerImageName.parse(REDIS_CONTAINER_IMAGE))
             .withExposedPorts(6379);

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -144,6 +144,24 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.net=ALL-UNNAMED</argLine>
+          <skipTests>${skipITs}</skipTests>
+          <systemPropertyVariables>
+            <version.mongo.server>${version.mongo.server}</version.mongo.server>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
@@ -51,9 +51,9 @@ import io.debezium.doc.FixFor;
  *
  * @author Jiri Pechanec
  */
-public class ApicurioRegistryTest {
+public class ApicurioRegistryTestIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApicurioRegistryTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApicurioRegistryTestIT.class);
 
     private static final List<String> capturedLogs = Collections.synchronizedList(new ArrayList<>());
 
@@ -75,7 +75,7 @@ public class ApicurioRegistryTest {
             .withNetwork(network)
             .withKafka(kafkaContainer)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
-            .withLogConsumer(ApicurioRegistryTest::captureMatchingLog)
+            .withLogConsumer(ApicurioRegistryTestIT::captureMatchingLog)
             .enableApicurioConverters()
             .dependsOn(kafkaContainer);
 

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ConnectorConfigurationIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ConnectorConfigurationIT.java
@@ -22,7 +22,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ContainerConfig;
 
-public class ConnectorConfigurationTest {
+public class ConnectorConfigurationIT {
 
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -45,7 +45,7 @@ public class ConnectorConfigurationTest {
 
     @Test
     public void shouldLoadConnectorConfigurationFromFile() throws IOException {
-        final InputStream configFile = ConnectorConfigurationTest.class.getClassLoader().getResourceAsStream("config.json");
+        final InputStream configFile = ConnectorConfigurationIT.class.getClassLoader().getResourceAsStream("config.json");
         final Connector connector = Connector.fromJson(configFile);
 
         final String json = connector.toJson();
@@ -74,7 +74,7 @@ public class ConnectorConfigurationTest {
         when(jdbcDatabaseContainer.getExposedPorts()).thenReturn(Arrays.asList(9090));
         when(jdbcDatabaseContainer.getContainerInfo()).thenReturn(inspectContainerResponse);
 
-        final InputStream configFile = ConnectorConfigurationTest.class.getClassLoader().getResourceAsStream("config.json");
+        final InputStream configFile = ConnectorConfigurationIT.class.getClassLoader().getResourceAsStream("config.json");
         final Connector connector = Connector.fromJson(configFile);
 
         connector.appendOrOverrideConfiguration(ConnectorConfiguration.forJdbcContainer(jdbcDatabaseContainer));

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerIT.java
@@ -44,9 +44,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-public class DebeziumContainerTest {
+public class DebeziumContainerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumContainerTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumContainerIT.class);
 
     private static final Network network = Network.newNetwork();
 

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetAuthContainerIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetAuthContainerIT.java
@@ -28,9 +28,9 @@ import io.debezium.testing.testcontainers.util.DockerUtils;
  * @see <a href="https://issues.redhat.com/browse/DBZ-5857">DBZ-5857</a>
  */
 @Flaky("DBZ-7507")
-public class MongoDbReplicaSetAuthTest {
+public class MongoDbReplicaSetAuthContainerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSetAuthTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSetAuthContainerIT.class);
 
     public static final String AUTH_DATABASE = "admin";
     public static final String TEST_DATABASE_1 = "fstDB";

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetContainerIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetContainerIT.java
@@ -44,9 +44,9 @@ import io.debezium.testing.testcontainers.util.PooledPortResolver;
 /**
  * @see <a href="https://issues.redhat.com/browse/DBZ-5857">DBZ-5857</a>
  */
-public class MongoDbReplicaSetTest {
+public class MongoDbReplicaSetContainerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSetTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSetContainerIT.class);
 
     public static final String MONGO_DOCKER_DESKTOP_PORT_PROPERTY = "mongodb.docker.desktop.ports";
 

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterContainerIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterContainerIT.java
@@ -33,9 +33,9 @@ import io.debezium.testing.testcontainers.util.DockerUtils;
  * @see <a href="https://issues.redhat.com/browse/DBZ-5857">DBZ-5857</a>
  */
 @Disabled
-public class MongoDbShardedClusterTest {
+public class MongoDbShardedClusterContainerIT {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(MongoDbShardedClusterTest.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(MongoDbShardedClusterContainerIT.class);
 
     @BeforeAll
     static void setupAll() {


### PR DESCRIPTION
## Context
Currently if someone wants to run tests without Docker by using the command:
```
$ mvn clean verify -DskipITs 
```
but the execution presents containers/integration tests not skipped, causing the build to fail in environments without Docker installed.

**Expected Behavior:**
Skip tests that use Docker with `-DskipITs` in maven

**Actual Behavior:** 
mvn executes tests that use Docker in some modules with  arg `-DskipITs`

## Changes

This issue affects some modules:

- `debezium-testing-testcontainers`
- `debezium-quarkus-outbox-integration-tests`
- `debezium-quarkus-outbox-reactive`
- `debezium-storage-redis`
- `debezium-connector-postgres`

The Tests are named without using the convention `IT` which permits to be executed with the `maven-failsafe-plugin` that has the property `skipITs`. Furthermore `debezium-testing-testcontainers` pom wasn't configured with a `maven-failsafe-plugin` configuration that permits to execute tests with integration test naming convention.
 
closes https://issues.redhat.com/browse/DBZ-8509