### PR TITLE
DBZ-9536 postgres-connector: Replaced casting connection to specific class/interface with Connection#unwrap method

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -180,7 +180,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {
-                Object value = column.getValue(() -> (BaseConnection) connection.connection(), connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(() -> connection.connection().unwrap(BaseConnection.class), connectorConfig.includeUnknownDatatypes());
                 if (sourceOfToasted) {
                     cachedOldToastedValues.put(columnName, value);
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -582,6 +582,6 @@ public class TypeRegistry {
     }
 
     private static TypeInfo getTypeInfo(PostgresConnection connection) throws SQLException {
-        return ((BaseConnection) connection.connection()).getTypeInfo();
+        return connection.connection().unwrap(BaseConnection.class).getTypeInfo();
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -609,7 +609,7 @@ public class PostgresConnection extends JdbcConnection {
 
     public Charset getDatabaseCharset() {
         try {
-            return Charset.forName(((BaseConnection) connection()).getEncoding().name());
+            return Charset.forName((connection().unwrap(BaseConnection.class)).getEncoding().name());
         }
         catch (SQLException e) {
             throw new DebeziumException("Couldn't obtain encoding for database " + database(), e);
@@ -618,7 +618,7 @@ public class PostgresConnection extends JdbcConnection {
 
     public TimestampUtils getTimestampUtils() {
         try {
-            return ((PgConnection) this.connection()).getTimestampUtils();
+            return this.connection().unwrap(PgConnection.class).getTimestampUtils();
         }
         catch (SQLException e) {
             throw new DebeziumException("Couldn't get timestamp utils from underlying connection", e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -866,7 +866,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     protected BaseConnection pgConnection() throws SQLException {
-        return (BaseConnection) connection(false);
+        return connection(false).unwrap(BaseConnection.class);
     }
 
     private SlotCreationResult parseSlotCreation(ResultSet rs) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -167,8 +167,9 @@ public class PostgresConnectionIT {
     private PgConnection getUnderlyingConnection(ReplicationConnection connection) throws Exception {
         Field connField = JdbcConnection.class.getDeclaredField("conn");
         connField.setAccessible(true);
+        Connection underlying = (Connection) connField.get(connection);
 
-        return (PgConnection) connField.get(connection);
+        return underlying.unwrap(PgConnection.class);
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9536

postgres-connector: Replaced casting connection to specific class/interface with Connection#unwrap method