### PR TITLE
DBZ-9141: Avoid messing up fields while using fields.include.list

### DIFF
--- a/debezium-sink/src/main/java/io/debezium/bindings/kafka/KafkaDebeziumSinkRecord.java
+++ b/debezium-sink/src/main/java/io/debezium/bindings/kafka/KafkaDebeziumSinkRecord.java
@@ -312,7 +312,7 @@ public class KafkaDebeziumSinkRecord implements DebeziumSinkRecord {
             final Schema schema = schemaBuilder.build();
             Struct filteredData = new Struct(schema);
             schema.fields().forEach(field -> {
-                Object fieldValue = data.get(field);
+                Object fieldValue = data.get(field.name());
                 if (null != fieldValue && (null == fieldsFilter || fieldsFilter.matches(topicName, field.name()))) {
                     filteredData.put(field.name(), fieldValue);
                 }


### PR DESCRIPTION
Before the PR, the data.get(field) is doing a lookup by id. But the id of field come from filteredData, so schema can be different, especially if we use `fields.include.list`.