### PR TITLE
[docs] Re-target link to correct topic ID

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1159,7 +1159,7 @@ The {prodname} JDBC sink connector has several configuration properties that you
 Many properties have default values.
 Information about the properties is organized as follows:
 
-* xref:jdbc-connector-properties-generic[JCBC connector Kafka consumer properties]
+* xref:jdbc-connector-properties-kafka-consumer[JCBC connector Kafka consumer properties]
 * xref:jdbc-connector-properties-connection[JDBC connector connection properties]
 * xref:jdbc-connector-properties-runtime[JDBC connector runtime properties]
 * xref:jdbc-connector-properties-extendable[JDBC connector extendable properties]


### PR DESCRIPTION
In the JDBC sink connector doc, a list at the head of the Connector properties topic provides easy access to the tables for each of the different types of properties. The first item in the list, is intended to link to the Kafka consumer properties, but the link URL targeted the non-existent ID `properties-generic` rather than the correct `properties-kafka-consumer`.
The error resulted in a failure in the downstream build.
Re-homed the target to the correct anchor ID and tested in a local Antora build.