### PR TITLE
DBZ-8595 Remove unnecesarry refreshes of schema

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -106,7 +106,6 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         if (snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot() && startingSlotInfo == null) {
             setSnapshotTransactionIsolationLevel(snapshotContext.onDemand);
         }
-        schema.refresh(jdbcConnection, false);
     }
 
     @Override
@@ -141,8 +140,6 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
             LOGGER.info("Waiting a maximum of '{}' seconds for each table lock", lockTimeout.getSeconds());
             jdbcConnection.executeWithoutCommitting(statements.toString());
-            // now that we have the locks, refresh the schema
-            schema.refresh(jdbcConnection, false);
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -147,13 +147,10 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 walPosition = new WalPositionLocator();
                 replicationStream.compareAndSet(null, replicationConnection.startStreaming(walPosition));
             }
-            // for large dbs, the refresh of schema can take too much time
-            // such that the connection times out. We must enable keep
-            // alive to ensure that it doesn't time out
+
+            // Start keep alive thread to prevent connection timeout during time-consuming operations the DB side.
             ReplicationStream stream = this.replicationStream.get();
             stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
-
-            initSchema();
 
             // If we need to do a pre-snapshot streaming catch up, we should allow the snapshot transaction to persist
             // but normally we want to start streaming without any open transactions.


### PR DESCRIPTION
Both `connectionCreated()` and `lockTablesForSchemaSnapshot()` are called only from `RelationalSnapshotChangeEventSource#doExecute()`. Before it we just determine snapshot tables, offset and do the locking of the captured tables. We don't need schema for these operations and it should be sufficient to refresh the schema only before taking the actual snapshot. At this point fo time tables are already lock, so we take schema refresh from consitent DB view.

https://issues.redhat.com/browse/DBZ-8595