### PR TITLE
DBZ-8884 Populate source.user_name based on start events

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -2171,7 +2171,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             final String excludeList = config.getString(LOG_MINING_USERNAME_EXCLUDE_LIST);
 
             if (includeList != null && excludeList != null) {
-                problems.accept(TABLE_EXCLUDE_LIST, excludeList,
+                problems.accept(LOG_MINING_USERNAME_EXCLUDE_LIST, excludeList,
                         String.format("\"%s\" is already specified", LOG_MINING_USERNAME_INCLUDE_LIST.name()));
                 return 1;
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -1514,6 +1515,50 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             }
         }
         return true;
+    }
+
+    /**
+     * Check whether an event with the given username should be skipped.
+     *
+     * @param userName the username, can be {@code null} or {@code empty}
+     * @return true to skip, false otherwise
+     */
+    protected boolean isUserNameSkipped(String userName) {
+        if (!Strings.isNullOrEmpty(userName)) {
+            final Set<String> userNameExcludes = connectorConfig.getLogMiningUsernameExcludes();
+            final Set<String> userNameIncludes = connectorConfig.getLogMiningUsernameIncludes();
+            if (userNameExcludes.contains(userName)) {
+                LOGGER.debug("Skipped transaction with excluded username {}", userName);
+                return true;
+            }
+            else if (!userNameIncludes.isEmpty() && !userNameIncludes.contains(userName)) {
+                LOGGER.debug("Skipped transaction with username {}", userName);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check whether an event with the given client identifier should be skipped.
+     *
+     * @param clientId the client identifier, can be {@code null} or {@code empty}
+     * @return true to skip, false otherwise
+     */
+    protected boolean isClientIdSkipped(String clientId) {
+        if (!Strings.isNullOrEmpty(clientId)) {
+            final Set<String> clientIdExcludes = connectorConfig.getLogMiningClientIdExcludes();
+            final Set<String> clientIdIncludes = connectorConfig.getLogMiningClientIdIncludes();
+            if (clientIdExcludes.contains(clientId)) {
+                LOGGER.debug("Skipped transaction with excluded client id {}", clientId);
+                return true;
+            }
+            else if (!clientIdIncludes.isEmpty() && !clientIdIncludes.contains(clientId)) {
+                LOGGER.debug("Skipped transaction with client id {}", clientId);
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer.buffered;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -105,18 +104,7 @@ public class BufferedLogMinerQueryBuilder extends AbstractLogMinerQueryBuilder {
 
         // Handle all operations except DDL changes
         final InClause operationInClause = InClause.builder().withField("OPERATION_CODE");
-        if (connectorConfig.isLobEnabled()) {
-            operationInClause.withValues(OPERATION_CODES_LOB);
-        }
-        else {
-            final List<Integer> operationCodes = new ArrayList<>(OPERATION_CODES_NO_LOB);
-            // The transaction start event needs to be handled when a persistent buffer (Infinispan) is used
-            // because it is needed to reset the event id counter when re-mining transaction events.
-            if (connectorConfig.getLogMiningBufferType() == OracleConnectorConfig.LogMiningBufferType.MEMORY) {
-                operationCodes.removeIf(operationCode -> operationCode == 6);
-            }
-            operationInClause.withValues(operationCodes);
-        }
+        operationInClause.withValues(connectorConfig.isLobEnabled() ? OPERATION_CODES_LOB : OPERATION_CODES_NO_LOB);
         predicate.append("(").append(operationInClause.build());
 
         // Handle DDL operations

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -805,6 +805,12 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                     LOGGER.debug("Skipped transaction with excluded username {}", transaction.getUserName());
                     return true;
                 }
+                else if (!getConfig().getLogMiningUsernameIncludes().isEmpty()) {
+                    if (!getConfig().getLogMiningUsernameIncludes().contains(transaction.getUserName())) {
+                        LOGGER.debug("Skipped transaction with username {}", transaction.getUserName());
+                        return true;
+                    }
+                }
             }
 
             // Check whether transaction should be skipped by LogMiner CLIENT_ID field

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -794,40 +794,11 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
      * mode.
      *
      * @param transaction the transaction, should not be {@code null}
-     * @return true if the transaction should be skipped and not disaptched, false otherwise
+     * @return true if the transaction should be skipped and not dispatched, false otherwise
      */
     private boolean isTransactionSkippedAtCommit(Transaction transaction) {
         // todo: can this be moved to earlier in the processing loop to avoid buffering?
-        if (transaction != null) {
-            // Check whether transaction should be skipped by LogMiner USERNAME field
-            if (!Strings.isNullOrBlank(transaction.getUserName())) {
-                if (getConfig().getLogMiningUsernameExcludes().contains(transaction.getUserName())) {
-                    LOGGER.debug("Skipped transaction with excluded username {}", transaction.getUserName());
-                    return true;
-                }
-                else if (!getConfig().getLogMiningUsernameIncludes().isEmpty()) {
-                    if (!getConfig().getLogMiningUsernameIncludes().contains(transaction.getUserName())) {
-                        LOGGER.debug("Skipped transaction with username {}", transaction.getUserName());
-                        return true;
-                    }
-                }
-            }
-
-            // Check whether transaction should be skipped by LogMiner CLIENT_ID field
-            if (!Strings.isNullOrBlank(transaction.getClientId())) {
-                if (getConfig().getLogMiningClientIdExcludes().contains(transaction.getClientId())) {
-                    LOGGER.debug("Skipped transaction with excluded client id {}", transaction.getClientId());
-                    return true;
-                }
-                else if (!getConfig().getLogMiningClientIdIncludes().isEmpty()) {
-                    if (!getConfig().getLogMiningClientIdIncludes().contains(transaction.getClientId())) {
-                        LOGGER.debug("Skipped transaction with client id {}", transaction.getClientId());
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
+        return transaction != null && (isUserNameSkipped(transaction.getUserName()) || isClientIdSkipped(transaction.getClientId()));
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -326,36 +326,10 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
             }
         }
 
-        // Check whether transaction should be skipped by USERNAME field
-        if (!Strings.isNullOrBlank(event.getUserName())) {
-            if (getConfig().getLogMiningUsernameExcludes().contains(event.getUserName())) {
-                LOGGER.debug("Skipped transaction with excluded username {}", event.getUserName());
-                skipCurrentTransaction = true;
-                return;
-            }
-            else if (!getConfig().getLogMiningUsernameIncludes().isEmpty()) {
-                if (!getConfig().getLogMiningUsernameIncludes().contains(event.getUserName())) {
-                    LOGGER.debug("Skipped transaction with username {}", event.getUserName());
-                    skipCurrentTransaction = true;
-                    return;
-                }
-            }
-        }
-
-        // Check whether transaction should be skipped by CLIENTID field
-        if (!Strings.isNullOrBlank(event.getClientId())) {
-            if (getConfig().getLogMiningClientIdExcludes().contains(event.getClientId())) {
-                LOGGER.debug("Skipped transaction with excluded client id {}", event.getClientId());
-                skipCurrentTransaction = true;
-                return;
-            }
-            else if (!getConfig().getLogMiningClientIdIncludes().isEmpty()) {
-                if (!getConfig().getLogMiningClientIdIncludes().contains(event.getClientId())) {
-                    LOGGER.debug("Skipped transaction with client id {}", event.getClientId());
-                    skipCurrentTransaction = true;
-                    return;
-                }
-            }
+        // Check whether transaction should be skipped by USERNAME or CLIENT_ID field
+        if (isUserNameSkipped(event.getUserName()) || isClientIdSkipped(event.getClientId())) {
+            skipCurrentTransaction = true;
+            return;
         }
 
         Loggings.logDebugAndTraceRecord(

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -333,6 +333,13 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
                 skipCurrentTransaction = true;
                 return;
             }
+            else if (!getConfig().getLogMiningUsernameIncludes().isEmpty()) {
+                if (!getConfig().getLogMiningUsernameIncludes().contains(event.getUserName())) {
+                    LOGGER.debug("Skipped transaction with username {}", event.getUserName());
+                    skipCurrentTransaction = true;
+                    return;
+                }
+            }
         }
 
         // Check whether transaction should be skipped by CLIENTID field

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -191,9 +191,7 @@ public class LogMinerQueryBuilderTest {
 
         final String codes = config.isLobEnabled()
                 ? "1,2,3,6,7,9,10,11,27,29,34,36,68,70,71,91,92,93,255"
-                : (config.getLogMiningBufferType() == OracleConnectorConfig.LogMiningBufferType.MEMORY)
-                        ? "1,2,3,7,27,34,36,255"
-                        : "1,2,3,6,7,27,34,36,255";
+                : "1,2,3,6,7,27,34,36,255";
 
         query += "(";
         query += "OPERATION_CODE IN (" + codes + ")";

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -118,6 +118,12 @@ public class LogMinerQueryBuilderTest {
         assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_CLIENTID_INCLUDE_LIST, "abc,xyz").build());
     }
 
+    @Test
+    @FixFor("DBZ-8884")
+    public void testLegacyTransactionStartBufferingBehavior() {
+        assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START, false).build());
+    }
+
     private void testLogMinerQueryFilterMode(LogMiningQueryFilterMode mode) {
         // Default configuration
         assertQuery(getBuilderForMode(mode));
@@ -191,7 +197,9 @@ public class LogMinerQueryBuilderTest {
 
         final String codes = config.isLobEnabled()
                 ? "1,2,3,6,7,9,10,11,27,29,34,36,68,70,71,91,92,93,255"
-                : "1,2,3,6,7,27,34,36,255";
+                : config.isLegacyLogMinerHeapTransactionStartBehaviorEnabled()
+                        ? "1,2,3,7,27,34,36,255"
+                        : "1,2,3,6,7,27,34,36,255";
 
         query += "(";
         query += "OPERATION_CODE IN (" + codes + ")";

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.runners.Parameterized.Parameters;
+
+import java.lang.management.ManagementFactory;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnector;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.junit.logging.LogInterceptor;
+
+/**
+ * Integration tests for various LogMiner username include/exclude list scenarios.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = ANY_LOGMINER, reason = "LogMiner specific")
+@RunWith(Parameterized.class)
+public class UsernameFilterIT extends AbstractAsyncEngineConnectorTest {
+
+    @Rule
+    public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
+
+    private static OracleConnection connection;
+
+    @BeforeClass
+    public static void beforeSuperClass() throws SQLException {
+        connection = TestHelper.testConnection();
+    }
+
+    @AfterClass
+    public static void closeConnection() throws SQLException {
+        if (connection != null && connection.isConnected()) {
+            connection.close();
+        }
+    }
+
+    @Parameters(name = "{index}: lobEnabled={0}")
+    public static Collection<Object[]> lobEnabled() {
+        return Arrays.asList(new Object[][]{
+                { "false" },
+                { "true" }
+        });
+    }
+
+    private final String lobEnabled;
+
+    public UsernameFilterIT(String lobEnabled) {
+        this.lobEnabled = lobEnabled;
+    }
+
+    @Test
+    @FixFor("DBZ-3978")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_BUFFERED, reason = "Buffered filters at commit time while unbuffered filters at transaction start")
+    public void shouldExcludeEventsByUsernameFilter() throws Exception {
+        try {
+            TestHelper.dropTable(connection, "dbz3978");
+
+            connection.execute("CREATE TABLE dbz3978 (id number(9,0), data varchar2(50), primary key (id))");
+            TestHelper.streamTable(connection, "dbz3978");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3978")
+                    .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.NO_DATA)
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOB_ENABLED, lobEnabled)
+                    // This test expects the filtering to occur in the connector, not the query
+                    .with(OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE, "none")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.executeWithoutCommitting("INSERT INTO debezium.dbz3978 VALUES (1, 'Test1')");
+            connection.executeWithoutCommitting("INSERT INTO debezium.dbz3978 VALUES (2, 'Test2')");
+            connection.execute("COMMIT");
+
+            // all messages are filtered out
+            assertThat(waitForAvailableRecords(10, TimeUnit.SECONDS)).isFalse();
+
+            // There should be at least 2 DML events captured but ignored
+            Long totalDmlCount = getStreamingMetric("TotalCapturedDmlCount");
+            assertThat(totalDmlCount).isGreaterThanOrEqualTo(2L);
+
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz3978");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-8884")
+    public void shouldIncludeEventsByUsernameFilterTransactionSplitOverMultipleMiningSessionsNoQueryFilter() throws Exception {
+        try {
+            TestHelper.dropTable(connection, "dbz8884");
+            TestHelper.dropTable(connection, "dbz8884b");
+
+            connection.execute("CREATE TABLE dbz8884 (id number(9,0), data varchar2(50), primary key(id))");
+            connection.execute("CREATE TABLE dbz8884b (id number(9,0), data varchar2(50), primary key(id))");
+
+            TestHelper.streamTable(connection, "dbz8884");
+            TestHelper.streamTable(connection, "dbz8884b");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8884")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOB_ENABLED, lobEnabled)
+                    // This test expects the filtering to occur in the connector, not the query
+                    .with(OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE, "none")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // For this use case, its important that we have some changes that happen in the mining step
+            // with the START event for tables that are not collected. This means that the first DML is
+            // not matched in the same mining step as the START event.
+            for (int i = 1; i <= 10; i++) {
+                connection.executeWithoutCommitting(String.format(
+                        "INSERT INTO dbz8884b (id,data) values (%d,'Test%d')", i, i));
+                Thread.sleep(1000);
+            }
+
+            // Now add events for the captured table.
+            for (int i = 1; i <= 10; i++) {
+                connection.executeWithoutCommitting(String.format(
+                        "INSERT INTO dbz8884 (id,data) values (%d,'Test%d')", i, i));
+                Thread.sleep(1000);
+            }
+
+            connection.execute("COMMIT");
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(10);
+
+            List<SourceRecord> records = sourceRecords.recordsForTopic(topicName("DEBEZIUM", "DBZ8884"));
+            assertThat(records).hasSize(10);
+
+            for (int i = 1; i <= 10; i++) {
+                SourceRecord record = records.get(i - 1);
+                assertThat(getAfter(record).get("ID")).isEqualTo(i);
+                assertThat(getAfter(record).get("DATA")).isEqualTo(String.format("Test%d", i));
+                assertThat(getSource(record).get("user_name")).isEqualTo("DEBEZIUM");
+            }
+
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz8884");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-8884")
+    public void shouldIncludeEventsByUsernameFilterTransactionSplitOverMultipleMiningSessionsWithQueryFilter() throws Exception {
+        try {
+            TestHelper.dropTable(connection, "dbz8884");
+            TestHelper.dropTable(connection, "dbz8884b");
+
+            connection.execute("CREATE TABLE dbz8884 (id number(9,0), data varchar2(50), primary key(id))");
+            connection.execute("CREATE TABLE dbz8884b (id number(9,0), data varchar2(50), primary key(id))");
+
+            TestHelper.streamTable(connection, "dbz8884");
+            TestHelper.streamTable(connection, "dbz8884b");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8884")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOB_ENABLED, lobEnabled)
+                    // This test expects the filtering to occur at the query level
+                    .with(OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE, "in")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // For this use case, its important that we have some changes that happen in the mining step
+            // with the START event for tables that are not collected. This means that the first DML is
+            // not matched in the same mining step as the START event.
+            for (int i = 1; i <= 10; i++) {
+                connection.executeWithoutCommitting(String.format(
+                        "INSERT INTO dbz8884b (id,data) values (%d,'Test%d')", i, i));
+                Thread.sleep(1000);
+            }
+
+            // Now add events for the captured table.
+            for (int i = 1; i <= 10; i++) {
+                connection.executeWithoutCommitting(String.format(
+                        "INSERT INTO dbz8884 (id,data) values (%d,'Test%d')", i, i));
+                Thread.sleep(1000);
+            }
+
+            connection.execute("COMMIT");
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(10);
+
+            List<SourceRecord> records = sourceRecords.recordsForTopic(topicName("DEBEZIUM", "DBZ8884"));
+            assertThat(records).hasSize(10);
+
+            for (int i = 1; i <= 10; i++) {
+                SourceRecord record = records.get(i - 1);
+                assertThat(getAfter(record).get("ID")).isEqualTo(i);
+                assertThat(getAfter(record).get("DATA")).isEqualTo(String.format("Test%d", i));
+                assertThat(getSource(record).get("user_name")).isEqualTo("DEBEZIUM");
+            }
+
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz8884");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-8884")
+    public void shouldOnlyCaptureEventsForIncludedUsernames() throws Exception {
+        TestHelper.dropTable(connection, "dbz8884");
+        try {
+            connection.execute("CREATE TABLE dbz8884 (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz8884");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8884")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "abc")
+                    .with(OracleConnectorConfig.LOB_ENABLED, lobEnabled)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final LogInterceptor logInterceptor = TestHelper.getEventProcessorLogInterceptor();
+
+            connection.execute("INSERT INTO dbz8884 (id,data) values (1,'abc')");
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(TestHelper.defaultMessageConsumerPollTimeout()))
+                    .until(() -> logInterceptor.containsMessage("Skipped transaction with username DEBEZIUM"));
+
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz8884");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-8884")
+    public void shouldThrowConfigurationExceptionWhenUsernameIncludeExcludeBothSpecified() throws Exception {
+        TestHelper.dropTable(connection, "dbz8884");
+        try {
+            connection.execute("CREATE TABLE dbz8884 (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz8884");
+
+            LogInterceptor logInterceptor = new LogInterceptor(UsernameFilterIT.class);
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8884")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOB_ENABLED, lobEnabled)
+                    .build();
+
+            start(OracleConnector.class, config);
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(TestHelper.defaultMessageConsumerPollTimeout()))
+                    .until(() -> logInterceptor.containsErrorMessage("Connector configuration is not valid. The " +
+                            "'log.mining.username.exclude.list' value is invalid: \"log.mining.username.include.list\" is already specified"));
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz8884");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getStreamingMetric(String metricName) throws JMException {
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        return (T) server.getAttribute(
+                getStreamingMetricsObjectName(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME),
+                metricName);
+    }
+
+    private static String topicName(String schemaName, String tableName) {
+        return String.format("%s.%s.%s", TestHelper.SERVER_NAME, schemaName, tableName);
+    }
+
+    private static Struct getAfter(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+    }
+
+    private static Struct getSource(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.SOURCE);
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
@@ -269,7 +269,7 @@ public class UsernameFilterIT extends AbstractAsyncEngineConnectorTest {
 
             waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
-            final LogInterceptor logInterceptor = TestHelper.getEventProcessorLogInterceptor();
+            final LogInterceptor logInterceptor = TestHelper.getAbstractEventProcessorLogInterceptor();
 
             connection.execute("INSERT INTO dbz8884 (id,data) values (1,'abc')");
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8884

Hi @jchipmunk, this reverts the change [DBZ-7473](https://issues.redhat.com/browse/DBZ-7473) you introduced.  I know that the delayed transaction construction was important for your environment, but doing so creates an issue with both capturing the username in events and filtering by usernames.

Oracle only records the username attribute in the `START` event and its only reflected in DML events for that transaction thereafter if the DML event is captured in the same query as the `START`. If there are two mining iterations where on the first there is only the `START` and some non-captured tables and in the second is where we see the first DML for a captured table, the username attribute reference is lost and LogMiner always populates the field as `UNKNOWN`.

The easiest solution is to fall back to the behavior before the change, we were use the `START` event to create the actual transaction record in the buffer. I understand this makes the lower SCN watermark advance more slowly, but the only solution we have for users at the moment is to toggle `lob.enabled` on, which does precisely the same, even if they do not want to parse or handle LOB operations.

I'm open to other ideas if you have any. Thanks!