### PR TITLE
DBZ-9522 Upgrade vitess-grpc-client version to 23.0.0-rc1

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -21,7 +21,7 @@
         <version.jetty>9.4.12.v20180830</version.jetty>
 
         <!-- Vitess dependencies -->
-        <version.vitess.grpc>21.0.2</version.vitess.grpc>
+        <version.vitess.grpc>23.0.0-rc1</version.vitess.grpc>
         <version.joda>2.10.1</version.joda>
         <version.google.protos>1.17.0</version.google.protos>
 


### PR DESCRIPTION
We need this new version for a significant performance optimization https://github.com/debezium/debezium-connector-vitess/pull/257