### PR TITLE
DBZ-8964 Debezium Engine Quarkus Extension: expose Debezium Notification Events

### DIFF
--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
@@ -113,17 +113,10 @@ public class EngineProcessor {
                 .build());
 
         additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClasses(DefaultNotificationHandler.class)
-                .setUnremovable()
-                .build());
-
-        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClasses(SnapshotHandler.class)
-                .setUnremovable()
-                .build());
-
-        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClasses(QuarkusNotificationChannel.class)
+                .addBeanClasses(
+                        DefaultNotificationHandler.class,
+                        SnapshotHandler.class,
+                        QuarkusNotificationChannel.class)
                 .setUnremovable()
                 .build());
     }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/src/main/java/io/quarkus/debezium/deployment/engine/EngineProcessor.java
@@ -68,6 +68,9 @@ import io.quarkus.debezium.engine.DefaultStateHandler;
 import io.quarkus.debezium.engine.capture.CapturingInvoker;
 import io.quarkus.debezium.engine.capture.CapturingSourceRecordInvokerRegistryProducer;
 import io.quarkus.debezium.engine.capture.DynamicCapturingInvokerSupplier;
+import io.quarkus.debezium.notification.DefaultNotificationHandler;
+import io.quarkus.debezium.notification.QuarkusNotificationChannel;
+import io.quarkus.debezium.notification.SnapshotHandler;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -108,6 +111,21 @@ public class EngineProcessor {
                 .builder()
                 .addBeanClasses(DefaultStateHandler.class)
                 .build());
+
+        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClasses(DefaultNotificationHandler.class)
+                .setUnremovable()
+                .build());
+
+        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClasses(SnapshotHandler.class)
+                .setUnremovable()
+                .build());
+
+        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClasses(QuarkusNotificationChannel.class)
+                .setUnremovable()
+                .build());
     }
 
     @BuildStep
