### PR TITLE
DBZ-9077 enforce CI to build all dependent modules

### DIFF
--- a/.github/actions/build-quarkus-extensions/action.yml
+++ b/.github/actions/build-quarkus-extensions/action.yml
@@ -24,8 +24,11 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
-
+    - name: Build Parent
+      shell: ${{ inputs.shell }}
+      run: >
+        ./mvnw clean install -DskipITs -DskipTests -B
     - name: Build Debezium Quarkus Extensions
       shell: ${{ inputs.shell }}
       run: >
-        ./mvnw clean install -B -pl :quarkus-debezium-parent -am -amd -Dnative
+        ./mvnw install -B -pl :quarkus-debezium-parent -am -amd -Dnative


### PR DESCRIPTION
## Context
To enforce the CI to build all dependent modules correctly, it is necessary to explicitly list all the required modules in the `-pl` (project list) parameter. Maven’s `-am` (also make) option only includes the direct and transitive dependencies of the modules specified in `-pl`, but it does not automatically include unrelated sibling modules or the entire module tree. Therefore, to ensure the complete set of interdependent modules is built—especially in a multi-module project—you must provide a comprehensive list of all relevant modules in the `-pl` argument. This approach guarantees that Maven can resolve all dependencies within the reactor and build them in the correct order during the CI process.

#closes https://issues.redhat.com/browse/DBZ-9077