### PR TITLE
[docs] Fix typo in table title

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -504,7 +504,7 @@ If the database does not support time or timestamps with time zones, the mapping
 |===
 
 [[jdbc-debezium-vector-logical-mappings]]
-.Mapings between Debezium Vector Types and Column Data Types
+.Mappings between Debezium Vector Types and Column Data Types
 |===
 |Logical Type |Db2 |MySQL |PostgreSQL |Oracle |SQL Server
 


### PR DESCRIPTION
Correct spelling in title of the JDBC vector types mappings table  