### PR TITLE
DBZ-9146 Remove nominalTime facet from OpenLineage events

### DIFF
--- a/debezium-core/src/main/java/io/debezium/openlineage/emitter/OpenLineageEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/openlineage/emitter/OpenLineageEmitter.java
@@ -10,7 +10,7 @@ import static io.debezium.openlineage.dataset.DatasetMetadata.DatasetType.OUTPUT
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 

--- a/debezium-core/src/main/java/io/debezium/openlineage/emitter/OpenLineageEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/openlineage/emitter/OpenLineageEmitter.java
@@ -10,6 +10,7 @@ import static io.debezium.openlineage.dataset.DatasetMetadata.DatasetType.OUTPUT
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -105,18 +106,13 @@ public class OpenLineageEmitter implements LineageEmitter {
                                 ProcessingEngineMetadata.debezium().version(),
                                 ProcessingEngineMetadata.debezium().name(),
                                 ProcessingEngineMetadata.debezium().openlineageAdapterVersion()))
-                .nominalTime(
-                        openLineageContext.getOpenLineage().newNominalTimeRunFacetBuilder()
-                                .nominalStartTime(ZonedDateTime.now())
-                                .nominalEndTime(ZonedDateTime.now())
-                                .build())
                 .put(DebeziumConfigFacet.FACET_KEY_NAME, new DebeziumConfigFacet(emitter.getProducer(), config.asMap()));
 
         addStackTrace(t, runFacetsBuilder);
 
         OpenLineage.RunEvent startEvent = openLineageContext.getOpenLineage().newRunEventBuilder()
                 .eventType(getEventType(state))
-                .eventTime(ZonedDateTime.now())
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
                 .run(openLineageContext.getOpenLineage().newRun(openLineageContext.getRunUuid(), runFacetsBuilder.build()))
                 .inputs(inputs)
                 .outputs(outputs)


### PR DESCRIPTION
According to OpenLineage docs:
https://openlineage.io/docs/spec/facets/run-facets/nominal_time
> The nominal usually means the time the job run was expected to run (like a scheduled time)

But facet contains current time, which is already passed to eventTime field.