### PR TITLE
Typo in the example code of the Custom Converter 'IsbnConverter' 

### DIFF
--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -169,7 +169,7 @@ The converter configuration is specific to each instance.
                 ConverterRegistration<SchemaBuilder> registration) {
 
             if ("isbn".equals(column.typeName())) {
-                registration.register(SchemaBuilder.string().name(isbnSchemaName)), x -> x.toString());
+                registration.register(SchemaBuilder.string().name(isbnSchemaName), x -> x.toString());
             }
         }
     }


### PR DESCRIPTION
This commit fixes the closing bracket typo in the example code of the Custom Converter 'IsbnConverter' because of an extra closing bracket in between the line 15 which was causing the code to throw an error.