### PR TITLE
Postgres Professional enterprise & 64bit xid

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -250,7 +250,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
      * @param buffer The replication stream buffer
      * @param processor The replication message processor
      */
-    private Boolean isEE = null;
+    volatile private Boolean isEE = null;
 
     private void handleBeginMessage(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
         final Lsn lsn = Lsn.valueOf(buffer.getLong()); // LSN


### PR DESCRIPTION
Postgres Professional version of Postgres RDBS uses 64-bit transaction IDs (XID) due to prevent so-called "transactio wraparound". Unfortunately, Debezium Postgres connector assums that XIDs are 32-bit, and it leads to incorrect transaction ids (actually, zero) in Kafka messages. This request aimed to fix this problem.