### PR TITLE
DBZ-8444 Migrate performance microbenchmarks to async engine

### DIFF
--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
@@ -49,7 +49,6 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
-import io.debezium.embedded.ConvertingEngineBuilderFactory;
 import io.debezium.embedded.EmbeddedEngineChangeEvent;
 import io.debezium.embedded.EmbeddedEngineConfig;
 import io.debezium.embedded.async.AsyncEngineConfig;
@@ -287,28 +286,6 @@ public class PostgresEndToEndPerf {
     }
 
     @State(Scope.Thread)
-    public static class EmbeddedEngineEndToEndPerfTest extends DebeziumEndToEndPerfTest {
-        public String getBaseTableName() {
-            return BASE_TABLE_NAME + "_engine";
-        }
-
-        public DebeziumEngine createEngine() {
-            Configuration config = defaultConnectorConfig()
-                    .with(PostgresConnectorConfig.SLOT_NAME, "engine_" + eventCount)
-                    // .with(EmbeddedEngineConfig.WAIT_FOR_COMPLETION_BEFORE_INTERRUPT_MS, CommonConnectorConfig.EXECUTOR_SHUTDOWN_TIMEOUT_SEC)
-                    .build();
-            Properties configProps = addSmtConfig(config);
-
-            return new ConvertingEngineBuilderFactory()
-                    .builder(KV_EVENT_FORMAT)
-                    .using(configProps)
-                    .notifying(getRecordConsumer(consumedLines))
-                    .using(this.getClass().getClassLoader())
-                    .build();
-        }
-    }
-
-    @State(Scope.Thread)
     public static class AsyncEngineEndToEndPerfTest extends DebeziumEndToEndPerfTest {
         @Param({ "1", "2", "4", "8", "16" })
         public int threadCount;
@@ -338,21 +315,6 @@ public class PostgresEndToEndPerf {
                     .notifying(getRecordConsumer(consumedLines))
                     .using(this.getClass().getClassLoader())
                     .build();
-        }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.SingleShotTime)
-    @OutputTimeUnit(TimeUnit.SECONDS)
-    @Fork(value = 1)
-    @Warmup(iterations = 1)
-    @Measurement(iterations = 1, time = 1)
-    public void processRecordsEmbeddedEngine(EmbeddedEngineEndToEndPerfTest state) {
-        List<EmbeddedEngineChangeEvent> records = new ArrayList<>();
-        while (records.size() < state.eventCount) {
-            List<EmbeddedEngineChangeEvent> temp = new ArrayList<>();
-            state.consumedLines.drainTo(temp);
-            records.addAll(temp);
         }
     }
 

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserPerf.java
@@ -131,7 +131,7 @@ public class LogMinerDmlParserPerf {
     @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
     public void testUpdates(ParserState state) {
-        state.dmlParser.parse(state.deleteDml, state.table);
+        state.dmlParser.parse(state.updateDml, state.table);
     }
 
     @Benchmark


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8444

Just for curiosity, Oracle microbenchmark numbers

* embedded engine:

```
Benchmark                                           (columnCount)  (dmlEvents)  (miningStrategy)   Mode  Cnt        Score        Error  Units
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              1          N/A               N/A  thrpt    3  1879060.534 ±  68113.973  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              2          N/A               N/A  thrpt    3   996384.807 ±  98246.248  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              5          N/A               N/A  thrpt    3   399696.024 ± 195095.453  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             10          N/A               N/A  thrpt    3   233348.983 ±  25210.877  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             20          N/A               N/A  thrpt    3   119452.802 ±  14187.666  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             50          N/A               N/A  thrpt    3    44075.951 ±   4534.130  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              1          N/A               N/A  thrpt    3  2820949.504 ± 149855.297  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              2          N/A               N/A  thrpt    3  1529314.077 ± 845151.338  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              5          N/A               N/A  thrpt    3   683778.457 ± 228171.260  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             10          N/A               N/A  thrpt    3   327613.243 ±  85037.653  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             20          N/A               N/A  thrpt    3   163378.646 ±  36319.655  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             50          N/A               N/A  thrpt    3    65781.022 ±   8620.477  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              1          N/A               N/A  thrpt    3  1789144.442 ± 374233.150  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              2          N/A               N/A  thrpt    3  1085500.847 ±  10443.444  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              5          N/A               N/A  thrpt    3   450728.183 ± 143940.082  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             10          N/A               N/A  thrpt    3   218992.231 ± 214185.388  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             20          N/A               N/A  thrpt    3   121850.039 ±   5203.660  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             50          N/A               N/A  thrpt    3    48707.143 ±   1745.060  ops/s
i.d.p.c.o.EndToEndPerf.capture                                N/A         1000  redo_log_catalog     ss            32.524                s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         1000    online_catalog     ss             8.545                s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         5000  redo_log_catalog     ss            27.906                s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         5000    online_catalog     ss             7.707                s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A        10000  redo_log_catalog     ss            25.727                s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A        10000    online_catalog     ss             5.640                s/op
```

* async engine:

```
Benchmark                                           (columnCount)  (dmlEvents)  (miningStrategy)   Mode  Cnt        Score         Error  Units
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              1          N/A               N/A  thrpt    3  1692755.422 ±  349304.974  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              2          N/A               N/A  thrpt    3   875249.821 ± 1616481.165  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes              5          N/A               N/A  thrpt    3   350754.841 ±   50260.576  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             10          N/A               N/A  thrpt    3   193491.370 ±  130267.226  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             20          N/A               N/A  thrpt    3   103913.934 ±   17547.187  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testDeletes             50          N/A               N/A  thrpt    3    40295.160 ±   10953.332  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              1          N/A               N/A  thrpt    3  2192101.060 ± 2769386.407  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              2          N/A               N/A  thrpt    3  1278978.574 ± 1901957.924  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts              5          N/A               N/A  thrpt    3   562303.266 ±  411194.388  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             10          N/A               N/A  thrpt    3   295535.403 ±  126617.723  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             20          N/A               N/A  thrpt    3   138985.585 ±   84457.405  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testInserts             50          N/A               N/A  thrpt    3    57115.509 ±   45481.640  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              1          N/A               N/A  thrpt    3  1359793.047 ± 1359869.946  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              2          N/A               N/A  thrpt    3   816819.198 ±  193223.164  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates              5          N/A               N/A  thrpt    3   325279.329 ±  550157.741  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             10          N/A               N/A  thrpt    3   204468.042 ±   10372.493  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             20          N/A               N/A  thrpt    3    98261.184 ±   30164.645  ops/s
i.d.p.c.o.parser.LogMinerDmlParserPerf.testUpdates             50          N/A               N/A  thrpt    3    36384.182 ±   19930.931  ops/s
i.d.p.c.o.EndToEndPerf.capture                                N/A         1000  redo_log_catalog     ss            27.778                 s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         1000    online_catalog     ss             8.958                 s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         5000  redo_log_catalog     ss            29.733                 s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A         5000    online_catalog     ss             7.480                 s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A        10000  redo_log_catalog     ss            37.075                 s/op
i.d.p.c.o.EndToEndPerf.capture                                N/A        10000    online_catalog     ss             5.442                 s/op
```

I run the tests several times and the numbers from the same test differ quite a lot, so it cannot be used for any conclusions about the performance as my laptop is probably not a stable test environment. It's really just for curiosity to have the numbers somewhere before removing embedded engine.