### PR TITLE
DBZ-8748 trim configuration keys when converting from properties

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -799,7 +799,7 @@ public interface Configuration {
     static Configuration from(Properties properties) {
         Properties props = new Properties();
         if (properties != null) {
-            props.putAll(properties);
+            properties.stringPropertyNames().forEach(key -> props.setProperty(key.trim(), properties.getProperty(key)));
         }
         return new Configuration() {
             @Override

--- a/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -59,6 +59,14 @@ public class ConfigurationTest {
         assertThat(config.getBoolean("1")).isNull(); // not a boolean
     }
 
+    @Test
+    public void shouldTrimWhenConvertingFromProperties() {
+        Properties props = new Properties();
+        props.setProperty("A ", "a");
+        config = Configuration.from(props);
+        assertThat(config.getString("A")).isEqualTo("a");
+    }
+
     /**
      * Test verifying that a Configuration object cannot be modified after creation.
      */


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8748

![dumbass me](https://github.com/user-attachments/assets/bed3a526-1ec3-4039-818b-218c4a40a144)

Specifically targeted at very observant people such as myself