### PR TITLE
DBZ-9169: Use JdbcConnection#quoteIdentifier(), remove JdbcConnection#quotedColumnIdString()

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -147,7 +147,7 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
     private String getReselectQuery(List<Column> reselectColumns, Table table, OracleConnection connection) {
         final TableId id = new TableId(null, table.id().schema(), table.id().table());
         final StringBuilder query = new StringBuilder("SELECT ")
-                .append(reselectColumns.stream().map(c -> connection.quotedColumnIdString(c.name())).collect(Collectors.joining(", ")))
+                .append(reselectColumns.stream().map(c -> connection.quoteIdentifier(c.name())).collect(Collectors.joining(", ")))
                 .append(" FROM ")
                 .append(id.toDoubleQuotedString())
                 .append(" WHERE ");
@@ -156,7 +156,7 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
             if (i > 0) {
                 query.append(" AND ");
             }
-            query.append(connection.quotedColumnIdString(table.primaryKeyColumnNames().get(i))).append("=?");
+            query.append(connection.quoteIdentifier(table.primaryKeyColumnNames().get(i))).append("=?");
         }
 
         return query.toString();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -655,7 +655,7 @@ public class OracleConnection extends JdbcConnection {
             final String commitScn = source.getString(SourceInfo.COMMIT_SCN_KEY);
             if (!Strings.isNullOrEmpty(commitScn)) {
                 final String query = String.format("SELECT %s FROM (SELECT * FROM %s AS OF SCN ?) WHERE %s",
-                        columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
+                        columns.stream().map(this::quoteIdentifier).collect(Collectors.joining(",")),
                         quotedTableIdString(oracleTableId),
                         keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
                 final List<Object> bindValues = new ArrayList<>(keyValues.size() + 1);
@@ -676,7 +676,7 @@ public class OracleConnection extends JdbcConnection {
         }
 
         final String query = String.format("SELECT %s FROM %s WHERE %s",
-                columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
+                columns.stream().map(this::quoteIdentifier).collect(Collectors.joining(",")),
                 quotedTableIdString(oracleTableId),
                 keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -622,16 +622,6 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     @Override
-    @Deprecated
-    public String quotedColumnIdString(String columnName) {
-        if (columnName.contains("\"")) {
-            columnName = columnName.replace("\"", "\"\"");
-        }
-
-        return super.quotedColumnIdString(columnName);
-    }
-
-    @Override
     protected int resolveNativeType(String typeName) {
         return getTypeRegistry().get(typeName).getRootType().getOid();
     }
@@ -826,7 +816,7 @@ public class PostgresConnection extends JdbcConnection {
     public Map<String, Object> reselectColumns(Table table, List<String> columns, List<String> keyColumns, List<Object> keyValues, Struct source)
             throws SQLException {
         final String query = String.format("SELECT %s FROM %s WHERE %s",
-                columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
+                columns.stream().map(this::quoteIdentifier).collect(Collectors.joining(",")),
                 quotedTableIdString(table.id()),
                 keyColumns.stream()
                         .map(key -> {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -205,7 +205,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
             connection.setAutoCommit(false);
             for (int i = 0; i < enumValues.size(); i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
-                        "s1.enumpk", connection.quotedColumnIdString(pkFieldName()), "'" + enumValues.get(i) + "'", i));
+                        "s1.enumpk", connection.quoteIdentifier(pkFieldName()), "'" + enumValues.get(i) + "'", i));
             }
             connection.commit();
         }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1689,16 +1689,6 @@ public class JdbcConnection implements AutoCloseable {
     }
 
     /**
-     * Prepares qualified column names with appropriate quote character as per the specific database's rules.
-     *
-     * @deprecated Use {@link #quoteIdentifier(String)} instead.
-     */
-    @Deprecated
-    public String quotedColumnIdString(String columnName) {
-        return openingQuoteCharacter + columnName + closingQuoteCharacter;
-    }
-
-    /**
      * Read JKS type keystore/truststore file according related password.
      */
     public KeyStore loadKeyStore(String filePath, char[] passwordArray) {
@@ -1723,7 +1713,7 @@ public class JdbcConnection implements AutoCloseable {
     public Map<String, Object> reselectColumns(Table table, List<String> columns, List<String> keyColumns, List<Object> keyValues, Struct source)
             throws SQLException {
         final String query = String.format("SELECT %s FROM %s WHERE %s",
-                columns.stream().map(this::quotedColumnIdString).collect(Collectors.joining(",")),
+                columns.stream().map(this::quoteIdentifier).collect(Collectors.joining(",")),
                 quotedTableIdString(table.id()),
                 keyColumns.stream().map(key -> key + "=?").collect(Collectors.joining(" AND ")));
         return reselectColumns(query, table.id(), columns, keyValues);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -70,7 +70,7 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
             throw new UnsupportedOperationException("The sort order of NULL values in the incremental snapshot key is unknown.");
         }
         final String orderBy = queryColumns.stream()
-                .map(c -> jdbcConnection.quotedColumnIdString(c.name()))
+                .map(c -> jdbcConnection.quoteIdentifier(c.name()))
                 .collect(Collectors.joining(", "));
         return jdbcConnection.buildSelectWithRowLimits(table.id(),
                 limit,
@@ -86,7 +86,7 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
             TableId tableId = table.id();
             projection = table.columns().stream()
                     .filter(column -> columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
-                    .map(column -> jdbcConnection.quotedColumnIdString(column.name()))
+                    .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                     .collect(Collectors.joining(", "));
         }
         return projection;
@@ -128,7 +128,7 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
             sql.append('(');
             for (int j = 0; j < i + 1; j++) {
                 final boolean isLastIterationForJ = (i == j);
-                final String pkColumnName = jdbcConnection.quotedColumnIdString(pkColumns.get(j).name());
+                final String pkColumnName = jdbcConnection.quoteIdentifier(pkColumns.get(j).name());
                 if (pkColumns.get(j).isRequired()) {
                     sql.append(pkColumnName);
                     sql.append(isLastIterationForJ ? " > ?" : " = ?");
@@ -222,7 +222,7 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     @Override
     public String buildMaxPrimaryKeyQuery(IncrementalSnapshotContext<T> context, Table table, Optional<String> additionalCondition) {
         final String orderBy = getQueryColumns(context, table).stream()
-                .map(c -> jdbcConnection.quotedColumnIdString(c.name()))
+                .map(c -> jdbcConnection.quoteIdentifier(c.name()))
                 .collect(Collectors.joining(" DESC, ")) + " DESC";
         String selectWithRowLimits = jdbcConnection.buildSelectWithRowLimits(table.id(), 1, buildProjection(table), Optional.empty(),
                 additionalCondition, orderBy);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilder.java
@@ -50,7 +50,7 @@ public class RowValueConstructorChunkQueryBuilder<T extends DataCollectionId> ex
         }
         for (int i = 0; i < pkColumns.size(); i++) {
             final boolean isLastIterationForI = (i == pkColumns.size() - 1);
-            final String pkColumnName = jdbcConnection.quotedColumnIdString(pkColumns.get(i).name());
+            final String pkColumnName = jdbcConnection.quoteIdentifier(pkColumns.get(i).name());
             sql.append(pkColumnName);
             if (!isLastIterationForI) {
                 sql.append(", ");

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -764,7 +764,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 .stream()
                 .filter(columnName -> additionalColumnFilter(partition, table.id(), columnName))
                 .filter(columnName -> connectorConfig.getColumnFilter().matches(table.id().catalog(), table.id().schema(), table.id().table(), columnName))
-                .map(jdbcConnection::quotedColumnIdString)
+                .map(jdbcConnection::quoteIdentifier)
                 .collect(Collectors.toList());
 
         if (columnNames.isEmpty()) {
@@ -772,7 +772,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
             columnNames = table.retrieveColumnNames()
                     .stream()
-                    .map(jdbcConnection::quotedColumnIdString)
+                    .map(jdbcConnection::quoteIdentifier)
                     .collect(Collectors.toList());
         }
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -452,7 +452,7 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
             for (int i = 0; i < rowCount; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + startingPkId + 1,
                         i + startingPkId));
             }
@@ -467,7 +467,7 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
             for (int i = 0; i < rowCount; i++) {
                 connection.execute(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + startingPkId + 1,
                         i + startingPkId));
                 actionOnInsert.run();

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -200,7 +200,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -228,7 +228,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -324,9 +324,9 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
                 connection.executeWithoutCommitting(
                         String.format("UPDATE %s SET aa = aa + 2000 WHERE %s > %s AND %s <= %s",
                                 tableName(),
-                                connection.quotedColumnIdString(pkFieldName()),
+                                connection.quoteIdentifier(pkFieldName()),
                                 i * batchSize,
-                                connection.quotedColumnIdString(pkFieldName()),
+                                connection.quoteIdentifier(pkFieldName()),
                                 (i + 1) * batchSize));
                 connection.commit();
             }
@@ -361,9 +361,9 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
                 connection.executeWithoutCommitting(
                         String.format("UPDATE %s SET aa = aa + 2000 WHERE %s > %s AND %s <= %s",
                                 tableName(),
-                                connection.quotedColumnIdString(pkFieldName()),
+                                connection.quoteIdentifier(pkFieldName()),
                                 i * batchSize,
-                                connection.quotedColumnIdString(pkFieldName()),
+                                connection.quoteIdentifier(pkFieldName()),
                                 (i + 1) * batchSize));
                 connection.commit();
             }
@@ -621,7 +621,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         try (JdbcConnection connection = databaseConnection()) {
             connection.execute(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                     tableName(),
-                    connection.quotedColumnIdString(pkFieldName()),
+                    connection.quoteIdentifier(pkFieldName()),
                     2 * ROW_COUNT + 1,
                     2 * ROW_COUNT));
         }
@@ -642,7 +642,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -689,7 +689,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         try (JdbcConnection connection = databaseConnection()) {
             connection.execute(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                     tableName(),
-                    connection.quotedColumnIdString(pkFieldName()),
+                    connection.quoteIdentifier(pkFieldName()),
                     2 * ROW_COUNT + 1,
                     2 * ROW_COUNT));
         }
@@ -710,7 +710,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -761,7 +761,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableToSnapshot,
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -812,7 +812,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableToSnapshot,
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -1139,7 +1139,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }
@@ -1173,7 +1173,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             for (int i = 0; i < ROW_COUNT; i++) {
                 connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                         tableName(),
-                        connection.quotedColumnIdString(pkFieldName()),
+                        connection.quoteIdentifier(pkFieldName()),
                         i + ROW_COUNT + 1,
                         i + ROW_COUNT));
             }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
         connection.setAutoCommit(false);
         for (int i = 0; i < ROW_COUNT; i++) {
             connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
-                    tableName, connection.quotedColumnIdString(pkFieldName()), i + 1, i));
+                    tableName, connection.quoteIdentifier(pkFieldName()), i + 1, i));
         }
         connection.commit();
     }
