### PR TITLE
DBZ-8982 Leave last event w/i single PK in JDBC

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/Buffer.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/Buffer.java
@@ -41,4 +41,10 @@ public interface Buffer {
      * @return the table descriptor
      */
     TableDescriptor getTableDescriptor();
+
+    /**
+     * to remove a {@link JdbcSinkRecord} from the internal buffer and
+     * @param record the Debezium sink record
+     */
+    void remove(JdbcSinkRecord record);
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -119,7 +119,12 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 if (upsertBufferToFlush != null && !upsertBufferToFlush.isEmpty()) {
                     // When a delete event arrives, update buffer must be flushed to avoid losing the delete
                     // for the same record after its update.
-                    flushBufferWithRetries(collectionId, upsertBufferToFlush);
+                    if (config.isUseReductionBuffer()) {
+                        upsertBufferToFlush.remove(record);
+                    }
+                    else {
+                        flushBufferWithRetries(collectionId, upsertBufferToFlush);
+                    }
                 }
 
                 flushBufferRecordsWithRetries(collectionId, getRecordsToFlush(deleteBufferByTable, collectionId, record));
@@ -129,7 +134,12 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 if (deleteBufferToFlush != null && !deleteBufferToFlush.isEmpty()) {
                     // When an insert arrives, delete buffer must be flushed to avoid losing an insert for the same record after its deletion.
                     // this because at the end we will always flush inserts before deletes.
-                    flushBufferWithRetries(collectionId, deleteBufferToFlush);
+                    if (config.isUseReductionBuffer()) {
+                        deleteBufferToFlush.remove(record);
+                    }
+                    else {
+                        flushBufferWithRetries(collectionId, deleteBufferToFlush);
+                    }
                 }
 
                 flushBufferRecordsWithRetries(collectionId, getRecordsToFlush(upsertBufferByTable, collectionId, record));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/RecordBuffer.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/RecordBuffer.java
@@ -88,4 +88,9 @@ public class RecordBuffer implements Buffer {
     public TableDescriptor getTableDescriptor() {
         return tableDescriptor;
     }
+
+    @Override
+    public void remove(JdbcSinkRecord record) {
+        throw new IllegalStateException("Can't remove record in simple buffer");
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/ReducedRecordBuffer.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/ReducedRecordBuffer.java
@@ -98,4 +98,19 @@ public class ReducedRecordBuffer implements Buffer {
     public TableDescriptor getTableDescriptor() {
         return tableDescriptor;
     }
+
+    @Override
+    public void remove(JdbcSinkRecord record) {
+        if (records.isEmpty()) {
+            return;
+        }
+
+        Struct keyStruct = record.getKeyStruct(connectorConfig.getPrimaryKeyMode(), connectorConfig.getPrimaryKeyFields());
+        if (keyStruct != null) {
+            records.remove(keyStruct);
+        }
+        else {
+            throw new ConnectException("No struct-based primary key defined for record key/value, reduction buffer require struct based primary key");
+        }
+    }
 }


### PR DESCRIPTION
With a reduction buffer, we can leave only the last event within all buffers (delete and upsert buffers) since we can reduce events not only within a single buffer but across both of them.
