### PR TITLE
[ci] Increase maven heap size to 4GiB

### DIFF
--- a/jenkins-jobs/pipelines/release/deploy_snapshots_pipeline.groovy
+++ b/jenkins-jobs/pipelines/release/deploy_snapshots_pipeline.groovy
@@ -55,7 +55,7 @@ node('Slave') {
 
         stage('Build and deploy Debezium') {
             dir(DEBEZIUM_DIR) {
-                sh "mvn clean deploy -U -s $env.HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,oracle-all,docs  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
+                sh "MAVEN_OPTS=\"-Xmx4096m -Xms512m\" mvn clean deploy -U -s $env.HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,oracle-all,docs  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
             }
         }
 
@@ -65,7 +65,7 @@ node('Slave') {
                     // Execute a dependency installation script if provided by the repository
                     sh "if [ -f install-artifacts.sh ]; then ./install-artifacts.sh; fi"
 
-                    sh "mvn clean deploy -s $env.HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,docs -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
+                    sh "MAVEN_OPTS=\"-Xmx4096m -Xms512m\" mvn clean deploy -s $env.HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,docs -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
                 }
             }
         }


### PR DESCRIPTION
With the default 512MiB it randomly fails with

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.1:single (default) on project debezium-storage-rocketmq: Failed to create assembly: Error creating assembly archive store: Problem creating zip: Execution exception: Java heap space -> [Help 1]