### PR TITLE
DBZ-8674 Fix race condition in execute snapshot

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -68,22 +68,20 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     }
 
     @Override
-    public void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
+    protected void doProcessHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
-        super.processHeartbeat(partition, offsetContext);
         readUntilGtidChange(partition, offsetContext);
     }
 
     @Override
-    public void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    protected void doProcessFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
-        super.processFilteredEvent(partition, offsetContext);
         boolean windowClosed = getContext().updateWindowState(offsetContext);
         if (windowClosed) {
             sendWindowEvents(partition, offsetContext);
@@ -92,12 +90,11 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     }
 
     @Override
-    public void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    protected void doProcessTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
-        super.processTransactionStartedEvent(partition, offsetContext);
         boolean windowClosed = getContext().updateWindowState(offsetContext);
         if (windowClosed) {
             sendWindowEvents(partition, offsetContext);
@@ -106,12 +103,11 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     }
 
     @Override
-    public void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    protected void doProcessTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
-        super.processTransactionCommittedEvent(partition, offsetContext);
         readUntilGtidChange(partition, offsetContext);
     }
 

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -56,6 +56,10 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
             return;
         }
         checkAndAddDataCollections(partition, offsetContext);
+        checkAndProcessStopFlag(partition, offsetContext);
+        if (getContext().currentDataCollectionId() == null) {
+            return;
+        }
         LOGGER.trace("Checking window for table '{}', key '{}', window contains '{}'", dataCollectionId, key, window);
         boolean windowClosed = getContext().updateWindowState(offsetContext);
         if (windowClosed) {
@@ -82,6 +86,9 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
+        if (getContext().currentDataCollectionId() == null) {
+            return;
+        }
         boolean windowClosed = getContext().updateWindowState(offsetContext);
         if (windowClosed) {
             sendWindowEvents(partition, offsetContext);
@@ -95,6 +102,9 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
+        if (getContext().currentDataCollectionId() == null) {
+            return;
+        }
         boolean windowClosed = getContext().updateWindowState(offsetContext);
         if (windowClosed) {
             sendWindowEvents(partition, offsetContext);
@@ -106,6 +116,9 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     protected void doProcessTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
+            return;
+        }
+        if (getContext().currentDataCollectionId() == null) {
             return;
         }
         readUntilGtidChange(partition, offsetContext);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotIT.java
@@ -279,7 +279,7 @@ public abstract class BinlogReadOnlyIncrementalSnapshotIT<C extends SourceConnec
 
         final List<SourceRecord> records = new ArrayList<>();
         final String topicName = topicName();
-        final String tableRemoveMessage = String.format("Removed '%s' from incremental snapshot collection list.", tableDataCollectionId());
+        final String tableRemoveMessage = String.format("Removed current collection '%s' from incremental snapshot collection list.", tableDataCollectionId());
 
         Awaitility.await()
                 .atMost(Duration.ofMinutes(2))

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
@@ -31,6 +31,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.engine.DebeziumEngine;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.kafka.KafkaClusterUtils;
 import io.debezium.pipeline.signal.actions.snapshotting.ExecuteSnapshot;
@@ -46,6 +47,8 @@ public abstract class BinlogSignalsIT<C extends SourceConnector> extends Abstrac
             .toAbsolutePath();
     protected final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase(SERVER_NAME, "incremental_snapshot-test").withDbHistoryPath(SCHEMA_HISTORY_PATH);
     protected static StrimziKafkaCluster kafkaCluster;
+    protected static KafkaCluster kafka;
+    public static final String EXCLUDED_TABLE = "a";
 
     @BeforeAll
     static void startKafka() {
@@ -88,6 +91,7 @@ public abstract class BinlogSignalsIT<C extends SourceConnector> extends Abstrac
 
     protected Configuration.Builder config() {
         return DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.TABLE_EXCLUDE_LIST, DATABASE.getDatabaseName() + "." + EXCLUDED_TABLE)
                 .with(BinlogConnectorConfig.INCLUDE_SQL_QUERY, true)
                 .with(BinlogConnectorConfig.USER, "mysqluser")
                 .with(BinlogConnectorConfig.PASSWORD, "mysqlpw")
@@ -200,6 +204,18 @@ public abstract class BinlogSignalsIT<C extends SourceConnector> extends Abstrac
                 "{\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"%s\"], \"type\": \"INCREMENTAL\"}}",
                 table);
         sendKafkaSignal(signalValue, signalTopic);
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            connection.executeWithoutCommitting(String.format("INSERT INTO %s (aa) VALUES (%s)", EXCLUDED_TABLE, 1));
+            connection.commit();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected JdbcConnection databaseConnection() {
+        return getTestDatabaseConnection(DATABASE.getDatabaseName());
     }
 
     protected void sendKafkaSignal(String signalValue, String signalTopic) throws ExecutionException, InterruptedException {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
@@ -47,7 +47,6 @@ public abstract class BinlogSignalsIT<C extends SourceConnector> extends Abstrac
             .toAbsolutePath();
     protected final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase(SERVER_NAME, "incremental_snapshot-test").withDbHistoryPath(SCHEMA_HISTORY_PATH);
     protected static StrimziKafkaCluster kafkaCluster;
-    protected static KafkaCluster kafka;
     public static final String EXCLUDED_TABLE = "a";
 
     @BeforeAll

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSignalsIT.java
@@ -20,6 +20,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.source.SourceConnector;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,6 +38,7 @@ import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.kafka.KafkaClusterUtils;
 import io.debezium.pipeline.signal.actions.snapshotting.ExecuteSnapshot;
 import io.debezium.pipeline.signal.channels.KafkaSignalChannel;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
 import io.strimzi.test.container.StrimziKafkaCluster;
 
 /**
@@ -202,7 +205,28 @@ public abstract class BinlogSignalsIT<C extends SourceConnector> extends Abstrac
         String signalValue = String.format(
                 "{\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"%s\"], \"type\": \"INCREMENTAL\"}}",
                 table);
+
+        // Intercept logs to detect when the Kafka signal has been consumed and the snapshot
+        // request has been queued in the state manager. This prevents a race condition where
+        // the INSERT binlog events below are processed by the streaming thread before the Kafka
+        // consumer thread has queued the snapshot request, leaving the queue empty and the
+        // snapshot never triggered.
+        //
+        // The wait is best-effort: if the connector is not yet running (e.g., in tests that
+        // send the signal before starting the connector), the timeout is ignored and we proceed.
+        final LogInterceptor signalInterceptor = new LogInterceptor(AbstractIncrementalSnapshotChangeEventSource.class);
         sendKafkaSignal(signalValue, signalTopic);
+
+        try {
+            Awaitility.await("Waiting for execute-snapshot signal to be queued")
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> signalInterceptor.containsMessage("Request data collections"));
+        }
+        catch (ConditionTimeoutException ignored) {
+            // The connector may not be running yet; the INSERT below will trigger
+            // checkAndAddDataCollections once the connector processes binlog events.
+        }
+
         try (JdbcConnection connection = databaseConnection()) {
             connection.setAutoCommit(false);
             connection.executeWithoutCommitting(String.format("INSERT INTO %s (aa) VALUES (%s)", EXCLUDED_TABLE, 1));

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
@@ -75,7 +75,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
                     throw new DebeziumException(
                             "Incremental snapshot is not properly configured, either sinalling data collection is not provided or connector-specific snapshotting not set");
                 }
-                dispatcher.getIncrementalSnapshotChangeEventSource().addDataCollectionNamesToSnapshot(
+                dispatcher.getIncrementalSnapshotChangeEventSource().requestAddDataCollectionNamesToSnapshot(
                         signalPayload, snapsthoConfigurationBuilder.build());
                 break;
             case BLOCKING:

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -576,24 +576,81 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         context.requestAddDataCollectionNamesToSnapshot(signalPayload, snapshotConfiguration);
     }
 
+    /**
+     * Template method for processing heartbeat events.
+     * This method is final to ensure the common workflow is always executed:
+     * 1. Check and add data collections (common behavior)
+     * 2. Execute connector-specific heartbeat processing (via hook method)
+     *
+     * Subclasses should override {@link #doProcessHeartbeat(Partition, OffsetContext)}
+     * instead of this method to add their specific logic.
+     */
     @Override
-    public void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
+    public final void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
         checkAndAddDataCollections(partition, offsetContext);
+        doProcessHeartbeat(partition, offsetContext);
     }
 
+    /**
+     * Template method for processing filtered events.
+     * Ensures common data collection management is always executed before connector-specific logic.
+     */
     @Override
-    public void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    public final void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         checkAndAddDataCollections(partition, offsetContext);
+        doProcessFilteredEvent(partition, offsetContext);
     }
 
+    /**
+     * Template method for processing transaction started events.
+     * Ensures common data collection management is always executed before connector-specific logic.
+     */
     @Override
-    public void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    public final void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         checkAndAddDataCollections(partition, offsetContext);
+        doProcessTransactionStartedEvent(partition, offsetContext);
     }
 
