### PR TITLE
Dbz 8753 Align JDBC storage configuration naming

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
@@ -29,29 +29,29 @@ public class JdbcCommonConfig {
     public static final String CONFIGURATION_FIELD_PREFIX_STRING = "jdbc.";
     public static final String CONFIGURATION_FIELD_CONNECTION_GROUP = CONFIGURATION_FIELD_PREFIX_STRING + "connection.";
 
-    public static final Field PROP_JDBC_URL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "url")
+    public static final Field PROP_JDBC_URL = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "url")
             .withDescription("URL of the database which will be used to access the database storage")
             .withValidation(Field::isRequired)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "url");
 
-    public static final Field PROP_USER = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "user")
+    public static final Field PROP_USER = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "user")
             .withDescription("Username of the database which will be used to access the database storage")
             .withValidation(Field::isRequired)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "user");
 
-    public static final Field PROP_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "password")
+    public static final Field PROP_PASSWORD = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "password")
             .withDescription("Password of the database which will be used to access the database storage")
             .withValidation(Field::isRequired)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "password");
 
     private static final long DEFAULT_WAIT_RETRY_DELAY = 3000L;
-    public static final Field PROP_WAIT_RETRY_DELAY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "wait.retry.delay.ms")
+    public static final Field PROP_WAIT_RETRY_DELAY = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "wait.retry.delay.ms")
             .withDescription("Delay of retry on wait for connection failure")
             .withDefault(DEFAULT_WAIT_RETRY_DELAY)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "wait.retry.delay.ms");
 
     private static final int DEFAULT_MAX_RETRIES = 5;
-    public static final Field PROP_MAX_RETRIES = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "retry.max.attempts")
+    public static final Field PROP_MAX_RETRIES = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "retry.max.attempts")
             .withDescription("Maximum number of retry attempts before giving up.")
             .withDefault(DEFAULT_MAX_RETRIES)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "retry.max.attempts");

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
@@ -27,28 +27,34 @@ public class JdbcCommonConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcCommonConfig.class);
 
     public static final String CONFIGURATION_FIELD_PREFIX_STRING = "jdbc.";
+    public static final String CONFIGURATION_FIELD_CONNECTION_GROUP = "connection.";
 
-    public static final Field PROP_JDBC_URL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "url")
+    public static final Field PROP_JDBC_URL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "url")
             .withDescription("URL of the database which will be used to access the database storage")
-            .withValidation(Field::isRequired);
+            .withValidation(Field::isRequired)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "url");
 
-    public static final Field PROP_USER = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "user")
+    public static final Field PROP_USER = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "user")
             .withDescription("Username of the database which will be used to access the database storage")
-            .withValidation(Field::isRequired);
+            .withValidation(Field::isRequired)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "user");
 
-    public static final Field PROP_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "password")
+    public static final Field PROP_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "password")
             .withDescription("Password of the database which will be used to access the database storage")
-            .withValidation(Field::isRequired);
+            .withValidation(Field::isRequired)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "password");
 
     private static final long DEFAULT_WAIT_RETRY_DELAY = 3000L;
-    public static final Field PROP_WAIT_RETRY_DELAY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "wait.retry.delay.ms")
+    public static final Field PROP_WAIT_RETRY_DELAY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "wait.retry.delay.ms")
             .withDescription("Delay of retry on wait for connection failure")
-            .withDefault(DEFAULT_WAIT_RETRY_DELAY);
+            .withDefault(DEFAULT_WAIT_RETRY_DELAY)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "wait.retry.delay.ms");
 
     private static final int DEFAULT_MAX_RETRIES = 5;
-    public static final Field PROP_MAX_RETRIES = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "retry.max.attempts")
+    public static final Field PROP_MAX_RETRIES = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "retry.max.attempts")
             .withDescription("Maximum number of retry attempts before giving up.")
