### PR TITLE
DBZ-8680 Postgres: Probe streaming connection during blocking snapshots

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -256,7 +256,14 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             if (context.isPaused()) {
                 LOGGER.info("Streaming will now pause");
                 context.streamingPaused();
-                context.waitSnapshotCompletion();
+                context.waitSnapshotCompletion(() -> {
+                    try {
+                        probeConnectionIfNeeded();
+                    }
+                    catch (SQLException e) {
+                        throw new DebeziumException(e);
+                    }
+                });
                 LOGGER.info("Streaming resumed");
             }
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
@@ -6,6 +6,7 @@
 
 package io.debezium.connector.postgresql;
 
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static io.debezium.pipeline.signal.actions.AbstractSnapshotSignal.SnapshotType.BLOCKING;
 
 import java.nio.file.Path;
@@ -22,6 +23,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.SkipWhenDatabaseVersion;
 import io.debezium.pipeline.AbstractBlockingSnapshotTest;
 import io.debezium.pipeline.signal.channels.FileSignalChannel;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
@@ -147,6 +149,61 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest<PostgresCon
         startConnector();
 
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+
+        waitForLogMessage("Snapshot completed", AbstractSnapshotChangeEventSource.class);
+
+        int signalingRecords = 1;
+
+        assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT + signalingRecords, 10));
+
+        insertRecords(ROW_COUNT, ROW_COUNT * 2);
+
+        assertStreamingRecordsArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT, 10));
+
+    }
+
+    @FixFor("DBZ-8680")
+    @Test
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 14, minor = 0, reason = "idle_session_timeout not supported for PG version < 14")
+    public void probeConnectionDuringBlockingSnapshot() throws Exception {
+        // Testing.Print.enable();
+
+        // This test ensures that the streaming connection is periodically probed while a blocking snapshot is taken. This helps reduce the risk
+        // of an idle disconnect during the snapshot due to inactivity on the streaming connection. If such a disconnect were to occur, then it
+        // would mean that the connector would fail to resume streaming after the snapshot is finished. What's worse: the snapshot completion
+        // may not be committed, leading to an infinite snapshot loop with the connector failing after every snapshot attempt.
+
+        // Avoid to start the streaming from data inserted before the connector start
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+
+        populateTable();
+
+        final long snapshotDelayMs = 10000;
+        startConnector(x -> config()
+                // Wait several seconds before starting the blocking snapshot. During this time, streaming has been paused, and could be at risk of
+                // an idle disconnection if the connector does not keep the connection active.
+                .with(CommonConnectorConfig.SNAPSHOT_DELAY_MS, snapshotDelayMs)
+                // When streaming is paused, the streaming connection is idle. Disconnect it if it's idle for too long.
+                // "options" is a PostgreSQL JDBC driver connection parameter that lets us pass through PG client configuration parameters.
+                // While this is a simple mechanism for the test, in complex cloud environments there could always be other factors that lead to
+                // idle TCP connections getting disconnected.
+                //
+                // For this test, the values must be lower than the snapshot delay, configured above.
+                .with(CommonConnectorConfig.DRIVER_CONFIG_PREFIX + "options", "-c idle_session_timeout=5000 -c idle_in_transaction_session_timeout=5000")
+                // The status update interval is also used as the frequency at which to probe the streaming connection. For this test, it must be
+                // less than the idle timeouts configured on the JDBC driver, configured above.
+                .with(PostgresConnectorConfig.STATUS_UPDATE_INTERVAL_MS, 2000)
+                // Disable retries: if the test is going to fail, this makes it fail cleaner:
+                .with(CommonConnectorConfig.ERRORS_MAX_RETRIES, 0)
+
+        );
+
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+
+        // Make sure the log message emitted by SNAPSHOT_DELAY_MS does get logged, thus ensuring that the snapshot took at least the configured
+        // snapshot delay, so that we know idle timeouts could be reached in a failing test scenario.
+        waitForLogMessage("The connector will wait for", AbstractSnapshotChangeEventSource.class);
 
         waitForLogMessage("Snapshot completed", AbstractSnapshotChangeEventSource.class);
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -407,6 +407,8 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
 
     public class ChangeEventSourceContextImpl implements ChangeEventSourceContext {
 
+        private static final Duration PAUSE_BETWEEN_HEARTBEAT_CALLBACKS = Duration.ofSeconds(1);
+
         private final Lock lock = new ReentrantLock();
         private final Condition snapshotFinished = lock.newCondition();
         private final Condition streamingPaused = lock.newCondition();
@@ -435,13 +437,21 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
 
         @Override
         public void waitSnapshotCompletion() throws InterruptedException {
+            waitSnapshotCompletion(() -> {
+            });
+        }
+
+        @Override
+        public void waitSnapshotCompletion(Runnable heartbeatCallback) throws InterruptedException {
             lock.lock();
             try {
                 while (paused) {
                     LOGGER.trace("Waiting for snapshot to be completed.");
-                    snapshotFinished.await();
-                    streaming = true;
+                    if (!snapshotFinished.await(PAUSE_BETWEEN_HEARTBEAT_CALLBACKS.toNanos(), TimeUnit.NANOSECONDS)) {
+                        heartbeatCallback.run();
+                    }
                 }
+                streaming = true;
             }
             finally {
                 lock.unlock();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSource.java
@@ -19,12 +19,39 @@ public interface ChangeEventSource {
          */
         boolean isRunning();
 
+        /**
+         * Called to indicate that the snapshot has been completed and that streaming should therefore continue.
+         */
         void resumeStreaming() throws InterruptedException;
 
+        /**
+         * Wait for the resumeStreaming function to be called, which indicates that a snapshot is done
+         * and that streaming should resume.
+         */
         void waitSnapshotCompletion() throws InterruptedException;
 
+        /**
+         * Wait for the resumeStreaming function to be called, which indicates that a snapshot is done
+         * and that streaming should resume.
+         *
+         * @param heartbeatCallback A callback function which will be periodically called while waiting for
+         *                          the snapshot to be completed.  Implementations should be kept simple and
+         *                          relatively fast: only do activities like generating activity on the
+         *                          streaming database connection to prevent idle timeouts.  Implementations
+         *                          should also check their own ElapsedTimeStrategy to control how often any
+         *                          heartbeat activities actually occur.
+         */
+        void waitSnapshotCompletion(Runnable heartbeatCallback) throws InterruptedException;
+
+        /**
+         * Called by the StreamingChangeEventSource to indicate that the streaming has now been paused, and
+         * that no streaming records are being processed anymore.
+         */
         void streamingPaused();
 
+        /**
+         * Wait for the streamingPaused function to be called.
+         */
         void waitStreamingPaused() throws InterruptedException;
     }
 }


### PR DESCRIPTION
If there is no activity on the streaming connection while the blocking snapshot is being taken, there is a possibility that the streaming connection might be disconnected.

Periodically run a probing query on the streaming connection during the blocking snapshot.

This is done by adding an overload of waitSnapshotCompletion which allows the user to provide a heartbeat callback function, which is regularly called while waiting.  This will allow other databases to easily add the functionality as well.