### PR TITLE
[docs] Fix page alias that cannot reference itself

### DIFF
--- a/documentation/modules/ROOT/pages/ai/embeddings.adoc
+++ b/documentation/modules/ROOT/pages/ai/embeddings.adoc
@@ -1,4 +1,4 @@
-:page-aliases: ai/embeddings.adoc
+:page-aliases: transforms/embeddings.adoc
 // Category: debezium-using
 // Type: assembly
 // ModuleID: embeddings-transformation


### PR DESCRIPTION
@vjuranek fyi I found that the doc was broken. 