### PR TITLE
[docs] Apply corrections to reselect post processor JSON example

### DIFF
--- a/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
@@ -79,12 +79,12 @@ To enable the connector to use the `ReselectColumnsPostProcessor`, add the follo
 
 [source,json,subs="+attributes,+quotes"]
 ----
-  "post.processors": "reselector", // <1>
-  "reselector.type": "io.debezium.processors.reselect.ReselectColumnsPostProcessor", // <2>
-  "reselector.reselect.columns.include.list": "_<schema>_.__<table>__:__<column>__,__<schema>__.__<table>__:__<column>__", // <3>
-  "reselector.reselect.unavailable.values": "true", // <4>
-  "reselector.reselect.null.values": "true" // <5>
-  "reselector.reselect.use.event.key": "false" // <6>
+  "post.processors" : "reselector", // <1>
+  "reselector.type" : "io.debezium.processors.reselect.ReselectColumnsPostProcessor", // <2>
+  "reselector.reselect.columns.include.list" : "_<schema>_.__<table>__:__<column>__,__<schema>__.__<table>__:__<column>__", // <3>
+  "reselector.reselect.unavailable.values" : "true", // <4>
+  "reselector.reselect.null.values" : "true", // <5>
+  "reselector.reselect.use.event.key" : "false," // <6>
 ----
 [cols="1,7",options="header"]
 |===


### PR DESCRIPTION
An earlier update to `main` applied formatting corrections to a JSON example in the reselect post processors documentation. 

Because the version of the example in the 3.0 branch includes one few line (`relector.reselect.error.handling.mode`), this update is not a direct backport of the earlier change; however, it applies the corrections identified in the earlier change to all of the shared lines in the example