### PR TITLE
DBZ-9092 Column name encrypted is not supported by MySqlParser

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -470,7 +470,6 @@ DUMPFILE                    : 'DUMPFILE';
 DUPLICATE                   : 'DUPLICATE';
 DYNAMIC                     : 'DYNAMIC';
 ENABLE                      : 'ENABLE';
-ENCRYPTED                   : 'ENCRYPTED';
 ENCRYPTION                  : 'ENCRYPTION';
 ENCRYPTION_KEY_ID           : 'ENCRYPTION_KEY_ID';
 END                         : 'END';

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -973,3 +973,5 @@ BEGIN
   AND i.strategy_id IS NULL;
 END
 #end
+
+CREATE TABLE IF NOT EXISTS table_with_encrypted_column_name(uuid VARCHAR(40) NOT NULL PRIMARY KEY, encrypted VARCHAR(40) DEFAULT NULL)


### PR DESCRIPTION
## Context

The following query is valid in Mysql but invalid for mariaDB:

```sql
CREATE TABLE IF NOT EXISTS table_with_encrypted_column_name(uuid VARCHAR(40) NOT NULL PRIMARY KEY, encrypted VARCHAR(40) DEFAULT NULL)
```

## changes
Removed the keyword `encrypted` in mysql grammar