### PR TITLE
DBZ-9415 Upgrade grpc version to align with netty upgrade

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -26,7 +26,7 @@
         <version.google.protos>1.17.0</version.google.protos>
 
         <!-- Spanner and Vitess dependencies -->
-        <version.grpc>1.56.1</version.grpc>
+        <version.grpc>1.67.1</version.grpc>
 
         <!-- Tracing -->
         <version.opentelemetry>1.23.0</version.opentelemetry>


### PR DESCRIPTION
We upgraded netty. We need to upgrade version.grpc to a version that is compatible with those newer netty libs.