### PR TITLE
DBZ-9366 Adjust relaxed quote insert column value list parsing

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -297,6 +297,11 @@ public class LogMinerDmlParser implements DmlParser {
                 if (c != '\'') {
                     collectedValue.append(c);
                 }
+                else if (lookAhead == '\'') {
+                    collectedValue.append('\'');
+                    index = index + 1;
+                    continue;
+                }
                 else if (useRelaxedQuotes && (lookAhead != ',' && lookAhead != ')')) {
                     // When using extended strings, LogMiner may provide the inserted column value without escaping
                     // apostrophes, which will lead to parsing issues. This rule attempts to isolate that use case
@@ -305,11 +310,6 @@ public class LogMinerDmlParser implements DmlParser {
                     // Obviously if the text has "'," or "')" as the text sequence, this rule will fail, but there
                     // really is no other way to identify this.
                     collectedValue.append(c);
-                    continue;
-                }
-                else if (lookAhead == '\'') {
-                    collectedValue.append('\'');
-                    index = index + 1;
                     continue;
                 }
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9366

## Changes

When relaxed quote parsing was enabled and string contains escaped quotes during the inserts and updates, the logic for parsing the column value would reduce the `''` sequence a single `'` for updates, but would leave the `''` untouched for inserts. This caused inserts to publish a value that was not identical to the same value present for updates.