### PR TITLE
DBZ-8566 Adds notes re: deprecation of Containerfile deployment steps

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2057,7 +2057,9 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 * xref:openshift-streams-db2-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1271,7 +1271,9 @@ You can use either of the following methods to deploy a {prodname} MongoDB conne
 * xref:openshift-streams-mongodb-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-mongodb-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-mongodb-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 .Additional resources
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2838,7 +2838,9 @@ You can use either of the following methods to deploy a {prodname} Oracle connec
 * xref:openshift-streams-oracle-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-oracle-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-oracle-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1744,7 +1744,7 @@ Represents the number of days since the epoch.
 |`INT64`
 |`io.debezium.time.MicroTime` +
  +
-Represents the time value in microseconds and does not include timezone information. 
+Represents the time value in microseconds and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
 
@@ -1752,7 +1752,7 @@ The precision can range from 0 (no fractional seconds) to 6 (microsecond precisi
 |`INT64`
 |`io.debezium.time.MicroTimestamp` +
  +
-Represents the number of microseconds past the epoch, and does not include timezone information. 
+Represents the number of microseconds past the epoch, and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
 
@@ -1780,7 +1780,7 @@ Represents the number of days since the epoch.
 |`INT64`
 |`io.debezium.time.NanoTime` +
  +
-Represents the time value in nanoseconds and does not include timezone information. 
+Represents the time value in nanoseconds and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
 
@@ -2652,7 +2652,9 @@ You can use either of the following methods to deploy a {prodname} PostgreSQL co
 * xref:openshift-streams-postgresql-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-postgresql-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-postgresql-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 .Additional resources
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2174,7 +2174,9 @@ You can use either of the following methods to deploy a {prodname} SQL Server co
 * xref:openshift-streams-sqlserver-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-sqlserver-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-sqlserver-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 .Additional resources
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2592,7 +2592,9 @@ You can use either of the following methods to deploy a {prodname} {connector-na
 * xref:openshift-streams-{context}-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+This Containerfile deployment method is deprecated.
+The instructions for this method are scheduled for removal in future versions of the documentation.
 
 .Additional resources
 


### PR DESCRIPTION
[DBZ-8566](https://issues.redhat.com/browse/DBZ-8566)  Adds note to the top-level Deployment topic in the product edition of the connector docs to notify users about future removal of the Containerfile version of the deployment instructions.