+    /**
+     * Template method for processing transaction committed events.
+     * Ensures common data collection management is always executed before connector-specific logic.
+     */
     @Override
-    public void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+    public final void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         checkAndAddDataCollections(partition, offsetContext);
+        doProcessTransactionCommittedEvent(partition, offsetContext);
+    }
+
+    /**
+     * Hook method for subclasses to implement heartbeat-specific processing.
+     * The common work of checking and adding data collections is already handled.
+     */
+    protected void doProcessHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
+        // Default implementation does nothing - subclasses can override if needed
+    }
+
+    /**
+     * Hook method for subclasses to implement filtered event-specific processing.
+     * The common work of checking and adding data collections is already handled.
+     */
+    protected void doProcessFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        // Default implementation does nothing - subclasses can override if needed
+    }
+
+    /**
+     * Hook method for subclasses to implement transaction started event-specific processing.
+     * The common work of checking and adding data collections is already handled.
+     */
+    protected void doProcessTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        // Default implementation does nothing - subclasses can override if needed
+    }
+
+    /**
+     * Hook method for subclasses to implement transaction committed event-specific processing.
+     * The common work of checking and adding data collections is already handled.
+     */
+    protected void doProcessTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        // Default implementation does nothing - subclasses can override if needed
     }
 
     protected void checkAndAddDataCollections(P partition, OffsetContext offsetContext) throws InterruptedException {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -18,11 +18,11 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -601,15 +601,13 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             LOGGER.warn("Context is null, skipping check and add data collections");
             return;
         }
-        LOGGER.debug("Check and add data collections {}", context.getDataCollectionsToAdd().keySet());
-        Map<SignalPayload, SnapshotConfiguration> map = context.getDataCollectionsToAdd();
-        Iterator<Map.Entry<SignalPayload, SnapshotConfiguration>> iterator = map.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<SignalPayload, SnapshotConfiguration> entry = iterator.next();
-            SignalPayload signalPayload = entry.getKey();
-            SnapshotConfiguration snapshotConfiguration = entry.getValue();
+        LOGGER.debug("Check and add data collections");
+        Queue<SignalDataCollection> queue = context.getDataCollectionsToAdd();
+        SignalDataCollection dataCollectionToAdd;
+        while ((dataCollectionToAdd = queue.poll()) != null) {
+            SignalPayload signalPayload = dataCollectionToAdd.getSignalPayload();
+            SnapshotConfiguration snapshotConfiguration = dataCollectionToAdd.getSnapshotConfiguration();
             addDataCollectionNamesToSnapshot(partition, offsetContext, signalPayload, snapshotConfiguration);
-            map.remove(signalPayload);
         }
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -18,6 +18,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -473,13 +474,10 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         }
     }
 
-    @Override
     @SuppressWarnings("unchecked")
-    public void addDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration)
+    protected void addDataCollectionNamesToSnapshot(P partition, OffsetContext offsetContext, SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration)
             throws InterruptedException {
 
-        final OffsetContext offsetContext = signalPayload.offsetContext;
-        final P partition = signalPayload.partition;
         final String correlationId = signalPayload.id;
 
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
@@ -568,6 +566,51 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
     public void requestStopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds) {
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
         context.requestSnapshotStop(dataCollectionIds);
+    }
+
+    @Override
+    public void requestAddDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration) {
+        final OffsetContext offsetContext = signalPayload.offsetContext;
+        LOGGER.info("Request data collections {}", signalPayload);
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+        context.requestAddDataCollectionNamesToSnapshot(signalPayload, snapshotConfiguration);
+    }
+
+    @Override
+    public void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    protected void checkAndAddDataCollections(P partition, OffsetContext offsetContext) throws InterruptedException {
+        if (context == null) {
+            LOGGER.warn("Context is null, skipping check and add data collections");
+            return;
+        }
+        LOGGER.debug("Check and add data collections {}", context.getDataCollectionsToAdd().keySet());
+        Map<SignalPayload, SnapshotConfiguration> map = context.getDataCollectionsToAdd();
+        Iterator<Map.Entry<SignalPayload, SnapshotConfiguration>> iterator = map.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<SignalPayload, SnapshotConfiguration> entry = iterator.next();
+            SignalPayload signalPayload = entry.getKey();
+            SnapshotConfiguration snapshotConfiguration = entry.getValue();
+            addDataCollectionNamesToSnapshot(partition, offsetContext, signalPayload, snapshotConfiguration);
+            map.remove(signalPayload);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -586,8 +586,13 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
      * instead of this method to add their specific logic.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public final void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+        if (context != null) {
+            checkAndAddDataCollections(partition, offsetContext);
+            checkAndProcessStopFlag(partition, offsetContext);
+        }
         doProcessHeartbeat(partition, offsetContext);
     }
 
@@ -596,8 +601,13 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
      * Ensures common data collection management is always executed before connector-specific logic.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public final void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+        if (context != null) {
+            checkAndAddDataCollections(partition, offsetContext);
+            checkAndProcessStopFlag(partition, offsetContext);
+        }
         doProcessFilteredEvent(partition, offsetContext);
     }
 
@@ -606,8 +616,13 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
      * Ensures common data collection management is always executed before connector-specific logic.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public final void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+        if (context != null) {
+            checkAndAddDataCollections(partition, offsetContext);
+            checkAndProcessStopFlag(partition, offsetContext);
+        }
         doProcessTransactionStartedEvent(partition, offsetContext);
     }
 
@@ -616,8 +631,13 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
      * Ensures common data collection management is always executed before connector-specific logic.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public final void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
+        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+        if (context != null) {
+            checkAndAddDataCollections(partition, offsetContext);
+            checkAndProcessStopFlag(partition, offsetContext);
+        }
         doProcessTransactionCommittedEvent(partition, offsetContext);
     }
 
@@ -655,7 +675,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     protected void checkAndAddDataCollections(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (context == null) {
-            LOGGER.warn("Context is null, skipping check and add data collections");
             return;
         }
         LOGGER.debug("Check and add data collections");
@@ -668,9 +687,10 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void checkAndProcessStopFlag(P partition, OffsetContext offsetContext) {
-        context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
+    protected void checkAndProcessStopFlag(P partition, OffsetContext offsetContext) {
+        if (context == null) {
+            return;
+        }
         List<String> dataCollectionsToStop = context.getDataCollectionsToStop();
         if (dataCollectionsToStop.isEmpty()) {
             return;

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -33,7 +34,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
@@ -97,6 +100,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
      */
     private final AtomicBoolean paused = new AtomicBoolean(false);
     private final LinkedBlockingQueue<String> dataCollectionsToStop = new LinkedBlockingQueue<>();
+    private final ConcurrentHashMap<SignalPayload, SnapshotConfiguration> dataCollectionsToAdd = new ConcurrentHashMap<>();
 
     public AbstractIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
@@ -192,6 +196,11 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         return drainedList;
     }
 
+    @Override
+    public void requestAddDataCollectionNamesToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration) {
+        dataCollectionsToAdd.put(signalPayload, snapshotConfiguration);
+    }
+
     public boolean snapshotRunning() {
         return !snapshotDataCollection.isEmpty();
     }
@@ -276,6 +285,10 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @Override
     public String getCorrelationId() {
         return this.correlationId;
+    }
+
+    public Map<SignalPayload, SnapshotConfiguration> getDataCollectionsToAdd() {
+        return dataCollectionsToAdd;
     }
 
     protected static <U> IncrementalSnapshotContext<U> init(AbstractIncrementalSnapshotContext<U> context, Map<String, ?> offsets) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -33,10 +33,9 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
 
     void init(P partition, OffsetContext offsetContext);
 
-    void addDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration)
-            throws InterruptedException;
-
     void requestStopSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds);
