### PR TITLE
DBZ-9237 Do not immediately fail JDBC sink if create table fails

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.hibernate.JDBCException;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.dialect.DatabaseVersion;
@@ -105,7 +106,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                     writeTruncate(dialect.getTruncateStatement(table));
                     continue;
                 }
-                catch (Exception e) {
+                catch (SQLException | JDBCException e) {
                     throw new ConnectException("Failed to process a sink record", e);
                 }
             }
@@ -187,7 +188,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             try {
                 tableDescriptor = checkAndApplyTableChangesIfNeeded(collectionId, record);
             }
-            catch (Exception e) {
+            catch (SQLException | JDBCException e) {
                 throw new ConnectException("Error while checking and applying table changes for collection '" + collectionId + "'", e);
             }
             return createBuffer(config, tableDescriptor, record);
@@ -286,19 +287,19 @@ public class JdbcChangeEventSink implements ChangeEventSink {
         }
     }
 
-    private TableDescriptor checkAndApplyTableChangesIfNeeded(CollectionId collectionId, JdbcSinkRecord record) throws Exception {
+    private TableDescriptor checkAndApplyTableChangesIfNeeded(CollectionId collectionId, JdbcSinkRecord record) throws SQLException {
         if (!hasTable(collectionId)) {
             // Table does not exist, lets attempt to create it.
             try {
                 return createTable(collectionId, record);
             }
-            catch (Exception ce) {
+            catch (SQLException | JDBCException ce) {
                 // It's possible the table may have been created in the interim, so try to alter.
                 LOGGER.warn("Table creation failed for '{}', attempting to alter the table", collectionId.toFullIdentiferString(), ce);
                 try {
                     return alterTableIfNeeded(collectionId, record);
                 }
-                catch (Exception ae) {
+                catch (SQLException | JDBCException ae) {
                     // The alter failed, hard stop.
                     LOGGER.error("Failed to alter the table '{}'.", collectionId.toFullIdentiferString(), ae);
                     throw ae;
@@ -310,7 +311,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             try {
                 return alterTableIfNeeded(collectionId, record);
             }
-            catch (Exception ae) {
+            catch (SQLException | JDBCException ae) {
                 LOGGER.error("Failed to alter the table '{}'.", collectionId.toFullIdentiferString(), ae);
                 throw ae;
             }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -105,7 +105,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                     writeTruncate(dialect.getTruncateStatement(table));
                     continue;
                 }
-                catch (SQLException e) {
+                catch (Exception e) {
                     throw new ConnectException("Failed to process a sink record", e);
                 }
             }
@@ -187,7 +187,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             try {
                 tableDescriptor = checkAndApplyTableChangesIfNeeded(collectionId, record);
             }
-            catch (SQLException e) {
+            catch (Exception e) {
                 throw new ConnectException("Error while checking and applying table changes for collection '" + collectionId + "'", e);
             }
             return createBuffer(config, tableDescriptor, record);
@@ -286,19 +286,19 @@ public class JdbcChangeEventSink implements ChangeEventSink {
         }
     }
 
-    private TableDescriptor checkAndApplyTableChangesIfNeeded(CollectionId collectionId, JdbcSinkRecord record) throws SQLException {
+    private TableDescriptor checkAndApplyTableChangesIfNeeded(CollectionId collectionId, JdbcSinkRecord record) throws Exception {
         if (!hasTable(collectionId)) {
             // Table does not exist, lets attempt to create it.
             try {
                 return createTable(collectionId, record);
             }
-            catch (SQLException ce) {
+            catch (Exception ce) {
                 // It's possible the table may have been created in the interim, so try to alter.
                 LOGGER.warn("Table creation failed for '{}', attempting to alter the table", collectionId.toFullIdentiferString(), ce);
                 try {
                     return alterTableIfNeeded(collectionId, record);
                 }
-                catch (SQLException ae) {
+                catch (Exception ae) {
                     // The alter failed, hard stop.
                     LOGGER.error("Failed to alter the table '{}'.", collectionId.toFullIdentiferString(), ae);
                     throw ae;
@@ -310,7 +310,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             try {
                 return alterTableIfNeeded(collectionId, record);
             }
-            catch (SQLException ae) {
+            catch (Exception ae) {
                 LOGGER.error("Failed to alter the table '{}'.", collectionId.toFullIdentiferString(), ae);
                 throw ae;
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9237

So the issue here is that when more than one task executes a `CREATE TABLE`, the non-first task will throw a runtime exception, `ConstraintViolationException` in case of PostgreSQL. These runtime exceptions were not being caught previously, and immediately forced the connector to fail. 

This PR is designed to instead fallthrough to the `ALTER TABLE` if the `CREATE TABLE` failed, as a more resilient way to deal with multiple tasks that may attempt to create the table concurrently, allowing the non-first tasks to safely fall through and process the insert, update, or upsert without failing.