### PR TITLE
DBZ 8957 Debezium Engine Quarkus Extension: Use Quarkus-style Configuration Properties

### DIFF
--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/SourceRecordDebezium.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/engine/SourceRecordDebezium.java
@@ -22,28 +22,27 @@ import io.debezium.engine.RecordChangeEvent;
 import io.debezium.engine.format.ChangeEventFormat;
 import io.debezium.runtime.Connector;
 import io.debezium.runtime.DebeziumStatus;
-import io.debezium.runtime.configuration.DebeziumEngineConfiguration;
 import io.quarkus.debezium.engine.capture.CapturingInvokerRegistry;
 
 @ApplicationScoped
 class SourceRecordDebezium extends RunnableDebezium {
 
-    private final DebeziumEngineConfiguration debeziumEngineConfiguration;
+    private final Map<String, String> configuration;
     private final DebeziumEngine<?> engine;
     private final Connector connector;
     private final StateHandler stateHandler;
 
-    SourceRecordDebezium(DebeziumEngineConfiguration debeziumEngineConfiguration,
+    SourceRecordDebezium(Map<String, String> configuration,
                          StateHandler stateHandler,
                          Connector connector,
                          CapturingInvokerRegistry<RecordChangeEvent<SourceRecord>> registry) {
-        this.debeziumEngineConfiguration = debeziumEngineConfiguration;
+        this.configuration = configuration;
         this.stateHandler = stateHandler;
         this.engine = DebeziumEngine.create(ChangeEventFormat.of(Connect.class))
                 .using(Configuration.empty()
                         .withSystemProperties(Function.identity())
                         .edit()
-                        .with(Configuration.from(debeziumEngineConfiguration.configuration()))
+                        .with(Configuration.from(configuration))
                         .build().asProperties())
                 .using(this.stateHandler.connectorCallback())
                 .using(this.stateHandler.completionCallback())
@@ -60,7 +59,7 @@ class SourceRecordDebezium extends RunnableDebezium {
 
     @Override
     public Map<String, String> configuration() {
-        return debeziumEngineConfiguration.configuration();
+        return configuration;
     }
 
     @Override

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/src/main/java/io/debezium/runtime/configuration/QuarkusDatasourceConfiguration.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/src/main/java/io/debezium/runtime/configuration/QuarkusDatasourceConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.runtime.configuration;
+
+import java.util.Map;
+
+/**
+ * Contains the Configuration of the Datasource that can be taken from DevServices or Quarkus datasource
+ */
+public interface QuarkusDatasourceConfiguration {
+
+    /**
+     * return the configuration compatible with Debezium
+     */
+    Map<String, String> asDebezium();
+
+    /**
+     * Identify the default definition of datasource
+     */
+    boolean isDefault();
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/pom.xml
@@ -29,6 +29,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/main/java/io/quarkus/debezium/postgres/deployment/PostgresEngineProcessor.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/main/java/io/quarkus/debezium/postgres/deployment/PostgresEngineProcessor.java
@@ -5,18 +5,28 @@
  */
 package io.quarkus.debezium.postgres.deployment;
 
+import java.util.List;
+
+import jakarta.inject.Singleton;
+
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorTask;
 import io.debezium.connector.postgresql.PostgresSourceInfoStructMaker;
 import io.debezium.connector.postgresql.snapshot.lock.NoSnapshotLock;
 import io.debezium.connector.postgresql.snapshot.lock.SharedSnapshotLock;
 import io.debezium.connector.postgresql.snapshot.query.SelectAllSnapshotQuery;
+import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem;
+import io.quarkus.debezium.configuration.DatasourceRecorder;
+import io.quarkus.debezium.configuration.PostgresDatasourceConfiguration;
 import io.quarkus.debezium.deployment.items.DebeziumConnectorBuildItem;
 import io.quarkus.debezium.engine.PostgresEngineProducer;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -25,6 +35,8 @@ import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 
 public class PostgresEngineProcessor {
 
+    public static final String POSTGRESQL = "postgresql";
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem("debezium-postgres");
@@ -32,7 +44,26 @@ public class PostgresEngineProcessor {
 
     @BuildStep
     public DebeziumConnectorBuildItem engine() {
-        return new DebeziumConnectorBuildItem("postgresql", PostgresEngineProducer.class);
+        return new DebeziumConnectorBuildItem(POSTGRESQL, PostgresEngineProducer.class);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void generateDatasourceConfig(
+                                         DatasourceRecorder datasourceRecorder,
+                                         BuildProducer<SyntheticBeanBuildItem> producer,
+                                         List<JdbcDataSourceBuildItem> jdbcDataSources) {
+
+        jdbcDataSources
+                .stream()
+                .filter(item -> item.getDbKind().equals(POSTGRESQL))
+                .forEach(item -> producer.produce(SyntheticBeanBuildItem
+                        .configure(PostgresDatasourceConfiguration.class)
+                        .scope(Singleton.class)
+                        .supplier(datasourceRecorder.convert(item.getName(), item.isDefault()))
+                        .setRuntimeInit()
+                        .name(item.getName())
+                        .done()));
     }
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
@@ -44,7 +75,7 @@ public class PostgresEngineProcessor {
             return;
         }
 
-        if (!datasource.getDbType().equals("postgresql")) {
+        if (!datasource.getDbType().equals(POSTGRESQL)) {
             return;
         }
 

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
@@ -158,6 +158,22 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-transforms</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/DatasourceParser.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/DatasourceParser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.configuration;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DatasourceParser {
+
+    public static final String REGEX = "jdbc:[a-z]+://(?<host>[^:/;?]+)(:(?<port>\\d+))?([/;](?<database>[^?;]+))?";
+    private static final Pattern pattern = Pattern.compile(REGEX);
+    private final String value;
+
+    public DatasourceParser(String value) {
+        this.value = value;
+    }
+
+    public Optional<JdbcDatasource> asString() {
+        Matcher matcher = pattern.matcher(value);
+
+        if (matcher.find()) {
+            String host = matcher.group("host");
+            String port = matcher.group("port");
+            String database = matcher.group("database");
+
+            return Optional.of(new JdbcDatasource(host, port, database));
+        }
+
+        return Optional.empty();
+    }
+
+    public record JdbcDatasource(String host, String port, String database) {
+
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/DatasourceRecorder.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/DatasourceRecorder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.configuration;
+
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class DatasourceRecorder {
+
+    public static final String PREFIX = "quarkus.datasource";
+    public static final String JDBC_URL = ".jdbc.url";
+    public static final String USERNAME = ".username";
+    public static final String PASSWORD = ".password";
+
+    public Supplier<PostgresDatasourceConfiguration> convert(String name, boolean defaultConfiguration) {
+        if (defaultConfiguration) {
+            String jdbcUrl = ConfigProvider.getConfig().getConfigValue(PREFIX + JDBC_URL).getValue();
+            String username = ConfigProvider.getConfig().getConfigValue(PREFIX + USERNAME).getValue();
+            String password = ConfigProvider.getConfig().getConfigValue(PREFIX + PASSWORD).getValue();
+
+            return createConfiguration(name, jdbcUrl, username, password, true);
+        }
+
+        String jdbcUrl = ConfigProvider.getConfig().getConfigValue(PREFIX + "." + name + JDBC_URL).getValue();
+        String username = ConfigProvider.getConfig().getConfigValue(PREFIX + "." + name + USERNAME).getValue();
+        String password = ConfigProvider.getConfig().getConfigValue(PREFIX + "." + name + PASSWORD).getValue();
+
+        if (jdbcUrl == null) {
+            return null;
+        }
+
+        return createConfiguration(name, jdbcUrl, username, password, false);
+    }
+
+    private Supplier<PostgresDatasourceConfiguration> createConfiguration(String name,
+                                                                          String jdbcUrl,
+                                                                          String username,
+                                                                          String password,
+                                                                          boolean isDefault) {
+        return () -> new DatasourceParser(jdbcUrl)
+                .asString()
+                .map(datasource -> new PostgresDatasourceConfiguration(
+                        datasource.host(),
+                        username,
+                        password,
+                        datasource.database(),
+                        datasource.port(),
+                        isDefault,
+                        name))
+                .orElse(null);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/PostgresDatasourceConfiguration.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/configuration/PostgresDatasourceConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.configuration;
+
+import java.util.Map;
+
+import io.debezium.runtime.configuration.QuarkusDatasourceConfiguration;
+
+public class PostgresDatasourceConfiguration implements QuarkusDatasourceConfiguration {
+    private final String host;
+    private final String username;
+    private final String password;
+    private final String database;
+    private final String port;
+    private final boolean isDefault;
+    private final String name;
+
+    public PostgresDatasourceConfiguration(String host,
+                                           String username,
+                                           String password,
+                                           String database,
+                                           String port,
+                                           boolean isDefault,
+                                           String name) {
+        this.host = host;
+        this.username = username;
+        this.password = password;
+        this.database = database;
+        this.port = port;
+        this.isDefault = isDefault;
+        this.name = name;
+    }
+
+    @Override
+    public Map<String, String> asDebezium() {
+        return Map.of(
+                "name", name.replaceAll("[<>]", ""),
+                "database.hostname", host,
+                "database.port", port,
+                "database.user", username,
+                "database.password", password,
+                "database.dbname", database);
+    }
+
+    @Override
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/engine/PostgresEngineProducer.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/engine/PostgresEngineProducer.java
@@ -6,7 +6,12 @@
 
 package io.quarkus.debezium.engine;
 
+import static java.util.Collections.emptyMap;
+
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -18,6 +23,7 @@ import io.debezium.runtime.Connector;
 import io.debezium.runtime.ConnectorProducer;
 import io.debezium.runtime.Debezium;
 import io.debezium.runtime.configuration.DebeziumEngineConfiguration;
+import io.quarkus.debezium.configuration.PostgresDatasourceConfiguration;
 import io.quarkus.debezium.engine.capture.CapturingInvokerRegistry;
 
 @ApplicationScoped
@@ -25,19 +31,46 @@ public class PostgresEngineProducer implements ConnectorProducer {
 
     public static final String CONNECTOR_CLASS = "connector.class";
     public static final Connector POSTGRES = new Connector("io.debezium.connector.postgresql.PostgresConnector");
+    public static final String DEBEZIUM_DATASOURCE_HOSTNAME = "database.hostname";
+
+    private final CapturingInvokerRegistry<RecordChangeEvent<SourceRecord>> registry;
+    private final StateHandler stateHandler;
+    private final Instance<PostgresDatasourceConfiguration> configurations;
 
     @Inject
-    private CapturingInvokerRegistry<RecordChangeEvent<SourceRecord>> registry;
-
-    @Inject
-    StateHandler stateHandler;
+    public PostgresEngineProducer(CapturingInvokerRegistry<RecordChangeEvent<SourceRecord>> registry,
+                                  StateHandler stateHandler,
+                                  Instance<PostgresDatasourceConfiguration> configurations) {
+        this.registry = registry;
+        this.stateHandler = stateHandler;
+        this.configurations = configurations;
+    }
 
     @Produces
     @Singleton
     public Debezium engine(DebeziumEngineConfiguration debeziumEngineConfiguration) {
-        debeziumEngineConfiguration.configuration().put(CONNECTOR_CLASS, POSTGRES.name());
+        Map<String, String> configurationMap = debeziumEngineConfiguration.configuration();
+        configurationMap.put(CONNECTOR_CLASS, POSTGRES.name());
 
-        return new SourceRecordDebezium(debeziumEngineConfiguration,
+        if (configurationMap.get(DEBEZIUM_DATASOURCE_HOSTNAME) != null) {
+            return new SourceRecordDebezium(configurationMap,
+                    stateHandler,
+                    POSTGRES,
+                    registry);
+        }
+
+        /**
+         * it's possible to manage multiple configurations and multiple Debezium Instances
+         * the {@link engine(DebeziumEngineConfiguration debeziumEngineConfiguration)} should return
+         * a registry of Debezium instances
+         */
+        configurationMap.putAll(configurations
+                .stream()
+                .findFirst()
+                .map(PostgresDatasourceConfiguration::asDebezium)
+                .orElse(emptyMap()));
+
+        return new SourceRecordDebezium(configurationMap,
                 stateHandler,
                 POSTGRES,
                 registry);

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/test/java/io/quarkus/debezium/engine/PostgresEngineProducerTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/test/java/io/quarkus/debezium/engine/PostgresEngineProducerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.debezium.engine.RecordChangeEvent;
+import io.quarkus.debezium.configuration.PostgresDatasourceConfiguration;
+import io.quarkus.debezium.engine.capture.CapturingInvokerRegistry;
+
+class PostgresEngineProducerTest {
+
+    private final Instance<PostgresDatasourceConfiguration> instance = Mockito.mock(Instance.class);
+    private final CapturingInvokerRegistry<RecordChangeEvent<SourceRecord>> registry = identifier -> event -> {
+    };
+    private final PostgresEngineProducer underTest = new PostgresEngineProducer(registry, Mockito.mock(DefaultStateHandler.class), instance);
+
+    @Test
+    @DisplayName("should merge configurations when debezium configuration doesn't contain datasource information")
+    void shouldMergeConfigurationsWhenDebeziumConfigurationIsWithoutDatasourceInformation() {
+        List<PostgresDatasourceConfiguration> configurations = List.of(new PostgresDatasourceConfiguration(
+                "host",
+                "username",
+                "password",
+                "database",
+                "1926",
+                true,
+                "<default>"));
+        when(instance.iterator()).thenReturn(configurations.iterator());
+        when(instance.stream()).thenReturn(configurations.stream());
+
+        assertThat(underTest.engine(() -> new HashMap<>(Map.of("name", "test")))
+                .configuration())
+                .isEqualTo(Map.of(
+                        "connector.class", "io.debezium.connector.postgresql.PostgresConnector",
+                        "name", "default",
+                        "database.hostname", "host",
+                        "database.port", "1926",
+                        "database.user", "username",
+                        "database.password", "password",
+                        "database.dbname", "database"));
+    }
+
+    @Test
+    @DisplayName("should use debezium configurations when contains datasource information")
+    void shouldUseDebeziumConfigurationWhenContainsDatasourceInformation() {
+        List<PostgresDatasourceConfiguration> configurations = List.of(new PostgresDatasourceConfiguration(
+                "host",
+                "username",
+                "password",
+                "database",
+                "1926",
+                true,
+                "<default>"));
+        when(instance.iterator()).thenReturn(configurations.iterator());
+        when(instance.stream()).thenReturn(configurations.stream());
+
+        assertThat(underTest.engine(() -> new HashMap<>(Map.of("name", "test", "database.hostname", "native")))
+                .configuration())
+                .isEqualTo(Map.of(
+                        "connector.class", "io.debezium.connector.postgresql.PostgresConnector",
+                        "name", "test",
+                        "database.hostname", "native"));
+    }
+}


### PR DESCRIPTION
## Context

Actually we inject configuration using quarkus configuration in the debezium way also for the datasource. These are present also in the Quarkus configuration in the form: 

```properties
quarkus.datasource.db-kind=postgresql 
quarkus.datasource.username=<your username>
quarkus.datasource.password=<your password>

quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/hibernate_orm_test
quarkus.datasource.jdbc.max-size=16
```

## Decision

We decided to also support the configuration of Debezium through Quarkus's default datasource configuration. If there is no override by Debezium, we can use it.

## Reference

#link: https://quarkus.io/guides/datasource
#closes https://issues.redhat.com/browse/DBZ-8957