### PR TITLE
DBZ-8769 Change schema history table's history_data column type to TEXT

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
@@ -37,7 +37,7 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
     private static final String DEFAULT_TABLE_DDL = "CREATE TABLE %s" +
             "(" +
             "id VARCHAR(36) NOT NULL," +
-            "history_data VARCHAR(65000)," +
+            "history_data TEXT," +
             "history_data_seq INTEGER," +
             "record_insert_ts TIMESTAMP NOT NULL," +
             "record_insert_seq INTEGER NOT NULL" +


### PR DESCRIPTION
When using debezium-storage-jdbc with MySQL, the creation of the default schema history table fails.
This PR changes the column type from VARCHAR to TEXT to resolve the issue.

Related Issue: https://issues.redhat.com/browse/DBZ-8769 
