### PR TITLE
DBZ-9097 Support KRaft for Kafka Cluster

### DIFF
--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
@@ -60,6 +60,7 @@ public final class ConfigProperties {
     public static final String STRIMZI_OPERATOR_VERSION = System.getProperty("test.strimzi.operator.version", "0.45.0");
     public static final boolean STRIMZI_OPERATOR_CONNECTORS = booleanProperty("test.strimzi.operator.connectors", true);
     public static final String STRIMZI_VERSION_KAFKA = System.getProperty("test.strimzi.version.kafka", "3.1.0");
+    public static final boolean FORCE_KRAFT = booleanProperty("test.force.kraft", false);
 
     // Apicurio Registry configuration
     public static final String APICURIO_LOG_LEVEL = System.getProperty("test.apicurio.log.level", "INFO");

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaBuilder.java
@@ -133,17 +133,20 @@ public final class FabricKafkaBuilder extends FabricBuilderWrapper<FabricKafkaBu
             if (ConfigProperties.FORCE_KRAFT) {
                 USE_KRAFT = true;
                 LOGGER.info("KRaft forced by configuration.");
-            } else if (kafkaVersion.compareTo(new ComparableVersion("4.0.0")) >= 0) {
+            }
+            else if (kafkaVersion.compareTo(new ComparableVersion("4.0.0")) >= 0) {
                 USE_KRAFT = true;
                 LOGGER.info("Kafka version >= 4.0.0 detected.");
-            } else if (!ConfigProperties.PRODUCT_BUILD && strimziVersion.compareTo(new ComparableVersion("0.46.0")) >= 0) {
+            }
+            else if (!ConfigProperties.PRODUCT_BUILD && strimziVersion.compareTo(new ComparableVersion("0.46.0")) >= 0) {
                 USE_KRAFT = true;
                 LOGGER.info("Strimzi version >= 0.46.0.");
             }
 
             if (USE_KRAFT) {
                 LOGGER.info("Using Kafka with KRaft is enabled.");
-            } else {
+            }
+            else {
                 LOGGER.warn("Using Kafka with Zookeeper is enabled. This way will become deprecated soon.");
             }
         }

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaBuilder.java
@@ -46,9 +46,9 @@ import io.strimzi.api.kafka.model.zookeeper.ZookeeperClusterSpecBuilder;
  */
 public final class FabricKafkaBuilder extends FabricBuilderWrapper<FabricKafkaBuilder, KafkaBuilder, Kafka> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FabricKafkaBuilder.class);
-    private static Boolean USE_KRAFT;
     public static String DEFAULT_KAFKA_NAME = "debezium-kafka-cluster";
     public static String DEFAULT_NODE_POOL_NAME = "node-pool";
+    private static Boolean useKraft;
 
     private FabricKafkaBuilder(KafkaBuilder kafkaBuilder) {
         super(kafkaBuilder);
@@ -125,32 +125,32 @@ public final class FabricKafkaBuilder extends FabricBuilderWrapper<FabricKafkaBu
     }
 
     public static boolean shouldKRaftBeUsed() {
-        if (USE_KRAFT == null) {
+        if (useKraft == null) {
             ComparableVersion kafkaVersion = new ComparableVersion(ConfigProperties.STRIMZI_VERSION_KAFKA);
             ComparableVersion strimziVersion = new ComparableVersion(ConfigProperties.STRIMZI_OPERATOR_VERSION);
 
-            USE_KRAFT = false;
+            useKraft = false;
             if (ConfigProperties.FORCE_KRAFT) {
-                USE_KRAFT = true;
+                useKraft = true;
                 LOGGER.info("KRaft forced by configuration.");
             }
             else if (kafkaVersion.compareTo(new ComparableVersion("4.0.0")) >= 0) {
-                USE_KRAFT = true;
+                useKraft = true;
                 LOGGER.info("Kafka version >= 4.0.0 detected.");
             }
             else if (!ConfigProperties.PRODUCT_BUILD && strimziVersion.compareTo(new ComparableVersion("0.46.0")) >= 0) {
-                USE_KRAFT = true;
+                useKraft = true;
                 LOGGER.info("Strimzi version >= 0.46.0.");
             }
 
-            if (USE_KRAFT) {
+            if (useKraft) {
                 LOGGER.info("Using Kafka with KRaft is enabled.");
             }
             else {
                 LOGGER.warn("Using Kafka with Zookeeper is enabled. This way will become deprecated soon.");
             }
         }
-        return USE_KRAFT;
+        return useKraft;
     }
 
     private static KafkaClusterSpec defaultKafkaSpec() {


### PR DESCRIPTION
With this PR we can run Kafka in KRaft mode without adding/changing any of the actual parameters. 
I have also added the param test.force.kraft in case we want to force the use of KRaft. 

And then, if the kafka version is equals or greater than 4.0.0, KRaft is used. And if the build is not productized and strimzi version is equals or greater than 0.46.0, we are also using KRaft (in this version Zookeeper is deprecated and no longer available).   