### PR TITLE
DBZ-9247 Added undefined_table error handling for PostgresConnectorTask heartbeat

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -214,6 +214,9 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                                     case "57P03":
                                         // Postgres error cannot_connect_now, see https://www.postgresql.org/docs/12/errcodes-appendix.html
                                         throw new RetriableException("Could not execute heartbeat action query (Error: " + sqlErrorId + ")", exception);
+                                    case "42P01":
+                                        // Postgres error undefined_table, see https://www.postgresql.org/docs/12/errcodes-appendix.html
+                                        throw new DebeziumException("Could not execute heartbeat action query (Error: " + sqlErrorId + ")", exception);
                                     default:
                                         break;
                                 }


### PR DESCRIPTION
 Added undefined_table error handling for PostgresConnectorTask heartbeat
Error code `42P01` throws a new `DebeziumException`