### PR TITLE
[docs] Updates xref to match new ModuleID for Creating Oracle user topic

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2470,7 +2470,7 @@ For details about setting up Oracle for use with the {prodname} connector, see t
 * xref:schemas-that-the-debezium-oracle-connector-excludes-when-capturing-change-events[]
 * xref:preparing-oracle-databases-for-use-with-debezium[]
 * xref:resizing-oracle-redo-logs-to-accommodate-the-data-dictionary[]
-* xref:creating-an-oracle-user-for-the-debezium-oracle-connector[]
+* xref:configuration-of-the-connectors-oracle-user-account[]
 * xref:running-the-connector-with-an-oracle-standby-database[]
 * xref:using-oracle-xstream-databases-with-debezium[]
 


### PR DESCRIPTION
(cherry picked from commit 1109dbbcf4d555f289cffa3cda140b64ba84aa72)

Adjusts xref target to match downstream ModuleID that was updated in DBZ-9129