### PR TITLE
[docs] Fix typo

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -70,7 +70,7 @@ If your source connector is configured to capture schema changes, in the JDBC co
 [[jdbc-at-least-once-delivery]]
 === At-least-once delivery
 
-The {prodname} JDBC sink connector guarantees that events that is consumes from Kafka topics are processed at least once.
+The {prodname} JDBC sink connector guarantees that events that it consumes from Kafka topics are processed at least once.
 
 // Type: concept
 // Title: Description of {prodname} JDBC use of multiple tasks


### PR DESCRIPTION
(cherry picked from commit 39dd8d68d93d16fbdb401b98f678c6945e5435db)