### PR TITLE
DBZ-8744 Limit archive logs to current log incarnation only

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -74,13 +74,15 @@ public class SqlUtils {
         final StringBuilder sb = new StringBuilder();
         sb.append("SELECT MIN(FIRST_CHANGE#) FROM (SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# ");
         sb.append("FROM ").append(LOG_VIEW).append(" ");
-        sb.append("UNION SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# ");
-        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" ");
-        sb.append("WHERE DEST_ID IN (").append(localArchiveLogDestinationsOnlyQuery(archiveDestinationName)).append(") ");
-        sb.append("AND STATUS='A'");
+        sb.append("UNION SELECT MIN(A.FIRST_CHANGE#) AS FIRST_CHANGE# ");
+        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" A, ").append(DATABASE_VIEW).append(" D ");
+        sb.append("WHERE A.DEST_ID IN (").append(localArchiveLogDestinationsOnlyQuery(archiveDestinationName)).append(") ");
+        sb.append("AND A.STATUS='A' ");
+        sb.append("AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# ");
+        sb.append("AND A.RESETLOGS_TIME = D.RESETLOGS_TIME");
 
         if (!archiveLogRetention.isNegative() && !archiveLogRetention.isZero()) {
-            sb.append(" AND FIRST_TIME >= SYSDATE - (").append(archiveLogRetention.toHours()).append("/24)");
+            sb.append(" AND A.FIRST_TIME >= SYSDATE - (").append(archiveLogRetention.toHours()).append("/24)");
         }
 
         return sb.append(")").toString();
@@ -88,12 +90,14 @@ public class SqlUtils {
 
     public static String allRedoThreadArchiveLogs(int threadId, String archiveDestinationName) {
         final StringBuilder sb = new StringBuilder();
-        sb.append("SELECT NAME, SEQUENCE#, FIRST_CHANGE#, NEXT_CHANGE# ");
-        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" ");
-        sb.append("WHERE DEST_ID IN (").append(localArchiveLogDestinationsOnlyQuery(archiveDestinationName)).append(") ");
-        sb.append("AND STATUS='A' ");
-        sb.append("AND THREAD#=").append(threadId).append(" ");
-        sb.append("ORDER BY SEQUENCE# DESC");
+        sb.append("SELECT A.NAME, A.SEQUENCE#, A.FIRST_CHANGE#, A.NEXT_CHANGE# ");
+        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" A, ").append(DATABASE_VIEW).append(" D ");
+        sb.append("WHERE A.DEST_ID IN (").append(localArchiveLogDestinationsOnlyQuery(archiveDestinationName)).append(") ");
+        sb.append("AND A.STATUS='A' ");
+        sb.append("AND A.THREAD#=").append(threadId).append(" ");
+        sb.append("AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# ");
+        sb.append("AND A.RESETLOGS_TIME = D.RESETLOGS_TIME ");
+        sb.append("ORDER BY A.SEQUENCE# DESC");
         return sb.toString();
     }
 
