### PR TITLE
Dbz 9244 3.2 remove reference to obsolete file from smt doc index

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -43,7 +43,6 @@
 ** xref:transformations/timezone-converter.adoc[Timezone Converter]
 ** xref:transformations/timescaledb.adoc[TimescaleDB Integration]
 ** xref:transformations/decode-logical-decoding-message-content.adoc[Decode Logical Decoding Message Content]
-** xref:transformations/convert-cloudevent-to-saveable-form.adoc[Convert CloudEvents to Saveable Form]
 ** xref:transformations/vector-to-json.adoc[Vector Data Types to JSON Types]
 * Post Processors
 ** xref:post-processors/index.adoc[Overview]

--- a/documentation/modules/ROOT/pages/transformations/index.adoc
+++ b/documentation/modules/ROOT/pages/transformations/index.adoc
@@ -45,12 +45,9 @@ The following SMTs are provided by {prodname}:
 |xref:transformations/decode-logical-decoding-message-content.adoc[Decode Logical Decoding Message Content]
 |Converts the binary content of logical decoding messages captured by the {prodname} PostgreSQL connector into a structured form.
 
-|xref:transformations/convert-cloudevent-to-saveable-form.adoc[Convert CloudEvents to Saveable Form]
-|Converts values of records deserialized by {prodname} CloudEvents converter to a structure suitable for {prodname} JDBC sink connector.
-
 |xref:transformations/vitess-use-local-vgtid.adoc[Vitess Use Local VGTID]
 |A transformation that reduces the size of VGTIDs that the Vitess connector emits.
-To reduce the amount of data in the event message, the SMT writes only the VGTID for the shard in which a change occurs. 
+To reduce the amount of data in the event message, the SMT writes only the VGTID for the shard in which a change occurs.
 The VGTIDs for other shards are removed.
 This transformation is designed for use only with the {prodname} connector for Vitess.
 


### PR DESCRIPTION
Cherry-pick changes from `main` to `3.2`.