### PR TITLE
When the error 'Unable to register metrics as an old set with the same name ......' occurs

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
@@ -53,8 +53,8 @@ public class JmxUtils {
                 catch (InstanceAlreadyExistsException e) {
                     if (attempt < REGISTRATION_RETRIES) {
                         LOGGER.warn(
-                                "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",
-                                REGISTRATION_RETRY_DELAY, attempt, REGISTRATION_RETRIES);
+                                "Unable to register metrics as an old set with the same name: {} exists, retrying in {} (attempt {} out of {})",
+                                objectName, REGISTRATION_RETRY_DELAY, attempt, REGISTRATION_RETRIES);
                         final Metronome metronome = Metronome.sleeper(REGISTRATION_RETRY_DELAY, Clock.system());
                         metronome.pause();
                     }


### PR DESCRIPTION
When the error 'Unable to register metrics as an old set with the same name' occurs, it can quickly locate the cause of the error

