### PR TITLE
[docs] Corrects refs to external Streams docs (downstream only)

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -62,7 +62,7 @@ spec:
 |Specifies the name and image name for the image output.
 Valid values for `output.type` are `docker` to push into a container registry such as Docker Hub or Quay, or `imagestream` to push the image to an internal OpenShift ImageStream.
 To use an ImageStream, an ImageStream resource must be deployed to the cluster.
-For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkConfiguringStreamsOpenShift}#type-Build-reference[{StreamsName} Build schema reference] in {NameConfiguringStreamsOpenShift}.
+For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsAPIReference}#type-Build-reference[Build schema reference] in the {NameStreamsAPIReference}.
 
 |5
 |The `plugins` configuration lists all of the connectors that you want to include in the Kafka Connect image.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -62,7 +62,7 @@ spec:
 |Specifies the name and image name for the image output.
 Valid values for `output.type` are `docker` to push into a container registry such as Docker Hub or Quay, or `imagestream` to push the image to an internal OpenShift ImageStream.
 To use an ImageStream, an ImageStream resource must be deployed to the cluster.
-For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkConfiguringStreamsOpenShift}#type-Build-reference[{StreamsName} Build schema reference] in {NameConfiguringStreamsOpenShift}.
+For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsAPIReference}#type-Build-reference[Build schema reference] in the {NameStreamsAPIReference}.
 
 |5
 |The `plugins` configuration lists all of the connectors that you want to include in the Kafka Connect image.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
@@ -59,7 +59,7 @@ spec:
 |Specifies the name and image name for the image output.
 Valid values for `output.type` are `docker` to push into a container registry such as Docker Hub or Quay, or `imagestream` to push the image to an internal OpenShift ImageStream.
 To use an ImageStream, an ImageStream resource must be deployed to the cluster.
-For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkConfiguringStreamsOpenShift}#type-Build-reference[{StreamsName} Build schema reference] in {NameConfiguringStreamsOpenShift}.
+For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsAPIReference}#type-Build-reference[Build schema reference] in the {NameStreamsAPIReference}.
 
 |5
 |The `plugins` configuration lists all of the connectors that you want to include in the Kafka Connect image.


### PR DESCRIPTION
Replaces obsolete attributes that referenced external docs in the Streams-based deployment instructions for the connectors. Because the attributes could not be resolved, the attribute text either rendered literally in the docs, or resulted in broken links.  