### PR TITLE
DBZ-9521 Flush commit queue on non-LOB tables

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -167,7 +167,7 @@ public class TransactionCommitConsumer implements AutoCloseable, BlockingConsume
         }
 
         if (!tryMerge(accumulatorEvent, event)) {
-            prepareAndDispatch(accumulatorEvent, accumulatorEventIndex);
+            flushRows();
             if (rowId.equals(currentLobDetails.rowId)) {
                 currentLobDetails.reset();
             }
@@ -515,7 +515,7 @@ public class TransactionCommitConsumer implements AutoCloseable, BlockingConsume
     }
 
     private void dispatchChangeEvent(LogMinerEvent event, long eventIndex) throws InterruptedException {
-        LOGGER.trace("\tEmitting event {} {}", event.getEventType(), event);
+        LOGGER.trace("\tEmitting event #{}: {} {}", eventIndex, event.getEventType(), event);
         delegate.accept(event, eventIndex, totalEvents);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -506,7 +506,8 @@ public class TransactionCommitConsumer implements AutoCloseable, BlockingConsume
     }
 
     private void dispatchChangeEvent(LogMinerEvent event) throws InterruptedException {
-        final long eventIndex = dispatchEventIndex++;
+        // Must be one based so that START_SCN/START_SCN_TS assignment works in delegate
+        final long eventIndex = ++dispatchEventIndex;
         LOGGER.trace("\tEmitting event #{}: {} {}", eventIndex, event.getEventType(), event);
         delegate.accept(event, eventIndex, totalEvents);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -20,7 +20,6 @@ import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Path;
-import java.sql.Clob;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
@@ -48,7 +47,6 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -6058,55 +6056,4 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
         return ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
     }
 
