### PR TITLE
Dbz 8940 Processing error because of incomplete date part of DATETIME datatype in MariaDB

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/AbstractBinlogConnectorIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/AbstractBinlogConnectorIT.java
@@ -11,6 +11,7 @@ import org.apache.kafka.connect.source.SourceConnector;
 
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.jdbc.JdbcConnection;
 
 /**
  * Abstract base class for all binlog-based connector integration tests.
@@ -50,4 +51,16 @@ public abstract class AbstractBinlogConnectorIT<C extends SourceConnector>
         }
     }
 
+    @Override
+    public void executeStatements(String targetDatabase, String... statements) {
+        try (JdbcConnection jdbcConnection = getTestDatabaseConnection(targetDatabase).connect();
+                var statement = jdbcConnection.connection().createStatement()) {
+            for (String sql : statements) {
+                statement.execute(sql);
+            }
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConnectorTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConnectorTest.java
@@ -24,4 +24,9 @@ public interface BinlogConnectorTest<C extends SourceConnector> {
     BinlogTestConnection getTestReplicaDatabaseConnection(String databaseName);
 
     boolean isMariaDb();
+
+    default void executeStatements(String databaseName, String... statements) {
+        throw new UnsupportedOperationException("not support operation for the datasource");
+    }
+
 }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/SnapshotSourceIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/SnapshotSourceIT.java
@@ -5,8 +5,12 @@
  */
 package io.debezium.connector.mariadb;
 
+import org.junit.Test;
+
 import io.debezium.config.Field;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.binlog.BinlogSnapshotSourceIT;
+import io.debezium.doc.FixFor;
 
 /**
  * @author Chris Cranford
@@ -25,5 +29,37 @@ public class SnapshotSourceIT extends BinlogSnapshotSourceIT<MariaDbConnector> i
     @Override
     protected String getSnapshotLockingModeNone() {
         return MariaDbConnectorConfig.SnapshotLockingMode.NONE.getValue();
+    }
+
+    @Test
+    @FixFor("DBZ-8940")
+    public void shouldCompleteTheSnapshotWithZeroDateValues() throws InterruptedException {
+        executeStatements(DATABASE.getDatabaseName(),
+                "CREATE TABLE zero_date_table (zero_date DATETIME);",
+                "INSERT INTO zero_date_table VALUES (\"2015-00-12 00:00:00\");");
+
+        config = simpleConfig()
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, "connector_test_ro_(.*).zero_date_table")
+                .build();
+
+        start(getConnectorClass(), config);
+
+        waitForSnapshotToBeCompleted(getConnectorName(), DATABASE.getServerName());
+    }
+
+    @Test
+    @FixFor("DBZ-8940")
+    public void shouldCompleteTheSnapshotWithDefaultZeroDateValue() throws InterruptedException {
+        executeStatements(DATABASE.getDatabaseName(),
+                "CREATE TABLE zero_date_table (zero_date DATETIME DEFAULT '2015-00-12 00:00:00');",
+                "INSERT INTO zero_date_table VALUES (NULL);");
+
+        config = simpleConfig()
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, "connector_test_ro_(.*).zero_date_table")
+                .build();
+
+        start(getConnectorClass(), config);
+
+        waitForSnapshotToBeCompleted(getConnectorName(), DATABASE.getServerName());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <version.informix.changestream.client>1.1.3</version.informix.changestream.client>
         <version.informix.driver>4.50.11</version.informix.driver>
         <version.cassandra.driver>4.14.0</version.cassandra.driver>
-        <version.mariadb.driver>3.5.0</version.mariadb.driver>
+        <version.mariadb.driver>3.5.3</version.mariadb.driver>
         <!-- These two should be aligned by major versions but minor could vary -->
         <!-- Oracle publishes the driver versions more frequently than the instant client -->
         <version.oracle.driver>21.15.0.0</version.oracle.driver>


### PR DESCRIPTION
## Context

MariaDB allows `DATETIME` values with incomplete date parts (e.g., `2015-00-12` is considered valid by MariaDB).
In Debezium MariaDB connector versions up to 3.0.7.Final, such values were silently converted to `null`.
Starting with 3.0.8.Final and 3.1.x, processing these incomplete DATETIME values causes the connector to fail with a `java.time.DateTimeException`.

## Changes

The current behavior causes the connector to fail when encountering invalid or incomplete DATETIME values. The root cause is a regression introduced by `maria-db-client` with version >`3.2.0`. We update the  client to `3.5.3`.

## References
[Supported values for datetime in MariaDB](https://mariadb.com/kb/en/datetime/#supported-values)
[Dates conatining zero day or month result into DateTimeException](https://jira.mariadb.org/browse/CONJ-1226)


closes https://issues.redhat.com/browse/DBZ-8940