### PR TITLE
DBZ-8651 Add libraries to override older Apicurio libs

### DIFF
--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/artifacts/OcpArtifactServerController.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/artifacts/OcpArtifactServerController.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.testing.system.tools.ConfigProperties;
 import io.debezium.testing.system.tools.OpenShiftUtils;
 import io.debezium.testing.system.tools.WaitConditions;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -116,16 +115,15 @@ public class OcpArtifactServerController {
                 "groovy/groovy",
                 "groovy/groovy-json",
                 "groovy/groovy-jsr223",
+                "jackson/jackson-databind",
                 "jackson/jackson-dataformat-csv",
                 "jackson/jackson-datatype-jsr310",
                 "jackson/jackson-jaxrs-base",
                 "jackson/jackson-jaxrs-json-provider",
                 "jackson/jackson-module-jaxb-annotations",
+                "jackson/jackson-module-afterburner",
                 "jackson/jackson-module-scala_2.13");
         List<String> artifacts = Stream.concat(commonArtifacts.stream(), extraArtifacts.stream()).collect(toList());
-        if (!ConfigProperties.PRODUCT_BUILD) {
-            artifacts.add("jackson/jackson-module-afterburner");
-        }
         return createPlugin("debezium-connector-" + database, artifacts);
     }
 


### PR DESCRIPTION
Apicurio depends on older libraries than JDBC sink requires to work properly. Libs which Apicurio depends on are part of Kafka distribution but by including Apicurio and its libs, the older Apicurio libs have precedence and JDBC sink fails to start. By including these libraries into the connector we are trying to put the libs on the class path before Apicurio libs so that the right ones are loaded for JDBC sink.

https://issues.redhat.com/browse/DBZ-8651