### PR TITLE
DBZ-9465 Adding pluggable off-heap  providers for memory buffer type

### DIFF
--- a/.github/workflows/connector-oracle-workflow.yml
+++ b/.github/workflows/connector-oracle-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'oracle-tests', 'oracle-infinispan-buffer,oracle-tests', 'oracle-ehcache,oracle-tests' ]
+        profile: [ 'oracle-tests', 'oracle-infinispan-buffer,oracle-tests', 'oracle-ehcache,oracle-tests', 'oracle-memory-chronicle-spillover,oracle-tests', 'oracle-memory-rocksdb-spillover,oracle-tests', 'oracle-memory-ehcache-spillover,oracle-tests', 'oracle-memory-infinispan-embedded-spillover,oracle-tests', 'oracle-memory-infinispan-remote-spillover,oracle-tests' ]
     name: Oracle - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -412,6 +412,131 @@ jobs:
   - job: tests
     trigger: pull_request
     # Suffix for job name
+    identifier: "oracle-19-memory-chronicle-spillover"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-spillover
+      - oracle-chronicle
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-memory-chronicle-spillover -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-memory-rocksdb-spillover"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-spillover
+      - oracle-rocksdb
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-memory-rocksdb-spillover -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-memory-ehcache-spillover"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-spillover
+      - oracle-ehcache-spillover
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-memory-ehcache-spillover -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-memory-infinispan-embedded-spillover"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-spillover
+      - oracle-infinispan-spillover
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-memory-infinispan-embedded-spillover -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-memory-infinispan-remote-spillover"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-logminer
+      - oracle-spillover
+      - oracle-infinispan-spillover
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_PROFILE_ARGS: "-Poracle-memory-infinispan-remote-spillover -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
     identifier: "oracle-19-se"
     targets:
       centos-stream-8-x86_64:

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -112,6 +112,20 @@
             <version>${version.jaxb.implementation}</version>
         </dependency>
 
+        <!-- Chronicle Queue Dependencies -->
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-queue</artifactId>
+            <version>${version.chronicle.queue}</version>
+        </dependency>
+
+        <!-- RocksDB Dependencies -->
+        <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>${version.rocksdbjni}</version>
+        </dependency>
+
         <!-- Introduce ehcache dependencies on Maven Central -->
         <dependency>
             <groupId>com.sun.istack</groupId>
@@ -227,6 +241,9 @@
         -->
         <version.istack>3.0.7</version.istack>
         <version.fastinfoset>1.2.15</version.fastinfoset>
+        
+        <version.chronicle.queue>2026.1</version.chronicle.queue>
+        <version.rocksdbjni>10.2.1</version.rocksdbjni>
 
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>
 
@@ -308,7 +325,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl</argLine>
+                    <argLine>
+                        -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+                        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens java.base/java.nio=ALL-UNNAMED
+                        --add-opens java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                    </argLine>
                     <systemPropertyVariables combine.children="append">
                         <database.connection.adapter>${adapter.name}</database.connection.adapter>
                         <log.mining.buffer.type>${log.mining.buffer.type.name}</log.mining.buffer.type>
@@ -336,11 +363,21 @@
                 <configuration>
                     <skipTests>${skipITs}</skipTests>
                     <enableAssertions>true</enableAssertions>
-                    <forkCount>0</forkCount>
-                    <argLine>-Djava.library.path=${instantclient.dir} -Ddebezium.embedded.shutdown.pause.before.interrupt.ms=20000</argLine>
+                    <argLine>
+                        -Djava.library.path=${instantclient.dir} -Ddebezium.embedded.shutdown.pause.before.interrupt.ms=20000
+                        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens java.base/java.nio=ALL-UNNAMED
+                        --add-opens java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                    </argLine>
                     <systemPropertyVariables>
                         <database.connection.adapter>${adapter.name}</database.connection.adapter>
                         <log.mining.buffer.type>${log.mining.buffer.type.name}</log.mining.buffer.type>
+                        <log.mining.buffer.spill.provider>${log.mining.buffer.spill.provider}</log.mining.buffer.spill.provider>
                         <internal.log.mining.read.only>${log.mining.read.only.mode}</internal.log.mining.read.only>
                         <javax.xml.parsers.SAXParserFactory>com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl</javax.xml.parsers.SAXParserFactory>
                         <version.oracle.server>${version.oracle.server}</version.oracle.server>
