### PR TITLE
[docs] Fix formatting in Kafka stop snapshot partial

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
@@ -25,4 +25,5 @@ Specify {data-collection} names by using the format `{collection-container}.{dat
 |===
 
 The following example shows a typical `stop-snapshot` Kafka message:
+
 include::{snippetsdir}/{context}-frag-signaling-fq-table-formats.adoc[leveloffset=+1,tags=stopping-incremental-snapshot-kafka-example]


### PR DESCRIPTION
Fixes a formatting error in which a missing new-line before an `include` directive causes code from the directive to be appended to the introductory sentence of the example for using the Kafka signaling channel to send a stop incremental snapshot signal:

> `The following example shows a typical stop-snapshot Kafka message: :leveloffset: +1`

This error is present in the documentation for all connectors that provide instructions for using the Kafka signaling channel to stop incremental snapshots. 

Tested in a local Antora build.