### PR TITLE
Prevent logging sensitive data in AbstractSchemaHistory

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -40,7 +40,10 @@ import io.debezium.relational.ddl.DdlParser;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
+import io.debezium.util.Loggings;
 import io.debezium.util.Testing;
+
+import ch.qos.logback.classic.Level;
 
 /**
  * @author Randall Hauch
@@ -301,6 +304,9 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
     @Test
     public void shouldSkipMessageOnDDLFilter() throws Exception {
         String topicName = "stop-on-ddlfilter-schema-changes";
+
+        final LogInterceptor logInterceptor = new LogInterceptor(Loggings.class);
+        logInterceptor.setLoggerLevel(Loggings.class, Level.TRACE);
 
         // Create the empty topic ...
         kafka.createTopic(topicName, 1, 1);

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
@@ -28,6 +28,7 @@ import io.debezium.relational.history.TableChanges.TableChangesSerializer;
 import io.debezium.text.MultipleParsingExceptions;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Clock;
+import io.debezium.util.Loggings;
 
 /**
  * @author Randall Hauch
@@ -131,8 +132,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
                         ddlParser.setCurrentSchema(recovered.schemaName()); // may be null
                     }
                     if (ddlFilter.test(ddl)) {
-                        logger.info("a DDL '{}' was filtered out of processing by regular expression '{}'", ddl,
-                                config.getString(DDL_FILTER));
+                        Loggings.logDebugAndTraceRecord(logger, ddl, "A DDL was filtered out of processing by regular expression '{}'", config.getString(DDL_FILTER));
                         return;
                     }
                     try {

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
@@ -132,7 +132,8 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
                         ddlParser.setCurrentSchema(recovered.schemaName()); // may be null
                     }
                     if (ddlFilter.test(ddl)) {
-                        Loggings.logDebugAndTraceRecord(logger, ddl, "A DDL was filtered out of processing by regular expression '{}'", config.getString(DDL_FILTER));
+                        logger.info("a DDL '{}' was filtered out of processing by regular expression '{}'",
+                                Loggings.maybeRedactSensitiveData(ddl), config.getString(DDL_FILTER));
                         return;
                     }
                     try {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8999

## Update DDL filter logging to prevent exposing sensitive data

### Problem
When Debezium connectors start up, they replay previously ingested DDL statements from Kafka schema history topics. During this process, the connector logs filtered DDL statements at INFO level, potentially exposing sensitive data like hashed passwords to log aggregation systems.

### Change
Updated the DDL filter logging in AbstractSchemaHistory to use debug/trace level instead of info level by replacing the direct logger call with Loggings.logDebugAndTraceRecord(). This prevents sensitive DDL content from appearing in standard logs and log aggregation platforms like Observe.

### Testing 
Testing performed on shopify [fork](https://github.com/Shopify/debezium) 