### PR TITLE
DBZ-9248 Add extended.headers.enabled configuration to enable/disable extended headers

### DIFF
--- a/debezium-common/src/main/java/io/debezium/config/ConfigurationNames.java
+++ b/debezium-common/src/main/java/io/debezium/config/ConfigurationNames.java
@@ -13,4 +13,5 @@ public interface ConfigurationNames {
     String DATABASE_PORT_PROPERTY_NAME = "port";
     String MONGODB_CONNECTION_STRING_PROPERTY_NAME = "mongodb.connection.string";
     String TASK_ID_PROPERTY_NAME = "task.id";
+    String EXTENDED_HEADERS_ENABLED = "extended.headers.enabled";
 }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -80,6 +80,7 @@ public abstract class CommonConnectorConfig {
     protected final boolean snapshotModeConfigurationBasedSnapshotOnDataError;
     protected final boolean isLogPositionCheckEnabled;
     protected final boolean isAdvancedMetricsEnabled;
+    private final boolean isExtendedHeadersEnabled;
 
     /**
      * The set of predefined versions e.g. for source struct maker version
@@ -1239,6 +1240,54 @@ public abstract class CommonConnectorConfig {
             .withValidation(Field::isListOfMap)
             .withDescription("The job's owners emitted by Debezium. A comma-separated list of key-value pairs.For example: k1=v1,k2=v2");
 
+    /**
+     * Configuration field for enabling or disabling extended Debezium context headers.
+     *
+     * <p>This field controls whether Debezium includes additional context headers in CDC events
+     * that provide essential metadata for tracking and identifying the source of change data
+     * capture events in downstream processing systems.</p>
+     *
+     * <p><strong>Configuration Details:</strong></p>
+     * <ul>
+     *   <li><strong>Type:</strong> Boolean</li>
+     *   <li><strong>Default:</strong> Not specified (implementation dependent)</li>
+     *   <li><strong>Importance:</strong> Low</li>
+     *   <li><strong>Group:</strong> Advanced (position 46)</li>
+     *   <li><strong>Width:</strong> Short</li>
+     * </ul>
+     *
+     * <p>When enabled, this configuration adds metadata headers that can be used by downstream
+     * systems for:</p>
+     * <ul>
+     *   <li>Event source tracking and lineage</li>
+     *   <li>Identifying the origin of CDC events</li>
+     *   <li>Enhanced monitoring and debugging capabilities</li>
+     * </ul>
+     *
+     * <p><strong>Usage Example:</strong></p>
+     * <pre>{@code
+     * // Enable extended headers
+     * config.put("extended.headers.enabled", true);
+     *
+     * // Disable extended headers (default behavior may vary)
+     * config.put("extended.headers.enabled", false);
+     * }</pre>
+     *
+     * @see ConfigurationNames#EXTENDED_HEADERS_ENABLED
+     * @see Field.Group#ADVANCED
+     * @since [3.2.1.Final, 3.3.0.Alpha1]
+     */
+    public static Field EXTENDED_HEADERS_ENABLED = Field.create(ConfigurationNames.EXTENDED_HEADERS_ENABLED)
+            .withDisplayName("Enable/Disable extended headers")
+            .withGroup(Field.createGroupEntry(Field.Group.ADVANCED, 46))
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withDefault(true)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(Field::isBoolean)
+            .withDescription(
+                    "Enable/Disable Debezium context headers that provides essential metadata for tracking and identifying the source of CDC events in downstream processing systems.");
+
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(
                     EVENT_PROCESSING_FAILURE_HANDLING_MODE,
@@ -1272,7 +1321,8 @@ public abstract class CommonConnectorConfig {
                     OPEN_LINEAGE_INTEGRATION_JOB_NAMESPACE,
                     OPEN_LINEAGE_INTEGRATION_JOB_DESCRIPTION,
                     OPEN_LINEAGE_INTEGRATION_JOB_TAGS,
-                    OPEN_LINEAGE_INTEGRATION_JOB_OWNERS)
+                    OPEN_LINEAGE_INTEGRATION_JOB_OWNERS,
+                    EXTENDED_HEADERS_ENABLED)
             .events(
                     CUSTOM_CONVERTERS,
                     CUSTOM_POST_PROCESSORS,
@@ -1385,6 +1435,7 @@ public abstract class CommonConnectorConfig {
         this.snapshotModeConfigurationBasedSnapshotOnDataError = config.getBoolean(SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_DATA_ERROR);
         this.isLogPositionCheckEnabled = config.getBoolean(LOG_POSITION_CHECK_ENABLED);
         this.isAdvancedMetricsEnabled = config.getBoolean(ADVANCED_METRICS_ENABLE);
+        this.isExtendedHeadersEnabled = config.getBoolean(EXTENDED_HEADERS_ENABLED);
 
         this.signalingDataCollectionId = !Strings.isNullOrBlank(this.signalingDataCollection)
                 ? TableId.parse(this.signalingDataCollection)
@@ -1736,6 +1787,10 @@ public abstract class CommonConnectorConfig {
 
     public boolean isAdvancedMetricsEnabled() {
         return isAdvancedMetricsEnabled;
+    }
+
+    public boolean isExtendedHeadersEnabled() {
+        return isExtendedHeadersEnabled;
     }
 
     public Duration getConnectionValidationTimeout() {

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -557,6 +557,11 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
     }
 
     private ConnectHeaders getExtendedHeaders(ConnectHeaders headers) {
+
+        if (!connectorConfig.isExtendedHeadersEnabled()) {
+            return headers;
+        }
+
         var extendedHeaders = new ConnectHeaders(headers);
         StreamSupport.stream(debeziumHeaderProducer.contextHeaders().spliterator(), false)
                 .forEach(extendedHeaders::add);

--- a/debezium-core/src/test/java/io/debezium/pipeline/EventDispatcherTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/EventDispatcherTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.common.DebeziumHeaderProducer;
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.signal.SignalProcessor;
+import io.debezium.pipeline.signal.channels.SourceSignalChannel;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.pipeline.txmetadata.TransactionStructMaker;
+import io.debezium.pipeline.txmetadata.spi.TransactionMetadataFactory;
+import io.debezium.processors.PostProcessorRegistry;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.SnapshotChangeRecordEmitter;
+import io.debezium.relational.TableSchema;
+import io.debezium.schema.DataCollectionFilters;
+import io.debezium.schema.DataCollectionSchema;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.service.spi.ServiceRegistry;
+import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.util.Clock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EventDispatcherTest {
+
+    @Mock
+    private Partition partition;
+
+    @Mock
+    private DataCollectionId dataCollectionId;
+
+    @Mock
+    private RelationalDatabaseConnectorConfig config;
+
+    @Mock
+    private TopicNamingStrategy<DataCollectionId> topicNamingStrategy;
+
+    @Mock
+    private DatabaseSchema<DataCollectionId> databaseSchema;
+
+    @Mock
+    private ChangeEventQueue<DataChangeEvent> changeEventQueue;
+
+    @Mock
+    private DataCollectionFilters.DataCollectionFilter<DataCollectionId> dataCollectionFilters;
+
+    @Mock
+    private ChangeEventCreator changeEventCreator;
+
+    @Mock
+    private EventMetadataProvider eventMetadataProvider;
+
+    @Mock
+    private SchemaNameAdjuster schemaNameAdjuster;
+
+    @Mock
+    private SignalProcessor<Partition, ?> signalProcessor;
+
+    @Mock
+    private CdcSourceTaskContext cdcSourceTaskContext;
+
+    @Mock
+    private TransactionStructMaker transactionStructMaker;
+
+    @Mock
+    private TransactionMetadataFactory transactionMetadataFactory;
+
+    @Mock
+    private SourceSignalChannel sourceSignalChannel;
+
+    @Mock
+    private SourceInfoStructMaker<AbstractSourceInfo> sourceInfoStructMaker;
+
+    @Mock
+    private Schema schema;
+
+    @Mock
+    private ServiceRegistry serviceRegistry;
+
+    @Mock
+    private PostProcessorRegistry postProcessorRegistry;
+
+    @Mock
+    private TableSchema dataCollectionSchema;
+
+    @Mock
+    private OffsetContext offsetContext;
+
+    @Mock
+    private Envelope envelope;
+
+    @Mock
+    private Struct struct;
+
+    private EventDispatcher<Partition, DataCollectionId> dispatcher;
+    private static ConnectHeaders connectHeaders;
+
+    @After
+    public void tearDown() throws Exception {
+        if (connectHeaders != null) {
+            connectHeaders.clear();
+        }
+    }
+
+    @Test
+    public void dispatchEventWithExtendedHeaders() throws InterruptedException {
+
+        DebeziumHeaderProducer debeziumHeaderProducer = new DebeziumHeaderProducer(cdcSourceTaskContext);
+        when(dataCollectionSchema.getEnvelopeSchema()).thenReturn(envelope);
+        when(envelope.read(any(), any(), any())).thenReturn(struct);
+        when(databaseSchema.schemaFor(any())).thenReturn(dataCollectionSchema);
+        when(config.getServiceRegistry()).thenReturn(serviceRegistry);
+        when(serviceRegistry.tryGetService(PostProcessorRegistry.class)).thenReturn(postProcessorRegistry);
+        when(config.getSourceInfoStructMaker()).thenReturn(sourceInfoStructMaker);
+        when(sourceInfoStructMaker.schema()).thenReturn(schema);
+        when(config.supportsOperationFiltering()).thenReturn(true);
+        when(signalProcessor.getSignalChannel(any())).thenReturn(sourceSignalChannel);
+        when(config.getTransactionMetadataFactory()).thenReturn(transactionMetadataFactory);
+        when(config.getTransactionMetadataFactory().getTransactionStructMaker()).thenReturn(transactionStructMaker);
+        when(config.getHeartbeatInterval()).thenReturn(Duration.ZERO);
+
+        when(config.isExtendedHeadersEnabled()).thenReturn(true);
+        when(cdcSourceTaskContext.getTaskId()).thenReturn("0");
+        when(cdcSourceTaskContext.getConnectorLogicalName()).thenReturn("test");
+        when(cdcSourceTaskContext.getConnectorPluginName()).thenReturn("plugin");
+
+        dispatcher = new EventDispatcher<>(config, topicNamingStrategy, databaseSchema, changeEventQueue, dataCollectionFilters, changeEventCreator,
+                eventMetadataProvider,
+                schemaNameAdjuster, signalProcessor, debeziumHeaderProducer);
+
+        Object[] data = new Object[]{ "col1", "col2" };
+        SnapshotChangeRecordEmitter<Partition> changeRecordEmitter = new SnapshotChangeRecordEmitter<>(partition, offsetContext, data, Clock.SYSTEM, config);
+
+        dispatcher.dispatchSnapshotEvent(partition, dataCollectionId, changeRecordEmitter, new PartitionSnapshotReceiver());
+
+        assertThat(connectHeaders).isNotEmpty();
+    }
+
+    @Test
+    public void dispatchEventWithoutExtendedHeaders() throws InterruptedException {
+
+        DebeziumHeaderProducer debeziumHeaderProducer = new DebeziumHeaderProducer(cdcSourceTaskContext);
+        when(dataCollectionSchema.getEnvelopeSchema()).thenReturn(envelope);
+        when(envelope.read(any(), any(), any())).thenReturn(struct);
+        when(databaseSchema.schemaFor(any())).thenReturn(dataCollectionSchema);
+        when(config.getServiceRegistry()).thenReturn(serviceRegistry);
+        when(serviceRegistry.tryGetService(PostProcessorRegistry.class)).thenReturn(postProcessorRegistry);
+        when(config.getSourceInfoStructMaker()).thenReturn(sourceInfoStructMaker);
+        when(sourceInfoStructMaker.schema()).thenReturn(schema);
+        when(config.supportsOperationFiltering()).thenReturn(true);
+        when(signalProcessor.getSignalChannel(any())).thenReturn(sourceSignalChannel);
+        when(config.getTransactionMetadataFactory()).thenReturn(transactionMetadataFactory);
+        when(config.getTransactionMetadataFactory().getTransactionStructMaker()).thenReturn(transactionStructMaker);
+        when(config.getHeartbeatInterval()).thenReturn(Duration.ZERO);
+
+        when(config.isExtendedHeadersEnabled()).thenReturn(false);
+
+        dispatcher = new EventDispatcher<>(config, topicNamingStrategy, databaseSchema, changeEventQueue, dataCollectionFilters, changeEventCreator,
+                eventMetadataProvider,
+                schemaNameAdjuster, signalProcessor, debeziumHeaderProducer);
+
+        Object[] data = new Object[]{ "col1", "col2" };
+        SnapshotChangeRecordEmitter<Partition> changeRecordEmitter = new SnapshotChangeRecordEmitter<>(partition, offsetContext, data, Clock.SYSTEM, config);
+
+        dispatcher.dispatchSnapshotEvent(partition, dataCollectionId, changeRecordEmitter, new PartitionSnapshotReceiver());
+
+        assertThat(connectHeaders).isNull();
+    }
+
+    private static class PartitionSnapshotReceiver implements EventDispatcher.SnapshotReceiver<Partition> {
+
+        @Override
+        public void completeSnapshot() throws InterruptedException {
+
+        }
+
+        @Override
+        public void changeRecord(Partition partition, DataCollectionSchema schema, Envelope.Operation operation, Object key, Struct value, OffsetContext offset,
+                                 ConnectHeaders headers)
+                throws InterruptedException {
+
+            connectHeaders = headers;
+        }
+    }
+}


### PR DESCRIPTION
With OpneLineage integration we added  [Extended Context Headers](https://github.com/debezium/debezium/blob/d4779a879bcffdd36b632d237b02dc5a8c331eb0/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java#L559) to every emitted records to support [OpenLineage SMT.](https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/transforms/openlineage/OpenLineage.java)

In scenario where OpenLineage integration is not of interest this could cause waste of space. 

We this change, we added a configuration to eventually disable the emission of those headers, there remain enabled by default.

closes: https://issues.redhat.com/browse/DBZ-9248
