### PR TITLE
DBZ-9003 Prevent `idle in transaction` connection state with initial only snapshots

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -121,6 +121,13 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
     }
 
     @Override
+    public void close() {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Override
     public void execute(ChangeEventSourceContext context, PostgresPartition partition, PostgresOffsetContext offsetContext)
             throws InterruptedException {
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -311,18 +311,26 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
     }
 
     protected void streamEvents(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException {
-        initStreamEvents(partition, offsetContext);
-        getSignalProcessor(previousOffsets).ifPresent(signalProcessor -> registerSignalActionsAndStartProcessor(signalProcessor,
-                eventDispatcher, this, connectorConfig));
+        try {
+            initStreamEvents(partition, offsetContext);
+            getSignalProcessor(previousOffsets).ifPresent(signalProcessor -> registerSignalActionsAndStartProcessor(signalProcessor,
+                    eventDispatcher, this, connectorConfig));
 
-        if (snapshotterService != null && !snapshotterService.getSnapshotter().shouldStream()) {
-            LOGGER.info("Streaming is disabled for snapshot mode {}", snapshotterService.getSnapshotter().name());
-            return;
+            if (snapshotterService != null && !snapshotterService.getSnapshotter().shouldStream()) {
+                LOGGER.info("Streaming is disabled for snapshot mode {}", snapshotterService.getSnapshotter().name());
+                return;
+            }
+
+            LOGGER.info("Starting streaming");
+            streamingSource.execute(context, partition, offsetContext);
+            LOGGER.info("Finished streaming");
         }
-
-        LOGGER.info("Starting streaming");
-        streamingSource.execute(context, partition, offsetContext);
-        LOGGER.info("Finished streaming");
+        finally {
+            if (streamingSource != null) {
+                // Close streaming source
+                streamingSource.close();
+            }
+        }
     }
 
     protected void initStreamEvents(P partition, O offsetContext) throws InterruptedException {
@@ -381,11 +389,6 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                 Thread.interrupted();
                 blockingSnapshotExecutor.shutdownNow();
                 blockingSnapshotExecutor.awaitTermination(SHUTDOWN_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-            }
-
-            if (streamingSource != null) {
-                // Close streaming source
-                streamingSource.close();
             }
 
             Optional<SignalProcessor<P, O>> processor = getSignalProcessor(previousOffsets);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9003

@jpechane this is in reference to the Zulip conversation [#community-postgresql > Snapshot connectors cause idle in transaction @ 💬](https://debezium.zulipchat.com/#narrow/channel/348249-community-postgresql/topic/Snapshot.20connectors.20cause.20idle.20in.20transaction/near/515885512). I need to test this change against my recent expectations with the Oracle LogMiner unification, but I have little cause for concern.