### PR TITLE
DBZ-8684 FIX SQL_ENUM_VALUES query

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -66,7 +66,7 @@ public class TypeRegistry {
     private static final String CATEGORY_ARRAY = "A";
     private static final String CATEGORY_ENUM = "E";
 
-    private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel) as values "
+    private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel order by t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
     private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8684

[FIX] adding order by enumsortorder will guarantee to have same array_agg output in case if a cdc topic is getting written from multiple sources and avoid new schema creation(avro)