### PR TITLE
DBZ-8858: Use the clustered index in sqlserver connector queries

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -80,7 +80,8 @@ public class SqlServerConnection extends JdbcConnection {
             + LSN_TIMESTAMP_SELECT_STATEMENT;
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION = "FROM [#db].cdc.[fn_cdc_get_all_changes_#table](?, ?, N'all update old')";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM [#db].cdc.[#table]";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$command_id] ASC, [__$seqval] ASC, [__$operation] ASC";
 
     /**
      * Queries the list of captured column names and their change table identifiers in the given database.
@@ -212,7 +213,14 @@ public class SqlServerConnection extends JdbcConnection {
             result += " WHERE " + String.join(" AND ", where) + " ";
         }
 
-        result += GET_ALL_CHANGES_FOR_TABLE_ORDER_BY;
+        switch (dataQueryMode) {
+            case FUNCTION:
+                result += GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY;
+                break;
+            case DIRECT:
+                result += GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY;
+                break;
+        }
 
         return result;
     }

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3319,7 +3319,7 @@ After the next failure, the connector stops, and user intervention is required t
 |Controls how the connector queries CDC data. The following modes are supported:
 
 * `function`: The data is queried by calling `cdc.[fn_cdc_get_all_changes_#]` function. This is the default mode.
-* `direct`: Makes the connector to query change tables directly. Switching to `direct` mode and creating an index on `(\\__$start_lsn ASC, __$seqval ASC, __$operation ASC)` columns for each change table significantly speeds up querying CDC data.
+* `direct`: Makes the connector to query change tables directly.
 
 |[[sqlserver-property-database-query-timeout-ms]]<<sqlserver-property-database-query-timeout-ms, `database.query.timeout.ms`>>
 |`600000` (10 minutes)


### PR DESCRIPTION
Adding `__$command_id ASC` to the `ORDER BY` clause of the query allows for the usage of the clustered index when the connector is running with `data.query.mode=direct`.