### PR TITLE
debezium/dbz#1409 Upgrade Apicurio to 3.2.5

### DIFF
--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -204,9 +204,6 @@
         <mariadb.ssl.port>3306</mariadb.ssl.port>
         <mariadb.replica.port>3306</mariadb.replica.port> <!-- by default use primary as 'replica' -->
         <mariadb.init.timeout>60000</mariadb.init.timeout> <!-- 60 seconds -->
-        <apicurio.image>quay.io/apicurio/apicurio-registry-mem</apicurio.image>
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <mariadb.replica.fileset.path>${project.basedir}/src/test/docker/init-replica</mariadb.replica.fileset.path>
         <!--
         By default, we should use the docker image maintained by the MariaDB team. This property is changed with different profiles.
@@ -468,6 +465,9 @@
                         <image>
                             <name>${apicurio.image}:${version.apicurio}</name>
                             <run>
+                                <env>
+                                    <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                </env>
                                 <namingStrategy>none</namingStrategy>
                                 <ports>
                                     <port>${apicurio.port}:8080</port>
@@ -478,7 +478,7 @@
                                     <color>blue</color>
                                 </log>
                                 <wait>
-                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <log>${apicurio.image.log}</log>
                                     <time>${apicurio.init.timeout}</time>
                                 </wait>
                             </run>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -192,9 +192,6 @@
         -->
         <docker.skip>false</docker.skip>
         <docker.exposeContainerInfo>docker.container</docker.exposeContainerInfo>
-        <!-- Apicurio container properties -->
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <!-- Mongo configuration -->
         <!-- See MongoDbPlatform enum for possible options -->
         <mongodb.platform>mongodb_docker</mongodb.platform>
@@ -219,8 +216,11 @@
                     <!--autoPull>always</autoPull-->
                     <images>
                         <image>
-                            <name>quay.io/apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                            <name>${apicurio.image}:${version.apicurio}</name>
                             <run>
+                                <env>
+                                    <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                </env>
                                 <namingStrategy>none</namingStrategy>
                                 <ports>
                                     <port>${apicurio.port}:8080</port>
@@ -231,7 +231,7 @@
                                     <color>blue</color>
                                 </log>
                                 <wait>
-                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <log>${apicurio.image.log}</log>
                                     <time>${apicurio.init.timeout}</time>
                                 </wait>
                             </run>
@@ -440,7 +440,7 @@
                 </plugins>
             </build>
             <properties>
-                <docker.filter>quay.io/apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
+                <docker.filter>quay.io/apicurio/apicurio-registry:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -231,9 +231,6 @@
         <mysql.ssl.port>3306</mysql.ssl.port>
         <mysql.replica.port>3306</mysql.replica.port> <!-- by default use primary as 'replica' -->
         <mysql.init.timeout>60000</mysql.init.timeout> <!-- 60 seconds -->
-        <apicurio.image>quay.io/apicurio/apicurio-registry-mem</apicurio.image>
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <mysql.server.image.source>container-registry.oracle.com/mysql/community-server</mysql.server.image.source>
         <mysql.database.protocol>jdbc:mysql</mysql.database.protocol>
         <mysql.database.jdbc.driver>com.mysql.cj.jdbc.Driver</mysql.database.jdbc.driver>
@@ -550,6 +547,9 @@
                         <image>
                             <name>${apicurio.image}:${version.apicurio}</name>
                             <run>
+                                <env>
+                                    <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                </env>
                                 <namingStrategy>none</namingStrategy>
                                 <ports>
                                     <port>${apicurio.port}:8080</port>
@@ -560,7 +560,7 @@
                                     <color>blue</color>
                                 </log>
                                 <wait>
-                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <log>${apicurio.image.log}</log>
                                     <time>${apicurio.init.timeout}</time>
                                 </wait>
                             </run>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -273,9 +273,6 @@
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>
         <connector.assembly.ref>connector-distribution</connector.assembly.ref>
-        <!-- Apicurion container properties -->
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
     </properties>
 
     <build>
@@ -861,8 +858,11 @@
                             <images>
                                 <!-- A container for the data server replica set -->
                                 <image>
-                                    <name>quay.io/apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                                    <name>${apicurio.image}:${version.apicurio}</name>
                                     <run>
+                                        <env>
+                                            <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                        </env>
                                         <namingStrategy>none</namingStrategy>
                                         <ports>
                                             <port>${apicurio.port}:8080</port>
@@ -873,7 +873,7 @@
                                             <color>blue</color>
                                         </log>
                                         <wait>
-                                            <log>.*apicurio-registry-app.*started in.*</log>
+                                            <log>${apicurio.image.log}</log>
                                             <time>${apicurio.init.timeout}</time>
                                         </wait>
                                     </run>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -37,11 +37,6 @@
         <!-- We're tracking the API changes of the SPI. -->
         <revapi.skip>false</revapi.skip>
 
-        <!-- Apicurion container properties -->
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
-        <apicurio.image>quay.io/apicurio/apicurio-registry-mem</apicurio.image>
-
         <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
 
@@ -320,6 +315,9 @@
                         <image>
                             <name>${apicurio.image}:${version.apicurio}</name>
                             <run>