@@ -137,6 +155,7 @@ public class EngineProcessor {
         resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.debezium.spi.snapshot.Snapshotter"));
         resources.produce(new NativeImageResourceBuildItem("META-INF/services/org.apache.kafka.connect.source.SourceConnector"));
         resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.debezium.pipeline.signal.channels.SignalChannelReader"));
+        resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel"));
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
@@ -189,6 +208,7 @@ public class EngineProcessor {
                 StandardActionProvider.class,
                 OffsetCommitPolicy.class,
                 SourceTask.class,
+                QuarkusNotificationChannel.class,
                 OffsetCommitPolicy.PeriodicCommitOffsetPolicy.class)
                 .reason(getClass().getName())
                 .build());

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
@@ -30,6 +30,16 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/DebeziumNotification.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/DebeziumNotification.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public record DebeziumNotification(String id, String aggregateType, String type, Map<String, String> additionalData, Long timestamp) implements Notification {
+    public static DebeziumNotification from(io.debezium.pipeline.notification.Notification notification) {
+        return new DebeziumNotification(
+                notification.getId(),
+                notification.getAggregateType(),
+                notification.getType(),
+                notification.getAdditionalData(),
+                notification.getTimestamp());
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/DefaultNotificationHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/DefaultNotificationHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import io.debezium.pipeline.notification.Notification;
+
+@ApplicationScoped
+public class DefaultNotificationHandler implements NotificationHandler {
+
+    private final Event<DebeziumNotification> debeziumNotification;
+
+    @Inject
+    public DefaultNotificationHandler(Event<DebeziumNotification> debeziumNotification) {
+        this.debeziumNotification = debeziumNotification;
+    }
+
+    @Override
+    public boolean isAvailable(String aggregateType) {
+        return true;
+    }
+
+    @Override
+    public void handle(Notification notification) {
+        debeziumNotification.fire(DebeziumNotification.from(notification));
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/Notification.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/Notification.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+public sealed interface Notification permits DebeziumNotification, SnapshotEvent {
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/NotificationHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/NotificationHandler.java
@@ -6,8 +6,23 @@
 
 package io.quarkus.debezium.notification;
 
+/**
+ *
+ * {@link NotificationHandler} is used to manage Debezium Notification
+ *
+ */
 public interface NotificationHandler {
+
+    /**
+     * Define the handler availability {@param aggregateType}
+     * @param aggregateType
+     * @return
+     */
     boolean isAvailable(String aggregateType);
 
+    /**
+     * handle the Debezium Notification
+     * @param notification
+     */
     void handle(io.debezium.pipeline.notification.Notification notification);
 }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/NotificationHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/NotificationHandler.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+public interface NotificationHandler {
+    boolean isAvailable(String aggregateType);
+
+    void handle(io.debezium.pipeline.notification.Notification notification);
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/QuarkusNotificationChannel.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/QuarkusNotificationChannel.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.pipeline.notification.Notification;
+import io.debezium.pipeline.notification.channels.NotificationChannel;
+
+@ApplicationScoped
+public class QuarkusNotificationChannel implements NotificationChannel {
+
+    private final Instance<NotificationHandler> notificationHandlers;
+
+    public QuarkusNotificationChannel() {
+        this.notificationHandlers = CDI.current().select(NotificationHandler.class);
+    }
+
+    public QuarkusNotificationChannel(Instance<NotificationHandler> notificationHandlers) {
+        this.notificationHandlers = notificationHandlers;
+    }
+
+    @Override
+    public void init(CommonConnectorConfig config) {
+        // ignore
+    }
+
+    @Override
+    public String name() {
+        return "quarkus";
+    }
+
+    @Override
+    public void send(Notification notification) {
+        notificationHandlers
+                .stream()
+                .filter(handler -> handler.isAvailable(notification.getAggregateType()))
+                .forEach(handler -> handler.handle(notification));
+    }
+
+    @Override
+    public void close() {
+        // ignore
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotAborted.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotAborted.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotAborted extends SnapshotEvent {
+    SnapshotAborted(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotCompleted.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotCompleted.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotCompleted extends SnapshotEvent {
+    SnapshotCompleted(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotEvent.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotEvent.java
@@ -65,8 +65,9 @@ public sealed abstract class SnapshotEvent implements Notification
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         SnapshotEvent that = (SnapshotEvent) o;
         return Objects.equals(id, that.id) && Objects.equals(additionalData, that.additionalData) && Objects.equals(timestamp, that.timestamp) && kind == that.kind;
     }

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotEvent.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotEvent.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public sealed abstract class SnapshotEvent implements Notification
+        permits SnapshotStarted, SnapshotInProgress, SnapshotTableScanCompleted, SnapshotAborted, SnapshotSkipped, SnapshotCompleted, SnapshotPaused, SnapshotResumed {
+
+    private final String id;
+    private final Map<String, String> additionalData;
+    private final Long timestamp;
+    private final Kind kind;
+
+    protected SnapshotEvent(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        this.id = id;
+        this.additionalData = additionalData;
+        this.timestamp = timestamp;
+        this.kind = kind;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Map<String, String> getAdditionalData() {
+        return additionalData;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public enum Kind {
+        INCREMENTAL("Incremental Snapshot"),
+        INITIAL("Initial Snapshot");
+
+        private final String description;
+
+        Kind(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public static Optional<Kind> from(String value) {
+            return Arrays.stream(Kind.values())
+                    .filter(kind -> kind.getDescription().equals(value))
+                    .findFirst();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SnapshotEvent that = (SnapshotEvent) o;
+        return Objects.equals(id, that.id) && Objects.equals(additionalData, that.additionalData) && Objects.equals(timestamp, that.timestamp) && kind == that.kind;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotHandler.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import io.debezium.pipeline.notification.Notification;
+import io.debezium.pipeline.notification.SnapshotStatus;
+import io.debezium.pipeline.spi.SnapshotResult;
+import io.quarkus.debezium.notification.SnapshotEvent.Kind;
+
+@ApplicationScoped
+public class SnapshotHandler implements NotificationHandler {
+    private final Event<SnapshotStarted> startedEvent;
+    private final Event<SnapshotInProgress> inProgressEvent;
+    private final Event<SnapshotTableScanCompleted> tableScanCompletedEvent;
+    private final Event<SnapshotCompleted> completedEvent;
+    private final Event<SnapshotAborted> abortedEvent;
+    private final Event<SnapshotSkipped> skippedEvent;
+    private final Event<SnapshotPaused> snapshotPausedEvent;
+    private final Event<SnapshotResumed> snapshotResumedEvent;
+    private final List<String> kinds = Arrays.stream(Kind.values()).map(Kind::getDescription).toList();
+
+    @Inject
+    public SnapshotHandler(Event<SnapshotStarted> startedEvent,
+                           Event<SnapshotInProgress> inProgressEvent,
+                           Event<SnapshotTableScanCompleted> tableScanCompletedEvent,
+                           Event<SnapshotCompleted> completedEvent,
+                           Event<SnapshotAborted> abortedEvent,
+                           Event<SnapshotSkipped> skippedEvent,
+                           Event<SnapshotPaused> snapshotPausedEvent,
+                           Event<SnapshotResumed> snapshotResumedEvent) {
+        this.startedEvent = startedEvent;
+        this.inProgressEvent = inProgressEvent;
+        this.tableScanCompletedEvent = tableScanCompletedEvent;
+        this.completedEvent = completedEvent;
+        this.abortedEvent = abortedEvent;
+        this.skippedEvent = skippedEvent;
+        this.snapshotPausedEvent = snapshotPausedEvent;
+        this.snapshotResumedEvent = snapshotResumedEvent;
+    }
+
+    @Override
+    public boolean isAvailable(String aggregateType) {
+        return kinds.contains(aggregateType);
+    }
+
+    @Override
+    public void handle(io.debezium.pipeline.notification.Notification notification) {
+        Kind.from(notification.getAggregateType())
+                .ifPresent(kind -> fire(kind, notification));
+    }
+
+    private void fire(Kind kind, Notification notification) {
+        if (notification.getType().equals(SnapshotStatus.STARTED.name())) {
+            startedEvent.fire(new SnapshotStarted(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.IN_PROGRESS.name())) {
+            inProgressEvent.fire(new SnapshotInProgress(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.TABLE_SCAN_COMPLETED.name())) {
+            tableScanCompletedEvent.fire(new SnapshotTableScanCompleted(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.COMPLETED.name())) {
+            completedEvent.fire(new SnapshotCompleted(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.ABORTED.name())) {
+            abortedEvent.fire(new SnapshotAborted(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotResult.SnapshotResultStatus.SKIPPED.name())) {
+            skippedEvent.fire(new SnapshotSkipped(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.PAUSED.name())) {
+            snapshotPausedEvent.fire(new SnapshotPaused(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+
+        if (notification.getType().equals(SnapshotStatus.RESUMED.name())) {
+            snapshotResumedEvent.fire(new SnapshotResumed(
+                    notification.getId(),
+                    notification.getAdditionalData(),
+                    notification.getTimestamp(), kind));
+        }
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotInProgress.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotInProgress.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotInProgress extends SnapshotEvent {
+    SnapshotInProgress(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotPaused.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotPaused.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotPaused extends SnapshotEvent {
+    SnapshotPaused(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotResumed.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotResumed.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotResumed extends SnapshotEvent {
+    SnapshotResumed(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotSkipped.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotSkipped.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotSkipped extends SnapshotEvent {
+    SnapshotSkipped(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotStarted.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotStarted.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotStarted extends SnapshotEvent {
+    SnapshotStarted(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotTableScanCompleted.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/java/io/quarkus/debezium/notification/SnapshotTableScanCompleted.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import java.util.Map;
+
+public final class SnapshotTableScanCompleted extends SnapshotEvent {
+    SnapshotTableScanCompleted(String id, Map<String, String> additionalData, Long timestamp, Kind kind) {
+        super(id, additionalData, timestamp, kind);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
@@ -1,0 +1,4 @@
+io.debezium.pipeline.notification.channels.SinkNotificationChannel
+io.debezium.pipeline.notification.channels.LogNotificationChannel
+io.debezium.pipeline.notification.channels.jmx.JmxNotificationChannel
+io.quarkus.debezium.notification.QuarkusNotificationChannel

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/QuarkusNotificationChannelTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/QuarkusNotificationChannelTest.java
@@ -6,7 +6,9 @@
 
 package io.quarkus.debezium.notification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.stream.Stream;

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/QuarkusNotificationChannelTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/QuarkusNotificationChannelTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.debezium.pipeline.notification.Notification;
+
+class QuarkusNotificationChannelTest {
+
+    private final Instance<NotificationHandler> notificationHandlers = Mockito.mock(Instance.class);
+    private final NotificationHandler avaiableNotificationHandler = Mockito.mock(NotificationHandler.class);
+    private final NotificationHandler notAvailablenotificationHandler = Mockito.mock(NotificationHandler.class);
+
+    @Test
+    @DisplayName("should handle the event only when the aggregateType is available for the handler")
+    void shouldHandleOnlyWhenIsAvailableForAggregateType() {
+        when(notificationHandlers.stream()).thenReturn(Stream.of(avaiableNotificationHandler, notAvailablenotificationHandler));
+        when(avaiableNotificationHandler.isAvailable("anAggregateType")).thenReturn(true);
+
+        QuarkusNotificationChannel underTest = new QuarkusNotificationChannel(notificationHandlers);
+
+        underTest.send(new Notification("id", "anAggregateType", "aType", Map.of("aKey", "aValue"), 1L));
+        verify(avaiableNotificationHandler, times(1)).handle(new Notification("id", "anAggregateType", "aType", Map.of("aKey", "aValue"), 1L));
+        verify(notAvailablenotificationHandler, times(0)).handle(new Notification("id", "anAggregateType", "aType", Map.of("aKey", "aValue"), 1L));
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/SnapshotHandlerTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/SnapshotHandlerTest.java
@@ -6,7 +6,9 @@
 
 package io.quarkus.debezium.notification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Map;
 

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/SnapshotHandlerTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/src/test/java/io/quarkus/debezium/notification/SnapshotHandlerTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.notification;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import jakarta.enterprise.event.Event;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.debezium.pipeline.notification.Notification;
+
+class SnapshotHandlerTest {
+
+    private final Event<SnapshotStarted> startedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotInProgress> inProgressEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotTableScanCompleted> tableScanCompletedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotCompleted> completedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotAborted> abortedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotSkipped> skippedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotPaused> snapshotPausedEvent = Mockito.mock(Event.class);
+    private final Event<SnapshotResumed> snapshotResumedEvent = Mockito.mock(Event.class);
+
+    @Test
+    @DisplayName("should fire snapshotStarted when snapshot started")
+    void shouldFireSnapshotStartedWhenNotificationIsSnapshotStarted() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "STARTED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(startedEvent, times(1)).fire(new SnapshotStarted(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire snapshotInProgress when snapshot in progress")
+    void shouldFireSnapshotInProgressWhenNotificationIsSnapshotInProgress() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "IN_PROGRESS", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(inProgressEvent, times(1)).fire(new SnapshotInProgress(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire tableScanCompletedEvent when snapshot table scan completed")
+    void shouldFireSnapshotTableScanCompletedEventWhenNotificationIsSnapshotTableScanCompleted() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "TABLE_SCAN_COMPLETED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(tableScanCompletedEvent, times(1)).fire(new SnapshotTableScanCompleted(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire completedEvent when snapshot is completed")
+    void shouldFireSnapshotCompletedEventEventWhenNotificationIsSnapshotIsCompleted() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "COMPLETED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(completedEvent, times(1)).fire(new SnapshotCompleted(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire abortedEvent when snapshot is aborted")
+    void shouldFireSnapshotAbortedEventEventWhenNotificationIsSnapshotIsAborted() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "ABORTED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(abortedEvent, times(1)).fire(new SnapshotAborted(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire skippedEvent when snapshot is skipped")
+    void shouldFireSnapshotSkippedEventEventWhenNotificationIsSnapshotIsSkipped() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "SKIPPED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(skippedEvent, times(1)).fire(new SnapshotSkipped(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire snapshotPausedEvent when snapshot is paused")
+    void shouldFireSnapshotPausedEventEventEventWhenNotificationIsSnapshotIsPaused() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "PAUSED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(snapshotPausedEvent, times(1)).fire(new SnapshotPaused(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotResumedEvent);
+    }
+
+    @Test
+    @DisplayName("should fire snapshotResumedEvent when snapshot is resumed")
+    void shouldFireSnapshotResumedEventEventEventWhenNotificationIsSnapshotIsResumed() {
+        SnapshotHandler underTest = new SnapshotHandler(
+                startedEvent,
+                inProgressEvent,
+                tableScanCompletedEvent,
+                completedEvent,
+                abortedEvent,
+                skippedEvent,
+                snapshotPausedEvent,
+                snapshotResumedEvent);
+
+        underTest.handle(new Notification("id", "Initial Snapshot", "RESUMED", Map.of(
+                "aKey", "aValue"), 1L));
+
+        verify(snapshotResumedEvent, times(1)).fire(new SnapshotResumed(
+                "id",
+                Map.of("aKey", "aValue"),
+                1L, SnapshotEvent.Kind.INITIAL));
+
+        verifyNoInteractions(startedEvent);
+        verifyNoInteractions(inProgressEvent);
+        verifyNoInteractions(tableScanCompletedEvent);
+        verifyNoInteractions(completedEvent);
+        verifyNoInteractions(abortedEvent);
+        verifyNoInteractions(skippedEvent);
+        verifyNoInteractions(snapshotPausedEvent);
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/test/java/io/quarkus/debezium/postgres/deployment/NotificationTest.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/src/test/java/io/quarkus/debezium/postgres/deployment/NotificationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.quarkus.debezium.postgres.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.debezium.notification.DebeziumNotification;
+import io.quarkus.debezium.notification.SnapshotEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(value = DatabaseTestResource.class)
+public class NotificationTest {
+
+    @Inject
+    SnapshotNotificationsHandler snapshotNotificationsHandler;
+
+    @Inject
+    DebeziumNotificationsHandler debeziumNotificationsHandler;
+
+    @RegisterExtension
+    static final QuarkusUnitTest setup = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(CapturingTest.CaptureProductsHandler.class))
+            .overrideConfigKey("quarkus.debezium.offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore")
+            .overrideConfigKey("quarkus.debezium.name", "test")
+            .overrideConfigKey("quarkus.debezium.topic.prefix", "dbserver1")
+            .overrideConfigKey("quarkus.debezium.plugin.name", "pgoutput")
+            .overrideConfigKey("quarkus.debezium.snapshot.mode", "initial")
+            .overrideConfigKey("quarkus.datasource.devservices.enabled", "false");
+
+    @Test
+    @DisplayName("should observe events for snapshot")
+    void shouldObserveSnapshotEvents() {
+        given().await()
+                .atMost(100, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(snapshotNotificationsHandler.isInvoked()).isTrue());
+
+    }
+
+    @Test
+    @DisplayName("should observe general events")
+    void shouldObserveDebeziumEvents() {
+        given().await()
+                .atMost(100, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(debeziumNotificationsHandler.isInvoked()).isTrue());
+
+    }
+
+    @ApplicationScoped
+    static class SnapshotNotificationsHandler {
+        private final AtomicBoolean invoked = new AtomicBoolean(false);
+
+        public void observe(@Observes SnapshotEvent event) {
+            invoked.set(true);
+        }
+
+        public boolean isInvoked() {
+            return invoked.getAndSet(false);
+        }
+    }
+
+    @ApplicationScoped
+    static class DebeziumNotificationsHandler {
+        private final AtomicBoolean invoked = new AtomicBoolean(false);
+
+        public void observe(@Observes DebeziumNotification event) {
+            invoked.set(true);
+        }
+
+        public boolean isInvoked() {
+            return invoked.getAndSet(false);
+        }
+    }
+}

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/engine/PostgresEngineProducer.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/src/main/java/io/quarkus/debezium/engine/PostgresEngineProducer.java
@@ -6,6 +6,8 @@
 
 package io.quarkus.debezium.engine;
 
+import static io.debezium.config.CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
@@ -19,6 +21,7 @@ import io.debezium.runtime.ConnectorProducer;
 import io.debezium.runtime.Debezium;
 import io.debezium.runtime.configuration.DebeziumEngineConfiguration;
 import io.quarkus.debezium.engine.capture.CapturingInvokerRegistry;
+import io.quarkus.debezium.notification.QuarkusNotificationChannel;
 
 @ApplicationScoped
 public class PostgresEngineProducer implements ConnectorProducer {
@@ -32,10 +35,15 @@ public class PostgresEngineProducer implements ConnectorProducer {
     @Inject
     StateHandler stateHandler;
 
+    @Inject
+    QuarkusNotificationChannel channel;
+
     @Produces
     @Singleton
     public Debezium engine(DebeziumEngineConfiguration debeziumEngineConfiguration) {
         debeziumEngineConfiguration.configuration().put(CONNECTOR_CLASS, POSTGRES.name());
+        debeziumEngineConfiguration.configuration().compute(NOTIFICATION_ENABLED_CHANNELS.name(),
+                (key, value) -> value == null ? channel.name() : value.concat("," + channel.name()));
 
         return new SourceRecordDebezium(debeziumEngineConfiguration,
                 stateHandler,


### PR DESCRIPTION
## Context

Debezium connectors can emit notification events related to internal state changes, such as:

- Snapshot completion
- Other Events

Quarkus developers need a declarative mechanism to observe these events.

## Decision

Introduce a series of events that are observable using `Observes` like:

```java
    @ApplicationScoped
    static class SnapshotNotificationsHandler {

        public void observe(@Observes SnapshotEvent event) {
            // here
        }

    }
```

## References

#link: https://github.com/debezium/debezium-design-documents/pull/16
#closes: https://issues.redhat.com/browse/DBZ-8964