### PR TITLE
DBZ-8680 Revert "DBZ-8680 Postgres: Probe streaming connection during…

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -260,14 +260,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             if (context.isPaused()) {
                 LOGGER.info("Streaming will now pause");
                 context.streamingPaused();
-                context.waitSnapshotCompletion(() -> {
-                    try {
-                        probeConnectionIfNeeded();
-                    }
-                    catch (SQLException e) {
-                        throw new DebeziumException(e);
-                    }
-                });
+                context.waitSnapshotCompletion();
                 LOGGER.info("Streaming resumed");
             }
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSource.java
@@ -31,19 +31,6 @@ public interface ChangeEventSource {
         void waitSnapshotCompletion() throws InterruptedException;
 
         /**
-         * Wait for the resumeStreaming function to be called, which indicates that a snapshot is done
-         * and that streaming should resume.
-         *
-         * @param heartbeatCallback A callback function which will be periodically called while waiting for
-         *                          the snapshot to be completed.  Implementations should be kept simple and
-         *                          relatively fast: only do activities like generating activity on the
-         *                          streaming database connection to prevent idle timeouts.  Implementations
-         *                          should also check their own ElapsedTimeStrategy to control how often any
-         *                          heartbeat activities actually occur.
-         */
-        void waitSnapshotCompletion(Runnable heartbeatCallback) throws InterruptedException;
-
-        /**
          * Called by the StreamingChangeEventSource to indicate that the streaming has now been paused, and
          * that no streaming records are being processed anymore.
          */


### PR DESCRIPTION
… blocking snapshots"

This partially reverts commit 988c8ce881c9c2882badb617a1cd0b9b01a3fd0e. Only some Javadocs added from that commit are still retained.

The reason for the revert is that this code mistakenly probes the snapshot connection during a snapshot.  I had originally thought it would be the streaming connection that gets probed.  The latter already has a keep-alive mechanism which I had overlooked, so nothing more seems to be needed at the moment in terms of keeping some active traffic on the streaming connection.