-            .withDefault(DEFAULT_MAX_RETRIES);
+            .withDefault(DEFAULT_MAX_RETRIES)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "retry.max.attempts");
 
     private String jdbcUrl;
     private String user;

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
@@ -27,7 +27,7 @@ public class JdbcCommonConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcCommonConfig.class);
 
     public static final String CONFIGURATION_FIELD_PREFIX_STRING = "jdbc.";
-    public static final String CONFIGURATION_FIELD_CONNECTION_GROUP = "connection.";
+    public static final String CONFIGURATION_FIELD_CONNECTION_GROUP = CONFIGURATION_FIELD_PREFIX_STRING + "connection.";
 
     public static final Field PROP_JDBC_URL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + CONFIGURATION_FIELD_CONNECTION_GROUP + "url")
             .withDescription("URL of the database which will be used to access the database storage")

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
@@ -27,7 +27,6 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
             .withDefault(DEFAULT_TABLE_NAME)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.name");
 
-
     /**
      * Table that will store database history.
      * id - Unique identifier(UUID)
@@ -64,7 +63,6 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
             .withDefault(DEFAULT_TABLE_SELECT)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.select");
 
-
     private static final String DEFAULT_TABLE_DATA_EXISTS_SELECT = "SELECT * FROM %s LIMIT 1";
 
     /**
@@ -75,14 +73,12 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
             .withDefault(DEFAULT_TABLE_DATA_EXISTS_SELECT)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.exists");
 
-
     private static final String DEFAULT_TABLE_DATA_INSERT = "INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_insert_seq) VALUES ( ?, ?, ?, ?, ? )";
 
     public static final Field PROP_TABLE_DATA_INSERT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.insert")
             .withDescription("INSERT statement to add new records to the schema storage table")
             .withDefault(DEFAULT_TABLE_DATA_INSERT)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.insert");
-
 
     private String tableName;
     private String tableCreate;

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryConfig.java
@@ -22,9 +22,11 @@ import io.debezium.util.Collect;
 public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
 
     private static final String DEFAULT_TABLE_NAME = "debezium_database_history";
-    public static final Field PROP_TABLE_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.name")
+    public static final Field PROP_TABLE_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.name")
             .withDescription("The database key that will be used to store the database schema history")
-            .withDefault(DEFAULT_TABLE_NAME);
+            .withDefault(DEFAULT_TABLE_NAME)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.name");
+
 
     /**
      * Table that will store database history.
@@ -46,9 +48,10 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
     /**
      * Field that will store the CREATE TABLE DDL for schema history.
      */
-    public static final Field PROP_TABLE_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.ddl")
+    public static final Field PROP_TABLE_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.ddl")
             .withDescription("CREATE TABLE statement for schema history table")
-            .withDefault(DEFAULT_TABLE_DDL);
+            .withDefault(DEFAULT_TABLE_DDL)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.ddl");
 
     private static final String DEFAULT_TABLE_SELECT = "SELECT id, history_data, history_data_seq FROM %s"
             + " ORDER BY record_insert_ts, record_insert_seq, id, history_data_seq";