-    @Test
-    @FixFor("DBZ-9521")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_BUFFERED, reason = "Only for buffered LogMiner")
-    public void shouldFlushLobChangesWhenTableWithoutLobColumnsAppearsInStream() throws Exception {
-        TestHelper.dropTable(connection, "dbz9521");
-        TestHelper.dropTable(connection, "dbz9521a");
-        try {
-            connection.execute("CREATE TABLE dbz9521 (id numeric(9,0) primary key, data clob, data2 varchar2(50))");
-            connection.execute("CREATE TABLE dbz9521a (id numeric(9,0) primary key, data varchar2(50))");
-            TestHelper.streamTable(connection, "dbz9521");
-            TestHelper.streamTable(connection, "dbz9521a");
-
-            // Configure with guardrail limit of 10 tables
-            Configuration config = TestHelper.defaultConfig()
-                    .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
-                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
-                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9521,DEBEZIUM\\.DBZ9521A")
-                    .build();
-
-            // The connector should start successfully
-            start(OracleConnector.class, config);
-            assertConnectorIsRunning();
-
-            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
-
-            connection.executeWithoutCommitting("INSERT INTO dbz9521a values (1, 'test1')");
-
-            final Clob clob1 = connection.connection().createClob();
-            clob1.setString(1, RandomStringUtils.randomAlphanumeric(8 * 1024));
-
-            connection.prepareUpdate("INSERT INTO dbz9521 values (1, ?, NULL)", ps -> ps.setClob(1, clob1));
-
-            connection.executeWithoutCommitting("INSERT INTO dbz9521a values (2, 'test2')");
-
-            connection.commit();
-
-            // This makes sure that when the second instance of DBZ9521A is seen and its immediately dispatched,
-            // the connector automatically flushes any pending events from prior LOB-enabled tables, should any
-            // exist before immediately dispatching the non-LOB table.
-            final SourceRecords sourceRecords = consumeRecordsByTopic(3);
-            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521")).hasSize(1);
-            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(2);
-
-            assertThat(sourceRecords.allRecordsInOrder().stream().map(SourceRecord::topic).toList()).containsExactly(
-                    "server1.DEBEZIUM.DBZ9521A", "server1.DEBEZIUM.DBZ9521", "server1.DEBEZIUM.DBZ9521A");
-        }
-        finally {
-            TestHelper.dropTable(connection, "dbz9521");
-            TestHelper.dropTable(connection, "dbz9521a");
-        }
-    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -20,6 +20,7 @@ import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.sql.Clob;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
@@ -47,6 +48,7 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -6054,5 +6056,57 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
 
     private Struct getBefore(SourceRecord record) {
         return ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+    }
+
+    @Test
+    @FixFor("DBZ-9521")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_BUFFERED, reason = "Only for buffered LogMiner")
+    public void shouldFlushLobChangesWhenTableWithoutLobColumnsAppearsInStream() throws Exception {
+        TestHelper.dropTable(connection, "dbz9521");
+        TestHelper.dropTable(connection, "dbz9521a");
+        try {
+            connection.execute("CREATE TABLE dbz9521 (id numeric(9,0) primary key, data clob, data2 varchar2(50))");
+            connection.execute("CREATE TABLE dbz9521a (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz9521");
+            TestHelper.streamTable(connection, "dbz9521a");
+
+            // Configure with guardrail limit of 10 tables
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9521,DEBEZIUM\\.DBZ9521A")
+                    .build();
+
+            // The connector should start successfully
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.executeWithoutCommitting("INSERT INTO dbz9521a values (1, 'test1')");
+
+            final Clob clob1 = connection.connection().createClob();
+            clob1.setString(1, RandomStringUtils.randomAlphanumeric(8 * 1024));
+
+            connection.prepareUpdate("INSERT INTO dbz9521 values (1, ?, NULL)", ps -> ps.setClob(1, clob1));
+
+            connection.executeWithoutCommitting("INSERT INTO dbz9521a values (2, 'test2')");
+
+            connection.commit();
+
+            // This makes sure that when the second instance of DBZ9521A is seen and its immediately dispatched,
+            // the connector automatically flushes any pending events from prior LOB-enabled tables, should any
+            // exist before immediately dispatching the non-LOB table.
+            final SourceRecords sourceRecords = consumeRecordsByTopic(3);
+            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521")).hasSize(1);
+            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(2);
+
+            assertThat(sourceRecords.allRecordsInOrder().stream().map(SourceRecord::topic).toList()).containsExactly(
+                    "server1.DEBEZIUM.DBZ9521A", "server1.DEBEZIUM.DBZ9521", "server1.DEBEZIUM.DBZ9521A");
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz9521");
+            TestHelper.dropTable(connection, "dbz9521a");
+        }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
@@ -199,7 +199,7 @@ public class TransactionCommitConsumerIT extends AbstractAsyncEngineConnectorTes
             assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(2);
 
             assertThat(sourceRecords.allRecordsInOrder().stream().map(SourceRecord::topic).toList()).containsExactly(
-                    "server1.DEBEZIUM.DBZ9521B", "server1.DEBEZIUM.DBZ9521A", "server1.DEBEZIUM.DBZ9521B");
+                    "server1.DEBEZIUM.DBZ9521B", "server1.DEBEZIUM.DBZ9521B", "server1.DEBEZIUM.DBZ9521A");
         }
         finally {
             TestHelper.dropTable(connection, "dbz9521a");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
@@ -7,10 +7,20 @@ package io.debezium.connector.oracle.logminer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.management.ManagementFactory;
+import java.math.BigInteger;
+import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -21,6 +31,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnStrategyRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
@@ -29,6 +40,7 @@ import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.junit.logging.LogInterceptor;
 
 /**
  * @author Chris Cranford
@@ -142,6 +154,126 @@ public class TransactionCommitConsumerIT extends AbstractAsyncEngineConnectorTes
             TestHelper.dropTable(connection, "email");
             TestHelper.dropTable(connection, "addresses");
         }
+    }
+
+    @Test
+    @FixFor("DBZ-9521")
+    public void shouldFlushQueuedLobChangesWhenChangeForTableWithoutLobColumnsAppearsInStream() throws Exception {
+        TestHelper.dropTable(connection, "dbz9521a");
+        TestHelper.dropTable(connection, "dbz9521b");
+        try {
+            connection.execute("CREATE TABLE dbz9521a (id numeric(9,0) primary key, data clob, data2 varchar2(50))");
+            connection.execute("CREATE TABLE dbz9521b (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz9521a");
+            TestHelper.streamTable(connection, "dbz9521b");
+
+            // Configure with guardrail limit of 10 tables
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.NO_DATA)
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9521A,DEBEZIUM\\.DBZ9521B")
+                    .build();
+
+            // The connector should start successfully
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.executeWithoutCommitting("INSERT INTO dbz9521b values (1, 'test1')");
+
+            final Clob clob1 = connection.connection().createClob();
+            clob1.setString(1, RandomStringUtils.randomAlphanumeric(8 * 1024));
+
+            connection.prepareUpdate("INSERT INTO dbz9521a values (1, ?, NULL)", ps -> ps.setClob(1, clob1));
+
+            connection.executeWithoutCommitting("INSERT INTO dbz9521b values (2, 'test2')");
+
+            connection.commit();
+
+            // This makes sure that when the second instance of DBZ9521B is seen and its immediately dispatched,
+            // the connector automatically flushes any pending events from prior LOB-enabled tables, should any
+            // exist before immediately dispatching the non-LOB table.
+            final SourceRecords sourceRecords = consumeRecordsByTopic(3);
+            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(1);
+            assertThat(sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(2);
+
+            assertThat(sourceRecords.allRecordsInOrder().stream().map(SourceRecord::topic).toList()).containsExactly(
+                    "server1.DEBEZIUM.DBZ9521B", "server1.DEBEZIUM.DBZ9521A", "server1.DEBEZIUM.DBZ9521B");
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz9521a");
+            TestHelper.dropTable(connection, "dbz9521b");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-9521")
+    public void shouldNotSkipEventsWhenOnlyNonLobColumnsAreMutatedOnTableWithLobColumns() throws Exception {
+        TestHelper.dropTable(connection, "dbz9521a");
+        TestHelper.dropTable(connection, "dbz9521b");
+        try {
+            connection.execute("CREATE TABLE dbz9521a (id numeric(9, 0) primary key, data1 clob, data2 varchar2(50))");
+            connection.execute("CREATE TABLE dbz9521b (id numeric(9,0) primary key, data1 clob)");
+            TestHelper.streamTable(connection, "dbz9521a");
+            TestHelper.streamTable(connection, "dbz9521b");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9521A,DEBEZIUM\\.DBZ9521B")
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .with(OracleConnectorConfig.SNAPSHOT_MODE, "no_data")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // Seed data first
+            connection.execute("INSERT INTO dbz9521a (id, data1) values (1, 'test')");
+            connection.execute("INSERT INTO dbz9521b (id, data1) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(2);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(1);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(1);
+
+            final LogInterceptor interceptor = TestHelper.getEventProcessorLogInterceptor();
+            connection.executeWithoutCommitting("INSERT INTO dbz9521a (id, data1) values (2, 'insert')");
+            connection.executeWithoutCommitting("INSERT INTO dbz9521b (id, data1) values (2, 'insert')");
+            connection.executeWithoutCommitting("UPDATE dbz9521b SET data1 = 'updated' WHERE id = 1");
+            connection.executeWithoutCommitting("UPDATE dbz9521a SET data1 = 'updated' WHERE id = 1");
+            connection.executeWithoutCommitting("UPDATE dbz9521a SET data2 = 'ok' WHERE id = 1");
+            connection.commit();
+
+            // Wait until we mine past the current SCN
+            final Scn currentScn = TestHelper.getCurrentScn();
+            Awaitility.await()
+                    .atMost(2, TimeUnit.MINUTES)
+                    .until(() -> {
+                        final BigInteger offsetScn = getStreamingMetric("OffsetScn");
+                        return offsetScn != null && Scn.valueOf(offsetScn.toString()).compareTo(currentScn) > 0;
+                    });
+
+            assertThat(interceptor.containsMessage("Skipping event "))
+                    .as("Should not skip events")
+                    .isFalse();
+
+            records = consumeRecordsByTopic(5);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(3);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(2);
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz9521a");
+            TestHelper.dropTable(connection, "dbz9521b");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getStreamingMetric(String metricName) throws JMException {
+        final MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        final ObjectName objectName = getStreamingMetricsObjectName(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+        return (T) mbeanServer.getAttribute(objectName, metricName);
     }
 
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumerIT.java
@@ -247,6 +247,11 @@ public class TransactionCommitConsumerIT extends AbstractAsyncEngineConnectorTes
 
             // Wait until we mine past the current SCN
             final Scn currentScn = TestHelper.getCurrentScn();
+
+            // Generate a change that will be after the CURRENT_SCN, that will be picked up after the
+            // Awaitility call below.
+            connection.execute("INSERT INTO dbz9521b (id, data1) values (3, 'data')");
+
             Awaitility.await()
                     .atMost(2, TimeUnit.MINUTES)
                     .until(() -> {
@@ -258,9 +263,9 @@ public class TransactionCommitConsumerIT extends AbstractAsyncEngineConnectorTes
                     .as("Should not skip events")
                     .isFalse();
 
-            records = consumeRecordsByTopic(5);
+            records = consumeRecordsByTopic(6);
             assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521A")).hasSize(3);
-            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(2);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ9521B")).hasSize(3);
         }
         finally {
             TestHelper.dropTable(connection, "dbz9521a");


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9521

Applying to 3.2, created PR for backport to run tests one last check.