### PR TITLE
[docs] Reflect connector type in title and anchor ID

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1,7 +1,7 @@
 // Category: debezium-using
 // Type: assembly
-[id="debezium-connector-for-jdbc"]
-= {prodname} connector for JDBC
+[id="debezium-sink-connector-for-jdbc"]
+= {prodname} sink connector for JDBC
 :context: jdbc
 :mbean-name: {context}
 :connector-file: {context}


### PR DESCRIPTION
Adds `sink` designation to initial ID and heading strings

Tested in local Antora build to ensure that the change does not introduce build errors.