### PR TITLE
[docs] Fix incorrect reference to `oraclepki.jar`

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3470,14 +3470,14 @@ Unlike the `database.host` property, the `database.url` property permits you to 
 ==== Oracle Wallet
 
 .Prerequisites
-* Verify with your database administrators that Oracle Wallet is configured on the Oracle database server. 
+* Verify with your database administrators that Oracle Wallet is configured on the Oracle database server.
 * Locate the `oraclepki.jar` inside the Oracle JDBC driver archive.
 
 .Procedure
 * Install `oraclepki.jar` in the location that contains the {prodname} Oracle connector JAR files.
-This is the same location that contains the Oracle JDBC driver `oraclepki.jar`.
+This is the same location to which you install the Oracle JDBC driver.
 * In the connector configuration, set the `database.url` property, rather than `database.hostname` property, to specify how {prodname} connects to the database.
-The `database.url` property defines an Oracle TNS-based connection string that is required to interact with Oracle Wallet. 
+The `database.url` property defines an Oracle TNS-based connection string that is required to interact with Oracle Wallet.
 For an example of a TNS connection string, see the sample mTLS configuration that appears after this list.
 * Set the Oracle JDBC driver property `oracle.net.wallet_location` to explicitly set the Oracle Wallet configuration to be used by the Oracle JDBC driver.
 


### PR DESCRIPTION
(cherry picked from commit a2954d7c4d64a7fbe313dfa82884760de7eb4d54)

Remove circular reference to the JAR file.