### PR TITLE
DBZ-8945 Apicurio registry configuration should include instructions for confluent compatibility mode

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -80,6 +80,7 @@ This makes each record even smaller. For an I/O bound system like Kafka, this me
 
 * Avro _Serdes_ (serializers and deserializers) for Kafka producers and consumers.
 Kafka consumer applications that you write to consume change event records can use Avro Serdes to deserialize the change event records.
+* Apicurio's _Confluent compatibility mode_, enabled by setting `as-confluent: true`, allows Apicurio Registry to serialize Kafka messages using the same wire format as Confluent Schema Registry (including the magic byte and 4-byte schema ID). This enables full interoperability with Confluent clients and tools, making Apicurio a drop-in replacement without requiring changes to producers or consumers.
 
 To use the {registry} with {prodname}, add {registry} converters and their dependencies to the Kafka Connect container image that you are using for running a {prodname} connector.
 
@@ -128,6 +129,28 @@ value.converter=io.apicurio.registry.utils.converter.AvroConverter
 value.converter.apicurio.registry.url=http://apicurio:8080/apis/registry/v2
 value.converter.apicurio.registry.auto-register=true
 value.converter.apicurio.registry.find-latest=true
+schema.name.adjustment.mode=avro
+----
+or you can use the _Confluent Compatibility mode_ as follows:
++
+[source,options="nowrap"]
+----
+key.converter=io.apicurio.registry.utils.converter.AvroConverter
+key.converter.apicurio.registry.url=http://apicurio:8080/apis/registry/v2
+key.converter.apicurio.registry.auto-register=true
+key.converter.apicurio.registry.find-latest=true
+key.converter.schemas.enable": "false"
+key.converter.apicurio.registry.headers.enabled": "false"
+key.converter.apicurio.registry.as-confluent": "true"
+key.converter.apicurio.use-id: "contentId"
+value.converter=io.apicurio.registry.utils.converter.AvroConverter
+value.converter.apicurio.registry.url=http://apicurio:8080/apis/registry/v2
+value.converter.apicurio.registry.auto-register=true
+value.converter.apicurio.registry.find-latest=true
+value.converter.schemas.enable": "false"
+value.converter.apicurio.registry.headers.enabled": "false"
+value.converter.apicurio.registry.as-confluent": "true"
+value.converter.apicurio.use-id: "contentId"
 schema.name.adjustment.mode=avro
 ----
 

--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -154,6 +154,14 @@ value.converter.apicurio.use-id: "contentId"
 schema.name.adjustment.mode=avro
 ----
 
+When using Apicurio Registry in Confluent compatibility mode, the parameters are configured in a specific way to imitate exactly how Confluent Schema Registry works, both on the wire format and in client expectations.
+
+* `converter.apicurio.registry.as-confluent: true`:
+Forces Apicurio to serialize Kafka messages with the same structure as Confluent (magic byte + 4-byte schema ID).
+* `converter.apicurio.use-id: true` (or `globalId`): Ensures that only a numeric schema ID is written in the message, matching what Confluent consumers expect.
+* `converter.schemas.enable: false`: Prevents embedding the full Avro schema inside the Kafka message, which Confluent deserializers do not expect (they fetch the schema by ID from the registry).
+* `converter.apicurio.registry.headers.enabled: false`: Disables Apicurio-specific metadata headers that Confluent clients wouldn't understand, keeping the message format clean and compatible.
+
 Internally, Kafka Connect always uses JSON key/value converters for storing configuration and offsets.
 
 // Type: procedure


### PR DESCRIPTION
### Context

The documentation on Avro schema registry has two sections - Apicurio registry and Confluent registry.   However it doesn't have anything for Apicurio in "compatibility mode".  however the Apicurio mode is not very popular but It's possible to run Apicurio serialization in compatibilty mode with just a few settings

### Changes
We propose to add a section in the avro serialization documentation that explain how to use the __confluent compatibility mode__. 

closes: https://issues.redhat.com/browse/DBZ-8945