### PR TITLE
DBZ-8775 Upgrade version.vitess.grpc to v21.0.2

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -21,7 +21,7 @@
         <version.jetty>9.4.12.v20180830</version.jetty>
 
         <!-- Vitess dependencies -->
-        <version.vitess.grpc>20.0.0</version.vitess.grpc>
+        <version.vitess.grpc>21.0.2</version.vitess.grpc>
         <version.joda>2.10.1</version.joda>
         <version.google.protos>1.17.0</version.google.protos>
 


### PR DESCRIPTION
We need to bump the client versions to get the feature in https://github.com/debezium/debezium-connector-vitess/pull/232