### PR TITLE
[docs] Fix KC YAML apicurio URL;sub attr for `build-number` placeholder

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -28,7 +28,7 @@ spec:
           - type: zip // <6>
             url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}.redhat-{registry-build-number}/apicurio-registry-distro-connect-converter-{registry-maven-version}.redhat-{registry-build-number}.zip  // <8>
           - type: zip
             url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -28,7 +28,7 @@ spec:
           - type: zip // <6>
             url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat.{registry-build-number}/apicurio-registry-distro-connect-converter-{registry-maven-version}.redhat-{registry-build-number}.zip  // <8>
           - type: zip
             url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
@@ -27,7 +27,7 @@ spec:
           - type: zip // <6>
             url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}.redhat-{registry-build-number}/apicurio-registry-distro-connect-converter-{registry-maven-version}.redhat-{registry-build-number}.zip  // <8>
           - type: zip
             url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar


### PR DESCRIPTION
Fixes a small error (dash [`-`]  vs.  dot [`.`]) that was present in the Apicurio URLs in the Kafka Connect CR YAML examples within the Streams deployment instructions.
Also replaces the `build-number` placeholder in the URL with an attribute.

Tested in a local downstream build.
This change relates only to content that is exposed in the downstream product edition of the docs and has no effect on the community version. 