### PR TITLE
Dbz 8687 enhance pg docs w info about replication slot failover

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2147,7 +2147,7 @@ The default `false` setting causes the custom converter to always return `null` 
 // ModuleID: setting-up-postgresql-to-run-a-debezium-connector
 // Title: Setting up PostgreSQL to run a {prodname} connector
 [[setting-up-postgresql]]
-== Setting up Postgres
+== Setting up PostgreSQL
 
 ifdef::community[]
 Before using the PostgreSQL connector to monitor the changes committed on a PostgreSQL server, decide which logical decoding plug-in you intend to use.
@@ -2516,30 +2516,38 @@ host    replication     <youruser>  ::1/128                 trust   // <3>
 For more information about network masks, see link:https://www.postgresql.org/docs/current/static/datatype-net-types.html[the PostgreSQL documentation].
 ====
 
+
+// Type: concept
 [[supported-postgresql-topologies]]
 === Supported PostgreSQL topologies
 
 The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
 
+// Type: concept
+[id="postgresql-supported-topologies-pg15"]
 ==== PostgreSQL 15 or earlier clusters
 
 When you deploy {prodname} in environments that run PostgreSQL 15 or earlier, you can configure logical replication slots only on the primary server in the cluster.
 You cannot configure logical replication on replica servers in the cluster.
+
 Consequently, the {prodname} PostgreSQL connector can connect and communicate only with the primary server.
 If the primary server fails, the connector stops.
+To recover from a failure, you must repair the cluster and then either promote the original primary server to `primary`, or promote a different PostgreSQL server to `primary`.
+For more information, see xref:postgresql-cluster-failures-capturing-from-new-primary[Capturing data from a new primary after a failure].
 
-Following a failure, after the cluster is repaired, you can once again promote the original primary server to `primary`, and then restart the connector.
-Alternately, you might promote a different PostgreSQL server to `primary`.
-Before you can promote a different server to primary, you must xref:setting-up-postgresql[properly configure] the server.
-Then, to enable the connector to consume from the new `primary` server, update properties in the connector configuration to match the details of the new server, for example, xref:postgresql-property-database-hostname[`database.hostname`], xref:postgresql-property-database-port[`database.port`], xref:postgresql-property-database-dbname[`database.dbname`], and xref:postgresql-property-slot-name[`slot.name`].
-After you update the configuration to point to the new primary, you can restart the connector.
-
+// Type: concept
+[id="postgresql-supported-topologies-pg16"]
 ==== PostgreSQL 16 or later clusters
 
-When you deploy {prodname} with PostgreSQL 16 or later, you can set up logical replication slots on replica servers.
-In a PostgreSQL 16 cluster, {prodname} can capture change events from servers other than the primary server.
+When you deploy {prodname} with a PostgreSQL 16 or later cluster, you can set up logical replication slots on replica servers.
+This feature enables {prodname} to capture change events from servers other than the primary server.
 However, be aware that {prodname} connections to replica servers generally experience higher latency than connections to a primary server.
 
+Also, bear in mind that replication slots on PostgreSQL replica servers are not automatically synchronized with corresponding slots on the primary server.
+To facilitate recovery after a failure in a PostgreSQL 16 cluster, you should periodically perform a manual synchronization to advance the position of the replication slot on the standby server to match the position on the primary server.
+
+// Type: concept
+[id="postgresql-supported-topologies-pg17"]
 ==== {prodname} with PostgreSQL 17 or later clusters
 
 When you deploy {prodname} with PostgreSQL 17 or later, you can set up logical replication slots on primary servers and enable those slots for failover.
@@ -4307,17 +4315,19 @@ For information about failure cases in which a slot has been removed, see the ne
 [id="postgresql-cluster-failures"]
 === Cluster failures
 
-PostgreSQL 15 or earlier permits logical replication slots _only on primary servers_.
-As a result, a {prodname} PostgreSQL connector can only capture events from the active primary server in a database cluster.
-In this environment, replication slots are not propagated to replica servers.
-If the primary server goes down, you must promote a new server to be primary.
+.PostgreSQL 15 or earlier
+In a PostgreSQL 15 or earlier cluster, you can create a logical replication slot only on the primary server.
+As a result, in a PostgreSQL 15 environment, a {prodname} PostgreSQL connector can capture events only from the active primary server in the cluster.
+In a PostgreSQL 15 cluster, replication slots on the primary node are not propagated to replica servers.
+If the primary server goes down, you must promote a standby node to primary.
 