@@ -56,24 +59,31 @@ public class JdbcSchemaHistoryConfig extends JdbcCommonConfig {
     /**
      * Field that will store the Schema history SELECT query.
      */
-    public static final Field PROP_TABLE_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.select")
+    public static final Field PROP_TABLE_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.select")
             .withDescription("SELECT statement to get the schema history from a database table")
-            .withDefault(DEFAULT_TABLE_SELECT);
+            .withDefault(DEFAULT_TABLE_SELECT)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.select");
+
 
     private static final String DEFAULT_TABLE_DATA_EXISTS_SELECT = "SELECT * FROM %s LIMIT 1";
 
     /**
      *  Field that will store the Schema history SELECT query to check existence of the table.
      */
-    public static final Field PROP_TABLE_DATA_EXISTS_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.exists")
+    public static final Field PROP_TABLE_DATA_EXISTS_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.exists")
             .withDescription("SELECT statement to check existence of the storage table")
-            .withDefault(DEFAULT_TABLE_DATA_EXISTS_SELECT);
+            .withDefault(DEFAULT_TABLE_DATA_EXISTS_SELECT)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.exists");
+
 
     private static final String DEFAULT_TABLE_DATA_INSERT = "INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_insert_seq) VALUES ( ?, ?, ?, ?, ? )";
 
-    public static final Field PROP_TABLE_DATA_INSERT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.insert")
+    public static final Field PROP_TABLE_DATA_INSERT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.insert")
             .withDescription("INSERT statement to add new records to the schema storage table")
-            .withDefault(DEFAULT_TABLE_DATA_INSERT);
+            .withDefault(DEFAULT_TABLE_DATA_INSERT)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "schema.history.table.insert");
+
+
     private String tableName;
     private String tableCreate;
     private String tableSelect;

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStoreConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStoreConfig.java
@@ -23,9 +23,13 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
     public static final String OFFSET_STORAGE_PREFIX = "offset.storage.";
 
     public static final String DEFAULT_TABLE_NAME = "debezium_offset_storage";
-    public static final Field PROP_TABLE_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.name")
+    public static final Field PROP_TABLE_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.name")
             .withDescription("Name of the table to store offsets")
-            .withDefault(DEFAULT_TABLE_NAME);
+            .withDefault(DEFAULT_TABLE_NAME)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.name");
+
+
+
 
     /**
      * JDBC Offset storage CREATE TABLE syntax.
@@ -44,9 +48,11 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
      * record_insert_ts - Timestamp when the record was inserted
      * record_insert_seq - Sequence number of record
      */
-    public static final Field PROP_TABLE_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.ddl")
+    public static final Field PROP_TABLE_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.ddl")
             .withDescription("Create table syntax for offset jdbc table")
-            .withDefault(DEFAULT_TABLE_DDL);
+            .withDefault(DEFAULT_TABLE_DDL)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.ddl");
+
 
     public static final String DEFAULT_TABLE_SELECT = "SELECT id, offset_key, offset_val FROM %s " +
             "ORDER BY record_insert_ts, record_insert_seq";
@@ -55,17 +61,21 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
 
     public static final String DEFAULT_TABLE_INSERT = "INSERT INTO %s(id, offset_key, offset_val, record_insert_ts, record_insert_seq) " +
             "VALUES ( ?, ?, ?, ?, ? )";
-    public static final Field PROP_TABLE_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.select")
+    public static final Field PROP_TABLE_SELECT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.select")
             .withDescription("Select syntax to get offset data from jdbc table")
-            .withDefault(DEFAULT_TABLE_SELECT);
+            .withDefault(DEFAULT_TABLE_SELECT)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.select");
 
-    public static final Field PROP_TABLE_DELETE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.delete")
+    public static final Field PROP_TABLE_DELETE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.delete")
             .withDescription("Delete syntax to delete offset data from jdbc table")
-            .withDefault(DEFAULT_TABLE_DELETE);
+            .withDefault(DEFAULT_TABLE_DELETE)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.delete");
 
-    public static final Field PROP_TABLE_INSERT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.insert")
+    public static final Field PROP_TABLE_INSERT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "table.insert")
             .withDescription("Insert syntax to add offset data to the jdbc table")
-            .withDefault(DEFAULT_TABLE_INSERT);
+            .withDefault(DEFAULT_TABLE_INSERT)
+            .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.insert");
+
 
     private String tableCreate;
     private String tableSelect;

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStoreConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/offset/JdbcOffsetBackingStoreConfig.java
@@ -28,9 +28,6 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
             .withDefault(DEFAULT_TABLE_NAME)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.name");
 
-
-
-
     /**
      * JDBC Offset storage CREATE TABLE syntax.
      */
