### PR TITLE
DBZ-9417 Infinispan ProtoStream compatibility for Java compiler > 22

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -271,6 +271,14 @@
                     <testExcludes>
                         <exclude>**/io/debezium/connector/oracle/xstream/**</exclude>
                     </testExcludes>
+                    <!-- necessary for compilers > 22 -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                            <version>${version.infinispan.protostream}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Context

We use Infinispan Protostream annotations to generate marshallers. On Java ≤21, the Protostream annotation processor is auto-discovered from the compile classpath. Starting with Java 22, a dedicated processor path is required.

## Decision

Define explicitly the annotation processor inside the  `maven-compiler-plugin`

## References:
protostream: https://github.com/infinispan/protostream?tab=readme-ov-file#annotation-processor
closes: https://issues.redhat.com/browse/DBZ-9417
