### PR TITLE
DBZ-9558 Fix JDK23+ edge case for timestamps in Postgres

### DIFF
--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -75,18 +75,14 @@ public class Timestamp {
         }
 
         // Fix rare JDK issue where one of the components of ChronoLocalDateTime is null
-        long dateTimeInstant;
         try {
-            dateTimeInstant = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+            return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
         }
         catch (NullPointerException e) {
             // Fallback for NPE from ChronoLocalDateTime#toLocalDate, see DBZ-9558
             var ignored = dateTime.toString();
-            dateTimeInstant = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+            return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
         }
-        return dateTimeInstant;
-
-        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
     }
 
     private Timestamp() {


### PR DESCRIPTION
See [this Zullip thread](https://debezium.zulipchat.com/#narrow/channel/348249-community-postgresql/topic/JDK23.20timestamp.20exceptions/with/544111326) and the [related Jira issue](https://issues.redhat.com/browse/DBZ-9558) for more details.

Fix edge case with `timestamp` values in Postgres on JDK23+.