### PR TITLE
DBZ-9623: Allow table named CYCLE in MySQL

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2807,6 +2807,7 @@ keywordsCanBeId
     | CURRENT
     | CURRENT_USER
     | CURSOR_NAME
+    | CYCLE
     | DATA
     | DATAFILE
     | DEALLOCATE


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9623