### PR TITLE
Fix default value of `poll.interval.ms` in MongoDB connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1898,7 +1898,7 @@ If xref:mongodb-property-max-queue-size[`max.queue.size`] is also set, writing t
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
 |[[mongodb-property-poll-interval-ms]]<<mongodb-property-poll-interval-ms, `+poll.interval.ms+`>>
-|`1000`
+|`500`
 |Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 500 milliseconds, or 0.5 second.
 
 |[[mongodb-property-connect-backoff-initial-delay-ms]]<<mongodb-property-connect-backoff-initial-delay-ms, `+connect.backoff.initial.delay.ms+`>>


### PR DESCRIPTION
The default value of `poll.interval.ms` is incorrectly documented as 1000ms in some parts of the documentation.

According to the source code and description, the correct default value is 500ms.

https://github.com/debezium/debezium/blob/6246808308200ae9877f25f3a04e378578def98c/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java#L642-L650

https://github.com/debezium/debezium/blob/6246808308200ae9877f25f3a04e378578def98c/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java#L572

![image](https://github.com/user-attachments/assets/808dd32f-4674-46c2-8488-f7241986b804)
