### PR TITLE
DBZ-8855 Add configured headers for read, insert, and delete events.

### DIFF
--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractChangedRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractChangedRecordStateTest.java
@@ -100,7 +100,9 @@ public class ExtractChangedRecordStateTest extends AbstractExtractStateTest {
 
             final SourceRecord createdRecord = createCreateRecord();
             final SourceRecord transformRecord = transform.apply(createdRecord);
-            assertThat(transformRecord.headers()).isEmpty();
+            assertThat(transformRecord.headers().size()).isEqualTo(2);
+            assertThat((List<?>) getSourceRecordHeader(transformRecord, "Changed").value()).isEmpty();
+            assertThat((List<?>) getSourceRecordHeader(transformRecord, "Unchanged").value()).isEmpty();
         }
     }
 

--- a/documentation/modules/ROOT/pages/transformations/event-changes.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-changes.adoc
@@ -88,7 +88,7 @@ The `ExtractChangedRecordState` SMT adds headers to the change event message to 
 The event changes SMT extracts the `before` and `after` fields from a {prodname} `UPDATE` change event in a Kafka record.
 The transformation examines the `before` and `after` event state structures to identify the fields that are altered by an operation, and those that remain unchanged.
 Depending on the connector configuration, the transformation then produces a modified event message that adds message headers to list the changed fields, the unchanged fields, or both.
-If the event represents an `INSERT` or `DELETE`, this single message transformation has no effect.
+If the event represents an `INSERT`, `DELETE`, or `READ`, this single message transformation adds the configured headers as an empty list, as there are no changed or unchanged fields.
 
 You can configure the event changes SMT for a {prodname} connector, or for a sink connector that consumes messages emitted by a {prodname} connector.
 Configure the event changes SMT for a sink connector if you want Apache Kafka to retain the entire original {prodname} change events.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8855

@jpechane I'm on the fence on this change because, on one hand I like the idea that it simplifies and provides consistent logic when paired with other transforms; however at the same time, I can see the argument that when paired with other transforms, perhaps having a predicate chain to run one or the other transform makes sense.

Let me know what you think.