### PR TITLE
DBZ-8735: Added documentation for Google Cloud Pub/Sub locational endpoints configuration

### DIFF
--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -729,6 +729,10 @@ i.e. after this value is reached, the wait time will not increase further by the
 Only to be used in a dev or test environment with the https://cloud.google.com/pubsub/docs/emulator[pubsub emulator].
 Unless this value is set, debezium-server will connect to a cloud pubsub instance running in a gcp project, which is the desired behavior in a production environment.
 
+|[[pubsub-region]]<<pubsub-region, `debezium.sink.pubsub.region`>>
+|
+|The Google Cloud region to connect to (e.g., `us-central1`, `asia-northeast1`). When specified, Debezium will use the locational endpoint for Pub/Sub in the format `{region}-pubsub.googleapis.com:443`. This allows connecting to locational endpoints instead of the global endpoint. Note that this parameter is ignored if `debezium.sink.pubsub.address` is specified.
+
 |===
 
 


### PR DESCRIPTION
This PR adds documentation for the new `debezium.sink.pubsub.region` configuration parameter introduced in [debezium-server PR #160](https://github.com/debezium/debezium-server/pull/160). 

Related Issue: https://issues.redhat.com/browse/DBZ-8735