### PR TITLE
DBZ-9356 Fix comparing ByteBuffer with byte array

### DIFF
--- a/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -42,6 +42,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.ValueConverter;
 import io.debezium.relational.ValueConverterProvider;
+import io.debezium.util.ByteBuffers;
 import io.debezium.util.Strings;
 
 /**
@@ -318,7 +319,13 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
     private boolean isUnavailableValueHolder(Schema schema, Object value) {
         switch (schema.type()) {
             case BYTES:
-                return unavailableValuePlaceholderBytes.equals(value);
+                if (value instanceof byte[] valueArray) {
+                    return ByteBuffers.equals(unavailableValuePlaceholderBytes, valueArray);
+                }
+                else if (value instanceof ByteBuffer valueBuffer) {
+                    return unavailableValuePlaceholderBytes.equals(valueBuffer);
+                }
+                return false;
             case MAP:
                 return unavailableValuePlaceholderMap.equals(value);
             case STRING:

--- a/debezium-core/src/main/java/io/debezium/util/ByteBuffers.java
+++ b/debezium-core/src/main/java/io/debezium/util/ByteBuffers.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import io.debezium.annotation.ThreadSafe;
+
+/**
+ * ByteBuffers-related utility methods.
+ *
+ * @author Shyama Praveena S
+ */
+@ThreadSafe
+public final class ByteBuffers {
+
+    /**
+     * Compares ByteBuffer with byte array.
+     *
+     * @param buffer the buffer to compare
+     * @param array the byte array to compare
+     * @return true if the content of buffer matches the array, false otherwise
+     */
+    public static boolean equals(ByteBuffer buffer, byte[] array) {
+        // Null checks
+        if (buffer == null && array == null) {
+            return true;
+        }
+        if (buffer == null || array == null) {
+            return false;
+        }
+
+        // Length check
+        if (buffer.remaining() != array.length) {
+            return false;
+        }
+
+        // For HeapByteBuffer, use the backing array directly
+        if (buffer.hasArray()) {
+            byte[] bufferArray = buffer.array();
+            int bufferOffset = buffer.arrayOffset();
+            int bufferLength = buffer.remaining();
+
+            // Compare the relevant portion of the buffer's backing array
+            return Arrays.equals(
+                    bufferArray, bufferOffset, bufferOffset + bufferLength,
+                    array, 0, array.length);
+        }
+
+        // For direct buffers, use element-by-element comparison
+        final int originalPosition = buffer.position();
+        for (int i = 0; i < array.length; i++) {
+            if (buffer.get(originalPosition + i) != array[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
The PostProcessor, ReselectColumnsPostProcessor, bug that otherwise occurs when the source table contains a BINARY type column is fixed by the modifications below. With these modifications, HeapByteBuffer and byte array objects will be accurately compared.