### PR TITLE
DBZ 8965 Debezium Engine Quarkus Extension: introduce PostProcessor handler

### DIFF
--- a/debezium-core/src/main/java/io/debezium/processors/PostProcessorFactory.java
+++ b/debezium-core/src/main/java/io/debezium/processors/PostProcessorFactory.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.processors;
+
+import java.util.List;
+
+import io.debezium.processors.spi.PostProcessor;
+
+public interface PostProcessorFactory {
+
+    List<PostProcessor> get();
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/PostProcessorGenerator.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/PostProcessorGenerator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.deployment;
+
+import java.lang.reflect.Modifier;
+import java.util.UUID;
+
+import org.apache.kafka.connect.data.Struct;
+import org.jboss.jandex.MethodInfo;
+
+import io.debezium.processors.spi.PostProcessor;
+import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.debezium.deployment.engine.GeneratedClassMetaData;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.runtime.util.HashUtil;
+
+public class PostProcessorGenerator {
+    private final ClassOutput output;
+
+    public PostProcessorGenerator(ClassOutput output) {
+        this.output = output;
+    }
+
+    /**
+     * it generates concrete classes based on the PostProcessor interface using gizmo:
+     * <p>
+     * public class GeneratedPostProcessor implements PostProcessor {
+     *     private final Object beanInstance;
+     *
+     *     void configure(Map<String, ?> properties) {
+     *         // empty configuration can be taken from CDI
+     *     }
+     *
+     *     void apply(Object key, Struct value) {
+     *         beanInstance.method(key, value);
+     *     }
+     *
+     *     void close() {
+     *         // resources can be managed outside
+     *     }
+     * }
+     * @param methodInfo
+     * @param beanInfo
+     * @return
+     */
+    public GeneratedClassMetaData generate(MethodInfo methodInfo, BeanInfo beanInfo) {
+        String name = generateClassName(beanInfo, methodInfo);
+        try (ClassCreator invoker = ClassCreator.builder()
+                .classOutput(this.output)
+                .className(name)
+                .interfaces(PostProcessor.class)
+                .build()) {
+
+            FieldDescriptor beanInstanceField = invoker.getFieldCreator("beanInstance", methodInfo
+                    .declaringClass()
+                    .name()
+                    .toString())
+                    .setModifiers(Modifier.PRIVATE)
+                    .getFieldDescriptor();
+
+            try (MethodCreator constructor = invoker.getMethodCreator("<init>", void.class, Object.class)) {
+                constructor.setModifiers(Modifier.PUBLIC);
+                constructor.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), constructor.getThis());
+                ResultHandle constructorThis = constructor.getThis();
+                ResultHandle beanInstance = constructor.getMethodParam(0);
+                constructor.writeInstanceField(beanInstanceField, constructorThis, beanInstance);
+                constructor.returnValue(null);
+            }
+
+            try (MethodCreator apply = invoker.getMethodCreator("apply", void.class, Object.class, Struct.class)) {
+                ResultHandle applyThis = apply.getThis();
+                ResultHandle delegate = apply.readInstanceField(beanInstanceField, applyThis);
+                ResultHandle eventObject = apply.getMethodParam(0);
+                ResultHandle eventStruct = apply.getMethodParam(1);
+
+                MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(
+                        methodInfo.declaringClass().toString(),
+                        methodInfo.name(),
+                        "V",
+                        methodInfo.parameterType(0).name().toString(),
+                        methodInfo.parameterType(1).name().toString());
+
+                apply.invokeVirtualMethod(methodDescriptor, delegate, eventObject, eventStruct);
+                apply.returnVoid();
+            }
+        }
+
+        return new GeneratedClassMetaData(UUID.randomUUID(), name.replace('/', '.'), beanInfo);
+    }
+
+    private String generateClassName(BeanInfo bean, MethodInfo methodInfo) {
+        return DotNames.internalPackageNameWithTrailingSlash(bean.getImplClazz().name())
+                + DotNames.simpleName(bean.getImplClazz().name())
+                + "_DebeziumPostProcessor" + "_"
+                + methodInfo.name() + "_"
+                + HashUtil.sha1(methodInfo.name() + "_" + methodInfo.returnType().name().toString());
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandler.java
@@ -35,4 +35,6 @@ class ClassesInConfigurationHandler {
     public static ClassesInConfigurationHandler TRANSFORM = new ClassesInConfigurationHandler("transforms");
 
     public static ClassesInConfigurationHandler PREDICATE = new ClassesInConfigurationHandler("predicates");
+
+    public static ClassesInConfigurationHandler POST_PROCESSOR = new ClassesInConfigurationHandler("post.processors");
 }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandler.java
@@ -28,6 +28,7 @@ class ClassesInConfigurationHandler {
         }
 
         return Arrays.stream(elements.split(DELIMITER))
+                .map(String::trim)
                 .map(value -> config.get(type + "." + value + ".type"))
                 .toList();
     }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
