### PR TITLE
DBZ-8749 Account for database system tz in snapshot source ts_ms

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -16,6 +16,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -565,6 +566,16 @@ public class OracleConnection extends JdbcConnection {
             }
             throw e;
         }
+    }
+
+    /**
+     * Get the database system time in the database system's time zone.
+     *
+     * @return the database system time
+     * @throws SQLException if a database exception occurred
+     */
+    public OffsetDateTime getDatabaseSystemTime() throws SQLException {
+        return singleOptionalValue("SELECT SYSTIMESTAMP FROM DUAL", rs -> rs.getObject(1, OffsetDateTime.class));
     }
 
     public boolean isArchiveLogDestinationValid(String archiveDestinationName) throws SQLException {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -214,12 +215,13 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     @Override
     protected Instant getSnapshotSourceTimestamp(JdbcConnection jdbcConnection, OracleOffsetContext offset, TableId tableId) {
         try {
-            Optional<Instant> snapshotTs = ((OracleConnection) jdbcConnection).getScnToTimestamp(offset.getScn());
-            if (snapshotTs.isEmpty()) {
-                throw new ConnectException("Failed reading SCN timestamp from source database");
-            }
-
-            return snapshotTs.get();
+            final OracleConnection oracleConnection = (OracleConnection) jdbcConnection;
+            return oracleConnection.getScnToTimestamp(offset.getScn())
+                    .orElseThrow(() -> new ConnectException("Failed reading SCN timestamp from database"))
+                    // Database host timezone adjustment
+                    .minusSeconds(oracleConnection.getDatabaseSystemTime().getOffset().getTotalSeconds())
+                    // JVM timezone adjustment
+                    .plusSeconds(ZoneId.systemDefault().getRules().getOffset(Instant.now()).getTotalSeconds());
         }
         catch (SQLException e) {
             throw new ConnectException("Failed reading SCN timestamp from source database", e);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -183,7 +182,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                     Stopwatch sw = Stopwatch.accumulating().start();
                     while (context.isRunning()) {
                         // Calculate time difference before each mining session to detect time zone offset changes (e.g. DST) on database server
-                        streamingMetrics.setDatabaseTimeDifference(getDatabaseSystemTime(jdbcConnection));
+                        streamingMetrics.setDatabaseTimeDifference(jdbcConnection.getDatabaseSystemTime());
 
                         if (archiveLogOnlyMode && !waitForStartScnInArchiveLogs(context, startScn)) {
                             break;
@@ -587,17 +586,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         connection.executeWithoutCommitting(NLS_SESSION_PARAMETERS);
         // This is necessary so that TIMESTAMP WITH LOCAL TIME ZONE is returned in UTC
         connection.executeWithoutCommitting("ALTER SESSION SET TIME_ZONE = '00:00'");
-    }
-
-    /**
-     * Get the database system time in the database system's time zone.
-     *
-     * @param connection database connection, should not be {@code null}
-     * @return the database system time
-     * @throws SQLException if a database exception occurred
-     */
-    private OffsetDateTime getDatabaseSystemTime(OracleConnection connection) throws SQLException {
-        return connection.singleOptionalValue("SELECT SYSTIMESTAMP FROM DUAL", rs -> rs.getObject(1, OffsetDateTime.class));
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8749

Verified locally setting Oracle container TZ=CET and leaving the TZ unset (UTC), and in both scenarios, a quick test of the envelope `ts_ms` and the `source.ts_ms` were within milliseconds of one another, as expected.