### PR TITLE
DBZ-9510 Documents the `NumberOfErroneousEvents` metric

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2265,7 +2265,7 @@ After the next failure, the connector stops, and user intervention is required t
 
 |[[mongodb-property-guardrail-collections-max]]<<mongodb-property-guardrail-collections-max, `+guardrail.collections.max+`>>
 |`0`
-|Specifies the maximum number of collections that the connector can capture. 
+|Specifies the maximum number of collections that the connector can capture.
 Exceeding this limit triggers the action specified by `guardrail.collections.limit.action`.
 Set this property to  `0` to prevent the connector from triggering guardrail actions.
 
@@ -2345,6 +2345,13 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 |`long`
 |Number of database disconnects.
 
+|`NumberOfErroneousEvents`
+|`long`
+|Records the number of change events that the connector identifies as erroneous during a snapshot operation.
+The connector increments this metric each time that it encounters an event that it cannot process during an initial, incremental, or ad hoc snapshot.
+Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
+The metric value persists for the lifetime of the connector task.
+If the snapshot is interrupted, and the connector task restarts, the metric count resets to `0`.
 |===
 
 // Type: reference
@@ -2370,6 +2377,14 @@ The {prodname} MongoDB connector also provides the following custom streaming me
 |`NumberOfPrimaryElections`
 |`long`
 |Number of primary node elections.
+
+|`NumberOfErroneousEvents`
+|`long`
+|Records the number of change events that the connector identifies as erroneous during streaming.
+The connector increments this metric each time that it encounters an event that it cannot process during the lifetime of the streaming session.
+Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
+The metric value persists for the lifetime of the connector task.
+After a connector restart, the metric count resets to `0`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2345,13 +2345,6 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 |`long`
 |Number of database disconnects.
 
-|`NumberOfErroneousEvents`
-|`long`
-|Records the number of change events that the connector identifies as erroneous during a snapshot operation.
-The connector increments this metric each time that it encounters an event that it cannot process during an initial, incremental, or ad hoc snapshot.
-Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
-The metric value persists for the lifetime of the connector task.
-If the snapshot is interrupted, and the connector task restarts, the metric count resets to `0`.
 |===
 
 // Type: reference
@@ -2377,14 +2370,6 @@ The {prodname} MongoDB connector also provides the following custom streaming me
 |`NumberOfPrimaryElections`
 |`long`
 |Number of primary node elections.
-
-|`NumberOfErroneousEvents`
-|`long`
-|Records the number of change events that the connector identifies as erroneous during streaming.
-The connector increments this metric each time that it encounters an event that it cannot process during the lifetime of the streaming session.
-Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
-The metric value persists for the lifetime of the connector task.
-After a connector restart, the metric count resets to `0`.
 
 |===
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -2,7 +2,7 @@ Snapshot metrics are not exposed unless a snapshot operation is active, or if a 
 
 The following table lists the snapshot metrics that are available.
 
-[cols="45%a,25%a,30%a",options="header"]
+[cols="35%a,20%a,45%a",options="header"]
 |===
 |Attributes |Type |Description
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -14,6 +14,14 @@ The following table lists the snapshot metrics that are available.
 |`long`
 |The number of milliseconds since the connector has read and processed the most recent event.
 
+|[[connectors-snaps-metric-numberoferroneousevents_{context}]]<<connectors-snaps-metric-numberoferroneousevents_{context}, `NumberOfErroneousEvents`>>
+|`long`
+|Records the number of change events that the connector identifies as erroneous during a snapshot operation.
+The connector increments this metric each time that it encounters an event that it cannot process during an initial, incremental, or ad hoc snapshot.
+Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
+The metric value persists for the lifetime of the connector task.
+If the snapshot is interrupted, and the connector task restarts, the metric count resets to `0`.
+
 |[[connectors-snaps-metric-totalnumberofeventsseen_{context}]]<<connectors-snaps-metric-totalnumberofeventsseen_{context}, `TotalNumberOfEventsSeen`>>
 |`long`
 |The total number of events that this connector has seen since last started or reset.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -1,6 +1,6 @@
 The following table lists the streaming metrics that are available.
 
-[cols="45%a,25%a,30%a",options="header"]
+[cols="35%a,20%a,45%a",options="header"]
 |===
 |Attributes |Type |Description
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -12,6 +12,14 @@ The following table lists the streaming metrics that are available.
 |`long`
 |The number of milliseconds since the connector has read and processed the most recent event.
 
+|[[connectors-strm-metric-numberoferroneousevents_{context}]]<<connectors-strm-metric-numberoferroneousevents_{context}, `NumberOfErroneousEvents`>>
+|`long`
+|Records the number of change events that the connector identifies as erroneous during streaming.
+The connector increments this metric each time that it encounters an event that it cannot process during the lifetime of the streaming session.
+Events might fail processing if they are malformed, are incompatible with the schema, or if they encounter failures during transformation.
+The metric value persists for the lifetime of the connector task.
+After a connector restart, the metric count resets to `0`.
+
 |[[connectors-strm-metric-totalnumberofeventsseen_{context}]]<<connectors-strm-metric-totalnumberofeventsseen_{context}, `TotalNumberOfEventsSeen`>>
 |`long`
 |The total number of data change events reported by the source database since the last connector start, or since a metrics reset.


### PR DESCRIPTION
[DBZ-9510](https://issues.redhat.com/browse/DBZ-9510)

Add entries for the `NumberOfErroneousEvents` metric to the shared tables of snapshot and streaming metrics.

Tested in a local Antora and downstream builds.

Please backport to `3.2` and `3.3`.