### PR TITLE
[docs] Updates xref to match new ModuleID for Creating Oracle user topic

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2470,7 +2470,7 @@ For details about setting up Oracle for use with the {prodname} connector, see t
 * xref:schemas-that-the-debezium-oracle-connector-excludes-when-capturing-change-events[]
 * xref:preparing-oracle-databases-for-use-with-debezium[]
 * xref:resizing-oracle-redo-logs-to-accommodate-the-data-dictionary[]
-* xref:creating-an-oracle-user-for-the-debezium-oracle-connector[]
+* xref:configuration-of-the-connectors-oracle-user-account[]
 * xref:running-the-connector-with-an-oracle-standby-database[]
 * xref:using-oracle-xstream-databases-with-debezium[]
 


### PR DESCRIPTION
Fixes a downstream build error by updating a cross-reference to refer to the correct  `ModuleID` for the topic _Creating a user account for the connector_.  DBZ-9129 replaced the original `ModuleID`, but did not update the target in the `xref` link that appears earlier in the file.