### PR TITLE
[docs] Convert callout description to table to fix redundant numbering

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -827,10 +827,20 @@ Include the following compile dependencies in your project's `pom.xml` file:
 <dependency>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-core</artifactId>
-    <version>${version.debezium}</version> // <1>
+    <version>${version.debezium}</version>
 </dependency>
 ----
-<1> `${version.debezium}` represents the version of the {prodname} connector.
+
+In the preceding example, the placeholder `${version.debezium}` represents the version of the {prodname} connector.
+Specify a value for the `version.debezium` property in the `<properties>` section of the `pom.xml file`.
+For example,
+
+[source,xml,subs="attributes+"]
+----
+<properties>
+    <version.debezium>{debezium-version}</version.debezium>
+</properties>
+----
 
 Declare your provider implementation in the `META-INF/services/io.debezium.pipeline.signal.actions.SignalActionProvider` file.
 


### PR DESCRIPTION
[docs] In the downstream Signaling documentation, the description for the single callout in the Debezium core module dependencies example is preceded by 12 rows of callout numbers. 
To eliminate this rendering error, this change reformats the single-entry list of callout descriptions, converting it to a paragraph.

The content is modified slightly to accommodate the new format.

Tested in local Antora and downstream builds. 