### PR TITLE
DRAFT DBZ-9323: Add built-in support for acquiring MSAL access tokens 

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -54,12 +54,6 @@
         <!-- Azure Identity -->
         <version.azure.identity>1.15.4</version.azure.identity>
 
-        <!-- Azure Core -->
-        <version.azure.core>1.57.0</version.azure.core>
-
-        <!-- MSAL4J-->
-        <version.msal4j>1.23.1</version.msal4j>
-
         <!-- K8s Config Map Storage -->
         <version.kubernetes.client>6.13.4</version.kubernetes.client>
 
@@ -584,20 +578,6 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
                 <version>${version.azure.identity}</version>
-            </dependency>
-
-            <!-- MSAL4J -->
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>msal4j</artifactId>
-                <version>${version.msal4j}</version>
-            </dependency>
-
-            <!-- Azure Core -->
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-core</artifactId>
-                <version>${version.azure.core}</version>
             </dependency>
 
             <!-- K8s Config Map Storage -->

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -58,6 +58,7 @@
             <scope>provided</scope>
         </dependency>
 
+
         <!-- Testing -->
         <dependency>
             <groupId>io.debezium</groupId>
@@ -165,6 +166,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>${version.azure.sdk}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,9 @@
         <!-- OpenTelemetry version to use for the attached test agent-->
         <version.opentelemetry.testing>2.10.0-alpha</version.opentelemetry.testing>
 
+        <!-- Azure SDK -->
+        <version.azure.sdk>1.3.0</version.azure.sdk>
+
         <!-- Testing -->
         <opentelemetry.agent.for.testing.artifact.relative.path>io/opentelemetry/javaagent/opentelemetry-agent-for-testing/${version.opentelemetry.testing}/opentelemetry-agent-for-testing-${version.opentelemetry.testing}.jar</opentelemetry.agent.for.testing.artifact.relative.path>
 


### PR DESCRIPTION
Added Azure Core and MSAL4J packages to the Debezium BOM. Since the BOM is used in the SQL Server connector, these dependencies should be included by default.

**Reason**
This change resolves issues when using Managed Identity, which previously failed due to a missing MSAL4J package. It should fix the issue with ActiveDirectoryAccessToken authentication as well.