@@ -139,7 +139,7 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
         for (int i = startRow + 1; i <= startRow + count; i++) {
             connection.executeWithoutCommitting(
                     String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
-                            tableName, connection.quotedColumnIdString(pkFieldName()), count + i, value));
+                            tableName, connection.quoteIdentifier(pkFieldName()), count + i, value));
         }
         connection.commit();
     }


### PR DESCRIPTION
This PR removes the deprecated `JdbcConnection#quotedColumnIdString()` in favor of `JdbcConnection#quoteIdentifier()`.

It doesn't include any additional tests based on the following:
1. https://github.com/debezium/debezium/pull/6464 and https://github.com/debezium/debezium/pull/6520 demonstrate that `JdbcConnection#quotedColumnIdString()` correctly quotes special characters on SQL Server, MySQL and MariaDB.
2. The implementation of `PostgresConnection#quotedColumnIdString()` is identical to `JdbcConnection#quotedColumnIdString()`, so it doesn't require additional testing.

This change also affects the Oracle connector. The thing is that Oracle doesn't allow double quotes in object names (see the [documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Database-Object-Names-and-Qualifiers.html)):
> Quoted identifiers can contain any characters and punctuations marks as well as spaces. However, neither quoted nor nonquoted identifiers can contain double quotation marks or the null character (`\0`).

So, technically, neither the old nor the new implementations are correct for Oracle. However, the Oracle connector already uses `TableId#toDoubleQuotedString()`, which doubles the double quote:
https://github.com/debezium/debezium/blob/3a53db5dbb74b7371943355d79ec3b96f47ab6cc/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java#L260-L262

Therefore, using `JdbcConnection#quoteIdentifier()` in the Oracle connector at least makes it consistent with the rest of the queries generated by the connector.