### PR TITLE
DBZ-8877

### DIFF
--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
@@ -143,10 +143,15 @@ public class MariaDbConnectorTask extends BinlogSourceTask<MariaDbPartition, Mar
 
         LOGGER.info("Reconnecting after finishing schema recovery");
         try {
+            if (!connection.isConnected()) {
+                LOGGER.warn("Connection was dropped during schema recovery. Reconnecting...");
+                connection = connectionFactory.mainConnection();
+            }
+
             connection.setAutoCommit(false);
         }
         catch (SQLException e) {
-            throw new DebeziumException(e);
+            throw new DebeziumException("Failed to reconnect after schema recovery", e);
         }
 
         // If the binlog position is not available it is necessary to re-execute snapshot

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -136,10 +136,15 @@ public class MySqlConnectorTask extends BinlogSourceTask<MySqlPartition, MySqlOf
         LOGGER.info("Reconnecting after finishing schema recovery");
 
         try {
+            if (!connection.isConnected()) {
+                LOGGER.warn("Connection was dropped during schema recovery. Reconnecting...");
+                connection = connectionFactory.mainConnection();
+            }
+
             connection.setAutoCommit(false);
         }
         catch (SQLException e) {
-            throw new DebeziumException(e);
+            throw new DebeziumException("Failed to reconnect after schema recovery", e);
         }
 
         // If the binlog position is not available it is necessary to re-execute snapshot


### PR DESCRIPTION
**Improve MySQL/MariaDB connector resilience during post-schema recovery reconnect**

While investigating an issue where the MySQL connector fails with:

_The client was disconnected by the server because of inactivity_

I found that even though the connector logs Reconnecting after finishing schema recovery, the actual connection object is reused and not revalidated. If the MySQL server silently drops the connection during a long schema recovery (due to wait_timeout), this leads to a failure when setAutoCommit(false) is called.

I contributed a patch that:

1. Validates the JDBC connection after schema recovery,
2. And reconnects if the existing connection is no longer valid