### PR TITLE
DBZ-7174: Add E2E REST test for Debezium status endpoint

### DIFF
--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package io.quarkus.sample.app;
 
 import static io.restassured.RestAssured.get;

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
@@ -1,8 +1,7 @@
 /*
  * Copyright Debezium Authors.
  *
- * Licensed under the Apache Software License version 2.0, available at
- * http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.quarkus.sample.app;

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/src/test/java/io/quarkus/sample/app/RestExtensionsIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.sample.app;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RestExtensionsIT {
+
+    @Test
+    @DisplayName("E2E check - Debezium status endpoint should respond OK")
+    void shouldReturnDebeziumStatus() {
+        await().untilAsserted(() -> {
+            get("/api/debezium/status")
+                    .then()
+                    .statusCode(200)
+                    .body(notNullValue());
+        });
+    }
+}


### PR DESCRIPTION
This PR implements an initial E2E REST test as requested by DBZ-7174.

- Module: `quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test`
- New test: `io.quarkus.sample.app.RestExtensionsIT`
- Verifies `/api/debezium/status` responds with HTTP 200 using Awaitility + RestAssured
- Keeps assertions relaxed (non-null payload) to avoid brittle checks while still validating endpoint health

Build & test:
- `mvn -Dtest=RestExtensionsIT test` → BUILD SUCCESS (1 test, 0 failures)

Jira: https://issues.redhat.com/browse/DBZ-7174
