### PR TITLE
DBZ-8879 Fix severe performance degradation

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -227,7 +227,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
                                          OffsetContext offset,
                                          ConnectHeaders headers)
                         throws InterruptedException {
-                    Loggings.logTraceAndTraceRecord(LOGGER, "Key: " + key + ", Value: " + value, "Received change record for {} operation with context {}", operation,
+                    Loggings.logTraceAndTraceRecord(LOGGER, Map.of("key", key, "value", value), "Received change record for {} operation with context {}", operation,
                             offset);
 
                     eventListener.onEvent(partition, dataCollectionSchema.id(), offset, key, value, operation);
@@ -289,7 +289,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
                                              ConnectHeaders headers)
                             throws InterruptedException {
 
-                        Loggings.logTraceAndTraceRecord(LOGGER, "Key: " + key + ", Value: " + value, "Received change record for {} operation with context {}", operation,
+                        Loggings.logTraceAndTraceRecord(LOGGER, Map.of("key", key, "value", value), "Received change record for {} operation with context {}", operation,
                                 offset);
 
                         if (isASignalEventToProcess(dataCollectionId, operation) && sourceSignalChannel != null) {
@@ -510,7 +510,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
 
             Objects.requireNonNull(value, "value must not be null");
 
-            Loggings.logTraceAndTraceRecord(LOGGER, "Key: " + key + ", Value: " + value, "Received change record for {} operation with context {}", operation,
+            Loggings.logTraceAndTraceRecord(LOGGER, Map.of("key", key, "value", value), "Received change record for {} operation with context {}", operation,
                     offsetContext);
 
             // Truncate events must have null key schema as they are sent to table topics without keys


### PR DESCRIPTION
[Zulip chat](https://debezium.zulipchat.com/#narrow/channel/302529-community-general/topic/Performance.20Regression.20after.203.2E1.2E0.2EBeta1)

[DBZ-8879](https://issues.redhat.com/browse/DBZ-8879)

The changes here https://github.com/debezium/debezium/pull/6222 caused us to call toString on every event even if we aren't logging trace level (dropping max throughput by 50% a severe performance degradation). Fix this by passing in as a map object that only calls toString if necessary.

Result is throughput is back to previous level ie 2x what it is without these changes.