### PR TITLE
DBZ-9296 Preload Mockito agent to avoid Java agent dynamic loading restriction in further JDK

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -70,7 +70,6 @@
         <version.fest>1.4</version.fest>
         <version.assertj>3.27.3</version.assertj>
         <version.jmh>1.21</version.jmh>
-        <version.mockito>5.17.0</version.mockito>
         <version.awaitility>4.0.1</version.awaitility>
         <version.testcontainers>1.20.6</version.testcontainers>
         <version.jsonpath>2.9.0</version.jsonpath>

--- a/debezium-connector-binlog/pom.xml
+++ b/debezium-connector-binlog/pom.xml
@@ -148,6 +148,7 @@
     </dependencies>
 
     <properties>
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
 
 </project>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -180,6 +180,8 @@
         <docker.filter>${docker.dbs}</docker.filter>
         <docker.skip>false</docker.skip>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/Pacific/Samoa /etc/localtime</docker.initimage>
+
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
         <plugins>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -172,6 +172,8 @@
         <mongodb.replica.size>1</mongodb.replica.size>
         <mongodb.shard.size>2</mongodb.shard.size>
         <mongodb.shard.replica.size>${mongodb.replica.size}</mongodb.shard.replica.size>
+
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
         <plugins>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -211,6 +211,8 @@
         <docker.filter>${docker.dbs}</docker.filter>
         <docker.skip>false</docker.skip>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/US/Samoa /etc/localtime</docker.initimage>
+
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
         <plugins>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -41,6 +41,8 @@
         <apicurio.port>8080</apicurio.port>
         <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <apicurio.image>quay.io/apicurio/apicurio-registry-mem</apicurio.image>
+
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
 
     <dependencies>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>debezium-core</artifactId>
     <name>Debezium Core</name>
 
+    <properties>
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.debezium</groupId>

--- a/debezium-openlineage/debezium-openlineage-core/pom.xml
+++ b/debezium-openlineage/debezium-openlineage-core/pom.xml
@@ -10,6 +10,10 @@
     <name>Debezium OpenLineage Core</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.debezium</groupId>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -42,7 +42,9 @@
         <!-- No test options by default -->
         <test.argline />
 
-        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
+        <!-- No mockito agent configured by default. Just override this in the project that uses mockito -->
+        <mockito.argLine />
+
 
         <!-- Assembly configuration -->
         <assembly.descriptor>connector-distribution</assembly.descriptor>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -11,6 +11,10 @@
     <name>Debezium Storage Redis Module</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -26,6 +30,12 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${version.kafka}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.mockito}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -16,6 +16,8 @@
     <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
     <maven.compiler.release>${debezium.java.specific.target}</maven.compiler.release>
     <maven.compiler.testRelease>${debezium.java.specific.target}</maven.compiler.testRelease>
+
+    <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
   </properties>
   <modules>
     <module>debezium-testing-testcontainers</module>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,8 @@
         <publish.poll.interval>30</publish.poll.interval>
         <!-- For credentials -->
         <publish.repository.id>central</publish.repository.id>
+
+        <version.mockito>5.17.0</version.mockito>
     </properties>
 
     <modules>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
@@ -12,6 +12,10 @@
 
     <name>Quarkus Debezium :: Extension :: Engine :: Runtime</name>
 
+    <properties>
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
@@ -15,6 +15,8 @@
     <properties>
         <!-- The below override should be removed when kafka is upgraded to 4.0.0 and quarkus to 3.25.0 -->
         <kafka.version.override>4.0.0</kafka.version.override>
+
+        <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-9296

[JEP-451](https://openjdk.org/jeps/451) added a warning to prepare to Disallow the Dynamic Loading of Agents.

This changes instruct `maven-surfire-plugin` and `maven-failsafe-plugin` to pre-loads the mockito agent. 

Effectively the WARN disappears. 