### PR TITLE
DBZ-8979 JdbcSchemaHistory Fails to Handle Data Sharding When Recovering Records

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
@@ -170,30 +170,26 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                             StringBuilder historyDataBuilder = new StringBuilder();
                             boolean isNotFirst = false;
                             while (rs.next()) {
-                                // warning: No continuity check - nice to have
-                                int recordInsertSeq = rs.getInt("history_data_seq");
+
+                                int insertSeq = rs.getInt("history_data_seq");
                                 String historyDataSpc = rs.getString("history_data");
-                                // Reduce if else execution
+
                                 if (isNotFirst) {
-                                    // must be ordered by ts asc !!!
-                                    // check if the prev record is the completed json
-                                    if (recordInsertSeq == 0) {
+                                    if (insertSeq == 0) {
                                         try {
                                             records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));
                                         } catch (IOException e) {
                                             throw new DebeziumException(e);
                                         }
-                                        // clear
                                         historyDataBuilder.setLength(0);
                                     }
                                     historyDataBuilder.append(historyDataSpc);
                                 } else {
-                                    // first record
                                     historyDataBuilder.append(historyDataSpc);
                                     isNotFirst = true;
                                 }
                             }
-                            // the last record  - must not be empty
+
                             if (!historyDataBuilder.isEmpty()) {
                                 try {
                                     records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
@@ -167,7 +167,7 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                         try (
                                 Statement stmt = conn.createStatement();
                                 ResultSet rs = stmt.executeQuery(config.getTableSelect())) {
-                            StringBuilder historyDataBuilder = new StringBuilder();
+                            StringBuilder historyDataStrBuilder = new StringBuilder();
                             boolean isNotFirst = false;
                             while (rs.next()) {
 
@@ -177,22 +177,22 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                                 if (isNotFirst) {
                                     if (insertSeq == 0) {
                                         try {
-                                            records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));
+                                            records.accept(new HistoryRecord(reader.read(historyDataStrBuilder.toString())));
                                         } catch (IOException e) {
                                             throw new DebeziumException(e);
                                         }
-                                        historyDataBuilder.setLength(0);
+                                        historyDataStrBuilder.setLength(0);
                                     }
-                                    historyDataBuilder.append(historyDataSpc);
+                                    historyDataStrBuilder.append(historyDataSpc);
                                 } else {
-                                    historyDataBuilder.append(historyDataSpc);
+                                    historyDataStrBuilder.append(historyDataSpc);
                                     isNotFirst = true;
                                 }
                             }
 
-                            if (!historyDataBuilder.isEmpty()) {
+                            if (!historyDataStrBuilder.isEmpty()) {
                                 try {
-                                    records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));
+                                    records.accept(new HistoryRecord(reader.read(historyDataStrBuilder.toString())));
                                 } catch (IOException e) {
                                     throw new DebeziumException(e);
                                 }

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
@@ -167,16 +167,38 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                         try (
                                 Statement stmt = conn.createStatement();
                                 ResultSet rs = stmt.executeQuery(config.getTableSelect())) {
+                            StringBuilder historyDataBuilder = new StringBuilder();
+                            boolean isNotFirst = false;
                             while (rs.next()) {
-                                String historyData = rs.getString("history_data");
-
-                                if (historyData.isEmpty() == false) {
-                                    try {
-                                        records.accept(new HistoryRecord(reader.read(historyData)));
+                                // warning: No continuity check - nice to have
+                                int recordInsertSeq = rs.getInt("history_data_seq");
+                                String historyDataSpc = rs.getString("history_data");
+                                // Reduce if else execution
+                                if (isNotFirst) {
+                                    // must be ordered by ts asc !!!
+                                    // check if the prev record is the completed json
+                                    if (recordInsertSeq == 0) {
+                                        try {
+                                            records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));
+                                        } catch (IOException e) {
+                                            throw new DebeziumException(e);
+                                        }
+                                        // clear
+                                        historyDataBuilder.setLength(0);
                                     }
-                                    catch (IOException e) {
-                                        throw new DebeziumException(e);
-                                    }
+                                    historyDataBuilder.append(historyDataSpc);
+                                } else {
+                                    // first record
+                                    historyDataBuilder.append(historyDataSpc);
+                                    isNotFirst = true;
+                                }
+                            }
+                            // the last record  - must not be empty
+                            if (!historyDataBuilder.isEmpty()) {
+                                try {
+                                    records.accept(new HistoryRecord(reader.read(historyDataBuilder.toString())));
+                                } catch (IOException e) {
+                                    throw new DebeziumException(e);
                                 }
                             }
                         }


### PR DESCRIPTION
[JdbcSchemaHistory Fails to Handle Data Sharding When Recovering Records](https://issues.redhat.com/browse/DBZ-8979)

https://issues.redhat.com/browse/DBZ-8979