### PR TITLE
Update Cassandra connector docs for conn config

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -955,7 +955,7 @@ To re-bootstrap an individual table, you can manually remove the recorded offset
 
 The Cassandra connector should be deployed each Cassandra node in a Cassandra cluster.
 The Cassandra connector Jar file takes in a CDC configuration (.properties) file.
-See xref:{link-cassandra-connector}#cassandra-example-configuration[see example configurations] for reference.
+See xref:{link-cassandra-connector}#cassandra-example-configuration[example configurations] for reference.
 
 [[cassandra-example-configuration]]
 === Example configuration
@@ -988,6 +988,45 @@ snapshot.consistency=ONE
 snapshot.mode=ALWAYS
 
 latest.commit.log.only=true
+----
+
+[[cassandra-connection-configuration]]
+=== Connection Configuration
+
+Cassanadra connector uses the Cassandra driver to configure connections to Cassanadra, which must be supplied using a
+separate `application.conf` file. You can find a full reference on the driver's configuration
+https://docs.datastax.com/en/developer/java-driver/4.2/manual/core/configuration/reference/[here] and below is an
+example:
+
+[source,properties,indent=0]
+----
+datastax-java-driver {
+  basic {
+    request.timeout = 20 seconds
+    contact-points = [ "spark-master-1:9042" ]
+    load-balancing-policy {
+      local-datacenter = "dc1"
+    }
+  }
+  advanced {
+    auth-provider {
+      class = PlainTextAuthProvider
+      username = user
+      password = pass
+    }
+    ssl-engine-factory {
+     ...
+    }
+  }
+}
+----
+
+In order for the Debezium connector to read/use this application configuration file, it must be set in the connector
+properties file as follows:
+
+[source,properties,indent=0]
+----
+cassandra.driver.config.file=/path/to/application/configuration.conf
 ----
 
 [[cassandra-monitoring]]
@@ -1091,29 +1130,9 @@ Must be one of 'INITIAL', 'ALWAYS', or 'NEVER'. The default snapshot mode is 'IN
 |No default
 |The absolute path of the YAML config file used by a Cassandra node.
 
-|[[cassandra-property-cassandra-hosts]]<<cassandra-property-cassandra-hosts, `cassandra.hosts`>>
-|`localhost`
-|One or more addresses of Cassandra nodes that driver uses to discover topology, separated by ","
-
-|[[cassandra-property-cassandra-port]]<<cassandra-property-cassandra-port, `cassandra.port`>>
-|`9042`
-|The port used to connect to Cassandra host(s).
-
-|[[cassandra-property-cassandra-username]]<<cassandra-property-cassandra-username, `cassandra.username`>>
-|No default
-|The username used when connecting to Cassandra hosts.
-
-|[[cassandra-property-cassandra-password]]<<cassandra-property-cassandra-password, `cassandra.password`>>
-|No default
-|The password used when connecting to Cassandra hosts.
-
-|[[cassandra-property-cassandra-ssl-enabled]]<<cassandra-property-cassandra-ssl-enabled, `cassandra.ssl.enabled`>>
-|`false`
-|If set to true, Cassandra connector agent will use SSL to connect to Cassandra node.
-
-|[[cassandra-property-cassandra-ssl-config-path]]<<cassandra-property-cassandra-ssl-config-path, `cassandra.ssl.config.path`>>
-|No default
-|The SSL config file path required for storage node. An example of config file can be found at the bottom of the page.
+|[[cassandra-property-cassandra-driver-config-file]]<<cassandra-property-cassandra-driver-config-file, `cassandra.driver.config.file`>>
+|`application.conf`
+|Path to Cassandra driver configuration file
 
 |[[cassandra-property-commit-log-real-time-processing-enabled]]<<cassandra-property-commit-log-real-time-processing-enabled, `commit.log.real.time.processing.enabled`>>
 |`false`


### PR DESCRIPTION
This commit updates the Cassandra connector documentation for connection configurations.
https://github.com/debezium/debezium-connector-cassandra/commit/3fe4963a61bf0919384f75267eb030f92ff15622#diff-cb8507d61cddae8b7d293cd7100ffe8afe87ef201c54a231d1a24243187f468a removed many of the Cassandra connection configuration parameters and replaced them with a single parameter, `cassandra.driver.config.file`, which is a path to a configuration file for the Cassandra driver. The removed connection parameters have to be configured with the Cassandra driver now, not with the connector itself. This commit updates the documentation to reflect this change. The language of the documentation is mostly taken from this blog post,
https://debezium.io/blog/2022/03/25/debezium-1-9-cr1-released/, which details the change.