### PR TITLE
DBZ-9086 Fix Postgres reselectColumns for serial primary key

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -824,7 +824,13 @@ public class PostgresConnection extends JdbcConnection {
         final String query = String.format("SELECT %s FROM %s WHERE %s",
                 columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
                 quotedTableIdString(table.id()),
-                keyColumns.stream().map(key -> key + "=?::" + table.columnWithName(key).typeName()).collect(Collectors.joining(" AND ")));
+                keyColumns.stream()
+                        .map(key -> {
+                            Column column = table.columnWithName(key);
+                            String castableType = typeRegistry.get(column.nativeType()).getName();
+                            return key + "=?::" + castableType;
+                        })
+                        .collect(Collectors.joining(" AND ")));
         return reselectColumns(query, table.id(), columns, keyValues);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9086

`::serial` cast caused errors when primary key was serial type