### PR TITLE
DBZ-8738 Fix stop notification id

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -537,6 +537,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             LOGGER.info("Removed current collection '{}' from incremental snapshot collection list.", stopCurrentTableId);
             tableScanCompleted(partition);
             stopped.add(stopCurrentTableId.identifier());
+            notificationService.incrementalSnapshotNotificationService().notifyAborted(context, partition, offsetContext, stopped);
             // If snapshot has no more collections, abort; otherwise advance to the next collection.
             if (!context.snapshotRunning()) {
                 LOGGER.info("Incremental snapshot has stopped.");
@@ -547,7 +548,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                 nextDataCollection(partition, offsetContext);
             }
         }
-        notificationService.incrementalSnapshotNotificationService().notifyAborted(context, partition, offsetContext, stopped);
+        else {
+            notificationService.incrementalSnapshotNotificationService().notifyAborted(context, partition, offsetContext, stopped);
+        }
         if (!context.snapshotRunning()) {
             context.unsetCorrelationId();
         }


### PR DESCRIPTION
The correlation id is unset before sending aborted notification for incremental snapshot, resulting in randomly generated id

![image](https://github.com/user-attachments/assets/c8f13b6e-1a75-42ac-9f5c-ddb0a3e351d2)