@@ -155,10 +159,16 @@ public class SqlUtils {
         if (!archiveLogOnlyMode) {
             sb.append("SELECT MIN(F.MEMBER) AS FILE_NAME, L.FIRST_CHANGE# FIRST_CHANGE, L.NEXT_CHANGE# NEXT_CHANGE, L.ARCHIVED, ");
             sb.append("L.STATUS, 'ONLINE' AS TYPE, L.SEQUENCE# AS SEQ, 'NO' AS DICT_START, 'NO' AS DICT_END, L.THREAD# AS THREAD ");
-            sb.append("FROM ").append(LOGFILE_VIEW).append(" F, ").append(LOG_VIEW).append(" L ");
+            sb.append("FROM ").append(LOGFILE_VIEW).append(" F, ");
+            sb.append(DATABASE_VIEW).append(" D, ");
+            sb.append(LOG_VIEW).append(" L ");
             sb.append("LEFT JOIN ").append(ARCHIVED_LOG_VIEW).append(" A ");
             sb.append("ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE# ");
-            sb.append("WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) ");
+            sb.append("WHERE ((");
+            sb.append("A.STATUS <> 'A' ");
+            sb.append("AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# ");
+            sb.append("AND A.RESETLOGS_TIME = D.RESETLOGS_TIME) ");
+            sb.append("OR A.FIRST_CHANGE# IS NULL) ");
             sb.append("AND L.STATUS != 'UNUSED' ");
             sb.append("AND F.GROUP# = L.GROUP# ");
             sb.append("GROUP BY F.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD# ");
@@ -166,12 +176,14 @@ public class SqlUtils {
         }
         sb.append("SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, A.NEXT_CHANGE# NEXT_CHANGE, 'YES', ");
         sb.append("NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, A.DICTIONARY_END, A.THREAD# AS THREAD ");
-        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" A ");
+        sb.append("FROM ").append(ARCHIVED_LOG_VIEW).append(" A, ").append(DATABASE_VIEW).append(" D ");
         sb.append("WHERE A.NAME IS NOT NULL ");
         sb.append("AND A.ARCHIVED = 'YES' ");
         sb.append("AND A.STATUS = 'A' ");
         sb.append("AND A.NEXT_CHANGE# > ").append(scn).append(" ");
         sb.append("AND A.DEST_ID IN (").append(localArchiveLogDestinationsOnlyQuery(archiveDestinationName)).append(") ");
+        sb.append("AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# ");
+        sb.append("AND A.RESETLOGS_TIME = D.RESETLOGS_TIME ");
 
         if (!archiveLogRetention.isNegative() && !archiveLogRetention.isZero()) {
             sb.append("AND A.FIRST_TIME >= SYSDATE - (").append(archiveLogRetention.toHours()).append("/24) ");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -25,27 +25,39 @@ public class SqlUtilsTest {
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
 
     @Test
-    public void testStatements() {
+    public void testDatabaseSupplementalLogMinCheckSql() {
         String result = SqlUtils.databaseSupplementalLoggingMinCheckQuery();
         String expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_MIN FROM V$DATABASE";
         assertThat(result).isEqualTo(expected);
+    }
 
-        result = SqlUtils.tableSupplementalLoggingCheckQuery();
-        expected = "SELECT 'KEY', LOG_GROUP_TYPE FROM ALL_LOG_GROUPS WHERE OWNER=? AND TABLE_NAME=?";
+    @Test
+    public void testTableSupplementalLogCheckSql() {
+        String result = SqlUtils.tableSupplementalLoggingCheckQuery();
+        String expected = "SELECT 'KEY', LOG_GROUP_TYPE FROM ALL_LOG_GROUPS WHERE OWNER=? AND TABLE_NAME=?";
         assertThat(result).isEqualTo(expected);
+    }
 
-        result = SqlUtils.getScnByTimeDeltaQuery(Scn.valueOf(123L), Duration.ofMinutes(1));
-        expected = "select timestamp_to_scn(CAST(scn_to_timestamp(123) as date) - INTERVAL '1' MINUTE) from dual";
+    @Test
+    public void testScnByTimeDeltaSql() {
+        String result = SqlUtils.getScnByTimeDeltaQuery(Scn.valueOf(123L), Duration.ofMinutes(1));
+        String expected = "select timestamp_to_scn(CAST(scn_to_timestamp(123) as date) - INTERVAL '1' MINUTE) from dual";
         assertThat(expected.equals(result)).isTrue();
         result = SqlUtils.getScnByTimeDeltaQuery(null, Duration.ofMinutes(1));
         assertThat(result).isNull();
+    }
 
-        result = SqlUtils.redoLogStatusQuery();
-        expected = "SELECT F.MEMBER, R.STATUS FROM V$LOGFILE F, V$LOG R WHERE F.GROUP# = R.GROUP# ORDER BY 2";
+    @Test
+    public void testRedoLogStatusSql() {
+        String result = SqlUtils.redoLogStatusQuery();
+        String expected = "SELECT F.MEMBER, R.STATUS FROM V$LOGFILE F, V$LOG R WHERE F.GROUP# = R.GROUP# ORDER BY 2";
         assertThat(expected.equals(result)).isTrue();
+    }
 
-        result = SqlUtils.switchHistoryQuery(null);
-        expected = "SELECT 'TOTAL', COUNT(1) FROM V$ARCHIVED_LOG WHERE FIRST_TIME > TRUNC(SYSDATE)" +
+    @Test
+    public void testLogSwitchHistorySql() {
+        String result = SqlUtils.switchHistoryQuery(null);
+        String expected = "SELECT 'TOTAL', COUNT(1) FROM V$ARCHIVED_LOG WHERE FIRST_TIME > TRUNC(SYSDATE)" +
                 " AND DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' AND TYPE='LOCAL' AND ROWNUM=1)";
         assertThat(result).isEqualTo(expected);
 
@@ -53,96 +65,107 @@ public class SqlUtilsTest {
         expected = "SELECT 'TOTAL', COUNT(1) FROM V$ARCHIVED_LOG WHERE FIRST_TIME > TRUNC(SYSDATE)" +
                 " AND DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' AND TYPE='LOCAL' AND UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_4')";
         assertThat(result).isEqualTo(expected);
+    }
 
-        result = SqlUtils.currentRedoNameQuery();
-        expected = "SELECT F.MEMBER FROM V$LOG LOG, V$LOGFILE F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.currentRedoLogSequenceQuery();
-        expected = "SELECT SEQUENCE# FROM V$LOG WHERE STATUS = 'CURRENT' ORDER BY SEQUENCE#";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.databaseSupplementalLoggingAllCheckQuery();
-        expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(0L), null);
-        expected = "SELECT MIN(FIRST_CHANGE#) FROM (SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG UNION SELECT MIN(FIRST_CHANGE#)" +
-                " AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS" +
-                " WHERE STATUS='VALID' AND TYPE='LOCAL' AND ROWNUM=1) AND STATUS='A')";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(1L), null);
-        expected = "SELECT MIN(FIRST_CHANGE#) FROM (SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG UNION SELECT MIN(FIRST_CHANGE#)" +
-                " AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS" +
-                " WHERE STATUS='VALID' AND TYPE='LOCAL' AND ROWNUM=1) AND STATUS='A' AND FIRST_TIME >= SYSDATE - (1/24))";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(0L), "LOG_ARCHIVE_DEST_3");
-        expected = "SELECT MIN(FIRST_CHANGE#) FROM (SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG UNION SELECT MIN(FIRST_CHANGE#)" +
-                " AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS" +
-                " WHERE STATUS='VALID' AND TYPE='LOCAL' AND UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_3') AND STATUS='A')";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(1L), "LOG_ARCHIVE_DEST_3");
-        expected = "SELECT MIN(FIRST_CHANGE#) FROM (SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG UNION SELECT MIN(FIRST_CHANGE#)" +
-                " AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS" +
-                " WHERE STATUS='VALID' AND TYPE='LOCAL' AND UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_3') AND STATUS='A' AND FIRST_TIME >= SYSDATE - (1/24))";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), false, null);
-        expected = "SELECT MIN(F.MEMBER) AS FILE_NAME, L.FIRST_CHANGE# FIRST_CHANGE, L.NEXT_CHANGE# NEXT_CHANGE, L.ARCHIVED, " +
-                "L.STATUS, 'ONLINE' AS TYPE, L.SEQUENCE# AS SEQ, 'NO' AS DICT_START, 'NO' AS DICT_END, L.THREAD# AS THREAD FROM V$LOGFILE F, " +
-                "V$LOG L LEFT JOIN V$ARCHIVED_LOG A ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE# " +
-                "WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) AND L.STATUS != 'UNUSED' AND F.GROUP# = L.GROUP# GROUP BY F.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, "
-                +
-                "L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD# UNION SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
-                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, " +
-                "A.DICTIONARY_END, A.THREAD# AS THREAD FROM V$ARCHIVED_LOG A WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' " +
-                "AND A.NEXT_CHANGE# > 10 AND A.DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' " +
-                "AND TYPE='LOCAL' AND ROWNUM=1) ORDER BY 7";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), false, "LOG_ARCHIVE_DEST_2");
-        expected = "SELECT MIN(F.MEMBER) AS FILE_NAME, L.FIRST_CHANGE# FIRST_CHANGE, L.NEXT_CHANGE# NEXT_CHANGE, L.ARCHIVED, " +
-                "L.STATUS, 'ONLINE' AS TYPE, L.SEQUENCE# AS SEQ, 'NO' AS DICT_START, 'NO' AS DICT_END, L.THREAD# AS THREAD FROM V$LOGFILE F, " +
-                "V$LOG L LEFT JOIN V$ARCHIVED_LOG A ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE# " +
-                "WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) AND L.STATUS != 'UNUSED' AND F.GROUP# = L.GROUP# GROUP BY F.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, "
-                +
-                "L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD# UNION SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
-                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, " +
-                "A.DICTIONARY_END, A.THREAD# AS THREAD FROM V$ARCHIVED_LOG A WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' " +
-                "AND A.NEXT_CHANGE# > 10 AND A.DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' " +
-                "AND TYPE='LOCAL' AND UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_2') ORDER BY 7";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), true, null);
-        expected = "SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
-                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, " +
-                "A.DICTIONARY_END, A.THREAD# AS THREAD FROM V$ARCHIVED_LOG A WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' " +
-                "AND A.NEXT_CHANGE# > 10 AND A.DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' " +
-                "AND TYPE='LOCAL' AND ROWNUM=1) ORDER BY 7";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(1L), false, null);
-        expected = "SELECT MIN(F.MEMBER) AS FILE_NAME, L.FIRST_CHANGE# FIRST_CHANGE, L.NEXT_CHANGE# NEXT_CHANGE, L.ARCHIVED, " +
-                "L.STATUS, 'ONLINE' AS TYPE, L.SEQUENCE# AS SEQ, 'NO' AS DICT_START, 'NO' AS DICT_END, L.THREAD# AS THREAD FROM V$LOGFILE F, " +
-                "V$LOG L LEFT JOIN V$ARCHIVED_LOG A ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE# " +
-                "WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) AND L.STATUS != 'UNUSED' AND F.GROUP# = L.GROUP# GROUP BY F.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, "
-                +
-                "L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD# UNION SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
-                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, " +
-                "A.DICTIONARY_END, A.THREAD# AS THREAD FROM V$ARCHIVED_LOG A WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' " +
-                "AND A.NEXT_CHANGE# > 10 AND A.DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' " +
-                "AND TYPE='LOCAL' AND ROWNUM=1) AND A.FIRST_TIME >= SYSDATE - (1/24) ORDER BY 7";
-        assertThat(result).isEqualTo(expected);
-
-        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(1L), true, null);
-        expected = "SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
-                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, A.DICTIONARY_BEGIN, " +
-                "A.DICTIONARY_END, A.THREAD# AS THREAD FROM V$ARCHIVED_LOG A WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' " +
-                "AND A.NEXT_CHANGE# > 10 AND A.DEST_ID IN (SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' " +
-                "AND TYPE='LOCAL' AND ROWNUM=1) AND A.FIRST_TIME >= SYSDATE - (1/24) ORDER BY 7";
+    @Test
+    public void testCurrentRedoLogFileNameSql() {
+        String result = SqlUtils.currentRedoNameQuery();
+        String expected = "SELECT F.MEMBER FROM V$LOG LOG, V$LOGFILE F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'";
         assertThat(result).isEqualTo(expected);
     }
