### PR TITLE
[docs] Bind Kafka container to localhost in podman

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka.adoc
@@ -51,7 +51,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ podman run -it --rm --name kafka --pod dbz quay.io/debezium/kafka:{debezium-docker-label}
+$ podman run -it --rm --name kafka --pod dbz -e HOST_NAME=127.0.0.1 quay.io/debezium/kafka:{debezium-docker-label}
 ----
 ====
 endif::community[]


### PR DESCRIPTION
Kafka otherwise bind to some randomly assigned IP address and further step in the tutorial, which starts Kafka Connect, fails with connection timeout exception.