### PR TITLE
DBZ-8141 Capture in-flight transaction within snapshot boundary

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -327,7 +327,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter<LogMinerStreamingC
                 startSession(connection);
 
                 LOGGER.info("\tQuerying transaction logs, please wait...");
-                connection.query("SELECT START_SCN, XID FROM V$LOGMNR_CONTENTS WHERE OPERATION_CODE=7 AND SCN >= " + currentScn + " AND START_SCN < " + currentScn,
+                connection.query("SELECT START_SCN, XID FROM V$LOGMNR_CONTENTS WHERE OPERATION_CODE=7 AND SCN >= " + currentScn + " AND START_SCN <= " + currentScn,
                         rs -> {
                             while (rs.next()) {
                                 final String transactionId = HexConverter.convertToHexString(rs.getBytes("XID"));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerAdapterTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerAdapterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
+import io.debezium.util.HexConverter;
+
+/**
+ * Unit tests for the {@link LogMinerAdapter} class.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER)
+public class LogMinerAdapterTest {
+
+    @Test
+    @FixFor("DBZ-8141")
+    public void shouldCaptureInProgressTransactionStartedOnSnapshotScnBoundary() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8141")
+                .build();
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        final LogMinerAdapter adapter = createAdapter(connectorConfig);
+        final List<LogFile> logs = List.of(new LogFile("abc", Scn.valueOf(20798000), Scn.MAX, BigInteger.valueOf(12345L), LogFile.Type.REDO, 1));
+
+        // Mock up adapter methods
+        Mockito.doReturn(Scn.valueOf(20798000)).when(adapter).getOldestScnAvailableInLogs(Mockito.any(), Mockito.any());
+        Mockito.doReturn(logs).when(adapter).getOrderedLogsFromScn(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.doNothing().when(adapter).addLogsToSession(Mockito.any(), Mockito.any());
+        Mockito.doNothing().when(adapter).startSession(Mockito.any());
+
+        final Connection connection = Mockito.mock(Connection.class);
+        final Statement statement = Mockito.mock(Statement.class);
+
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, false);
+        Mockito.when(rs.getBytes("XID")).thenReturn(HexConverter.convertFromHex("ABCD"));
+        Mockito.when(rs.getString("START_SCN")).thenReturn("20798317");
+
+        final OracleConnection oracleConnection = Mockito.mock(OracleConnection.class);
+        Mockito.when(oracleConnection.connection()).thenReturn(connection);
+        Mockito.when(connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(Mockito.anyString())).thenReturn(rs);
+        Mockito.when(oracleConnection.query(Mockito.any(), Mockito.any())).thenCallRealMethod();
+        Mockito.when(oracleConnection.query(Mockito.any(), Mockito.any(), Mockito.any())).thenCallRealMethod();
+
+        final Map<String, Scn> pendingTransactions = new LinkedHashMap<>();
+
+        final Scn currentScn = Scn.valueOf("20798317");
+        adapter.getPendingTransactionsFromLogs(oracleConnection, currentScn, pendingTransactions);
+
+        assertThat(pendingTransactions).containsExactly(entry("abcd", Scn.valueOf(20798317)));
+    }
+
+    private static LogMinerAdapter createAdapter(OracleConnectorConfig connectorConfig) {
+        return Mockito.spy(new LogMinerAdapter(connectorConfig));
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8141

I need to add a test to this PR, and given the depth of the code and the fact an integration test could easily generate a false positive if the LogMiner data isn't generated exactly 100% correctly, so I will likely just create a mock for the `LogMinerAdapter` and expose some private methods for testing to just have a unit test for it to be safe.  Will do that tomorrow if the existing Oracle tests pass.