@@ -53,7 +50,6 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
             .withDefault(DEFAULT_TABLE_DDL)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.ddl");
 
-
     public static final String DEFAULT_TABLE_SELECT = "SELECT id, offset_key, offset_val FROM %s " +
             "ORDER BY record_insert_ts, record_insert_seq";
 
@@ -75,7 +71,6 @@ public class JdbcOffsetBackingStoreConfig extends JdbcCommonConfig {
             .withDescription("Insert syntax to add offset data to the jdbc table")
             .withDefault(DEFAULT_TABLE_INSERT)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "offset.table.insert");
-
 
     private String tableCreate;
     private String tableSelect;

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
@@ -35,8 +35,6 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.SkipWhenDatabaseVersion;
 import io.debezium.storage.jdbc.history.JdbcSchemaHistory;
-import io.debezium.storage.jdbc.history.JdbcSchemaHistoryConfig;
-import io.debezium.storage.jdbc.offset.JdbcOffsetBackingStoreConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -104,7 +102,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
         }
     }
 
-    private Configuration.Builder config(String jdbcUrl) {
+    private Configuration.Builder deprecatedConfig(String jdbcUrl) {
         return Configuration.create()
                 .with(MySqlConnectorConfig.HOSTNAME, container.getHost())
                 .with(MySqlConnectorConfig.PORT, container.getMappedPort(PORT))
@@ -151,7 +149,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    public void shouldStartCorrectlyWithJdbcOffsetStorage() throws InterruptedException, IOException {
+    public void shouldStartCorrectlyWithDeprecatedJdbcOffsetStorage() throws InterruptedException, IOException {
         String masterPort = System.getProperty("database.port", "3306");
         String replicaPort = System.getProperty("database.replica.port", "3306");
         boolean replicaIsMaster = masterPort.equals(replicaPort);
@@ -165,7 +163,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
 
         // Use the DB configuration to define the connector's configuration to use the "replica"
         // which may be the same as the "master" ...
-        Configuration config = config(jdbcUrl).build();
+        Configuration config = deprecatedConfig(jdbcUrl).build();
 
         // Start the connector ...
         start(MySqlConnector.class, config);

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
@@ -133,7 +133,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
                 .with("offset.storage", "io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore")
                 .with("schema.history.internal.jdbc.url", "jdbc:sqlite:" + SCHEMA_HISTORY_PATH)
                 .with("schema.history.internal.jdbc.user", "user")
-                .with("schema.history.internal.jdbc.password" , "pass");
+                .with("schema.history.internal.jdbc.password", "pass");
     }
 
     private Configuration.Builder config(String jdbcUrl) {
@@ -167,7 +167,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
                 .with("offset.storage", "io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore")
                 .with("schema.history.internal.jdbc.connection.url", "jdbc:sqlite:" + SCHEMA_HISTORY_PATH)
                 .with("schema.history.internal.jdbc.connection.user", "user")
-                .with("schema.history.internal.jdbc.connection.password" , "pass");
+                .with("schema.history.internal.jdbc.connection.password", "pass");
     }
 
     private JdbcConnection testConnection() {


### PR DESCRIPTION
## Context

JDBC storage configuration names are not aligned with the others storage module. This misalignment can create some issue on configurations. The Proposal convention is the following:

| current    | new |
| -------- | ------- |
| offset.storage.jdbc.*  | offset.storage.jdbc.connection.*    |
| offset.storage.jdbc.offset.table.* | offset.storage.jdbc.table.*     |
| schema.history.internal.jdbc.* | schema.history.internal.jdbc.connection.*|
| schema.history.internal.jdbc.schema.history.table.* | schema.history.internal.jdbc.table.*|

## Changes

The `JdbcSchemaHistoryConfig`, `JdbcOffsetBackingStoreConfig` fields are aligned with the new convention and the current names are deprecated for future removal.

closes https://issues.redhat.com/browse/DBZ-8573