+
+    void requestAddDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, SnapshotConfiguration snapshotConfiguration);
 
     default void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
     }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -9,7 +9,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.relational.Table;
 
 public interface IncrementalSnapshotContext<T> {
@@ -77,4 +79,7 @@ public interface IncrementalSnapshotContext<T> {
 
     List<String> getDataCollectionsToStop();
 
+    void requestAddDataCollectionNamesToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration);
+
+    Map<SignalPayload, SnapshotConfiguration> getDataCollectionsToAdd();
 }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -8,6 +8,7 @@ package io.debezium.pipeline.source.snapshot.incremental;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 
 import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
@@ -81,5 +82,5 @@ public interface IncrementalSnapshotContext<T> {
 
     void requestAddDataCollectionNamesToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration);
 
-    Map<SignalPayload, SnapshotConfiguration> getDataCollectionsToAdd();
+    Queue<SignalDataCollection> getDataCollectionsToAdd();
 }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManager.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManager.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
+
+/**
+ * A thread-safe state manager for incremental snapshots that centralizes the management
+ * of shared state to prevent race conditions and provide consistent operations.
+ *
+ * This class manages:
+ * - Signal-based data collection operations (add/stop requests)
+ * - Snapshot state control (pause/resume)
+ * - Window management for deduplication
+ * - Thread-safe access to shared resources
+ *
+ * @author Debezium Authors
+ */
+@ThreadSafe
+public class IncrementalSnapshotStateManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalSnapshotStateManager.class);
+
+    // Signal-based operations
+    private final ConcurrentLinkedQueue<SignalDataCollection> dataCollectionsToAdd = new ConcurrentLinkedQueue<>();
+    private final LinkedBlockingQueue<String> dataCollectionsToStop = new LinkedBlockingQueue<>();
+
+    // Snapshot state control
+    private final AtomicBoolean paused = new AtomicBoolean(false);
+    private volatile boolean windowOpened = false;
+    private volatile String currentChunkId;
+
+    // Thread-safe synchronization for window operations
+    private final ReadWriteLock windowLock = new ReentrantReadWriteLock();
+
+    /**
+     * Requests to add data collections to the snapshot.
+     * This operation is thread-safe and can be called concurrently.
+     *
+     * @param signalPayload the signal payload containing collection information
+     * @param snapshotConfiguration the snapshot configuration
+     */
+    public void requestAddDataCollectionToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration) {
+        SignalDataCollection dataCollection = new SignalDataCollection(signalPayload, snapshotConfiguration);
+        dataCollectionsToAdd.add(dataCollection);
+        LOGGER.debug("Added data collection to snapshot queue: {}", signalPayload.id);
+    }
+
+    /**
+     * Polls and returns the next data collection to be added to the snapshot.
+     * This operation is thread-safe and removes the element from the queue atomically.
+     *
+     * @return the next SignalDataCollection to add, or null if queue is empty
+     */
+    public SignalDataCollection pollDataCollectionToAdd() {
+        return dataCollectionsToAdd.poll();
+    }
+
+    /**
+     * Requests to stop snapshot processing for the specified data collections.
+     * This operation is thread-safe and can be called concurrently.
+     *
+     * @param dataCollectionIds list of data collection identifiers to stop, or null/empty for all
+     */
+    public void requestStopSnapshot(List<String> dataCollectionIds) {
+        if (dataCollectionIds == null || dataCollectionIds.isEmpty()) {
+            dataCollectionsToStop.add(".*");
+            LOGGER.debug("Requested to stop all data collections");
+        }
+        else {
+            dataCollectionsToStop.addAll(dataCollectionIds);
+            LOGGER.debug("Requested to stop data collections: {}", dataCollectionIds);
+        }
+    }
+
+    /**
+     * Drains all pending stop requests into the provided list.
+     * This operation is thread-safe and atomic.
+     *
+     * @return list of data collection identifiers that should be stopped
+     */
+    public List<String> drainDataCollectionsToStop() {
+        List<String> drainedList = new ArrayList<>();
+        dataCollectionsToStop.drainTo(drainedList);
+        return drainedList;
+    }
+
+    /**
+     * Pauses the incremental snapshot.
+     * This operation is thread-safe and idempotent.
+     */
+    public void pauseSnapshot() {
+        if (paused.compareAndSet(false, true)) {
+            LOGGER.info("Incremental snapshot paused");
+        }
+        else {
+            LOGGER.debug("Incremental snapshot is already paused");
+        }
+    }
+
+    /**
+     * Resumes the incremental snapshot.
+     * This operation is thread-safe and idempotent.
+     */
+    public void resumeSnapshot() {
+        if (paused.compareAndSet(true, false)) {
+            LOGGER.info("Incremental snapshot resumed");
+        }
+        else {
+            LOGGER.debug("Incremental snapshot is not paused");
+        }
+    }
+
+    /**
+     * Checks if the incremental snapshot is currently paused.
+     *
+     * @return true if paused, false otherwise
+     */
+    public boolean isSnapshotPaused() {
+        return paused.get();
+    }
+
+    /**
+     * Opens the snapshot window for the specified chunk ID.
+     * This operation is thread-safe and validates the chunk ID.
+     *
+     * @param chunkId the chunk ID to open the window for
+     * @return true if window was opened, false if request was ignored
+     */
+    public boolean openWindow(String chunkId) {
+        windowLock.writeLock().lock();
+        try {
+            if (isUnexpectedChunk(chunkId)) {
+                LOGGER.info("Received request to open window with id = '{}', expected = '{}', request ignored",
+                        chunkId, currentChunkId);
+                return false;
+            }
+            LOGGER.debug("Opening window for incremental snapshot chunk: {}", chunkId);
+            windowOpened = true;
+            return true;
+        }
+        finally {
+            windowLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Closes the snapshot window for the specified chunk ID.
+     * This operation is thread-safe and validates the chunk ID.
+     *
+     * @param chunkId the chunk ID to close the window for
+     * @return true if window was closed, false if request was ignored
+     */
+    public boolean closeWindow(String chunkId) {
+        windowLock.writeLock().lock();
+        try {
+            if (isUnexpectedChunk(chunkId)) {
+                LOGGER.info("Received request to close window with id = '{}', expected = '{}', request ignored",
+                        chunkId, currentChunkId);
+                return false;
+            }
+            LOGGER.debug("Closing window for incremental snapshot chunk: {}", chunkId);
+            windowOpened = false;
+            return true;
+        }
+        finally {
+            windowLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Checks if deduplication is needed based on window state.
+     * This operation is thread-safe for reading.
+     *
+     * @return true if deduplication is needed (window is open), false otherwise
+     */
+    public boolean deduplicationNeeded() {
+        windowLock.readLock().lock();
+        try {
+            return windowOpened;
+        }
+        finally {
+            windowLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Sets the current chunk ID for window validation.
+     * This operation is thread-safe.
+     *
+     * @param chunkId the current chunk ID
+     */
+    public void setCurrentChunkId(String chunkId) {
+        windowLock.writeLock().lock();
+        try {
+            this.currentChunkId = chunkId;
+            LOGGER.debug("Set current chunk ID to: {}", chunkId);
+        }
+        finally {
+            windowLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Gets the current chunk ID.
+     * This operation is thread-safe for reading.
+     *
+     * @return the current chunk ID
+     */
+    public String getCurrentChunkId() {
+        windowLock.readLock().lock();
+        try {
+            return currentChunkId;
+        }
+        finally {
+            windowLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Checks if the given chunk ID is unexpected (doesn't match current chunk).
+     * This method should be called within appropriate locks.
+     *
+     * @param chunkId the chunk ID to validate
+     * @return true if the chunk ID is unexpected, false otherwise
+     */
+    private boolean isUnexpectedChunk(String chunkId) {
+        return currentChunkId == null || !chunkId.startsWith(currentChunkId);
+    }
+
+    /**
+     * Clears all pending operations and resets state.
+     * This operation is thread-safe and can be used for cleanup.
+     */
+    public void clear() {
+        windowLock.writeLock().lock();
+        try {
+            dataCollectionsToAdd.clear();
+            dataCollectionsToStop.clear();
+            paused.set(false);
+            windowOpened = false;
+            currentChunkId = null;
+            LOGGER.debug("Cleared incremental snapshot state manager");
+        }
+        finally {
+            windowLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Gets the number of pending data collections to be added.
+     *
+     * @return the size of the add queue
+     */
+    public int getPendingAddCount() {
+        return dataCollectionsToAdd.size();
+    }
+
+    /**
+     * Gets the number of pending data collections to be stopped.
+     *
+     * @return the size of the stop queue
+     */
+    public int getPendingStopCount() {
+        return dataCollectionsToStop.size();
+    }
+
+    /**
+     * Returns a summary of the current state for debugging purposes.
+     *
+     * @return string representation of current state
+     */
+    @Override
+    public String toString() {
+        windowLock.readLock().lock();
+        try {
+            return String.format("IncrementalSnapshotStateManager{" +
+                    "pendingAdds=%d, pendingStops=%d, paused=%s, windowOpened=%s, currentChunkId='%s'}",
+                    getPendingAddCount(), getPendingStopCount(),
+                    paused.get(), windowOpened, currentChunkId);
+        }
+        finally {
+            windowLock.readLock().unlock();
+        }
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManager.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManager.java
@@ -241,7 +241,7 @@ public class IncrementalSnapshotStateManager {
      * @return true if the chunk ID is unexpected, false otherwise
      */
     private boolean isUnexpectedChunk(String chunkId) {
-        return currentChunkId == null || !chunkId.startsWith(currentChunkId);
+        return chunkId == null || currentChunkId == null || !chunkId.startsWith(currentChunkId);
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
@@ -95,7 +95,7 @@ public class SignalBasedIncrementalSnapshotChangeEventSource<P extends Partition
 
     @Override
     @SuppressWarnings("unchecked")
-    public void processMessage(Partition partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) {
+    public void processMessage(P partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException {
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
         if (context == null) {
             LOGGER.warn("Context is null, skipping message processing");

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
@@ -101,6 +101,8 @@ public class SignalBasedIncrementalSnapshotChangeEventSource<P extends Partition
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
+        checkAndAddDataCollections(partition, offsetContext);
+        checkAndProcessStopFlag(partition, offsetContext);
         LOGGER.trace("Checking window for table '{}', key '{}', window contains '{}'", dataCollectionId, maybeRedactSensitiveData(key), window);
         if (!window.isEmpty() && context.deduplicationNeeded()) {
             deduplicateWindow(dataCollectionId, key);

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalDataCollection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalDataCollection.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
+
+/**
+ * A container class that holds both the signal payload and snapshot configuration for incremental snapshots.
+ */
+public class SignalDataCollection {
+    private final SignalPayload signalPayload;
+    private final SnapshotConfiguration snapshotConfiguration;
+
+    public SignalDataCollection(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration) {
+        this.signalPayload = signalPayload;
+        this.snapshotConfiguration = snapshotConfiguration;
+    }
+
+    public SignalPayload getSignalPayload() {
+        return signalPayload;
+    }
+
+    public SnapshotConfiguration getSnapshotConfiguration() {
+        return snapshotConfiguration;
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManagerTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManagerTest.java
@@ -5,11 +5,11 @@
  */
 package io.debezium.pipeline.source.snapshot.incremental;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
@@ -34,23 +34,23 @@ public class IncrementalSnapshotStateManagerTest {
         IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
 
         // Initial state should not be paused
-        assertFalse("Should not be paused initially", stateManager.isSnapshotPaused());
+        assertFalse(stateManager.isSnapshotPaused(), "Should not be paused initially");
 
         // Pause operation
         stateManager.pauseSnapshot();
-        assertTrue("Should be paused after pause", stateManager.isSnapshotPaused());
+        assertTrue(stateManager.isSnapshotPaused(), "Should be paused after pause");
 
         // Idempotent pause
         stateManager.pauseSnapshot();
-        assertTrue("Should remain paused after second pause", stateManager.isSnapshotPaused());
+        assertTrue(stateManager.isSnapshotPaused(), "Should remain paused after second pause");
 
         // Resume operation
         stateManager.resumeSnapshot();
-        assertFalse("Should not be paused after resume", stateManager.isSnapshotPaused());
+        assertFalse(stateManager.isSnapshotPaused(), "Should not be paused after resume");
 
         // Idempotent resume
         stateManager.resumeSnapshot();
-        assertFalse("Should remain not paused after second resume", stateManager.isSnapshotPaused());
+        assertFalse(stateManager.isSnapshotPaused(), "Should remain not paused after second resume");
     }
 
     @Test
@@ -60,21 +60,21 @@ public class IncrementalSnapshotStateManagerTest {
 
         // Set current chunk ID
         stateManager.setCurrentChunkId(chunkId);
-        assertEquals("Chunk ID should match", chunkId, stateManager.getCurrentChunkId());
+        assertEquals(chunkId, stateManager.getCurrentChunkId(), "Chunk ID should match");
 
         // Open window
-        assertTrue("Should open window for valid chunk", stateManager.openWindow(chunkId));
-        assertTrue("Should need deduplication when window is open", stateManager.deduplicationNeeded());
+        assertTrue(stateManager.openWindow(chunkId), "Should open window for valid chunk");
+        assertTrue(stateManager.deduplicationNeeded(), "Should need deduplication when window is open");
 
         // Try to open with different chunk (should be ignored)
-        assertFalse("Should ignore window open for different chunk", stateManager.openWindow("different-chunk"));
+        assertFalse(stateManager.openWindow("different-chunk"), "Should ignore window open for different chunk");
 
         // Close window
-        assertTrue("Should close window for valid chunk", stateManager.closeWindow(chunkId));
-        assertFalse("Should not need deduplication when window is closed", stateManager.deduplicationNeeded());
+        assertTrue(stateManager.closeWindow(chunkId), "Should close window for valid chunk");
+        assertFalse(stateManager.deduplicationNeeded(), "Should not need deduplication when window is closed");
 
         // Try to close with different chunk (should be ignored)
-        assertFalse("Should ignore window close for different chunk", stateManager.closeWindow("different-chunk"));
+        assertFalse(stateManager.closeWindow("different-chunk"), "Should ignore window close for different chunk");
     }
 
     @Test
@@ -89,33 +89,33 @@ public class IncrementalSnapshotStateManagerTest {
         stateManager.requestAddDataCollectionToSnapshot(payload1, config);
         stateManager.requestAddDataCollectionToSnapshot(payload2, config);
 
-        assertEquals("Should have 2 pending adds", 2, stateManager.getPendingAddCount());
+        assertEquals(2, stateManager.getPendingAddCount(), "Should have 2 pending adds");
 
         // Test polling
         SignalDataCollection polled1 = stateManager.pollDataCollectionToAdd();
-        assertNotNull("Should poll first collection", polled1);
-        assertEquals("Should poll correct collection", payload1, polled1.getSignalPayload());
+        assertNotNull(polled1, "Should poll first collection");
+        assertEquals(payload1, polled1.getSignalPayload(), "Should poll correct collection");
 
         SignalDataCollection polled2 = stateManager.pollDataCollectionToAdd();
-        assertNotNull("Should poll second collection", polled2);
-        assertEquals("Should poll correct collection", payload2, polled2.getSignalPayload());
+        assertNotNull(polled2, "Should poll second collection");
+        assertEquals(payload2, polled2.getSignalPayload(), "Should poll correct collection");
 
         // No more collections
-        assertNull("Should return null when no more collections", stateManager.pollDataCollectionToAdd());
-        assertEquals("Should have 0 pending adds", 0, stateManager.getPendingAddCount());
+        assertNull(stateManager.pollDataCollectionToAdd(), "Should return null when no more collections");
+        assertEquals(0, stateManager.getPendingAddCount(), "Should have 0 pending adds");
 
         // Test stop operations
         List<String> collectionsToStop = Arrays.asList("table1", "table2");
         stateManager.requestStopSnapshot(collectionsToStop);
 
-        assertEquals("Should have 2 pending stops", 2, stateManager.getPendingStopCount());
+        assertEquals(2, stateManager.getPendingStopCount(), "Should have 2 pending stops");
 
         List<String> stoppedCollections = stateManager.drainDataCollectionsToStop();
-        assertEquals("Should drain all collections", 2, stoppedCollections.size());
-        assertTrue("Should contain table1", stoppedCollections.contains("table1"));
-        assertTrue("Should contain table2", stoppedCollections.contains("table2"));
+        assertEquals(2, stoppedCollections.size(), "Should drain all collections");
+        assertTrue(stoppedCollections.contains("table1"), "Should contain table1");
+        assertTrue(stoppedCollections.contains("table2"), "Should contain table2");
 
-        assertEquals("Should have 0 pending stops after drain", 0, stateManager.getPendingStopCount());
+        assertEquals(0, stateManager.getPendingStopCount(), "Should have 0 pending stops after drain");
     }
 
     @Test
@@ -149,9 +149,9 @@ public class IncrementalSnapshotStateManagerTest {
         executor.shutdown();
 
         // Verify all operations completed without race conditions
-        assertEquals("All collections should be added", numThreads * operationsPerThread, addedCount.get());
-        assertEquals("State manager should have all pending collections",
-                numThreads * operationsPerThread, stateManager.getPendingAddCount());
+        assertEquals(numThreads * operationsPerThread, addedCount.get(), "All collections should be added");
+        assertEquals(numThreads * operationsPerThread, stateManager.getPendingAddCount(),
+                "State manager should have all pending collections");
 
         // Poll all collections to verify queue integrity
         int polledCount = 0;
@@ -159,7 +159,7 @@ public class IncrementalSnapshotStateManagerTest {
             polledCount++;
         }
 
-        assertEquals("Should poll all added collections", numThreads * operationsPerThread, polledCount);
+        assertEquals(numThreads * operationsPerThread, polledCount, "Should poll all added collections");
     }
 
     @Test
@@ -170,15 +170,15 @@ public class IncrementalSnapshotStateManagerTest {
         stateManager.requestStopSnapshot(null);
 
         List<String> stopped = stateManager.drainDataCollectionsToStop();
-        assertEquals("Should have wildcard stop", 1, stopped.size());
-        assertEquals("Should contain wildcard", ".*", stopped.get(0));
+        assertEquals(1, stopped.size(), "Should have wildcard stop");
+        assertEquals(".*", stopped.get(0), "Should contain wildcard");
 
         // Request stop with empty list should also stop all
         stateManager.requestStopSnapshot(Arrays.asList());
 
         stopped = stateManager.drainDataCollectionsToStop();
-        assertEquals("Should have wildcard stop", 1, stopped.size());
-        assertEquals("Should contain wildcard", ".*", stopped.get(0));
+        assertEquals(1, stopped.size(), "Should have wildcard stop");
+        assertEquals(".*", stopped.get(0), "Should contain wildcard");
     }
 
     @Test
@@ -202,11 +202,11 @@ public class IncrementalSnapshotStateManagerTest {
         stateManager.clear();
 
         // Verify everything is cleared
-        assertFalse("Should not be paused after clear", stateManager.isSnapshotPaused());
-        assertFalse("Should not need deduplication after clear", stateManager.deduplicationNeeded());
-        assertEquals("Should have no pending adds", 0, stateManager.getPendingAddCount());
-        assertEquals("Should have no pending stops", 0, stateManager.getPendingStopCount());
-        assertNull("Current chunk ID should be null", stateManager.getCurrentChunkId());
+        assertFalse(stateManager.isSnapshotPaused(), "Should not be paused after clear");
+        assertFalse(stateManager.deduplicationNeeded(), "Should not need deduplication after clear");
+        assertEquals(0, stateManager.getPendingAddCount(), "Should have no pending adds");
+        assertEquals(0, stateManager.getPendingStopCount(), "Should have no pending stops");
+        assertNull(stateManager.getCurrentChunkId(), "Current chunk ID should be null");
     }
 
     @Test
@@ -214,9 +214,9 @@ public class IncrementalSnapshotStateManagerTest {
         IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
 
         String initialState = stateManager.toString();
-        assertTrue("Should contain class name", initialState.contains("IncrementalSnapshotStateManager"));
-        assertTrue("Should contain state info", initialState.contains("pendingAdds=0"));
-        assertTrue("Should contain pause state", initialState.contains("paused=false"));
+        assertTrue(initialState.contains("IncrementalSnapshotStateManager"), "Should contain class name");
+        assertTrue(initialState.contains("pendingAdds=0"), "Should contain state info");
+        assertTrue(initialState.contains("paused=false"), "Should contain pause state");
 
         // Add some state and verify toString reflects changes
         stateManager.pauseSnapshot();
@@ -224,9 +224,9 @@ public class IncrementalSnapshotStateManagerTest {
         stateManager.requestAddDataCollectionToSnapshot(createMockSignalPayload("test"), new SnapshotConfiguration());
 
         String stateWithData = stateManager.toString();
-        assertTrue("Should show paused state", stateWithData.contains("paused=true"));
-        assertTrue("Should show pending adds", stateWithData.contains("pendingAdds=1"));
-        assertTrue("Should show chunk ID", stateWithData.contains("currentChunkId='test'"));
+        assertTrue(stateWithData.contains("paused=true"), "Should show paused state");
+        assertTrue(stateWithData.contains("pendingAdds=1"), "Should show pending adds");
+        assertTrue(stateWithData.contains("currentChunkId='test'"), "Should show chunk ID");
     }
 
     private SignalPayload createMockSignalPayload(String id) {

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManagerTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotStateManagerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
+
+/**
+ * Test for IncrementalSnapshotStateManager to verify thread-safe operations
+ * and race condition prevention.
+ */
+public class IncrementalSnapshotStateManagerTest {
+
+    @Test
+    public void testPauseResumeOperations() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+
+        // Initial state should not be paused
+        assertFalse("Should not be paused initially", stateManager.isSnapshotPaused());
+
+        // Pause operation
+        stateManager.pauseSnapshot();
+        assertTrue("Should be paused after pause", stateManager.isSnapshotPaused());
+
+        // Idempotent pause
+        stateManager.pauseSnapshot();
+        assertTrue("Should remain paused after second pause", stateManager.isSnapshotPaused());
+
+        // Resume operation
+        stateManager.resumeSnapshot();
+        assertFalse("Should not be paused after resume", stateManager.isSnapshotPaused());
+
+        // Idempotent resume
+        stateManager.resumeSnapshot();
+        assertFalse("Should remain not paused after second resume", stateManager.isSnapshotPaused());
+    }
+
+    @Test
+    public void testWindowOperations() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+        String chunkId = "test-chunk-123";
+
+        // Set current chunk ID
+        stateManager.setCurrentChunkId(chunkId);
+        assertEquals("Chunk ID should match", chunkId, stateManager.getCurrentChunkId());
+
+        // Open window
+        assertTrue("Should open window for valid chunk", stateManager.openWindow(chunkId));
+        assertTrue("Should need deduplication when window is open", stateManager.deduplicationNeeded());
+
+        // Try to open with different chunk (should be ignored)
+        assertFalse("Should ignore window open for different chunk", stateManager.openWindow("different-chunk"));
+
+        // Close window
+        assertTrue("Should close window for valid chunk", stateManager.closeWindow(chunkId));
+        assertFalse("Should not need deduplication when window is closed", stateManager.deduplicationNeeded());
+
+        // Try to close with different chunk (should be ignored)
+        assertFalse("Should ignore window close for different chunk", stateManager.closeWindow("different-chunk"));
+    }
+
+    @Test
+    public void testDataCollectionOperations() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+
+        // Test add operations
+        SignalPayload payload1 = createMockSignalPayload("collection1");
+        SignalPayload payload2 = createMockSignalPayload("collection2");
+        SnapshotConfiguration config = new SnapshotConfiguration();
+
+        stateManager.requestAddDataCollectionToSnapshot(payload1, config);
+        stateManager.requestAddDataCollectionToSnapshot(payload2, config);
+
+        assertEquals("Should have 2 pending adds", 2, stateManager.getPendingAddCount());
+
+        // Test polling
+        SignalDataCollection polled1 = stateManager.pollDataCollectionToAdd();
+        assertNotNull("Should poll first collection", polled1);
+        assertEquals("Should poll correct collection", payload1, polled1.getSignalPayload());
+
+        SignalDataCollection polled2 = stateManager.pollDataCollectionToAdd();
+        assertNotNull("Should poll second collection", polled2);
+        assertEquals("Should poll correct collection", payload2, polled2.getSignalPayload());
+
+        // No more collections
+        assertNull("Should return null when no more collections", stateManager.pollDataCollectionToAdd());
+        assertEquals("Should have 0 pending adds", 0, stateManager.getPendingAddCount());
+
+        // Test stop operations
+        List<String> collectionsToStop = Arrays.asList("table1", "table2");
+        stateManager.requestStopSnapshot(collectionsToStop);
+
+        assertEquals("Should have 2 pending stops", 2, stateManager.getPendingStopCount());
+
+        List<String> stoppedCollections = stateManager.drainDataCollectionsToStop();
+        assertEquals("Should drain all collections", 2, stoppedCollections.size());
+        assertTrue("Should contain table1", stoppedCollections.contains("table1"));
+        assertTrue("Should contain table2", stoppedCollections.contains("table2"));
+
+        assertEquals("Should have 0 pending stops after drain", 0, stateManager.getPendingStopCount());
+    }
+
+    @Test
+    public void testConcurrentOperations() throws InterruptedException {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+        int numThreads = 10;
+        int operationsPerThread = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger addedCount = new AtomicInteger(0);
+
+        // Start multiple threads that add collections concurrently
+        for (int i = 0; i < numThreads; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        SignalPayload payload = createMockSignalPayload("collection_" + threadId + "_" + j);
+                        SnapshotConfiguration config = new SnapshotConfiguration();
+                        stateManager.requestAddDataCollectionToSnapshot(payload, config);
+                        addedCount.incrementAndGet();
+                    }
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // Wait for all threads to complete
+        executor.shutdown();
+
+        // Verify all operations completed without race conditions
+        assertEquals("All collections should be added", numThreads * operationsPerThread, addedCount.get());
+        assertEquals("State manager should have all pending collections",
+                numThreads * operationsPerThread, stateManager.getPendingAddCount());
+
+        // Poll all collections to verify queue integrity
+        int polledCount = 0;
+        while (stateManager.pollDataCollectionToAdd() != null) {
+            polledCount++;
+        }
+
+        assertEquals("Should poll all added collections", numThreads * operationsPerThread, polledCount);
+    }
+
+    @Test
+    public void testStopAllCollections() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+
+        // Request stop with null should stop all
+        stateManager.requestStopSnapshot(null);
+
+        List<String> stopped = stateManager.drainDataCollectionsToStop();
+        assertEquals("Should have wildcard stop", 1, stopped.size());
+        assertEquals("Should contain wildcard", ".*", stopped.get(0));
+
+        // Request stop with empty list should also stop all
+        stateManager.requestStopSnapshot(Arrays.asList());
+
+        stopped = stateManager.drainDataCollectionsToStop();
+        assertEquals("Should have wildcard stop", 1, stopped.size());
+        assertEquals("Should contain wildcard", ".*", stopped.get(0));
+    }
+
+    @Test
+    public void testClearOperations() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+
+        // Set up some state
+        stateManager.setCurrentChunkId("test-chunk");
+        stateManager.pauseSnapshot();
+        stateManager.openWindow("test-chunk");
+        stateManager.requestAddDataCollectionToSnapshot(createMockSignalPayload("test"), new SnapshotConfiguration());
+        stateManager.requestStopSnapshot(Arrays.asList("table1"));
+
+        // Verify state is set
+        assertTrue(stateManager.isSnapshotPaused());
+        assertTrue(stateManager.deduplicationNeeded());
+        assertEquals(1, stateManager.getPendingAddCount());
+        assertEquals(1, stateManager.getPendingStopCount());
+
+        // Clear all state
+        stateManager.clear();
+
+        // Verify everything is cleared
+        assertFalse("Should not be paused after clear", stateManager.isSnapshotPaused());
+        assertFalse("Should not need deduplication after clear", stateManager.deduplicationNeeded());
+        assertEquals("Should have no pending adds", 0, stateManager.getPendingAddCount());
+        assertEquals("Should have no pending stops", 0, stateManager.getPendingStopCount());
+        assertNull("Current chunk ID should be null", stateManager.getCurrentChunkId());
+    }
+
+    @Test
+    public void testToString() {
+        IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
+
+        String initialState = stateManager.toString();
+        assertTrue("Should contain class name", initialState.contains("IncrementalSnapshotStateManager"));
+        assertTrue("Should contain state info", initialState.contains("pendingAdds=0"));
+        assertTrue("Should contain pause state", initialState.contains("paused=false"));
+
+        // Add some state and verify toString reflects changes
+        stateManager.pauseSnapshot();
+        stateManager.setCurrentChunkId("test");
+        stateManager.requestAddDataCollectionToSnapshot(createMockSignalPayload("test"), new SnapshotConfiguration());
+
+        String stateWithData = stateManager.toString();
+        assertTrue("Should show paused state", stateWithData.contains("paused=true"));
+        assertTrue("Should show pending adds", stateWithData.contains("pendingAdds=1"));
+        assertTrue("Should show chunk ID", stateWithData.contains("currentChunkId='test'"));
+    }
+
+    private SignalPayload createMockSignalPayload(String id) {
+        // Create a simple mock SignalPayload for testing
+        return new SignalPayload(null, id, "test-type", null, null, null);
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -12,10 +12,10 @@ import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationS
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -60,6 +60,7 @@ import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
 import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.SignalDataCollection;
 import io.debezium.pipeline.source.snapshot.incremental.WatermarkWindowCloser;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
@@ -483,15 +484,13 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             LOGGER.warn("Context is null, skipping check and add data collections");
             return;
         }
-        LOGGER.debug("Check and add data collections {}", context.getDataCollectionsToAdd().keySet());
-        Map<SignalPayload, SnapshotConfiguration> map = context.getDataCollectionsToAdd();
-        Iterator<Map.Entry<SignalPayload, SnapshotConfiguration>> iterator = map.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<SignalPayload, SnapshotConfiguration> entry = iterator.next();
-            SignalPayload signalPayload = entry.getKey();
-            SnapshotConfiguration snapshotConfiguration = entry.getValue();
+        LOGGER.debug("Check and add data collections");
+        Queue<SignalDataCollection> queue = context.getDataCollectionsToAdd();
+        SignalDataCollection dataCollectionToAdd;
+        while ((dataCollectionToAdd = queue.poll()) != null) {
+            SignalPayload signalPayload = dataCollectionToAdd.getSignalPayload();
+            SnapshotConfiguration snapshotConfiguration = dataCollectionToAdd.getSnapshotConfiguration();
             addDataCollectionNamesToSnapshot(partition, offsetContext, signalPayload, snapshotConfiguration);
-            map.remove(signalPayload);
         }
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -12,6 +12,7 @@ import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationS
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -400,14 +401,11 @@ public class MongoDbIncrementalSnapshotChangeEventSource
         return key.get() != null ? new Object[]{ key.get() } : null;
     }
 
-    @Override
     @SuppressWarnings("unchecked")
-    public void addDataCollectionNamesToSnapshot(SignalPayload<MongoDbPartition> signalPayload,
-                                                 SnapshotConfiguration snapshotConfiguration)
+    protected void addDataCollectionNamesToSnapshot(MongoDbPartition partition, OffsetContext offsetContext, SignalPayload<MongoDbPartition> signalPayload,
+                                                    SnapshotConfiguration snapshotConfiguration)
             throws InterruptedException {
 
-        final MongoDbPartition partition = signalPayload.partition;
-        final OffsetContext offsetContext = signalPayload.offsetContext;
         final String correlationId = signalPayload.id;
 
         if (!Strings.isNullOrEmpty(snapshotConfiguration.getSurrogateKey())) {
@@ -449,6 +447,52 @@ public class MongoDbIncrementalSnapshotChangeEventSource
     public void requestStopSnapshot(MongoDbPartition partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionPatterns) {
         context = (IncrementalSnapshotContext<CollectionId>) offsetContext.getIncrementalSnapshotContext();
         context.requestSnapshotStop(dataCollectionPatterns);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void requestAddDataCollectionNamesToSnapshot(SignalPayload<MongoDbPartition> signalPayload, SnapshotConfiguration snapshotConfiguration) {
+        final OffsetContext offsetContext = signalPayload.offsetContext;
+        LOGGER.info("Request data collections {}", signalPayload);
+        context = (IncrementalSnapshotContext<CollectionId>) offsetContext.getIncrementalSnapshotContext();
+        context.requestAddDataCollectionNamesToSnapshot(signalPayload, snapshotConfiguration);
+    }
+
+    @Override
+    public void processHeartbeat(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processFilteredEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processTransactionStartedEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    @Override
+    public void processTransactionCommittedEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
+        checkAndAddDataCollections(partition, offsetContext);
+    }
+
+    private void checkAndAddDataCollections(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
+        if (context == null) {
+            LOGGER.warn("Context is null, skipping check and add data collections");
+            return;
+        }
+        LOGGER.debug("Check and add data collections {}", context.getDataCollectionsToAdd().keySet());
+        Map<SignalPayload, SnapshotConfiguration> map = context.getDataCollectionsToAdd();
+        Iterator<Map.Entry<SignalPayload, SnapshotConfiguration>> iterator = map.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<SignalPayload, SnapshotConfiguration> entry = iterator.next();
+            SignalPayload signalPayload = entry.getKey();
+            SnapshotConfiguration snapshotConfiguration = entry.getValue();
+            addDataCollectionNamesToSnapshot(partition, offsetContext, signalPayload, snapshotConfiguration);
+            map.remove(signalPayload);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -758,6 +802,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             LOGGER.warn("Context is null, skipping message processing");
             return;
         }
+        checkAndAddDataCollections(partition, offsetContext);
         LOGGER.trace("Checking window for table '{}', key '{}', window contains '{}'", dataCollectionId, key, window);
         if (!window.isEmpty() && context.deduplicationNeeded()) {
             deduplicateWindow(dataCollectionId, key);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -784,6 +784,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             return;
         }
         checkAndAddDataCollections(partition, offsetContext);
+        checkAndProcessStopFlag(partition, offsetContext);
         LOGGER.trace("Checking window for table '{}', key '{}', window contains '{}'", dataCollectionId, key, window);
         if (!window.isEmpty() && context.deduplicationNeeded()) {
             deduplicateWindow(dataCollectionId, key);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -459,25 +459,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
         context.requestAddDataCollectionNamesToSnapshot(signalPayload, snapshotConfiguration);
     }
 
-    @Override
-    public void processHeartbeat(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
-    }
-
-    @Override
-    public void processFilteredEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
-    }
-
-    @Override
-    public void processTransactionStartedEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
-    }
-
-    @Override
-    public void processTransactionCommittedEvent(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
-        checkAndAddDataCollections(partition, offsetContext);
-    }
+    // No need to override process* methods - they're handled by the template method pattern in the abstract class
 
     private void checkAndAddDataCollections(MongoDbPartition partition, OffsetContext offsetContext) throws InterruptedException {
         if (context == null) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -39,6 +39,7 @@ import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
 import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.SignalDataCollection;
 import io.debezium.relational.Table;
 import io.debezium.util.HexConverter;
 
@@ -106,7 +107,7 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
     private AtomicBoolean paused = new AtomicBoolean(false);
     private final LinkedBlockingQueue<String> dataCollectionsToStop = new LinkedBlockingQueue<>();
     private ObjectMapper mapper = new ObjectMapper();
-    private final ConcurrentHashMap<SignalPayload, SnapshotConfiguration> dataCollectionsToAdd = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<SignalDataCollection> dataCollectionsToAdd = new ConcurrentLinkedQueue<>();
 
     private TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
     };
@@ -194,11 +195,11 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     @Override
     public void requestAddDataCollectionNamesToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration) {
-        dataCollectionsToAdd.put(signalPayload, snapshotConfiguration);
+        dataCollectionsToAdd.add(new SignalDataCollection(signalPayload, snapshotConfiguration));
     }
 
     @Override
-    public Map<SignalPayload, SnapshotConfiguration> getDataCollectionsToAdd() {
+    public Queue<SignalDataCollection> getDataCollectionsToAdd() {
         return dataCollectionsToAdd;
     }
 
@@ -300,13 +301,11 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     @Override
     public void requestSnapshotStop(List<String> dataCollectionIds) {
-        if (snapshotRunning()) {
-            if (dataCollectionIds == null || dataCollectionIds.isEmpty()) {
-                dataCollectionsToStop.add(".*");
-            }
-            else {
-                dataCollectionsToStop.addAll(dataCollectionIds);
-            }
+        if (dataCollectionIds == null || dataCollectionIds.isEmpty()) {
+            dataCollectionsToStop.add(".*");
+        }
+        else {
+            dataCollectionsToStop.addAll(dataCollectionIds);
         }
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
@@ -18,9 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -39,6 +37,7 @@ import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
 import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotStateManager;
 import io.debezium.pipeline.source.snapshot.incremental.SignalDataCollection;
 import io.debezium.relational.Table;
 import io.debezium.util.HexConverter;
@@ -102,12 +101,10 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
     private String correlationId;
 
     /**
-     * Determines if the incremental snapshot was paused or not.
+     * Centralized state manager for thread-safe operations
      */
-    private AtomicBoolean paused = new AtomicBoolean(false);
-    private final LinkedBlockingQueue<String> dataCollectionsToStop = new LinkedBlockingQueue<>();
+    private final IncrementalSnapshotStateManager stateManager = new IncrementalSnapshotStateManager();
     private ObjectMapper mapper = new ObjectMapper();
-    private final ConcurrentLinkedQueue<SignalDataCollection> dataCollectionsToAdd = new ConcurrentLinkedQueue<>();
 
     private TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
     };
@@ -136,17 +133,15 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
     }
 
     public void pauseSnapshot() {
-        LOGGER.info("Pausing incremental snapshot");
-        paused.set(true);
+        stateManager.pauseSnapshot();
     }
 
     public void resumeSnapshot() {
-        LOGGER.info("Resuming incremental snapshot");
-        paused.set(false);
+        stateManager.resumeSnapshot();
     }
 
     public boolean isSnapshotPaused() {
-        return paused.get();
+        return stateManager.isSnapshotPaused();
     }
 
     /**
@@ -188,19 +183,112 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     @Override
     public List<String> getDataCollectionsToStop() {
-        List<String> drainedList = new ArrayList<>();
-        dataCollectionsToStop.drainTo(drainedList);
-        return drainedList;
+        return stateManager.drainDataCollectionsToStop();
     }
 
     @Override
     public void requestAddDataCollectionNamesToSnapshot(SignalPayload signalPayload, SnapshotConfiguration snapshotConfiguration) {
-        dataCollectionsToAdd.add(new SignalDataCollection(signalPayload, snapshotConfiguration));
+        stateManager.requestAddDataCollectionToSnapshot(signalPayload, snapshotConfiguration);
     }
 
     @Override
     public Queue<SignalDataCollection> getDataCollectionsToAdd() {
-        return dataCollectionsToAdd;
+        // Return a view that allows polling but maintains the state manager's thread safety
+        return new Queue<SignalDataCollection>() {
+            @Override
+            public SignalDataCollection poll() {
+                return stateManager.pollDataCollectionToAdd();
+            }
+
+            @Override
+            public boolean add(SignalDataCollection e) {
+                throw new UnsupportedOperationException("Use requestAddDataCollectionNamesToSnapshot instead");
+            }
+
+            @Override
+            public boolean offer(SignalDataCollection e) {
+                throw new UnsupportedOperationException("Use requestAddDataCollectionNamesToSnapshot instead");
+            }
+
+            @Override
+            public SignalDataCollection remove() {
+                SignalDataCollection result = poll();
+                if (result == null) {
+                    throw new java.util.NoSuchElementException();
+                }
+                return result;
+            }
+
+            @Override
+            public SignalDataCollection element() {
+                throw new UnsupportedOperationException("Peek operations not supported for thread safety");
+            }
+
+            @Override
+            public SignalDataCollection peek() {
+                throw new UnsupportedOperationException("Peek operations not supported for thread safety");
+            }
+
+            @Override
+            public int size() {
+                return stateManager.getPendingAddCount();
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return size() == 0;
+            }
+
+            @Override
+            public boolean contains(Object o) {
+                throw new UnsupportedOperationException("Contains operations not supported for thread safety");
+            }
+
+            @Override
+            public java.util.Iterator<SignalDataCollection> iterator() {
+                throw new UnsupportedOperationException("Iterator operations not supported for thread safety");
+            }
+
+            @Override
+            public Object[] toArray() {
+                throw new UnsupportedOperationException("Array operations not supported for thread safety");
+            }
+
+            @Override
+            public <T> T[] toArray(T[] a) {
+                throw new UnsupportedOperationException("Array operations not supported for thread safety");
+            }
+
+            @Override
+            public boolean remove(Object o) {
+                throw new UnsupportedOperationException("Individual remove operations not supported");
+            }
+
+            @Override
+            public boolean containsAll(java.util.Collection<?> c) {
+                throw new UnsupportedOperationException("Bulk operations not supported for thread safety");
+            }
+
+            @Override
+            public boolean addAll(java.util.Collection<? extends SignalDataCollection> c) {
+                throw new UnsupportedOperationException("Use requestAddDataCollectionNamesToSnapshot instead");
+            }
+
+            @Override
+            public boolean removeAll(java.util.Collection<?> c) {
+                throw new UnsupportedOperationException("Bulk remove operations not supported");
+            }
+
+            @Override
+            public boolean retainAll(java.util.Collection<?> c) {
+                throw new UnsupportedOperationException("Retain operations not supported");
+            }
+
+            @Override
+            public void clear() {
+                throw new UnsupportedOperationException("Use state manager clear() instead");
+            }
+        };
     }
 
     private String dataCollectionsToSnapshotAsString() {
@@ -301,12 +389,7 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     @Override
     public void requestSnapshotStop(List<String> dataCollectionIds) {
-        if (dataCollectionIds == null || dataCollectionIds.isEmpty()) {
-            dataCollectionsToStop.add(".*");
-        }
-        else {
-            dataCollectionsToStop.addAll(dataCollectionIds);
-        }
+        stateManager.requestStopSnapshot(dataCollectionIds);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -136,8 +136,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
     }
 
     @Override
-    public void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
-        super.processTransactionCommittedEvent(partition, offsetContext);
+    protected void doProcessTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
@@ -149,8 +148,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
     }
 
     @Override
-    public void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
-        super.processHeartbeat(partition, offsetContext);
+    protected void doProcessHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -115,7 +115,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
 
     @Override
     public void processMessage(P partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException {
-
+        checkAndAddDataCollections(partition, offsetContext);
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
@@ -137,7 +137,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
 
     @Override
     public void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
-
+        super.processTransactionCommittedEvent(partition, offsetContext);
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
@@ -150,7 +150,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
 
     @Override
     public void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
-
+        super.processHeartbeat(partition, offsetContext);
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -116,6 +116,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
     @Override
     public void processMessage(P partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException {
         checkAndAddDataCollections(partition, offsetContext);
+        checkAndProcessStopFlag(partition, offsetContext);
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
             return;
@@ -139,6 +140,9 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
     protected void doProcessTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
         if (getContext() == null) {
             LOGGER.warn("Context is null, skipping message processing");
+            return;
+        }
+        if (getContext().currentDataCollectionId() == null) {
             return;
         }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotCollationSortOrderMismatchIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotCollationSortOrderMismatchIT.java
@@ -306,7 +306,7 @@ public class IncrementalSnapshotCollationSortOrderMismatchIT extends AbstractSna
             if (records.allRecordsInOrder().isEmpty()) {
                 noRecords++;
                 assertThat(noRecords).describedAs(String.format("Too many no data record results, %d < %d", dbChanges.size(), recordCount))
-                        .isLessThanOrEqualTo(5);
+                        .isLessThanOrEqualTo(8);
                 continue;
             }
             noRecords = 0;

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -502,10 +503,10 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         Map<String, List<SourceRecord>> recordsByTopic = dbChanges.stream().collect(Collectors.groupingBy(SourceRecord::topic,
                 Collectors.mapping(Function.identity(), Collectors.toList())));
 
-        Map<Integer, Integer> dbChangesA = recordsByTopic.get(topicNames().get(0)).stream()
+        Map<Integer, Integer> dbChangesA = recordsByTopic.getOrDefault(topicNames().get(0), Collections.emptyList()).stream()
                 .collect(Collectors.toMap(r -> ((Struct) r.key()).getInt32(pkFieldName()),
                         record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName())));
-        Map<Integer, Integer> dbChangesB = recordsByTopic.get(topicNames().get(1)).stream()
+        Map<Integer, Integer> dbChangesB = recordsByTopic.getOrDefault(topicNames().get(1), Collections.emptyList()).stream()
                 .collect(Collectors.toMap(r -> ((Struct) r.key()).getInt32(pkFieldName()),
                         record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName())));
 
@@ -1319,13 +1320,19 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
                 .distinct()
                 .collect(Collectors.toList())).contains("ad-hoc");
 
-        Struct inProgress = incrementalSnapshotNotification.stream().filter(s -> s.getString("type").equals("IN_PROGRESS")).findFirst().get();
+        Struct inProgress = incrementalSnapshotNotification.stream()
+                .filter(s -> s.getString("type").equals("IN_PROGRESS"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected an IN_PROGRESS incremental snapshot notification"));
         assertThat(inProgress.getMap("additional_data"))
                 .containsEntry("current_collection_in_progress", tableDataCollectionId())
                 .containsEntry("maximum_key", "1000")
                 .containsEntry("last_processed_key", String.valueOf(defaultIncrementalSnapshotChunkSize()));
 
-        Struct completed = incrementalSnapshotNotification.stream().filter(s -> s.getString("type").equals("TABLE_SCAN_COMPLETED")).findFirst().get();
+        Struct completed = incrementalSnapshotNotification.stream()
+                .filter(s -> s.getString("type").equals("TABLE_SCAN_COMPLETED"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected a TABLE_SCAN_COMPLETED incremental snapshot notification"));
         assertThat(completed.getMap("additional_data"))
                 .containsEntry("total_rows_scanned", "1000");
     }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
             .toAbsolutePath();
     protected static final int PARTITION_NO = 0;
     protected static final String SERVER_NAME = "test_server";
-    private static final int MAXIMUM_NO_RECORDS_CONSUMES = 5;
+    private static final int MAXIMUM_NO_RECORDS_CONSUMES = 9;
     protected final Path signalsFile = Paths.get("src", "test", "resources")
             .resolve("debezium_signaling_file.txt");
 


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/DBZ-8674

The key changes made are:
Signal thread sets `dataCollectionsToAdd` 

The `dataCollectionsToAdd` is checked and cleared atomically in the binlog thread via `checkAndReadChunkIfRequired`.

`readChunk` is now only called from binlog thread methods - (`checkAndReadChunkIfRequired` is called in `processMessage`, `processHeartbeat `, `processFilteredEvent `, `processTransactionStartedEvent `, `processTransactionCommittedEvent ` methods)