### PR TITLE
[docs] Adjustments to resolve downstream build errors

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
@@ -235,7 +235,7 @@ Custom implementation::
 You can provide your own `CollectionNameStrategy` implementation.
 
 |[[mongodb-sink-property-collection-name-format]]<<mongodb-sink-property-collection-name-format, `+collection.name.format+`>>
-| `${topic}`
+| `$\{topic}`
 | Template for deriving the target collection name from the Kafka topic name.
 
 |[[mongodb-sink-property-column-naming-strategy]]<<mongodb-sink-property-column-naming-strategy, `+column.naming.strategy+`>>

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2954,10 +2954,12 @@ internal.log.mining.read.only=true
 The preceding setting prevents the database from creating and updating the `LOG_MINING_FLUSH` table.
 You can use the `internal.log.mining.read.only` property with an Oracle Standalone database, or with an Oracle RAC installation.
 
+// Type: concept
+// ModuleID: debezium-oracle-connector-extended-max-string-size
 [id="support-for-extended-max-string-size"]
 === Extended max string size
 
-The database parameter `max_string_size` controls how the Oracle database, and by extension, Debezium, interprets values for `VARCHAR2`, `NVARCHAR2`, and `RAW` fields.
+The database parameter `max_string_size` controls how the Oracle database, and by extension, the {prodname} Oracle connector, interprets values for `VARCHAR2`, `NVARCHAR2`, and `RAW` fields.
 The default, `STANDARD`, means the lengths for these data types align with the same limits with releases prior to Oracle 12c (4000 bytes for `VARCHAR2` and `NVARCHAR2` and 2000 bytes for `RAW`).
 When configured as `EXTENDED`, these columns now allow up to 32767 bytes of data to be stored.
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2642,7 +2642,9 @@ Consult with your database administrator to evaluate whether the database might 
 // Type: procedure
 // ModuleID: oracle-connector-specifying-the-archive-log-destination
 // Title: Specifying the archive log destination that the {prodname} Oracle connector uses
+[id="archive-log-destinations"]
 === Archive log destinations
+
 
 Oracle database administrators can configure up to 31 different destinations for archive logs.
 Administrators can set parameters for each destination to designate it for a specific use, for example, log shipping for physical standbys, or external storage to allow for extended log retention.
@@ -2655,7 +2657,7 @@ If your Oracle environment includes multiple destinations that satisfy that crit
 * To specify the archive log destination that you want {prodname} to use, set the xref:oracle-property-archive-destination-name[`archive.destination.name`] property in the connector configuration. +
  +
 For example, suppose that a database is configured with two archive destination paths, `/path/one` and `/path/two`, and that the `V$ARCHIVE_DEST_STATUS` table associates these paths with destination names that are specified in the column `DEST_NAME`.
-If both destinations satisfy the criteria for {prodname} -- that is, their `status` is `VALID` and their `type` is `LOCAL` -- to configure the connector to use the archive logs that the database writes to `/path/two`, set the value of `archive.destination.name` to the value in the `DEST_NAME` column that is associated with `/path/two` in the `V$ARCHIVE_DEST_STATUS` table.
+If both destinations satisfy the criteria for {prodname} -- that is, if their `status` is `VALID` and their `type` is `LOCAL` -- to configure the connector to use the archive logs that the database writes to `/path/two`, set the value of `archive.destination.name` to the value in the `DEST_NAME` column that is associated with `/path/two` in the `V$ARCHIVE_DEST_STATUS` table.
 For example, if the `DEST_NAME` is `LOG_ARCHIVE_DEST_3` for `/path/two`, you would configure Debezium as follows:
 
 [source,json]
@@ -4348,12 +4350,12 @@ Any transaction that exceeds this configured value is discarded entirely, and th
 
 |[[oracle-property-archive-destination-name]]<<oracle-property-archive-destination-name, `+archive.destination.name+`>>
 |No default
-|Specifies the configured Oracle archive destination(s) to use when mining archive logs with LogMiner. +
- +
+|Specifies the configured Oracle archive destination(s) to use when mining archive logs with LogMiner.
+
 The default behavior automatically selects the first valid, local configured destination.
-However, you can use a specific destination can be used by providing the destination name, for example, `LOG_ARCHIVE_DEST_5`. +
- +
-Please see xref:#_archive_log_destinations[] for more information if your primary and standby instances use different names.
+However, you can use a specific destination can be used by providing the destination name, for example, `LOG_ARCHIVE_DEST_5`.
+
+For information about specifying the archive destination in environments where the primary and standby instances use different names, see xref:archive-log-destinations[Archive log destinations]. 
 
 |[[oracle-property-log-mining-username-include-list]]<<oracle-property-log-mining-username-include-list, `+log.mining.username.include.list+`>>
 |No default


### PR DESCRIPTION
Adjusts the following issues constructions that led to errors in the downstream User guide build:

- Missing ID that prevented tooling from creating downstream topic module file
- Non-standard ID and xref formatting (` xref:#_archive_log_destinations[]`
- Escaped curly brace preceding property value that the parser mistook for an asciidoc attribute