### PR TITLE
DBZ-8710 Allow specifying case-sensitive database and PDB names

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -40,6 +40,7 @@ import io.debezium.config.Field;
 import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
 import io.debezium.connector.oracle.logminer.LogFile;
 import io.debezium.connector.oracle.logminer.SqlUtils;
+import io.debezium.connector.oracle.util.OracleUtils;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -247,8 +248,9 @@ public class OracleConnection extends JdbcConnection {
 
     @Override
     protected String resolveCatalogName(String catalogName) {
-        final String pdbName = config().getString("pdb.name");
-        return (!Strings.isNullOrEmpty(pdbName) ? pdbName : config().getString("dbname")).toUpperCase();
+        final String pdbName = OracleUtils.getObjectName(config().getString("pdb.name"));
+        final String databaseName = OracleUtils.getObjectName(config().getString("dbname"));
+        return !Strings.isNullOrEmpty(pdbName) ? pdbName : databaseName;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -40,6 +40,7 @@ import io.debezium.connector.oracle.logminer.processor.ehcache.EhcacheLogMinerEv
 import io.debezium.connector.oracle.logminer.processor.infinispan.EmbeddedInfinispanLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.infinispan.RemoteInfinispanLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.memory.MemoryLogMinerEventProcessor;
+import io.debezium.connector.oracle.util.OracleUtils;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
@@ -844,8 +845,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 ColumnFilterMode.SCHEMA,
                 false);
 
-        this.databaseName = toUpperCase(config.getString(DATABASE_NAME));
-        this.pdbName = toUpperCase(config.getString(PDB_NAME));
+        this.databaseName = OracleUtils.getObjectName(config.getString(DATABASE_NAME));
+        this.pdbName = OracleUtils.getObjectName(config.getString(PDB_NAME));
         this.xoutServerName = config.getString(XSTREAM_SERVER_NAME);
         this.intervalHandlingMode = IntervalHandlingMode.parse(config.getString(INTERVAL_HANDLING_MODE));
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE));
@@ -908,10 +909,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.openLogReplicatorSource = config.getString(OLR_SOURCE);
         this.openLogReplicatorHostname = config.getString(OLR_HOST);
         this.openLogReplicatorPort = config.getInteger(OLR_PORT, 0);
-    }
-
-    private static String toUpperCase(String property) {
-        return property == null ? null : property.toUpperCase();
     }
 
     public String getDatabaseName() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/util/OracleUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/util/OracleUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.util;
+
+import io.debezium.util.Strings;
+
+/**
+ * Oracle-specific utility methods.
+ *
+ * @author Chris Cranford
+ */
+public class OracleUtils {
+
+    /**
+     * Get the object name using Oracle case-semantics. If the name is quoted, its case is left as is,
+     * but if it isn't quoted, the case is automatically converted to upper-case.
+     *
+     * @param objectName the object name
+     * @return the object name with case-semantics applied
+     */
+    public static String getObjectName(String objectName) {
+        if (!Strings.isNullOrEmpty(objectName)) {
+            if (objectName.startsWith("\"") && objectName.endsWith("\"") && objectName.length() > 2) {
+                return objectName.substring(1, objectName.length() - 1);
+            }
+            return objectName.toUpperCase();
+        }
+        return objectName;
+    }
+
+    private OracleUtils() {
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8710

## Changes

The goal of this change is to be backward compatible by applying upper-case semantics to `database.dbname` and `database.pdb.name` when these two configuration properties are not specified in double-quotes. If these are defined in double quotes, the case will be treated as provided for case-sensitive use cases.

Example 1 - Values will be uppercased (case insensitive)
```
"database.dbname": "orclcdb",
"database.pdb.name": "pdb1"
```

Example 2 - Values left as-is (case sensitive)
```
"database.dbname": "\"orclcdb\"",
"database.pdb.name": "\"pdb1\"",
```