### PR TITLE
DBZ-8742 Update the way tests calculates the default zoned times for MariaDB

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
@@ -1063,19 +1063,6 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
     }
 
     private String getZonedDateTimeIsoString(ZonedDateTime zdt) {
-        if (isMariaDb()) {
-            // MariaDB applies the time-zone shift to the SHOW CREATE TABLE response when generating
-            // the SQL for the default value resolution which MySQL does not. This is because MariaDB
-            // pushes the "timezone=auto" connection argument to the server level whereas the MySQL
-            // "connectionTimeZone" is managed at the driver level on data responses only. In this
-            // case, MariaDB's default value resolution will always account for the current host
-            // time-zone difference with the host-system's time-zone.
-            long serverOffsetSecs = UniqueDatabase.TIMEZONE.getRules().getOffset(zdt.toInstant()).getTotalSeconds();
-            long hostOffsetSecs = ZoneOffset.systemDefault().getRules().getOffset(zdt.toInstant()).getTotalSeconds();
-            long timeDelta = serverOffsetSecs - hostOffsetSecs;
-            zdt = zdt.minusSeconds(timeDelta);
-            return ZonedTimestamp.toIsoString(zdt, UniqueDatabase.TIMEZONE, BinlogValueConverters::adjustTemporal, null);
-        }
         return ZonedTimestamp.toIsoString(zdt, ZoneId.systemDefault(), BinlogValueConverters::adjustTemporal, null);
     }
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRegressionIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRegressionIT.java
@@ -94,7 +94,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
-                .with("database.connectionTimeZone", DATABASE.timezone())
+                .with("database.connectionTimeZone", DATABASE.getTimezone())
                 .build();
         // Start the connector ...
         start(getConnectorClass(), config);
@@ -210,7 +210,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
 
                 // '2014-09-08 17:51:04.777'
                 String c4 = after.getString("c4"); // timestamp
-                assertTimestamp(c4);
+                assertTimestamp(DATABASE.getTimezone(), c4);
             }
             else if (record.topic().endsWith("dbz_114_zerovaluetest")) {
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
@@ -449,7 +449,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
                 .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(BinlogConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT)
-                .with("database.connectionTimeZone", DATABASE.timezone())
+                .with("database.connectionTimeZone", DATABASE.getTimezone())
                 .build();
         // Start the connector ...
         start(getConnectorClass(), config);
@@ -554,7 +554,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
 
                 // '2014-09-08 17:51:04.777'
                 String c4 = after.getString("c4"); // MySQL timestamp, so always ZonedTimestamp
-                assertTimestamp(c4);
+                assertTimestamp(DATABASE.getTimezone(), c4);
             }
             else if (record.topic().endsWith("dbz_114_zerovaluetest")) {
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
@@ -789,7 +789,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
 
                 OffsetDateTime expected = ZonedDateTime.of(
                         LocalDateTime.of(2014, 9, 8, 17, 51, 4, (int) TimeUnit.MILLISECONDS.toNanos(nanos)),
-                        UniqueDatabase.TIMEZONE)
+                        DATABASE.getTimezone())
                         .withZoneSameInstant(ZoneOffset.UTC)
                         .toOffsetDateTime();
 
@@ -1068,7 +1068,7 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
 
                     // '2014-09-08 17:51:04.777'
                     String c4 = after.getString("c4"); // timestamp
-                    assertTimestamp(c4);
+                    assertTimestamp(DATABASE.getTimezone(), c4);
                 }
             });
         }
@@ -1198,12 +1198,13 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
         });
     }
 
