### PR TITLE
DBZ-9328 Add support for tracing.* config options in MongoEventRouter

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouter.java
@@ -34,6 +34,7 @@ import io.debezium.time.Timestamp;
 import io.debezium.transforms.ConnectRecordUtil;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition;
 import io.debezium.transforms.outbox.EventRouterDelegate;
+import io.debezium.transforms.tracing.ActivateTracingSpan;
 
 /**
  * Debezium MongoDB Outbox Event Router SMT
@@ -334,6 +335,20 @@ public class MongoEventRouter<R extends ConnectRecord<R>> implements Transformat
         fieldNameConverter.put(
                 MongoEventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR.name(),
                 EventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR.name());
+
+        // Add tracing config
+
+        fieldNameConverter.put(
+                MongoEventRouterConfigDefinition.TRACING_SPAN_CONTEXT_FIELD.name(),
+                ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD.name());
+
+        fieldNameConverter.put(
+                MongoEventRouterConfigDefinition.TRACING_OPERATION_NAME.name(),
+                ActivateTracingSpan.TRACING_OPERATION_NAME.name());
+
+        fieldNameConverter.put(
+                MongoEventRouterConfigDefinition.TRACING_CONTEXT_FIELD_REQUIRED.name(),
+                ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED.name());
 
         return fieldNameConverter;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
@@ -101,6 +101,32 @@ public class MongoEventRouterConfigDefinition {
             .withDescription("Whether or not to try unescaping a JSON string and make it real JSON. It will infer schema information" +
                     " from payload and update the record schema accordingly. If content is not JSON, it just produces a warning" +
                     " and emits the record unchanged");
+    // Tracing config
+
+    public static final Field TRACING_SPAN_CONTEXT_FIELD = Field.create("tracing.span.context.field")
+            .withDisplayName("Serialized tracing span context field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDefault(ActivateTracingSpan.DEFAULT_TRACING_SPAN_CONTEXT_FIELD)
+            .withDescription("The name of the field containing java.util.Properties representation of serialized span context. Defaults to '"
+                    + ActivateTracingSpan.DEFAULT_TRACING_SPAN_CONTEXT_FIELD + "'");
+
+    public static final Field TRACING_OPERATION_NAME = Field.create("tracing.operation.name")
+            .withDisplayName("Tracing operation name")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDefault(ActivateTracingSpan.DEFAULT_TRACING_OPERATION_NAME)
+            .withDescription("The operation name representing Debezium processing span. Default is '" + ActivateTracingSpan.DEFAULT_TRACING_OPERATION_NAME + "'");
+
+    public static final Field TRACING_CONTEXT_FIELD_REQUIRED = Field.create("tracing.with.context.field.only")
+            .withDisplayName("Trace only events with context field present")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDefault(false)
+            .withDescription("Set to `true` when only events that have serialized context field should be traced.");
 
     /**
      * There are 3 configuration groups available:

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
@@ -989,7 +989,6 @@ public class MongoEventRouterTest {
 
         ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
 
-        
         Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
         spanContextField.setAccessible(true);
         String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
@@ -1026,7 +1025,6 @@ public class MongoEventRouterTest {
 
         ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
 
-        
         Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
         spanContextField.setAccessible(true);
         String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
@@ -1062,7 +1060,7 @@ public class MongoEventRouterTest {
         tracingField.setAccessible(true);
 
         ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
-        
+
         Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
         spanContextField.setAccessible(true);
         String actualSpanContextValue = (String) spanContextField.get(tracingSmt);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
@@ -9,6 +9,7 @@ import static io.debezium.connector.mongodb.MongoDbSchema.UPDATED_DESCRIPTION_SC
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -39,6 +40,7 @@ import io.debezium.data.Json;
 import io.debezium.data.VerifyRecord;
 import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition;
+import io.debezium.transforms.tracing.ActivateTracingSpan;
 
 /**
  * Unit tests for {@link MongoEventRouter}
@@ -967,4 +969,152 @@ public class MongoEventRouterTest {
         final Struct body = envelope.create(after, null, Instant.now());
         return new SourceRecord(new HashMap<>(), new HashMap<>(), "db.outbox", envelope.schema(), body);
     }
+
+    @Test
+    public void tracingCustomConfigParsing() throws Exception {
+        final Map<String, String> config = new HashMap<>();
+        config.put(MongoEventRouterConfigDefinition.TRACING_SPAN_CONTEXT_FIELD.name(), "myField");
+        config.put(MongoEventRouterConfigDefinition.TRACING_CONTEXT_FIELD_REQUIRED.name(), "false");
+        config.put(MongoEventRouterConfigDefinition.TRACING_OPERATION_NAME.name(), "customOperation");
+        router.configure(config);
+
+        // Access the private 'eventRouterDelegate' field
+        Field delegateField = MongoEventRouter.class.getDeclaredField("eventRouterDelegate");
+        delegateField.setAccessible(true);
+        Object delegate = delegateField.get(router);
+
+        // Access the 'tracingSmt' field inside the delegate
+        Field tracingField = delegate.getClass().getDeclaredField("tracingSmt");
+        tracingField.setAccessible(true);
+
+        ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
+
+        
+        Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
+        spanContextField.setAccessible(true);
+        String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
+
+        Field operationNameField = tracingSmt.getClass().getDeclaredField("operationName");
+        operationNameField.setAccessible(true);
+        String actualOperationNameValue = (String) operationNameField.get(tracingSmt);
+
+        Field requireContextField = tracingSmt.getClass().getDeclaredField("requireContextField");
+        requireContextField.setAccessible(true);
+        boolean actualRequireContextValue = (boolean) requireContextField.get(tracingSmt);
+
+        assertThat(actualSpanContextValue).isEqualTo("myField");
+        assertThat(actualRequireContextValue).isEqualTo(false);
+        assertThat(actualOperationNameValue).isEqualTo("customOperation");
+
+    }
+
+    @Test
+    public void tracingCustomConfigParsing_default_TRACING_SPAN_CONTEXT_FIELD() throws Exception {
+        final Map<String, String> config = new HashMap<>();
+        config.put(MongoEventRouterConfigDefinition.TRACING_CONTEXT_FIELD_REQUIRED.name(), "true");
+        config.put(MongoEventRouterConfigDefinition.TRACING_OPERATION_NAME.name(), "customOperation");
+        router.configure(config);
+
+        // Access the private 'eventRouterDelegate' field
+        Field delegateField = MongoEventRouter.class.getDeclaredField("eventRouterDelegate");
+        delegateField.setAccessible(true);
+        Object delegate = delegateField.get(router);
+
+        // Access the 'tracingSmt' field inside the delegate
+        Field tracingField = delegate.getClass().getDeclaredField("tracingSmt");
+        tracingField.setAccessible(true);
+
+        ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
+
+        
+        Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
+        spanContextField.setAccessible(true);
+        String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
+
+        Field operationNameField = tracingSmt.getClass().getDeclaredField("operationName");
+        operationNameField.setAccessible(true);
+        String actualOperationNameValue = (String) operationNameField.get(tracingSmt);
+
+        Field requireContextField = tracingSmt.getClass().getDeclaredField("requireContextField");
+        requireContextField.setAccessible(true);
+        boolean actualRequireContextValue = (boolean) requireContextField.get(tracingSmt);
+
+        assertThat(actualSpanContextValue).isEqualTo(ActivateTracingSpan.DEFAULT_TRACING_SPAN_CONTEXT_FIELD);
+        assertThat(actualRequireContextValue).isEqualTo(true);
+        assertThat(actualOperationNameValue).isEqualTo("customOperation");
+
+    }
+
+    @Test
+    public void tracingCustomConfigParsing_default_TRACING_CONTEXT_FIELD_REQUIRED() throws Exception {
+        final Map<String, String> config = new HashMap<>();
+        config.put(MongoEventRouterConfigDefinition.TRACING_SPAN_CONTEXT_FIELD.name(), "myField");
+        config.put(MongoEventRouterConfigDefinition.TRACING_OPERATION_NAME.name(), "customOperation");
+        router.configure(config);
+
+        // Access the private 'eventRouterDelegate' field
+        Field delegateField = MongoEventRouter.class.getDeclaredField("eventRouterDelegate");
+        delegateField.setAccessible(true);
+        Object delegate = delegateField.get(router);
+
+        // Access the 'tracingSmt' field inside the delegate
+        Field tracingField = delegate.getClass().getDeclaredField("tracingSmt");
+        tracingField.setAccessible(true);
+
+        ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
+        
+        Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
+        spanContextField.setAccessible(true);
+        String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
+
+        Field operationNameField = tracingSmt.getClass().getDeclaredField("operationName");
+        operationNameField.setAccessible(true);
+        String actualOperationNameValue = (String) operationNameField.get(tracingSmt);
+
+        Field requireContextField = tracingSmt.getClass().getDeclaredField("requireContextField");
+        requireContextField.setAccessible(true);
+        boolean actualRequireContextValue = (boolean) requireContextField.get(tracingSmt);
+
+        assertThat(actualSpanContextValue).isEqualTo("myField");
+        assertThat(actualRequireContextValue).isEqualTo(true);
+        assertThat(actualOperationNameValue).isEqualTo("customOperation");
+
+    }
+
+    @Test
+    public void tracingCustomConfigParsing_default_TRACING_OPERATION_NAME() throws Exception {
+        final Map<String, String> config = new HashMap<>();
+        config.put(MongoEventRouterConfigDefinition.TRACING_SPAN_CONTEXT_FIELD.name(), "myField");
+        config.put(MongoEventRouterConfigDefinition.TRACING_CONTEXT_FIELD_REQUIRED.name(), "false");
+        router.configure(config);
+
+        // Access the private 'eventRouterDelegate' field
+        Field delegateField = MongoEventRouter.class.getDeclaredField("eventRouterDelegate");
+        delegateField.setAccessible(true);
+        Object delegate = delegateField.get(router);
+
+        // Access the 'tracingSmt' field inside the delegate
+        Field tracingField = delegate.getClass().getDeclaredField("tracingSmt");
+        tracingField.setAccessible(true);
+
+        ActivateTracingSpan tracingSmt = (ActivateTracingSpan) tracingField.get(delegate);
+
+        Field spanContextField = tracingSmt.getClass().getDeclaredField("spanContextField");
+        spanContextField.setAccessible(true);
+        String actualSpanContextValue = (String) spanContextField.get(tracingSmt);
+
+        Field operationNameField = tracingSmt.getClass().getDeclaredField("operationName");
+        operationNameField.setAccessible(true);
+        String actualOperationNameValue = (String) operationNameField.get(tracingSmt);
+
+        Field requireContextField = tracingSmt.getClass().getDeclaredField("requireContextField");
+        requireContextField.setAccessible(true);
+        boolean actualRequireContextValue = (boolean) requireContextField.get(tracingSmt);
+
+        assertThat(actualSpanContextValue).isEqualTo("myField");
+        assertThat(actualRequireContextValue).isEqualTo(false);
+        assertThat(actualOperationNameValue).isEqualTo("debezium-read");
+
+    }
+
 }

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -166,6 +166,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Required by VerifyRecord -->
         <dependency>

--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
@@ -42,8 +42,8 @@ public class ActivateTracingSpan<R extends ConnectRecord<R>> implements Transfor
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActivateTracingSpan.class);
 
-    private static final String DEFAULT_TRACING_SPAN_CONTEXT_FIELD = "tracingspancontext";
-    private static final String DEFAULT_TRACING_OPERATION_NAME = "debezium-read";
+    public static final String DEFAULT_TRACING_SPAN_CONTEXT_FIELD = "tracingspancontext";
+    public static final String DEFAULT_TRACING_OPERATION_NAME = "debezium-read";
 
     private static final boolean OPEN_TELEMETRY_AVAILABLE = resolveOpenTelemetryApiAvailable();
 


### PR DESCRIPTION
This PR fixes the configuration bug described here:

https://issues.redhat.com/browse/DBZ-9328