### PR TITLE
DBZ-9161 Postgres: log errors from keepalive thread for replication

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -827,7 +827,10 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                 metronome.pause();
                             }
                             catch (Exception exp) {
-                                throw new RuntimeException("received unexpected exception will perform keep alive", exp);
+                                // Immediately log the error. Don't rethrow the exception, because it will
+                                // never be seen (or be seen in a timely manner).
+                                LOGGER.error("Unexpected exception while performing keepalive status update on the replication stream", exp);
+                                return;
                             }
                         }
                     });


### PR DESCRIPTION
A background keepalive thread is used to periodically send status updates on the replication stream. If this status update fails, we should immediately log the failure.

The old code catches and rethrows the exception.  This is a problem because:

1.  The exception is not logged at all.  The ExecutorService would rethrow the exception when the "get" function is called on the Future.  However, we never check for results of this future at all by calling "get", so... nothing gets logged.

2.  Even if we did call "get" on the Future in the stopKeepAlive function, the exception would not be immediately logged.  Having the log message be outputted at the correct time the exception actually happened is better for end-user debugging.