### PR TITLE
Dbz 8832 Unexpected null value for Field Configuration deprecated aliases

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/Field.java
+++ b/debezium-core/src/main/java/io/debezium/config/Field.java
@@ -839,7 +839,7 @@ public final class Field {
      */
     public Field withDefault(String defaultValue) {
         return new Field(name(), displayName(), type(), width, description(), importance(), dependents,
-                () -> defaultValue, validator, recommender, isRequired, group, allowedValues);
+                () -> defaultValue, validator, recommender, isRequired, group, allowedValues, deprecatedAliases);
     }
 
     /**

--- a/debezium-core/src/test/java/io/debezium/config/FieldTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/FieldTest.java
@@ -1,0 +1,33 @@
+package io.debezium.config;
+
+import io.debezium.doc.FixFor;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FieldTest {
+
+    @Test
+    @FixFor("")
+    public void shouldHaveDeprecatedAliasesAndDefault() {
+        Field field = Field.create("new.field")
+                .withDescription("a description")
+                .withDeprecatedAliases("deprecated.field")
+                .withDefault("default");
+
+        assertThat(field.deprecatedAliases()).isNotEmpty();
+        assertThat(field.defaultValue()).isNotNull();
+    }
+
+    @Test
+    @FixFor("")
+    public void shouldHaveDefaultAndDeprecatedAliases() {
+        Field field = Field.create("new.field")
+                .withDescription("a description")
+                .withDefault("default")
+                .withDeprecatedAliases("deprecated.field");
+
+        assertThat(field.deprecatedAliases()).isNotEmpty();
+        assertThat(field.defaultValue()).isNotNull();
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/config/FieldTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/FieldTest.java
@@ -1,9 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.config;
 
-import io.debezium.doc.FixFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.debezium.doc.FixFor;
 
 public class FieldTest {
 

--- a/debezium-core/src/test/java/io/debezium/config/FieldTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/FieldTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FieldTest {
 
     @Test
-    @FixFor("")
+    @FixFor("DBZ-8832")
     public void shouldHaveDeprecatedAliasesAndDefault() {
         Field field = Field.create("new.field")
                 .withDescription("a description")
@@ -20,7 +20,7 @@ public class FieldTest {
     }
 
     @Test
-    @FixFor("")
+    @FixFor("DBZ-8832")
     public void shouldHaveDefaultAndDeprecatedAliases() {
         Field field = Field.create("new.field")
                 .withDescription("a description")


### PR DESCRIPTION
## Context

the method `withDefault()` for `Field` class used for configuration purpose create a new `Field` value without `deprecatedAliases`

**Expected Behavior:**  
the values for deprecated aliases should be mantained even if we have a default one

closes: https://issues.redhat.com/browse/DBZ-8832