### PR TITLE
DBZ-9617: Gracefully cleanup the coordinator thread while stopping the task

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -463,9 +463,11 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     public final void stop() {
         try {
             performCommit();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             LOGGER.warn("Error while performing commit.", e);
-        } finally {
+        }
+        finally {
             stop(false);
             DebeziumOpenLineageEmitter.cleanup(DebeziumOpenLineageEmitter.connectorContext(config.asMap(), connectorName()));
         }


### PR DESCRIPTION
Addressing: https://issues.redhat.com/browse/DBZ-9617