### PR TITLE
DBZ-9117: Create schemaNamePattern from schemaName for schema introspection

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -615,7 +615,7 @@ public class OracleConnection extends JdbcConnection {
 
     @Override
     protected Map<TableId, List<Column>> getColumnsDetails(String catalogName,
-                                                           String schemaNamePattern,
+                                                           String schemaName,
                                                            String tableName,
                                                            Tables.TableFilter tableFilter,
                                                            ColumnNameFilter columnFilter,
@@ -628,7 +628,7 @@ public class OracleConnection extends JdbcConnection {
         if (tableName != null && tableName.contains("/")) {
             tableName = tableName.replace("/", "//");
         }
-        return super.getColumnsDetails(catalogName, schemaNamePattern, tableName, tableFilter, columnFilter, metadata, viewIds);
+        return super.getColumnsDetails(catalogName, schemaName, tableName, tableFilter, columnFilter, metadata, viewIds);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -201,14 +201,14 @@ public class OracleConnection extends JdbcConnection {
     }
 
     @Override
-    public Set<TableId> readTableNames(String databaseCatalog, String schemaNamePattern, String tableNamePattern,
+    public Set<TableId> readTableNames(String catalogName, String schemaNamePattern, String tableNamePattern,
                                        String[] tableTypes)
             throws SQLException {
 
         Set<TableId> tableIds = super.readTableNames(null, schemaNamePattern, tableNamePattern, tableTypes);
 
         return tableIds.stream()
-                .map(t -> new TableId(databaseCatalog, t.schema(), t.table()))
+                .map(t -> new TableId(catalogName, t.schema(), t.table()))
                 .collect(Collectors.toSet());
     }
 
@@ -614,7 +614,7 @@ public class OracleConnection extends JdbcConnection {
     }
 
     @Override
-    protected Map<TableId, List<Column>> getColumnsDetails(String databaseCatalog,
+    protected Map<TableId, List<Column>> getColumnsDetails(String catalogName,
                                                            String schemaNamePattern,
                                                            String tableName,
                                                            Tables.TableFilter tableFilter,
@@ -628,7 +628,7 @@ public class OracleConnection extends JdbcConnection {
         if (tableName != null && tableName.contains("/")) {
             tableName = tableName.replace("/", "//");
         }
-        return super.getColumnsDetails(databaseCatalog, schemaNamePattern, tableName, tableFilter, columnFilter, metadata, viewIds);
+        return super.getColumnsDetails(catalogName, schemaNamePattern, tableName, tableFilter, columnFilter, metadata, viewIds);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1194,7 +1194,8 @@ public class JdbcConnection implements AutoCloseable {
         Map<TableId, List<Attribute>> attributesByTable = new HashMap<>();
 
         int totalTables = 0;
-        try (ResultSet rs = metadata.getTables(catalogName, schemaName, null, supportedTableTypes())) {
+        String schemaNamePattern = createPatternFromName(schemaName, metadata.getSearchStringEscape());
+        try (ResultSet rs = metadata.getTables(catalogName, schemaNamePattern, null, supportedTableTypes())) {
             while (rs.next()) {
                 final String metaCatalogName = resolveCatalogName(rs.getString(1));
                 final String metaSchemaName = rs.getString(2);
@@ -1306,7 +1307,8 @@ public class JdbcConnection implements AutoCloseable {
             throws SQLException {
         Map<TableId, List<Column>> columnsByTable = new HashMap<>();
         String tableNamePattern = createPatternFromName(tableName, metadata.getSearchStringEscape());
-        try (ResultSet columnMetadata = metadata.getColumns(catalogName, schemaName, tableNamePattern, null)) {
+        String schemaNamePattern = createPatternFromName(schemaName, metadata.getSearchStringEscape());
+        try (ResultSet columnMetadata = metadata.getColumns(catalogName, schemaNamePattern, tableNamePattern, null)) {
             while (columnMetadata.next()) {
                 String metaCatalogName = resolveCatalogName(columnMetadata.getString(1));
                 String metaSchemaName = columnMetadata.getString(2);


### PR DESCRIPTION
This is a continuation of the effort started in https://github.com/debezium/debezium/pull/6464.

Here's the change summary:

### Use consistent parameter and variable naming in `JdbcConnection`

The parameter and variable names in some `JdbcConnection` methods are inconsistent:
1. There is `tableName` but `databaseCatalog`. The latter has been renamed to `catalogName` for consistency.
2. The collision between the `tableName` parameter and the table name introspected via the JDBC is addressed by naming the variable representing the introspected value as `metaTableName`, but `catalogName` is not prefixed with "metadata" because it doesn't conflict with `databaseCatalog`.

Before making the actual code changes, I'd like to unify the naming. This way, the changes themselves are easier to review and validate.

### Rename `schemaNamePattern` parameter to `schemaName` in `JdbcConnection` methods

Even though all modified methods accept the `schemaNamePattern` parameter, all callers pass a schema name there. This is the root cause of the bug. Since there are no cases when a caller actually needs to pass a pattern, we change the name and the semantics of this parameter. Now it's `schemaName`.

#### No changes in `JdbcConnection#readTableNames()`

Note that this method still accepts `schemaNamePattern` and `tableNamePattern`. The reason is that all callers of this method pass `null` for both of the parameters, so whether these arguments are interpreted as names or patterns doesn't matter. In order to prevent similar escaping issues from happening in the future, it might be a good idea to just remove these parameters at all.

### Create `schemaNamePattern` from `schemaName`

This is the actual bug fix. The same was done in https://github.com/debezium/debezium/pull/6464 for table names.

`SpecialCharsInNamesIT` has been modified to use schema names with special characters (from both the SQL and LIKE pattern syntaxes) to cover the change.