### PR TITLE
DBZ-9170 Align configuration for post processors to transforms, predicates

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReselectColumnsProcessorIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReselectColumnsProcessorIT.java
@@ -64,7 +64,7 @@ public abstract class BinlogReselectColumnsProcessorIT<C extends SourceConnector
         return DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("dbz4321"))
                 .with(BinlogConnectorConfig.CUSTOM_POST_PROCESSORS, "reselector")
-                .with("reselector.type", ReselectColumnsPostProcessor.class.getName());
+                .with("post.processors.reselector.type", ReselectColumnsPostProcessor.class.getName());
     }
 
     @Override

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleReselectColumnsProcessorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleReselectColumnsProcessorIT.java
@@ -83,7 +83,7 @@ public class OracleReselectColumnsProcessorIT extends AbstractReselectProcessorT
         return TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ4321")
                 .with(OracleConnectorConfig.CUSTOM_POST_PROCESSORS, "reselector")
-                .with("reselector.type", ReselectColumnsPostProcessor.class.getName());
+                .with("post.processors.reselector.type", ReselectColumnsPostProcessor.class.getName());
     }
 
     @Override
@@ -148,7 +148,7 @@ public class OracleReselectColumnsProcessorIT extends AbstractReselectProcessorT
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ7729")
                     .with(OracleConnectorConfig.MSG_KEY_COLUMNS, "(.*).DEBEZIUM.DBZ7729:DATA3")
                     .with(OracleConnectorConfig.LOB_ENABLED, "true")
-                    .with("reselector.reselect.columns.include.list", "DEBEZIUM.DBZ7729:DATA")
+                    .with("post.processors.reselector.reselect.columns.include.list", "DEBEZIUM.DBZ7729:DATA")
                     .build();
 
             start(getConnectorClass(), config);
@@ -204,7 +204,7 @@ public class OracleReselectColumnsProcessorIT extends AbstractReselectProcessorT
 
             Configuration config = getConfigurationBuilder()
                     .with(OracleConnectorConfig.LOB_ENABLED, "true")
-                    .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                    .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                     .build();
             start(OracleConnector.class, config);
             assertConnectorIsRunning();
@@ -254,7 +254,7 @@ public class OracleReselectColumnsProcessorIT extends AbstractReselectProcessorT
 
             Configuration config = getConfigurationBuilder()
                     .with(OracleConnectorConfig.LOB_ENABLED, "true")
-                    .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                    .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                     .build();
             start(OracleConnector.class, config);
             assertConnectorIsRunning();
@@ -304,7 +304,7 @@ public class OracleReselectColumnsProcessorIT extends AbstractReselectProcessorT
 
             Configuration config = getConfigurationBuilder()
                     .with(OracleConnectorConfig.LOB_ENABLED, "true")
-                    .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                    .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                     .build();
 
             start(OracleConnector.class, config);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
@@ -74,7 +74,7 @@ public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcesso
         return TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz4321")
                 .with(PostgresConnectorConfig.CUSTOM_POST_PROCESSORS, "reselector")
-                .with("reselector.type", ReselectColumnsPostProcessor.class.getName());
+                .with("post.processors.reselector.type", ReselectColumnsPostProcessor.class.getName());
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerReselectColumnsProcessorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerReselectColumnsProcessorIT.java
@@ -59,7 +59,7 @@ public class SqlServerReselectColumnsProcessorIT extends AbstractReselectProcess
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo\\.dbz4321")
                 .with(SqlServerConnectorConfig.CUSTOM_POST_PROCESSORS, "reselector")
-                .with("reselector.type", ReselectColumnsPostProcessor.class.getName());
+                .with("post.processors.reselector.type", ReselectColumnsPostProcessor.class.getName());
     }
 
     @Override

--- a/debezium-embedded/src/test/java/io/debezium/processors/AbstractReselectProcessorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/processors/AbstractReselectProcessorTest.java
@@ -81,9 +81,9 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
 
         Configuration config = getConfigurationBuilder()
                 .with("snapshot.mode", "initial")
-                .with("reselector.reselect.null.values", "false")
-                .with("reselector.reselect.unavailable.values", "false")
-                .with("reselector.reselect.columns.include.list", reselectColumnsList()).build();
+                .with("post.processors.reselector.reselect.null.values", "false")
+                .with("post.processors.reselector.reselect.unavailable.values", "false")
+                .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList()).build();
 
         start(getConnectorClass(), config);
         assertConnectorIsRunning();
@@ -116,7 +116,7 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
 
         Configuration config = getConfigurationBuilder()
                 .with("snapshot.mode", "initial")
-                .with("reselector.reselect.columns.include.list", reselectColumnsList()).build();
+                .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList()).build();
 
         start(getConnectorClass(), config);
         assertConnectorIsRunning();
@@ -146,7 +146,7 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
         LogInterceptor interceptor = getReselectLogInterceptor();
 
         Configuration config = getConfigurationBuilder()
-                .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                 .build();
 
         start(getConnectorClass(), config);
@@ -202,7 +202,7 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
 
         Configuration config = getConfigurationBuilder()
                 .with("snapshot.mode", "initial")
-                .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                 .build();
 
         start(getConnectorClass(), config);
@@ -229,7 +229,7 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
         enableTableForCdc();
 
         Configuration config = getConfigurationBuilder()
-                .with("reselector.reselect.columns.include.list", reselectColumnsList())
+                .with("post.processors.reselector.reselect.columns.include.list", reselectColumnsList())
                 .build();
 
         start(getConnectorClass(), config);
@@ -271,7 +271,7 @@ public abstract class AbstractReselectProcessorTest<T extends SourceConnector> e
         enableTableForCdc();
 
         Configuration config = getConfigurationBuilder()
-                .without("reselector.type")
+                .without("post.processors.reselector.type")
                 .build();
 
         start(getConnectorClass(), config);


### PR DESCRIPTION
## Context

Actually the configuration for post processing is the following:

```txt
  "post.processors": "reselector", 
  "reselector.type": "io.debezium.processors.reselect.ReselectColumnsPostProcessor", 
  "reselector.reselect.columns.include.list": "<schema>.<table>:<column>,<schema>.<table>:<column>", 
  "reselector.reselect.unavailable.values": "true", 
  "reselector.reselect.null.values": "true" 
  "reselector.reselect.use.event.key": "false" 
  "reselector.reselect.error.handling.mode": "WARN"
```

which differs from the canonical convention used for `transformers`, `predicates` like:

```txt
transforms=t0
transforms.t0.add.fields=op,table
transforms.t0.add.headers=db,table
transforms.t0.negate=false
```

## Changes
We support both aligning the new configuration to `transformers` and `predicates`.

```txt
  "post.processors": "reselector", 
  "post.processors.reselector.type": "io.debezium.processors.reselect.ReselectColumnsPostProcessor", 
  "post.processors.reselector.reselect.columns.include.list": "<schema>.<table>:<column>,<schema>.<table>:<column>", 
  "post.processors.reselector.reselect.unavailable.values": "true", 
  "post.processors.reselector.reselect.null.values": "true" 
  "post.processors.reselector.reselect.use.event.key": "false" 
  "post.processors.reselector.reselect.error.handling.mode": "WARN"
```