### PR TITLE
Dbz 9286 remove hard line breaks in shared props def lists

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -2,50 +2,67 @@ The following list describes advanced {connector-name} connector configuration p
 The default values for these properties rarely require changes.
 Therefore, you do not need to specify them in the connector configuration.
 
+////
+INSERT NEW PROPERTIES IN ALPHABETICAL ORDER
+////
+
+
 ifdef::community[]
 [id="{context}-property-binlog-buffer-size"]
 xref:{context}-property-binlog-buffer-size[`binlog.buffer.size`]::
-*Default value:* `0` +
+
+Default value::: `0`
+
+Description:::
 The size of a look-ahead buffer used by the binlog reader.
-The default setting of `0` disables buffering. +
+The default setting of `0` disables buffering.
 +
 Under specific conditions, it is possible that the {connector-name} binlog contains uncommitted data finished by a `ROLLBACK` statement.
-Typical examples are using savepoints or mixing temporary and regular table changes in a single transaction. +
+Typical examples are using savepoints or mixing temporary and regular table changes in a single transaction.
 +
 When a beginning of a transaction is detected then {prodname} tries to roll forward the binlog position and find either `COMMIT` or `ROLLBACK` so it can determine whether to stream the changes from the transaction.
 The size of the binlog buffer defines the maximum number of changes in the transaction that {prodname} can buffer while searching for transaction boundaries.
-If the size of the transaction is larger than the buffer then {prodname} must rewind and re-read the events that have not fit into the buffer while streaming. +
+If the size of the transaction is larger than the buffer then {prodname} must rewind and re-read the events that have not fit into the buffer while streaming.
 +
-NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
+NOTE: This feature is incubating.
+Feedback is encouraged.
+It is expected that this feature is not completely polished.
 endif::community[]
 
 
 [id="{context}-property-connect-keep-alive"]
 xref:{context}-property-connect-keep-alive[`connect.keep.alive`]::
-Default value: `true` +
+
+Default value::: `true`
+
+Description:::
 A Boolean value that specifies whether a separate thread should be used to ensure that the connection to the {connector-name} server or cluster is kept alive.
 
 
 [id="{context}-property-converters"]
 xref:{context}-property-converters[`converters`]::
-Default value: No default +
-Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `boolean`. +
+
+Default value::: No default
+
+Description:::
+Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, `boolean`.
++
 This property is required to enable the connector to use a custom converter.
- +
++
 For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
-The `.type` property uses the following format: +
+The `.type` property uses the following format:
 +
 `_<converterSymbolicName>_.type`
 +
-For example, +
+For example,
 +
  boolean.type: io.debezium.connector.binlog.converters.TinyIntOneToBooleanConverter
 +
 If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
-To associate these additional configuration parameter with a converter, prefix the parameter name with the symbolic name of the converter. +
+To associate these additional configuration parameter with a converter, prefix the parameter name with the symbolic name of the converter.
 +
-For example, to define a `selector` parameter that specifies the subset of columns that the `boolean` converter processes, add the following property: +
+For example, to define a `selector` parameter that specifies the subset of columns that the `boolean` converter processes, add the following property:
 
  boolean.selector=db1.table1.*, db1.table2.column1
 
