### PR TITLE
DBZ-9272 Add option to use CTE-based LogMiner queries

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -228,6 +228,11 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             statement.setString(1, startScn.toString());
             statement.setString(2, endScn.toString());
 
+            if (getConfig().isLogMiningUseCteQuery()) {
+                statement.setString(3, startScn.toString());
+                statement.setString(4, endScn.toString());
+            }
+
             executeAndProcessQuery(statement);
 
             logActiveTransactions();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -263,6 +263,10 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
             statement.setFetchDirection(ResultSet.FETCH_FORWARD);
             statement.setString(1, minCommitScn.toString());
 
+            if (getConfig().isLogMiningUseCteQuery()) {
+                statement.setString(2, minCommitScn.toString());
+            }
+
             lastCommitScn = minCommitScn;
 
             executeAndProcessQuery(statement);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CteQueryIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CteQueryIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnector;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+
+/**
+ * Tests using LogMiner with the internal CTE-based query functionality.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = ANY_LOGMINER)
+public class CteQueryIT extends AbstractAsyncEngineConnectorTest {
+
+    @Rule
+    public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
+
+    private static OracleConnection connection;
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        connection = TestHelper.testConnection();
+    }
+
+    @AfterClass
+    public static void closeConnection() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-9272")
+    public void shouldStreamChangesUsingCteBasedQueries() throws Exception {
+        TestHelper.dropTable(connection, "dbz9272");
+        try {
+            connection.execute("CREATE TABLE dbz9272 (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz9272");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9272")
+                    .with(OracleConnectorConfig.LOG_MINING_USE_CTE_QUERY, "true")
+                    .with(OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE, "in")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz9272 values (1, 'insert')");
+            connection.execute("UPDATE dbz9272 SET data = 'update' where ID = 1");
+            connection.execute("DELETE FROM dbz9272 WHERE id = 1");
+
+            List<SourceRecord> records = consumeRecordsByTopic(4).recordsForTopic("server1.DEBEZIUM.DBZ9272");
+            assertThat(records).hasSize(4);
+
+            Struct value = ((Struct) records.get(0).value());
+            VerifyRecord.isValidInsert(records.get(0), "ID", 1);
+            assertThat(value.getStruct(Envelope.FieldName.AFTER).get("ID")).isEqualTo(1);
+            assertThat(value.getStruct(Envelope.FieldName.AFTER).get("DATA")).isEqualTo("insert");
+
+            value = ((Struct) records.get(1).value());
+            VerifyRecord.isValidUpdate(records.get(1), "ID", 1);
+            assertThat(value.getStruct(Envelope.FieldName.BEFORE).get("ID")).isEqualTo(1);
+            assertThat(value.getStruct(Envelope.FieldName.BEFORE).get("DATA")).isEqualTo("insert");
+            assertThat(value.getStruct(Envelope.FieldName.AFTER).get("ID")).isEqualTo(1);
+            assertThat(value.getStruct(Envelope.FieldName.AFTER).get("DATA")).isEqualTo("update");
+
+            value = ((Struct) records.get(2).value());
+            VerifyRecord.isValidDelete(records.get(2), "ID", 1);
+            assertThat(value.getStruct(Envelope.FieldName.BEFORE).get("ID")).isEqualTo(1);
+            assertThat(value.getStruct(Envelope.FieldName.BEFORE).get("DATA")).isEqualTo("update");
+
+            VerifyRecord.isValidTombstone(records.get(3));
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz9272");
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9272 

While the `log.mining.query.filter.mode` provides ways to push query criteria to the Oracle database to filter the change stream so that we get the least amount of events in the connector, this is not always adequate, especially in situations where there may be far more activity for non-captured tables. In these situations, this can lead to the connector receiving a large number of transaction commit or rollback marker events that have no changes in the transaction.

This PR introduces a new internal, experimental feature that enables the use of a CTE-based query. The CTE query is designed to apply the same filter as the main query, but limits the scope to only non-transaction marker changes (inserts, updates, deletes, LOB operations, DDL, and so on). The outer query then uses the list of transaction IDs generated by the CTE query to limit the final result set provided to Debezium only to contain relevant transactions.

There are a few caveats:

1. The use of `internal.log.mining.use.cte.query` requires `log.mining.query.filter.mode` to be set.
2. Due to the CTE being cached in the PGA, large `log.mining.batch.size.*` settings may lead to PGA_AGGREGATE_LIMIT errors. If so, the `log.mining.batch.size.*` settings should be reduced to a smaller chunk pass.
3. The CTE uses an Oracle hint to enforce join orders, and if the database chooses to ignore the hint, the events could  be provided out of order, which could cause events to be missed. This will require some testing across variety of environments.
4. The CTE query and the outer query will force LogMiner to read the logs twice. This should generally be a non-issue if your logs are not sized too large and your batch sizes are reasonable. But this will may cause slightly higher IO on the database. In effect, we're trying to take advantage of the database to optimize, sort, and return the data set as efficiently as possible before it goes over the network wire.

@nathan-smit-1 @jeremy-l-ford - This may be an interesting thing to play with :tada: 