### PR TITLE
DBZ-8610 Add SnapshotSkipped metric

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -56,6 +56,11 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
     }
 
     @Override
+    public boolean getSnapshotSkipped() {
+        return snapshotMeter.getSnapshotSkipped();
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         return snapshotMeter.getSnapshotDurationInSeconds();
     }
@@ -96,6 +101,10 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
 
     void snapshotAborted() {
         snapshotMeter.snapshotAborted();
+    }
+
+    void snapshotSkipped() {
+        snapshotMeter.snapshotSkipped();
     }
 
     void rowsScanned(TableId tableId, long numRows) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
@@ -64,6 +64,11 @@ class SqlServerSnapshotTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServe
     }
 
     @Override
+    public void snapshotSkipped(SqlServerPartition partition) {
+        onPartitionEvent(partition, SqlServerSnapshotPartitionMetrics::snapshotSkipped);
+    }
+
+    @Override
     public void dataCollectionSnapshotCompleted(SqlServerPartition partition, DataCollectionId dataCollectionId, long numRows) {
         onPartitionEvent(partition, bean -> bean.dataCollectionSnapshotCompleted(dataCollectionId, numRows));
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -35,6 +35,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     private final AtomicBoolean snapshotPaused = new AtomicBoolean();
     private final AtomicBoolean snapshotCompleted = new AtomicBoolean();
     private final AtomicBoolean snapshotAborted = new AtomicBoolean();
+    private final AtomicBoolean snapshotSkipped = new AtomicBoolean();
     private final AtomicLong startTime = new AtomicLong();
     private final AtomicLong stopTime = new AtomicLong();
     private final AtomicLong startPauseTime = new AtomicLong();
@@ -89,6 +90,11 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     @Override
+    public boolean getSnapshotSkipped() {
+        return this.snapshotSkipped.get();
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         final long startMillis = startTime.get();
         if (startMillis <= 0L) {
@@ -129,6 +135,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotPaused.set(false);
         this.snapshotCompleted.set(false);
         this.snapshotAborted.set(false);
+        this.snapshotSkipped.set(false);
         this.startTime.set(clock.currentTimeInMillis());
         this.stopTime.set(0L);
         this.startPauseTime.set(0);
@@ -141,6 +148,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotPaused.set(true);
         this.snapshotCompleted.set(false);
         this.snapshotAborted.set(false);
+        this.snapshotSkipped.set(false);
         this.startPauseTime.set(clock.currentTimeInMillis());
         this.stopPauseTime.set(0L);
     }
@@ -150,6 +158,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotPaused.set(false);
         this.snapshotCompleted.set(false);
         this.snapshotAborted.set(false);
+        this.snapshotSkipped.set(false);
         final long currTime = clock.currentTimeInMillis();
         this.stopPauseTime.set(currTime);
 
@@ -170,6 +179,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotAborted.set(false);
         this.snapshotRunning.set(false);
         this.snapshotPaused.set(false);
+        this.snapshotSkipped.set(false);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
@@ -178,6 +188,14 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotAborted.set(true);
         this.snapshotRunning.set(false);
         this.snapshotPaused.set(false);
+        this.snapshotSkipped.set(false);
+        this.stopTime.set(clock.currentTimeInMillis());
+    }
+
+    public void snapshotSkipped() {
+        // snapshotSkipped is an additive metric on top of the other snapshot metrics,
+        // it doesn't reset the state of the other metrics
+        this.snapshotSkipped.set(true);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
@@ -236,6 +254,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         snapshotPaused.set(false);
         snapshotCompleted.set(false);
         snapshotAborted.set(false);
+        snapshotSkipped.set(false);
         startTime.set(0);
         stopTime.set(0);
         startPauseTime.set(0);

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -71,6 +71,11 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
+    public boolean getSnapshotSkipped() {
+        return snapshotMeter.getSnapshotSkipped();
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         return snapshotMeter.getSnapshotDurationInSeconds();
     }
@@ -118,6 +123,11 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     @Override
     public void snapshotAborted(P partition) {
         snapshotMeter.snapshotAborted();
+    }
+
+    @Override
+    public void snapshotSkipped(P partition) {
+        snapshotMeter.snapshotSkipped();
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -24,6 +24,8 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
 
     boolean getSnapshotAborted();
 
+    boolean getSnapshotSkipped();
+
     long getSnapshotDurationInSeconds();
 
     long getSnapshotPausedDurationInSeconds();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -82,6 +82,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
         Offsets<P, OffsetContext> offsets = getOffsets(ctx, previousOffset, snapshottingTask);
         if (snapshottingTask.shouldSkipSnapshot()) {
             LOGGER.debug("Skipping snapshotting");
+            snapshotProgressListener.snapshotSkipped(partition);
             notificationService.initialSnapshotNotificationService().notifySkipped(offsets.getTheOnlyPartition(), offsets.getTheOnlyOffset());
             return SnapshotResult.skipped(previousOffset);
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
@@ -28,6 +28,8 @@ public interface SnapshotProgressListener<P extends Partition> {
 
     void snapshotAborted(P partition);
 
+    void snapshotSkipped(P partition);
+
     void dataCollectionSnapshotCompleted(P partition, DataCollectionId dataCollectionId, long numRows);
 
     void rowsScanned(P partition, TableId tableId, long numRows);
@@ -69,6 +71,10 @@ public interface SnapshotProgressListener<P extends Partition> {
 
             @Override
             public void snapshotAborted(P partition) {
+            }
+
+            @Override
+            public void snapshotSkipped(P partition) {
             }
 
             @Override

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -58,6 +58,10 @@ The following table lists the snapshot metrics that are available.
 |`boolean`
 |Whether the snapshot completed.
 
+|[[connectors-snaps-metric-snapshotskipped_{context}]]<<connectors-snaps-metric-snapshotskipped_{context}, `SnapshotSkipped`>>
+|`boolean`
+|Whether the snapshot was skipped.
+
 |[[connectors-snaps-metric-snapshotdurationinseconds_{context}]]<<connectors-snaps-metric-snapshotdurationinseconds_{context}, `SnapshotDurationInSeconds`>>
 |`long`
 |The total number of seconds that the snapshot has taken so far, even if not complete. Includes also time when snapshot was paused.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8610 

Add SnapshotSkipped metric as an additive metric which doesn't reset the other snapshot metrics. 

**Build CI errors**
This commit is related to a [PR](https://github.com/debezium/debezium-connector-spanner/pull/115) which implements the changes to the SnapshotProgressListener in `debezium-connector-spanner`. Due to a circular dependency (the spanner connector depends on debezium-core interfaces and the debezium CI depends on the spanner-connector CI test) the failing spanner connector build step should probably be manually ignored. Once this change is in main the corresponding PR in the spanner connector can be merged which will resolve the issue.

**Alternative approach to adding the snapshotSkipped metric**
The currently proposed implementation will preserve backward compatibility in external code depending on the snapshot state metrics. Alternatively SnapshotSkipped can be treated as another independent state of the snapshot. Note that this might cause issues in external code depending on the snapshot state always being in one of the current states -SnapshotCompleted, SnapshotAborted, SnapshotStarted, SnapshotPaused, SnapshotResumed.

Example alternative implementation:
```java
    public void snapshotSkipped() {
        this.snapshotCompleted.set(false);
        this.snapshotAborted.set(false);
        this.snapshotRunning.set(false);
        this.snapshotPaused.set(false);
        this.snapshotSkipped.set(true);
        this.stopTime.set(clock.currentTimeInMillis());
    }
```