### PR TITLE
DBZ-9000 Improve connector-level transaction filtering

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -325,6 +325,18 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     protected void handleStartEvent(LogMinerEventRow event) {
         final String transactionId = event.getTransactionId();
         if (!isRecentlyProcessed(transactionId)) {
+
+            // The internal.log.mining.buffer.memory.legacy.transaction.start property is only applicable for
+            // heap-based caches; however when its set the START event will not be provided, and therefore we
+            // attempt to do the filtering for username and client id at commit time. That means that events
+            // for the transaction will get buffered. The default behavior is the internal property is not
+            // enabled, so START events are observed, and can be used to filter entire transactions upfront,
+            // preventing the need to buffer the transaction to only later discard it.
+            if (isUserNameSkipped(event.getUserName()) || isClientIdSkipped(event.getClientId())) {
+                markTransactionSkipped(event.getTransactionId(), event.getScn());
+                return;
+            }
+
             final Transaction transaction = getTransactionCache().getTransaction(transactionId);
             if (transaction == null) {
                 getTransactionCache().addTransaction(transactionFactory.createTransaction(event));
@@ -342,7 +354,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     protected void handleCommitEvent(LogMinerEventRow row) throws InterruptedException {
         final String transactionId = row.getTransactionId();
         if (isRecentlyProcessed(transactionId)) {
-            LOGGER.debug("\tTransaction is already committed, skipped.");
+            LOGGER.debug("Transaction {} has already been committed or was marked for skip.", transactionId);
             return;
         }
 
@@ -645,12 +657,12 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
         if (!minCacheScn.isNull()) {
             abandonTransactions(getConfig().getLogMiningTransactionRetention());
-
             getProcessedTransactionsCache().removeIf(entry -> Scn.valueOf(entry.getValue()).compareTo(minCacheScn) < 0);
             getSchemaChangesCache().removeIf(entry -> Scn.valueOf(entry.getKey()).compareTo(minCacheScn) < 0);
         }
         else {
-            getSchemaChangesCache().removeIf(e -> true);
+            getProcessedTransactionsCache().clear();
+            getSchemaChangesCache().clear();
         }
 
         if (!lastProcessedScn.isNull() && lastProcessedScn.compareTo(endScn) < 0) {
@@ -684,6 +696,16 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             getMetrics().setOffsetScn(getOffsetContext().getScn());
             return new ProcessResult(miningSessionStartScn, endScn);
         }
+    }
+
+    /**
+     * Marks the specific transaction as skipped.
+     *
+     * @param transactionId the transaction identifier, should not be {@code null}
+     * @param eventScn the transaction's starting system change number, should not be {@code null}
+     */
+    protected void markTransactionSkipped(String transactionId, Scn eventScn) {
+        getProcessedTransactionsCache().put(transactionId, eventScn.toString());
     }
 
     /**
@@ -813,7 +835,13 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
      * @return true if the transaction should be skipped and not dispatched, false otherwise
      */
     private boolean isTransactionSkippedAtCommit(Transaction transaction) {
-        // todo: can this be moved to earlier in the processing loop to avoid buffering?
+        // As mentioned in the handleStartEvent method, internal.log.mining.buffer.memory.legacy.transaction.start
+        // restores legacy behavior to omit providing START events to the connector when using heap-based caches.
+        // In these cases, the transaction will be buffered regardless, and therefore we still need to check if we
+        // can skip the transaction at commit-time, although this is not always reliable. That's because Oracle
+        // only guarantees providing the USERNAME and CLIENT_ID fields if and only if the START event is present
+        // in the mining step. So for full reliability, it's best to leave the internal configuration set to its
+        // default of false to guarantee transactions are skipped for username and client id values.
         return transaction != null && (isUserNameSkipped(transaction.getUserName()) || isClientIdSkipped(transaction.getClientId()));
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/CacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/CacheProvider.java
@@ -59,10 +59,10 @@ public interface CacheProvider<T extends Transaction> extends AutoCloseable {
      *
      * <ul>
      *     <li>Key - The unique transaction id</li>
-     *     <li>Value - The transaction's commit or rollback system change number</li>
+     *     <li>Value - The processed transaction object/li>
      * </ul>
      *
      * @return the processed transactions cache, never {@code null}
      */
-    LogMinerCache<String, String> getProcessedTransactionsCache();
+    LogMinerCache<String, ProcessedTransaction> getProcessedTransactionsCache();
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ProcessedTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ProcessedTransaction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import java.util.Objects;
+
+import io.debezium.connector.oracle.Scn;
+
+/**
+ * Represents a transaction that was processed or skipped.
+ *
+ * @author Chris Cranford
+ */
+public class ProcessedTransaction {
+
+    public enum ProcessType {
+        PROCESSED,
+        SKIPPED
+    }
+
+    private final String transactionId;
+    private final Scn startScn;
+    private final ProcessType processType;
+
+    public ProcessedTransaction(String transactionId, Scn startScn, ProcessType processType) {
+        this.transactionId = transactionId;
+        this.startScn = startScn;
+        this.processType = processType;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public Scn getStartScn() {
+        return startScn;
+    }
+
+    public ProcessType getProcessType() {
+        return processType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ProcessedTransaction that = (ProcessedTransaction) o;
+        return Objects.equals(transactionId, that.transactionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return transactionId.hashCode();
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
@@ -39,6 +39,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
 import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
 
 /**
@@ -54,7 +55,7 @@ public class EhcacheCacheProvider extends AbstractCacheProvider<EhcacheTransacti
     private final boolean dropBufferOnStop;
     private final CacheManager cacheManager;
     private final EhcacheLogMinerTransactionCache transactionCache;
-    private final EhcacheLogMinerCache<String, String> processedTransactionsCache;
+    private final EhcacheLogMinerCache<String, ProcessedTransaction> processedTransactionsCache;
     private final EhcacheLogMinerCache<String, String> schemaChangesCache;
 
     public EhcacheCacheProvider(OracleConnectorConfig connectorConfig) {
@@ -81,7 +82,7 @@ public class EhcacheCacheProvider extends AbstractCacheProvider<EhcacheTransacti
     }
 
     @Override
-    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+    public LogMinerCache<String, ProcessedTransaction> getProcessedTransactionsCache() {
         return processedTransactionsCache;
     }
 
@@ -174,9 +175,9 @@ public class EhcacheCacheProvider extends AbstractCacheProvider<EhcacheTransacti
                 evictionListener);
     }
 
-    private EhcacheLogMinerCache<String, String> createProcessedTransactionCache(EhcacheEvictionListener evictionListener) {
+    private EhcacheLogMinerCache<String, ProcessedTransaction> createProcessedTransactionCache(EhcacheEvictionListener evictionListener) {
         return new EhcacheLogMinerCache<>(
-                getCache(PROCESSED_TRANSACTIONS_CACHE_NAME, String.class, String.class, evictionListener),
+                getCache(PROCESSED_TRANSACTIONS_CACHE_NAME, String.class, ProcessedTransaction.class, evictionListener),
                 PROCESSED_TRANSACTIONS_CACHE_NAME,
                 evictionListener);
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/serialization/ProcessedTransactionSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/serialization/ProcessedTransactionSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.ehcache.serialization;
+
+import java.io.IOException;
+
+import org.ehcache.spi.serialization.Serializer;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction.ProcessType;
+
+/**
+ * An Ehcache {@link Serializer} implementation for storing an {@link ProcessedTransaction} in the cache.
+ *
+ * @author Chris Cranford
+ */
+public class ProcessedTransactionSerializer extends AbstractEhcacheSerializer<ProcessedTransaction> {
+
+    public ProcessedTransactionSerializer(ClassLoader classLoader) {
+    }
+
+    @Override
+    protected void serialize(ProcessedTransaction object, SerializerOutputStream stream) throws IOException {
+        stream.writeString(object.getTransactionId());
+        stream.writeString(object.getStartScn().toString());
+        stream.writeString(object.getProcessType().toString());
+    }
+
+    @Override
+    protected ProcessedTransaction deserialize(SerializerInputStream stream) throws IOException {
+        final String transactionId = stream.readString();
+        final Scn startScn = readScn(stream.readString());
+        final ProcessType processType = readProcessType(stream.readString());
+        return new ProcessedTransaction(transactionId, startScn, processType);
+    }
+
+    private Scn readScn(String value) {
+        return value.equals("null") ? Scn.NULL : Scn.valueOf(value);
+    }
+
+    private ProcessType readProcessType(String value) {
+        try {
+            return ProcessType.valueOf(value);
+        }
+        catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/EmbeddedInfinispanCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/EmbeddedInfinispanCacheProvider.java
@@ -31,6 +31,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
 
 /**
  * Provides access to various transaction-focused caches to store transaction details in Infinispan
@@ -45,7 +46,7 @@ public class EmbeddedInfinispanCacheProvider extends AbstractCacheProvider<Infin
     private final boolean dropBufferOnStop;
     private final EmbeddedCacheManager cacheManager;
     private final InfinispanLogMinerTransactionCache transactionCache;
-    private final InfinispanLogMinerCache<String, String> processedTransactionsCache;
+    private final InfinispanLogMinerCache<String, ProcessedTransaction> processedTransactionsCache;
     private final InfinispanLogMinerCache<String, String> schemaChangesCache;
 
     public EmbeddedInfinispanCacheProvider(OracleConnectorConfig connectorConfig) {
@@ -72,7 +73,7 @@ public class EmbeddedInfinispanCacheProvider extends AbstractCacheProvider<Infin
     }
 
     @Override
-    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+    public LogMinerCache<String, ProcessedTransaction> getProcessedTransactionsCache() {
         return processedTransactionsCache;
     }
 
@@ -100,7 +101,7 @@ public class EmbeddedInfinispanCacheProvider extends AbstractCacheProvider<Infin
                 createCache(EVENTS_CACHE_NAME, connectorConfig, LOG_MINING_BUFFER_INFINISPAN_CACHE_EVENTS));
     }
 
-    private InfinispanLogMinerCache<String, String> createProcessedTransactionsCache(OracleConnectorConfig connectorConfig) {
+    private InfinispanLogMinerCache<String, ProcessedTransaction> createProcessedTransactionsCache(OracleConnectorConfig connectorConfig) {
         return new InfinispanLogMinerCache<>(
                 createCache(PROCESSED_TRANSACTIONS_CACHE_NAME, connectorConfig, LOG_MINING_BUFFER_INFINISPAN_CACHE_PROCESSED_TRANSACTIONS));
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/RemoteInfinispanCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/RemoteInfinispanCacheProvider.java
@@ -29,7 +29,9 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
 import io.debezium.connector.oracle.logminer.buffered.infinispan.marshalling.LogMinerEventMarshallerImpl;
+import io.debezium.connector.oracle.logminer.buffered.infinispan.marshalling.ProcessedTransactionMarshallerImpl;
 import io.debezium.connector.oracle.logminer.buffered.infinispan.marshalling.TransactionMarshallerImpl;
 
 /**
@@ -51,7 +53,7 @@ public class RemoteInfinispanCacheProvider extends AbstractCacheProvider<Infinis
     private final boolean dropBufferOnStop;
     private final RemoteCacheManager cacheManager;
     private final LogMinerTransactionCache<InfinispanTransaction> transactionCache;
-    private final InfinispanLogMinerCache<String, String> processedTransactionsCache;
+    private final InfinispanLogMinerCache<String, ProcessedTransaction> processedTransactionsCache;
     private final InfinispanLogMinerCache<String, String> schemaChangesCache;
 
     public RemoteInfinispanCacheProvider(OracleConnectorConfig connectorConfig) {
@@ -78,7 +80,7 @@ public class RemoteInfinispanCacheProvider extends AbstractCacheProvider<Infinis
     }
 
     @Override
-    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+    public LogMinerCache<String, ProcessedTransaction> getProcessedTransactionsCache() {
         return processedTransactionsCache;
     }
 
@@ -128,7 +130,7 @@ public class RemoteInfinispanCacheProvider extends AbstractCacheProvider<Infinis
                 createCache(EVENTS_CACHE_NAME, connectorConfig, LOG_MINING_BUFFER_INFINISPAN_CACHE_EVENTS));
     }
 
-    private InfinispanLogMinerCache<String, String> createProcessedTransactionCache(OracleConnectorConfig connectorConfig) {
+    private InfinispanLogMinerCache<String, ProcessedTransaction> createProcessedTransactionCache(OracleConnectorConfig connectorConfig) {
         return new InfinispanLogMinerCache<>(
                 createCache(PROCESSED_TRANSACTIONS_CACHE_NAME, connectorConfig, LOG_MINING_BUFFER_INFINISPAN_CACHE_PROCESSED_TRANSACTIONS));
     }
@@ -144,6 +146,7 @@ public class RemoteInfinispanCacheProvider extends AbstractCacheProvider<Infinis
                 // todo: why must these be defined manually rather than automated like embedded mode?
                 .addContextInitializer(TransactionMarshallerImpl.class.getName())
                 .addContextInitializer(LogMinerEventMarshallerImpl.class.getName())
+                .addContextInitializer(ProcessedTransactionMarshallerImpl.class.getName())
                 .build();
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/marshalling/ProcessedTransactionAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/marshalling/ProcessedTransactionAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.infinispan.marshalling;
+
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction.ProcessType;
+
+/**
+ * An Infinispan ProtoStream adapter for marshalling a {@link ProcessedTransaction} instance.
+ *
+ * This class defines a factory for creating {@link ProcessedTransaction} instances when hydrating from the
+ * protocol buffer data store as well as field handlers to extract values from a given instance for
+ * serialization to a protocol buffer stream.
+ *
+ * @author Chris Cranford
+ */
+@ProtoAdapter(ProcessedTransaction.class)
+public class ProcessedTransactionAdapter {
+    /**
+     * A ProtoStream factory that creates a {@link ProcessedTransaction} instance from field values.
+     *
+     * @param transactionId the transaction identifier
+     * @param scn the starting system change number of the transaction
+     * @param processType type or how the transaction is "processed"
+     * @return the constructed instance
+     */
+    @ProtoFactory
+    public ProcessedTransaction factory(String transactionId, String scn, String processType) {
+        return new ProcessedTransaction(transactionId, Scn.valueOf(scn), ProcessType.valueOf(processType));
+    }
+
+    /**
+     * A ProtoStream handler to extract the {@code transactionId} field from the {@link ProcessedTransaction}.
+     *
+     * @param processedTransaction the processed transaction object
+     * @return the transaction identifier
+     */
+    @ProtoField(number = 1)
+    public String getTransactionId(ProcessedTransaction processedTransaction) {
+        return processedTransaction.getTransactionId();
+    }
+
+    /**
+     * A ProtoStream handler to extract the {@code startScn} field from the {@link ProcessedTransaction}.
+     *
+     * @param processedTransaction the processed transaction object
+     * @return the transaction's starting system change number
+     */
+    @ProtoField(number = 2)
+    public String getScn(ProcessedTransaction processedTransaction) {
+        return processedTransaction.getStartScn().toString();
+    }
+
+    /**
+     * A ProtoStream handler to extract the {@code processType} field from the {@link ProcessedTransaction}.
+     *
+     * @param processedTransaction the processed transaction object
+     * @return the process type
+     */
+    @ProtoField(number = 3)
+    public String getProcessType(ProcessedTransaction processedTransaction) {
+        return processedTransaction.getProcessType().toString();
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/marshalling/ProcessedTransactionMarshaller.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/marshalling/ProcessedTransactionMarshaller.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.infinispan.marshalling;
+
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.protostream.annotations.ProtoSchema;
+
+/**
+ * An interface that is used by the ProtoStream framework to designate the adapters and path to
+ * where the Protocol Buffers .proto file will be generated based on the adapters at compile time.
+ *
+ * @author Chris Cranford
+ */
+@ProtoSchema(includeClasses = { ProcessedTransactionAdapter.class }, schemaFilePath = "/")
+public interface ProcessedTransactionMarshaller extends SerializationContextInitializer {
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryCacheProvider.java
@@ -12,6 +12,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
 import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction;
 
 /**
  * Provides access to various transaction-focused caches to store transaction details in memory
@@ -24,7 +25,7 @@ public class MemoryCacheProvider extends AbstractCacheProvider<MemoryTransaction
     private static final Logger LOGGER = LoggerFactory.getLogger(MemoryCacheProvider.class);
 
     private final MemoryLogMinerTransactionCache transactionCache;
-    private final MemoryBasedLogMinerCache<String, String> processedTransactionsCache;
+    private final MemoryBasedLogMinerCache<String, ProcessedTransaction> processedTransactionsCache;
     private final MemoryBasedLogMinerCache<String, String> schemaChangesCache;
 
     public MemoryCacheProvider(OracleConnectorConfig connectorConfig) {
@@ -46,7 +47,7 @@ public class MemoryCacheProvider extends AbstractCacheProvider<MemoryTransaction
     }
 
     @Override
-    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+    public LogMinerCache<String, ProcessedTransaction> getProcessedTransactionsCache() {
         return processedTransactionsCache;
     }
 

--- a/debezium-connector-oracle/src/main/resources/ehcache/configuration-template.xml
+++ b/debezium-connector-oracle/src/main/resources/ehcache/configuration-template.xml
@@ -5,6 +5,9 @@
         <serializer type="io.debezium.connector.oracle.logminer.buffered.ehcache.EhcacheTransaction">
             io.debezium.connector.oracle.logminer.buffered.ehcache.serialization.EhcacheTransactionSerializer
         </serializer>
+        <serializer type="io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction">
+            io.debezium.connector.oracle.logminer.buffered.ehcache.serialization.ProcessedTransactionSerializer
+        </serializer>
         <serializer type="io.debezium.connector.oracle.logminer.events.LogMinerEvent">
             io.debezium.connector.oracle.logminer.buffered.ehcache.serialization.LogMinerEventSerializer
         </serializer>
@@ -32,7 +35,7 @@
     <cache alias="processed-transactions">
         <!-- Debezium specifically sets the key/value types -->
         <key-type>java.lang.String</key-type>
-        <value-type>java.lang.String</value-type>
+        <value-type>io.debezium.connector.oracle.logminer.buffered.ProcessedTransaction</value-type>
         ${log.mining.buffer.ehcache.processedtransactions.config}
     </cache>
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -219,6 +219,10 @@ public class TestHelper {
                 .with(OracleConnectorConfig.SNAPSHOT_DATABASE_ERRORS_MAX_RETRIES, 3);
     }
 
+    public static LogMiningBufferType getLogMiningBufferType(Configuration config) {
+        return LogMiningBufferType.parse(config.getString(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE));
+    }
+
     public static String getEhcacheGlobalCacheConfig() {
         return "<persistence directory=\"./target/data\"/>";
     }


### PR DESCRIPTION
Fixes debezium/dbz#1360 

https://issues.redhat.com/browse/DBZ-9000

When using LogMiner in buffered mode paired with connector-level filtering, the connector would previously perform the filter at commit time to unnecessarily buffer the entire transaction to discard it later.

This change moves that filtering logic to the start of the transaction so it can be discarded immediately if the username or client id filters apply.