### PR TITLE
DBZ-9388: Fix ClassCastException when processing LinkedHashMap in document encoding

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -420,12 +420,6 @@ public class MongoDataConverter {
                             if (keyObject instanceof BsonValue bsonValue) {
                                 documentMapBuilder.field(entryKey, getSchema(bsonValue.getBsonType()));
                             }
-                            else if (keyObject instanceof Map<?, ?>) {
-                                // Handle LinkedHashMap objects from JSON parsing
-                                // This is a workaround for the production issue where JSON parsing
-                                // creates LinkedHashMap instead of BsonValue objects
-                                documentMapBuilder.field(entryKey, Schema.STRING_SCHEMA);
-                            }
                             else {
                                 // Fallback for other types
                                 documentMapBuilder.field(entryKey, Schema.STRING_SCHEMA);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
 import io.debezium.doc.FixFor;
+import io.debezium.util.Testing;
 
 /**
  * Unit test for {@code MongoDataConverter}.
@@ -294,8 +295,8 @@ public class MongoDataConverterTest {
         // For now, just verify that the method executes without ClassCastException
         // The actual struct population depends on the implementation of the fix
         // We'll adjust the expected output once the fix is properly implemented
-        System.out.println("Actual struct output: " + documentMapStruct.toString());
-        System.out.println("Actual document struct output: " + documentStruct.toString());
+        Testing.print("Actual struct output: " + documentMapStruct.toString());
+        Testing.print("Actual document struct output: " + documentStruct.toString());
 
         // The main goal is that no ClassCastException occurs
         // The struct content will be validated once the fix is complete


### PR DESCRIPTION
This PR attempts to fix the issue [DBZ-9388](https://issues.redhat.com/projects/DBZ/issues/DBZ-9388). Which seems to happen because of the way JSON serialization/deserialization works in async processing
- Jackson ObjectMapper creates LinkedHashMap instead of BsonValue 
- Type mismatch when MongoDataConverter expects BsonValue but receives LinkedHashMap
