### PR TITLE
[DBZ-8609] Upgrade AssertJ-DB to 3.0.0

### DIFF
--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -18,7 +18,7 @@
         <!-- Other artifact versions -->
         <version.hibernate>6.4.8.Final</version.hibernate>
         <version.c3p0>0.9.5.5</version.c3p0>
-        <version.assertjdb>2.0.2</version.assertjdb>
+        <version.assertjdb>3.0.0</version.assertjdb>
         <!--
         By default only run the integration tests for MySQL, PostgreSQL, and SQL Server.
         Other tags include it-db2 and it-oracle for the DB2 and Oracle integration tests.

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(createRecord);
         consume(factory.deleteRecord(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -77,7 +77,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(createRecord);
         consume(factory.deleteRecord(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -103,7 +103,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(createRecord);
         consume(factory.deleteRecordMultipleKeyColumns(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER);
@@ -127,7 +127,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         final KafkaDebeziumSinkRecord deleteRecord = factory.deleteRecord(topicName);
         consume(deleteRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(deleteRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(deleteRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -152,7 +152,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         final KafkaDebeziumSinkRecord deleteRecord = factory.deleteRecordMultipleKeyColumns(topicName);
         consume(deleteRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(deleteRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(deleteRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER);
@@ -181,7 +181,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(factory.tombstoneRecord(topicName));
         consume(deleteRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(deleteRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(deleteRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -206,7 +206,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(createRecord);
         consume(factory.truncateRecord(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -232,7 +232,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(createRecord);
         consume(factory.truncateRecord(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         // will skip truncate event since there is no operation "t" in flatten value
         if (factory.isFlattened()) {
             tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
@@ -267,7 +267,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         consume(truncateRecord);
         consume(secondRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(firstRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(firstRecord));
         // will skip truncate event since there is no operation "t" in flatten value
         if (factory.isFlattened()) {
             tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
@@ -302,7 +302,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
         records.add(factory.createRecord(topicName, (byte) 1));
         consume(records);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(deleteRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(deleteRecord));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkInsertModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkInsertModeTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecordNoKey(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 1);
@@ -87,7 +87,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(6);
 
         getSink().assertColumnType(tableAssert, "__connect_topic", ValueType.TEXT, topicName, topicName);
@@ -115,7 +115,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 2));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
@@ -141,7 +141,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 2));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
@@ -194,7 +194,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 1));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(6);
 
         getSink().assertColumnType(tableAssert, "__connect_topic", ValueType.TEXT, topicName);
@@ -222,7 +222,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 1));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -248,7 +248,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 1));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -273,7 +273,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
 
         // No changes detected because there is no existing record.
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -298,7 +298,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
 
         // No changes detected because there is no existing record.
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(6);
 
         getSink().assertColumnType(tableAssert, "__connect_topic", ValueType.TEXT);
@@ -326,7 +326,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
 
         // No changes detected because there is no existing record.
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -352,7 +352,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
         consume(createRecord);
 
         // No changes detected because there is no existing record.
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -382,7 +382,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
 
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(2);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkPrimaryKeyModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkPrimaryKeyModeTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -85,7 +85,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(6);
 
         getSink().assertColumnType(tableAssert, "__connect_topic", ValueType.TEXT, topicName);
@@ -115,7 +115,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(6);
 
         getSink().assertColumnType(tableAssert, "__connect_topic", ValueType.TEXT, topicName);
@@ -145,14 +145,14 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
         getSink().assertColumnType(tableAssert, "name", ValueType.TEXT, "John Doe");
         getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT, "John Doe$");
 
-        TestHelper.assertTable(dataSource(), destinationTableName)
+        TestHelper.assertTable(assertDbConnection(), destinationTableName)
                 .exists()
                 .hasNumberOfColumns(3)
                 .column("id").isNumber(false).hasValues((byte) 1)
@@ -179,7 +179,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER, (byte) 1);
@@ -207,14 +207,14 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
         getSink().assertColumnType(tableAssert, "name", ValueType.TEXT, "John Doe");
         getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT, "John Doe$");
 
-        TestHelper.assertTable(dataSource(), destinationTableName)
+        TestHelper.assertTable(assertDbConnection(), destinationTableName)
                 .exists()
                 .hasNumberOfColumns(3)
                 .column("id").isNumber(false).hasValues((byte) 1)
@@ -246,7 +246,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(kafkaSinkRecordWithHeader);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER, (byte) 1);
@@ -274,7 +274,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -300,7 +300,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -328,7 +328,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -356,7 +356,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER, (byte) 1);
@@ -402,7 +402,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord1);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(4);
 
         getSink().assertColumnType(tableAssert, "id1_value", ValueType.NUMBER, (byte) 11);
@@ -428,7 +428,7 @@ public abstract class AbstractJdbcSinkPrimaryKeyModeTest extends AbstractJdbcSin
 
         final String destinationTableName = destinationTableName(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id1", ValueType.NUMBER, (byte) 1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkSaveConvertedCloudEventTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkSaveConvertedCloudEventTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractJdbcSinkSaveConvertedCloudEventTest extends Abstra
 
         final String destinationTableName = destinationTableName(convertedRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.TEXT);
@@ -102,7 +102,7 @@ public abstract class AbstractJdbcSinkSaveConvertedCloudEventTest extends Abstra
 
         final String destinationTableName = destinationTableName(convertedRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.TEXT);
@@ -140,7 +140,7 @@ public abstract class AbstractJdbcSinkSaveConvertedCloudEventTest extends Abstra
 
         final String destinationTableName = destinationTableName(convertedRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName);
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.TEXT);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkSchemaEvolutionTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkSchemaEvolutionTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
         final KafkaDebeziumSinkRecord createRecord = factory.createRecordNoKey(topicName);
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -140,7 +140,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
         final KafkaDebeziumSinkRecord updateRecord = factory.updateRecord(topicName);
         consume(updateRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(updateRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(updateRecord));
         tableAssert.hasNumberOfRows(1).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -163,7 +163,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
         final KafkaDebeziumSinkRecord deleteRecord = factory.deleteRecord(topicName);
         consume(deleteRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(deleteRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(deleteRecord));
         tableAssert.hasNumberOfRows(0).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -206,7 +206,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
                 .build();
         consume(updateRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(2).hasNumberOfColumns(5);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -243,7 +243,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
                 .build();
         consume(updateRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
@@ -294,7 +294,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
                 .build();
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(1).hasNumberOfColumns(19);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -358,7 +358,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
                 .build();
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(1).hasNumberOfColumns(19);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -444,7 +444,7 @@ public abstract class AbstractJdbcSinkSchemaEvolutionTest extends AbstractJdbcSi
                 .build();
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.hasNumberOfRows(1).hasNumberOfColumns(19);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
@@ -17,6 +17,9 @@ import javax.sql.DataSource;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
+import org.assertj.db.type.AssertDbConnection;
+import org.assertj.db.type.AssertDbConnectionFactory;
+import org.assertj.db.type.lettercase.LetterCase;
 import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,6 +114,16 @@ public abstract class AbstractJdbcSinkTest {
         catch (SQLException e) {
             throw new RuntimeException("Failed to create data source", e);
         }
+    }
+
+    protected AssertDbConnection assertDbConnection() {
+        return AssertDbConnectionFactory.of(dataSource()).create();
+    }
+
+    protected AssertDbConnection assertDbConnection(LetterCase tableLetterCase, LetterCase columnLetterCase, LetterCase primaryKeyLetterCase) {
+        return AssertDbConnectionFactory.of(dataSource())
+                .letterCase(tableLetterCase, columnLetterCase, primaryKeyLetterCase)
+                .create();
     }
 
     /**

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkDeleteEnabledIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkDeleteEnabledIT.java
@@ -38,11 +38,11 @@ public class JdbcSinkDeleteEnabledIT extends AbstractJdbcSinkDeleteEnabledTest {
         sink.execute("create table TEST_TRUNCATE_DB2_TABLE(id int not null, name varchar(255), primary key(id))");
         sink.execute("insert into TEST_TRUNCATE_DB2_TABLE(id,name) values(1,'jdbc')");
 
-        TableAssert tableAssert = TestHelper.assertTable(dataSource(), "TEST_TRUNCATE_DB2_TABLE");
+        TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), "TEST_TRUNCATE_DB2_TABLE");
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(2);
 
         sink.execute("truncate table TEST_TRUNCATE_DB2_TABLE IMMEDIATE");
-        tableAssert = TestHelper.assertTable(dataSource(), "TEST_TRUNCATE_DB2_TABLE");
+        tableAssert = TestHelper.assertTable(assertDbConnection(), "TEST_TRUNCATE_DB2_TABLE");
         tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(2);
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkInsertModeIT.java
@@ -87,7 +87,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
                 List.of("geometry", "point", "g"), List.of(geometrySchema, pointSchema, geometrySchema), Arrays.asList(new Object[]{ geometryValue, pointValue, null }));
         consume(createGeometryRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createGeometryRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createGeometryRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(4);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -157,7 +157,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
         final List<KafkaDebeziumSinkRecord> records = List.of(recordA, recordB, recordC);
         consume(records);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(recordA));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(recordA));
         tableAssert.hasNumberOfRows(2).hasNumberOfColumns(3);
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkFieldFilterIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkFieldFilterIT.java
@@ -57,7 +57,7 @@ public class JdbcSinkFieldFilterIT extends AbstractJdbcSinkTest {
         final KafkaDebeziumSinkRecord createRecord = factory.createRecordNoKey(topicName);
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().column("id").value().isEqualTo(1);
         tableAssert.exists().column("name").value().isEqualTo("John Doe");
         tableAssert.exists().hasNumberOfColumns(2);
@@ -81,7 +81,7 @@ public class JdbcSinkFieldFilterIT extends AbstractJdbcSinkTest {
         final KafkaDebeziumSinkRecord createRecord = factory.createRecordNoKey(topicName);
         consume(createRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfColumns(2);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, 1);
@@ -109,7 +109,7 @@ public class JdbcSinkFieldFilterIT extends AbstractJdbcSinkTest {
         consume(createRecord);
         consume(factory.createRecord(topicName, (byte) 1));
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(2);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -118,7 +118,7 @@ public class JdbcSinkFieldFilterIT extends AbstractJdbcSinkTest {
         final KafkaDebeziumSinkRecord updateRecord = factory.updateRecord(topicName);
         consume(updateRecord);
 
-        final TableAssert tableAssertForUpdate = TestHelper.assertTable(dataSource(), destinationTableName(updateRecord));
+        final TableAssert tableAssertForUpdate = TestHelper.assertTable(assertDbConnection(), destinationTableName(updateRecord));
         tableAssertForUpdate.exists().hasNumberOfRows(1).hasNumberOfColumns(2);
 
         getSink().assertColumnType(tableAssertForUpdate, "id", ValueType.NUMBER, (byte) 1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -16,7 +16,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.assertj.db.api.TableAssert;
-import org.assertj.db.type.DataSourceWithLetterCase;
+import org.assertj.db.type.AssertDbConnection;
 import org.assertj.db.type.ValueType;
 import org.assertj.db.type.lettercase.CaseComparisons;
 import org.assertj.db.type.lettercase.CaseConversions;
@@ -106,7 +106,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
                 Arrays.asList(new Object[]{ geometryValue, pointValue, geographyValue }));
         consume(createGeometryRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createGeometryRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createGeometryRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(5);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);
@@ -185,7 +185,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
         final List<KafkaDebeziumSinkRecord> records = List.of(recordA, recordB, recordC);
         consume(records);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(recordA));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(recordA));
         tableAssert.hasNumberOfRows(2).hasNumberOfColumns(3);
     }
 
@@ -212,8 +212,8 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
         consume(createSimpleRecord1);
         consume(createSimpleRecord2);
 
-        DataSourceWithLetterCase dataSourceWithLetterCase = new DataSourceWithLetterCase(dataSource(), LetterCase.TABLE_DEFAULT, UPPER_CASE_STRICT, UPPER_CASE_STRICT);
-        final TableAssert tableAssert = TestHelper.assertTable(dataSourceWithLetterCase, destinationTableName(createSimpleRecord1));
+        AssertDbConnection assertDbConnection = assertDbConnection(LetterCase.TABLE_DEFAULT, UPPER_CASE_STRICT, UPPER_CASE_STRICT);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection, destinationTableName(createSimpleRecord1));
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "ID", ValueType.NUMBER, (byte) 1, (byte) 2);
@@ -243,9 +243,8 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
         consume(createSimpleRecord1);
         consume(createSimpleRecord2);
 
-        DataSourceWithLetterCase dataSourceWithLetterCase = new DataSourceWithLetterCase(dataSource(), LetterCase.TABLE_DEFAULT, LOWER_CASE_STRICT, LOWER_CASE_STRICT);
-
-        final TableAssert tableAssert = TestHelper.assertTable(dataSourceWithLetterCase, destinationTableName(createSimpleRecord1), null, null);
+        AssertDbConnection assertDbConnection = assertDbConnection(LetterCase.TABLE_DEFAULT, LOWER_CASE_STRICT, LOWER_CASE_STRICT);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection, destinationTableName(createSimpleRecord1), null, null);
         tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(3);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
@@ -282,7 +281,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
                 Arrays.asList(new Object[]{ "-infinity", "infinity", "[2010-01-01 14:30, infinity)" }));
         consume(createInfinityRecord);
 
-        final TableAssert tableAssert = TestHelper.assertTable(dataSource(), destinationTableName(createInfinityRecord));
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createInfinityRecord));
         tableAssert.exists().hasNumberOfRows(1).hasNumberOfColumns(4);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/TestHelper.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/TestHelper.java
@@ -18,8 +18,7 @@ import java.util.TreeMap;
 import javax.sql.DataSource;
 
 import org.assertj.db.api.TableAssert;
-import org.assertj.db.type.Source;
-import org.assertj.db.type.Table;
+import org.assertj.db.type.AssertDbConnection;
 
 /**
  * @author Chris Cranford
@@ -77,16 +76,16 @@ public class TestHelper {
         return System.getProperty("sink.time_zone", "UTC");
     }
 
-    public static TableAssert assertTable(DataSource dataSource, String tableName) {
-        return assertThat(new Table(dataSource, tableName));
+    public static TableAssert assertTable(AssertDbConnection assertDbConnection, String tableName) {
+        return assertThat(assertDbConnection.table(tableName).build());
     }
 
-    public static TableAssert assertTable(DataSource dataSource, String tableName, String[] columnsToCheck, String[] columnsToExclude) {
-        return assertThat(new Table(dataSource, tableName, columnsToCheck, columnsToExclude));
-    }
-
-    public static TableAssert assertTable(Source source, String tableName) {
-        return assertThat(new Table(source, tableName));
+    public static TableAssert assertTable(AssertDbConnection assertDbConnection, String tableName, String[] columnsToCheck, String[] columnsToExclude) {
+        return assertThat(assertDbConnection
+                .table(tableName)
+                .columnsToCheck(columnsToCheck)
+                .columnsToExclude(columnsToExclude)
+                .build());
     }
 
     /**


### PR DESCRIPTION
### Overview

- Upgrade AssertJ-DB from 2.0.2 to 3.0.0
- Use new AssertDbConnection factory