+                                <env>
+                                    <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                </env>
                                 <namingStrategy>none</namingStrategy>
                                 <ports>
                                     <port>${apicurio.port}:8080</port>
@@ -330,7 +328,7 @@
                                     <color>blue</color>
                                 </log>
                                 <wait>
-                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <log>${apicurio.image.log}</log>
                                     <time>${apicurio.init.timeout}</time>
                                 </wait>
                             </run>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -25,10 +25,6 @@
         <docker.skip>false</docker.skip>
         <docker.platform>linux/amd64</docker.platform>
         <docker.showLogs>true</docker.showLogs>
-        <!-- Apicurion container properties -->
-        <apicurio.image>quay.io/apicurio/apicurio-registry-mem</apicurio.image>
-        <apicurio.port>8080</apicurio.port>
-        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <connector.assembly.msal>connector-distribution-with-jsr310</connector.assembly.msal> <!-- Use the assembly descriptor with JSR310 support when adding Azure Identity -->
     </properties>
 
@@ -230,6 +226,9 @@
                         <image>
                             <name>${apicurio.image}:${version.apicurio}</name>
                             <run>
+                                <env>
+                                    <QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>${apicurio.image.audit.level}</QUARKUS_LOG_CATEGORY__IO_APICURIO_REGISTRY_LOGGING_AUDIT__LEVEL>
+                                </env>
                                 <namingStrategy>none</namingStrategy>
                                 <ports>
                                     <port>${apicurio.port}:8080</port>
@@ -240,7 +239,7 @@
                                     <color>blue</color>
                                 </log>
                                 <wait>
-                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <log>${apicurio.image.log}</log>
                                     <time>${apicurio.init.timeout}</time>
                                 </wait>
                             </run>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -66,6 +66,14 @@
         <net.bytebuddy.experimental>false</net.bytebuddy.experimental>
 
         <version.openlineage>1.31.0</version.openlineage>
+
+        <!-- Apicurio -->
+        <apicurio.image>quay.io/apicurio/apicurio-registry</apicurio.image>
+        <apicurio.image.log>.*Using the following RegistryStorage.*</apicurio.image.log>
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
+        <apicurio.image.audit.level>OFF</apicurio.image.audit.level> <!-- Controls audit logging level -->
+
     </properties>
 
     <dependencyManagement>

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.testing.testcontainers;
 
+import static io.debezium.testing.testcontainers.util.ContainerImageVersions.NUMBERS_ONLY_VERSION_REGEX_PATTERN;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
@@ -15,13 +17,13 @@ public class ApicurioRegistryContainer extends GenericContainer<ApicurioRegistry
     private static final String APICURIO_VERSION = getApicurioVersion();
     private static final Integer APICURIO_PORT = 8080;
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
-    public static final String APICURIO_REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry-mem";
+    public static final String APICURIO_REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry";
 
     public ApicurioRegistryContainer() {
         super(APICURIO_REGISTRY_IMAGE + ":" + APICURIO_VERSION);
 
         this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*apicurio-registry-app.*started in.*");
+                .withRegEx(".*Using the following RegistryStorage.*");
 
         addExposedPort(APICURIO_PORT);
     }
@@ -29,6 +31,6 @@ public class ApicurioRegistryContainer extends GenericContainer<ApicurioRegistry
     public static String getApicurioVersion() {
         String apicurioVersionTestProperty = System.getProperty(TEST_PROPERTY_PREFIX + "apicurio.version");
         return apicurioVersionTestProperty != null ? apicurioVersionTestProperty
-                : ContainerImageVersions.getStableVersion(APICURIO_REGISTRY_IMAGE);
+                : ContainerImageVersions.getStableVersion(APICURIO_REGISTRY_IMAGE, NUMBERS_ONLY_VERSION_REGEX_PATTERN);
     }
 }

--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -192,7 +192,7 @@ The following example uses a non-production, in-memory, {registry} instance:
 [source,subs="attributes+"]
 ----
 docker run -it --rm --name apicurio \
-    -p 8080:8080 apicurio/apicurio-registry-mem:{apicurio-version}
+    -p 8080:8080 apicurio/apicurio-registry:{apicurio-version}
 ----
 
 . Run the {prodname} container image for Kafka Connect, configuring it to provide the Avro converter by enabling Apicurio via `ENABLE_APICURIO_CONVERTERS=true` environment variable:

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <quarkus.version.runtime>3.33.1.1</quarkus.version.runtime>
 
         <!-- Apicurio -->
-        <version.apicurio>2.6.13.Final</version.apicurio>
+        <version.apicurio>3.2.4</version.apicurio>
         <!-- hibernate -->
         <version.hibernate>7.2.6.Final</version.hibernate>
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <quarkus.version.runtime>3.33.1.1</quarkus.version.runtime>
 
         <!-- Apicurio -->
-        <version.apicurio>3.2.4</version.apicurio>
+        <version.apicurio>3.2.5</version.apicurio>
         <!-- hibernate -->
         <version.hibernate>7.2.6.Final</version.hibernate>
 


### PR DESCRIPTION
Fixes debezium/dbz#1409

https://issues.redhat.com/browse/DBZ-9538

- [ ] Update sibling repository apicurio image names