+.PostgreSQL 16 or later
 When you use {prodname} with PostgreSQL 16 or later, you can create logical replication slots on replicas, but you must manually synchronize the replication slot on the replica with the corresponding slot on the primary server.
-Synchronization is not automatic.
+Synchronization of replica slots is not automatic.
 
+.PostgreSQL 17 or later
 When you use {prodname} with PostgreSQL 17 or later, you can configure replication slots on a primary server for automatic failover, so that {prodname} does not miss any change events.
 When a replication slot is configured for failover, PostgreSQL automatically synchronizes the replication slot from the primary to the replica, enabling {prodname} to continue reading from the slot after the replica is promoted and becomes the new primary.
-
 
 ifdef::product[]
 [IMPORTANT]
@@ -4346,18 +4356,53 @@ The new primary must have a replication slot that is configured to use the `pgou
 Only then can you point the connector to the new server and restart the connector.
 endif::product[]
 
-If you configure the user of failover replication slots in environments that run PostgreSQL 17 or later, after a failover occurs, it's important to take the following steps:
+// Type: procedure
+[id="postgresql-cluster-failures-recovering-from-failures-pg17-cluster"]
+==== Recovering from failures in a PostgreSQL 17 cluster
 
-* Pause {prodname} until you can verify that you have an intact replication slot that has not lost data.
+Environments that run PostgreSQL 17 or later support the use of failover replication slots.
+If a failure occurs in a PostgreSQL 17 or later cluster, and a standby is configured with a failover replication slot, complete the following steps to enable {prodname} to resume capture:
 
-* Re-create the {prodname} replication slot before you allow applications to write to the *new* primary.
-  This is crucial.
-  Without this process, your application can miss change events.
+. Pause {prodname} until you can verify that you have an intact replication slot that has not lost data.
 
-* Verify that {prodname} is able to read all changes in the slot from **before the old primary failed**.
+. Re-create the {prodname} replication slot before you allow applications to write to the *new* primary.
+  If you permit applications to write to the new primary before you re-create the replication slot, your application can miss change events.
 
-One reliable method of recovering and verifying whether any changes are lost is to recover a backup of the failed primary from the point immediately before it failed.
-Although this can be administratively difficult, it permits you to inspect the replication slot for any unconsumed changes.
+. Restart the connector.
+
+. Verify that {prodname} can read the LSN from the replication slot for any change that occurred before the original primary failed.
+ +
+For example, recover a backup of the failed primary from the point immediately before failure, and identify the last position that is recorded in the slot.
+Although retrieving backup data can be administratively difficult, inspecting the backup provides a mechanism for reliably determining whether {prodname} has consumed all changes.
+
+// Type: procedure
+[id="postgresql-cluster-failures-capturing-from-new-pg15-primary"]
+==== Capturing data from a new primary server after a failure in a PostgreSQL 15 or earlier cluster
+
+Following the failure of the primary server in a PostgreSQL 15 or earlier cluster, you might decide to configure {prodname} to capture data from one of the former replica servers rather than from the original primary server.
+To enable {prodname} to capture data from a former replica server, complete the following procedure.
+
+.Procedure
+. Repair the condition that caused the cluster to fail.
+. While the connector is stopped, update the values of properties in the connector configuration to reflect the details of the new server.
+For example, verify that the configuration includes the correct values for the following properties:
+
+* xref:postgresql-property-database-hostname[`database.hostname`]
+* xref:postgresql-property-database-port[`database.port`]
+* xref:postgresql-property-database-dbname[`database.dbname`]
+* xref:postgresql-property-database-user[`database.user`]
+* xref:postgresql-property-database-password[`database.password`]
+* xref:postgresql-property-slot-name[`slot.name`]
+. Configure the new primary server to work with {prodname} by completing the following tasks:
+
+* xref:configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in[Configure a replication slot] on the server.
+* Ensure that {prodname} can xref:setting-up-postgresql-permissions-required-by-debezium-connectors[perform replications] and xref:postgresql-replication-user-privileges[create publications] on the server.
++
+For more information about how to configure the PostgreSQL server to work with {prodname}, see xref:setting-up-postgresql[Setting up PostgreSQL].
+
+. Promote the standby PostgreSQL node to `primary`.
+. Restart the connector.
+. Perform a snapshot on the new primary server to capture the initial state of the data on the server and ensure that no data is lost.
 
 [id="postgresql-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4307,38 +4307,57 @@ For information about failure cases in which a slot has been removed, see the ne
 [id="postgresql-cluster-failures"]
 === Cluster failures
 
-Prior to version 16, PostgreSQL allows logical replication slots _only on primary servers_. This means that you can point a {prodname} PostgreSQL connector to only the active primary server of a database cluster.
-Also, replication slots themselves are not propagated to replicas.
-If the primary server goes down, a new primary must be promoted.
+PostgreSQL 15 or earlier permits logical replication slots _only on primary servers_.
+As a result, a {prodname} PostgreSQL connector can only capture events from the active primary server in a database cluster.
+In this environment, replication slots are not propagated to replica servers.
+If the primary server goes down, you must promote a new server to be primary.
 
-When using version 16 or newer, you can create logical replication slots also on replicas, but you need to take care of keeping them in sync with the corresponding slot on the primary server yourself.
+When you use {prodname} with PostgreSQL 16 or later, you can create logical replication slots on replicas, but you must manually synchronize the replication slot on the replica with the corresponding slot on the primary server.
+Synchronization is not automatic.
 
-When using version 17 or newer, replication slots on a primary can be enabled for automatic failover.
-In this case Postgres itself can take care of synchronizing a slot from primary to replica automatically,
-allowing {prodname} to continue reading from that slot after promoting a replica to new primary,
-without missing any change events.
+When you use {prodname} with PostgreSQL 17 or later, you can configure replication slots on a primary server for automatic failover, so that {prodname} does not miss any change events.
+When a replication slot is configured for failover, PostgreSQL automatically synchronizes the replication slot from the primary to the replica, enabling {prodname} to continue reading from the slot after the replica is promoted and becomes the new primary.
+
+
+ifdef::product[]
+[IMPORTANT]
+====
+The use of {prodname} with PostgreSQL 17 and the ability to configure replication slots for failover to replica servers is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 [NOTE]
 ====
-Some managed PostgresSQL services (AWS RDS and GCP CloudSQL for example) implement replication to a standby via disk replication. This means that the replication slot does get replicated and will remain available after a failover.
+Some managed PostgreSQL services (for example, AWS RDS and GCP CloudSQL) use disk replication to implement replication to a standby.
+As a result, these services automatically replicate the replication slot so that it is available after a failover.
 ====
 
 ifdef::community[]
-The new primary must have the xref:installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
+The new primary must have the xref:installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes.
+Only then can you point the connector to the new server and restart the connector.
 endif::community[]
 
 ifdef::product[]
-The new primary must have a replication slot that is configured for use by the `pgoutput` plug-in and the database in which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
+The new primary must have a replication slot that is configured to use the `pgoutput` plug-in, and must include the database for which you want to capture changes.
+Only then can you point the connector to the new server and restart the connector.
 endif::product[]
 
-When not using failover replication slots, as supported by Postgres 17 and newer,
-there are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover:
+If you configure the user of failover replication slots in environments that run PostgreSQL 17 or later, after a failover occurs, it's important to take the following steps:
 
-* There must be a process that re-creates the {prodname} replication slot before allowing the application to write to the *new* primary. This is crucial. Without this process, your application can miss change events.
+* Pause {prodname} until you can verify that you have an intact replication slot that has not lost data.
 
-* You might need to verify that {prodname} was able to read all changes in the slot **before the old primary failed**.
+* Re-create the {prodname} replication slot before you allow applications to write to the *new* primary.
+  This is crucial.
+  Without this process, your application can miss change events.
 
-One reliable method of recovering and verifying whether any changes were lost is to recover a backup of the failed primary to the point immediately before it failed. While this can be administratively difficult, it allows you to inspect the replication slot for any unconsumed changes.
+* Verify that {prodname} is able to read all changes in the slot from **before the old primary failed**.
+
+One reliable method of recovering and verifying whether any changes are lost is to recover a backup of the failed primary from the point immediately before it failed.
+Although this can be administratively difficult, it permits you to inspect the replication slot for any unconsumed changes.
 
 [id="postgresql-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2516,25 +2516,47 @@ host    replication     <youruser>  ::1/128                 trust   // <3>
 For more information about network masks, see link:https://www.postgresql.org/docs/current/static/datatype-net-types.html[the PostgreSQL documentation].
 ====
 
-ifdef::community[]
 [[supported-postgresql-topologies]]
 === Supported PostgreSQL topologies
 
 The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
 
-PostgreSQL (for all versions <= 16) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can restart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
+==== PostgreSQL 15 or earlier clusters
 
-When using PostgreSQL 16 or newer, you can set up logical replication slots also on replica servers,
-and {prodname} does not need to connect to your primary server for ingesting change events.
-In comparison to connecting to the primary,
-connecting to a replica will yield slightly increased latencies, though.
+When you deploy {prodname} in environments that run PostgreSQL 15 or earlier, you can configure logical replication slots only on the primary server in the cluster.
+You cannot configure logical replication on replica servers in the cluster.
+Consequently, the {prodname} PostgreSQL connector can connect and communicate only with the primary server.
+If the primary server fails, the connector stops.
 
-When using PostgreSQL 17 or newer, you can set up logical replication slots on primary serves which are enabled for failover.
-The state of such a failover slot can automatically be propagated to one or more replica servers,
-allowing {prodname} to continue to ingest changes from a replica promoted to primary after a failure,
-without missing any events.
+Following a failure, after the cluster is repaired, you can once again promote the original primary server to `primary`, and then restart the connector.
+Alternately, you might promote a different PostgreSQL server to `primary`.
+Before you can promote a different server to primary, you must xref:setting-up-postgresql[properly configure] the server.
+Then, to enable the connector to consume from the new `primary` server, update properties in the connector configuration to match the details of the new server, for example, xref:postgresql-property-database-hostname[`database.hostname`], xref:postgresql-property-database-port[`database.port`], xref:postgresql-property-database-dbname[`database.dbname`], and xref:postgresql-property-slot-name[`slot.name`].
+After you update the configuration to point to the new primary, you can restart the connector.
 
-endif::community[]
+==== PostgreSQL 16 or later clusters
+
+When you deploy {prodname} with PostgreSQL 16 or later, you can set up logical replication slots on replica servers.
+In a PostgreSQL 16 cluster, {prodname} can capture change events from servers other than the primary server.
+However, be aware that {prodname} connections to replica servers generally experience higher latency than connections to a primary server.
+
+==== {prodname} with PostgreSQL 17 or later clusters
+
+When you deploy {prodname} with PostgreSQL 17 or later, you can set up logical replication slots on primary servers and enable those slots for failover.
+PostgreSQL can automatically propagate the state of a failover slot to one or more replica servers.
+In environments where automatic replication is enabled, if a failure occurs, an available replica is automatically promoted to primary.
+{prodname} can continue to ingest changes from the new primary server, without requiring any configuration changes, thus helping to ensure that the connector does not miss any events.
+
+ifdef::product[]
+[IMPORTANT]
+====
+The use of {prodname} with PostgreSQL 17 and the ability to configure replication slots for failover to replica servers is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 // Type: concept
 // ModuleID: configuring-postgresql-to-manage-debezium-wal-disk-space-consumption


### PR DESCRIPTION
[DBZ-8687](https://issues.redhat.com/browse/DBZ-8687)

Updates the PostgreSQL _Supported topologies_ topic to remove community-only conditional to expose information about using the PG connector in cluster environments that run PG 15 vs. 16 vs. 17. Adds a product-conditionalized note that specifies that using the connector with PG17 is a TP feature.   

Supersedes #6220 