### PR TITLE
Upgrade vitess client version

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -21,7 +21,7 @@
         <version.jetty>9.4.12.v20180830</version.jetty>
 
         <!-- Vitess dependencies -->
-        <version.vitess.grpc>17.0.0</version.vitess.grpc>
+        <version.vitess.grpc>20.0.0</version.vitess.grpc>
         <version.joda>2.10.1</version.joda>
         <version.google.protos>1.17.0</version.google.protos>
 


### PR DESCRIPTION
Upgrade to new vitess client version. Allows us to both backward & forward compatibly handle enum/set types correctly. See [DBZ-8561](https://issues.redhat.com/browse/DBZ-8561) for more details and https://github.com/debezium/debezium-connector-vitess/pull/222