### PR TITLE
DBZ-9153 Typo in the example code of the Custom Converter

### DIFF
--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -169,7 +169,7 @@ The converter configuration is specific to each instance.
                 ConverterRegistration<SchemaBuilder> registration) {
 
             if ("isbn".equals(column.typeName())) {
-                registration.register(SchemaBuilder.string().name(isbnSchemaName)), x -> x.toString());
+                registration.register(SchemaBuilder.string().name(isbnSchemaName), x -> x.toString());
             }
         }
     }


### PR DESCRIPTION
This commit fixes the closing bracket typo in the example code of the Custom Converter 'IsbnConverter' due to an extra closing bracket on line 15, which was causing the code to throw an error.

![image](https://github.com/user-attachments/assets/6646fa2b-f6f5-4ea7-a861-9d09d5add8dd)
