### PR TITLE
DBZ-8525: Improves log message introduced in #6222

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -304,7 +304,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                     }
                     if (LOGGER.isInfoEnabled()) {
                         Loggings.logInfoAndTraceRecord(LOGGER, context.maximumKey().orElse(new Object[0]),
-                                "Incremental snapshot for table '{}' will end at position", currentTableId);
+                                "Incremental snapshot for table '{}' will end at maximum key", currentTableId);
                     }
                 }
 


### PR DESCRIPTION
This PR improves the log message introduced with the change done in #6222 
Current log line:
`Incremental snapshot for table 's1.part2' will end at position`
Update to log line
`Incremental snapshot for table 's1.part2' will end at maximum key`