### PR TITLE
DBZ-9082 Add option to specify custom keystore and truststore for Redis sink

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -43,7 +43,7 @@
         <!-- Storages -->
 
         <!-- Redis -->
-        <version.jedis>4.1.1</version.jedis>
+        <version.jedis>6.0.0</version.jedis>
 
         <!-- S3 -->
         <version.s3>2.26.30</version.s3>

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -44,6 +44,36 @@ public class RedisCommonConfig {
             .withDescription("Use SSL for Redis connection")
             .withDefault(DEFAULT_SSL_ENABLED);
 
+    private static final String DEFAULT_TRUSTSTORE_PATH = "";
+    private static final Field PROP_SSL_TRUSTSTORE_PATH = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.path")
+            .withDescription("Path to the truststore file")
+            .withDefault(DEFAULT_TRUSTSTORE_PATH);
+
+    private static final String DEFAULT_TRUSTSTORE_PASSWORD = "";
+    private static final Field PROP_SSL_TRUSTSTORE_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.password")
+            .withDescription("Password for the truststore")
+            .withDefault(DEFAULT_TRUSTSTORE_PASSWORD);
+
+    private static final String DEFAULT_TRUSTSTORE_TYPE = "JKS";
+    private static final Field PROP_SSL_TRUSTSTORE_TYPE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.type")
+            .withDescription("Type of the truststore (e.g., JKS, PKCS12), defaults to JKS")
+            .withDefault(DEFAULT_TRUSTSTORE_TYPE);
+
+    private static final String DEFAULT_KEYSTORE_PATH = "";
+    private static final Field PROP_SSL_KEYSTORE_PATH = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.path")
+            .withDescription("Path to the keystore file")
+            .withDefault(DEFAULT_KEYSTORE_PATH);
+
+    private static final String DEFAULT_KEYSTORE_PASSWORD = "";
+    private static final Field PROP_SSL_KEYSTORE_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.password")
+            .withDescription("Password for the keystore")
+            .withDefault(DEFAULT_KEYSTORE_PASSWORD);
+
+    private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
+    private static final Field PROP_SSL_KEYSTORE_TYPE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.type")
+            .withDescription("Type of the keystore (e.g., JKS, PKCS12), defaults to JKS")
+            .withDefault(DEFAULT_KEYSTORE_TYPE);
+
     private static final boolean DEFAULT_HOSTNAME_VERIFICATION = false;
     private static final Field PROP_SSL_HOSTNAME_VERIFICATION_ENABLED = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.hostname.verification.enabled")
             .withDescription("Enable hostname verification")
@@ -99,8 +129,15 @@ public class RedisCommonConfig {
     private int dbIndex;
     private String user;
     private String password;
+
     private boolean sslEnabled;
     private boolean hostnameVerificationEnabled;
+    private String truststorePath;
+    private String truststorePassword;
+    private String truststoreType;
+    private String keystorePath;
+    private String keystorePassword;
+    private String keystoreType;
 
     private Integer initialRetryDelay;
     private Integer maxRetryDelay;
@@ -126,9 +163,14 @@ public class RedisCommonConfig {
     }
 
     protected List<Field> getAllConfigurationFields() {
-        return Collect.arrayListOf(PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD, PROP_SSL_ENABLED, PROP_SSL_HOSTNAME_VERIFICATION_ENABLED,
-                PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT, PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY, PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT,
-                PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
+        return Collect.arrayListOf(
+                PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD,
+                PROP_SSL_ENABLED, PROP_SSL_HOSTNAME_VERIFICATION_ENABLED,
+                PROP_SSL_TRUSTSTORE_PATH, PROP_SSL_TRUSTSTORE_PASSWORD, PROP_SSL_TRUSTSTORE_TYPE,
+                PROP_SSL_KEYSTORE_PATH, PROP_SSL_KEYSTORE_PASSWORD, PROP_SSL_KEYSTORE_TYPE,
+                PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
+                PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY,
+                PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
     }
 
     protected void init(Configuration config) {
@@ -136,8 +178,15 @@ public class RedisCommonConfig {
         dbIndex = config.getInteger(PROP_DB_INDEX);
         user = config.getString(PROP_USER);
         password = config.getString(PROP_PASSWORD);
+
         sslEnabled = config.getBoolean(PROP_SSL_ENABLED);
         hostnameVerificationEnabled = config.getBoolean(PROP_SSL_HOSTNAME_VERIFICATION_ENABLED);
+        truststorePath = config.getString(PROP_SSL_TRUSTSTORE_PATH);
+        truststorePassword = config.getString(PROP_SSL_TRUSTSTORE_PASSWORD);
+        truststoreType = config.getString(PROP_SSL_TRUSTSTORE_TYPE);
+        keystorePath = config.getString(PROP_SSL_KEYSTORE_PATH);
+        keystorePassword = config.getString(PROP_SSL_KEYSTORE_PASSWORD);
+        keystoreType = config.getString(PROP_SSL_KEYSTORE_TYPE);
 
         initialRetryDelay = config.getInteger(PROP_RETRY_INITIAL_DELAY);
         maxRetryDelay = config.getInteger(PROP_RETRY_MAX_DELAY);
@@ -216,4 +265,27 @@ public class RedisCommonConfig {
         return waitRetryDelay;
     }
 
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeystoreType() {
+        return keystoreType;
+    }
 }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -119,6 +119,30 @@ public class RedisConnection {
     }
 
     /**
+     * Creates a new RedisConnection instance from the provided RedisCommonConfig.
+     *
+     * @param config the RedisCommonConfig containing connection parameters
+     * @return a new RedisConnection instance
+     */
+    public static RedisConnection getInstance(RedisCommonConfig config) {
+        return new RedisConnection(
+                config.getAddress(),
+                config.getDbIndex(),
+                config.getUser(),
+                config.getPassword(),
+                config.getConnectionTimeout(),
+                config.getSocketTimeout(),
+                config.isSslEnabled(),
+                config.isHostnameVerificationEnabled(),
+                config.getTruststorePath(),
+                config.getTruststorePassword(),
+                config.getTruststoreType(),
+                config.getKeystorePath(),
+                config.getKeystorePassword(),
+                config.getKeystoreType());
+    }
+
+    /**
      *
      * @param clientName
      * @param waitEnabled

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.storage.redis;
 
+import java.io.File;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLParameters;
@@ -19,6 +20,8 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisClientConfig.Builder;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 
@@ -42,6 +45,12 @@ public class RedisConnection {
     private final int socketTimeout;
     private final boolean sslEnabled;
     private final boolean hostnameVerificationEnabled;
+    private final String truststorePath;
+    private final String truststorePassword;
+    private final String truststoreType;
+    private final String keystorePath;
+    private final String keystorePassword;
+    private final String keystoreType;
 
     /**
      *
@@ -68,6 +77,29 @@ public class RedisConnection {
      */
     public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
                            boolean hostnameVerificationEnabled) {
+        this(address, dbIndex, user, password, connectionTimeout, socketTimeout, sslEnabled, hostnameVerificationEnabled,
+                null, null, null, null, null, null);
+    }
+
+    /**
+     *
+     * @param address
+     * @param user
+     * @param password
+     * @param connectionTimeout
+     * @param socketTimeout
+     * @param sslEnabled
+     * @param hostnameVerificationEnabled
+     * @param truststorePath
+     * @param truststorePassword
+     * @param truststoreType
+     * @param keystorePath
+     * @param keystorePassword
+     * @param keystoreType
+     */
+    public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
+                           boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
+                           String keystorePath, String keystorePassword, String keystoreType) {
         validateHostPort(address);
 
         this.address = address;
@@ -78,6 +110,12 @@ public class RedisConnection {
         this.socketTimeout = socketTimeout;
         this.sslEnabled = sslEnabled;
         this.hostnameVerificationEnabled = hostnameVerificationEnabled;
+        this.truststorePath = truststorePath;
+        this.truststorePassword = truststorePassword;
+        this.truststoreType = truststoreType;
+        this.keystorePath = keystorePath;
+        this.keystorePassword = keystorePassword;
+        this.keystoreType = keystoreType;
     }
 
     /**
@@ -105,19 +143,39 @@ public class RedisConnection {
                     .socketTimeoutMillis(this.socketTimeout)
                     .ssl(this.sslEnabled);
 
+            boolean configureSslOptions = this.sslEnabled && (!Strings.isNullOrEmpty(this.truststorePath) ||
+                    !Strings.isNullOrEmpty(this.keystorePath));
+
+            // The SslOptions in Jedis override the default SSL context if explicitly configured.
+            // - When a custom truststore or keystore is provided for the Jedis client, hostname verification
+            // must also be configured explicitly through the SslOptions.
+            // - If no custom truststore or keystore is provided, hostname verification will rely on the
+            // SSLParameters, which use the truststore or keystore specified via system properties.
+            if (configureSslOptions) {
+                var tsPasswordRaw = !Strings.isNullOrEmpty(truststorePassword) ? truststorePassword.toCharArray() : null;
+                var ksPasswordRaw = !Strings.isNullOrEmpty(keystorePassword) ? keystorePassword.toCharArray() : null;
+                var sslOptions = SslOptions.builder()
+                        .truststore(new File(truststorePath), tsPasswordRaw)
+                        .trustStoreType(truststoreType)
+                        .keystore(new File(keystorePath), ksPasswordRaw)
+                        .keyStoreType(keystoreType)
+                        .sslVerifyMode(hostnameVerificationEnabled ? SslVerifyMode.FULL : SslVerifyMode.CA)
+                        .build();
+                configBuilder.sslOptions(sslOptions);
+            }
+            else if (hostnameVerificationEnabled) {
+                // Enforce strict hostname verification to prevent man-in-the-middle attacks.
+                var sslParameters = new SSLParameters();
+                sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+                configBuilder.sslParameters(sslParameters);
+            }
+
             if (!Strings.isNullOrEmpty(this.user)) {
                 configBuilder = configBuilder.user(this.user);
             }
 
             if (!Strings.isNullOrEmpty(this.password)) {
                 configBuilder = configBuilder.password(this.password);
-            }
-
-            if (hostnameVerificationEnabled) {
-                // Enforce strict hostname verification to prevent man-in-the-middle attacks.
-                var sslParameters = new SSLParameters();
-                sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-                configBuilder.sslParameters(sslParameters);
             }
 
             client = new Jedis(address, configBuilder.build());

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
@@ -56,7 +56,9 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
 
     void connect() {
         RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled());
+                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled(),
+                config.getTruststorePath(), config.getTruststorePassword(), config.getTruststoreType(),
+                config.getKeystorePath(), config.getKeystorePassword(), config.getKeystoreType());
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_SCHEMA_HISTORY, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
@@ -55,10 +55,7 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
     private RedisSchemaHistoryConfig config;
 
     void connect() {
-        RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled(),
-                config.getTruststorePath(), config.getTruststorePassword(), config.getTruststoreType(),
-                config.getKeystorePath(), config.getKeystorePassword(), config.getKeystoreType());
+        RedisConnection redisConnection = RedisConnection.getInstance(config);
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_SCHEMA_HISTORY, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
@@ -48,7 +48,9 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
     void connect() {
         closeClient();
         RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled());
+                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled(),
+                config.getTruststorePath(), config.getTruststorePassword(), config.getTruststoreType(),
+                config.getKeystorePath(), config.getKeystorePassword(), config.getKeystoreType());
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
@@ -47,10 +47,7 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
 
     void connect() {
         closeClient();
-        RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled(),
-                config.getTruststorePath(), config.getTruststorePassword(), config.getTruststoreType(),
-                config.getKeystorePath(), config.getKeystorePassword(), config.getKeystoreType());
+        RedisConnection redisConnection = RedisConnection.getInstance(config);
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/documentation/modules/ROOT/pages/configuration/storage.adoc
+++ b/documentation/modules/ROOT/pages/configuration/storage.adoc
@@ -529,6 +529,30 @@ INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_inse
 |false
 |Specifies whether {prodname} has hostname verification enabled when communicating with Redis to store offset data.
 
+|[[offset-storage-redis-truststore-path]]<<offset-storage-redis-truststore-path, `offset.storage.redis.ssl.truststore.path`>>
+|No default
+|The path to the trust store file used for SSL/TLS connections to Redis for offset storage. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[offset-storage-redis-truststore-password]]<<offset-storage-redis-truststore-password, `offset.storage.redis.ssl.truststore.password`>>
+|No default
+|The password for the trust store file used for SSL/TLS connections to Redis for offset storage. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[offset-storage-redis-truststore-type]]<<offset-storage-redis-truststore-type, `offset.storage.redis.ssl.truststore.type`>>
+|JKS
+|The type of the trust store file used for SSL/TLS connections to Redis for offset storage. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[offset-storage-redis-keystore-path]]<<offset-storage-redis-keystore-path, `offset.storage.redis.ssl.keystore.path`>>
+|No default
+|The path to the key store file used for SSL/TLS connections to Redis for offset storage. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[offset-storage-redis-keystore-password]]<<offset-storage-redis-keystore-password, `offset.storage.redis.ssl.keystore.password`>>
+|No default
+|The password for the key store file used for SSL/TLS connections to Redis for offset storage. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[offset-storage-redis-keystore-type]]<<offset-storage-redis-keystore-type, `offset.storage.redis.ssl.keystore.type`>>
+|JKS
+|The type of the key store file used for SSL/TLS connections to Redis for offset storage.
+
 |[[offset-storage-redis-connection-timeout-ms]]<<offset-storage-redis-connection-timeout-ms, `offset.storage.redis.connection.timeout.ms`>>
 |2000
 |Specifies the time, in milliseconds, that {prodname} waits to establish a connection to Redis before the connection times out.
@@ -607,6 +631,30 @@ If a data packet is not transferred with the specified interval, {prodname} clos
 |[[schema-history-internal-redis-hostname-verification-enabled]]<<schema-history-internal-redis-hostname-verification-enabled,`schema.history.internal.storage.redis.ssl.hostname.verification.enabled`>>
 |false
 |Specifies whether {prodname} has hostname verification enabled when communicating with Redis to store schema history data.
+
+|[[schema-history-internal-redis-truststore-path]]<<schema-history-internal-redis-truststore-path, `schema.history.internal.storage.redis.ssl.truststore.path`>>
+|No default
+|The path to the trust store file used for SSL/TLS connections to Redis to store schema history data.
+
+|[[schema-history-internal-redis-truststore-password]]<<schema-history-internal-redis-truststore-password, `schema.history.internal.storage.redis.ssl.truststore.password`>>
+|No default
+|The password for the trust store file used for SSL/TLS connections to Redis to store schema history data.
+
+|[[schema-history-internal-redis-truststore-type]]<<schema-history-internal-redis-truststore-type, `schema.history.internal.storage.redis.ssl.truststore.type`>>
+|JKS
+|The type of the trust store file used for SSL/TLS connections to Redis to store schema history data.
+
+|[[schema-history-internal-redis-keystore-path]]<<schema-history-internal-redis-keystore-path, `schema.history.internal.storage.redis.ssl.keystore.path`>>
+|No default
+|The path to the key store file used for SSL/TLS connections to Redis to store schema history data.
+
+|[[schema-history-internal-redis-keystore-password]]<<schema-history-internal-redis-keystore-password, `schema.history.internal.storage.redis.ssl.keystore.password`>>
+|No default
+|The password for the key store file used for SSL/TLS connections to Redis to store schema history data.
+
+|[[schema-history-internal-redis-keystore-type]]<<schema-history-internal-redis-keystore-type, `schema.history.internal.storage.redis.ssl.keystore.type`>>
+|JKS
+|The type of the key store file used for SSL/TLS connections to Redis to store schema history data.
 
 |[[schema-history-internal-redis-connection-timeout-ms]]<<schema-history-internal-redis-connection-timeout-ms, `schema.history.internal.storage.redis.connection.timeout.ms`>>
 |2000

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -242,6 +242,30 @@ Available options
 |
 |(Optional)  If using Redis to store offsets, whether or not to enable hostname verification with Redis. If the `redis.address` configuration is not supplied, and the `redis.address` is taken from the Redis sink, will attempt to load the value from `debezium.sink.redis.ssl.hostname.verification.enabled`. Default is 'false'
 
+|[[debezium-source-offset-redis-ssl-truststore-path]]<<debezium-source-offset-redis-ssl-truststore-path, `debezium.source.offset.storage.redis.ssl.truststore.path`>>
+|
+|(Optional) If using Redis to store offsets with SSL enabled, the path to the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-offset-redis-ssl-truststore-password]]<<debezium-source-offset-redis-ssl-truststore-password, `debezium.source.offset.storage.redis.ssl.truststore.password`>>
+|
+|(Optional) If using Redis to store offsets with SSL enabled, the password for the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-offset-redis-ssl-truststore-type]]<<debezium-source-offset-redis-ssl-truststore-type, `debezium.source.offset.storage.redis.ssl.truststore.type`>>
+|`JKS`
+|(Optional) If using Redis to store offsets with SSL enabled, the type of the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-offset-redis-ssl-keystore-path]]<<debezium-source-offset-redis-ssl-keystore-path, `debezium.source.offset.storage.redis.ssl.keystore.path`>>
+|
+|(Optional) If using Redis to store offsets with SSL enabled, the path to the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-offset-redis-ssl-keystore-password]]<<debezium-source-offset-redis-ssl-keystore-password, `debezium.source.offset.storage.redis.ssl.keystore.password`>>
+|
+|(Optional) If using Redis to store offsets with SSL enabled, the password for the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-offset-redis-ssl-keystore-type]]<<debezium-source-offset-redis-ssl-keystore-type, `debezium.source.offset.storage.redis.ssl.keystore.type`>>
+|`JKS`
+|(Optional) If using Redis to store offsets with SSL enabled, the type of the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
 |[[debezium-source-offset-redis-key]]<<debezium-source-offset-redis-key, `debezium.source.offset.storage.redis.key`>>
 |
 |(Optional)  If using Redis to store offsets, define the hash key in redis. If the `redis.key` configuration is not supplied, and the default value is `metadata:debezium:offsets`
@@ -298,6 +322,30 @@ There are also other options available
 |[[debezium-source-database-history-redis-hostname-verification-enabled]]<<debezium-source-database-history-redis-hostname-verification-enabled, `debezium.source.schema.history.internal.redis.ssl.hostname.verification.enabled`>>
 |
 |Enable hostname verification if using `RedisSchemaHistory`.
+
+|[[debezium-source-database-history-redis-ssl-truststore-path]]<<debezium-source-database-history-redis-ssl-truststore-path, `debezium.source.schema.history.internal.redis.ssl.truststore.path`>>
+|
+|(Optional) If using Redis to store schema history with SSL enabled, the path to the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-database-history-redis-ssl-truststore-password]]<<debezium-source-database-history-redis-ssl-truststore-password, `debezium.source.schema.history.internal.redis.ssl.truststore.password`>>
+|
+|(Optional) If using Redis to store schema history with SSL enabled, the password for the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-database-history-redis-ssl-truststore-type]]<<debezium-source-database-history-redis-ssl-truststore-type, `debezium.source.schema.history.internal.redis.ssl.truststore.type`>>
+|`JKS`
+|(Optional) If using Redis to store schema history with SSL enabled, the type of the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-database-history-redis-ssl-keystore-path]]<<debezium-source-database-history-redis-ssl-keystore-path, `debezium.source.schema.history.internal.redis.ssl.keystore.path`>>
+|
+|(Optional) If using Redis to store schema history with SSL enabled, the path to the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-database-history-redis-ssl-keystore-password]]<<debezium-source-database-history-redis-ssl-keystore-password, `debezium.source.schema.history.internal.redis.ssl.keystore.password`>>
+|
+|(Optional) If using Redis to store schema history with SSL enabled, the password for the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[debezium-source-database-history-redis-ssl-keystore-type]]<<debezium-source-database-history-redis-ssl-keystore-type, `debezium.source.schema.history.internal.redis.ssl.keystore.type`>>
+|`JKS`
+|(Optional) If using Redis to store schema history with SSL enabled, the type of the key store file. If set, Redis connections will use this property over other configuration or system properties.
 
 |[[debezium-source-database-history-redis-key]]<<debezium-source-database-history-redis-key, `debezium.source.schema.history.internal.redis.key`>>
 |
@@ -1085,6 +1133,30 @@ The Stream is a data type which models a _log data structure_ in a more abstract
 |[[redis-hostname-verification-enabled]]<<redis-hostname-verification-enabled, `debezium.sink.redis.ssl.hostname.verification.enabled`>>
 |`false`
 |(Optional) A Boolean value that specifies whether connections to Redis should verify the hostname of the server.
+
+|[[redis-ssl-truststore-path]]<<redis-ssl-truststore-path, `debezium.sink.redis.ssl.truststore.path`>>
+|
+|(Optional) If using Redis sink with SSL enabled, the path to the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[redis-ssl-truststore-password]]<<redis-ssl-truststore-password, `debezium.sink.redis.ssl.truststore.password`>>
+|
+|(Optional) If using Redis sink with SSL enabled, the password for the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[redis-ssl-truststore-type]]<<redis-ssl-truststore-type, `debezium.sink.redis.ssl.truststore.type`>>
+|`JKS`
+|(Optional) If using Redis sink with SSL enabled, the type of the trust store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[redis-ssl-keystore-path]]<<redis-ssl-keystore-path, `debezium.sink.redis.ssl.keystore.path`>>
+|
+|(Optional) If using Redis sink with SSL enabled, the path to the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[redis-ssl-keystore-password]]<<redis-ssl-keystore-password, `debezium.sink.redis.ssl.keystore.password`>>
+|
+|(Optional) If using Redis sink with SSL enabled, the password for the key store file. If set, Redis connections will use this property over other configuration or system properties.
+
+|[[redis-ssl-keystore-type]]<<redis-ssl-keystore-type, `debezium.sink.redis.ssl.keystore.type`>>
+|`JKS`
+|(Optional) If using Redis sink with SSL enabled, the type of the key store file. If set, Redis connections will use this property over other configuration or system properties.
 
 |[[redis-null-key]]<<redis-null-key, `debezium.sink.redis.null.key`>>
 |`default`


### PR DESCRIPTION
This change introduces additional configuration options for specifying custom keystore/truststore for the jedis client in redis sink. This allows the client to use different keys and certificates than the default ones passed to the JVM.

This change updates the Jedis client to version 6.0.0. and takes advantage of the newly introduced SSL options to set the keystore/truststore. The options are applied only if redis.ssl.enabled is true.

Configuration properties for each new SSL options:
`redis.ssl.truststore.path`: Specifies the path to the truststore file used for SSL.
`redis.ssl.truststore.password`: Specifies the password for the truststore file.
`redis.ssl.truststore.type`: Specifies the type of the truststore (e.g., JKS, PKCS12) (default: JKS).
`redis.ssl.keystore.path`: Specifies the path to the keystore file used for SSL.
`redis.ssl.keystore.password`: Specifies the password for the keystore file.
`redis.ssl.keystore.type`: Specifies the type of the keystore (e.g., JKS, PKCS12) (default: JKS).

This update introduces a factory method that creates a RedisConnection directly from a shared configuration object (RedisCommonConfig). Previously, both Debezium and Debezium Server needed to duplicate any changes made to Redis connection parameters, leading to tight coupling and maintenance overhead. By centralizing connection creation through a common config, any updates to the Redis connection settings now only need to be made in Debezium.
