### PR TITLE
DBZ-8660 Add Quote replacement when formatting jdbc url to allow special characters

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
@@ -311,7 +312,7 @@ public class JdbcConnection implements AutoCloseable {
 
                 if (value != null) {
                     // And replace the variable ...
-                    url = url.replaceAll("\\$\\{" + name + "\\}", value);
+                    url = url.replaceAll("\\$\\{" + name + "\\}", Matcher.quoteReplacement(value));
                 }
             }
         }


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/DBZ-8660

Fixed a bug where we connections to databases with `$` in name was failing on verify step (found for sqlserver).
Added a unit test which checks if patternBasedFactory creates correct jdbc url for config with special characters