+
+    @Test
+    public void testCurrentRedoLogSequenceSql() {
+        String result = SqlUtils.currentRedoLogSequenceQuery();
+        String expected = "SELECT SEQUENCE# FROM V$LOG WHERE STATUS = 'CURRENT' ORDER BY SEQUENCE#";
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDatabaseSupplementalLogAllCheckSql() {
+        String result = SqlUtils.databaseSupplementalLoggingAllCheckQuery();
+        String expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE";
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testOldestFirstArchiveLogChangeSql() {
+        final String sqlStem = "SELECT MIN(FIRST_CHANGE#) " +
+                "FROM (" +
+                "SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# " +
+                "FROM V$LOG " +
+                "UNION " +
+                "SELECT MIN(A.FIRST_CHANGE#) AS FIRST_CHANGE# " +
+                "FROM V$ARCHIVED_LOG A, V$DATABASE D " +
+                "WHERE A.DEST_ID IN (" +
+                "SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS " +
+                "WHERE STATUS='VALID' " +
+                "AND TYPE='LOCAL' " +
+                "AND %s) " +
+                "AND A.STATUS='A' " +
+                "AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# " +
+                "AND A.RESETLOGS_TIME = D.RESETLOGS_TIME" +
+                "%s)";
+
+        String result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(0L), null);
+        assertThat(result).isEqualTo(String.format(sqlStem, "ROWNUM=1", ""));
+
+        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(1L), null);
+        assertThat(result).isEqualTo(String.format(sqlStem, "ROWNUM=1", " AND A.FIRST_TIME >= SYSDATE - (1/24)"));
+
+        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(0L), "LOG_ARCHIVE_DEST_3");
+        assertThat(result).isEqualTo(String.format(sqlStem, "UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_3'", ""));
+
+        result = SqlUtils.oldestFirstChangeQuery(Duration.ofHours(1L), "LOG_ARCHIVE_DEST_3");
+        assertThat(result).isEqualTo(String.format(sqlStem, "UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_3'", " AND A.FIRST_TIME >= SYSDATE - (1/24)"));
+    }
+
+    @Test
+    public void testAllMinableLogsSql() {
+        final String onlineLogsStem = "SELECT MIN(F.MEMBER) AS FILE_NAME, L.FIRST_CHANGE# FIRST_CHANGE, " +
+                "L.NEXT_CHANGE# NEXT_CHANGE, L.ARCHIVED, L.STATUS, 'ONLINE' AS TYPE, L.SEQUENCE# AS SEQ, " +
+                "'NO' AS DICT_START, 'NO' AS DICT_END, L.THREAD# AS THREAD " +
+                "FROM V$LOGFILE F, V$DATABASE D, V$LOG L " +
+                "LEFT JOIN V$ARCHIVED_LOG A " +
+                "ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE# " +
+                "WHERE ((A.STATUS <> 'A' " +
+                "AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# AND A.RESETLOGS_TIME = D.RESETLOGS_TIME) " +
+                "OR A.FIRST_CHANGE# IS NULL) " +
+                "AND L.STATUS != 'UNUSED' " +
+                "AND F.GROUP# = L.GROUP# " +
+                "GROUP BY F.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD#";
+
+        final String archiveLogsStem = "SELECT A.NAME AS FILE_NAME, A.FIRST_CHANGE# FIRST_CHANGE, " +
+                "A.NEXT_CHANGE# NEXT_CHANGE, 'YES', NULL, 'ARCHIVED', A.SEQUENCE# AS SEQ, " +
+                "A.DICTIONARY_BEGIN, A.DICTIONARY_END, A.THREAD# AS THREAD " +
+                "FROM V$ARCHIVED_LOG A, V$DATABASE D " +
+                "WHERE A.NAME IS NOT NULL " +
+                "AND A.ARCHIVED = 'YES' " +
+                "AND A.STATUS = 'A' " +
+                "AND A.NEXT_CHANGE# > %d " +
+                "AND A.DEST_ID IN (" +
+                "SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE STATUS='VALID' AND TYPE='LOCAL' AND %s) " +
+                "AND A.RESETLOGS_CHANGE# = D.RESETLOGS_CHANGE# " +
+                "AND A.RESETLOGS_TIME = D.RESETLOGS_TIME " +
+                "%s" +
+                "ORDER BY 7";
+
+        final String combinedStem = onlineLogsStem + " UNION " + archiveLogsStem;
+
+        String result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), false, null);
+        assertThat(result).isEqualTo(String.format(combinedStem, 10, "ROWNUM=1", ""));
+
+        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), false, "LOG_ARCHIVE_DEST_2");
+        assertThat(result).isEqualTo(String.format(combinedStem, 10, "UPPER(DEST_NAME)='LOG_ARCHIVE_DEST_2'", ""));
+
+        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(0L), true, null);
+        assertThat(result).isEqualTo(String.format(archiveLogsStem, 10, "ROWNUM=1", ""));
+
+        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(1L), false, null);
+        assertThat(result).isEqualTo(String.format(combinedStem, 10, "ROWNUM=1", "AND A.FIRST_TIME >= SYSDATE - (1/24) "));
+
+        result = SqlUtils.allMinableLogsQuery(Scn.valueOf(10L), Duration.ofHours(1L), true, null);
+        assertThat(result).isEqualTo(String.format(archiveLogsStem, 10, "ROWNUM=1", "AND A.FIRST_TIME >= SYSDATE - (1/24) "));
+    }
+
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8744

### Premise

In Oracle, when you refresh an instance from another, you do so by copying the other instance's database data files into the new instance along with all the recent archive logs, adding them to the catalog during the recovery process. This makes sure that when you refresh from the backup of the other instance, you have all changes. 

Once you've finished the refresh/recovery, the DBA most often elects to create a new log incarnation. You can think of this as closing off the log stream you restored from and starting a brand new log stream for the newly refreshed instance. When you do this, log sequences are reset.

If the DBA accidentally leaves the old archive logs from the prior incarnation in the catalog, this confuses Debezium and it will continuously report a log inconsistency. 

This fix addresses that by making sure when a new log incarnation is created, the archive logs that are fetched by the connector are only those that match the current incarnation, which avoids the need for the DBA to immediately remove the old archive logs from the catalog.