### PR TITLE
DBZ-8291 DBZ-6709 Handle store.only.captured.tables.ddl regression

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -349,9 +349,6 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
     public static final Field TABLES_IGNORE_BUILTIN = RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN
             .withDependents(DATABASE_INCLUDE_LIST_NAME);
 
-    public static final Field STORE_ONLY_CAPTURED_DATABASES_DDL = HistorizedRelationalDatabaseConnectorConfig.STORE_ONLY_CAPTURED_DATABASES_DDL
-            .withDefault(true);
-
     public static final Field ON_CONNECT_STATEMENTS = Field.create("database.initial.statements")
             .withDisplayName("Initial statements")
             .withType(ConfigDef.Type.STRING)
@@ -667,8 +664,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     SCHEMA_INCLUDE_LIST,
                     SCHEMA_EXCLUDE_LIST,
                     RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE,
-                    RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
-                    HistorizedRelationalDatabaseConnectorConfig.STORE_ONLY_CAPTURED_DATABASES_DDL)
+                    RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
             .type(
                     HOSTNAME,
                     PORT,
@@ -697,8 +693,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     ROW_COUNT_FOR_STREAMING_RESULT_SETS,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
-                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES,
-                    STORE_ONLY_CAPTURED_DATABASES_DDL)
+                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .events(
                     INCLUDE_SQL_QUERY,
                     TABLES_IGNORE_BUILTIN,

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogNotificationsIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogNotificationsIT.java
@@ -19,6 +19,7 @@ import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.pipeline.notification.AbstractNotificationsIT;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 /**
  * @author Chris Cranford
@@ -60,7 +61,9 @@ public abstract class BinlogNotificationsIT<C extends SourceConnector> extends A
 
     @Override
     protected Configuration.Builder config() {
-        return DATABASE.defaultConfig().with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue());
+        return DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
+                .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
     }
 
     @Override

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
@@ -57,7 +57,6 @@ import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.SnapshotTablesRowCountOrder;
 import io.debezium.relational.history.MemorySchemaHistory;
-import io.debezium.relational.history.SchemaHistory;
 
 /**
  * @author Randall Hauch
@@ -155,7 +154,7 @@ public abstract class BinlogSnapshotSourceIT<C extends SourceConnector> extends 
                     .with(BinlogConnectorConfig.USER, "cloud")
                     .with(BinlogConnectorConfig.PASSWORD, "cloudpass")
                     .with(BinlogConnectorConfig.TEST_DISABLE_GLOBAL_LOCKING, "true")
-                    .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedTables);
+                    .with(BinlogConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedTables);
         }
         if (!data) {
             builder.with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA);
@@ -226,7 +225,7 @@ public abstract class BinlogSnapshotSourceIT<C extends SourceConnector> extends 
                     .isEqualTo(schemaEventsCount);
             assertThat(schemaChanges.ddlRecordsForDatabaseOrEmpty("").size()
                     + schemaChanges.ddlRecordsForDatabaseOrEmpty(OTHER_DATABASE.getDatabaseName()).size())
-                    .isEqualTo(useGlobalLock ? 1 : 5);
+                    .isEqualTo(1);
         }
 
         if (!useGlobalLock) {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
@@ -259,6 +259,9 @@ public abstract class UniqueDatabase {
             builder.with(FileSchemaHistory.FILE_PATH, dbHistoryPath);
         }
 
+        // enable database DDL capture
+        builder.with(BinlogConnectorConfig.STORE_ONLY_CAPTURED_DATABASES_DDL, true);
+
         return builder;
     }
 


### PR DESCRIPTION
closes https://issues.redhat.com/browse/DBZ-8291 and https://issues.redhat.com/browse/DBZ-6709 