### PR TITLE
DBZ-9009 Fixing compilation failure in debezium-core 3.1 branch

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import java.io.Closeable;
 import java.util.Map;
 
 import io.debezium.pipeline.spi.OffsetContext;
@@ -15,7 +16,8 @@ import io.debezium.pipeline.spi.Partition;
  *
  * @author Gunnar Morling
  */
-public interface StreamingChangeEventSource<P extends Partition, O extends OffsetContext> extends ChangeEventSource {
+public interface StreamingChangeEventSource<P extends Partition, O extends OffsetContext> extends ChangeEventSource,
+        Closeable {
 
     /**
      * Initializes the streaming source.
@@ -72,5 +74,9 @@ public interface StreamingChangeEventSource<P extends Partition, O extends Offse
 
     default O getOffsetContext() {
         return null;
+    }
+
+    @Override
+    default void close() {
     }
 }


### PR DESCRIPTION
Fixing compilation failure. Issue [ticket](https://issues.redhat.com/browse/DBZ-9009).