### PR TITLE
DBZ-8648 Avoid NPE with primary key mode `record_value` and delete events

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcKafkaSinkRecord.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcKafkaSinkRecord.java
@@ -175,6 +175,9 @@ public class JdbcKafkaSinkRecord extends KafkaDebeziumSinkRecord implements Jdbc
         if (flattened) {
             recordFields = valueSchema().fields().stream();
         }
+        else if (isDelete()) {
+            recordFields = ((Struct) value()).getStruct(Envelope.FieldName.BEFORE).schema().fields().stream();
+        }
         else {
             recordFields = ((Struct) value()).getStruct(Envelope.FieldName.AFTER).schema().fields().stream();
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8648