### PR TITLE
DBZ-9129 Document how to restrict access for Oracle LogMiner user

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2573,7 +2573,7 @@ Because the retention policy that is configured for each destination might diffe
 // ModuleID: configuration-of-the-connectors-oracle-user-account
 // Title: Configuration of the connector's Oracle user account
 [id="creating-users-for-the-connector"]
-=== Creating users for the connector
+=== Creating a user account for the connector
 
 For the {prodname} Oracle connector to capture change events, it must run as an Oracle LogMiner user that has specific permissions.
 


### PR DESCRIPTION
[DBZ-9129](https://issues.redhat.com/browse/DBZ-9129)

Provides information about how to configure the LogMiner user account for the Oracle connector to limit universal access to tables in the database. 

Tested in a local Antora build.