### PR TITLE
DBZ-8771 fix docs and comment of minimum Java version requirement from 11 to 21

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -19,7 +19,7 @@ You can reach us here:
 The following software is required to work with the Debezium codebase and build it locally:
 
 * [Git 2.2.1](https://git-scm.com) or later
-* JDK 11 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 21 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The [Command Query Responsibility Separation (CQRS)](http://martinfowler.com/bli
 The following software is required to work with the Debezium codebase and build it locally:
 
 * [Git](https://git-scm.com) 2.2.1 or later
-* JDK 17 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 21 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8 or later  
   (or invoke the wrapper with `./mvnw` for Maven commands)

--- a/README_JA.md
+++ b/README_JA.md
@@ -55,7 +55,7 @@ Debezium が非常に価値あるものとなる状況は多くあります。�
 Debezium のコードベースでを編集・ビルドする為には以下に示すソフトウェアが必要です。
 
 * [Git](https://git-scm.com) 2.2.1 or later
-* JDK 11 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 21 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -60,7 +60,7 @@ CDC(Change Data Capture)를 사용하면 데이터가 오리지널 데이터베�
 아래의 소프트웨어는 로컬에서 Debezium을 빌드하기 위해 필요합니다.
 
 * [Git](https://git-scm.com) 2.2.1 버전 이상
-* JDK 17 버전 이상, 예) [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 21 버전 이상, 예) [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Docker Engine](https://docs.docker.com/engine/install/) 또는 [Docker Desktop](https://docs.docker.com/desktop/) 1.9 버전 이상
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8 버전 이상  
   (or invoke the wrapper with `./mvnw` for Maven commands)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -53,7 +53,7 @@ Debezium有很多非常有价值的使用场景，我们在这儿仅仅列出几
 使用Debezium代码库并在本地配置它需要以下软件：
 
 * [Git](https://git-scm.com) 2.2.1 or later
-* JDK 17 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 21 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 

--- a/debezium-connector-jdbc/README.md
+++ b/debezium-connector-jdbc/README.md
@@ -91,7 +91,7 @@ These relational model classes can be found in the `io.debezium.connector.jdbc.r
 The following is required in order to work with the Debezium JDBC sink connector code base, and to build it locally:
 
 * [Git](https://git-scm.com) 2.2.1 or later
-* JDK 17 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk)
+* JDK 21 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk)
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 * [Apache Maven](https://maven.apache.org/index.html) 3.9.8 or later
   (or invoke the wrapper with `.mvnw` for Maven commands)

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -22,6 +22,7 @@ asciidoc:
     ojdbc-version: '21.15.0.0'
     informix-jdbc-version: '4.50.11'
     ifx-changestream-version: '1.1.3'
+    min-java-connectors-version: '17'
     community: true
     registry: 'Apicurio Registry'
     registry-name-full: Apicurio API and Schema Registry

--- a/documentation/modules/ROOT/pages/install.adoc
+++ b/documentation/modules/ROOT/pages/install.adoc
@@ -80,7 +80,7 @@ Alternatively, you can add further directories to the plugin path by specifying 
 (e.g. `-e KAFKA_CONNECT_PLUGINS_DIR=/kafka/connect/,/path/to/further/plugins`).
 When using the container image for Kafka Connect provided by Confluent, you can specify the `CONNECT_PLUGIN_PATH` environment variable to achieve the same.
 
-Note that Java 11 or later is required to run the {prodname} connectors or {prodname} UI.
+Note that Java {min-java-connectors-version} or later is required to run the {prodname} connectors or {prodname} UI.
 
 ifeval::['{page-version}' != 'main']
 === Consuming Snapshot Releases

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.compiler.release>${debezium.java.connector.target}</maven.compiler.release>
         <maven.compiler.testRelease>${debezium.java.connector.target}</maven.compiler.testRelease>
 
-        <!-- Enforce JDK 11 for building (handled via JBoss parent POM)-->
+        <!-- Minimum JDK version required for building the project -->
         <jdk.min.version>${debezium.java.source}</jdk.min.version>
 
         <!-- Maven Plugins -->


### PR DESCRIPTION
As mentioned in the title, I have updated the documentation to state that JDK 21 is required

https://issues.redhat.com/browse/DBZ-8771