### PR TITLE
Dbz 8840 doc update to sqlserver schema history mbean name

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -3219,6 +3219,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[db2-schema-history-metrics]]
 === Schema history metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-schema-history]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -544,6 +544,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[mariadb-schema-history-metrics]]
 === Schema history metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-schema-history]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -618,6 +618,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[mysql-schema-history-metrics]]
 === Schema history metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-schema-history]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3320,8 +3320,8 @@ The {prodname} for Oracle connector relies on the Oracle JDBC driver's built-in 
 
 You can use either of the following methods to establish mTLS connections between {prodname} and Oracle:
 
-* xref:#using-mtls-secure-connections-java-key-trust-stores[Using Java key and trust stores to configure mTLS connections]
-* xref:#using-mtls-secure-connections-oracle-wallet[Using Oracle Wallet to configure mTLS connections]
+* xref:using-mtls-secure-connections-java-key-trust-stores[Using Java key and trust stores to configure mTLS connections]
+* xref:using-mtls-secure-connections-oracle-wallet[Using Oracle Wallet to configure mTLS connections]
 
 // Type: procedure
 // ModuleID: oracle-connector-using-java-key-trust-stores-to-configure-mtls

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4757,6 +4757,7 @@ This should always be `0`; however when allowing unparsable DDL to be skipped, t
 
 [[oracle-monitoring-schema-history]]
 
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-schema-history]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4224,7 +4224,7 @@ The {prodname} PostgreSQL connector provides two types of metrics that are in ad
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
-/ Type: concept
+// Type: concept
 // ModuleID: monitoring-debezium-postgresql-connectors-customized-mbean-names
 // Title: Customized names for PostgreSQL connector snapshot and streaming MBean objects
 === Customized MBean names

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3602,4 +3602,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[sqlserver-schema-history-metrics]]
 === Schema history metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=sqlserver-schema-history]
+
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -27,6 +27,14 @@ tag::sqlserver-streaming[]
 The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<topic.prefix>_,task=_<task.id>_,context=streaming`.
 end::sqlserver-streaming[]
 
+tag::common-schema-history[]
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_`.
+end::common-schema-history[]
+
+tag::sqlserver-schema-history[]
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_,task=_<task.id>_`.
+end::sqlserver-schema-history[]
+
 
 // Shared
 tag::mbeans-shared[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -1,3 +1,4 @@
+
 The following table lists the schema history metrics that are available.
 
 [cols="45%a,25%a,30%a",options="header"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -1,5 +1,3 @@
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_`.
-
 The following table lists the schema history metrics that are available.
 
 [cols="45%a,25%a,30%a",options="header"]


### PR DESCRIPTION
[DBZ-8840](https://issues.redhat.com/browse/DBZ-8840)

Refactors the _Schema history metrics_ topic in the Db2, MariaDB, MySQL, Oracle, and SQL Server connector files  to correct the schema history MBean name for SQL Server to include the `task.id`. In the original version of the topics, a common MBean name was shared to all of the relevant connectors via an entry in a shared file  `ref-connector-monitoring-schema-history-metrics.adoc`.

To assign a unique MBean name for SQL Server, it was necessary to remove the single MBean name from the beginning of the shared file, and create two separate name entries in the fragment file {{/partials/frag-common-mbean-name.adoc}} that is already used to provide instances of other MBean names. The single MBean name is now replaced by one of the following: 

- A common MBean name for use in the Db2, MariaDB, MySQL, and Oracle connector Schema history topics
- A SQL Server-specific schema history MBean names 

Each of these entries in fragment file is implemented as a tagged region, which can be uniquely referenced via an `include` directive.

In the _Schema history metrics_ topic for each connector file, I added a second `include` directive to import just the MBean name for the connector (`common-schema-history` or `sqlserver-schema-history`) on the line that precedes the existing directive. The original `include` directive now provides just the metrics table. 

This approach should facilitate subsequent global changes to the naming format should that become necessary. 

Tested in local Antora and downstream builds.
