### PR TITLE
DBZ-9018: fix issues using latest jdbc driver

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
@@ -18,13 +18,16 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.HeaderFrom;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.junit.SkipTestDependingOnDecoderPluginNameRule;
 import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
 import io.debezium.connector.postgresql.transforms.DecodeLogicalDecodingMessageContent;
 import io.debezium.converters.AbstractCloudEventsConverterTest;
@@ -59,6 +62,9 @@ public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<Pos
             ");";
 
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);";
+
+    @Rule
+    public final TestRule skipName = new SkipTestDependingOnDecoderPluginNameRule();
 
     @Before
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2737,8 +2737,7 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         final Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SHOULD_FLUSH_LSN_IN_SOURCE_DB, "false")
                 .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false")
-                .with(PostgresConnectorConfig.STATUS_UPDATE_INTERVAL_MS, 10_000);
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false");
 
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2737,7 +2737,8 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         final Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SHOULD_FLUSH_LSN_IN_SOURCE_DB, "false")
                 .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false");
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false")
+                .with(PostgresConnectorConfig.STATUS_UPDATE_INTERVAL_MS, 10_000);
 
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1096,7 +1096,7 @@ public class JdbcConnection implements AutoCloseable {
                 String catalogName = rs.getString(1);
                 String schemaName = rs.getString(2);
                 String tableName = rs.getString(3);
-                TableId tableId = new TableId(catalogName, schemaName, tableName);
+                TableId tableId = createTableId(catalogName, schemaName, tableName);
                 tableIds.add(tableId);
             }
         }
@@ -1198,14 +1198,14 @@ public class JdbcConnection implements AutoCloseable {
                 final String tableType = rs.getString(4);
                 if (isTableType(tableType)) {
                     totalTables++;
-                    TableId tableId = new TableId(catalogName, schemaName, tableName);
+                    TableId tableId = createTableId(catalogName, schemaName, tableName);
                     if (tableFilter == null || tableFilter.isIncluded(tableId)) {
                         tableIds.add(tableId);
                         attributesByTable.putAll(getAttributeDetails(tableId, tableType));
                     }
                 }
                 else {
-                    TableId tableId = new TableId(catalogName, schemaName, tableName);
+                    TableId tableId = createTableId(catalogName, schemaName, tableName);
                     viewIds.add(tableId);
                 }
             }
@@ -1277,7 +1277,7 @@ public class JdbcConnection implements AutoCloseable {
                 String catalogName = resolveCatalogName(columnMetadata.getString(1));
                 String schemaName = columnMetadata.getString(2);
                 String metaTableName = columnMetadata.getString(3);
-                TableId tableId = new TableId(catalogName, schemaName, metaTableName);
+                TableId tableId = createTableId(catalogName, schemaName, metaTableName);
 
                 // exclude views and non-captured tables
                 if (viewIds.contains(tableId) ||


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9018 

Apache Camel-Quarkus debezium-postgres update & delete tests are failing after upgrading the Postgres JDBC driver from 42.7.4 to 42.7.5 [1].

In Version 42.7.5 `getTables` includes the database name [2] and `TableIds` created using 'catalogName/databaseName', 'schemaName', and 'table' from the result-set do not equal the `TableIds` created from messages read from the replication stream that feature only 'schemaName' and 'table'.

Fixed unit test problem in `PostgresConnectorIT`. In Version 42.7.0 the LSN of the of the keepAlive message is used to advance the flush LSN [3].  This causes the test to fail if a 'status-update' packet is sent during the test.  We can set the 'status-update' interval so that it is not sent during test execution.

Also Added the `SkipTestDependingOnDecoderPluginNameRule` to `CloundEventsConverterIT` in order to correctly skip a test that should not be run when the decoderPlungin name is not 'pgoutput'


1. https://github.com/apache/camel-quarkus/issues/6911
2. https://github.com/pgjdbc/pgjdbc/blob/REL42.7.5/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L1434
3. https://github.com/pgjdbc/pgjdbc/pull/2941/files#diff-5d411513d3e0fcbc7d3eefaaaf24e5a845a9655d277f6ab1e54f7f9de66d7df9R241