### PR TITLE
DBZ-8882 Prefix Oracle infinispan profiles with `oracle-`

### DIFF
--- a/.github/actions/build-debezium-oracle/action.yml
+++ b/.github/actions/build-debezium-oracle/action.yml
@@ -8,7 +8,7 @@ inputs:
   profile:
     description: "The profiles to use to run tests with"
     required: false
-    default: "infinispan-buffer,oracle-tests"
+    default: "oracle-infinispan-buffer,oracle-tests"
   shell:
     description: "The shell to use"
     required: false

--- a/.github/workflows/connector-oracle-workflow.yml
+++ b/.github/workflows/connector-oracle-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'oracle-tests', 'infinispan-buffer,oracle-tests', 'oracle-ehcache,oracle-tests' ]
+        profile: [ 'oracle-tests', 'oracle-infinispan-buffer,oracle-tests', 'oracle-ehcache,oracle-tests' ]
     name: Oracle - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -337,3 +337,25 @@ jobs:
             TEST_PROFILE: oracle
 
   ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-ispn"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-infinispan
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-infinispan-buffer -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -662,7 +662,7 @@
         </profile>
         <!-- This profile should be used for testing connector with Infinispan only -->
         <profile>
-            <id>infinispan-buffer</id>
+            <id>oracle-infinispan-buffer</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -672,7 +672,7 @@
             <!-- todo: when using this profile, enforce oracle-xstream being mutually exclusive -->
         </profile>
         <profile>
-            <id>infinispan-buffer-remote</id>
+            <id>oracle-infinispan-buffer-remote</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8882

Prefix the Infinispan-specific profiles to match the other buffer profiles. I've also added a new job on the testing farm to test the Oracle connector with embedded ISPN using Oracle 19.  