### PR TITLE
DBZ-6387 Disable testing with `isostring` temporal precision mode

### DIFF
--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -2031,7 +2031,9 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
 
         int dateTime7NanoSeconds = 456789000;
         if (source.getOptions().isColumnTypePropagated() && SinkType.SQLSERVER.is(sink.getType())) {
-            dateTime7NanoSeconds = 456789100;
+            if (source.getOptions().getTemporalPrecisionMode() != TemporalPrecisionMode.MICROSECONDS) {
+                dateTime7NanoSeconds = 456789100;
+            }
         }
 
         final boolean connect = TemporalPrecisionMode.CONNECT.equals(source.getOptions().getTemporalPrecisionMode());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/e2e/source/SourcePipelineInvocationContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/e2e/source/SourcePipelineInvocationContextProvider.java
@@ -227,6 +227,12 @@ public class SourcePipelineInvocationContextProvider implements BeforeAllCallbac
                     // MySQL explicitly prohibits the use of adaptive so we only allow the other two in the matrix.
                     continue;
                 }
+                if (TemporalPrecisionMode.ISOSTRING == temporalPrecisionMode) {
+                    // Tests currently are not designed to support ISOSTRING as it changes the target
+                    // column type expectations for the tests, using text-based column types rather
+                    // than expected temporal types like DATE, TIME, etc.
+                    continue;
+                }
                 result.add(temporalPrecisionMode);
             }
             return result;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6387

The JDBC sink tests were not designed to expect the temporal columns to be created as strings when `isostring` is set as the source's temporal precision mode. This PR disables that mode in the test suite for now, and a follow-up PR will update the tests to introduce this.