### PR TITLE
DBZ-8721 Detect Default Value Changes in ExtractChangedRecordState

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractChangedRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractChangedRecordState.java
@@ -84,7 +84,9 @@ public class ExtractChangedRecordState<R extends ConnectRecord<R>> implements Tr
             Struct afterValue = requireStruct(after, "After value should be struct.");
             Struct beforeValue = requireStruct(before, "Before value should be struct.");
             afterValue.schema().fields().forEach(field -> {
-                if (!Objects.equals(afterValue.get(field), beforeValue.get(field))) {
+                Object afterFieldValue = afterValue.getWithoutDefault(field.name());
+                Object beforeFieldValue = beforeValue.getWithoutDefault(field.name());
+                if (!Objects.equals(afterFieldValue, beforeFieldValue)) {
                     changedNames.add(field.name());
                 }
                 else {


### PR DESCRIPTION
Ensure that when a field is update from its default value to null or vice versa the change is detected by the SMT and added to the appropriate header.