### PR TITLE
[fix] Sandbox release snapshot jenkins pipeline

### DIFF
--- a/jenkins-jobs/job-dsl/release/release_deploy_snapshots.groovy
+++ b/jenkins-jobs/job-dsl/release/release_deploy_snapshots.groovy
@@ -35,6 +35,7 @@ pipelineJob('release/release-deploy_snapshots_pipeline') {
     definition {
         cps {
             script(readFileFromWorkspace('jenkins-jobs/pipelines/release/deploy_snapshots_pipeline.groovy'))
+            sanbox()
         }
     }
 }


### PR DESCRIPTION
Add sandbox check to the release snapshot Jenkins pipeline in order to make it work without any admin approval. 