### PR TITLE
DBZ-8557: Implement keyset pagination in sqlserver connector

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
@@ -22,6 +22,8 @@ public class Lsn implements Comparable<Lsn>, Nullable {
 
     public static final Lsn NULL = new Lsn(null);
 
+    public static final Lsn ZERO = valueOf(new byte[10]);
+
     private final byte[] binary;
     private int[] unsignedBinary;
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -478,6 +478,14 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     + "The value of '" + DataQueryMode.DIRECT.getValue()
                     + "' makes the connector to query the change tables directly.");
 
+    public static final Field STREAMING_FETCH_SIZE = Field.create("streaming.fetch.size")
+            .withDisplayName("Streaming fetch size")
+            .withDefault(0)
+            .withType(Type.INT)
+            .withImportance(Importance.LOW)
+            .withDescription("Specifies the maximum number of rows that should be read in one go from each table while streaming. "
+                    + "The connector will read the table contents in multiple batches of this size. Defaults to 0 which means no limit.");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("SQL Server")
             .type(
@@ -498,7 +506,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES,
                     QUERY_FETCH_SIZE,
-                    DATA_QUERY_MODE)
+                    DATA_QUERY_MODE,
+                    STREAMING_FETCH_SIZE)
             .events(SOURCE_INFO_STRUCT_MAKER)
             .excluding(
                     SCHEMA_INCLUDE_LIST,
@@ -525,6 +534,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final boolean optionRecompile;
     private final int queryFetchSize;
     private final DataQueryMode dataQueryMode;
+    private final int streamingFetchSize;
 
     public SqlServerConnectorConfig(Configuration config) {
         super(
@@ -568,6 +578,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
         this.dataQueryMode = DataQueryMode.parse(config.getString(DATA_QUERY_MODE), DATA_QUERY_MODE.defaultValueAsString());
         this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
+        this.streamingFetchSize = config.getInteger(STREAMING_FETCH_SIZE);
     }
 
     public List<String> getDatabaseNames() {
@@ -716,5 +727,9 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         return count;
+    }
+
+    public int getStreamingFetchSize() {
+        return streamingFetchSize;
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -18,13 +18,15 @@ import io.debezium.connector.Nullable;
  */
 public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
 
-    public static final TxLogPosition NULL = new TxLogPosition(null, null);
+    public static final TxLogPosition NULL = new TxLogPosition(null, null, 0);
     private final Lsn commitLsn;
     private final Lsn inTxLsn;
+    private int operation;
 
-    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn) {
+    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn, int operation) {
         this.commitLsn = commitLsn;
         this.inTxLsn = inTxLsn;
+        this.operation = operation;
     }
 
     public Lsn getCommitLsn() {
@@ -35,9 +37,13 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         return inTxLsn;
     }
 
+    public int getOperation() {
+        return operation;
+    }
+
     @Override
     public String toString() {
-        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + ")";
+        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + "," + operation + ")";
     }
 
     @Override
@@ -46,6 +52,7 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         int result = 1;
         result = prime * result + ((commitLsn == null) ? 0 : commitLsn.hashCode());
         result = prime * result + ((inTxLsn == null) ? 0 : inTxLsn.hashCode());
+        result = prime * result + operation;
         return result;
     }
 
@@ -86,15 +93,20 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         return comparison == 0 ? inTxLsn.compareTo(o.inTxLsn) : comparison;
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn) {
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation) {
         return commitLsn == null && inTxLsn == null ? NULL
                 : new TxLogPosition(
                         commitLsn == null ? Lsn.NULL : commitLsn,
-                        inTxLsn == null ? Lsn.NULL : inTxLsn);
+                        inTxLsn == null ? Lsn.NULL : inTxLsn,
+                        operation);
+    }
+
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn) {
+        return valueOf(commitLsn, inTxLsn, 0);
     }
 
     public static TxLogPosition valueOf(Lsn commitLsn) {
-        return valueOf(commitLsn, Lsn.NULL);
+        return valueOf(commitLsn, Lsn.NULL, 0);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertNull;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -158,16 +157,14 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
                             final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE_1, tableName);
                             final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE_1);
                             final AtomicReference<Boolean> found = new AtomicReference<>(false);
-                            SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
-                            connection.getChangesForTables(TestHelper.TEST_DATABASE_1, tables, minLsn, maxLsn, resultsets -> {
-                                final ResultSet rs = resultsets[0];
+                            try (ResultSet rs = connection.getChangesForTable(ct, minLsn, maxLsn)) {
                                 while (rs.next()) {
                                     if (rs.getInt("id") == -1) {
                                         found.set(true);
                                         break;
                                     }
                                 }
-                            });
+                            }
                             return found.get();
                         }
                         catch (Exception e) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeTableResultSet.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeTableResultSet.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.relational.ChangeTable;
 
 /**
@@ -78,7 +79,7 @@ public abstract class ChangeTableResultSet<C extends ChangeTable, T extends Comp
         }
         else {
             if (maxRowsPerResultSet > 0 && rowsReadPerResultSet > maxRowsPerResultSet) {
-                throw new RuntimeException("Number of rows read from the result set is greater than the configured max rows per a result set");
+                throw new DebeziumException("Number of rows read from the result set is greater than the configured max rows per a result set");
             }
 
             if (maxRowsPerResultSet > 0 && rowsReadPerResultSet == maxRowsPerResultSet) {

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3317,6 +3317,12 @@ After the next failure, the connector stops, and user intervention is required t
 |`600000` (10 minutes)
 |Specifies the time, in milliseconds, that the connector waits for a query to complete.
 Set the value to `0` (zero) to remove the timeout limit.
+
+|[[sqlserver-property-streaming-fetch-size]]<<sqlserver-property-streaming-fetch-size, `streaming.fetch.size`>>
+|`0`
+|Specifies the maximum number of rows that should be read in one go from each table while streaming.
+The connector will read the table contents in multiple batches of this size. Defaults to `0` which means no limit.
+
 |===
 
 [id="debezium-sqlserver-connector-database-history-configuration-properties"]


### PR DESCRIPTION
Sqlserver connector requires unbounded memory to process big transactions. This happens due to the fact that `mssql-jdbc` driver buffers any not yet consumed result sets in memory in order to execute the next select statement. On the other hand the connector doesn't limit the number of rows it selects. This leads to almost all transaction rows being buffered in memory.

An obvious solution to that is to limit the number of rows selected. This patch does exactly that. It introduces a new connector setting called `streaming.fetch.size` (by analogy with `snapshot.fetch.size`) with the default value of `0` which means the old behavior is preserved.