### PR TITLE
Dbz 9414 fix downstream build error due to misinterpreted formatting tags

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -273,7 +273,7 @@ By default, the connector uses the names of the source topic and the event field
 The constructed SQL does not automatically delimit identifiers with quotes to preserve the case of the original strings.
 As a result, by default, the text case of table or column names in the destination database depends entirely on how the database handles name strings when the case is not specified.
 
-For example, if the destination database dialect is Oracle and the event's topic is `orders`, the destination table will be created as `ORDERS` because Oracle defaults to upper-case names when the name is not quoted.
+For example, if the destination database dialect is Oracle and the event's topic is `orders`, the destination table will be created as `ORDERS` because Oracle defaults to uppercase names when the name is not quoted.
 Similarly, if the destination database dialect is PostgreSQL and the event's topic is `ORDERS`, the destination table will be created as `orders` because PostgreSQL defaults to lower-case names when the name is not quoted.
 
 To explicitly preserve the case of the table and field names that are present in a Kafka event, in the connector configuration, set the value of the `quote.identifiers` property to `true`.
@@ -574,33 +574,38 @@ If you find a mapping could be improved, please let us know.
 endif::community[]
 ====
 
+
+// Type: concept
+// ModuleID: debezium-jdbc-connector-transformations-for-modifying-the-format-of-events-before-processing
+// Title: Transformations for modifying the format of events before processing
 [[jdbc-transformations]]
 == Transformations
 
 The {prodname} JDBC connector provides several transformations that can be added to the connector configuration to modify the consumed events in-flight before they're processed by the connector.
 
-=== Naming transformations
+Naming transformations::
 
 The {prodname} provides two naming transformations that are specifically designed to change either the topic or field names within the event to the configured naming style.
 The naming transformations can be configured with one of the following naming styles:
 
 `camel_case`::
-Removes all `.` and `_` characters, and makes the immediate next character uppercase.
-For example, the value `inventory.customers` would be changed to `inventoryCustomers`.
+Removes all period (`.`) and underscore (`_`) characters, and converts the immediate next character to uppercase.
+For example, the value `inventory.customers` is changed to `inventoryCustomers`.
 `snake_case`::
-Removes all `.` and replaces them with an `_` character. Additionally, any numeric sequences will be prefixed with an `_` while any capitalized character will be converted to lower case and prepended with an `_` character, too.
-For example, the value `public.inventory` would become `public_inventory`, while `TopicWith123Numbers` would become `topic_with_123_numbers`.
+Removes all period (`.`) characters and replaces them with underscore (`_`) characters.
+Additionally, all numeric sequences are prefixed with an underscore (`_`), and all uppercase characters are converted to lowercase and then prefixed with an underscore (`_`) character.
+For example, the value `public.inventory` becomes `public_inventory`, while `TopicWith123Numbers` becomes `topic_with_123_numbers`.
 `upper_case`::
-Converts to upper case.
+Converts to uppercase.
 For example, the value `public.inventory` would become `PUBLIC.INVENTORY`.
 `lower_case`::
-Converts to lower case.
+Converts to lowercase.
 For example, the value `PUBLIC.INVENTORY` would become `public.inventory`.
 
 In addition, these transformations optionally provide a way to apply a prefix or a suffix to the transformed name, too.
 
 
-==== CollectionNameTransformation
+CollectionNameTransformation:::
 
 The `CollectionNameTransformation` aims to provide a way to change the case of the topic names before the event is consumed.
 
@@ -638,7 +643,7 @@ For example, given a topic called `public.inventory`, the topic name would becom
 }
 ----
 
-==== FieldNameTransformation
+FieldNameTransformation:::
 
 The `FieldNameTransformation` aims to provide a way to change the case of the field names before the event is consumed.
 If the event is a {prodname} source connector event, only the fields within the `before` and `after` sections are changed.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -575,25 +575,31 @@ endif::community[]
 ====
 
 
-// Type: concept
-// ModuleID: debezium-jdbc-connector-transformations-for-modifying-the-format-of-events-before-processing
-// Title: Transformations for modifying the format of events before processing
+// Type: assembly
+// ModuleID: debezium-jdbc-connector-transformations-that-modify-the-format-of-events-before-processing
+// Title: Transformations that modify the format of events before processing
 [[jdbc-transformations]]
 == Transformations
 
 The {prodname} JDBC connector provides several transformations that can be added to the connector configuration to modify the consumed events in-flight before they're processed by the connector.
 
-Naming transformations::
 