@@ -60,7 +60,6 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import io.quarkus.arc.processor.DotNames;
-import io.quarkus.debezium.deployment.PostProcessorGenerator;
 import io.quarkus.debezium.deployment.dotnames.DebeziumDotNames;
 import io.quarkus.debezium.deployment.items.DebeziumConnectorBuildItem;
 import io.quarkus.debezium.deployment.items.DebeziumGeneratedInvokerBuildItem;

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
@@ -7,6 +7,7 @@
 package io.quarkus.debezium.deployment.engine;
 
 import static io.quarkus.debezium.deployment.dotnames.DebeziumDotNames.CapturingDotName.CAPTURING;
+import static io.quarkus.debezium.deployment.engine.ClassesInConfigurationHandler.POST_PROCESSOR;
 import static io.quarkus.debezium.deployment.engine.ClassesInConfigurationHandler.PREDICATE;
 import static io.quarkus.debezium.deployment.engine.ClassesInConfigurationHandler.TRANSFORM;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
@@ -164,6 +165,12 @@ public class EngineProcessor {
         PREDICATE.extract(debeziumEngineConfiguration.configuration())
                 .forEach(predicate -> reflectiveClasses.produce(ReflectiveClassBuildItem
                         .builder(predicate)
+                        .reason(getClass().getName())
+                        .build()));
+
+        POST_PROCESSOR.extract(debeziumEngineConfiguration.configuration())
+                .forEach(postProcessor -> reflectiveClasses.produce(ReflectiveClassBuildItem
+                        .builder(postProcessor)
                         .reason(getClass().getName())
                         .build()));
 

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/GeneratedClassMetaData.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/GeneratedClassMetaData.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 import io.quarkus.arc.processor.BeanInfo;
 
-public record InvokerMetaData(UUID id, String invokerClassName, BeanInfo mediator) {
+public record GeneratedClassMetaData(UUID id, String generatedClassName, BeanInfo mediator) {
 
     public String getShortIdentifier() {
         return id.toString().split("-")[0].replaceAll("\\D", "");

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/InvokerGenerator.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/InvokerGenerator.java
@@ -47,7 +47,7 @@ public class InvokerGenerator {
      * @param beanInfo
      * @return
      */
-    public InvokerMetaData generate(MethodInfo methodInfo, BeanInfo beanInfo) {
+    public GeneratedClassMetaData generate(MethodInfo methodInfo, BeanInfo beanInfo) {
         String name = generateClassName(beanInfo, methodInfo);
 
         try (ClassCreator invoker = ClassCreator.builder()
@@ -87,7 +87,7 @@ public class InvokerGenerator {
                 capture.returnVoid();
             }
 
-            return new InvokerMetaData(UUID.randomUUID(), name.replace('/', '.'), beanInfo);
+            return new GeneratedClassMetaData(UUID.randomUUID(), name.replace('/', '.'), beanInfo);
         }
     }
 

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/PostProcessorGenerator.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/PostProcessorGenerator.java
@@ -4,9 +4,10 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.quarkus.debezium.deployment;
+package io.quarkus.debezium.deployment.engine;
 
 import java.lang.reflect.Modifier;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.kafka.connect.data.Struct;
@@ -15,7 +16,6 @@ import org.jboss.jandex.MethodInfo;
 import io.debezium.processors.spi.PostProcessor;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.DotNames;
-import io.quarkus.debezium.deployment.engine.GeneratedClassMetaData;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -92,6 +92,16 @@ public class PostProcessorGenerator {
 
                 apply.invokeVirtualMethod(methodDescriptor, delegate, eventObject, eventStruct);
                 apply.returnVoid();
+            }
+
+            try (MethodCreator configure = invoker.getMethodCreator("configure", void.class, Map.class)) {
+                configure.setModifiers(Modifier.PUBLIC);
+                configure.returnVoid();
+            }
+
+            try (MethodCreator close = invoker.getMethodCreator("close", void.class)) {
+                close.setModifiers(Modifier.PUBLIC);
+                close.returnVoid();
             }
         }
 

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/resources/META-INF/services/io.debezium.processors.PostProcessorFactory
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/resources/META-INF/services/io.debezium.processors.PostProcessorFactory
@@ -1,0 +1,1 @@
+io.quarkus.debezium.engine.post.processing.ArcPostProcessorFactory

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/test/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandlerTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/test/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandlerTest.java
@@ -44,6 +44,14 @@ class ClassesInConfigurationHandlerTest {
             "predicates", "p2",
             "enabled", "false");
 
+    private static final Map<String, String> CONFIGURATION_WITH_POST_PROCESSING = Map.of(
+            "post.processors", "reselector",
+            "reselector.type", "io.debezium.processors.reselect.ReselectColumnsPostProcessor",
+            "reselector.reselect.unavailable.values", "true",
+            "reselector.reselect.null.values", "true",
+            "reselector.reselect.use.event.key", "false",
+            "reselector.reselect.error.handling.mode", "WARN");
+
     @Test
     @DisplayName("should return empty when there are no transforms")
     void shouldBeEmptyWithoutTransforms() {
@@ -68,6 +76,15 @@ class ClassesInConfigurationHandlerTest {
         assertThat(underTest.extract(CONFIGURATION_WITH_MULTIPLE_TRANSFORMATION)).containsExactly(
                 "io.debezium.transforms.ExtractNewRecordState",
                 "io.debezium.transforms.ExtractNewRecordState");
+    }
+
+    @Test
+    @DisplayName("should return multiple classes when there is more than one transform")
+    void shouldBeMultipleElementWhenThereIsMoreThanOnePostProcessor() {
+        ClassesInConfigurationHandler underTest = ClassesInConfigurationHandler.POST_PROCESSOR;
+
+        assertThat(underTest.extract(CONFIGURATION_WITH_POST_PROCESSING)).containsExactly(
+                "io.debezium.processors.reselect.ReselectColumnsPostProcessor");
     }
 
     @Test

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/test/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandlerTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/test/java/io/quarkus/debezium/deployment/engine/ClassesInConfigurationHandlerTest.java
@@ -45,12 +45,9 @@ class ClassesInConfigurationHandlerTest {
             "enabled", "false");
 
     private static final Map<String, String> CONFIGURATION_WITH_POST_PROCESSING = Map.of(
-            "post.processors", "reselector",
-            "reselector.type", "io.debezium.processors.reselect.ReselectColumnsPostProcessor",
-            "reselector.reselect.unavailable.values", "true",
-            "reselector.reselect.null.values", "true",
-            "reselector.reselect.use.event.key", "false",
-            "reselector.reselect.error.handling.mode", "WARN");
+            "post.processors", "reselector, another",
+            "post.processors.reselector.type", "io.debezium.processors.reselect.ReselectColumnsPostProcessor",
+            "post.processors.another.type", "io.debezium.processors.reselect.AnotherReselectColumnsPostProcessor");
 
     @Test
     @DisplayName("should return empty when there are no transforms")
@@ -79,12 +76,13 @@ class ClassesInConfigurationHandlerTest {
     }
 
     @Test
-    @DisplayName("should return multiple classes when there is more than one transform")
-    void shouldBeMultipleElementWhenThereIsMoreThanOnePostProcessor() {
+    @DisplayName("should return multiple classes when there is more than one post processors even with spaces")
+    void shouldBeMultipleElementWhenThereIsMoreThanOnePostProcessorEvenWithSpaces() {
         ClassesInConfigurationHandler underTest = ClassesInConfigurationHandler.POST_PROCESSOR;
 
         assertThat(underTest.extract(CONFIGURATION_WITH_POST_PROCESSING)).containsExactly(
-                "io.debezium.processors.reselect.ReselectColumnsPostProcessor");
+                "io.debezium.processors.reselect.ReselectColumnsPostProcessor",
+                "io.debezium.processors.reselect.AnotherReselectColumnsPostProcessor");
     }
 
     @Test

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/post/processing/ArcPostProcessorFactory.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/post/processing/ArcPostProcessorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.engine.post.processing;
+
+import java.util.List;
+
+import io.debezium.processors.PostProcessorFactory;
+import io.debezium.processors.spi.PostProcessor;
+import io.quarkus.arc.Arc;
+
+public class ArcPostProcessorFactory implements PostProcessorFactory {
+
+    @Override
+    public List<PostProcessor> get() {
+        return Arc.container().select(PostProcessor.class)
+                .stream()
+                .toList();
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/post/processing/DynamicPostProcessingSupplier.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/post/processing/DynamicPostProcessingSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.engine.post.processing;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
+
+import io.debezium.processors.spi.PostProcessor;
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class DynamicPostProcessingSupplier {
+
+    public static final String BASE_NAME = "postProcessing";
+
+    public Supplier<PostProcessor> createPostProcessor(Class<?> mediatorClazz, Class<? extends PostProcessor> invokerClazz) {
+        try {
+            Object mediator = Arc.container().instance(mediatorClazz).get();
+            PostProcessor instance = invokerClazz
+                    .getDeclaredConstructor(Object.class)
+                    .newInstance(mediator);
+
+            return () -> instance;
+
+        }
+        catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/dotnames/DebeziumDotNames.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/dotnames/DebeziumDotNames.java
@@ -19,6 +19,9 @@ import io.quarkus.arc.processor.BeanInfo;
 
 public class DebeziumDotNames {
 
+    public static final DotName DEBEZIUM_ENGINE_PROCESSOR = DotName.createSimple("io.quarkus.debezium.deployment.engine.EngineProcessor");
+    public static final List<DotName> ANNOTATED_WITH_INJECT_SERVICE = List.of(
+            DotName.createSimple("io.debezium.processors.PostProcessorRegistry"));
     public static final DotName CAPTURING = DotName.createSimple(Capturing.class.getName());
     public static final DotName POST_PROCESSING = DotName.createSimple(PostProcessing.class.getName());
     public static final List<DotName> dotNames = List.of(CAPTURING, POST_PROCESSING);

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/dotnames/DebeziumDotNames.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/dotnames/DebeziumDotNames.java
@@ -6,28 +6,47 @@
 
 package io.quarkus.debezium.deployment.dotnames;
 
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 
 import io.debezium.runtime.Capturing;
+import io.debezium.runtime.PostProcessing;
 import io.quarkus.arc.processor.BeanInfo;
 
 public class DebeziumDotNames {
-    public static class CapturingDotName {
-        public static final DotName CAPTURING = DotName.createSimple(Capturing.class.getName());
 
-        public static boolean filter(MethodInfo info) {
-            return info.annotations()
-                    .stream()
-                    .anyMatch(instance -> CAPTURING.equals(instance.name()));
-        }
+    public static final DotName CAPTURING = DotName.createSimple(Capturing.class.getName());
+    public static final DotName POST_PROCESSING = DotName.createSimple(PostProcessing.class.getName());
+    public static final List<DotName> dotNames = List.of(CAPTURING, POST_PROCESSING);
 
-        public static boolean filter(BeanInfo info) {
-            return info.getTarget()
-                    .map(annotation -> annotation.asClass().methods()
-                            .stream()
-                            .anyMatch(CapturingDotName::filter))
-                    .orElse(false);
-        }
+    public boolean filter(BeanInfo info) {
+        return info.getTarget()
+                .map(annotation -> annotation.asClass().methods()
+                        .stream()
+                        .anyMatch(this::filter))
+                .orElse(false);
     }
+
+    public boolean filter(MethodInfo info) {
+        return info.annotations()
+                .stream()
+                .anyMatch(instance -> dotNames
+                        .stream()
+                        .anyMatch(debeziumDotName -> debeziumDotName.equals(instance.name())));
+    }
+
+    public DotName get(MethodInfo info) {
+        return dotNames
+                .stream()
+                .map(info::annotation)
+                .filter(Objects::nonNull)
+                .map(AnnotationInstance::name)
+                .findFirst()
+                .orElse(null);
+    }
+
 }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/items/DebeziumGeneratedPostProcessorBuildItem.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/items/DebeziumGeneratedPostProcessorBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.deployment.items;
+
+import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class DebeziumGeneratedPostProcessorBuildItem extends MultiBuildItem {
+    private final String generatedClassName;
+    private final BeanInfo mediator;
+    private final String id;
+
+    public DebeziumGeneratedPostProcessorBuildItem(String generatedClassName, BeanInfo mediator, String id) {
+        this.generatedClassName = generatedClassName;
+        this.mediator = mediator;
+        this.id = id;
+    }
+
+    public String getGeneratedClassName() {
+        return generatedClassName;
+    }
+
+    public BeanInfo getMediator() {
+        return mediator;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/items/DebeziumMediatorBuildItem.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/src/main/java/io/quarkus/debezium/deployment/items/DebeziumMediatorBuildItem.java
@@ -6,21 +6,24 @@
 
 package io.quarkus.debezium.deployment.items;
 
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Represents a method annotated with {@code Capturing}
+ * Represents a method annotated with {@code Capturing, PostProcessing}
  */
 public final class DebeziumMediatorBuildItem extends MultiBuildItem {
     private final BeanInfo bean;
     private final MethodInfo methodInfo;
+    private final DotName dotName;
 
-    public DebeziumMediatorBuildItem(BeanInfo bean, MethodInfo methodInfo) {
+    public DebeziumMediatorBuildItem(BeanInfo bean, MethodInfo methodInfo, DotName dotName) {
         this.bean = bean;
         this.methodInfo = methodInfo;
+        this.dotName = dotName;
     }
 
     public BeanInfo getBean() {
@@ -29,5 +32,9 @@ public final class DebeziumMediatorBuildItem extends MultiBuildItem {
 
     public MethodInfo getMethodInfo() {
         return methodInfo;
+    }
+
+    public DotName getDotName() {
+        return dotName;
     }
 }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/src/main/java/io/debezium/runtime/PostProcessing.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/src/main/java/io/debezium/runtime/PostProcessing.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.debezium.common.annotation.Incubating;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Incubating()
+public @interface PostProcessing {
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/test/java/io/quarkus/debezium/postgres/deployment/PostProcessingTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/test/java/io/quarkus/debezium/postgres/deployment/PostProcessingTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.postgres.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.debezium.runtime.Debezium;
+import io.debezium.runtime.DebeziumStatus;
+import io.debezium.runtime.PostProcessing;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(value = DatabaseTestResource.class)
+public class PostProcessingTest {
+
+    @Inject
+    PostProcessingHandler postProcessingHandler;
+
+    @Inject
+    Debezium debezium;
+
+    @BeforeEach
+    void setUp() {
+        given().await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(debezium.status())
+                        .isEqualTo(new DebeziumStatus(DebeziumStatus.State.POLLING)));
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest setup = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(CapturingTest.CaptureProductsHandler.class))
+            .overrideConfigKey("quarkus.debezium.offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore")
+            .overrideConfigKey("quarkus.debezium.name", "test")
+            .overrideConfigKey("quarkus.debezium.topic.prefix", "dbserver1")
+            .overrideConfigKey("quarkus.debezium.plugin.name", "pgoutput")
+            .overrideConfigKey("quarkus.debezium.snapshot.mode", "initial")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
+
+    @Test
+    @DisplayName("should use post processor")
+    void shouldApplyPostProcessor() {
+        given().await()
+                .atMost(100, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(postProcessingHandler.key()).isEqualTo(1));
+
+    }
+
+    @ApplicationScoped
+    static class PostProcessingHandler {
+        private final List<Integer> ids = new ArrayList<>();
+
+        @PostProcessing()
+        public void postProcessing(Object key, Struct struct) {
+            this.ids.add(((Struct) key)
+                    .getInt32("id"));
+        }
+
+        public int key() {
+            return ids.isEmpty() ? 0 : ids.getFirst();
+        }
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/main/resources/application.properties
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/main/resources/application.properties
@@ -17,6 +17,14 @@ quarkus.debezium.predicates.p2.pattern=inventory.inventory.products
 quarkus.debezium.predicates.p2.type=org.apache.kafka.connect.transforms.predicates.TopicNameMatches
 quarkus.debezium.predicates=p2
 
+# PostProcessor
+quarkus.debezium.post.processors=reselector
+quarkus.debezium.post.processors.reselector.type=io.debezium.processors.reselect.ReselectColumnsPostProcessor
+quarkus.debezium.post.processors.reselector.reselect.unavailable.values=true
+quarkus.debezium.post.processors.reselector.reselect.null.values=true
+quarkus.debezium.post.processors.reselector.reselect.use.event.key=false
+quarkus.debezium.post.processors.reselector.reselect.error.handling.mode=WARN
+
 
 quarkus.datasource.devservices.enabled=false
 quarkus.debezium.database.hostname=localhost


### PR DESCRIPTION
## Context

Post processors perform lightweight, per-message mutations, similar to the modifications that are performed by single message transformations (SMTs). Quarkus developers should be able to define `post-processor` in the *normal* way and using a Quarkus way.

## Decision
In the context of Quarkus, we introduce an annotation `PostProcessing` in order to create `post-processor` inside the Quarkus CDI. like in this example:

```java
    @ApplicationScoped
    static class PostProcessingHandler {

        @PostProcessing()
        public void postProcessing(Object key, Struct struct) {
             // do your stuff
        }
    }
```

in this PR we introduce:

- [X]  `PostProcessing` annotation
- [X]  native build for PostProcessing generated classes

## References

#depends https://github.com/debezium/debezium/pull/6523
#closes https://issues.redhat.com/browse/DBZ-8965
#link: https://github.com/debezium/debezium-design-documents/pull/16


## Side notes

We have introduced a `factory` to retrieve CDI beans (`post-processors`) into the debezium core. Due to time and complexity of `BeanRegistry` and `ServiceRegistry`, we have introduced it in `debezium-core/src/main/java/io/debezium/processors/PostProcessorRegistryServiceProvider.java` . [We should evaluate a better approach](https://issues.redhat.com/browse/DBZ-8958) taking into account the lesson learned from #6458 
