### PR TITLE
DBZ-9062 Fix Oracle metrics regression and align behavior

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -1562,6 +1562,19 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     }
 
     /**
+     * Update common metrics on {@code COMMIT} events.
+     *
+     * @param event the event, should not be {@code null}
+     * @param commitDuration the duration of the commit operation, should not be {@code null}
+     */
+    protected void updateCommitMetrics(LogMinerEventRow event, Duration commitDuration) {
+        getMetrics().incrementCommittedTransactionCount();
+        getMetrics().setCommitScn(event.getScn());
+        getMetrics().setOffsetScn(getOffsetContext().getScn());
+        getMetrics().setLastCommitDuration(commitDuration);
+    }
+
+    /**
      * Check whether the event's table represents a dropped table that has been purged or is in the database's
      * object recycle-bin.
      *

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -492,10 +492,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
         }
 
-        getMetrics().incrementCommittedTransactionCount();
-        getMetrics().setCommitScn(commitScn);
-        getMetrics().setOffsetScn(getOffsetContext().getScn());
-        getMetrics().setLastCommitDuration(Duration.between(start, Instant.now()));
+        updateCommitMetrics(row, Duration.between(start, Instant.now()));
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -485,11 +485,10 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             getEventDispatcher().dispatchHeartbeatEvent(getPartition(), getOffsetContext());
         }
 
-        getMetrics().calculateLagFromSource(row.getChangeTime());
-
         if (transaction != null) {
             finalizeTransaction(transactionId, commitScn, false);
             cleanupAfterTransactionRemovedFromCache(transaction, false);
+            getMetrics().calculateLagFromSource(row.getChangeTime());
             getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
         }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -361,6 +361,8 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
         getOffsetContext().setUserName(event.getUserName());
         getOffsetContext().setTransactionId(event.getTransactionId());
         getOffsetContext().setTransactionSequence(null);
+
+        getMetrics().setActiveTransactionCount(1L);
     }
 
     @Override
@@ -389,6 +391,7 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
 
         getBatchMetrics().commitObserved();
 
+        getMetrics().setActiveTransactionCount(0L);
         updateCommitMetrics(event, Duration.between(commitStartTime, Instant.now()));
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -197,6 +197,7 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
 
     @Override
     protected void enqueueEvent(LogMinerEventRow event, LogMinerEvent dispatchedEvent) throws InterruptedException {
+        getMetrics().calculateLagFromSource(event.getChangeTime());
         accumulator.accept(dispatchedEvent);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -372,6 +372,8 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
                 event.getTransactionId(),
                 event.getScn());
 
+        final Instant commitStartTime = Instant.now();
+
         // These are COMMIT specific attributes that must be recorded
         getOffsetContext().getCommitScn().recordCommit(event);
         getOffsetContext().setEventScn(event.getScn());
@@ -386,6 +388,8 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
         getEventDispatcher().dispatchTransactionCommittedEvent(getPartition(), getOffsetContext(), event.getChangeTime());
 
         getBatchMetrics().commitObserved();
+
+        updateCommitMetrics(event, Duration.between(commitStartTime, Instant.now()));
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9062

This addresses several metrics issues:
- Fixes regression on lag calculation that was mistakenly changed
- Aligned commit metrics
- Introduced setting active transaction count to 1 on `START` and 0 on `COMMIT` for unbuffered impl.