### PR TITLE
[docs] Describes default Vitess `skipped.operations` behavior

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1720,10 +1720,8 @@ You can configure the connector to skip the following types of operations:
 * `d` (delete)
 * `t` (truncate)
 
-Set the value to `none` if you do not want the connector to skip any operations.
-
-The {prodname} Vitess connector emits `truncate` events only to its internal schema history topic and not data change topics.
-As a result, if you retain the default `t` value, the connector streams all `insert`, `update`, and `delete` operations; that is, it behaves as when the property is set to `none`.
+Because the {prodname} Vitess connector never emits `truncate` events to data change topics, setting the default `t` option has the same effect as setting the property to `none`.
+That is, the connector streams all `insert`, `update`, and `delete` operations. 
 
 |[[vitess-property-provide-transaction-metadata]]<<vitess-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1722,6 +1722,9 @@ You can configure the connector to skip the following types of operations:
 
 Set the value to `none` if you do not want the connector to skip any operations.
 
+The {prodname} Vitess connector emits `truncate` events only to its internal schema history topic and not data change topics.
+As a result, if you retain the default `t` value, the connector streams all `insert`, `update`, and `delete` operations; that is, it behaves as when the property is set to `none`.
+
 |[[vitess-property-provide-transaction-metadata]]<<vitess-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:vitess-transaction-metadata[Transaction metadata] for details.


### PR DESCRIPTION
This change follows up on [DBZ-8456](https://issues.redhat.com/browse/DBZ-8456) to update the description of the `skipped.operations` property for the Vitess connector to align with other connectors.

Similar to Db2, MongoDB, and SQL Server, the Vitess connector does not emit truncate events to data change topics. Thus, setting the value of the `skipped-operations` property for the connector to the default `t` (truncate) value, is equivalent to configuring the connector not to skip any events. i.e, setting the value to `none`. 
