### PR TITLE
DBZ-8885: Add an option to reset the lagBehindSource metric separately

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetrics.java
@@ -60,6 +60,11 @@ class SqlServerStreamingPartitionMetrics extends AbstractSqlServerPartitionMetri
     }
 
     @Override
+    public void resetLagBehindSource() {
+        streamingMeter.resetLagBehindSource();
+    }
+
+    @Override
     public void reset() {
         super.reset();
         streamingMeter.reset();

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/StreamingMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/StreamingMeter.java
@@ -66,6 +66,11 @@ public class StreamingMeter implements StreamingMetricsMXBean {
         return lastTransactionId.get();
     }
 
+    @Override
+    public void resetLagBehindSource() {
+        lagBehindSource.set(null);
+    }
+
     public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
         final Instant eventTimestamp = metadataProvider.getEventTimestamp(source, offset, key, value);
         if (eventTimestamp != null) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -99,6 +99,11 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
+    public void resetLagBehindSource() {
+        streamingMeter.resetLagBehindSource();
+    }
+
+    @Override
     public void reset() {
         super.reset();
         streamingMeter.reset();

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/StreamingMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/StreamingMetricsMXBean.java
@@ -19,4 +19,6 @@ public interface StreamingMetricsMXBean extends SchemaMetricsMXBean {
     long getNumberOfCommittedTransactions();
 
     String getLastTransactionId();
+
+    void resetLagBehindSource();
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8885

During idle periods at the source, when no records are received by the connector, the `lagBehindSource` metric retains its old value, incorrectly indicating that the connector is lagging behind. A mechanism is needed to reset the `lagBehindSource` metric in such cases.  

Currently, there is no way to reset this metric individually; only a group reset is available, which resets all metrics in `StreamingMeter` together. Additionally, `StreamingMeter` is a private variable in `DefaultStreamingChangeEventSourceMetrics`, making it inaccessible when extending this class. 

This PR provides a getter method for StreamingMeter object and provides a method to reset the `lagBehindSource` separately.