### PR TITLE
[docs] Fix oboslete JDBC passthrough prefix

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2078,7 +2078,7 @@ The SQL Server connector can capture changes from an Always On read-only replica
 .Prerequisites
 * Change data capture is configured and enabled on the primary node.
 SQL Server does not support CDC directly on replicas.
-* The configuration option `database.applicationIntent` is set to `ReadOnly`.
+* The configuration option `driver.applicationIntent` is set to `ReadOnly`.
 This is required by SQL Server.
 When {prodname} detects this configuration option, it responds by taking the following actions:
 


### PR DESCRIPTION
Should be backported to 3.0 and 3.1