-The {prodname} provides two naming transformations that are specifically designed to change either the topic or field names within the event to the configured naming style.
-The naming transformations can be configured with one of the following naming styles:
+// Type: assembly
+// ModuleID: debezium-jdbc-connector-naming-transformations
+// Title: Transformation that alter topic names
+=== Naming transformations
+
+The {prodname} JDBC connector provides two naming transformations that you can apply to change the naming styles of topic or field names within an event.
+Optionally, you can also use the naming transformations to apply a prefix or suffix to the transformed name.
+
+You can configure naming transformations to use one of the following naming styles:
 
 `camel_case`::
-Removes all period (`.`) and underscore (`_`) characters, and converts the immediate next character to uppercase.
+Removes all period (`.`) and underscore (`+_+`) characters, and converts the immediate next character to uppercase.
 For example, the value `inventory.customers` is changed to `inventoryCustomers`.
 `snake_case`::
-Removes all period (`.`) characters and replaces them with underscore (`_`) characters.
-Additionally, all numeric sequences are prefixed with an underscore (`_`), and all uppercase characters are converted to lowercase and then prefixed with an underscore (`_`) character.
+Removes all period (`.`) characters and replaces them with underscore (`+_+`) characters.
+Additionally, all numeric sequences are prefixed with an underscore (`+_+`), and all uppercase characters are converted to lowercase and then prefixed with an underscore (`+_+`) character.
 For example, the value `public.inventory` becomes `public_inventory`, while `TopicWith123Numbers` becomes `topic_with_123_numbers`.
 `upper_case`::
 Converts to uppercase.
@@ -602,15 +608,13 @@ For example, the value `public.inventory` would become `PUBLIC.INVENTORY`.
 Converts to lowercase.
 For example, the value `PUBLIC.INVENTORY` would become `public.inventory`.
 
-In addition, these transformations optionally provide a way to apply a prefix or a suffix to the transformed name, too.
 
+The connector provides the following naming transformations:
 
-CollectionNameTransformation:::
-
-The `CollectionNameTransformation` aims to provide a way to change the case of the topic names before the event is consumed.
-
+CollectionNameTransformation::
+The `CollectionNameTransformation` provides a way to change the case of the topic names before the event is consumed.
 This transformation has the following configuration properties:
-
++
 [cols="30%a,25%a,45%a"]
 |===
 |Property |Default |Description
@@ -628,10 +632,10 @@ This transformation has the following configuration properties:
 |Specifies the suffix that is applied to the topic name after transformation.
 
 |===
-
-The following configuration example illustrates using the `CollectionNameTransformation` SMT to set the topic name to uppercase and prefixes the topic name with `ADT_`.
-For example, given a topic called `public.inventory`, the topic name would become `ADT_PUBLIC.INVENTORY`.
-
++
+The following configuration example illustrates using the `CollectionNameTransformation` SMT to set the topic name to uppercase and prefix the topic name with `ADT_`.
+For example, given a topic called `public.inventory`, the topic name becomes `ADT_PUBLIC.INVENTORY`.
++
 .Example CollectionNameTransformation configuration
 [source,json]
 ----
@@ -643,14 +647,15 @@ For example, given a topic called `public.inventory`, the topic name would becom
 }
 ----
 
-FieldNameTransformation:::
 
-The `FieldNameTransformation` aims to provide a way to change the case of the field names before the event is consumed.
+
+FieldNameTransformation::
+The `FieldNameTransformation` provides a way to change the case of field names before the event is consumed.
 If the event is a {prodname} source connector event, only the fields within the `before` and `after` sections are changed.
-When the event is not a {prodname} source connector event, all top-level field names will be changed.
-
+When the event is not a {prodname} source connector event, all top-level field names are changed.
++
 This transformation has the following configuration properties:
-
++
 [cols="30%a,25%a,45%a"]
 |===
 |Property |Default |Description
@@ -668,10 +673,10 @@ This transformation has the following configuration properties:
 |Specifies the suffix that is applied to the field name after transformation.
 
 |===
-
-The following configuration example illustrates using the `FieldNameTransformation` SMT to set the field names name to lowercase and prefixes them with `adt_`.
-For example, should the event contain the field `ID`, the field will become `adt_id`.
-
++
+The following example shows how to configure the `FieldNameTransformation` SMT to convert field names name to lowercase and prefix the names with the string `adt_`.
+After you apply the SMT to an event that includes a field with the name `ID`, the field is renamed to `adt_id`.
++
 .Example FieldNameTransformation configuration
 [source,json]
 ----


### PR DESCRIPTION
[DBZ-9414 ](https://issues.redhat.com/browse/DBZ-9414)

- Content edits and fixes to address build errors.
- Refactoring of JDBC Transformations topic; 4th level headings converted to description list entries.
- Miscellaneous editorial changes.

Tested in local Antora and downstream builds.