### PR TITLE
DBZ-8651 Skip adding Apicurio bits into JDBC sink connector tests

### DIFF
--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/artifacts/OcpArtifactServerController.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/artifacts/OcpArtifactServerController.java
@@ -111,19 +111,26 @@ public class OcpArtifactServerController {
         List<String> commonArtifacts = List.of(
                 "debezium-connector-" + database,
                 "debezium-scripting",
-                "connect-converter",
                 "groovy/groovy",
                 "groovy/groovy-json",
-                "groovy/groovy-jsr223",
-                "jackson/jackson-databind",
-                "jackson/jackson-dataformat-csv",
-                "jackson/jackson-datatype-jsr310",
-                "jackson/jackson-jaxrs-base",
-                "jackson/jackson-jaxrs-json-provider",
-                "jackson/jackson-module-jaxb-annotations",
-                "jackson/jackson-module-afterburner",
-                "jackson/jackson-module-scala_2.13");
-        List<String> artifacts = Stream.concat(commonArtifacts.stream(), extraArtifacts.stream()).collect(toList());
+                "groovy/groovy-jsr223");
+        Stream<String> artifactsStream = Stream.concat(commonArtifacts.stream(), extraArtifacts.stream());
+        if (!database.equalsIgnoreCase("jdbc")) {
+            List<String> apicurio = List.of(
+                    // add archive with Apicurio converters
+                    "connect-converter",
+                    // and libraries to override old libs pulled by Apicurio
+                    "jackson/jackson-databind",
+                    "jackson/jackson-dataformat-csv",
+                    "jackson/jackson-datatype-jsr310",
+                    "jackson/jackson-jaxrs-base",
+                    "jackson/jackson-jaxrs-json-provider",
+                    "jackson/jackson-module-jaxb-annotations",
+                    "jackson/jackson-module-afterburner",
+                    "jackson/jackson-module-scala_2.13");
+            artifactsStream = Stream.concat(artifactsStream, apicurio.stream());
+        }
+        List<String> artifacts = artifactsStream.collect(toList());
         return createPlugin("debezium-connector-" + database, artifacts);
     }
 

--- a/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/fixtures/connectors/ConnectorFixture.java
+++ b/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/fixtures/connectors/ConnectorFixture.java
@@ -47,13 +47,15 @@ public abstract class ConnectorFixture<T extends DatabaseController<?>> extends 
     public void setup() throws Exception {
         String connectorName = connectorBaseName + TestUtils.getUniqueId();
         connectorConfig = connectorConfig(connectorName);
+        addApicurioConfig();
+        connectController.deployConnector(connectorConfig);
+        store(ConnectorConfigBuilder.class, connectorConfig);
+    }
 
+    protected void addApicurioConfig() {
         if (apicurioController != null) {
             connectorConfig.addApicurioAvroSupport(apicurioController.getRegistryApiAddress());
         }
-
-        connectController.deployConnector(connectorConfig);
-        store(ConnectorConfigBuilder.class, connectorConfig);
     }
 
     @Override

--- a/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/fixtures/connectors/JdbcSinkConnector.java
+++ b/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/fixtures/connectors/JdbcSinkConnector.java
@@ -28,4 +28,9 @@ public class JdbcSinkConnector extends ConnectorFixture<MySqlController> {
     public ConnectorConfigBuilder connectorConfig(String connectorName) {
         return new ConnectorFactories(kafkaController).jdbcSink(dbController, connectorName);
     }
+
+    @Override
+    protected void addApicurioConfig() {
+        // Skip adding Apicurio config as JDBC sink tests don't use Apicurio anyway.
+    }
 }


### PR DESCRIPTION
We don't run any JDBC sink test with Apicurio anyway at the moment, so there's no need to add these libs into JDBC sink pluing.

Related DBZ issues: DBZ-8675 and DBZ-8676.

https://issues.redhat.com/browse/DBZ-8651