@@ -53,86 +70,115 @@ For example, to define a `selector` parameter that specifies the subset of colum
 
 [id="{context}-property-custom-metric-tags"]
 xref:{context}-property-custom-metric-tags[`custom.metric.tags`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 Defines tags that customize MBean object names by adding metadata that provides contextual information.
 Specify a comma-separated list of key-value pairs.
-Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
-`k1=v1,k2=v2` +
- +
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,
+`k1=v1,k2=v2`.
++
 The connector appends the specified tags to the base MBean object name.
 Tags can help you to organize and categorize metrics data.
 You can define tags to identify particular application instances, environments, regions, versions, and so forth.
++
 For more information, see xref:customized-mbean-names[Customized MBean names].
 
 [id="{context}-property-database-initial-statements"]
 xref:{context}-property-database-initial-statements[`database.initial.statements`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 A semicolon separated list of SQL statements to be executed when a JDBC connection, not the connection that is reading the transaction log, to the database is established.
-To specify a semicolon as a character in a SQL statement and not as a delimiter, use two semicolons, (`;;`). +
+To specify a semicolon as a character in a SQL statement and not as a delimiter, use two semicolons, (`;;`).
 +
 The connector might establish JDBC connections at its own discretion, so this property is ony for configuring session parameters. It is not for executing DML statements.
 
 
 [id="{context}-property-database-query-timeout-ms"]
 xref:{context}-property-database-query-timeout-ms[`database.query.timeout.ms`]::
-Default value: `600000` (10 minutes) +
+
+Default value::: `600000` (10 minutes)
+Description:::
 Specifies the time, in milliseconds, that the connector waits for a query to complete.
++
 Set the value to `0` (zero) to remove the timeout limit.
 
 
 
 [id="{context}-property-database-ssl-keystore"]
 xref:{context}-property-database-ssl-keystore[`database.ssl.keystore`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 An optional setting that specifies the location of the key store file.
 A key store file can be used for two-way authentication between the client and the {connector-name} server.
 
 
 [id="{context}-property-database-ssl-keystore-password"]
 xref:{context}-property-database-ssl-keystore-password[`database.ssl.keystore.password`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 The password for the key store file.
 Specify a password only if the xref:{context}-property-database-ssl-keystore[`database.ssl.keystore`] is configured.
 
 
 [id="{context}-property-database-ssl-mode"]
 xref:{context}-property-database-ssl-mode[`database.ssl.mode`]::
-Default value: `preferred` +
+
+Default value::: `preferred`
+
+Description:::
 Specifies whether the connector uses an encrypted connection.
++
 The following settings are available:
 
-`disabled`::: Specifies the use of an unencrypted connection.
+`disabled`:::: Specifies the use of an unencrypted connection.
 
-`preferred` (Default)::: The connector establishes an encrypted connection if the server supports secure connections.
+`preferred`:::: The connector establishes an encrypted connection if the server supports secure connections.
 If the server does not support secure connections, the connector falls back to using an unencrypted connection.
 
-`required`::: The connector establishes an encrypted connection.
+`required`:::: The connector establishes an encrypted connection.
 If it is unable to establish an encrypted connection, the connector fails.
 
-`verify_ca`::: The connector behaves as when you set the `required` option, but it also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates.
-If the server TLS certificate does not match any valid CA certificates, the connector fails. +
+`verify_ca`:::: The connector behaves as when you set the `required` option, but it also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates.
+If the server TLS certificate does not match any valid CA certificates, the connector fails.
 
-`verify_identity`::: The connector behaves as when you set the `verify_ca` option, but it also verifies that the server certificate matches the host of the remote connection.
+`verify_identity`:::: The connector behaves as when you set the `verify_ca` option, but it also verifies that the server certificate matches the host of the remote connection.
 
 [id="{context}-property-database-ssl-truststore"]
 xref:{context}-property-database-ssl-truststore[`database.ssl.truststore`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 The location of the trust store file for the server certificate verification.
 
 
 
 [id="{context}-property-database-ssl-truststore-password"]
 xref:{context}-property-database-ssl-truststore-password[`database.ssl.truststore.password`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 The password for the trust store file.
 Used to check the integrity of the truststore, and unlock the truststore.
 
 
 [id="{context}-property-enable-time-adjuster"]
 xref:{context}-property-enable-time-adjuster[`enable.time.adjuster`]::
-Default value: `true` +
+
+Default value::: `true`
+
+Description:::
 Boolean value that indicates whether the connector converts a 2-digit year specification to 4 digits.
-Set the value to `false` when conversion is fully delegated to the database. +
+Set the value to `false` when conversion is fully delegated to the database.
 +
 {connector-name} users can insert year values with either 2-digits or 4-digits.
 2-digit values are mapped to a year in the range 1970 - 2069.
@@ -142,56 +188,69 @@ By default, the connector performs the conversion.
 
 [id="{context}-property-errors-max-retries"]
 xref:{context}-property-errors-max-retries[`errors.max.retries`]::
-Default value: `-1` +
-Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+
+Default value::: `-1`
+
+Description:::
+Specifies how the connector responds after an operation that results in a retriable error, such as a connection error.
++
 Set one of the following options:
 
-`-1`::: No limit.
+`-1`:::: No limit.
 The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
 
-`0`::: Disabled.
+`0`:::: Disabled.
 The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
-`> 0`::: The connector restarts automatically until it reaches the specified maximum number of retries.
+`>0`:::: The connector restarts automatically until it reaches the specified maximum number of retries.
 After the next failure, the connector stops, and user intervention is required to restart it.
 
 
 
 [id="{context}-property-event-converting-failure-handling-mode"]
 xref:{context}-property-event-converting-failure-handling-mode[`event.converting.failure.handling.mode`]::
-Default value: `warn` +
-Specifies how the connector responds when it cannot convert a table record due to a mismatch between the data type of a column and the type specified by the {prodname} internal schema. +
+
+Default value::: `warn`
+
+Description:::
+Specifies how the connector responds when it cannot convert a table record due to a mismatch between the data type of a column and the type specified by the {prodname} internal schema.
 Set one of the following options:
 
-`fail`:::  An exception reports that conversion failed because the data type of the field did not match the schema type, and indicates that it might be necessary to restart the connector in `schema _only_recovery` mode to enable a successful conversion.
-`warn`::: The connector writes a `null` value to the event field for the column that failed conversion, writes a message to the warning log . +
-`skip`:::  The connector writes a `null` value to the event field for the column that failed conversion, and writes a message to the debug log.
+`fail`::::  An exception reports that conversion failed because the data type of the field did not match the schema type, and indicates that it might be necessary to restart the connector in `schema _only_recovery` mode to enable a successful conversion.
+`warn`:::: The connector writes a `null` value to the event field for the column that failed conversion, writes a message to the warning log .
+`skip`::::  The connector writes a `null` value to the event field for the column that failed conversion, and writes a message to the debug log.
 
 
 
 [id="{context}-property-event-processing-failure-handling-mode"]
 xref:{context}-property-event-processing-failure-handling-mode[`event.processing.failure.handling.mode`]::
-Default value: `fail` +
+
+Default value::: `fail`
+
+Description:::
 Specifies how the connector handles failures that occur when processing events, for example, if it encounters a corrupted event.
 The following settings are available:
 
-`fail`::: The connector raises an exception that reports the problematic event and its position.
+`fail`:::: The connector raises an exception that reports the problematic event and its position.
 The connector then stops.
 
-`warn`::: The connector does not raise an exception.
+`warn`:::: The connector does not raise an exception.
 Instead, it logs the problematic event and its position, and then skips the event.
 
-`ignore`::: The connector ignores the problematic event, and does not generate a log entry.
+`ignore`:::: The connector ignores the problematic event, and does not generate a log entry.
 
 
 
 [id="{context}-property-heartbeat-action-query"]
 xref:{context}-property-heartbeat-action-query[`heartbeat.action.query`]::
-Default value: No default +
-Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
+
+Default value::: No default
+
+Description:::
+Specifies a query that the connector executes on the source database when the connector sends a heartbeat message.
 +
-For example, the following query periodically captures the state of the executed GTID set in the source database. +
+For example, the following query periodically captures the state of the executed GTID set in the source database.
 +
 `INSERT INTO gtid_history_table (select @gtid_executed)`
 
@@ -199,20 +258,28 @@ For example, the following query periodically captures the state of the executed
 
 [id="{context}-property-heartbeat-interval-ms"]
 xref:{context}-property-heartbeat-interval-ms[`heartbeat.interval.ms`]::
-Default value: `0` +
+
+Default value::: `0`
+
+Description:::
 Specifies how frequently the connector sends heartbeat messages to a Kafka topic.
-By default, the connector does not send heartbeat messages. +
+By default, the connector does not send heartbeat messages.
 +
-Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database.
+Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts.
+To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
 
 
 
 [id="{context}-property-incremental-snapshot-allow-schema-changes"]
 xref:{context}-property-incremental-snapshot-allow-schema-changes[`incremental.snapshot.allow.schema.changes`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 Specifies whether the connector allows schema changes during an incremental snapshot.
-When the value is set to `true`, the connector detects schema change during an incremental snapshot, and re-select a current chunk to avoid locking DDLs. +
- +
+When the value is set to `true`, the connector detects schema change during an incremental snapshot, and re-select a current chunk to avoid locking DDLs.
++
 Changes to a primary key are not supported.
 Changing the primary during an incremental snapshot, can lead to incorrect results.
 A further limitation is that if a schema change affects only the default values of columns, then the change is not detected until the DDL is processed from the binlog stream.
@@ -222,7 +289,10 @@ This does not affect the values of snapshot events, but the schema of these snap
 
 [id="{context}-property-incremental-snapshot-chunk-size"]
 xref:{context}-property-incremental-snapshot-chunk-size[`incremental.snapshot.chunk.size`]::
-Default value: `1024` +
+
+Default value::: `1024`
+
+Description:::
 The maximum number of rows that the connector fetches and reads into memory when it retrieves an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
@@ -232,14 +302,18 @@ Adjust the chunk size to a value that provides the best performance in your envi
 
 [id="{context}-property-incremental-snapshot-watermarking-strategy"]
 xref:{context}-property-incremental-snapshot-watermarking-strategy[`incremental.snapshot.watermarking.strategy`]::
-Default value: `insert_insert` +
-Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes. +
+
+Default value::: `insert_insert`
+
+Description:::
+Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes.
++
 You can specify one of the following options:
 
-`insert_insert` (default)::: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.
+`insert_insert` (default):::: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.
 After the snapshot completes, {prodname} inserts a second entry that records the signal to close the window.
 
-`insert_delete`::: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads, it writes a single entry to the signaling data collection to record the signal to open the snapshot window.
+`insert_delete`:::: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads, it writes a single entry to the signaling data collection to record the signal to open the snapshot window.
 After the snapshot completes, this entry is removed.
 No entry is created for the signal to close the snapshot window.
 Set this option to prevent rapid growth of the signaling data collection.
@@ -248,14 +322,20 @@ Set this option to prevent rapid growth of the signaling data collection.
 
 [id="{context}-property-max-batch-size"]
 xref:{context}-property-max-batch-size[`max.batch.size`]::
-Default value: `2048` +
+
+Default value::: `2048`
+
+Description:::
 Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector.
 
 
 
 [id="{context}-property-max-queue-size"]
 xref:{context}-property-max-queue-size[`max.queue.size`]::
-Default value: `8192` +
+
+Default value::: `8192`
+
+Description:::
 A positive integer value that specifies the maximum number of records that the blocking queue can hold.
 When {prodname} reads events streamed from the database, it places the events in the blocking queue before it writes them to Kafka.
 The blocking queue can provide backpressure for reading change events from the database
@@ -267,10 +347,13 @@ Always set `max.queue.size` to a value that is larger than the value of xref:{co
 
 [id="{context}-property-max-queue-size-in-bytes"]
 xref:{context}-property-max-queue-size-in-bytes[`max.queue.size.in.bytes`]::
-Default value: `0` +
+
+Default value::: `0`
+
+Description:::
 A long integer value that specifies the maximum volume of the blocking queue in bytes.
 By default, volume limits are not specified for the blocking queue.
-To specify the number of bytes that the queue can consume, set this property to a positive long value. +
+To specify the number of bytes that the queue can consume, set this property to a positive long value.
 If xref:{context}-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
@@ -278,9 +361,13 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 
 [id="{context}-property-min-row-count-to-stream-results"]
 xref:{context}-property-min-row-count-to-stream-results[`min.row.count.to.stream.results`]::
-Default value: `1000` +
+
+Default value::: `1000`
+
+Description:::
 During a snapshot, the connector queries each table for which the connector is configured to capture changes. The connector uses each query result to produce a read event that contains data for all rows in that table.
-This property determines whether the {connector-name} connector puts results for a table into memory, which is fast but requires large amounts of memory, or streams the results, which can be slower but work for very large tables. The setting of this property specifies the minimum number of rows a table must contain before the connector streams results. +
+This property determines whether the {connector-name} connector puts results for a table into memory, which is fast but requires large amounts of memory, or streams the results, which can be slower but work for very large tables.
+The setting of this property specifies the minimum number of rows a table must contain before the connector streams results.
 +
 To skip all table size checks and always stream all results during a snapshot, set this property to `0`.
 
@@ -288,7 +375,10 @@ To skip all table size checks and always stream all results during a snapshot, s
 
 [id="{context}-property-notification-enabled-channels"]
 xref:{context}-property-notification-enabled-channels[`notification.enabled.channels`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 List of notification channel names that are enabled for the connector.
 By default, the following channels are available:
 
@@ -305,15 +395,22 @@ endif::community[]
 
 [id="{context}-property-poll-interval-ms"]
 xref:{context}-property-poll-interval-ms[`poll.interval.ms`]::
-Default value: `500` (0.5 seconds) +
+
+Default value::: `500` (0.5 seconds)
+
+Description:::
 Positive integer value that specifies the number of milliseconds the connector waits for new change events to appear before it starts processing a batch of events.
 
 
 
 [id="{context}-property-provide-transaction-metadata"]
 xref:{context}-property-provide-transaction-metadata[`provide.transaction.metadata`]::
-Default value: `false` +
-Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this.
+
+Default value::: `false`
+
+Description:::
+Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata.
+Specify `true` if you want the connector to do this.
 For more information, see xref:{context}-transaction-metadata[Transaction metadata].
 
 
@@ -321,23 +418,33 @@ For more information, see xref:{context}-transaction-metadata[Transaction metada
 ifdef::community[]
 [id="{context}-property-read-only"]
 xref:{context}-property-read-only[`read.only`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 Specifies whether a connector writes watermarks to the signal data collection to track the progress of an incremental snapshot.
 Set the value to `true` to enable a connector that has a read-only connection to the database to use an incremental snapshot watermarking strategy that does not require writing to the signal data collection.
 endif::community[]
 
 [id="{context}-property-signal-data-collection"]
 xref:{context}-property-signal-data-collection[`signal.data.collection`]::
-Default value: No default +
-Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[signals] to the connector. +
-Use the following format to specify the collection name: +
+
+Default value::: No default
+
+Description:::
+Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[signals] to the connector.
+Use the following format to specify the collection name:
++
 `_<databaseName>_._<tableName>_`
 
 
 
 [id="{context}-property-signal-enabled-channels"]
 xref:{context}-property-signal-enabled-channels[`signal.enabled.channels`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 List of the signaling channel names that are enabled for the connector.
 By default, the following channels are available:
 
@@ -355,29 +462,39 @@ endif::community[]
 
 [id="{context}-property-skipped-operations"]
 xref:{context}-property-skipped-operations[`skipped.operations`]::
-Default value: `t` +
+
+Default value::: `t`
+
+Description:::
 A comma-separated list of the operation types that you want the connector to skip during streaming.
-You can configure the connector to skip the following types of operations:
++
+Set one of the following options to specify the operations to skip:
 
-* `c` (insert/create)
-* `u` (update)
-* `d` (delete)
-* `t` (truncate)
-
-Set the value to `none` if you do not want the connector to skip any operations.
+`c`:::: Insert/create operations.
+`u`:::: Update operations.
+`d`:::: Delete operations.
+`t`:::: Truncate operations.
+`none`:::: The connector does not skip any operations.
 
 
 
 [id="{context}-property-snapshot-delay-ms"]
 xref:{context}-property-snapshot-delay-ms[`snapshot.delay.ms`]::
-Default value: No default +
-An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
+
+Default value::: No default
+
+Description:::
+An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts.
+If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
 
 
 [id="{context}-property-snapshot-fetch-size"]
 xref:{context}-property-snapshot-fetch-size[`snapshot.fetch.size`]::
-Default value: Unset +
+
+Default value::: Unset
+
+Description:::
 By default, during a snapshot, the connector reads table content in batches of rows.
 Set this property to specify the maximum number of rows in a batch.
 
@@ -386,12 +503,16 @@ include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=snapshot-fetch-si
 
 [id="{context}-property-snapshot-include-collection-list"]
 xref:{context}-property-snapshot-include-collection-list[`snapshot.include.collection.list`]::
-Default value: All tables specified in the `table.include.list`. +
+
+Default value::: All tables specified in the `table.include.list`.
+
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>.<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
-This property takes effect only if the connector's xref:{context}-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `never`. +
-This property does not affect the behavior of incremental snapshots. +
- +
++
+This property takes effect only if the connector's xref:{context}-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `never`.
+This property does not affect the behavior of incremental snapshots.
++
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
 
@@ -399,35 +520,43 @@ That is, the specified expression is matched against the entire name string of t
 
 [id="{context}-property-snapshot-lock-timeout-ms"]
 xref:{context}-property-snapshot-lock-timeout-ms[`snapshot.lock.timeout.ms`]::
-Default value: `10000` +
+
+Default value::: `10000`
+
+Description:::
 Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
 If the connector cannot acquire table locks in this time interval, the snapshot fails.
++
 For more information, see the documentation that describes xref:{context}-snapshots[how {connector-name} connectors perform database snapshots].
 
 
 
 [id="{context}-property-snapshot-locking-mode"]
 xref:{context}-property-snapshot-locking-mode[`snapshot.locking.mode`]::
-Default value: `minimal` +
+
+Default value::: `minimal`
+
+Description:::
 Specifies whether and for how long the connector holds the global {connector-name} read lock, which prevents any updates to the database while the connector is performing a snapshot.
++
 The following settings are available:
 
-`minimal`::: The connector holds the global read lock for only the initial phase of the snapshot during which it reads the database schemas and other metadata.
+`minimal`:::: The connector holds the global read lock for only the initial phase of the snapshot during which it reads the database schemas and other metadata.
 During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table.
 To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction.
 Although the release of the global read lock permits other {connector-name} clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction. +
 
-`extended`::: Blocks all write operations for the duration of the snapshot.
+`extended`:::: Blocks all write operations for the duration of the snapshot.
 Use this setting if clients submit concurrent operations that are incompatible with the REPEATABLE READ isolation level in {connector-name}. +
 
-`none`::: Prevents the connector from acquiring any table locks during the snapshot.
+`none`:::: Prevents the connector from acquiring any table locks during the snapshot.
 Although this option is allowed with all snapshot modes, it is safe to use _only_ if no schema changes occur while the snapshot is running.
 Tables that are defined with the MyISAM engine always acquire a table lock.
 As a result, such tables are locked even if you set this option.
 This behavior differs from tables that are defined by the InnoDB engine, which acquire row-level locks.
 
 ifdef::community[]
-`custom`::: The connector performs a snapshot according to the implementation specified by the xref:{context}-property-snapshot-locking-mode-custom-name[`snapshot.locking.mode.custom.name`] property, which is a custom implementation of the `io.debezium.spi.snapshot.SnapshotLock` interface.
+`custom`:::: The connector performs a snapshot according to the implementation specified by the xref:{context}-property-snapshot-locking-mode-custom-name[`snapshot.locking.mode.custom.name`] property, which is a custom implementation of the `io.debezium.spi.snapshot.SnapshotLock` interface.
 endif::community[]
 
 
@@ -435,8 +564,12 @@ endif::community[]
 ifdef::community[]
 [id="{context}-property-snapshot-locking-mode-custom-name"]
 xref:{context}-property-snapshot-locking-mode-custom-name[`snapshot.locking.mode.custom.name`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 When xref:{context}-property-snapshot-locking-mode[`snapshot.locking.mode`] is set to `custom`, use this setting to specify the name of the custom implementation provided in the `name()` method that is defined by the 'io.debezium.spi.snapshot.SnapshotLock' interface.
++
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
 
 
@@ -444,10 +577,13 @@ endif::community[]
 
 [id="{context}-property-snapshot-max-threads"]
 xref:{context}-property-snapshot-max-threads[`snapshot.max.threads`]::
-Default value: `1` +
+
+Default value::: `1`
+
+Description:::
 Specifies the number of threads that the connector uses when performing an initial snapshot.
 To enable parallel initial snapshots, set the property to a value greater than 1.
-In a parallel initial snapshot, the connector processes multiple tables concurrently. +
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
 +
 ifdef::community[]
 NOTE: Parallel initial snapshots is an incubating feature.
@@ -471,50 +607,54 @@ endif::product[]
 
 [id="{context}-property-snapshot-mode"]
 xref:{context}-property-snapshot-mode[`snapshot.mode`]::
-Default value: `initial` +
+
+Default value::: `initial`
+
+Description:::
 Specifies the criteria for running a snapshot when the connector starts.
++
 The following settings are available:
 
-`always`::: The connector performs a snapshot every time that it starts.
+`always`:::: The connector performs a snapshot every time that it starts.
 The snapshot includes the structure and data of the captured tables.
 Specify this value to populate topics with a complete representation of the data from the captured tables every time that the connector starts.
 
-`initial` (default)::: The connector runs a snapshot only when no offsets have been recorded for the logical server name, or if it detects that an earlier snapshot failed to complete.
+`initial`:::: The connector runs a snapshot only when no offsets have been recorded for the logical server name, or if it detects that an earlier snapshot failed to complete.
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
-`initial_only`::: The connector runs a snapshot only when no offsets have been recorded for the logical server name.
+`initial_only`:::: The connector runs a snapshot only when no offsets have been recorded for the logical server name.
 After the snapshot completes, the connector stops.
 It does not transition to streaming to read change events from the binlog.
 
-`schema_only`::: Deprecated, see `no_data`.
+`schema_only`:::: Deprecated, see `no_data`.
 
-`no_data`::: The connector runs a snapshot that captures only the schema, but not any table data.
+`no_data`:::: The connector runs a snapshot that captures only the schema, but not any table data.
 Set this option if you do not need the topics to contain a consistent snapshot of the data, but you want to capture any schema changes that were applied after the last connector restart.
 
-`schema_only_recovery`::: Deprecated, see `recovery`.
+`schema_only_recovery`:::: Deprecated, see `recovery`.
 
-`recovery`:::  Set this option to restore a database schema history topic that is lost or corrupted.
+`recovery`:::: Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.
-You can also set the property to periodically prune a database schema history topic that experiences unexpected growth. +
+You can also set the property to periodically prune a database schema history topic that experiences unexpected growth.
 +
 [WARNING]
 ====
 Do not use this mode to perform a snapshot if schema changes were committed to the database after the last connector shutdown.
 ====
-`never`::: When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes.
+`never`:::: When the connector starts, rather than performing a snapshot, it immediately begins to stream event records for subsequent database changes.
 This option is under consideration for future deprecation, in favor of the `no_data` option.
 
-`when_needed`::: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
+`when_needed`:::: After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
 
 * It cannot detect any topic offsets.
 * A previously recorded offset specifies a binlog position or GTID that is not available on the server.
 
 ifdef::community[]
-`configuration_based`::: With this option, you control snapshot behavior through a set of connector properties that have the prefix 'snapshot.mode.configuration.based'.
+`configuration_based`:::: With this option, you control snapshot behavior through a set of connector properties that have the prefix 'snapshot.mode.configuration.based'.
 endif::community[]
 
 ifdef::community[]
-`custom`::: The connector performs a snapshot according to the implementation specified by the xref:{context}-property-snapshot-mode-custom-name[`snapshot.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
+`custom`:::: The connector performs a snapshot according to the implementation specified by the xref:{context}-property-snapshot-mode-custom-name[`snapshot.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.Snapshotter` interface.
 endif::community[]
 
 
@@ -522,42 +662,60 @@ endif::community[]
 ifdef::community[]
 [id="{context}-property-snapshot-mode-configuration-based-snapshot-data"]
 xref:{context}-property-snapshot-mode-configuration-based-snapshot-data[`snapshot.mode.configuration.based.snapshot.data`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 If the `snapshot.mode` is set to `configuration_based`, set this property to specify whether the connector includes table data when it performs a snapshot.
 endif::community[]
 
 ifdef::community[]
 [id="{context}-property-snapshot-mode-configuration-based-snapshot-on-data-error"]
 xref:{context}-property-snapshot-mode-configuration-based-snapshot-on-data-error[`snapshot.mode.configuration.based.snapshot.on.data.error`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 If the `snapshot.mode` is set to `configuration_based`, set this property to specify whether the connector includes table data in a snapshot in the event that data is no longer available in the transaction log.
 endif::community[]
 
 ifdef::community[]
 [id="{context}-property-snapshot-mode-configuration-based-snapshot-on-schema-error"]
 xref:{context}-property-snapshot-mode-configuration-based-snapshot-on-schema-error[`snapshot.mode.configuration.based.snapshot.on.schema.error`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 If the `snapshot.mode` is set to `configuration_based`, set this property to specify whether the connector includes table schema in a snapshot if the schema history topic is not available.
 endif::community[]
 
 ifdef::community[]
 [id="{context}-property-snapshot-mode-configuration-based-snapshot-schema"]
 xref:{context}-property-snapshot-mode-configuration-based-snapshot-schema[`snapshot.mode.configuration.based.snapshot.schema`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 If the `snapshot.mode` is set to `configuration_based`, set this property to specify whether the connector includes the table schema when it performs a snapshot.
 endif::community[]
 
 ifdef::community[]
 [id="{context}-property-snapshot-mode-configuration-based-start-stream"]
 xref:{context}-property-snapshot-mode-configuration-based-start-stream[`snapshot.mode.configuration.based.start.stream`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 If the `snapshot.mode` is set to `configuration_based`, set this property to specify whether the connector begins to stream change events after a snapshot completes.
 endif::community[]
 
 ifdef::community[]
 [id="{context}-property-snapshot-mode-custom-name"]
 xref:{context}-property-snapshot-mode-custom-name[`snapshot.mode.custom.name`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 If `snapshot.mode` is set to `custom`, use this setting to specify the name of the custom implementation that is provided in the `name()` method that is defined in the 'io.debezium.spi.snapshot.Snapshotter' interface.
 After a connector restart, {prodname} calls the specified custom implementation to determine whether to perform a snapshot.
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
@@ -565,14 +723,18 @@ endif::community[]
 
 [id="{context}-property-snapshot-query-mode"]
 xref:{context}-property-snapshot-query-mode[`snapshot.query.mode`]::
-Default value: `select_all` +
-Specifies how the connector queries data while performing a snapshot. +
+
+Default value::: `select_all`
+
+Description:::
+Specifies how the connector queries data while performing a snapshot.
++
 Set one of the following options:
 
-`select_all` (default)::: The connector uses a `select all` query to retrieve rows from captured tables, optionally adjusting the columns selected based on the column `include` and `exclude` list configurations.
+`select_all` (default):::: The connector uses a `select all` query to retrieve rows from captured tables, optionally adjusting the columns selected based on the column `include` and `exclude` list configurations.
 
 ifdef::community[]
-`custom`::: The connector performs a snapshot query according to the implementation specified by the xref:{context}-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface. +
+`custom`:::: The connector performs a snapshot query according to the implementation specified by the xref:{context}-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface.
 endif::community[]
 +
 This setting enables you to manage snapshot content in a more flexible manner compared to using the xref:{context}-property-snapshot-select-statement-overrides[`snapshot.select.statement.overrides`] property.
@@ -582,31 +744,39 @@ This setting enables you to manage snapshot content in a more flexible manner co
 ifdef::community[]
 [id="{context}-property-snapshot-snapshot-query-mode-custom-name"]
 xref:{context}-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 When xref:{context}-property-snapshot-query-mode[`snapshot.query.mode`] is set as `custom`, use this setting to specify the name of the custom implementation provided in the `name()` method that is defined by the 'io.debezium.spi.snapshot.SnapshotQuery' interface.
 For more information, see xref:connector-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 [id="{context}-property-snapshot-select-statement-overrides"]
 xref:{context}-property-snapshot-select-statement-overrides[`snapshot.select.statement.overrides`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 Specifies the table rows to include in a snapshot.
 Use the property if you want a snapshot to include only a subset of the rows in a table.
 This property affects snapshots only.
 It does not apply to events that the connector reads from the log.
- +
-The property contains a comma-separated list of fully-qualified table names in the form `_<databaseName>.<tableName>_`. For example, +
 +
-`+"snapshot.select.statement.overrides": "inventory.products,customers.orders"+` +
+The property contains a comma-separated list of fully-qualified table names in the form `_<databaseName>.<tableName>_`. For example,
++
+`+"snapshot.select.statement.overrides": "inventory.products,customers.orders"+`
 +
 For each table in the list, add a further configuration property that specifies the `SELECT` statement for the connector to run on the table when it takes a snapshot.
 The specified `SELECT` statement determines the subset of table rows to include in the snapshot.
-Use the following format to specify the name of this `SELECT` statement property: +
+Use the following format to specify the name of this `SELECT` statement property:
 +
 `snapshot.select.statement.overrides._<databaseName>_._<tableName>_`
++
 For example,
-`snapshot.select.statement.overrides.customers.orders` +
- +
++
+`snapshot.select.statement.overrides.customers.orders`
++
 From a `customers.orders` table that includes the soft-delete column, `delete_flag`, add the following properties if you want a snapshot to include only those records that are not soft-deleted:
 +
 ----
@@ -619,21 +789,28 @@ In the resulting snapshot, the connector includes only the records for which `de
 
 [id="{context}-property-snapshot-tables-order-by-row-count"]
 xref:{context}-property-snapshot-tables-order-by-row-count[`snapshot.tables.order.by.row.count`]::
-Default value: `disabled` +
+
+Default value::: `disabled`
+
+Description:::
 Specifies the order in which the connector processes tables when it performs an initial snapshot.
++
 Set one of the following options:
 
-`descending`::: The connector snapshots tables in order, based on the number of rows from the highest to the lowest.
-`ascending`::: The connector snapshots tables in order, based on the number of rows, from lowest to highest.
-`disabled`::: The connector disregards row count when performing an initial snapshot.
+`descending`:::: The connector snapshots tables in order, based on the number of rows from the highest to the lowest.
+`ascending`:::: The connector snapshots tables in order, based on the number of rows, from lowest to highest.
+`disabled`:::: The connector disregards row count when performing an initial snapshot.
 
 
 
 ifdef::community[]
 [id="{context}-property-source-struct-version"]
 xref:{context}-property-source-struct-version[`source.struct.version`]::
-Default value: `v2` +
-Schema version for the `source` block in {prodname} events.  {prodname} 0.10 introduced a few breaking changes to the structure of the `source` block in order to unify the exposed structure across all the connectors. +
+
+Default value::: `v2`
+
+Description:::
+Schema version for the `source` block in {prodname} events.  {prodname} 0.10 introduced a few breaking changes to the structure of the `source` block in order to unify the exposed structure across all the connectors.
 +
 By setting this option to `v1`, the structure used in earlier versions can be produced. However, this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
@@ -642,7 +819,10 @@ endif::community[]
 
 [id="{context}-property-streaming-delay-ms"]
 xref:{context}-property-streaming-delay-ms[`streaming.delay.ms`]::
-Default value: `0` +
+
+Default value::: `0`
+
+Description:::
 Specifies the time, in milliseconds, that the connector delays the start of the streaming process after it completes a snapshot.
 Setting a delay interval helps to prevent the connector from restarting snapshots in the event that a failure occurs immediately after the snapshot completes, but before the streaming process begins.
 Set a delay value that is higher than the value of the {link-kafka-docs}/#connectconfigs_offset.flush.interval.ms[`offset.flush.interval.ms`] property that is set for the Kafka Connect worker.
@@ -651,7 +831,10 @@ Set a delay value that is higher than the value of the {link-kafka-docs}/#connec
 
 [id="{context}-property-table-ignore-builtin"]
 xref:{context}-property-table-ignore-builtin[`table.ignore.builtin`]::
-Default value: `true` +
+
+Default value::: `true`
+
+Description:::
 A Boolean value that specifies whether built-in system tables should be ignored.
 This applies regardless of the table include and exclude lists.
 By default, changes that occur to the values in system tables are excluded from capture, and {prodname} does not generate events for system table changes.
@@ -660,7 +843,10 @@ By default, changes that occur to the values in system tables are excluded from 
 
 [id="{context}-property-topic-cache-size"]
 xref:{context}-property-topic-cache-size[`topic.cache.size`]::
-Default value: `10000` +
+
+Default value::: `10000`
+
+Description:::
 Specifies the number of topic names that can be stored in memory in a bounded concurrent hash map.
 The connector uses the cache to help determine the topic name that corresponds to a data collection.
 
@@ -668,26 +854,35 @@ The connector uses the cache to help determine the topic name that corresponds t
 
 [id="{context}-property-topic-delimiter"]
 xref:{context}-property-topic-delimiter[`topic.delimiter`]::
-Default value: `.` +
+
+Default value::: `.` (period)
+
+Description:::
 Specifies the delimiter that the connector inserts between components of the topic name.
 
 
 
 [id="{context}-property-topic-heartbeat-prefix"]
 xref:{context}-property-topic-heartbeat-prefix[`topic.heartbeat.prefix`]::
-Default value: `__debezium-heartbeat` +
+
+Default value::: `__debezium-heartbeat`
+
+Description:::
 Specifies the name of the topic to which the connector sends heartbeat messages.
-The topic name takes the following format: +
+The topic name takes the following format:
 +
-_topic.heartbeat.prefix_._topic.prefix_ +
+_topic.heartbeat.prefix_._topic.prefix_
 +
-For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
+For example, when you set the default value for this property, and the topic prefix is `fulfillment`, the topic name is `__debezium-heartbeat.fulfillment`.
 
 
 
 [id="{context}-property-topic-naming-strategy"]
 xref:{context}-property-topic-naming-strategy[`topic.naming.strategy`]::
-Default value: `io.debezium.schema.DefaultTopicNamingStrategy` +
+
+Default value::: `io.debezium.schema.DefaultTopicNamingStrategy`
+
+Description:::
 The name of the `TopicNamingStrategy` class that the connector uses.
 The specified strategy determines how the connector names the topics that store event records for data changes, schema changes, transactions, heartbeats, and so forth.
 
@@ -695,11 +890,14 @@ The specified strategy determines how the connector names the topics that store 
 
 [id="{context}-property-topic-transaction"]
 xref:{context}-property-topic-transaction[`topic.transaction`]::
-Default value: `transaction` +
+
+Default value::: `transaction`
+
+Description:::
 Specifies the name of the topic to which the connector sends transaction metadata messages.
-The topic name takes the following pattern: +
+The topic name takes the following pattern:
 +
-_topic.prefix_._topic.transaction_ +
+_topic.prefix_._topic.transaction_
 +
 For example, if the topic prefix is `fulfillment`, the default topic name is `fulfillment.transaction`.
 
@@ -707,22 +905,12 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 [id="{context}-property-use-nongraceful-disconnect"]
 xref:{context}-property-use-nongraceful-disconnect[`use.nongraceful.disconnect`]::
-Default value: false +
-A Boolean value that specifies whether the binary log client's keepalive thread sets the `SO_LINGER` socket option to  `0` to immediately close stale TCP connections. +
-Set the value to `true` if the connector experiences deadlocks in `SSLSocketImpl.close`. +
+
+Default value::: false
+
+Description:::
+A Boolean value that specifies whether the binary log client's keepalive thread sets the `SO_LINGER` socket option to  `0` to immediately close stale TCP connections.
+Set the value to `true` if the connector experiences deadlocks in `SSLSocketImpl.close`.
 ifdef::community[]
 For more information, see https://github.com/osheroff/mysql-binlog-connector-java/issues/133[Issue 133] in the https://github.com/osheroff/mysql-binlog-connector-java[mysql-binlog-connector-java] GitHub repository.
 endif::community[]
-
-[id="{context}-property-extended-headers-enabled"]
-xref:{context}-property-extended-headers-enabled[`extended.headers.enabled`]::
-
-Default value::: `true` 
-Description::: This property specifies whether {prodname} adds context headers with the prefix `__debezium.context.` to the messages that it emits.
-
-These headers are required by the OpenLineage integration and provide metadata that enables downstream processing systems to track and identify the sources of change events.
-
-The property adds following headers:
-`__debezium.context.connectorLogicalName`:: The logical name of the {prodname} connector.
-`__debezium.context.taskId`:: The unique identifier of the connector task.
-`__debezium.context.connectorName`::  The name of the {prodname} connector.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -2,16 +2,19 @@ The following configuration properties are _required_ unless a default value is 
 
 [id="{context}-property-bigint-unsigned-handling-mode"]
 xref:{context}-property-bigint-unsigned-handling-mode[`bigint.unsigned.handling.mode`]::
- +
-Default value: `long` +
+
+Default value::: `long`
+
+Description:::
 Specifies how the connector represents BIGINT UNSIGNED columns in change events.
++
 Set one of the following options:
 
-`long`::: Uses Java `long` data types to represent BIGINT UNSIGNED column values.
+`long`:::: Uses Java `long` data types to represent BIGINT UNSIGNED column values.
 Although the `long` type does not offer the greatest precision, it is easy implement in most consumers.
 In most environments, this is the preferred setting.
 
-`precise`::: Uses `java.math.BigDecimal` data types to represent values.
+`precise`:::: Uses `java.math.BigDecimal` data types to represent values.
 The connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` data type to represent values in encoded binary format.
 Set this option if the connector typically works with values larger than 2^63.
 The `long` data type cannot convey values of that size.
@@ -20,24 +23,33 @@ The `long` data type cannot convey values of that size.
 
 [id="{context}-property-binary-handling-mode"]
 xref:{context}-property-binary-handling-mode[`binary.handling.mode`]::
-Default value: `bytes` +
+
+
+Default value::: `bytes`
+
+Description:::
 Specifies how the connector represents values for binary columns, such as, `blob`, `binary`, `varbinary`, in change events. +
+
 Set one of the following options:
-`bytes`::: Represents binary data as a byte array.
 
-`base64`::: Represents binary data as a base64-encoded String.
+`bytes`:::: Represents binary data as a byte array.
 
-`base64-url-safe`::: Represents binary data as a base64-url-safe-encoded String.
+`base64`:::: Represents binary data as a base64-encoded String.
 
-`hex`::: Represents binary data as a hex-encoded (base16) String.
+`base64-url-safe`:::: Represents binary data as a base64-url-safe-encoded String.
+
+`hex`:::: Represents binary data as a hex-encoded (base16) String.
 
 
 [id="{context}-property-column-exclude-list"]
 xref:{context}-property-column-exclude-list[`column.exclude.list`]::
-Default value: _empty string_ +
+
+Default value::: _empty string_
+
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values.
 Other columns in the source record are captured as usual.
-Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 +
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name.
@@ -47,32 +59,33 @@ If you include this property in the configuration, do not also set the `column.i
 
 [id="{context}-property-column-include-list"]
 xref:{context}-property-column-include-list[`column.include.list`]::
-Default value:  _empty string_ +
-An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values.
+
+Default value:::  _empty string_ +
+
+Description::: An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values.
 Other columns are omitted from the event record.
-Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 +
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name. +
 If you include this property in the configuration, do not set the `column.exclude.list` property.
 
-////
-[id="{context}-property-column-mask-hash"]
-[id="{context}-property-column-mask-hash-v2"]
-xref:{context}-property-column-mask-hash[`column.mask.hash._hashAlgorithm_.with.salt._salt_`] +
-xref:{context}-property-column-mask-hash-v2[`column.mask.hash.v2._hashAlgorithm_.with.salt._salt_`]::
-////
+
 [id="{context}-property-column-mask-hash"]
 xref:{context}-property-column-mask-hash[`column.mask.hash._hashAlgorithm_.with.salt._salt_`]::
 [id="{context}-property-column-mask-hash-v2"]
 xref:{context}-property-column-mask-hash-v2[`column.mask.hash.v2._hashAlgorithm_.with.salt._salt_`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.
-Fully-qualified names for columns are of the form `_<databaseName>_._<tableName>_._<columnName>_`. +
+Fully-qualified names for columns are of the form `_<databaseName>_._<tableName>_._<columnName>_`.
++
 To match the name of a column {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 In the resulting change event record, the values for the specified columns are replaced with pseudonyms.
- +
++
 A pseudonym consists of the hashed value that results from applying the specified _hashAlgorithm_ and _salt_.
 Based on the hash function that is used, referential integrity is maintained, while column values are replaced with pseudonyms.
 Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation. +
@@ -84,7 +97,7 @@ column.mask.hash.SHA-256.with.salt.CzQMA0cB5K = inventory.orders.customerName, i
 ----
 +
 If necessary, the pseudonym is automatically shortened to the length of the column.
-The connector configuration can include multiple properties that specify different hash algorithms and salts. +
+The connector configuration can include multiple properties that specify different hash algorithms and salts.
 +
 Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked. +
 +
@@ -94,7 +107,10 @@ Hashing strategy version 2 ensures fidelity of values that are hashed in differe
 
 [id="{context}-property-column-mask-with-length-chars"]
 xref:{context}-property-column-mask-with-length-chars[`column.mask.with._length_.chars`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.
 Set this property if you want the connector to mask the values for a set of columns, for example, if they contain sensitive data.
 Set `_length_` to a positive integer to replace data in the specified columns with the number of asterisk (`*`) characters specified by the _length_ in the property name.
@@ -110,18 +126,23 @@ You can specify multiple properties with different lengths in a single configura
 
 [id="{context}-property-column-propagate-source-type"]
 xref:{context}-property-column-propagate-source-type[`column.propagate.source.type`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names of columns for which you want the connector to emit extra parameters that represent column metadata.
 When this property is set, the connector adds the following fields to the schema of event records:
 
 * `pass:[_]pass:[_]debezium.source.column.type`
 * `pass:[_]pass:[_]debezium.source.column.length`
-* `pass:[_]pass:[_]debezium.source.column.scale` +
- +
-These parameters propagate a column's original type name and length (for variable-width types), respectively. +
-Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases. +
- +
-The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
+* `pass:[_]pass:[_]debezium.source.column.scale`
++
+These parameters propagate a column's original type name and length (for variable-width types), respectively.
++
+Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases.
++
+The fully-qualified name of a column observes one of the following formats: `_databaseName_._tableName_._columnName_`, or `_databaseName_._schemaName_._tableName_._columnName_`.
++
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 
@@ -129,7 +150,9 @@ That is, the specified expression is matched against the entire name string of t
 
 [id="{context}-property-column-truncate-to-length-chars"]
 xref:{context}-property-column-truncate-to-length-chars[`column.truncate.to._length_.chars`]::
-Default value: No default +
+
+Default value::: No default
+Description:::
 An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.
 Set this property if you want to truncate the data in a set of columns when it exceeds the number of characters specified by the _length_ in the property name.
 Set `length` to a positive integer value, for example, `column.truncate.to.20.chars`.
@@ -144,14 +167,18 @@ You can specify multiple properties with different lengths in a single configura
 
 [id="{context}-property-connect-timeout-ms"]
 xref:{context}-property-connect-timeout-ms[`connect.timeout.ms`]::
-Default value: `30000` (30 seconds) +
+
+Default value::: `30000` (30 seconds)
+Description:::
 A positive integer value that specifies the maximum time in milliseconds that the connector waits to establish a connection to the {connector-name} database server before the connection request times out.
 
 
 
 [id="{context}-property-connector-class"]
 xref:{context}-property-connector-class[`connector.class`]::
-Default value: No default +
+
+Default value::: No default
+Description:::
 The name of the Java class for the connector.
 Always specify
 ifdef::MARIADB[]
@@ -165,86 +192,113 @@ for the {connector-name} connector.
 
 [id="{context}-property-database-exclude-list"]
 xref:{context}-property-database-exclude-list[`database.exclude.list`]::
-Default value: _empty string_ +
-An optional, comma-separated list of regular expressions that match the names of databases from which you do not want the connector to capture changes.
-The connector captures changes in any database that is not named in the `database.exclude.list`. +
+
+Default value::: _empty string_
+Description::: An optional, comma-separated list of regular expressions that match the names of databases from which you do not want the connector to capture changes.
+The connector captures changes in any database that is not named in the `database.exclude.list`.
 +
 To match the name of a database, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name. +
+That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
++
 If you include this property in the configuration, do not also set the `database.include.list` property.
 
 
 [id="{context}-property-database-hostname"]
 xref:{context}-property-database-hostname[`database.hostname`]::
-Default value: No default +
-The IP address or hostname of the {connector-name} database server.
+
+Default value::: No default
+Description::: The IP address or hostname of the {connector-name} database server.
 
 
 
 [id="{context}-property-database-include-list"]
 xref:{context}-property-database-include-list[`database.include.list`]::
-Default value: _empty string_ +
-An optional, comma-separated list of regular expressions that match the names of the databases from which the connector captures changes.
+
+Default value::: _empty string_
+
+Description::: An optional, comma-separated list of regular expressions that match the names of the databases from which the connector captures changes.
 The connector does not capture changes in any database whose name is not in `database.include.list`.
-By default, the connector captures changes in all databases. +
+By default, the connector captures changes in all databases.
 +
 To match the name of a database, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name. +
+That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
++
 If you include this property in the configuration, do not also set the `database.exclude.list` property.
 
 
 ifdef::MYSQL[]
 [id="{context}-property-database-jdbc-driver"]
 xref:{context}-property-database-jdbc-driver[`database.jdbc.driver`]::
-Default value: `com.mysql.cj.jdbc.Driver` +
+
+Default value::: `com.mysql.cj.jdbc.Driver`
+
+Description:::
 Specifies the name of the driver class that the connector uses.
-You can use this setting to specify a driver other than the one that is packaged with the connector.
++
+Set this property to configure a driver other than the one that is packaged with the connector.
 endif::MYSQL[]
 
 
 [id="{context}-property-database-password"]
 xref:{context}-property-database-password[`database.password`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 The password of the {connector-name} user that the connector uses to connect to the {connector-name} database server.
 
 
 [id="{context}-property-database-port"]
 xref:{context}-property-database-port[`database.port`]::
-Default value: `3306` +
+
+Default value::: `3306`
+
+Description:::
 Integer port number of the {connector-name} database server.
 
 
 ifdef::MYSQL[]
 [id="{context}-property-database-protocol"]
 xref:{context}-property-database-protocol[`database.protocol`]::
-Default value: `jdbc:mysql` +
+
+Default value::: `jdbc:mysql`
+
+Description:::
 Specifies the JDBC protocol that the driver connection string uses to connect to the database.
 endif::MYSQL[]
 
 
 [id="{context}-property-database-server-id"]
 xref:{context}-property-database-server-id[`database.server.id`]::
-Default value: No default +
-The numeric ID of this database client.
+
+Default value::: No default
+
+Description::: The numeric ID of this database client.
 The specified ID must be unique across all currently running database processes in the {connector-name} cluster.
-To enable it to read the binlog, the connector uses this unique ID to join the {connector-name} database cluster as another server.
+To enable reading from the binlog, the connector uses this unique ID to join the {connector-name} database cluster as another server.
 
 
 
 [id="{context}-property-database-user"]
 xref:{context}-property-database-user[`database.user`]::
-Default value: No default +
+
+Default value::: No default
+Description:::
 The name of the {connector-name} user that the connector uses to connect to the {connector-name} database server.
 
 
 
 [id="{context}-property-decimal-handling-mode"]
 xref:{context}-property-decimal-handling-mode[`decimal.handling.mode`]::
-Default value: `precise` +
-Specifies how the connector handles values for `DECIMAL` and `NUMERIC` columns in change events. +
+
+Default value::: `precise`
+
+Description:::
+Specifies how the connector handles values for `DECIMAL` and `NUMERIC` columns in change events.
++
 Set one of the following options:
 
-`precise` (default)::: Uses `java.math.BigDecimal` values in binary form to represent values precisely.
+`precise`::: Uses `java.math.BigDecimal` values in binary form to represent values precisely.
 
 `double`::: Uses the `double` data type to represent values.
 This option can result in a loss of precision, but it is easier for most consumers to use.
@@ -256,28 +310,44 @@ This option is easy to consume, but can result in the loss of semantic informati
 
 
 [id="{context}-property-event-deserialization-failure-handling-mode"]
-xref:{context}-property-event-deserialization-failure-handling-mode[`event.deserialization.failure.handling.mode`]::
-Default value: `fail` +
+xref:{context}-property-event-deserialization-failure-handling-mode[`event.deserialization.failure.handling.mode`] _Deprecated_::
+
+Default value::: `fail`
+
+Description:::
 Specifies how the connector reacts after an exception occurs during deserialization of binlog events.
-This option is deprecated, please use xref:{context}-property-event-processing-failure-handling-mode[`event.processing.failure.handling.mode`] option instead.
++
+[NOTE]
+====
+This option is deprecated.
 
-`fail`::: Propagates the exception, which indicates the problematic event and its binlog offset, and causes the connector to stop.
+Use the xref:{context}-property-event-processing-failure-handling-mode[`event.processing.failure.handling.mode`] property instead.
+====
++
+This property accepts the following options:
 
-`warn`::: Logs the problematic event and its binlog offset and then skips the event.
+`fail`:::: Propagates the exception, which indicates the problematic event and its binlog offset, and causes the connector to stop.
 
-`ignore`::: Passes over the problematic event and does not log anything.
+`warn`:::: Logs the problematic event and its binlog offset and then skips the event.
+
+`ignore`:::: Passes over the problematic event and does not log anything.
+
 
 
 
 [id="{context}-property-field-name-adjustment-mode"]
 xref:{context}-property-field-name-adjustment-mode[`field.name.adjustment.mode`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 Specifies how field names should be adjusted for compatibility with the message converter used by the connector.
++
 Set one of the following options:
 
-`none`::: No adjustment.
-`avro`::: Replaces characters that are not valid in Avro names with underscore characters.
-`avro_unicode`::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx`. +
+`none`:::: No adjustment.
+`avro`:::: Replaces characters that are not valid in Avro names with underscore characters.
+`avro_unicode`:::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx`. +
 +
 [NOTE]
 ====
@@ -290,38 +360,50 @@ For more information, see: {link-prefix}:{link-avro-serialization}#avro-naming[A
 
 [id="{context}-property-gtid-source-excludes"]
 xref:{context}-property-gtid-source-excludes[`gtid.source.excludes`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 A comma-separated list of regular expressions that match source domain IDs in the GTID set that the connector uses to find the binlog position on the {connector-name} server.
-When this property is set, the connector uses only the GTID ranges that have source UUIDs that do not match any of the specified `exclude` patterns. +
- +
+When this property is set, the connector uses only the GTID ranges that have source UUIDs that do not match any of the specified `exclude` patterns.
++
 To match the value of a GTID, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the GTID's domain identifier. +
-If you include this property in the configuration, do not also set the `gtid.source.includes` property.
+That is, the specified expression is matched against the GTID's domain identifier.
++
+If you set this property, do not also set the `gtid.source.includes` property.
 
 
 
 [id="{context}-property-gtid-source-includes"]
 xref:{context}-property-gtid-source-includes[`gtid.source.includes`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 A comma-separated list of regular expressions that match source domain IDs in the GTID set used that the connector uses to find the binlog position on the {connector-name} server.
-When this property is set, the connector uses only the GTID ranges that have source UUIDs that match one of the specified `include` patterns. +
- +
+When this property is set, the connector uses only the GTID ranges that have source UUIDs that match one of the specified `include` patterns.
++
 To match the value of a GTID, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the GTID's domain identifier. +
-If you include this property in the configuration, do not also set the `gtid.source.excludes` property.
+That is, the specified expression is matched against the GTID's domain identifier.
++
+If you set this property, do not also set the `gtid.source.excludes` property.
 
 
 [id="{context}-property-include-query"]
 xref:{context}-property-include-query[`include.query`]::
-Default value: `false` +
-Boolean value that specifies whether the connector should include the original SQL query that generated the change event. +
- +
-If you set this option to `true` then you must also configure {connector-name} with the `binlog_annotate_row_events` option set to `ON`.
-When `include.query` is `true`, the query is not present for events that the snapshot process generates. +
- +
-Setting `include.query` to `true` might expose tables or fields that are explicitly excluded or masked by including the original SQL statement in the change event.
-For this reason, the default setting is `false`. +
- +
+
+Default value::: `false`
+
+Description:::
+Boolean value that specifies whether the change event that the connector emits includes the SQL query that generated the change.
++
+CAUTION: Setting this property to `true` might expose information about tables or fields that you explicitly excluded or masked via other settings.
++
+To enable this property, the database property `binlog_annotate_row_events` must be set to `ON`.
++
+Setting this property has no effect on events that the snapshot process generates.
+Snapshot events do not include the original SQL query.
++
 For more information about configuring the database to return the original `SQL` statement for each log event, see xref:enable-query-log-events[Enabling query log events].
 
 
@@ -329,7 +411,10 @@ For more information about configuring the database to return the original `SQL`
 
 [id="{context}-property-include-schema-changes"]
 xref:{context}-property-include-schema-changes[`include.schema.changes`]::
-Default value: `true` +
+
+Default value::: `true`
+
+Description:::
 Boolean value that specifies whether the connector publishes changes in the database schema to a Kafka topic with the same name as the topic prefix.
 The connector records each schema change with a key that contains the database name, and a value that is a JSON structure that describes the schema update.
 This mechanism for recording schema changes is independent of the connector's internal recording of changes to the database schema history.
@@ -338,8 +423,11 @@ This mechanism for recording schema changes is independent of the connector's in
 
 [id="{context}-property-include-schema-comments"]
 xref:{context}-property-include-schema-comments[`include.schema.comments`]::
-Default value: `false` +
-Boolean value that specifies whether the connector parses and publishes table and column comments on metadata objects. +
+
+Default value::: `false`
+
+Description:::
+Boolean value that specifies whether the connector parses and publishes table and column comments on metadata objects.
 +
 NOTE: When you set this option to `true`, the schema comments that the connector includes can add a significant amount of string data to each schema object.
 Increasing the number and size of logical schema objects increases the amount of memory that the connector uses.
@@ -348,48 +436,55 @@ Increasing the number and size of logical schema objects increases the amount of
 
 [id="{context}-property-inconsistent-schema-handling-mode"]
 xref:{context}-property-inconsistent-schema-handling-mode[`inconsistent.schema.handling.mode`]::
-Default value: `fail` +
+
+Default value::: `fail`
+
+Description:::
 Specifies how the connector responds to binlog events that refer to tables that are not present in the internal schema representation.
-That is, the internal representation is not consistent with the database. +
+That is, the internal representation is not consistent with the database.
++
 Set one of the following options:
 
-`fail`::: The connector throws an exception that reports the problematic event and its binlog offset.
+`fail`:::: The connector throws an exception that reports the problematic event and its binlog offset.
 The connector then stops.
 
-`warn`::: The connector logs the problematic event and its binlog offset, and then skips the event.
+`warn`:::: The connector logs the problematic event and its binlog offset, and then skips the event.
 
-`skip`::: The connector skips the problematic event and does not report it in the log.
+`skip`:::: The connector skips the problematic event and does not report it in the log.
 
 
 
 [id="{context}-property-message-key-columns"]
 xref:{context}-property-message-key-columns[`message.key.columns`]::
-Default value: No default +
-A list of expressions that specify the columns that the connector uses to form custom message keys for change event records that it publishes to the Kafka topics for specified tables. +
+
+Default value::: No default
+
+Description:::
+A list of expressions that specify the columns that the connector uses to form custom message keys for change event records that it publishes to the Kafka topics for specified tables.
 By default, {prodname} uses the primary key column of a table as the message key for records that it emits.
 In place of the default, or to specify a key for tables that lack a primary key, you can configure custom message keys based on one or more columns.
- +
++
 To establish a custom message key for a table, list the table, followed by the columns to use as the message key.
-Each list entry takes the following format: +
- +
-`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_` +
- +
+Each list entry takes the following format:
++
+`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_`
++
 To base a table key on multiple column names, insert commas between the column names.
- +
++
 Each fully-qualified table name is a regular expression in the following format:
- +
-`_<databaseName>_._<tableName>_` +
- +
++
+`_<databaseName>_._<tableName>_`
++
 The property can include entries for multiple tables.
-Use a semicolon to separate table entries in the list. +
- +
-The following example sets the message key for the tables `inventory.customers` and `purchase.orders`: +
- +
-`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4` +
- +
+Use a semicolon to separate table entries in the list.
++
+The following example sets the message key for the tables `inventory.customers` and `purchase.orders`:
++
+`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4`
++
 For the table `inventory.customer`, the columns `pk1` and `pk2` are specified as the message key.
 For the `purchaseorders` tables in any database, the columns `pk3` and `pk4` server as the message key.
- +
++
 There is no limit to the number of columns that you use to create custom message keys.
 However, it's best to use the minimum number that are required to specify a unique key.
 
@@ -397,29 +492,40 @@ However, it's best to use the minimum number that are required to specify a uniq
 
 [id="{context}-property-name"]
 xref:{context}-property-name[`name`]::
-Default value: No default +
+
+Default value::: No default
+
+Description:::
 Unique name for the connector.
-If you attempt to use the same name to register another connector, registration fails.
+If you attempt to use the same name to register multiple connectors, registration fails.
 This property is required by all Kafka Connect connectors.
 
 
 [id="{context}-property-schema-name-adjustment-mode"]
 xref:{context}-property-schema-name-adjustment-mode[`schema.name.adjustment.mode`]::
-Default value: No default +
-Specifies how the connector adjusts schema names for compatibility with the message converter used by the connector.
-Set one of the following options:
 
-`none`::: No adjustment.
-`avro`::: Replaces characters that are not valid in Avro names with underscore characters.
-`avro_unicode`::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx.` +
- +
+Default value::: No default
+
+Description:::
+Specifies how the connector adjusts schema names for compatibility with the message converter used by the connector.
++
+Set one of the following options:
++
+
+`none`:::: No adjustment.
+`avro`:::: Replaces characters that are not valid in Avro names with underscore characters.
+`avro_unicode`:::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx.`
++
 NOTE: `_` is an escape sequence, similar to a backslash in Java
 
 
 
 [id="{context}-property-skip-messages-without-change"]
 xref:{context}-property-skip-messages-without-change[`skip.messages.without.change`]::
-Default value: `false` +
+
+Default value::: `false`
+
+Description:::
 Specifies whether the connector emits messages for records when it does not detect a change in the included columns.
 Columns are considered to be included if they are listed in the `column.include.list`, or are not listed in the `column.exclude.list`.
 Set the value to `true` to prevent the connector from capturing records when no changes are present in the included columns.
@@ -427,75 +533,97 @@ Set the value to `true` to prevent the connector from capturing records when no 
 
 [id="{context}-property-table-exclude-list"]
 xref:{context}-property-table-exclude-list[`table.exclude.list`]::
-Default value: _empty string_ +
+
+Default value::: _empty string_
+
+Description:::
 An optional, comma-separated list of regular expressions that match fully-qualified table identifiers of tables from which you do not want the connector to capture changes.
 The connector captures changes in any table that is not included in `table.exclude.list`.
-Each identifier is of the form _databaseName_._tableName_. +
+Each identifier is of the form _databaseName_._tableName_.
 +
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name. +
-If you include this property in the configuration, do not also set the `table.include.list` property.
+That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
++
+If you set this property, do not also set the `table.include.list` property.
 
 
 
 [id="{context}-property-table-include-list"]
 xref:{context}-property-table-include-list[`table.include.list`]::
-Default value: _empty string_ +
+
+Default value::: _empty string_
+
+Description:::
 An optional, comma-separated list of regular expressions that match fully-qualified table identifiers of tables whose changes you want to capture.
 The connector does not capture changes in any table that is not included in `table.include.list`.
 Each identifier is of the form _databaseName_._tableName_.
-By default, the connector captures changes in all non-system tables in every database from which it is configured to captures changes. +
+By default, the connector captures changes in all non-system tables in every database from which it is configured to captures changes.
 +
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name. +
-If you include this property in the configuration, do not also set the `table.exclude.list` property.
+That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
++
+If you set this property, do not also set the `table.exclude.list` property.
 
 
 
 [id="{context}-property-tasks-max"]
 xref:{context}-property-tasks-max[`tasks.max`]::
-Default value: `1` +
+
+Default value::: `1`
+
+Description:::
 The maximum number of tasks to create for this connector.
 Because the {connector-name} connector always uses a single task, changing the default value has no effect.
 
 
-
-
 [id="{context}-property-time-precision-mode"]
 xref:{context}-property-time-precision-mode[`time.precision.mode`]::
-Default value: `adaptive_time_microseconds` +
+
+Default value::: `adaptive_time_microseconds`
+
+Description:::
 Specifies the type of precision that the connector uses to represent time, date, and timestamps values.
-Set one of the following options: +
 +
-`adaptive_time_microseconds` (default)::: The connector captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds. +
+Set one of the following options:
 +
+
+`adaptive_time_microseconds`:::: The connector captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds.
 ifdef::community[]
-`adaptive` (deprecated)::: The connector captures time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the data type of the column. +
+`adaptive`::::  (deprecated) The connector captures time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the data type of the column.
 endif::community[]
-+
-`connect`::: The connector always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.
+`connect`:::: The connector always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.
+
 
 
 
 [id="{context}-property-tombstones-on-delete"]
 xref:{context}-property-tombstones-on-delete[`tombstones.on.delete`]::
-Default value: `true` +
+
+Default value::: `true`
+
+Description:::
 Specifies whether a _delete_ event is followed by a tombstone event.
 After a source record is deleted, the connector can emit a tombstone event (the default behavior) to enable Kafka to completely delete all events that pertain to the key of the deleted row in case {link-kafka-docs}/#compaction[log compaction] is enabled for the topic.
-Set one of the following options: +
 +
-`true` (default)::: The connector represents delete operations by emitting a _delete_ event and a subsequent tombstone event. +
+Set one of the following options:
++
 
-`false`::: The connector emits only _delete_ events. +
+`true`::::
+The connector represents delete operations by emitting a _delete_ event and a subsequent tombstone event.
+
+`false`::::
+The connector emits only _delete_ events.
 
 
 
 [id="{context}-property-topic-prefix"]
 xref:{context}-property-topic-prefix[`topic.prefix`]::
-Default value: No default +
-Topic prefix that provides a namespace for the particular {connector-name} database server or cluster in which {prodname} is capturing changes.
+
+Default value::: No default
+Description:::
+A string that specifies the namespace for the {connector-name} database server or cluster from which {prodname} captures changes.
 Because the topic prefix is used to name all of the Kafka topics that receive events that this connector emits, it's important that the topic prefix is unique across all connectors.
-Values must contain only alphanumeric characters, hyphens, dots, and underscores. +
+Values must contain only alphanumeric characters, hyphens, dots, and underscores.
 +
 [WARNING]
 ====


### PR DESCRIPTION
[DBZ-9286](https://issues.redhat.com/browse/DBZ-9286)

Formatting updates to remove trailing `+' characters that are used to enforce hard line breaks, as required to prepare files for downstream migration to DITA. 
Also updated a few of the descriptions.

- [x]  Required properties shared file (`ref-mariadb-mysql-rqd-connector-cfg-props.adoc`)
- [x]  Advanced properties shared file (`ref-mariadb-mysql-adv-connector-cfg-props.adoc`)