@@ -805,6 +842,178 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Memory spillover profiles (chronicle/rocksdb/ehcache) -->
+        <profile>
+            <id>oracle-memory-chronicle-spillover</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.buffer.spill.provider>chronicle</log.mining.buffer.spill.provider>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>oracle-memory-rocksdb-spillover</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.buffer.spill.provider>rocksdb</log.mining.buffer.spill.provider>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>oracle-memory-ehcache-spillover</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.buffer.spill.provider>ehcache</log.mining.buffer.spill.provider>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>oracle-memory-infinispan-embedded-spillover</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.buffer.spill.provider>infinispan_embedded</log.mining.buffer.spill.provider>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>oracle-memory-infinispan-remote-spillover</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.buffer.spill.provider>infinispan_remote</log.mining.buffer.spill.provider>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceIT.java</exclude>
+                                <exclude>**/EmbeddedInfinispanStreamingChangeEventSourceTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- This profile should be used for testing connector with EhCache only -->
         <profile>
             <id>oracle-ehcache</id>

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -253,6 +253,10 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
     @SuppressWarnings("unchecked")
     private <T extends Transaction> CacheProvider<T> createCacheProvider(OracleConnectorConfig connectorConfig) {
+        if (connectorConfig.getLogMiningBufferType() == OracleConnectorConfig.LogMiningBufferType.MEMORY && connectorConfig.isLogMiningBufferSpillEnabled()) {
+            return (CacheProvider<T>) connectorConfig.getLogMiningBufferSpillProvider().createCacheProvider(connectorConfig);
+        }
+        // Default logic for other types
         return (CacheProvider<T>) switch (connectorConfig.getLogMiningBufferType()) {
             case MEMORY -> new MemoryCacheProvider(connectorConfig);
             case INFINISPAN_EMBEDDED -> new EmbeddedInfinispanCacheProvider(connectorConfig);
@@ -263,6 +267,10 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
     @SuppressWarnings("unchecked")
     private <T extends Transaction> TransactionFactory<T> createTransactionFactory(OracleConnectorConfig connectorConfig) {
+        if (connectorConfig.getLogMiningBufferType() == OracleConnectorConfig.LogMiningBufferType.MEMORY && connectorConfig.isLogMiningBufferSpillEnabled()) {
+            return (TransactionFactory<T>) connectorConfig.getLogMiningBufferSpillProvider().createTransactionFactory();
+        }
+        // Default logic for other types
         return (TransactionFactory<T>) switch (connectorConfig.getLogMiningBufferType()) {
             case MEMORY -> new MemoryTransactionFactory();
             case INFINISPAN_EMBEDDED, INFINISPAN_REMOTE -> new InfinispanTransactionFactory();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/CompositeTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/CompositeTransactionCache.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.memory.MemoryTransaction;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * A composite transaction cache that manages both in-memory and spillover caches.
+ * This class provides a unified interface for transaction management while handling
+ * the complexity of routing events between memory and disk-based storage.
+ *
+ * @param <T> the transaction type
+ * @author Debezium Authors
+ */
+public class CompositeTransactionCache<T extends Transaction> extends AbstractLogMinerTransactionCache<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompositeTransactionCache.class);
+
+    /**
+     * Lightweight key for tracking (rowId, eventKey) pairs in insertion order.
+     */
+    private record IndexKey(String rowId, Integer eventKey) {
+    }
+
+    /**
+     * Lightweight index structure used only for spilled transactions. Keeps rowId -> eventKey lists
+     * and minimal index bookkeeping. Created lazily when a transaction starts spilling.
+     * Implements FIFO eviction using LinkedHashMap to maintain a sliding window of the most recent indexed events.
+     * Single-threaded since LogMiner processing is single-threaded.
+     */
+    private static class SpilloverRowIdIndex {
+        private final Map<String, Deque<Integer>> rowIndex = new HashMap<>();
+        private final LinkedHashMap<IndexKey, Integer> insertionOrder;
+
+        SpilloverRowIdIndex(int maxSize) {
+            // LinkedHashMap with access-order=false (insertion order) and automatic eldest removal
+            this.insertionOrder = new LinkedHashMap<IndexKey, Integer>(16, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<IndexKey, Integer> eldest) {
+                    if (size() > maxSize) {
+                        // Remove from rowIndex when evicted from insertionOrder
+                        IndexKey key = eldest.getKey();
+                        Deque<Integer> eventKeys = rowIndex.get(key.rowId);
+                        if (eventKeys != null) {
+                            eventKeys.removeFirstOccurrence(key.eventKey);
+                            if (eventKeys.isEmpty()) {
+                                rowIndex.remove(key.rowId);
+                            }
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+            };
+        }
+
+        Map<String, Deque<Integer>> getRowIndex() {
+            return rowIndex;
+        }
+
+        /**
+         * Adds an entry to the index, tracking it in insertion order.
+         * Automatic eviction happens via LinkedHashMap.removeEldestEntry().
+         */
+        void addEntry(String rowId, Integer eventKey) {
+            rowIndex.computeIfAbsent(rowId, k -> new ArrayDeque<>()).addLast(eventKey);
+            // Use lightweight record key for tracking insertion order
+            insertionOrder.put(new IndexKey(rowId, eventKey), eventKey);
+        }
+
+        void clear() {
+            rowIndex.clear();
+            insertionOrder.clear();
+        }
+    }
+
+    // Core components
+    private final LogMinerTransactionCache<T> spilloverCache;
+    private final SpillStrategy spillStrategy;
+    private final MemoryTransactionCacheAdapter<T> memoryEventStore;
+    // Single-threaded data structures (LogMiner processing is single-threaded)
+    private final Map<String, T> transactionRegistry = new HashMap<>();
+    private final Map<String, TransactionState> transactionStates = new HashMap<>();
+    private final Map<String, SpilloverRowIdIndex> spilloverRowIdIndexes = new HashMap<>();
+
+    // Maximum number of indexed entries per transaction before disabling index
+    private final int indexThreshold;
+
+    /**
+     * Creates a new composite transaction cache.
+     */
+    public CompositeTransactionCache(LogMinerTransactionCache<T> spilloverCache,
+                                     SpillStrategy spillStrategy) {
+        this(spilloverCache, spillStrategy, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a new composite transaction cache with index threshold.
+     */
+    public CompositeTransactionCache(LogMinerTransactionCache<T> spilloverCache,
+                                     SpillStrategy spillStrategy,
+                                     int indexThreshold) {
+        this.spilloverCache = spilloverCache;
+        this.spillStrategy = spillStrategy;
+        this.indexThreshold = indexThreshold;
+
+        // Create memory event store internally (adapter maps provider transactions to memory)
+        this.memoryEventStore = new MemoryTransactionCacheAdapter<>();
+    }
+
+    /**
+     * Helper method to check if a transaction is in the spilling state.
+     */
+    private boolean isSpilling(String transactionId) {
+        TransactionState state = transactionStates.get(transactionId);
+        return state == TransactionState.SPILLING;
+    }
+
+    /**
+     * Helper method to transition a transaction to the spilling state.
+     * This is the ONLY place where spilloverCache.addTransaction() is called.
+     */
+    private void transitionToSpilling(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Update state
+        transactionStates.put(transactionId, TransactionState.SPILLING);
+
+        // Register with spillover provider
+        spilloverCache.addTransaction(transaction);
+
+        LOGGER.debug("Transaction {} transitioned to SPILLING state.", transactionId);
+    }
+
+    @Override
+    public T getTransaction(String transactionId) {
+        // Return from transaction registry
+        return transactionRegistry.get(transactionId);
+    }
+
+    @Override
+    public void addTransaction(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Add to transaction registry
+        transactionRegistry.put(transactionId, transaction);
+
+        // Set initial state to MEMORY
+        transactionStates.put(transactionId, TransactionState.MEMORY);
+
+        // Register transaction with memory adapter which will create the internal MemoryTransaction
+        memoryEventStore.addTransaction(transaction);
+
+        if (spillStrategy != null) {
+            spillStrategy.onTransactionCreated(transactionId);
+        }
+    }
+
+    @Override
+    public void removeTransaction(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Remove from transaction registry
+        transactionRegistry.remove(transactionId);
+
+        // Remove state tracking
+        transactionStates.remove(transactionId);
+
+        // Remove from memory event store
+        memoryEventStore.removeTransaction(transaction);
+
+        // Remove from spillover if present
+        spilloverCache.removeTransaction(transaction);
+
+        // Remove any per-transaction index
+        spilloverRowIdIndexes.remove(transactionId);
+
+        if (spillStrategy != null) {
+            spillStrategy.onTransactionRemoved(transactionId);
+        }
+    }
+
+    @Override
+    public boolean containsTransaction(String transactionId) {
+        return transactionRegistry.containsKey(transactionId);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return transactionRegistry.isEmpty();
+    }
+
+    @Override
+    public int getTransactionCount() {
+        return transactionRegistry.size();
+    }
+
+    @Override
+    public <R> R streamTransactionsAndReturn(Function<Stream<T>, R> consumer) {
+        return consumer.apply(transactionRegistry.values().stream());
+    }
+
+    @Override
+    public void transactions(Consumer<Stream<T>> consumer) {
+        consumer.accept(transactionRegistry.values().stream());
+    }
+
+    @Override
+    public void eventKeys(Consumer<Stream<String>> consumer) {
+        memoryEventStore
+                .eventKeys(memoryStream -> spilloverCache.eventKeys(spilloverStream -> consumer.accept(Stream.concat(memoryStream, spilloverStream))));
+    }
+
+    @Override
+    public void forEachEvent(T transaction, InterruptiblePredicate<LogMinerEvent> predicate)
+            throws InterruptedException {
+
+        String transactionId = transaction.getTransactionId();
+
+        // Track if predicate has requested early termination (using array for lambda capture)
+        final boolean[] shouldContinue = { true };
+
+        // Wrap predicate to track termination
+        InterruptiblePredicate<LogMinerEvent> trackingPredicate = event -> {
+            if (!shouldContinue[0]) {
+                return false;
+            }
+            boolean result = predicate.test(event);
+            if (!result) {
+                shouldContinue[0] = false;
+            }
+            return result;
+        };
+
+        // First, iterate through in-memory events (early events in insertion order)
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        memoryEventStore.forEachEvent(memTx, trackingPredicate);
+
+        // Then, iterate through spilled events (later events) only if predicate hasn't terminated
+        if (shouldContinue[0] && isSpilling(transactionId)) {
+            spilloverCache.forEachEvent(transaction, trackingPredicate);
+        }
+    }
+
+    @Override
+    public LogMinerEvent getTransactionEvent(T transaction, int eventKey) {
+        String transactionId = transaction.getTransactionId();
+
+        // Check if event is in memory first
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        LogMinerEvent event = memoryEventStore.getTransactionEvent(memTx, eventKey);
+        if (event != null) {
+            return event;
+        }
+
+        // If not in memory and transaction is spilling, check spill storage
+        if (isSpilling(transactionId)) {
+            return spilloverCache.getTransactionEvent(transaction, eventKey);
+        }
+
+        return null;
+    }
+
+    @Override
+    public T getAndRemoveTransaction(String transactionId) {
+        // Get and remove transaction from registry
+        T transaction = transactionRegistry.remove(transactionId);
+        if (transaction != null) {
+
+            if (spillStrategy != null) {
+                spillStrategy.onTransactionRemoved(transactionId);
+            }
+
+            return transaction;
+        }
+        return null;
+    }
+
+    @Override
+    public void addTransactionEvent(T transaction, int eventKey, LogMinerEvent event) {
+        String transactionId = transaction.getTransactionId();
+
+        try {
+            if (isSpilling(transactionId)) {
+                // Already spilling - add to spillover
+                spilloverCache.addTransactionEvent(transaction, eventKey, event);
+                updateSpilloverRowIdIndex(transactionId, eventKey, event);
+            }
+            else {
+                // Check if we should start spilling
+                TransactionView view = new TransactionViewImpl(transactionId);
+                if (spillStrategy != null && spillStrategy.shouldSpill(transactionId, event, view)) {
+                    // Transition to spilling state
+                    transitionToSpilling(transaction);
+
+                    // Add event to spillover
+                    spilloverCache.addTransactionEvent(transaction, eventKey, event);
+                    updateSpilloverRowIdIndex(transactionId, eventKey, event);
+                }
+                else {
+                    // Add to memory event store via adapter
+                    MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+                    memoryEventStore.addTransactionEvent(memTx, eventKey, event);
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to add event " + eventKey + " to transaction " + transactionId, e);
+        }
+    }
+
+    private void updateSpilloverRowIdIndex(String txId, int eventKey, LogMinerEvent event) {
+        // Get or create index lazily
+        SpilloverRowIdIndex index = spilloverRowIdIndexes.computeIfAbsent(txId, k -> new SpilloverRowIdIndex(indexThreshold));
+
+        try {
+            String rowId = event.getRowId();
+
+            // Add the new entry (automatic eviction via LinkedHashMap.removeEldestEntry())
+            index.addEntry(rowId, eventKey);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to update spillover rowId index for transaction {}.", txId, e);
+        }
+    }
+
+    @Override
+    public void removeTransactionEvents(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Always remove from memory event store (transaction may have events in both memory and spillover)
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        memoryEventStore.removeTransactionEvents(memTx);
+        memoryEventStore.removeTransaction(memTx);
+
+        // Remove from spillover if transaction is spilling
+        if (isSpilling(transactionId)) {
+            spilloverCache.removeTransactionEvents(transaction);
+            spilloverCache.removeTransaction(transaction);
+        }
+
+        // Clean up index
+        SpilloverRowIdIndex index = spilloverRowIdIndexes.remove(transactionId);
+        if (index != null) {
+            index.clear();
+        }
+
+        // Finally remove state tracking (now that we're done using isSpilling())
+        transactionStates.remove(transactionId);
+    }
+
+    @Override
+    public boolean removeTransactionEventWithRowId(T transaction, String rowId) {
+        String transactionId = transaction.getTransactionId();
+
+        // If transaction is spilling, try spilled index first
+        if (isSpilling(transactionId)) {
+            SpilloverRowIdIndex index = spilloverRowIdIndexes.get(transactionId);
+            if (index != null) {
+                if (tryRemoveFromSpilledIndex(transaction, index, rowId)) {
+                    return true;
+                }
+            }
+
+            // Fall back to spill provider scan
+            if (tryRemoveFromSpillProvider(transaction, rowId)) {
+                return true;
+            }
+        }
+
+        // Fallback to memory event store
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        return memoryEventStore.removeTransactionEventWithRowId(memTx, rowId);
+    }
+
+    private boolean tryRemoveFromSpilledIndex(T transaction, SpilloverRowIdIndex index, String rowId) {
+        Deque<Integer> eventKeys = index.getRowIndex().get(rowId);
+        if (eventKeys == null) {
+            return false;
+        }
+
+        // Get the most recent eventKey for this rowId (last in the deque)
+        // If eventKeys exists in the map, it must contain at least one element
+        Integer eventKey = eventKeys.pollLast();
+
+        // Remove the event from spillover cache
+        boolean removed = spilloverCache.removeTransactionEventWithEventKey(transaction, eventKey);
+        if (removed) {
+            // Clean up the index if this was the last eventKey for this rowId
+            if (eventKeys.isEmpty()) {
+                index.getRowIndex().remove(rowId);
+            }
+        }
+        return removed;
+    }
+
+    private boolean tryRemoveFromSpillProvider(T transaction, String rowId) {
+        try {
+            return spilloverCache.removeTransactionEventWithRowId(transaction, rowId);
+        }
+        catch (Exception e) {
+            throw new DebeziumException(
+                    "Fatal error while trying to remove rowId '" + rowId + "' from spillover storage for transaction " + transaction.getTransactionId(), e);
+        }
+    }
+
+    @Override
+    public boolean containsTransactionEvent(T transaction, int eventKey) {
+        String transactionId = transaction.getTransactionId();
+
+        // Check memory event store first
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        if (memoryEventStore.containsTransactionEvent(memTx, eventKey)) {
+            return true;
+        }
+
+        // Check spillover if spilling
+        if (isSpilling(transactionId)) {
+            return spilloverCache.containsTransactionEvent(transaction, eventKey);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int getTransactionEventCount(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Count from memory event store
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        int count = memoryEventStore.getTransactionEventCount(memTx);
+
+        try {
+            // Add spilled count if transaction is spilling
+            if (isSpilling(transactionId)) {
+                int spilled = spilloverCache.getTransactionEventCount(transaction);
+                if (spilled > 0) {
+                    count += spilled;
+                }
+            }
+        }
+        catch (Exception e) {
+            LOGGER.debug("Failed to get spilled event count for tx={}: {}", transactionId, e.getMessage());
+        }
+
+        return count;
+    }
+
+    @Override
+    public int getTransactionEvents() {
+        // Calculate on-demand from both caches
+        int memoryEvents = memoryEventStore.getTransactionEvents();
+        int spilloverEvents = spilloverCache.getTransactionEvents();
+        return memoryEvents + spilloverEvents;
+    }
+
+    @Override
+    public void clear() {
+        transactionRegistry.clear();
+        transactionStates.clear();
+        memoryEventStore.clear();
+        spilloverCache.clear();
+        spilloverRowIdIndexes.clear();
+    }
+
+    @Override
+    public void syncTransaction(T transaction) {
+        String transactionId = transaction.getTransactionId();
+
+        // Sync memory event store
+        MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+        memoryEventStore.syncTransaction(memTx);
+
+        // If spilling, also sync spillover cache
+        if (isSpilling(transactionId)) {
+            spilloverCache.syncTransaction(transaction);
+        }
+    }
+
+    /**
+     * Implementation of TransactionView for spill strategy decisions.
+     */
+    private class TransactionViewImpl implements TransactionView {
+        private final String transactionId;
+
+        TransactionViewImpl(String transactionId) {
+            this.transactionId = transactionId;
+        }
+
+        @Override
+        public long memoryEventCount() {
+            MemoryTransaction memTx = memoryEventStore.getTransaction(transactionId);
+            return memoryEventStore.getTransactionEventCount(memTx);
+        }
+
+        @Override
+        public long totalEventCount() {
+            T transaction = transactionRegistry.get(transactionId);
+            if (transaction == null) {
+                return 0;
+            }
+
+            long memoryCount = memoryEventCount();
+            long spilledCount = 0;
+            if (isSpilling(transactionId)) {
+                spilledCount = spilloverCache.getTransactionEventCount(transaction);
+            }
+            return memoryCount + spilledCount;
+        }
+    }
+
+    enum TransactionState {
+        MEMORY,
+        SPILLING
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/EventCountStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/EventCountStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * A spill strategy that triggers spilling when a transaction exceeds a specified event count threshold.
+ * This is the default strategy for determining when transactions should begin spilling to off-heap storage.
+ *
+ * @author Debezium Authors
+ */
+public class EventCountStrategy implements SpillStrategy {
+
+    private final long spillThreshold;
+
+    public EventCountStrategy(long spillThreshold) {
+        this.spillThreshold = spillThreshold;
+    }
+
+    @Override
+    public boolean shouldSpill(String txId, LogMinerEvent latest, TransactionView view) {
+        return view.totalEventCount() >= spillThreshold;
+    }
+
+    public long getSpillThreshold() {
+        return spillThreshold;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
@@ -155,6 +155,21 @@ public interface LogMinerTransactionCache<T extends Transaction> {
     boolean removeTransactionEventWithRowId(T transaction, String rowId);
 
     /**
+     * Removes a specific transaction event by event key. This method is intended for
+     * providers that can tombstone or otherwise remove an event given its eventKey
+     * without scanning by rowId. Implementations that cannot efficiently remove by
+     * eventKey may return {@code false}.
+     *
+     * @param transaction the transaction, should not be {@code null}
+     * @param eventKey the event's unique assigned id
+     * @return {@code true} if the event was found and removed, {@code false} if it was not found
+     */
+    default boolean removeTransactionEventWithEventKey(T transaction, int eventKey) {
+        // Default implementation falls back to not supported. Providers should override
+        return false;
+    }
+
+    /**
      * Checks whether a specific transaction's event with the event key is cached.
      *
      * @param transaction the transaction, should not be {@code null}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/MemoryTransactionCacheAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/MemoryTransactionCacheAdapter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import io.debezium.connector.oracle.logminer.buffered.memory.MemoryLogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.memory.MemoryTransaction;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * An adapter that maps provider transactions to internal MemoryTransaction instances.
+ * Single-threaded since LogMiner processing is single-threaded.
+ */
+public class MemoryTransactionCacheAdapter<T extends Transaction> {
+
+    private final MemoryLogMinerTransactionCache delegate;
+    private final Map<String, MemoryTransaction> transactionsById = new HashMap<>();
+
+    public MemoryTransactionCacheAdapter() {
+        this(new MemoryLogMinerTransactionCache());
+    }
+
+    public MemoryTransactionCacheAdapter(MemoryLogMinerTransactionCache delegate) {
+        this.delegate = delegate == null ? new MemoryLogMinerTransactionCache() : delegate;
+    }
+
+    public void addTransaction(T transaction) {
+        MemoryTransaction memTx = new MemoryTransaction(transaction);
+        transactionsById.put(transaction.getTransactionId(), memTx);
+        delegate.addTransaction(memTx);
+    }
+
+    /** For compatibility, allow adding a MemoryTransaction directly. */
+    public void addTransaction(MemoryTransaction memTx) {
+        transactionsById.put(memTx.getTransactionId(), memTx);
+        delegate.addTransaction(memTx);
+    }
+
+    public MemoryTransaction getTransaction(String transactionId) {
+        return transactionsById.get(transactionId);
+    }
+
+    public void removeTransaction(MemoryTransaction memTx) {
+        if (memTx == null) {
+            return;
+        }
+        transactionsById.remove(memTx.getTransactionId());
+        delegate.removeTransaction(memTx);
+    }
+
+    public void removeTransaction(T transaction) {
+        String id = transaction.getTransactionId();
+        MemoryTransaction memTx = transactionsById.remove(id);
+        if (memTx != null) {
+            delegate.removeTransaction(memTx);
+        }
+    }
+
+    public boolean containsTransaction(String transactionId) {
+        return transactionsById.containsKey(transactionId);
+    }
+
+    public boolean isEmpty() {
+        return transactionsById.isEmpty();
+    }
+
+    public int getTransactionCount() {
+        return transactionsById.size();
+    }
+
+    public <R> R streamTransactionsAndReturn(Function<Stream<MemoryTransaction>, R> consumer) {
+        return consumer.apply(transactionsById.values().stream());
+    }
+
+    public void transactions(Consumer<Stream<MemoryTransaction>> consumer) {
+        consumer.accept(transactionsById.values().stream());
+    }
+
+    public void eventKeys(Consumer<Stream<String>> consumer) {
+        delegate.eventKeys(consumer);
+    }
+
+    public void forEachEvent(MemoryTransaction transaction,
+                             io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache.InterruptiblePredicate<LogMinerEvent> predicate)
+            throws InterruptedException {
+        delegate.forEachEvent(transaction, predicate);
+    }
+
+    public LogMinerEvent getTransactionEvent(MemoryTransaction transaction, int eventKey) {
+        return delegate.getTransactionEvent(transaction, eventKey);
+    }
+
+    public MemoryTransaction getAndRemoveTransaction(String transactionId) {
+        MemoryTransaction tx = transactionsById.remove(transactionId);
+        if (tx != null) {
+            delegate.removeTransaction(tx);
+        }
+        return tx;
+    }
+
+    public void addTransactionEvent(MemoryTransaction transaction, int eventKey, LogMinerEvent event) {
+        delegate.addTransactionEvent(transaction, eventKey, event);
+    }
+
+    public void removeTransactionEvents(MemoryTransaction transaction) {
+        delegate.removeTransactionEvents(transaction);
+        transactionsById.remove(transaction.getTransactionId());
+    }
+
+    public boolean removeTransactionEventWithRowId(MemoryTransaction transaction, String rowId) {
+        return delegate.removeTransactionEventWithRowId(transaction, rowId);
+    }
+
+    public boolean containsTransactionEvent(MemoryTransaction transaction, int eventKey) {
+        return delegate.containsTransactionEvent(transaction, eventKey);
+    }
+
+    public boolean removeTransactionEventWithEventKey(MemoryTransaction transaction, int eventKey) {
+        return delegate.removeTransactionEventWithEventKey(transaction, eventKey);
+    }
+
+    public int getTransactionEventCount(MemoryTransaction transaction) {
+        return delegate.getTransactionEventCount(transaction);
+    }
+
+    public int getTransactionEvents() {
+        return delegate.getTransactionEvents();
+    }
+
+    public void clear() {
+        transactionsById.clear();
+        delegate.clear();
+    }
+
+    public void syncTransaction(MemoryTransaction transaction) {
+        delegate.syncTransaction(transaction);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/SpillStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/SpillStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * Interface for determining when a transaction should begin spilling events to an off-heap provider.
+ * This allows for pluggable strategies to decide spill behavior based on different criteria.
+ *
+ * @author Debezium Authors
+ */
+public interface SpillStrategy {
+
+    /**
+     * Determines if a transaction should begin spilling events to the spillover provider.
+     *
+     * @param txId the transaction ID
+     * @param latest the latest event being added to the transaction
+     * @param view a view of the transaction's current state
+     * @return true if the transaction should begin spilling, false otherwise
+     */
+    boolean shouldSpill(String txId, LogMinerEvent latest, TransactionView view);
+
+    /**
+     * Called when a new transaction is created. This allows the strategy to initialize
+     * any per-transaction state or tracking required for spill decisions.
+     * The default implementation does nothing.
+     *
+     * @param txId the transaction ID of the newly created transaction
+     */
+    default void onTransactionCreated(String txId) {
+    }
+
+    /**
+     * Called when a transaction is removed from the cache. This allows the strategy to
+     * clean up any per-transaction state or tracking that was maintained for spill decisions.
+     * The default implementation does nothing.
+     *
+     * @param txId the transaction ID of the removed transaction
+     */
+    default void onTransactionRemoved(String txId) {
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/TransactionView.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/TransactionView.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+/**
+ * Provides a view of a transaction's current state for spill strategy decisions.
+ *
+ * @author Debezium Authors
+ */
+public interface TransactionView {
+
+    /**
+     * Gets the number of events currently stored in memory for this transaction.
+     *
+     * @return the count of in-memory events
+     */
+    long memoryEventCount();
+
+    /**
+     * Gets the total number of events for this transaction (memory + spilled).
+     *
+     * @return the total count of events
+     */
+    long totalEventCount();
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleCacheProvider.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
+import io.debezium.connector.oracle.logminer.buffered.CompositeTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.EventCountStrategy;
+import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
+import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.SpillStrategy;
+import io.debezium.connector.oracle.logminer.buffered.memory.MemoryBasedLogMinerCache;
+import io.debezium.util.Strings;
+
+import net.openhft.chronicle.queue.RollCycles;
+
+/**
+ * Chronicle Queue-based cache provider implementation that creates Chronicle-backed transaction cache.
+ * This provider enables spill-to-disk functionality for LogMiner transactions.
+ *
+ * @author Debezium Team
+ */
+public class ChronicleCacheProvider extends AbstractCacheProvider<ChronicleTransaction> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChronicleCacheProvider.class);
+
+    private final CompositeTransactionCache<ChronicleTransaction> transactionCache;
+    private final MemoryBasedLogMinerCache<String, String> processedTransactionsCache;
+    private final MemoryBasedLogMinerCache<String, String> schemaChangesCache;
+
+    public ChronicleCacheProvider(OracleConnectorConfig connectorConfig) {
+
+        if (!connectorConfig.isLogMiningBufferSpillEnabled()) {
+            throw new DebeziumException("Chronicle Queue spill must be enabled to use ChronicleCacheProvider");
+        }
+
+        String spillPath = connectorConfig.getLogMiningBufferSpillPath();
+        if (Strings.isNullOrEmpty(spillPath)) {
+            throw new DebeziumException("Chronicle Queue spill path must be configured when spill is enabled");
+        }
+
+        Path spillDirectory = Paths.get(spillPath);
+        long spillThreshold = connectorConfig.getLogMiningBufferSpillThreshold();
+        String rollCycle = connectorConfig.getChronicleRollCycle();
+
+        if (Strings.isNullOrEmpty(rollCycle)) {
+            throw new DebeziumException("Chronicle roll cycle must be configured when spill is enabled");
+        }
+        try {
+            RollCycles.valueOf(rollCycle);
+        }
+        catch (IllegalArgumentException e) {
+            throw new DebeziumException("Invalid Chronicle roll cycle name '" + rollCycle + "'", e);
+        }
+
+        LOGGER.info("Creating Chronicle Queue transaction cache with spill path: {} and threshold: {} events",
+                spillDirectory, spillThreshold);
+        LOGGER.info("Spillover data is ephemeral and will be cleaned up automatically on connector stop");
+
+        // Proactively purge any leftover spill subdirectories from a previous unclean shutdown.
+        purgeLeftoverSpillDirectories(spillDirectory);
+
+        try {
+            // Create the spillover cache and strategy
+            ChronicleLogMinerTransactionCache spilloverCache = new ChronicleLogMinerTransactionCache(spillDirectory, rollCycle);
+            SpillStrategy strategy = new EventCountStrategy(spillThreshold);
+
+            // Create the composite transaction store with configured index threshold
+            int indexThreshold = connectorConfig.getLogMiningBufferSpillInMemoryIndexThreshold();
+            this.transactionCache = new CompositeTransactionCache<ChronicleTransaction>(spilloverCache, strategy, indexThreshold);
+
+            // TODO: Investigate using Chronicle Map for disk-backed processedTransactions and schemaChanges caches
+            this.processedTransactionsCache = new MemoryBasedLogMinerCache<>();
+            this.schemaChangesCache = new MemoryBasedLogMinerCache<>();
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to create Chronicle Queue transaction cache", e);
+        }
+    }
+
+    @Override
+    public LogMinerTransactionCache<ChronicleTransaction> getTransactionCache() {
+        return transactionCache;
+    }
+
+    @Override
+    public LogMinerCache<String, String> getSchemaChangesCache() {
+        return schemaChangesCache;
+    }
+
+    @Override
+    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+        return processedTransactionsCache;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (transactionCache != null) {
+            // Always clean up spillover data on connector stop
+            transactionCache.clear();
+        }
+    }
+
+    private void purgeLeftoverSpillDirectories(Path spillDirectory) {
+        if (spillDirectory == null) {
+            return;
+        }
+        try (Stream<Path> children = Files.list(spillDirectory)) {
+            children.filter(Files::isDirectory).forEach(dir -> {
+                try {
+                    LOGGER.info("Purging leftover Chronicle spill directory {} from previous unclean shutdown", dir);
+                    deleteRecursively(dir);
+                }
+                catch (IOException e) {
+                    LOGGER.warn("Failed to purge leftover Chronicle spill directory {}", dir, e);
+                }
+            });
+        }
+        catch (IOException e) {
+            LOGGER.debug("No existing spill directories to purge at {} ({})", spillDirectory, e.getMessage());
+        }
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.deleteIfExists(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.deleteIfExists(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleEventSerializer.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+import io.debezium.relational.TableId;
+
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Chronicle Queue serializer for LogMinerEvent objects.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleEventSerializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChronicleEventSerializer.class);
+
+    // Type identifiers for efficient serialization
+    public static final byte TYPE_DML_EVENT = 1;
+    public static final byte TYPE_SELECT_LOB_LOCATOR = 2;
+    public static final byte TYPE_EXTENDED_STRING_BEGIN = 3;
+    public static final byte TYPE_XML_BEGIN = 4;
+    public static final byte TYPE_XML_WRITE = 5;
+    public static final byte TYPE_XML_END = 6;
+    public static final byte TYPE_LOB_WRITE = 7;
+    public static final byte TYPE_TRUNCATE = 8;
+    public static final byte TYPE_REDO_SQL_DML = 9;
+    public static final byte TYPE_GENERIC_LOG_MINER_EVENT = 10;
+    public static final byte TYPE_LOB_ERASE = 11;
+    public static final byte TYPE_EXTENDED_STRING_WRITE = 12;
+
+    // Value type markers
+    static final byte VALUE_TYPE_NULL = 0;
+    static final byte VALUE_TYPE_STRING = 1;
+    static final byte VALUE_TYPE_INTEGER = 2;
+    static final byte VALUE_TYPE_LONG = 3;
+    static final byte VALUE_TYPE_DOUBLE = 4;
+    static final byte VALUE_TYPE_FLOAT = 5;
+    static final byte VALUE_TYPE_BOOLEAN = 6;
+    static final byte VALUE_TYPE_BIG_DECIMAL = 7;
+    static final byte VALUE_TYPE_BYTES = 8;
+    static final byte VALUE_TYPE_UNAVAILABLE = 9;
+
+    // Sentinel values
+    private static final String UNAVAILABLE_VALUE_SENTINEL = "$$DBZ-UNAVAILABLE-VALUE$$";
+    // Named sentinel constants for readability (public so serializers can reuse them)
+    public static final long NULL_SCN = -1L;
+    public static final long NULL_CHANGE_TIME = Long.MIN_VALUE;
+    // Marker used when serializing arrays to indicate 'null' array
+    public static final int ARRAY_NULL_COUNT = -1;
+
+    /**
+     * Convert Instant to epoch microseconds for storage.
+     */
+    public static long instantToMicros(Instant instant) {
+        return (instant != null) ? instant.toEpochMilli() * 1000 : NULL_CHANGE_TIME;
+    }
+
+    /**
+     * Convert stored epoch microseconds back to Instant.
+     */
+    public static Instant microsToInstant(long micros) {
+        return (micros == NULL_CHANGE_TIME) ? null : Instant.ofEpochMilli(micros / 1000);
+    }
+
+    /**
+     * Writes a LogMinerEvent to Chronicle Queue storage.
+     *
+     * @param appender the Chronicle Queue appender
+     * @param eventKey the event key within the transaction
+     * @param event the LogMinerEvent to write
+     * @return the sequence index of the written document
+     */
+    public static long writeEvent(ExcerptAppender appender, int eventKey, LogMinerEvent event) {
+        try (DocumentContext context = appender.writingDocument()) {
+            ValueOut valueOut = context.wire().getValueOut();
+
+            valueOut.int32(eventKey);
+
+            EventSerializerStrategy serializer = ChronicleEventSerializerRegistry.getSerializer(event.getClass());
+
+            valueOut.int8(serializer.getTypeId());
+
+            serializer.writeEvent(valueOut, event);
+
+            return context.index();
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to write event " + eventKey + " to Chronicle Queue", e);
+        }
+    }
+
+    /**
+     * Reads a LogMinerEvent from Chronicle Queue storage.
+     *
+     * @param tailer the Chronicle Queue tailer positioned at the event
+     * @return the reconstructed LogMinerEvent or null if no more events
+     */
+    public static LogMinerEvent readEvent(ExcerptTailer tailer) {
+        try (DocumentContext context = tailer.readingDocument()) {
+            if (!context.isPresent()) {
+                return null;
+            }
+
+            ValueIn valueIn = context.wire().getValueIn();
+
+            valueIn.int32();
+
+            byte typeId = valueIn.int8();
+
+            EventSerializerStrategy deserializer = ChronicleEventSerializerRegistry.getDeserializer(typeId);
+
+            return deserializer.readEvent(valueIn);
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to read event from Chronicle Queue", e);
+        }
+    }
+
+    /**
+     * Reads a LogMinerEvent and its eventKey from Chronicle Queue storage.
+     *
+     * @param tailer the Chronicle Queue tailer positioned at the event
+     * @return a pair of eventKey and LogMinerEvent, or null if no more events
+     */
+    public static EventKeyAndEvent readEventWithKey(ExcerptTailer tailer) {
+        try (DocumentContext context = tailer.readingDocument()) {
+            if (!context.isPresent()) {
+                return null;
+            }
+
+            ValueIn valueIn = context.wire().getValueIn();
+
+            int eventKey = valueIn.int32();
+
+            byte typeId = valueIn.int8();
+
+            EventSerializerStrategy deserializer = ChronicleEventSerializerRegistry.getDeserializer(typeId);
+
+            LogMinerEvent event = deserializer.readEvent(valueIn);
+            return new EventKeyAndEvent(eventKey, event);
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to read event with key from Chronicle Queue", e);
+        }
+    }
+
+    // Strategy interface for event serialization
+    public interface EventSerializerStrategy {
+        byte getTypeId();
+
+        void writeEvent(ValueOut valueOut, LogMinerEvent event);
+
+        LogMinerEvent readEvent(ValueIn valueIn);
+    }
+
+    // Base serializer with common functionality
+    public abstract static class BaseEventSerializer implements EventSerializerStrategy {
+
+        protected void writeCommonFields(ValueOut valueOut, LogMinerEvent event) {
+            valueOut.int8((byte) event.getEventType().ordinal());
+
+            long scnValue = event.getScn().isNull() ? NULL_SCN : event.getScn().longValue();
+            valueOut.int64(scnValue);
+
+            long changeTimeMicros = instantToMicros(event.getChangeTime());
+            valueOut.int64(changeTimeMicros);
+
+            TableId tableId = event.getTableId();
+            writeString(valueOut, tableId.catalog());
+            writeString(valueOut, tableId.schema());
+            writeString(valueOut, tableId.table());
+
+            writeString(valueOut, event.getRowId());
+            writeString(valueOut, event.getRsId());
+        }
+
+        protected LogMinerEvent readCommonFields(ValueIn valueIn, EventType eventType) {
+            long scnValue = valueIn.int64();
+            Scn scn = scnValue == NULL_SCN ? Scn.NULL : Scn.valueOf(scnValue);
+
+            long changeTimeMicros = valueIn.int64();
+            Instant changeTime = microsToInstant(changeTimeMicros);
+
+            String catalog = readString(valueIn);
+            String schema = readString(valueIn);
+            String table = readString(valueIn);
+            TableId tableId = new TableId(catalog, schema, table);
+
+            String rowId = readString(valueIn);
+            String rsId = readString(valueIn);
+
+            return new LogMinerEvent(eventType, scn, tableId, rowId, rsId, changeTime);
+        }
+
+        protected void writeString(ValueOut valueOut, String str) {
+            valueOut.text(str);
+        }
+
+        protected String readString(ValueIn valueIn) {
+            return valueIn.text();
+        }
+
+        protected void writeObject(ValueOut valueOut, Object value) {
+            if (value == null) {
+                valueOut.int8(VALUE_TYPE_NULL);
+            }
+            else if (value == OracleValueConverters.UNAVAILABLE_VALUE) {
+                valueOut.int8(VALUE_TYPE_UNAVAILABLE);
+                writeString(valueOut, UNAVAILABLE_VALUE_SENTINEL);
+            }
+            else if (value instanceof String str) {
+                valueOut.int8(VALUE_TYPE_STRING);
+                writeString(valueOut, str);
+            }
+            else if (value instanceof Integer i) {
+                valueOut.int8(VALUE_TYPE_INTEGER);
+                valueOut.int32(i);
+            }
+            else if (value instanceof Long l) {
+                valueOut.int8(VALUE_TYPE_LONG);
+                valueOut.int64(l);
+            }
+            else if (value instanceof Double d) {
+                valueOut.int8(VALUE_TYPE_DOUBLE);
+                valueOut.float64(d);
+            }
+            else if (value instanceof Float f) {
+                valueOut.int8(VALUE_TYPE_FLOAT);
+                valueOut.float32(f);
+            }
+            else if (value instanceof Boolean b) {
+                valueOut.int8(VALUE_TYPE_BOOLEAN);
+                valueOut.bool(b);
+            }
+            else if (value instanceof BigDecimal bd) {
+                valueOut.int8(VALUE_TYPE_BIG_DECIMAL);
+                writeString(valueOut, bd.toString());
+            }
+            else if (value instanceof byte[] bytes) {
+                valueOut.int8(VALUE_TYPE_BYTES);
+                valueOut.int32(bytes.length);
+                valueOut.bytes(bytes);
+            }
+            else if (value instanceof ByteBuffer buffer) {
+                valueOut.int8(VALUE_TYPE_BYTES);
+                valueOut.int32(buffer.remaining());
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.duplicate().get(bytes);
+                valueOut.bytes(bytes);
+            }
+            else {
+                LOGGER.debug("Unknown object type {} serializing as string: {}",
+                        value.getClass().getName(), value);
+                valueOut.int8(VALUE_TYPE_STRING);
+                writeString(valueOut, value.toString());
+            }
+        }
+
+        protected Object readObject(ValueIn valueIn) {
+            byte typeMarker = valueIn.int8();
+            switch (typeMarker) {
+                case VALUE_TYPE_NULL:
+                    return null;
+                case VALUE_TYPE_UNAVAILABLE:
+                    String stringValue = readString(valueIn);
+                    if (UNAVAILABLE_VALUE_SENTINEL.equals(stringValue)) {
+                        return OracleValueConverters.UNAVAILABLE_VALUE;
+                    }
+                    return stringValue;
+                case VALUE_TYPE_STRING:
+                    return readString(valueIn);
+                case VALUE_TYPE_INTEGER:
+                    return valueIn.int32();
+                case VALUE_TYPE_LONG:
+                    return valueIn.int64();
+                case VALUE_TYPE_DOUBLE:
+                    return valueIn.float64();
+                case VALUE_TYPE_FLOAT:
+                    return valueIn.float32();
+                case VALUE_TYPE_BOOLEAN:
+                    return valueIn.bool();
+                case VALUE_TYPE_BIG_DECIMAL:
+                    return new BigDecimal(readString(valueIn));
+                case VALUE_TYPE_BYTES:
+                    int length = valueIn.int32();
+                    byte[] bytes = new byte[length];
+                    valueIn.bytes(bytes);
+                    return bytes;
+                default:
+                    throw new DebeziumException("Unknown value type marker: " + typeMarker);
+            }
+        }
+
+        protected void writeValuesArray(ValueOut valueOut, Object[] values) {
+            if (values != null) {
+                valueOut.int32(values.length);
+                for (Object value : values) {
+                    writeObject(valueOut, value);
+                }
+            }
+            else {
+                valueOut.int32(ChronicleEventSerializer.ARRAY_NULL_COUNT);
+            }
+        }
+
+        protected Object[] readValuesArray(ValueIn valueIn) {
+            int count = valueIn.int32();
+            if (count < 0) {
+                return null;
+            }
+
+            Object[] values = new Object[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = readObject(valueIn);
+            }
+            return values;
+        }
+
+        protected void writeDmlEntry(ValueOut valueOut, LogMinerDmlEntry dmlEntry) {
+            writeValuesArray(valueOut, dmlEntry.getOldValues());
+            writeValuesArray(valueOut, dmlEntry.getNewValues());
+            writeString(valueOut, dmlEntry.getObjectOwner());
+            writeString(valueOut, dmlEntry.getObjectName());
+        }
+
+        protected LogMinerDmlEntryImpl readDmlEntry(ValueIn valueIn, EventType eventType) {
+            Object[] oldValues = readValuesArray(valueIn);
+            Object[] newValues = readValuesArray(valueIn);
+            String objectOwner = readString(valueIn);
+            String objectName = readString(valueIn);
+            return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+        }
+    }
+
+    public record EventKeyAndEvent(int eventKey, LogMinerEvent event) {
+    }
+
+    public static class GenericLogMinerEventSerializer extends BaseEventSerializer {
+
+        @Override
+        public byte getTypeId() {
+            return TYPE_GENERIC_LOG_MINER_EVENT;
+        }
+
+        @Override
+        public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+            writeCommonFields(valueOut, event);
+        }
+
+        @Override
+        public LogMinerEvent readEvent(ValueIn valueIn) {
+            byte eventTypeOrdinal = valueIn.int8();
+            EventType[] eventTypes = EventType.values();
+            if (eventTypeOrdinal < 0 || eventTypeOrdinal >= eventTypes.length) {
+                throw new DebeziumException("Invalid EventType ordinal: " + eventTypeOrdinal +
+                        ". Valid range is 0-" + (eventTypes.length - 1));
+            }
+            EventType eventType = eventTypes[eventTypeOrdinal];
+
+            return readCommonFields(valueIn, eventType);
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleEventSerializerRegistry.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleEventSerializerRegistry.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.DmlEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.ExtendedStringBeginEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.ExtendedStringWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.LobEraseEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.LobWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.RedoSqlDmlEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.SelectLobLocatorEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.TruncateEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.XmlBeginEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.XmlEndEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.serialization.XmlWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.events.DmlEvent;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringBeginEvent;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LobEraseEvent;
+import io.debezium.connector.oracle.logminer.events.LobWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.RedoSqlDmlEvent;
+import io.debezium.connector.oracle.logminer.events.SelectLobLocatorEvent;
+import io.debezium.connector.oracle.logminer.events.TruncateEvent;
+import io.debezium.connector.oracle.logminer.events.XmlBeginEvent;
+import io.debezium.connector.oracle.logminer.events.XmlEndEvent;
+import io.debezium.connector.oracle.logminer.events.XmlWriteEvent;
+
+/**
+ * Registry for mapping LogMinerEvent classes to their corresponding serializers.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleEventSerializerRegistry {
+
+    private static final String UNKNOWN_TYPE_ID_FORMAT = "Unknown Type ID: %d";
+    private static final Map<Class<? extends LogMinerEvent>, ChronicleEventSerializer.EventSerializerStrategy> SERIALIZER_REGISTRY = createSerializerRegistry();
+    private static final Map<Byte, ChronicleEventSerializer.EventSerializerStrategy> TYPE_ID_REGISTRY = createTypeIdRegistry();
+
+    private static final Map<Byte, String> TYPE_ID_TO_CLASS_NAME = createTypeIdToClassNameRegistry();
+
+    private static Map<Class<? extends LogMinerEvent>, ChronicleEventSerializer.EventSerializerStrategy> createSerializerRegistry() {
+        Map<Class<? extends LogMinerEvent>, ChronicleEventSerializer.EventSerializerStrategy> registry = new HashMap<>();
+
+        registry.put(DmlEvent.class, new DmlEventSerializer());
+        registry.put(SelectLobLocatorEvent.class, new SelectLobLocatorEventSerializer());
+        registry.put(ExtendedStringBeginEvent.class, new ExtendedStringBeginEventSerializer());
+        registry.put(XmlBeginEvent.class, new XmlBeginEventSerializer());
+        registry.put(XmlWriteEvent.class, new XmlWriteEventSerializer());
+        registry.put(XmlEndEvent.class, new XmlEndEventSerializer());
+        registry.put(LobWriteEvent.class, new LobWriteEventSerializer());
+        registry.put(TruncateEvent.class, new TruncateEventSerializer());
+        registry.put(RedoSqlDmlEvent.class, new RedoSqlDmlEventSerializer());
+        registry.put(LobEraseEvent.class, new LobEraseEventSerializer());
+        registry.put(ExtendedStringWriteEvent.class, new ExtendedStringWriteEventSerializer());
+
+        return registry;
+    }
+
+    private static Map<Byte, ChronicleEventSerializer.EventSerializerStrategy> createTypeIdRegistry() {
+        Map<Byte, ChronicleEventSerializer.EventSerializerStrategy> registry = new HashMap<>();
+
+        registry.put(ChronicleEventSerializer.TYPE_DML_EVENT, new DmlEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_SELECT_LOB_LOCATOR, new SelectLobLocatorEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_EXTENDED_STRING_BEGIN, new ExtendedStringBeginEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_XML_BEGIN, new XmlBeginEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_XML_WRITE, new XmlWriteEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_XML_END, new XmlEndEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_LOB_WRITE, new LobWriteEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_TRUNCATE, new TruncateEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_REDO_SQL_DML, new RedoSqlDmlEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_LOB_ERASE, new LobEraseEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_EXTENDED_STRING_WRITE, new ExtendedStringWriteEventSerializer());
+        registry.put(ChronicleEventSerializer.TYPE_GENERIC_LOG_MINER_EVENT, new ChronicleEventSerializer.GenericLogMinerEventSerializer());
+
+        return registry;
+    }
+
+    private static Map<Byte, String> createTypeIdToClassNameRegistry() {
+        Map<Byte, String> registry = new HashMap<>();
+        registry.put(ChronicleEventSerializer.TYPE_DML_EVENT, DmlEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_SELECT_LOB_LOCATOR, SelectLobLocatorEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_EXTENDED_STRING_BEGIN, ExtendedStringBeginEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_XML_BEGIN, XmlBeginEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_XML_WRITE, XmlWriteEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_XML_END, XmlEndEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_LOB_WRITE, LobWriteEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_TRUNCATE, TruncateEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_REDO_SQL_DML, RedoSqlDmlEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_LOB_ERASE, LobEraseEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_EXTENDED_STRING_WRITE, ExtendedStringWriteEvent.class.getName());
+        registry.put(ChronicleEventSerializer.TYPE_GENERIC_LOG_MINER_EVENT, LogMinerEvent.class.getName());
+        return registry;
+    }
+
+    /**
+     * Get the class name for a given type ID for debugging purposes.
+     *
+     * @param typeId the type identifier
+     * @return the corresponding class name, or "Unknown" if not found
+     */
+    public static String getClassName(byte typeId) {
+        return TYPE_ID_TO_CLASS_NAME.getOrDefault(typeId, String.format(UNKNOWN_TYPE_ID_FORMAT, typeId));
+    }
+
+    /**
+     * Get the appropriate serializer for a given event class.
+     *
+     * @param eventClass the event class
+     * @return the corresponding serializer strategy
+     */
+    public static ChronicleEventSerializer.EventSerializerStrategy getSerializer(Class<? extends LogMinerEvent> eventClass) {
+        ChronicleEventSerializer.EventSerializerStrategy serializer = SERIALIZER_REGISTRY.get(eventClass);
+        if (serializer == null) {
+            // For base LogMinerEvent class, use a generic serializer
+            if (eventClass == LogMinerEvent.class) {
+                return new ChronicleEventSerializer.GenericLogMinerEventSerializer();
+            }
+            // Default to DML serializer for unknown types
+            return new DmlEventSerializer();
+        }
+        return serializer;
+    }
+
+    /**
+     * Get the appropriate deserializer for a given type ID.
+     *
+     * @param typeId the type identifier
+     * @return the corresponding serializer strategy
+     */
+    public static ChronicleEventSerializer.EventSerializerStrategy getDeserializer(byte typeId) {
+        ChronicleEventSerializer.EventSerializerStrategy deserializer = TYPE_ID_REGISTRY.get(typeId);
+        if (deserializer == null) {
+            throw new IllegalArgumentException("Unknown event type ID: " + typeId);
+        }
+        return deserializer;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleLogMinerTransactionCache.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.AbstractLogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.events.DmlEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.TailerDirection;
+
+/**
+ * Chronicle Queue-based implementation for transaction caching.
+ * Handles the mechanics of spilling events to Chronicle Queue files.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleLogMinerTransactionCache extends AbstractLogMinerTransactionCache<ChronicleTransaction> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChronicleLogMinerTransactionCache.class);
+
+    // Single-threaded data structures (LogMiner processing is single-threaded)
+    private final Map<String, ChronicleQueueWrapper> chronicleQueueByTx = new HashMap<>();
+    private final Map<String, Map<Integer, Long>> chronicleIndexByTx = new HashMap<>();
+    private final Map<String, TreeSet<Integer>> spilledEventKeyTombstonesByTx = new HashMap<>();
+    private final Map<String, TreeSet<Integer>> eventIdsByTransactionId = new HashMap<>();
+    private final Map<String, ChronicleTransaction> transactions = new HashMap<>();
+
+    private final Path spillDirectory;
+    private final String rollCycle;
+
+    /**
+     * Creates a new Chronicle spillover cache.
+     *
+     * @param spillDirectory the directory for Chronicle Queue storage
+     * @param rollCycle the Chronicle Queue roll cycle
+     */
+    public ChronicleLogMinerTransactionCache(Path spillDirectory, String rollCycle) {
+        this.spillDirectory = spillDirectory;
+        this.rollCycle = rollCycle;
+    }
+
+    @Override
+    public ChronicleTransaction getTransaction(String transactionId) {
+        return transactions.get(transactionId);
+    }
+
+    @Override
+    public void addTransaction(ChronicleTransaction transaction) {
+        String txId = transaction.getTransactionId();
+        transactions.put(txId, transaction);
+        eventIdsByTransactionId.put(txId, new TreeSet<>());
+    }
+
+    @Override
+    public void removeTransaction(ChronicleTransaction transaction) {
+        String txId = transaction.getTransactionId();
+        transactions.remove(txId);
+    }
+
+    @Override
+    public boolean containsTransaction(String transactionId) {
+        return eventIdsByTransactionId.containsKey(transactionId);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return eventIdsByTransactionId.isEmpty();
+    }
+
+    @Override
+    public int getTransactionCount() {
+        return eventIdsByTransactionId.size();
+    }
+
+    @Override
+    public <R> R streamTransactionsAndReturn(Function<Stream<ChronicleTransaction>, R> consumer) {
+        return consumer.apply(transactions.values().stream());
+    }
+
+    @Override
+    public void transactions(Consumer<Stream<ChronicleTransaction>> consumer) {
+        consumer.accept(transactions.values().stream());
+    }
+
+    @Override
+    public void eventKeys(Consumer<Stream<String>> consumer) {
+        consumer.accept(eventIdsByTransactionId.entrySet().stream()
+                .flatMap(entry -> {
+                    String transactionId = entry.getKey();
+                    return entry.getValue().stream().map(eventId -> transactionId + "-" + eventId);
+                }));
+    }
+
+    @Override
+    public void forEachEvent(ChronicleTransaction transaction,
+                             io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache.InterruptiblePredicate<LogMinerEvent> predicate)
+            throws InterruptedException {
+        String txId = transaction.getTransactionId();
+        ChronicleQueueWrapper queueWrapper = chronicleQueueByTx.get(txId);
+        if (queueWrapper == null || !queueWrapper.isInitialized()) {
+            return;
+        }
+
+        TreeSet<Integer> tombstones = spilledEventKeyTombstonesByTx.get(txId);
+        if (tombstones == null) {
+            try (ExcerptTailer tailer = queueWrapper.createTailer()) {
+                ChronicleEventSerializer.EventKeyAndEvent keyAndEvent;
+                while ((keyAndEvent = ChronicleEventSerializer.readEventWithKey(tailer)) != null) {
+                    if (keyAndEvent.event() instanceof DmlEvent) {
+                        // event contains DML
+                    }
+                    if (!predicate.test(keyAndEvent.event())) {
+                        break;
+                    }
+                }
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to iterate spilled events for transaction {}", txId, e);
+            }
+            return;
+        }
+
+        try (ExcerptTailer tailer = queueWrapper.createTailer()) {
+            ChronicleEventSerializer.EventKeyAndEvent keyAndEvent;
+            while ((keyAndEvent = ChronicleEventSerializer.readEventWithKey(tailer)) != null) {
+                if (tombstones.contains(keyAndEvent.eventKey())) {
+                    continue;
+                }
+                if (!predicate.test(keyAndEvent.event())) {
+                    break;
+                }
+            }
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to iterate spilled events for transaction {}", txId, e);
+        }
+    }
+
+    @Override
+    public LogMinerEvent getTransactionEvent(ChronicleTransaction transaction, int eventKey) {
+        String txId = transaction.getTransactionId();
+        Map<Integer, Long> indexMap = chronicleIndexByTx.get(txId);
+        if (indexMap != null) {
+            Long index = indexMap.get(eventKey);
+            if (index != null) {
+                ChronicleQueueWrapper queueWrapper = chronicleQueueByTx.get(txId);
+                if (queueWrapper != null && queueWrapper.isInitialized()) {
+                    try (ExcerptTailer tailer = queueWrapper.createTailer()) {
+                        if (tailer.moveToIndex(index)) {
+                            ChronicleEventSerializer.EventKeyAndEvent keyAndEvent = ChronicleEventSerializer.readEventWithKey(tailer);
+                            if (keyAndEvent != null && keyAndEvent.eventKey() == eventKey) {
+                                // If this event was tombstoned, consider it removed.
+                                TreeSet<Integer> tombstones = spilledEventKeyTombstonesByTx.get(txId);
+                                if (tombstones != null && tombstones.contains(eventKey)) {
+                                    return null;
+                                }
+                                return keyAndEvent.event();
+                            }
+                        }
+                    }
+                    catch (Exception e) {
+                        LOGGER.warn("Failed to read event {} for transaction {} from index", eventKey, txId, e);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ChronicleTransaction getAndRemoveTransaction(String transactionId) {
+        ChronicleTransaction transaction = getTransaction(transactionId);
+        if (transaction != null) {
+            removeTransaction(transaction);
+        }
+        return transaction;
+    }
+
+    @Override
+    public void addTransactionEvent(ChronicleTransaction transaction, int eventKey, LogMinerEvent event) {
+        String txId = transaction.getTransactionId();
+        TreeSet<Integer> eventSet = eventIdsByTransactionId.get(txId);
+        if (eventSet == null) {
+            throw new IllegalStateException("Transaction " + txId + " not initialized. Call addTransaction first.");
+        }
+        spillEventToChronicleQueue(txId, eventKey, event);
+        eventSet.add(eventKey);
+    }
+
+    @Override
+    public void removeTransactionEvents(ChronicleTransaction transaction) {
+        String txId = transaction.getTransactionId();
+        // Remove all event-related data structures (matching canonical pattern)
+        eventIdsByTransactionId.remove(txId);
+        chronicleIndexByTx.remove(txId);
+        spilledEventKeyTombstonesByTx.remove(txId);
+
+        // Close and clean up Chronicle queue resources
+        ChronicleQueueWrapper wrapper = chronicleQueueByTx.remove(txId);
+        if (wrapper != null) {
+            try {
+                wrapper.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to close Chronicle queue for transaction {}", txId, e);
+            }
+            try {
+                wrapper.deleteQueueDirectory();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to delete Chronicle queue directory for transaction {}", txId, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean removeTransactionEventWithRowId(ChronicleTransaction transaction, String rowId) {
+        return removeTransactionEventWithRowId(transaction.getTransactionId(), rowId);
+    }
+
+    @Override
+    public boolean containsTransactionEvent(ChronicleTransaction transaction, int eventKey) {
+        final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (events == null || !events.contains(eventKey)) {
+            return false;
+        }
+
+        final var tombstones = spilledEventKeyTombstonesByTx.get(transaction.getTransactionId());
+        return tombstones == null || !tombstones.contains(eventKey);
+    }
+
+    @Override
+    public boolean removeTransactionEventWithEventKey(ChronicleTransaction transaction, int eventKey) {
+        String txId = transaction.getTransactionId();
+        TreeSet<Integer> tombstoneSet = spilledEventKeyTombstonesByTx.computeIfAbsent(txId, id -> new TreeSet<>());
+        return tombstoneSet.add(eventKey);
+    }
+
+    @Override
+    public int getTransactionEventCount(ChronicleTransaction transaction) {
+        final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (events == null) {
+            return 0;
+        }
+
+        final var tombstones = spilledEventKeyTombstonesByTx.get(transaction.getTransactionId());
+        final int tombstoneCount = (tombstones != null) ? tombstones.size() : 0;
+
+        return events.size() - tombstoneCount;
+    }
+
+    @Override
+    public int getTransactionEvents() {
+        long totalEvents = eventIdsByTransactionId.values().stream().mapToLong(Set::size).sum();
+        long totalTombstones = spilledEventKeyTombstonesByTx.values().stream().mapToLong(Set::size).sum();
+        return (int) (totalEvents - totalTombstones);
+    }
+
+    @Override
+    public void clear() {
+        transactions.clear();
+        eventIdsByTransactionId.clear();
+        chronicleIndexByTx.clear();
+        spilledEventKeyTombstonesByTx.clear();
+
+        chronicleQueueByTx.values().forEach(wrapper -> {
+            try {
+                wrapper.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to close Chronicle queue during clear", e);
+            }
+            try {
+                wrapper.deleteQueueDirectory();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to delete Chronicle queue directory during clear", e);
+            }
+        });
+        chronicleQueueByTx.clear();
+    }
+
+    @Override
+    public void syncTransaction(ChronicleTransaction transaction) {
+        // No-op
+    }
+
+    public boolean removeTransactionEventWithRowId(String txId, String rowId) {
+        Integer latestEventKey = findLatestSpilledEventKey(txId, rowId);
+        if (latestEventKey != null) {
+            TreeSet<Integer> tombstoneSet = spilledEventKeyTombstonesByTx.computeIfAbsent(txId, id -> new TreeSet<>());
+            tombstoneSet.add(latestEventKey);
+            return true;
+        }
+        return false;
+    }
+
+    private void spillEventToChronicleQueue(String txId, int eventKey, LogMinerEvent event) {
+        ChronicleQueueWrapper queueWrapper = chronicleQueueByTx.computeIfAbsent(txId,
+                id -> {
+                    ChronicleQueueWrapper wrapper = new ChronicleQueueWrapper(spillDirectory.toString(), id, rollCycle);
+                    wrapper.initialize();
+                    return wrapper;
+                });
+        try {
+            long chronicleIndex = ChronicleEventSerializer.writeEvent(queueWrapper.getAppender(), eventKey, event);
+            chronicleIndexByTx.computeIfAbsent(txId, k -> new HashMap<>()).put(eventKey, chronicleIndex);
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to write event " + eventKey + " to Chronicle Queue", e);
+        }
+    }
+
+    /**
+     * Finds the eventKey of the most recent spilled event with the specified rowId.
+     * Iterates backward through spilled events to find the latest (most recent) event with matching rowId.
+     *
+     * @param txId the transaction ID
+     * @param rowId the row ID to search for
+     * @return the eventKey of the latest matching event, or null if not found
+     */
+    private Integer findLatestSpilledEventKey(String txId, String rowId) {
+        ChronicleQueueWrapper queueWrapper = chronicleQueueByTx.get(txId);
+        if (queueWrapper == null || !queueWrapper.isInitialized()) {
+            return null;
+        }
+
+        TreeSet<Integer> tombstones = spilledEventKeyTombstonesByTx.computeIfAbsent(txId, k -> new TreeSet<>());
+        try (ExcerptTailer tailer = queueWrapper.createTailer()) {
+            tailer.direction(TailerDirection.BACKWARD).toEnd();
+
+            ChronicleEventSerializer.EventKeyAndEvent keyAndEvent;
+            while ((keyAndEvent = ChronicleEventSerializer.readEventWithKey(tailer)) != null) {
+                if (tombstones.contains(keyAndEvent.eventKey())) {
+                    continue;
+                }
+                if (rowId.equals(keyAndEvent.event().getRowId())) {
+                    return keyAndEvent.eventKey();
+                }
+            }
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to find latest spilled event with rowId {} in transaction {}", rowId, txId, e);
+        }
+        return null;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleQueueWrapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleQueueWrapper.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.RollCycles;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+
+/**
+ * A wrapper around Chronicle Queue that encapsulates queue creation, configuration,
+ * and basic append/read operations for the Oracle LogMiner spill-to-disk functionality.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleQueueWrapper implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChronicleQueueWrapper.class);
+
+    private final String basePath;
+    private final String transactionId;
+    private final String rollCycleName;
+    private ChronicleQueue queue;
+    private ExcerptAppender appender;
+
+    /**
+     * Creates a new Chronicle Queue wrapper for the specified transaction.
+     *
+     * @param basePath the base path for Chronicle Queue storage
+     * @param transactionId the transaction ID (used as subdirectory name)
+     * @param rollCycleName the Chronicle Queue roll cycle name
+     */
+    public ChronicleQueueWrapper(String basePath, String transactionId, String rollCycleName) {
+        this.basePath = basePath;
+        this.transactionId = transactionId;
+        this.rollCycleName = rollCycleName;
+    }
+
+    /**
+     * Initializes the Chronicle Queue and creates the directory if needed.
+     * Must be called before using append or read operations.
+     */
+    public synchronized void initialize() {
+        if (queue != null) {
+            return;
+        }
+
+        try {
+            Path queuePath = Paths.get(basePath, transactionId);
+            Files.createDirectories(queuePath);
+
+            LOGGER.debug("Creating Chronicle Queue for transaction {} at path {} with roll cycle {}",
+                    transactionId, queuePath, rollCycleName);
+
+            RollCycles rollCycle = RollCycles.valueOf(rollCycleName);
+            queue = SingleChronicleQueueBuilder.single(queuePath.toString())
+                    .rollCycle(rollCycle)
+                    .build();
+
+            appender = queue.createAppender();
+
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to create Chronicle Queue directory for transaction " + transactionId, e);
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to initialize Chronicle Queue for transaction " + transactionId, e);
+        }
+    }
+
+    /**
+     * Gets an appender for writing to the queue.
+     * Must call initialize() first.
+     *
+     * @return the appender instance
+     */
+    public ExcerptAppender getAppender() {
+        if (appender == null) {
+            throw new IllegalStateException("ChronicleQueueWrapper not initialized for transaction " + transactionId);
+        }
+        return appender;
+    }
+
+    /**
+     * Creates a new tailer for reading from the queue.
+     * Must call initialize() first.
+     *
+     * @return a new tailer instance positioned at the start
+     */
+    public ExcerptTailer createTailer() {
+        if (queue == null) {
+            throw new IllegalStateException("ChronicleQueueWrapper not initialized for transaction " + transactionId);
+        }
+        return queue.createTailer();
+    }
+
+    public boolean isInitialized() {
+        return queue != null;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
+     * Deletes the queue directory and all its contents.
+     * The queue must be closed before calling this method.
+     */
+    public void deleteQueueDirectory() {
+        if (queue != null) {
+            throw new IllegalStateException("Queue must be closed before deleting directory for transaction " + transactionId);
+        }
+
+        try {
+            Path queuePath = Paths.get(basePath, transactionId);
+            if (Files.exists(queuePath)) {
+                LOGGER.debug("Deleting Chronicle Queue directory for transaction {} at path {}", transactionId, queuePath);
+                deleteDirectoryRecursively(queuePath);
+            }
+        }
+        catch (IOException e) {
+            LOGGER.warn("Failed to delete Chronicle Queue directory for transaction {}", transactionId, e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (appender != null) {
+            try {
+                appender.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error closing Chronicle Queue appender for transaction {}", transactionId, e);
+            }
+            appender = null;
+        }
+
+        if (queue != null) {
+            try {
+                queue.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error closing Chronicle Queue for transaction {}", transactionId, e);
+            }
+            queue = null;
+        }
+    }
+
+    private static void deleteDirectoryRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+
+        try (Stream<Path> stream = Files.walk(path)) {
+            List<Path> paths = stream.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path p : paths) {
+                Files.deleteIfExists(p);
+            }
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleTransaction.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.buffered.AbstractTransaction;
+
+/**
+ * A {@link AbstractTransaction} implementation for the Chronicle Queue spill-to-disk buffer.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleTransaction extends AbstractTransaction {
+
+    private int numberOfEvents;
+    private static final long UNASSIGNED_INDEX = -1L;
+    private long startQueueIndex = UNASSIGNED_INDEX;
+
+    public ChronicleTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThread, String clientId) {
+        super(transactionId, startScn, changeTime, userName, redoThread, clientId);
+        start();
+    }
+
+    public ChronicleTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThread, int numberOfEvents, String clientId) {
+        super(transactionId, startScn, changeTime, userName, redoThread, clientId);
+        this.numberOfEvents = numberOfEvents;
+    }
+
+    @Override
+    public int getNumberOfEvents() {
+        return numberOfEvents;
+    }
+
+    @Override
+    public int getNextEventId() {
+        return numberOfEvents++;
+    }
+
+    public void setStartQueueIndex(long index) {
+        this.startQueueIndex = index;
+    }
+
+    public long getStartQueueIndex() {
+        return startQueueIndex;
+    }
+
+    @Override
+    public void start() {
+        numberOfEvents = 0;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleTransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/ChronicleTransactionFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle;
+
+import io.debezium.connector.oracle.logminer.buffered.TransactionFactory;
+import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+
+/**
+ * Transaction factory implementation for {@link ChronicleTransaction}.
+ *
+ * @author Debezium Authors
+ */
+public class ChronicleTransactionFactory implements TransactionFactory<ChronicleTransaction> {
+    @Override
+    public ChronicleTransaction createTransaction(LogMinerEventRow event) {
+        return new ChronicleTransaction(event.getTransactionId(), event.getScn(), event.getChangeTime(),
+                event.getUserName(), event.getThread(), event.getClientId());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/DmlEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/DmlEventSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.DmlEvent;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for DML events
+ */
+public class DmlEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_DML_EVENT;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof DmlEvent)) {
+            throw new DebeziumException("Expected DmlEvent but got " + event.getClass().getSimpleName());
+        }
+
+        DmlEvent dmlEvent = (DmlEvent) event;
+        LogMinerDmlEntry dmlEntry = dmlEvent.getDmlEntry();
+
+        writeCommonFields(valueOut, event);
+
+        writeValuesArray(valueOut, dmlEntry.getOldValues());
+
+        writeValuesArray(valueOut, dmlEntry.getNewValues());
+
+        writeString(valueOut, dmlEntry.getObjectOwner());
+        writeString(valueOut, dmlEntry.getObjectName());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        Object[] oldValues = readValuesArray(valueIn);
+
+        Object[] newValues = readValuesArray(valueIn);
+
+        String objectOwner = readString(valueIn);
+        String objectName = readString(valueIn);
+
+        LogMinerDmlEntry dmlEntry = new LogMinerDmlEntryImpl(
+                eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+
+        return new DmlEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/ExtendedStringBeginEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/ExtendedStringBeginEventSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringBeginEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for ExtendedStringBeginEvent.
+ */
+public class ExtendedStringBeginEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_EXTENDED_STRING_BEGIN;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof ExtendedStringBeginEvent)) {
+            throw new DebeziumException("Expected ExtendedStringBeginEvent but got " + event.getClass().getSimpleName());
+        }
+
+        ExtendedStringBeginEvent extendedStringEvent = (ExtendedStringBeginEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, extendedStringEvent.getColumnName());
+
+        writeDmlEntry(valueOut, extendedStringEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String columnName = readString(valueIn);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(valueIn, eventType);
+
+        return new ExtendedStringBeginEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/ExtendedStringWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/ExtendedStringWriteEventSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for {@link ExtendedStringWriteEvent}.
+ *
+ * @author Debezium Authors
+ */
+public class ExtendedStringWriteEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_EXTENDED_STRING_WRITE;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof ExtendedStringWriteEvent)) {
+            throw new DebeziumException("Expected ExtendedStringWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        ExtendedStringWriteEvent writeEvent = (ExtendedStringWriteEvent) event;
+
+        writeCommonFields(valueOut, event);
+        writeString(valueOut, writeEvent.getData());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+        String data = readString(valueIn);
+
+        return new ExtendedStringWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(), data);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/LobEraseEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/LobEraseEventSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LobEraseEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for {@link LobEraseEvent}.
+ *
+ * @author Debezium Authors
+ */
+public class LobEraseEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_LOB_ERASE;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof LobEraseEvent)) {
+            throw new DebeziumException("Expected LobEraseEvent but got " + event.getClass().getSimpleName());
+        }
+
+        // LobEraseEvent has no additional fields beyond the base LogMinerEvent
+        writeCommonFields(valueOut, event);
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        return new LobEraseEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/LobWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/LobWriteEventSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LobWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for LobWriteEvent.
+ */
+public class LobWriteEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_LOB_WRITE;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof LobWriteEvent)) {
+            throw new DebeziumException("Expected LobWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        LobWriteEvent lobWriteEvent = (LobWriteEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, lobWriteEvent.getData());
+        valueOut.int32(lobWriteEvent.getOffset());
+        valueOut.int32(lobWriteEvent.getLength());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String data = readString(valueIn);
+        int offset = valueIn.int32();
+        int length = valueIn.int32();
+
+        return new LobWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                data, offset, length);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/RedoSqlDmlEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/RedoSqlDmlEventSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.RedoSqlDmlEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for RedoSqlDmlEvent.
+ */
+public class RedoSqlDmlEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_REDO_SQL_DML;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof RedoSqlDmlEvent)) {
+            throw new DebeziumException("Expected RedoSqlDmlEvent but got " + event.getClass().getSimpleName());
+        }
+
+        RedoSqlDmlEvent redoSqlEvent = (RedoSqlDmlEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, redoSqlEvent.getRedoSql());
+
+        writeDmlEntry(valueOut, redoSqlEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String redoSql = readString(valueIn);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(valueIn, eventType);
+
+        return new RedoSqlDmlEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, redoSql);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/SelectLobLocatorEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/SelectLobLocatorEventSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.SelectLobLocatorEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for SelectLobLocatorEvent.
+ */
+public class SelectLobLocatorEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_SELECT_LOB_LOCATOR;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof SelectLobLocatorEvent)) {
+            throw new DebeziumException("Expected SelectLobLocatorEvent but got " + event.getClass().getSimpleName());
+        }
+
+        SelectLobLocatorEvent selectLobEvent = (SelectLobLocatorEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, selectLobEvent.getColumnName());
+        valueOut.bool(selectLobEvent.isBinary());
+
+        writeDmlEntry(valueOut, selectLobEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String columnName = readString(valueIn);
+        boolean binary = valueIn.bool();
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(valueIn, eventType);
+
+        return new SelectLobLocatorEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName, binary);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/TruncateEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/TruncateEventSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.TruncateEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for TruncateEvent.
+ */
+public class TruncateEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_TRUNCATE;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof TruncateEvent)) {
+            throw new DebeziumException("Expected TruncateEvent but got " + event.getClass().getSimpleName());
+        }
+
+        TruncateEvent truncateEvent = (TruncateEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeDmlEntry(valueOut, truncateEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(valueIn, eventType);
+
+        return new TruncateEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlBeginEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlBeginEventSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlBeginEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for XmlBeginEvent.
+ */
+public class XmlBeginEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_XML_BEGIN;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof XmlBeginEvent)) {
+            throw new DebeziumException("Expected XmlBeginEvent but got " + event.getClass().getSimpleName());
+        }
+
+        XmlBeginEvent xmlBeginEvent = (XmlBeginEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, xmlBeginEvent.getColumnName());
+
+        writeDmlEntry(valueOut, xmlBeginEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String columnName = readString(valueIn);
+
+        LogMinerDmlEntry dmlEntry = readDmlEntry(valueIn, eventType);
+
+        return new XmlBeginEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlEndEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlEndEventSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlEndEvent;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for XmlEndEvent.
+ */
+public class XmlEndEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_XML_END;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof XmlEndEvent)) {
+            throw new DebeziumException("Expected XmlEndEvent but got " + event.getClass().getSimpleName());
+        }
+
+        writeCommonFields(valueOut, event);
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        return new XmlEndEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/chronicle/serialization/XmlWriteEventSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.chronicle.serialization;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.chronicle.ChronicleEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlWriteEvent;
+
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.ValueOut;
+
+/**
+ * Serializer for XmlWriteEvent.
+ */
+public class XmlWriteEventSerializer extends ChronicleEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return ChronicleEventSerializer.TYPE_XML_WRITE;
+    }
+
+    @Override
+    public void writeEvent(ValueOut valueOut, LogMinerEvent event) {
+        if (!(event instanceof XmlWriteEvent)) {
+            throw new DebeziumException("Expected XmlWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        XmlWriteEvent xmlWriteEvent = (XmlWriteEvent) event;
+
+        writeCommonFields(valueOut, event);
+
+        writeString(valueOut, xmlWriteEvent.getXml());
+        valueOut.int32(xmlWriteEvent.getLength());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(ValueIn valueIn) {
+        byte eventTypeOrdinal = valueIn.int8();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(valueIn, eventType);
+
+        String xml = readString(valueIn);
+        int length = valueIn.int32();
+
+        return new XmlWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                xml, length);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -173,6 +173,18 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
     }
 
     @Override
+    public boolean removeTransactionEventWithEventKey(EhcacheTransaction transaction, int eventKey) {
+        final var eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (eventIds != null && eventIds.contains(eventKey)) {
+            final String eventKeyStr = transaction.getEventId(eventKey);
+            eventCache.remove(eventKeyStr);
+            eventIds.remove(eventKey);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public int getTransactionEventCount(EhcacheTransaction transaction) {
         final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
         if (events != null) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryTransaction.java
@@ -24,6 +24,15 @@ public class MemoryTransaction extends AbstractTransaction {
         start();
     }
 
+    /**
+     * Copy constructor that creates a MemoryTransaction from any Transaction implementation
+     */
+    public MemoryTransaction(io.debezium.connector.oracle.logminer.buffered.Transaction source) {
+        this(source.getTransactionId(), source.getStartScn(), source.getChangeTime(),
+                source.getUserName(), Integer.valueOf(source.getRedoThreadId()),
+                source.getClientId());
+    }
+
     @Override
     public int getNumberOfEvents() {
         return numberOfEvents;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbCacheProvider.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.logminer.buffered.AbstractCacheProvider;
+import io.debezium.connector.oracle.logminer.buffered.CompositeTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.EventCountStrategy;
+import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
+import io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.SpillStrategy;
+
+/**
+ * A cache provider that uses RocksDB for the transaction cache.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbCacheProvider extends AbstractCacheProvider<RocksDbTransaction> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbCacheProvider.class);
+
+    private final CompositeTransactionCache<RocksDbTransaction> transactionCache;
+    private final RocksDbLogMinerTransactionCache spilloverCache;
+    private final RocksDbLogMinerCache<String, String> processedTransactionsCache;
+    private final RocksDbLogMinerCache<String, String> schemaChangesCache;
+    private final Path dbPath;
+
+    static {
+        RocksDB.loadLibrary();
+    }
+
+    public RocksDbCacheProvider(OracleConnectorConfig connectorConfig) {
+        if (!connectorConfig.isLogMiningBufferSpillEnabled()) {
+            throw new DebeziumException("RocksDB spill-to-disk is not enabled.");
+        }
+
+        this.dbPath = Paths.get(connectorConfig.getLogMiningBufferSpillPath());
+        long spillThreshold = connectorConfig.getLogMiningBufferSpillThreshold();
+
+        LOGGER.info("Creating RocksDB transaction cache with spill path: {} and threshold: {} events",
+                dbPath, spillThreshold);
+        LOGGER.info("Spillover data is ephemeral and will be cleaned up automatically on connector stop");
+
+        try {
+            if (Files.exists(dbPath)) {
+                Files.walkFileTree(dbPath, new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        Files.deleteIfExists(file);
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                        Files.deleteIfExists(dir);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            }
+            Files.createDirectories(dbPath);
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Could not create RocksDB directory: " + dbPath, e);
+        }
+
+        try {
+            // Create RocksDB Options from config
+            Options options = new Options()
+                    .setCreateIfMissing(true)
+                    .setMaxBackgroundJobs(connectorConfig.getRocksDbMaxBackgroundJobs())
+                    .setWriteBufferSize(connectorConfig.getRocksDbWriteBufferSizeMb() * 1024 * 1024)
+                    .setMaxWriteBufferNumber(connectorConfig.getRocksDbMaxWriteBufferNumber())
+                    .setTargetFileSizeBase(connectorConfig.getRocksDbTargetFileSizeMb() * 1024 * 1024)
+                    .setMaxBytesForLevelBase(connectorConfig.getRocksDbMaxBytesForLevelBaseMb() * 1024 * 1024);
+
+            // Set compression types
+            String compression = connectorConfig.getRocksDbCompression();
+            if ("LZ4".equalsIgnoreCase(compression)) {
+                options.setCompressionType(org.rocksdb.CompressionType.LZ4_COMPRESSION);
+            }
+            else if ("SNAPPY".equalsIgnoreCase(compression)) {
+                options.setCompressionType(org.rocksdb.CompressionType.SNAPPY_COMPRESSION);
+            }
+            else if ("ZSTD".equalsIgnoreCase(compression)) {
+                options.setCompressionType(org.rocksdb.CompressionType.ZSTD_COMPRESSION);
+            }
+            else if ("NONE".equalsIgnoreCase(compression)) {
+                options.setCompressionType(org.rocksdb.CompressionType.NO_COMPRESSION);
+            }
+            else {
+                throw new DebeziumException("Unsupported RocksDB compression type: " + compression);
+            }
+
+            String bottommostCompression = connectorConfig.getRocksDbBottommostCompression();
+            if ("LZ4".equalsIgnoreCase(bottommostCompression)) {
+                options.setBottommostCompressionType(org.rocksdb.CompressionType.LZ4_COMPRESSION);
+            }
+            else if ("SNAPPY".equalsIgnoreCase(bottommostCompression)) {
+                options.setBottommostCompressionType(org.rocksdb.CompressionType.SNAPPY_COMPRESSION);
+            }
+            else if ("ZSTD".equalsIgnoreCase(bottommostCompression)) {
+                options.setBottommostCompressionType(org.rocksdb.CompressionType.ZSTD_COMPRESSION);
+            }
+            else if ("NONE".equalsIgnoreCase(bottommostCompression)) {
+                options.setBottommostCompressionType(org.rocksdb.CompressionType.NO_COMPRESSION);
+            }
+            else {
+                throw new DebeziumException("Unsupported RocksDB bottommost compression type: " + bottommostCompression);
+            }
+
+            DBOptions dbOptions = new DBOptions(options);
+
+            // Create the spillover cache with configured options
+            this.spilloverCache = new RocksDbLogMinerTransactionCache(dbPath.toString(), options, dbOptions, connectorConfig.getRocksDbBatchFlushThreshold());
+            SpillStrategy strategy = new EventCountStrategy(spillThreshold);
+
+            // Create the composite transaction store with configured index threshold
+            int indexThreshold = connectorConfig.getLogMiningBufferSpillInMemoryIndexThreshold();
+            this.transactionCache = new CompositeTransactionCache<RocksDbTransaction>(this.spilloverCache, strategy, indexThreshold);
+
+            // Create column families for processedTransactions and schemaChanges caches
+            ColumnFamilyHandle processedTransactionsCF = spilloverCache.createColumnFamily(PROCESSED_TRANSACTIONS_CACHE_NAME);
+            ColumnFamilyHandle schemaChangesCF = spilloverCache.createColumnFamily(SCHEMA_CHANGES_CACHE_NAME);
+
+            // Create RocksDB-backed caches for processedTransactions and schemaChanges
+            this.processedTransactionsCache = new RocksDbLogMinerCache<>(
+                    spilloverCache.getDb(),
+                    processedTransactionsCF,
+                    PROCESSED_TRANSACTIONS_CACHE_NAME);
+            this.schemaChangesCache = new RocksDbLogMinerCache<>(
+                    spilloverCache.getDb(),
+                    schemaChangesCF,
+                    SCHEMA_CHANGES_CACHE_NAME);
+        }
+        catch (Exception e) {
+            throw new DebeziumException("Failed to create RocksDB transaction cache", e);
+        }
+    }
+
+    @Override
+    public LogMinerTransactionCache<RocksDbTransaction> getTransactionCache() {
+        return transactionCache;
+    }
+
+    @Override
+    public LogMinerCache<String, String> getSchemaChangesCache() {
+        return schemaChangesCache;
+    }
+
+    @Override
+    public LogMinerCache<String, String> getProcessedTransactionsCache() {
+        return processedTransactionsCache;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (transactionCache != null) {
+            transactionCache.clear();
+            spilloverCache.close();
+            // Remove the RocksDB directory so spillover data is ephemeral across connector restarts
+            try {
+                if (Files.exists(dbPath)) {
+                    Files.walkFileTree(dbPath, new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                            Files.deleteIfExists(file);
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                            Files.deleteIfExists(dir);
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            catch (IOException e) {
+                LOGGER.warn("Failed to delete RocksDB spill directory {}: {}", dbPath, e.getMessage());
+            }
+
+            LOGGER.info("Cleaned up and removed RocksDB spill directories and closed database (spillover data is ephemeral)");
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbEventSerializer.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.relational.TableId;
+
+/**
+ * RocksDB serializer for LogMinerEvent objects.
+ * @author Debezium Authors
+ */
+public class RocksDbEventSerializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbEventSerializer.class);
+
+    public static final byte TYPE_DML_EVENT = 1;
+    public static final byte TYPE_SELECT_LOB_LOCATOR = 2;
+    public static final byte TYPE_EXTENDED_STRING_BEGIN = 3;
+    public static final byte TYPE_XML_BEGIN = 4;
+    public static final byte TYPE_XML_WRITE = 5;
+    public static final byte TYPE_XML_END = 6;
+    public static final byte TYPE_LOB_WRITE = 7;
+    public static final byte TYPE_TRUNCATE = 8;
+    public static final byte TYPE_REDO_SQL_DML = 9;
+    public static final byte TYPE_GENERIC_LOG_MINER_EVENT = 10;
+    public static final byte TYPE_LOB_ERASE = 11;
+    public static final byte TYPE_EXTENDED_STRING_WRITE = 12;
+
+    static final byte VALUE_TYPE_NULL = 0;
+    static final byte VALUE_TYPE_STRING = 1;
+    static final byte VALUE_TYPE_INTEGER = 2;
+    static final byte VALUE_TYPE_LONG = 3;
+    static final byte VALUE_TYPE_DOUBLE = 4;
+    static final byte VALUE_TYPE_FLOAT = 5;
+    static final byte VALUE_TYPE_BOOLEAN = 6;
+    static final byte VALUE_TYPE_BIG_DECIMAL = 7;
+    static final byte VALUE_TYPE_BYTES = 8;
+    static final byte VALUE_TYPE_UNAVAILABLE = 9;
+
+    private static final String UNAVAILABLE_VALUE_SENTINEL = "$$DBZ-UNAVAILABLE-VALUE$$";
+    public static final long NULL_SCN = -1L;
+    public static final long NULL_CHANGE_TIME = Long.MIN_VALUE;
+    // Marker used when serializing arrays to indicate 'null' array
+    public static final int ARRAY_NULL_COUNT = -1;
+
+    /**
+     * Convert Instant to epoch microseconds for storage.
+     */
+    public static long instantToMicros(Instant instant) {
+        return (instant != null) ? instant.toEpochMilli() * 1000 : NULL_CHANGE_TIME;
+    }
+
+    /**
+     * Convert stored epoch microseconds back to Instant.
+     */
+    public static Instant microsToInstant(long micros) {
+        return (micros == NULL_CHANGE_TIME) ? null : Instant.ofEpochMilli(micros / 1000);
+    }
+
+    /**
+     * Writes a LogMinerEvent to RocksDB storage.
+     *
+     * @param out the output stream
+     * @param eventKey the event key within the transaction
+     * @param event the LogMinerEvent to write
+     * @throws IOException if an I/O error occurs
+     */
+    public static void writeEvent(DataOutputStream out, int eventKey, LogMinerEvent event) throws IOException {
+        out.writeInt(eventKey);
+
+        EventSerializerStrategy serializer = RocksDbEventSerializerRegistry.getSerializer(event.getClass());
+
+        out.writeByte(serializer.getTypeId());
+
+        serializer.writeEvent(out, event);
+    }
+
+    /**
+     * Reads a LogMinerEvent from RocksDB storage.
+     *
+     * @param in the input stream
+     * @return the reconstructed LogMinerEvent
+     * @throws IOException if an I/O error occurs
+     */
+    public static LogMinerEvent readEvent(DataInputStream in) throws IOException {
+        in.readInt(); // eventKey - consumed but not returned
+
+        byte typeId = in.readByte();
+
+        EventSerializerStrategy deserializer = RocksDbEventSerializerRegistry.getDeserializer(typeId);
+
+        return deserializer.readEvent(in);
+    }
+
+    /**
+     * Serializes a LogMinerEvent to a byte array.
+     *
+     * @param event the LogMinerEvent to serialize
+     * @return the serialized byte array
+     * @throws DebeziumException if serialization fails
+     */
+    public static byte[] serialize(LogMinerEvent event) {
+        try (java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+                java.io.DataOutputStream dos = new java.io.DataOutputStream(baos)) {
+            writeEvent(dos, 0, event); // eventKey is not used in this context
+            return baos.toByteArray();
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to serialize event", e);
+        }
+    }
+
+    /**
+     * Deserializes a LogMinerEvent from a byte array.
+     *
+     * @param data the byte array to deserialize
+     * @return the deserialized LogMinerEvent
+     * @throws DebeziumException if deserialization fails
+     */
+    public static LogMinerEvent deserialize(byte[] data) {
+        try (java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(data);
+                java.io.DataInputStream dis = new java.io.DataInputStream(bais)) {
+            return readEvent(dis);
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to deserialize event", e);
+        }
+    }
+
+    // Strategy interface for event serialization
+    public interface EventSerializerStrategy {
+        /**
+         * @return The unique byte identifier for the event type.
+         */
+        byte getTypeId();
+
+        /**
+         * Writes the event-specific fields to the output stream.
+         *
+         * @param out the output stream
+         * @param event the event to write
+         * @throws IOException if an I/O error occurs
+         */
+        void writeEvent(DataOutputStream out, LogMinerEvent event) throws IOException;
+
+        /**
+         * Reads the event-specific fields from the input stream.
+         *
+         * @param in the input stream
+         * @return the reconstructed LogMinerEvent
+         * @throws IOException if an I/O error occurs
+         */
+        LogMinerEvent readEvent(DataInputStream in) throws IOException;
+    }
+
+    // Base serializer with common functionality
+    public abstract static class BaseEventSerializer implements EventSerializerStrategy {
+
+        protected void writeCommonFields(DataOutputStream out, LogMinerEvent event) throws IOException {
+            out.writeByte((byte) event.getEventType().ordinal());
+
+            long scnValue = event.getScn().isNull() ? NULL_SCN : event.getScn().longValue();
+            out.writeLong(scnValue);
+
+            long changeTimeMicros = instantToMicros(event.getChangeTime());
+            out.writeLong(changeTimeMicros);
+
+            TableId tableId = event.getTableId();
+            writeString(out, tableId.catalog());
+            writeString(out, tableId.schema());
+            writeString(out, tableId.table());
+
+            writeString(out, event.getRowId());
+            writeString(out, event.getRsId());
+        }
+
+        protected LogMinerEvent readCommonFields(DataInputStream in, EventType eventType) throws IOException {
+            long scnValue = in.readLong();
+            Scn scn = scnValue == NULL_SCN ? Scn.NULL : Scn.valueOf(scnValue);
+
+            long changeTimeMicros = in.readLong();
+            Instant changeTime = microsToInstant(changeTimeMicros);
+
+            String catalog = readString(in);
+            String schema = readString(in);
+            String table = readString(in);
+            TableId tableId = new TableId(catalog, schema, table);
+
+            String rowId = readString(in);
+            String rsId = readString(in);
+
+            return new LogMinerEvent(eventType, scn, tableId, rowId, rsId, changeTime);
+        }
+
+        protected void writeString(DataOutputStream out, String str) throws IOException {
+            if (str == null) {
+                out.writeBoolean(true); // null flag = true (consistent with ehcache)
+            }
+            else {
+                out.writeBoolean(false); // null flag = false (consistent with ehcache)
+                // Use custom UTF-8 encoding for large strings to avoid writeUTF 64KB limit
+                byte[] utf8Bytes = str.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                out.writeInt(utf8Bytes.length);
+                out.write(utf8Bytes);
+            }
+        }
+
+        protected String readString(DataInputStream in) throws IOException {
+            boolean isNull = in.readBoolean();
+            if (isNull) {
+                return null;
+            }
+            // Read custom UTF-8 encoding
+            int length = in.readInt();
+            byte[] utf8Bytes = new byte[length];
+            in.readFully(utf8Bytes);
+            return new String(utf8Bytes, java.nio.charset.StandardCharsets.UTF_8);
+        }
+
+        protected void writeObject(DataOutputStream out, Object value) throws IOException {
+            if (value == null) {
+                out.writeByte(VALUE_TYPE_NULL);
+            }
+            else if (value == OracleValueConverters.UNAVAILABLE_VALUE) {
+                out.writeByte(VALUE_TYPE_UNAVAILABLE);
+                writeString(out, UNAVAILABLE_VALUE_SENTINEL);
+            }
+            else if (value instanceof String) {
+                out.writeByte(VALUE_TYPE_STRING);
+                writeString(out, (String) value);
+            }
+            else if (value instanceof Integer) {
+                out.writeByte(VALUE_TYPE_INTEGER);
+                out.writeInt((Integer) value);
+            }
+            else if (value instanceof Long) {
+                out.writeByte(VALUE_TYPE_LONG);
+                out.writeLong((Long) value);
+            }
+            else if (value instanceof Double) {
+                out.writeByte(VALUE_TYPE_DOUBLE);
+                out.writeDouble((Double) value);
+            }
+            else if (value instanceof Float) {
+                out.writeByte(VALUE_TYPE_FLOAT);
+                out.writeFloat((Float) value);
+            }
+            else if (value instanceof Boolean) {
+                out.writeByte(VALUE_TYPE_BOOLEAN);
+                out.writeBoolean((Boolean) value);
+            }
+            else if (value instanceof java.math.BigDecimal) {
+                out.writeByte(VALUE_TYPE_BIG_DECIMAL);
+                writeString(out, value.toString());
+            }
+            else if (value instanceof byte[]) {
+                out.writeByte(VALUE_TYPE_BYTES);
+                byte[] bytes = (byte[]) value;
+                out.writeInt(bytes.length);
+                out.write(bytes);
+            }
+            else if (value instanceof java.nio.ByteBuffer) {
+                java.nio.ByteBuffer buffer = (java.nio.ByteBuffer) value;
+                out.writeByte(VALUE_TYPE_BYTES);
+                out.writeInt(buffer.remaining());
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.duplicate().get(bytes);
+                out.write(bytes);
+            }
+            else {
+                LOGGER.debug("Unknown object type {} serializing as string: {}",
+                        value.getClass().getName(), value);
+                out.writeByte(VALUE_TYPE_STRING);
+                writeString(out, value.toString());
+            }
+        }
+
+        protected Object readObject(DataInputStream in) throws IOException {
+            byte typeMarker = in.readByte();
+            switch (typeMarker) {
+                case VALUE_TYPE_NULL:
+                    return null;
+                case VALUE_TYPE_UNAVAILABLE:
+                    String stringValue = readString(in);
+                    if (UNAVAILABLE_VALUE_SENTINEL.equals(stringValue)) {
+                        return OracleValueConverters.UNAVAILABLE_VALUE;
+                    }
+                    return stringValue;
+                case VALUE_TYPE_STRING:
+                    return readString(in);
+                case VALUE_TYPE_INTEGER:
+                    return in.readInt();
+                case VALUE_TYPE_LONG:
+                    return in.readLong();
+                case VALUE_TYPE_DOUBLE:
+                    return in.readDouble();
+                case VALUE_TYPE_FLOAT:
+                    return in.readFloat();
+                case VALUE_TYPE_BOOLEAN:
+                    return in.readBoolean();
+                case VALUE_TYPE_BIG_DECIMAL:
+                    return new java.math.BigDecimal(readString(in));
+                case VALUE_TYPE_BYTES:
+                    int length = in.readInt();
+                    byte[] bytes = new byte[length];
+                    in.readFully(bytes);
+                    return bytes;
+                default:
+                    throw new DebeziumException("Unknown value type marker: " + typeMarker);
+            }
+        }
+
+        /**
+         * Writes an array of values using the protected writeObject helper. Uses -1 to mark null arrays.
+         */
+        protected void writeValuesArray(DataOutputStream out, Object[] values) throws IOException {
+            if (values == null) {
+                out.writeInt(ARRAY_NULL_COUNT);
+                return;
+            }
+            out.writeInt(values.length);
+            for (Object value : values) {
+                writeObject(out, value);
+            }
+        }
+
+        /**
+         * Reads an array of values using the protected readObject helper. Returns null when -1 marker is read.
+         */
+        protected Object[] readValuesArray(DataInputStream in) throws IOException {
+            int length = in.readInt();
+            if (length == ARRAY_NULL_COUNT) {
+                return null;
+            }
+            Object[] values = new Object[length];
+            for (int i = 0; i < length; i++) {
+                values[i] = readObject(in);
+            }
+            return values;
+        }
+    }
+
+    // Record to hold eventKey and event together
+    public record EventKeyAndEvent(int eventKey, LogMinerEvent event) {
+    }
+
+    // Generic serializer for base LogMinerEvent class
+    public static class GenericLogMinerEventSerializer extends BaseEventSerializer {
+
+        @Override
+        public byte getTypeId() {
+            return TYPE_GENERIC_LOG_MINER_EVENT;
+        }
+
+        @Override
+        public void writeEvent(DataOutputStream out, LogMinerEvent event) throws IOException {
+            // Write common fields only - no additional DML-specific data
+            writeCommonFields(out, event);
+        }
+
+        @Override
+        public LogMinerEvent readEvent(DataInputStream in) throws IOException {
+            // Read event type
+            byte eventTypeOrdinal = in.readByte();
+            EventType eventType = EventType.values()[eventTypeOrdinal];
+
+            // Read common fields
+            return readCommonFields(in, eventType);
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbEventSerializerRegistry.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbEventSerializerRegistry.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.DmlEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.ExtendedStringBeginEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.ExtendedStringWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.LobEraseEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.LobWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.RedoSqlDmlEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.SelectLobLocatorEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.TruncateEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.XmlBeginEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.XmlEndEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.XmlWriteEventSerializer;
+import io.debezium.connector.oracle.logminer.events.DmlEvent;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringBeginEvent;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LobEraseEvent;
+import io.debezium.connector.oracle.logminer.events.LobWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.RedoSqlDmlEvent;
+import io.debezium.connector.oracle.logminer.events.SelectLobLocatorEvent;
+import io.debezium.connector.oracle.logminer.events.TruncateEvent;
+import io.debezium.connector.oracle.logminer.events.XmlBeginEvent;
+import io.debezium.connector.oracle.logminer.events.XmlEndEvent;
+import io.debezium.connector.oracle.logminer.events.XmlWriteEvent;
+
+/**
+ * Registry for mapping LogMinerEvent classes to their corresponding RocksDB serializers.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbEventSerializerRegistry {
+
+    private static final Map<Class<? extends LogMinerEvent>, RocksDbEventSerializer.EventSerializerStrategy> SERIALIZER_REGISTRY = createSerializerRegistry();
+    private static final Map<Byte, RocksDbEventSerializer.EventSerializerStrategy> TYPE_ID_REGISTRY = createTypeIdRegistry();
+    /**
+     * Map from type id to the serializer's class name. Helpful for debugging/logging.
+     */
+    private static final Map<Byte, String> TYPE_ID_TO_CLASS_NAME = createTypeIdToClassNameRegistry();
+
+    private static Map<Class<? extends LogMinerEvent>, RocksDbEventSerializer.EventSerializerStrategy> createSerializerRegistry() {
+        final Map<Class<? extends LogMinerEvent>, RocksDbEventSerializer.EventSerializerStrategy> map = new HashMap<>();
+
+        // Explicitly map event classes to their serializers. This is clearer and easier to
+        // extend than relying on instanceof checks during registration.
+        map.put(DmlEvent.class, new DmlEventSerializer());
+        map.put(SelectLobLocatorEvent.class, new SelectLobLocatorEventSerializer());
+        map.put(ExtendedStringBeginEvent.class, new ExtendedStringBeginEventSerializer());
+        map.put(LobWriteEvent.class, new LobWriteEventSerializer());
+        map.put(LobEraseEvent.class, new LobEraseEventSerializer());
+        map.put(TruncateEvent.class, new TruncateEventSerializer());
+        map.put(XmlBeginEvent.class, new XmlBeginEventSerializer());
+        map.put(XmlWriteEvent.class, new XmlWriteEventSerializer());
+        map.put(XmlEndEvent.class, new XmlEndEventSerializer());
+        map.put(RedoSqlDmlEvent.class, new RedoSqlDmlEventSerializer());
+        map.put(ExtendedStringWriteEvent.class, new ExtendedStringWriteEventSerializer());
+
+        return java.util.Collections.unmodifiableMap(map);
+    }
+
+    private static Map<Byte, RocksDbEventSerializer.EventSerializerStrategy> createTypeIdRegistry() {
+        final Map<Byte, RocksDbEventSerializer.EventSerializerStrategy> map = new HashMap<>();
+
+        // Populate type id -> serializer map from the serializer instances in the serializer registry
+        for (RocksDbEventSerializer.EventSerializerStrategy serializer : SERIALIZER_REGISTRY.values()) {
+            map.put(serializer.getTypeId(), serializer);
+        }
+
+        // Add generic serializer for base LogMinerEvent class
+        map.put(RocksDbEventSerializer.TYPE_GENERIC_LOG_MINER_EVENT, new RocksDbEventSerializer.GenericLogMinerEventSerializer());
+
+        return java.util.Collections.unmodifiableMap(map);
+    }
+
+    private static Map<Byte, String> createTypeIdToClassNameRegistry() {
+        final Map<Byte, String> map = new HashMap<>();
+        for (Map.Entry<Byte, RocksDbEventSerializer.EventSerializerStrategy> e : createTypeIdRegistry().entrySet()) {
+            map.put(e.getKey(), e.getValue().getClass().getName());
+        }
+        return java.util.Collections.unmodifiableMap(map);
+    }
+
+    public static RocksDbEventSerializer.EventSerializerStrategy getSerializer(Class<? extends LogMinerEvent> eventClass) {
+        RocksDbEventSerializer.EventSerializerStrategy serializer = SERIALIZER_REGISTRY.get(eventClass);
+        if (serializer != null) {
+            return serializer;
+        }
+        // For base LogMinerEvent class, return the generic serializer instance
+        if (eventClass == LogMinerEvent.class) {
+            return TYPE_ID_REGISTRY.get(RocksDbEventSerializer.TYPE_GENERIC_LOG_MINER_EVENT);
+        }
+        // Default to DML serializer for unknown types (preserve previous behaviour)
+        return SERIALIZER_REGISTRY.get(DmlEvent.class);
+    }
+
+    public static RocksDbEventSerializer.EventSerializerStrategy getDeserializer(byte typeId) {
+        RocksDbEventSerializer.EventSerializerStrategy deserializer = TYPE_ID_REGISTRY.get(typeId);
+        if (deserializer == null) {
+            String className = TYPE_ID_TO_CLASS_NAME.get(typeId);
+            throw new IllegalArgumentException("Unknown event type ID for RocksDB deserialization: " + typeId
+                    + (className != null ? (" (expected: " + className + ")") : ""));
+        }
+        return deserializer;
+    }
+
+    /**
+     * Returns the serializer class name associated with a type id, if available.
+     */
+    public static String getSerializerClassNameForTypeId(byte typeId) {
+        return TYPE_ID_TO_CLASS_NAME.get(typeId);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbLogMinerCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbLogMinerCache.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.LogMinerCache;
+
+/**
+ * An implementation of {@link LogMinerCache} for RocksDB backed disk caches.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbLogMinerCache<K, V> implements LogMinerCache<K, V> {
+
+    private final RocksDB db;
+    private final ColumnFamilyHandle columnFamily;
+    private final String cacheName;
+
+    public RocksDbLogMinerCache(RocksDB db, ColumnFamilyHandle columnFamily, String cacheName) {
+        this.db = db;
+        this.columnFamily = columnFamily;
+        this.cacheName = cacheName;
+    }
+
+    @Override
+    public void entries(Consumer<Stream<Entry<K, V>>> streamConsumer) {
+        List<Entry<K, V>> entries = new ArrayList<>();
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                @SuppressWarnings("unchecked")
+                K key = (K) new String(iterator.key(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                V value = (V) new String(iterator.value(), StandardCharsets.UTF_8);
+                entries.add(new Entry<>(key, value));
+                iterator.next();
+            }
+        }
+        streamConsumer.accept(entries.stream());
+    }
+
+    @Override
+    public void clear() {
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                db.delete(columnFamily, iterator.key());
+                iterator.next();
+            }
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to clear RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public V get(K key) {
+        try {
+            byte[] keyBytes = key.toString().getBytes(StandardCharsets.UTF_8);
+            byte[] valueBytes = db.get(columnFamily, keyBytes);
+            if (valueBytes == null) {
+                return null;
+            }
+            @SuppressWarnings("unchecked")
+            V value = (V) new String(valueBytes, StandardCharsets.UTF_8);
+            return value;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to get value from RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            return !iterator.isValid();
+        }
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        try {
+            byte[] keyBytes = key.toString().getBytes(StandardCharsets.UTF_8);
+            byte[] value = db.get(columnFamily, keyBytes);
+            return value != null;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to check key existence in RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public void put(K key, V value) {
+        try {
+            byte[] keyBytes = key.toString().getBytes(StandardCharsets.UTF_8);
+            byte[] valueBytes = value.toString().getBytes(StandardCharsets.UTF_8);
+            db.put(columnFamily, keyBytes, valueBytes);
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to put value into RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public V remove(K key) {
+        try {
+            byte[] keyBytes = key.toString().getBytes(StandardCharsets.UTF_8);
+            byte[] valueBytes = db.get(columnFamily, keyBytes);
+            if (valueBytes != null) {
+                db.delete(columnFamily, keyBytes);
+                @SuppressWarnings("unchecked")
+                V value = (V) new String(valueBytes, StandardCharsets.UTF_8);
+                return value;
+            }
+            return null;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to remove value from RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public int size() {
+        int count = 0;
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                count++;
+                iterator.next();
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public void forEach(BiConsumer<K, V> action) {
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                @SuppressWarnings("unchecked")
+                K key = (K) new String(iterator.key(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                V value = (V) new String(iterator.value(), StandardCharsets.UTF_8);
+                action.accept(key, value);
+                iterator.next();
+            }
+        }
+    }
+
+    @Override
+    public void removeIf(Predicate<Entry<K, V>> predicate) {
+        List<byte[]> keysToRemove = new ArrayList<>();
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                @SuppressWarnings("unchecked")
+                K key = (K) new String(iterator.key(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                V value = (V) new String(iterator.value(), StandardCharsets.UTF_8);
+                if (predicate.test(new Entry<>(key, value))) {
+                    keysToRemove.add(iterator.key());
+                }
+                iterator.next();
+            }
+        }
+
+        try {
+            for (byte[] keyBytes : keysToRemove) {
+                db.delete(columnFamily, keyBytes);
+            }
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to remove entries from RocksDB cache: " + cacheName, e);
+        }
+    }
+
+    @Override
+    public <T> T streamAndReturn(Function<Stream<Entry<K, V>>, T> function) {
+        List<Entry<K, V>> entries = new ArrayList<>();
+        try (RocksIterator iterator = db.newIterator(columnFamily)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                @SuppressWarnings("unchecked")
+                K key = (K) new String(iterator.key(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                V value = (V) new String(iterator.value(), StandardCharsets.UTF_8);
+                entries.add(new Entry<>(key, value));
+                iterator.next();
+            }
+        }
+        try (Stream<Entry<K, V>> stream = entries.stream()) {
+            return function.apply(stream);
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbLogMinerTransactionCache.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.FlushOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.AbstractLogMinerTransactionCache;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.RocksDbKeySerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization.RocksDbTransactionSerializer;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * A {@link io.debezium.connector.oracle.logminer.buffered.LogMinerTransactionCache} that uses RocksDB as the backing store.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbLogMinerTransactionCache extends AbstractLogMinerTransactionCache<RocksDbTransaction> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbLogMinerTransactionCache.class);
+
+    // Static byte arrays for column family names to avoid repeated allocations
+    private static final byte[] EVENTS_CF_NAME = "events".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] ROW_ID_INDEX_CF_NAME = "rowIdIndex".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TRANSACTIONS_CF_NAME = "transactions".getBytes(StandardCharsets.UTF_8);
+
+    private RocksDB db;
+    private DBOptions dbOptions; // Keep reference for proper resource management
+    private WriteOptions writeOptions; // Write options with WAL disabled for performance
+
+    // Use single column family for all transaction events (performance improvement)
+    private ColumnFamilyHandle eventsColumnFamily;
+    private ColumnFamilyHandle rowIdIndexColumnFamily; // Secondary index for rowId lookups
+    private ColumnFamilyHandle transactionsColumnFamily; // Stores transaction metadata (username etc.)
+
+    // Heap-backed cache for quick access to specific metadata
+    private final Map<String, TreeSet<Integer>> eventIdsByTransactionId = new HashMap<>();
+
+    // Batch flushing for better performance
+    private final int batchFlushThreshold;
+    private int pendingWrites = 0;
+
+    @SuppressWarnings("resource")
+    public RocksDbLogMinerTransactionCache(String dbPath, Options options, DBOptions dbOptions, int batchFlushThreshold) {
+        this.dbOptions = dbOptions;
+        this.batchFlushThreshold = batchFlushThreshold;
+        // Disable WAL since this is a spillover cache - data can be regenerated from source
+        this.writeOptions = new WriteOptions().setDisableWAL(true);
+        initializeDatabase(dbPath, options, dbOptions);
+        // Heap cache is ephemeral and built on-demand as transactions are added
+    }
+
+    private void initializeDatabase(String dbPath, Options options, DBOptions dbOptions) {
+        try {
+            List<ColumnFamilyDescriptor> existingCFDescriptors = new ArrayList<>();
+            List<ColumnFamilyHandle> existingCFHandles = new ArrayList<>();
+
+            try {
+                List<byte[]> existingCFNames = RocksDB.listColumnFamilies(options, dbPath);
+                if (existingCFNames.isEmpty()) {
+                    existingCFDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, new ColumnFamilyOptions()));
+                }
+                else {
+                    for (byte[] cfName : existingCFNames) {
+                        existingCFDescriptors.add(new ColumnFamilyDescriptor(cfName, new ColumnFamilyOptions()));
+                    }
+                }
+            }
+            catch (RocksDBException e) {
+                existingCFDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, new ColumnFamilyOptions()));
+            }
+
+            this.db = RocksDB.open(dbOptions, dbPath, existingCFDescriptors, existingCFHandles);
+
+            ColumnFamilyHandle eventsHandle = null;
+            ColumnFamilyHandle indexHandle = null;
+            ColumnFamilyHandle txHandle = null;
+
+            for (ColumnFamilyHandle handle : existingCFHandles) {
+                byte[] name = handle.getName();
+                if (java.util.Arrays.equals(name, EVENTS_CF_NAME)) {
+                    eventsHandle = handle;
+                }
+                else if (java.util.Arrays.equals(name, ROW_ID_INDEX_CF_NAME)) {
+                    indexHandle = handle;
+                }
+                else if (java.util.Arrays.equals(name, TRANSACTIONS_CF_NAME)) {
+                    txHandle = handle;
+                }
+            }
+
+            if (eventsHandle == null) {
+                ColumnFamilyDescriptor eventsDescriptor = new ColumnFamilyDescriptor(EVENTS_CF_NAME, new ColumnFamilyOptions());
+                eventsHandle = db.createColumnFamily(eventsDescriptor);
+            }
+
+            if (indexHandle == null) {
+                ColumnFamilyDescriptor indexDescriptor = new ColumnFamilyDescriptor(ROW_ID_INDEX_CF_NAME, new ColumnFamilyOptions());
+                indexHandle = db.createColumnFamily(indexDescriptor);
+            }
+
+            if (txHandle == null) {
+                ColumnFamilyDescriptor txDescriptor = new ColumnFamilyDescriptor(TRANSACTIONS_CF_NAME, new ColumnFamilyOptions());
+                txHandle = db.createColumnFamily(txDescriptor);
+            }
+
+            this.eventsColumnFamily = eventsHandle;
+            this.rowIdIndexColumnFamily = indexHandle;
+            this.transactionsColumnFamily = txHandle;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Could not open RocksDB", e);
+        }
+    }
+
+    @Override
+    public void addTransaction(RocksDbTransaction transaction) {
+        try {
+            byte[] key = transaction.getTransactionId().getBytes(StandardCharsets.UTF_8);
+            byte[] value = RocksDbTransactionSerializer.serialize(transaction);
+            db.put(transactionsColumnFamily, writeOptions, key, value);
+
+            // Initialize heap cache entry for this transaction
+            eventIdsByTransactionId.put(transaction.getTransactionId(), new TreeSet<>());
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Could not persist transaction metadata for " + transaction.getTransactionId(), e);
+        }
+    }
+
+    @Override
+    public void addTransactionEvent(RocksDbTransaction transaction, int eventKey, LogMinerEvent event) {
+
+        try {
+            byte[] compositeKey = RocksDbKeySerializer.createEventKey(transaction.getTransactionId(), eventKey);
+            byte[] serializedEvent = RocksDbEventSerializer.serialize(event);
+
+            // Log composite key as hex to avoid non-printable character pollution in logs
+            LOGGER.debug("Adding event to RocksDB: txId={}, eventKey={}, rowId={}, compositeKeyHex={}",
+                    transaction.getTransactionId(), eventKey, event.getRowId(), bytesToHex(compositeKey));
+
+            db.put(eventsColumnFamily, writeOptions, compositeKey, serializedEvent);
+
+            if (event.getRowId() != null) {
+                byte[] indexKey = RocksDbKeySerializer.createRowIdIndexKey(transaction.getTransactionId(), event.getRowId());
+                byte[] eventKeyBytes = RocksDbKeySerializer.intToBytes(eventKey);
+                db.put(rowIdIndexColumnFamily, writeOptions, indexKey, eventKeyBytes);
+                LOGGER.debug("Added secondary index: txId={}, rowId={}, eventKey={}",
+                        transaction.getTransactionId(), event.getRowId(), eventKey);
+            }
+
+            // Update heap cache with event ID
+            eventIdsByTransactionId.get(transaction.getTransactionId()).add(eventKey);
+
+            pendingWrites++;
+            if (pendingWrites >= batchFlushThreshold) {
+                db.flush(new FlushOptions(), eventsColumnFamily);
+                db.flush(new FlushOptions(), rowIdIndexColumnFamily);
+                pendingWrites = 0;
+                LOGGER.debug("Performed batch flush after {} writes", batchFlushThreshold);
+            }
+
+            // Persist updated transaction metadata for correct event count on restore
+            try {
+                byte[] txKey = transaction.getTransactionId().getBytes(StandardCharsets.UTF_8);
+                byte[] txValue = RocksDbTransactionSerializer.serialize(transaction);
+                db.put(transactionsColumnFamily, writeOptions, txKey, txValue);
+            }
+            catch (RocksDBException e) {
+                LOGGER.warn("Failed to persist updated transaction metadata for {}: {}", transaction.getTransactionId(), e.getMessage());
+            }
+
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Could not add event to transaction " + transaction.getTransactionId(), e);
+        }
+    }
+
+    @Override
+    public boolean containsTransactionEvent(RocksDbTransaction transaction, int eventKey) {
+        // Use heap cache for fast lookup
+        final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (events != null) {
+            return events.contains(eventKey);
+        }
+        return false;
+    }
+
+    @Override
+    public LogMinerEvent getTransactionEvent(RocksDbTransaction transaction, int eventKey) {
+        try {
+            byte[] compositeKey = RocksDbKeySerializer.createEventKey(transaction.getTransactionId(), eventKey);
+            byte[] value = db.get(eventsColumnFamily, compositeKey);
+            return value != null ? RocksDbEventSerializer.deserialize(value) : null;
+        }
+        catch (RocksDBException e) {
+            LOGGER.warn("Failed to read event {} for transaction {} from RocksDB", eventKey, transaction.getTransactionId(), e);
+            // Return null and let the caller decide how to handle a missing event (like Chronicle)
+            return null;
+        }
+    }
+
+    @Override
+    public void forEachEvent(RocksDbTransaction transaction, InterruptiblePredicate<LogMinerEvent> predicate) throws InterruptedException {
+        // Use heap cache for efficient iteration
+        final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (events != null) {
+            try (var stream = events.stream()) {
+                final java.util.Iterator<Integer> iterator = stream.iterator();
+                while (iterator.hasNext()) {
+                    final LogMinerEvent event = getTransactionEvent(transaction, iterator.next());
+                    if (event != null && !predicate.test(event)) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void removeTransaction(RocksDbTransaction transaction) {
+        String txId = transaction.getTransactionId();
+
+        try {
+            byte[] prefix = txId.getBytes(StandardCharsets.UTF_8);
+
+            byte[] endKey = new byte[prefix.length];
+            System.arraycopy(prefix, 0, endKey, 0, prefix.length);
+            endKey[endKey.length - 1] = (byte) (endKey[endKey.length - 1] + 1);
+
+            db.deleteRange(eventsColumnFamily, prefix, endKey);
+
+            db.deleteRange(rowIdIndexColumnFamily, prefix, endKey);
+
+            db.delete(transactionsColumnFamily, prefix);
+
+            // Remove from heap cache
+            eventIdsByTransactionId.remove(txId);
+
+            forceFlush();
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Could not remove transaction " + txId, e);
+        }
+    }
+
+    @Override
+    public void clear() {
+        try (RocksIterator iterator = db.newIterator(transactionsColumnFamily)) {
+            for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
+                RocksDbTransaction transaction = RocksDbTransactionSerializer.deserialize(iterator.value());
+                removeTransaction(transaction);
+            }
+        }
+        // Clear heap cache
+        eventIdsByTransactionId.clear();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        // Use heap cache for fast empty check
+        return eventIdsByTransactionId.isEmpty();
+    }
+
+    @Override
+    public int getTransactionCount() {
+        // Use heap cache for fast count
+        return eventIdsByTransactionId.size();
+    }
+
+    @Override
+    public <R> R streamTransactionsAndReturn(Function<Stream<RocksDbTransaction>, R> consumer) {
+        try (RocksIterator iterator = db.newIterator(transactionsColumnFamily)) {
+            iterator.seekToFirst();
+            Stream<RocksDbTransaction> stream = StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize(
+                            new RocksDbTransactionIterator(iterator),
+                            Spliterator.ORDERED),
+                    false);
+            return consumer.apply(stream);
+        }
+    }
+
+    @Override
+    public void transactions(Consumer<Stream<RocksDbTransaction>> consumer) {
+        try (RocksIterator iterator = db.newIterator(transactionsColumnFamily)) {
+            iterator.seekToFirst();
+            Stream<RocksDbTransaction> stream = StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize(
+                            new RocksDbTransactionIterator(iterator),
+                            Spliterator.ORDERED),
+                    false);
+            consumer.accept(stream);
+        }
+    }
+
+    @Override
+    public RocksDbTransaction getTransaction(String transactionId) {
+        try {
+            byte[] key = transactionId.getBytes(StandardCharsets.UTF_8);
+            byte[] data = db.get(transactionsColumnFamily, key);
+            if (data != null) {
+                return RocksDbTransactionSerializer.deserialize(data);
+            }
+            return null;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to restore transaction metadata for " + transactionId, e);
+        }
+    }
+
+    @Override
+    public RocksDbTransaction getAndRemoveTransaction(String transactionId) {
+        RocksDbTransaction transaction = getTransaction(transactionId);
+        if (transaction != null) {
+            removeTransaction(transaction);
+        }
+        return transaction;
+    }
+
+    @Override
+    public boolean containsTransaction(String transactionId) {
+        // Use heap cache for fast containment check
+        return eventIdsByTransactionId.containsKey(transactionId);
+    }
+
+    @Override
+    public void eventKeys(Consumer<Stream<String>> consumer) {
+        Stream<String> eventKeyStream = StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                        new RocksDbTransactionIterator(db.newIterator(transactionsColumnFamily)),
+                        Spliterator.ORDERED),
+                false)
+                .flatMap(transaction -> {
+                    String transactionId = transaction.getTransactionId();
+
+                    List<String> transactionEventKeys = new ArrayList<>();
+                    try (RocksIterator iterator = db.newIterator(eventsColumnFamily)) {
+                        byte[] prefix = transactionId.getBytes(StandardCharsets.UTF_8);
+                        iterator.seek(prefix);
+
+                        while (iterator.isValid()) {
+                            byte[] key = iterator.key();
+                            if (!startsWith(key, prefix)) {
+                                break; // No more keys for this transaction
+                            }
+
+                            int eventKey = ByteBuffer.wrap(key, prefix.length, 4).getInt();
+                            transactionEventKeys.add(transaction.getEventId(eventKey));
+
+                            iterator.next();
+                        }
+                    }
+                    return transactionEventKeys.stream();
+                });
+        consumer.accept(eventKeyStream);
+    }
+
+    @Override
+    public void removeTransactionEvents(RocksDbTransaction transaction) {
+        // Remove from heap cache
+        eventIdsByTransactionId.remove(transaction.getTransactionId());
+        removeTransaction(transaction);
+    }
+
+    @Override
+    public boolean removeTransactionEventWithRowId(RocksDbTransaction transaction, String rowId) {
+        // Use heap cache to find events efficiently
+        final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (eventIds == null) {
+            return false;
+        }
+
+        try {
+            // Iterate in descending order to find the latest event (like Ehcache does)
+            for (Integer eventId : eventIds.descendingSet()) {
+                byte[] compositeKey = RocksDbKeySerializer.createEventKey(transaction.getTransactionId(), eventId);
+                byte[] eventData = db.get(eventsColumnFamily, compositeKey);
+
+                if (eventData != null) {
+                    final LogMinerEvent event = RocksDbEventSerializer.deserialize(eventData);
+                    if (event != null && event.getRowId().equals(rowId)) {
+                        db.delete(eventsColumnFamily, writeOptions, compositeKey);
+
+                        byte[] indexKey = RocksDbKeySerializer.createRowIdIndexKey(transaction.getTransactionId(), rowId);
+                        db.delete(rowIdIndexColumnFamily, writeOptions, indexKey);
+
+                        // Remove from heap cache
+                        eventIds.remove(eventId);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Could not remove event from transaction " + transaction.getTransactionId(), e);
+        }
+    }
+
+    @Override
+    public boolean removeTransactionEventWithEventKey(RocksDbTransaction transaction, int eventKey) {
+        // Check heap cache first
+        final var eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (eventIds != null && eventIds.contains(eventKey)) {
+            try {
+                byte[] compositeKey = RocksDbKeySerializer.createEventKey(transaction.getTransactionId(), eventKey);
+
+                // Get the event data to clean up index
+                byte[] existingData = db.get(eventsColumnFamily, compositeKey);
+
+                if (existingData != null) {
+                    db.delete(eventsColumnFamily, writeOptions, compositeKey);
+
+                    try {
+                        LogMinerEvent event = RocksDbEventSerializer.deserialize(existingData);
+                        if (event.getRowId() != null) {
+                            byte[] indexKey = RocksDbKeySerializer.createRowIdIndexKey(transaction.getTransactionId(), event.getRowId());
+                            db.delete(rowIdIndexColumnFamily, writeOptions, indexKey);
+                        }
+                    }
+                    catch (Exception e) {
+                        LOGGER.warn("Failed to deserialize event for index cleanup: txId={}, eventKey={}",
+                                transaction.getTransactionId(), eventKey, e);
+                    }
+
+                    // Remove from heap cache (Ehcache optimization)
+                    eventIds.remove(eventKey);
+
+                    LOGGER.info("Removed event from RocksDB: txId={}, eventKey={}, compositeKey={}",
+                            transaction.getTransactionId(), eventKey, new String(compositeKey, StandardCharsets.UTF_8));
+                    return true;
+                }
+            }
+            catch (RocksDBException e) {
+                throw new DebeziumException("Could not remove event with key " + eventKey + " from transaction " + transaction.getTransactionId(), e);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int getTransactionEventCount(RocksDbTransaction transaction) {
+        // Use heap cache for fast count
+        final var events = eventIdsByTransactionId.get(transaction.getTransactionId());
+        if (events != null) {
+            return events.size();
+        }
+        return 0;
+    }
+
+    @Override
+    public int getTransactionEvents() {
+        // Use heap cache for efficient total count
+        return eventIdsByTransactionId.values().stream().mapToInt(Set::size).sum();
+    }
+
+    @Override
+    public void syncTransaction(RocksDbTransaction transaction) {
+    }
+
+    public void close() {
+        forceFlush();
+
+        if (writeOptions != null) {
+            writeOptions.close();
+        }
+        if (eventsColumnFamily != null) {
+            eventsColumnFamily.close();
+        }
+        if (rowIdIndexColumnFamily != null) {
+            rowIdIndexColumnFamily.close();
+        }
+        if (transactionsColumnFamily != null) {
+            transactionsColumnFamily.close();
+        }
+        if (db != null) {
+            db.close();
+        }
+        if (dbOptions != null) {
+            dbOptions.close();
+        }
+    }
+
+    /**
+     * Force flush any pending writes to disk.
+     */
+    private void forceFlush() {
+        if (pendingWrites > 0) {
+            try {
+                db.flush(new FlushOptions(), eventsColumnFamily);
+                db.flush(new FlushOptions(), rowIdIndexColumnFamily);
+                LOGGER.debug("Force flushed {} pending writes", pendingWrites);
+                pendingWrites = 0;
+            }
+            catch (RocksDBException e) {
+                LOGGER.warn("Failed to force flush pending writes", e);
+            }
+        }
+    }
+
+    private boolean startsWith(byte[] array, byte[] prefix) {
+        if (array.length < prefix.length) {
+            return false;
+        }
+        for (int i = 0; i < prefix.length; i++) {
+            if (array[i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Get the RocksDB instance for creating additional caches.
+     *
+     * @return the RocksDB instance
+     */
+    public RocksDB getDb() {
+        return db;
+    }
+
+    /**
+     * Create a column family for use by other caches.
+     *
+     * @param name the column family name
+     * @return the column family handle
+     */
+    public ColumnFamilyHandle createColumnFamily(String name) {
+        try {
+            ColumnFamilyDescriptor descriptor = new ColumnFamilyDescriptor(
+                    name.getBytes(StandardCharsets.UTF_8),
+                    new ColumnFamilyOptions());
+            return db.createColumnFamily(descriptor);
+        }
+        catch (RocksDBException e) {
+            throw new DebeziumException("Failed to create column family: " + name, e);
+        }
+    }
+
+    /**
+     * A simple iterator over RocksDB transactions for streaming.
+     */
+    private static class RocksDbTransactionIterator implements java.util.Iterator<RocksDbTransaction> {
+        private final RocksIterator rocksIterator;
+
+        RocksDbTransactionIterator(RocksIterator rocksIterator) {
+            this.rocksIterator = rocksIterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return rocksIterator.isValid();
+        }
+
+        @Override
+        public RocksDbTransaction next() {
+            byte[] value = rocksIterator.value();
+            rocksIterator.next();
+            return RocksDbTransactionSerializer.deserialize(value);
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbTransaction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.buffered.AbstractTransaction;
+
+/**
+ * A {@link AbstractTransaction} implementation for the RocksDB spill-to-disk buffer.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbTransaction extends AbstractTransaction {
+
+    private int numberOfEvents;
+
+    public RocksDbTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThread, String clientId) {
+        super(transactionId, startScn, changeTime, userName, redoThread, clientId);
+        start();
+    }
+
+    public RocksDbTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThread, int numberOfEvents, String clientId) {
+        super(transactionId, startScn, changeTime, userName, redoThread, clientId);
+        this.numberOfEvents = numberOfEvents;
+    }
+
+    @Override
+    public int getNumberOfEvents() {
+        return numberOfEvents;
+    }
+
+    @Override
+    public int getNextEventId() {
+        return numberOfEvents++;
+    }
+
+    @Override
+    public void start() {
+        numberOfEvents = 0;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbTransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/RocksDbTransactionFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb;
+
+import io.debezium.connector.oracle.logminer.buffered.TransactionFactory;
+import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+
+/**
+ * A factory for creating {@link RocksDbTransaction} instances.
+ *
+ * @author Debezium Authors
+ */
+public class RocksDbTransactionFactory implements TransactionFactory<RocksDbTransaction> {
+
+    @Override
+    public RocksDbTransaction createTransaction(LogMinerEventRow event) {
+        return new RocksDbTransaction(event.getTransactionId(), event.getScn(), event.getChangeTime(), event.getUserName(), event.getThread(), event.getClientId());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/DmlEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/DmlEventSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.DmlEvent;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * RocksDB serializer for DML events.
+ *
+ * @author Debezium Authors
+ */
+public class DmlEventSerializer extends io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_DML_EVENT;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream out, LogMinerEvent event) throws IOException {
+        if (!(event instanceof DmlEvent)) {
+            throw new DebeziumException("Expected DmlEvent but got " + event.getClass().getName());
+        }
+        DmlEvent dmlEvent = (DmlEvent) event;
+        LogMinerDmlEntry dmlEntry = dmlEvent.getDmlEntry();
+
+        // use inherited helper
+        writeCommonFields(out, event);
+
+        // write dml entry values and object details
+        writeValuesArray(out, dmlEntry.getOldValues());
+        writeValuesArray(out, dmlEntry.getNewValues());
+        writeString(out, dmlEntry.getObjectOwner());
+        writeString(out, dmlEntry.getObjectName());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream in) throws IOException {
+        byte eventTypeOrdinal = in.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(in, eventType);
+
+        Object[] oldValues = readValuesArray(in);
+        Object[] newValues = readValuesArray(in);
+        String objectOwner = readString(in);
+        String objectName = readString(in);
+
+        LogMinerDmlEntry dmlEntry = new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+
+        return new DmlEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(), baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(), dmlEntry);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/ExtendedStringBeginEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/ExtendedStringBeginEventSerializer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringBeginEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * Serializer for {@link ExtendedStringBeginEvent}.
+ */
+public class ExtendedStringBeginEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_EXTENDED_STRING_BEGIN;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dos, LogMinerEvent event) throws IOException {
+        if (!(event instanceof ExtendedStringBeginEvent)) {
+            throw new DebeziumException("Expected ExtendedStringBeginEvent but got " + event.getClass().getSimpleName());
+        }
+
+        ExtendedStringBeginEvent extendedStringEvent = (ExtendedStringBeginEvent) event;
+
+        writeCommonFields(dos, event);
+
+        writeString(dos, extendedStringEvent.getColumnName());
+
+        // Write DML entry
+        writeDmlEntry(dos, extendedStringEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dis) throws IOException {
+        // Read event type
+        byte eventTypeOrdinal = dis.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dis, eventType);
+
+        String columnName = readString(dis);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(dis, eventType);
+
+        return new ExtendedStringBeginEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName);
+    }
+
+    private void writeDmlEntry(DataOutputStream dos, LogMinerDmlEntry dmlEntry) throws IOException {
+        writeValuesArray(dos, dmlEntry.getOldValues());
+        writeValuesArray(dos, dmlEntry.getNewValues());
+        writeString(dos, dmlEntry.getObjectOwner());
+        writeString(dos, dmlEntry.getObjectName());
+    }
+
+    private LogMinerDmlEntryImpl readDmlEntry(DataInputStream dis, EventType eventType) throws IOException {
+        Object[] oldValues = readValuesArray(dis);
+        Object[] newValues = readValuesArray(dis);
+        String objectOwner = readString(dis);
+        String objectName = readString(dis);
+
+        return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/ExtendedStringWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/ExtendedStringWriteEventSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.ExtendedStringWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * Serializer for {@link ExtendedStringWriteEvent}.
+ */
+public class ExtendedStringWriteEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_EXTENDED_STRING_WRITE;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dos, LogMinerEvent event) throws IOException {
+        if (!(event instanceof ExtendedStringWriteEvent)) {
+            throw new DebeziumException("Expected ExtendedStringWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        ExtendedStringWriteEvent writeEvent = (ExtendedStringWriteEvent) event;
+
+        writeCommonFields(dos, writeEvent);
+
+        writeString(dos, writeEvent.getData());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dis) throws IOException {
+        byte eventTypeOrdinal = dis.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dis, eventType);
+
+        String data = readString(dis);
+
+        return new ExtendedStringWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(), data);
+    }
+
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/LobEraseEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/LobEraseEventSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LobEraseEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * Serializer for {@link LobEraseEvent} objects.
+ *
+ * @author Debezium Authors
+ */
+public class LobEraseEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_LOB_ERASE;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dataOutput, LogMinerEvent event) throws IOException {
+        if (!(event instanceof LobEraseEvent)) {
+            throw new IllegalArgumentException("Expected LobEraseEvent but got " + event.getClass().getSimpleName());
+        }
+
+        writeCommonFields(dataOutput, event);
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dataInput) throws IOException {
+        byte eventTypeOrdinal = dataInput.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dataInput, eventType);
+
+        return new LobEraseEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/LobWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/LobWriteEventSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LobWriteEvent;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+
+/**
+ * Serializer for {@link LobWriteEvent}.
+ */
+public class LobWriteEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_LOB_WRITE;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dos, LogMinerEvent event) throws IOException {
+        if (!(event instanceof LobWriteEvent)) {
+            throw new DebeziumException("Expected LobWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        LobWriteEvent lobWriteEvent = (LobWriteEvent) event;
+
+        writeCommonFields(dos, lobWriteEvent);
+
+        writeString(dos, lobWriteEvent.getData());
+        dos.writeInt(lobWriteEvent.getOffset());
+        dos.writeInt(lobWriteEvent.getLength());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dis) throws IOException {
+        byte eventTypeOrdinal = dis.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dis, eventType);
+
+        String data = readString(dis);
+        int offset = dis.readInt();
+        int length = dis.readInt();
+
+        return new LobWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                data, offset, length);
+    }
+
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RedoSqlDmlEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RedoSqlDmlEventSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.RedoSqlDmlEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * Serializer for {@link RedoSqlDmlEvent}.
+ */
+public class RedoSqlDmlEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_REDO_SQL_DML;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dos, LogMinerEvent event) throws IOException {
+        if (!(event instanceof RedoSqlDmlEvent)) {
+            throw new DebeziumException("Expected RedoSqlDmlEvent but got " + event.getClass().getSimpleName());
+        }
+
+        RedoSqlDmlEvent redoSqlEvent = (RedoSqlDmlEvent) event;
+
+        writeCommonFields(dos, event);
+
+        writeString(dos, redoSqlEvent.getRedoSql());
+
+        writeDmlEntry(dos, redoSqlEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dis) throws IOException {
+        byte eventTypeOrdinal = dis.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dis, eventType);
+
+        String redoSql = readString(dis);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(dis, eventType);
+
+        return new RedoSqlDmlEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, redoSql);
+    }
+
+    private void writeDmlEntry(DataOutputStream dos, LogMinerDmlEntry dmlEntry) throws IOException {
+        writeValuesArray(dos, dmlEntry.getOldValues());
+        writeValuesArray(dos, dmlEntry.getNewValues());
+        writeString(dos, dmlEntry.getObjectOwner());
+        writeString(dos, dmlEntry.getObjectName());
+    }
+
+    private LogMinerDmlEntryImpl readDmlEntry(DataInputStream dis, EventType eventType) throws IOException {
+        Object[] oldValues = readValuesArray(dis);
+        Object[] newValues = readValuesArray(dis);
+        String objectOwner = readString(dis);
+        String objectName = readString(dis);
+
+        return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RocksDbKeySerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RocksDbKeySerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility class for creating byte[] keys for use with RocksDB.
+ */
+public final class RocksDbKeySerializer {
+
+    private RocksDbKeySerializer() {
+    }
+
+    public static byte[] createEventKey(String transactionId, int eventKey) {
+        byte[] transactionIdBytes = transactionId.getBytes(StandardCharsets.UTF_8);
+        byte[] eventKeyBytes = intToBytes(eventKey);
+        byte[] compositeKey = new byte[transactionIdBytes.length + eventKeyBytes.length];
+        System.arraycopy(transactionIdBytes, 0, compositeKey, 0, transactionIdBytes.length);
+        System.arraycopy(eventKeyBytes, 0, compositeKey, transactionIdBytes.length, eventKeyBytes.length);
+        return compositeKey;
+    }
+
+    public static byte[] createRowIdIndexKey(String transactionId, String rowId) {
+        byte[] transactionIdBytes = transactionId.getBytes(StandardCharsets.UTF_8);
+        byte[] rowIdBytes = rowId.getBytes(StandardCharsets.UTF_8);
+        byte[] indexKey = new byte[transactionIdBytes.length + rowIdBytes.length];
+        System.arraycopy(transactionIdBytes, 0, indexKey, 0, transactionIdBytes.length);
+        System.arraycopy(rowIdBytes, 0, indexKey, transactionIdBytes.length, rowIdBytes.length);
+        return indexKey;
+    }
+
+    public static byte[] intToBytes(int value) {
+        return new byte[]{
+                (byte) (value >>> 24),
+                (byte) (value >>> 16),
+                (byte) (value >>> 8),
+                (byte) value
+        };
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RocksDbTransactionSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/RocksDbTransactionSerializer.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbTransaction;
+
+/**
+ * Handles serialization and deserialization for RocksDbTransaction metadata.
+ *
+ * This utility reuses the string helpers provided by {@link RocksDbEventSerializer.BaseEventSerializer}
+ * by creating a singleton instance and delegating to the protected helpers. The class still exposes
+ * static convenience methods for callers.
+ */
+public final class RocksDbTransactionSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    private static final RocksDbTransactionSerializer INSTANCE = new RocksDbTransactionSerializer();
+
+    private RocksDbTransactionSerializer() {
+        // private singleton
+    }
+
+    /**
+     * Serializes a RocksDbTransaction object into a byte array.
+     * @param tx The transaction to serialize.
+     * @return A byte array representing the transaction.
+     */
+    public static byte[] serialize(RocksDbTransaction tx) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); DataOutputStream out = new DataOutputStream(baos)) {
+            INSTANCE.writeString(out, tx.getTransactionId());
+            INSTANCE.writeString(out, tx.getStartScn() == null || tx.getStartScn().isNull() ? "null" : tx.getStartScn().toString());
+            INSTANCE.writeString(out, tx.getChangeTime() == null ? null : tx.getChangeTime().toString());
+            INSTANCE.writeString(out, tx.getUserName());
+            out.writeInt(tx.getRedoThreadId());
+            out.writeInt(tx.getNumberOfEvents());
+            INSTANCE.writeString(out, tx.getClientId());
+            out.flush();
+            return baos.toByteArray();
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to serialize transaction metadata for " + tx.getTransactionId(), e);
+        }
+    }
+
+    /**
+     * Deserializes a byte array back into a RocksDbTransaction object.
+     * @param data The byte array to deserialize.
+     * @return The reconstructed RocksDbTransaction object.
+     */
+    public static RocksDbTransaction deserialize(byte[] data) {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data); DataInputStream in = new DataInputStream(bais)) {
+            String transactionId = INSTANCE.readString(in);
+            String scnString = INSTANCE.readString(in);
+            Scn scn = "null".equals(scnString) ? Scn.NULL : Scn.valueOf(scnString);
+            String changeTimeString = INSTANCE.readString(in);
+            Instant changeTime = changeTimeString == null ? null : Instant.parse(changeTimeString);
+            String userName = INSTANCE.readString(in);
+            int redoThread = in.readInt();
+            int numberOfEvents = in.readInt();
+            String clientId = INSTANCE.readString(in);
+
+            // Reconstruct the transaction object using the constructor that accepts the numberOfEvents
+            Integer redoThreadObj = redoThread == -1 ? null : Integer.valueOf(redoThread);
+            RocksDbTransaction tx = new RocksDbTransaction(transactionId, scn, changeTime, userName, redoThreadObj, numberOfEvents, clientId);
+            return tx;
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to deserialize transaction metadata", e);
+        }
+    }
+
+    // The class extends BaseEventSerializer only to reuse the protected helpers; the
+    // RocksDbEventSerializerStrategy methods are not used by this utility
+    @Override
+    public byte getTypeId() {
+        throw new UnsupportedOperationException("Not a RocksDbEventSerializerStrategy implementation");
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream out, io.debezium.connector.oracle.logminer.events.LogMinerEvent event) throws IOException {
+        throw new UnsupportedOperationException("Not a RocksDbEventSerializerStrategy implementation");
+    }
+
+    @Override
+    public io.debezium.connector.oracle.logminer.events.LogMinerEvent readEvent(DataInputStream in) throws IOException {
+        throw new UnsupportedOperationException("Not a RocksDbEventSerializerStrategy implementation");
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/SelectLobLocatorEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/SelectLobLocatorEventSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.SelectLobLocatorEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * Serializer for SelectLobLocatorEvent.
+ */
+public class SelectLobLocatorEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    // reuse helpers from BaseEventSerializer
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_SELECT_LOB_LOCATOR;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dos, LogMinerEvent event) throws IOException {
+        if (!(event instanceof SelectLobLocatorEvent)) {
+            throw new DebeziumException("Expected SelectLobLocatorEvent but got " + event.getClass().getSimpleName());
+        }
+
+        SelectLobLocatorEvent selectLobEvent = (SelectLobLocatorEvent) event;
+
+        writeCommonFields(dos, event);
+
+        writeString(dos, selectLobEvent.getColumnName());
+        dos.writeBoolean(selectLobEvent.isBinary());
+
+        writeDmlEntry(dos, selectLobEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dis) throws IOException {
+        byte eventTypeOrdinal = dis.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dis, eventType);
+
+        String columnName = readString(dis);
+        boolean binary = dis.readBoolean();
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(dis, eventType);
+
+        return new SelectLobLocatorEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName, binary);
+    }
+
+    private void writeDmlEntry(DataOutputStream dos, LogMinerDmlEntry dmlEntry) throws IOException {
+        writeValuesArray(dos, dmlEntry.getOldValues());
+        writeValuesArray(dos, dmlEntry.getNewValues());
+        writeString(dos, dmlEntry.getObjectOwner());
+        writeString(dos, dmlEntry.getObjectName());
+    }
+
+    private LogMinerDmlEntryImpl readDmlEntry(DataInputStream dis, EventType eventType) throws IOException {
+        Object[] oldValues = readValuesArray(dis);
+        Object[] newValues = readValuesArray(dis);
+        String objectOwner = readString(dis);
+        String objectName = readString(dis);
+
+        return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/TruncateEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/TruncateEventSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.TruncateEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * Serializer for TruncateEvent.
+ */
+public class TruncateEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_TRUNCATE;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dataOutput, LogMinerEvent event) throws IOException {
+        if (!(event instanceof TruncateEvent)) {
+            throw new DebeziumException("Expected TruncateEvent but got " + event.getClass().getSimpleName());
+        }
+
+        TruncateEvent truncateEvent = (TruncateEvent) event;
+
+        writeCommonFields(dataOutput, event);
+
+        writeDmlEntry(dataOutput, truncateEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dataInput) throws IOException {
+        byte eventTypeOrdinal = dataInput.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dataInput, eventType);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(dataInput, eventType);
+
+        return new TruncateEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry);
+    }
+
+    private void writeDmlEntry(DataOutputStream dataOutput, LogMinerDmlEntry dmlEntry) throws IOException {
+        writeValuesArray(dataOutput, dmlEntry.getOldValues());
+        writeValuesArray(dataOutput, dmlEntry.getNewValues());
+        writeString(dataOutput, dmlEntry.getObjectOwner());
+        writeString(dataOutput, dmlEntry.getObjectName());
+    }
+
+    private LogMinerDmlEntryImpl readDmlEntry(DataInputStream dataInput, EventType eventType) throws IOException {
+        Object[] oldValues = readValuesArray(dataInput);
+        Object[] newValues = readValuesArray(dataInput);
+        String objectOwner = readString(dataInput);
+        String objectName = readString(dataInput);
+
+        return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlBeginEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlBeginEventSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlBeginEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+
+/**
+ * Serializer for XmlBeginEvent.
+ */
+public class XmlBeginEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_XML_BEGIN;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dataOutput, LogMinerEvent event) throws IOException {
+        if (!(event instanceof XmlBeginEvent)) {
+            throw new DebeziumException("Expected XmlBeginEvent but got " + event.getClass().getSimpleName());
+        }
+
+        XmlBeginEvent xmlBeginEvent = (XmlBeginEvent) event;
+
+        writeCommonFields(dataOutput, event);
+
+        writeString(dataOutput, xmlBeginEvent.getColumnName());
+
+        writeDmlEntry(dataOutput, xmlBeginEvent.getDmlEntry());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dataInput) throws IOException {
+        byte eventTypeOrdinal = dataInput.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dataInput, eventType);
+
+        String columnName = readString(dataInput);
+
+        LogMinerDmlEntryImpl dmlEntry = readDmlEntry(dataInput, eventType);
+
+        return new XmlBeginEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                dmlEntry, columnName);
+    }
+
+    private void writeDmlEntry(DataOutputStream dataOutput, LogMinerDmlEntry dmlEntry) throws IOException {
+        writeValuesArray(dataOutput, dmlEntry.getOldValues());
+        writeValuesArray(dataOutput, dmlEntry.getNewValues());
+        writeString(dataOutput, dmlEntry.getObjectOwner());
+        writeString(dataOutput, dmlEntry.getObjectName());
+    }
+
+    private LogMinerDmlEntryImpl readDmlEntry(DataInputStream dataInput, EventType eventType) throws IOException {
+        Object[] oldValues = readValuesArray(dataInput);
+        Object[] newValues = readValuesArray(dataInput);
+        String objectOwner = readString(dataInput);
+        String objectName = readString(dataInput);
+
+        return new LogMinerDmlEntryImpl(eventType.getValue(), newValues, oldValues, objectOwner, objectName);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlEndEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlEndEventSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlEndEvent;
+
+/**
+ * Serializer for XmlEndEvent.
+ */
+public class XmlEndEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_XML_END;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dataOutput, LogMinerEvent event) throws IOException {
+        if (!(event instanceof XmlEndEvent)) {
+            throw new DebeziumException("Expected XmlEndEvent but got " + event.getClass().getSimpleName());
+        }
+
+        writeCommonFields(dataOutput, event);
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dataInput) throws IOException {
+        byte eventTypeOrdinal = dataInput.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dataInput, eventType);
+
+        return new XmlEndEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime());
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlWriteEventSerializer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/rocksdb/serialization/XmlWriteEventSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered.rocksdb.serialization;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.logminer.buffered.rocksdb.RocksDbEventSerializer;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEvent;
+import io.debezium.connector.oracle.logminer.events.XmlWriteEvent;
+
+/**
+ * Serializer for XmlWriteEvent.
+ */
+public class XmlWriteEventSerializer extends RocksDbEventSerializer.BaseEventSerializer {
+
+    @Override
+    public byte getTypeId() {
+        return RocksDbEventSerializer.TYPE_XML_WRITE;
+    }
+
+    @Override
+    public void writeEvent(DataOutputStream dataOutput, LogMinerEvent event) throws IOException {
+        if (!(event instanceof XmlWriteEvent)) {
+            throw new DebeziumException("Expected XmlWriteEvent but got " + event.getClass().getSimpleName());
+        }
+
+        XmlWriteEvent xmlWriteEvent = (XmlWriteEvent) event;
+
+        writeCommonFields(dataOutput, event);
+
+        writeString(dataOutput, xmlWriteEvent.getXml());
+        dataOutput.writeInt(xmlWriteEvent.getLength());
+    }
+
+    @Override
+    public LogMinerEvent readEvent(DataInputStream dataInput) throws IOException {
+        byte eventTypeOrdinal = dataInput.readByte();
+        EventType eventType = EventType.values()[eventTypeOrdinal];
+
+        LogMinerEvent baseEvent = readCommonFields(dataInput, eventType);
+
+        String xml = readString(dataInput);
+        int length = dataInput.readInt();
+
+        return new XmlWriteEvent(eventType, baseEvent.getScn(), baseEvent.getTableId(),
+                baseEvent.getRowId(), baseEvent.getRsId(), baseEvent.getChangeTime(),
+                xml, length);
+    }
+}


### PR DESCRIPTION
Relates to discussion here:  [discussion](https://debezium.zulipchat.com/#narrow/channel/348250-community-oracle/topic/Hitting.20heap.20limits.20during.20large.20transaction).  Creating as draft PR for feedback.  There is still work to be done but I've already made a lot of decisions which may be questionable and so wanted to send this through.

High Level:  When there are large transactions in Oracle, Debezium can OOM as the entire transaction must be stored in heap.  In order to avoid this, allow a configurable threshold at which we spill from heap to an off-heap provider.  This allows most transactions to use heap and only move to slower off-heap providers when necessary.

Current principles
1. Spilled data should be ephemeral extension of heap and not survive restarts
2. Spilled transactions are split between heap and off-heap (i.e. don't try to push the existing transaction data to disk, just spill from the next event on that meets threshold)

Current Implementation:
I've added Chronicle Queue and Rocksdb as new off-heap providers.  I then added the existing Ehcache buffer type as a new spill provider which requires some small code changes.  I've created CompositeTransactionCache which is a sort of facade to coordinate things which is one of the main things I'm unsure about as it created some weirdness managing the MemoryTransaction.

The advantage is I can make specific decisions about spill and heap.  I was also able add a configurable index to hopefully help the off-heap providers when it comes to partial rollbacks.  I created three new profiles for testing that set the threshold to 0 to always spill.  All tests should be passing but I added exclusions for the infinispanITs as I don't think those make sense here.

Currently the spill is just based on number of events seen and I don't have any new metrics yet but I've tried to cater for potential of other strategies being used.

Chronicle Queue Specific concerns:
1.   As discussed the Chronicle Queue team only publish EA jars to MVN and so currently I have selected 5.27ea8 but this isn't ideal
2. For Java 17+ additional parameters have to be passed as outlined here:  https://chronicle.software/chronicle-support-java-17/  I currently set these in the profile and in my local DBZ server testing I add them in the run.sh file
3. For chronicle specifically, I made each transaction its own individual folder and manage each separately.  I'm not sure if this is the right decision but it helps keep things clean and in my view it isn't the intention to have thousands of transactions spilling concurrently to disk.

Rocksdb specific concerns:
1. There are some issues with the fat jar on the latest version and so I selected 10.2.1 but probably not a huge issue:  https://github.com/facebook/rocksdb/issues/13893#issuecomment-3240464232
2. When I used defaults I was failing on some of the lob tests (timing out) and so had to add additional configurable options but I'm not a rocksdb expert and don't know the best way to tune it.

I haven't done a lot of testing yet.  I need a more extensive test for partial rollbacks.  Currently I have tested all three providers with the following test:  Set threshold to 50 000, Insert 10 000 000 rows in batches of 100 000.  Update all rows.  Delete all rows.  None of the solutions ran out of heap (currently set to 8gb).  I would like to do more benchmarks especially against just the memory buffer type to see if I've added overhead somewhere.