### PR TITLE
DBZ-8875: Replace deprecated poll and commitRecord methods to support Kafka 4.0

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -383,11 +383,6 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
     }
 
     @Override
-    public void commitRecord(SourceRecord record) throws InterruptedException {
-        // Do nothing
-    }
-
-    @Override
     public void commit() throws InterruptedException {
         boolean locked = commitLock.tryLock();
 

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -23,6 +23,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -467,7 +468,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     protected abstract void doStop();
 
     @Override
-    public void commitRecord(SourceRecord record) throws InterruptedException {
+    public void commitRecord(SourceRecord record, RecordMetadata metadata) throws InterruptedException {
         Loggings.logTraceAndTraceRecord(LOGGER, record, "Committing record");
 
         Map<String, ?> currentOffset = record.sourceOffset();

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/KafkaSignalChannel.java
@@ -176,8 +176,7 @@ public class KafkaSignalChannel implements SignalChannelReader {
     public List<SignalRecord> read() {
 
         LOGGER.debug("Reading signal form kafka");
-        // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
-        ConsumerRecords<String, String> recoveredRecords = signalsConsumer.poll(pollTimeoutMs.toMillis());
+        ConsumerRecords<String, String> recoveredRecords = signalsConsumer.poll(pollTimeoutMs);
 
         return StreamSupport.stream(recoveredRecords.spliterator(), false)
                 .map(this::processSignal)

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -820,7 +820,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord>, Embed
 
             @Override
             public synchronized void markProcessed(SourceRecord record) throws InterruptedException {
-                task.commitRecord(record);
+                task.commitRecord(record, null);
                 recordsSinceLastCommit += 1;
                 offsetWriter.offset((Map<String, Object>) record.sourcePartition(), (Map<String, Object>) record.sourceOffset());
             }

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -1230,7 +1230,7 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
 
         @Override
         public void markProcessed(SourceRecord record) throws InterruptedException {
-            task.commitRecord(record);
+            task.commitRecord(record, null);
             recordsSinceLastCommit += 1;
             offsetWriter.offset(record.sourcePartition(), record.sourceOffset());
         }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -319,8 +319,7 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 endOffset = getEndOffsetOfDbHistoryTopic(endOffset, historyConsumer);
                 LOGGER.debug("End offset of database schema history topic is {}", endOffset);
 
-                // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
-                ConsumerRecords<String, String> recoveredRecords = historyConsumer.poll(this.pollInterval.toMillis());
+                ConsumerRecords<String, String> recoveredRecords = historyConsumer.poll(this.pollInterval);
                 int numRecordsProcessed = 0;
 
                 for (ConsumerRecord<String, String> record : recoveredRecords) {

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -457,11 +457,11 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 }
 
                 final DescribeTopicsResult result = admin.describeTopics(Collections.singleton(topicName));
-                if (result.values().size() != 1) {
-                    LOGGER.info("Expected one topic '{}' to match the query but got {}", topicName, result.values().size());
+                if (result.topicNameValues().size() != 1) {
+                    LOGGER.info("Expected one topic '{}' to match the query but got {}", topicName, result.topicNameValues().size());
                     return;
                 }
-                final TopicDescription topicDesc = result.values().values().iterator().next().get();
+                final TopicDescription topicDesc = result.topicNameValues().values().iterator().next().get();
                 if (topicDesc == null) {
                     LOGGER.info("Could not get description for topic '{}'", topicName);
                     return;

--- a/pom.xml
+++ b/pom.xml
@@ -107,16 +107,18 @@
 
         <!-- Kafka and it's dependencies MUST reflect what the Kafka version uses -->
         <version.kafka>3.9.0</version.kafka>
-        <version.zookeeper>3.8.4</version.zookeeper>
         <!-- NOTE: These two versions are maintained separately due to decoupling jackson and databind for downstream -->
         <version.jackson>2.16.2</version.jackson>
         <version.jackson.databind>2.16.2</version.jackson.databind>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.netty>4.1.118.Final</version.netty>
-        <version.zstd-jni>1.5.6-4</version.zstd-jni>
+        <version.zstd-jni>1.5.6-6</version.zstd-jni>
 
         <!-- Scala version used to build Kafka -->
         <version.kafka.scala>2.13</version.kafka.scala>
+
+        <!-- Kafka no longer needs ZooKeeper but it is kept for testing with older Kafka dependencies -->
+        <version.zookeeper>3.8.4</version.zookeeper>
 
         <!-- ANTLR -->
         <!-- Align with Antlr runtime version pulled in via Quarkus -->


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/DBZ-8875