### PR TITLE
DBZ-9027 Support UUID columns in debezium-connector-mariadb

### DIFF
--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -223,6 +223,9 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
                 new DataTypeResolver.DataTypeEntry(Types.VARCHAR, MariaDBParser.LONG)
                         .setSuffixTokens(MariaDBParser.VARCHAR)));
 
+        dataTypeResolverBuilder.registerDataTypes(MariaDBParser.UuidDataTypeContext.class.getCanonicalName(), Arrays.asList(
+                new DataTypeResolver.DataTypeEntry(Types.OTHER, MariaDBParser.UUID)));
+
         return dataTypeResolverBuilder.build();
     }
 

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/UuidColumnIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/UuidColumnIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.AbstractBinlogConnectorIT;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.data.Envelope.FieldName;
+import io.debezium.data.Uuid;
+import io.debezium.doc.FixFor;
+import io.debezium.schema.SchemaFactory;
+
+/**
+ * @author Wouter Coekaerts
+ */
+public class UuidColumnIT extends AbstractBinlogConnectorIT<MariaDbConnector> implements MariaDbCommon {
+    private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-uuid-column.txt").toAbsolutePath();
+    private final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase("uuidcolumnit", "uuid_column_test").withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-9027")
+    public void shouldHandleUuidStreaming() throws Exception {
+        shouldHandleUuid(SnapshotMode.NEVER);
+    }
+
+    @Test
+    @FixFor("DBZ-9027")
+    public void shouldHandleUuidSnapshot() throws Exception {
+        shouldHandleUuid(SnapshotMode.INITIAL);
+    }
+
+    private void shouldHandleUuid(SnapshotMode snapshotMode) throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, snapshotMode)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("test_uuid"))
+                .build();
+
+        start(getConnectorClass(), config);
+
+        int insertRecordCount = 4; // number of insert statements in uuid_column_test.sql
+        List<SourceRecord> records = consumeSkippingSchemaChanges(insertRecordCount);
+
+        // verify the schema
+        Schema schema = records.get(0).valueSchema().field(FieldName.AFTER).schema();
+        assertThat(schema.field("id").schema()).isEqualTo(Uuid.schema());
+
+        // verify all the values: the UUID value should equal the value put in the "expected" char column
+        for (SourceRecord insertRecord : records) {
+            Struct after = ((Struct) insertRecord.value()).getStruct("after");
+            String expected = after.getString("expected");
+            assertThat(after.getString("id")).isEqualTo(expected);
+        }
+
+        stopConnector();
+    }
+
+    /** Consume numberOfRecords, but skipping SchemaChange events */
+    private List<SourceRecord> consumeSkippingSchemaChanges(int numberOfRecords) throws InterruptedException {
+        List<SourceRecord> recordList = new ArrayList<>();
+        consumeRecordsUntil((i, r) -> recordList.size() == numberOfRecords, (i, r) -> "", 3,
+                r -> {
+                    if (!((Struct) r.value()).schema().name().endsWith(SchemaFactory.SCHEMA_CHANGE_VALUE)) {
+                        recordList.add(r);
+                    }
+                }, true);
+        assertThat(recordList).hasSize(numberOfRecords);
+        return recordList;
+    }
+}

--- a/debezium-connector-mariadb/src/test/resources/ddl/uuid_column_test.sql
+++ b/debezium-connector-mariadb/src/test/resources/ddl/uuid_column_test.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `test_uuid` (
+    `id` uuid NOT NULL,
+    `expected` char(36),
+    PRIMARY KEY (`id`)
+);
+
+INSERT INTO test_uuid (`id`, `expected`) values ( '01020304-0506-0708-090a-0b0c0d0e0f10', '01020304-0506-0708-090a-0b0c0d0e0f10');
+INSERT INTO test_uuid (`id`, `expected`) values ( '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
+INSERT INTO test_uuid (`id`, `expected`) values ( '00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001');
+INSERT INTO test_uuid (`id`, `expected`) values ( 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'ffffffff-ffff-ffff-ffff-ffffffffffff');


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9027

This makes UUIDs columns in mariadb work.

I just noticed before submitting this PR that by pure coincidence work was being done on this already today in #6419 .
My changes here are bit more complete: they also handle the value conversion.

I put the tests in the mariadb module, instead of in the common binlog module with annotations on it to ignore them for mysql. I'm not sure what the preferred way is.
Note that this PR is putting the first file in `debezium-connector-mariadb/src/test/resources/ddl/`.

In the test I added a consumeSkippingSchemaChanges helper method because the number of records to skip is different between testing streaming vs snapshots; and I didn't want to hardcode imo fragile numbers of how many records to skip when.