### PR TITLE
Documentation typo fix

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -156,7 +156,7 @@ The following `.properties` example sets several event flattening SMT options:
 ----
 transforms=unwrap,...
 transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
-transforms.unwrap.delete.tombtone.handling.mode=rewrite
+transforms.unwrap.delete.tombstone.handling.mode=rewrite
 transforms.unwrap.add.fields=table,lsn
 ----
 


### PR DESCRIPTION
Fixed typo "tombtone" -> "tombstone" in the example configuration.