-    private void assertTimestamp(String c4) {
+    private void assertTimestamp(ZoneId timezoneId, String c4) {
         // '2014-09-08 17:51:04.777'
         // MySQL container is in UTC and the test time is during summer time period
         String expectedValue = isMariaDb() ? "2014-09-08T17:51:04.770" : "2014-09-08T17:51:04.780";
+
         ZonedDateTime expectedTimestamp = ZonedDateTime.ofInstant(
-                LocalDateTime.parse(expectedValue).atZone(ZoneId.of("US/Samoa")).toInstant(),
+                LocalDateTime.parse(expectedValue).atZone(timezoneId).toInstant(),
                 ZoneId.systemDefault());
         ZoneId defaultZoneId = ZoneId.systemDefault();
         ZonedDateTime c4DateTime = ZonedDateTime.parse(c4, ZonedTimestamp.FORMATTER).withZoneSameInstant(defaultZoneId);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
@@ -356,7 +356,7 @@ public abstract class BinlogStreamingSourceIT<C extends SourceConnector> extends
         // TIMESTAMP should be converted to UTC, using the DB's (or connection's) time zone
         ZonedDateTime expectedTimestamp = ZonedDateTime.of(
                 LocalDateTime.parse(dateTime),
-                UniqueDatabase.TIMEZONE)
+                REGRESSION_DATABASE.getTimezone())
                 .withZoneSameInstant(ZoneOffset.UTC);
 
         String expectedTimestampString = expectedTimestamp.format(ZonedTimestamp.FORMATTER);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
@@ -47,8 +47,6 @@ import io.debezium.storage.file.history.FileSchemaHistory;
  */
 public abstract class UniqueDatabase {
 
-    public static final ZoneId TIMEZONE = ZoneId.of("US/Samoa");
-
     private static final String DEFAULT_DATABASE = "mysql";
     private static final String[] CREATE_DATABASE_DDL = new String[]{
             "CREATE DATABASE `$DBNAME$`;",
@@ -280,9 +278,7 @@ public abstract class UniqueDatabase {
     /**
      * @return timezone in which the database is located
      */
-    public ZoneId timezone() {
-        return TIMEZONE;
-    }
+    public abstract ZoneId getTimezone();
 
     protected Configuration.Builder applyConnectorDefaultJdbcConfiguration(Configuration.Builder builder) {
         return builder;

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -195,6 +195,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
+                                    <TZ>CET</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.port}:3306</port>
@@ -249,6 +250,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
+                                    <TZ>CET</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.ssl.port}:3306</port>
@@ -312,6 +314,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
+                                    <TZ>CET</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.gtid.port}:3306</port>
@@ -367,6 +370,7 @@
                                     <MARIADB_ROOT_PASSWORD>debezium-rocks</MARIADB_ROOT_PASSWORD>
                                     <MARIADB_USER>${mariadb.replica.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.replica.password}</MARIADB_PASSWORD>
+                                    <TZ>CET</TZ>
                                 </env>
                                 <links>
                                     <link>database-gtids</link>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -195,7 +195,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>Pacific/Pago_Pago</TZ>
+                                    <TZ>UTC</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.port}:3306</port>
@@ -250,7 +250,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>Pacific/Pago_Pago</TZ>
+                                    <TZ>UTC</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.ssl.port}:3306</port>
@@ -314,7 +314,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>Pacific/Pago_Pago</TZ>
+                                    <TZ>UTC</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.gtid.port}:3306</port>
@@ -370,7 +370,7 @@
                                     <MARIADB_ROOT_PASSWORD>debezium-rocks</MARIADB_ROOT_PASSWORD>
                                     <MARIADB_USER>${mariadb.replica.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.replica.password}</MARIADB_PASSWORD>
-                                    <TZ>Pacific/Pago_Pago</TZ>
+                                    <TZ>UTC</TZ>
                                 </env>
                                 <links>
                                     <link>database-gtids</link>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -195,7 +195,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>CET</TZ>
+                                    <TZ>Pacific/Pago_Pago</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.port}:3306</port>
@@ -250,7 +250,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>CET</TZ>
+                                    <TZ>Pacific/Pago_Pago</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.ssl.port}:3306</port>
@@ -314,7 +314,7 @@
                                     <MARIADB_DATABASE>mysql</MARIADB_DATABASE> <!-- database created upon init -->
                                     <MARIADB_USER>${mariadb.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
-                                    <TZ>CET</TZ>
+                                    <TZ>Pacific/Pago_Pago</TZ>
                                 </env>
                                 <ports>
                                     <port>${mariadb.gtid.port}:3306</port>
@@ -370,7 +370,7 @@
                                     <MARIADB_ROOT_PASSWORD>debezium-rocks</MARIADB_ROOT_PASSWORD>
                                     <MARIADB_USER>${mariadb.replica.user}</MARIADB_USER>
                                     <MARIADB_PASSWORD>${mariadb.replica.password}</MARIADB_PASSWORD>
-                                    <TZ>CET</TZ>
+                                    <TZ>Pacific/Pago_Pago</TZ>
                                 </env>
                                 <links>
                                     <link>database-gtids</link>

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/util/MariaDbUniqueDatabase.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/util/MariaDbUniqueDatabase.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mariadb.util;
 
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Random;
 
@@ -54,6 +55,11 @@ public class MariaDbUniqueDatabase extends UniqueDatabase {
         }
 
         return builder;
+    }
+
+    @Override
+    public ZoneId getTimezone() {
+        return ZoneId.of("UTC");
     }
 
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUniqueDatabase.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUniqueDatabase.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mysql;
 
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Random;
 
@@ -61,5 +62,10 @@ public class MySqlUniqueDatabase extends UniqueDatabase {
         }
 
         return builder;
+    }
+
+    @Override
+    public ZoneId getTimezone() {
+        return ZoneId.of("US/Samoa");
     }
 }


### PR DESCRIPTION
In the MariaDB driver version 3.5 some fixes has been applied to how the default zoned times are calculated. Those changes lead to change the behavior of the tests. This PR updates the affected test cases.
