### PR TITLE
DBZ-9634 Unparseable DDLs for Mariadb

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mariadb/generated/MariaDBParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mariadb/generated/MariaDBParser.g4
@@ -758,8 +758,8 @@ alterSpecification
     | ENABLE KEYS                                                         # alterByEnableKeys
     | RENAME renameFormat = (TO | AS)? (uid | fullId)                     # alterByRename
     | ORDER BY uidList                                                    # alterByOrder
-    | CONVERT TO CHARACTER SET charsetName (COLLATE collationName)?       # alterByConvertCharset
-    | DEFAULT? CHARACTER SET '=' charsetName (COLLATE '=' collationName)? # alterByDefaultCharset
+    | CONVERT TO charSet charsetName (COLLATE collationName)?             # alterByConvertCharacterset
+    | DEFAULT? charSet '=' charsetName (COLLATE '=' collationName)?       # alterByDefaultCharset
     | DISCARD TABLESPACE                                                  # alterByDiscardTablespace
     | IMPORT TABLESPACE                                                   # alterByImportTablespace
     | FORCE                                                               # alterByForce
@@ -856,7 +856,7 @@ dropSequence // sequence is MariaDB-specific only
 //    Other DDL statements
 
 renameTable
-    : RENAME TABLE ifExists? renameTableClause (',' renameTableClause)*
+    : RENAME (TABLE | TABLES) ifExists? renameTableClause (',' renameTableClause)*
     ;
 
 renameTableClause

--- a/debezium-ddl-parser/src/test/resources/mariadb/examples/fast/ddl_alter.sql
+++ b/debezium-ddl-parser/src/test/resources/mariadb/examples/fast/ddl_alter.sql
@@ -53,6 +53,10 @@ alter table default.task add column xxxx varchar(200) comment 'cdc test';
 alter table `some_table` add unique if not exists `id_unique` (`id`)
 alter table if exists `add_test` add column if not exists `new_col` text default 'my_default';
 alter table user_details add index if not exists `country_id_index` (country_id), algorithm=NOCOPY;
+alter table table_name CONVERT TO CHARACTER SET utf8mb4;
+alter table table_name CONVERT TO CHARSET utf8mb4;
+alter table table_name DEFAULT CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+alter table table_name DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 #end
 #begin
 -- Alter database

--- a/debezium-ddl-parser/src/test/resources/mariadb/examples/fast/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mariadb/examples/fast/ddl_create.sql
@@ -248,6 +248,7 @@ RENAME TABLE table_b TO table_a;
 RENAME TABLE current_db.tbl_name TO other_db.tbl_name;
 rename table debezium_all_types_old to debezium_all_types, test_json_object_old wait 10 to test_json_object;
 RENAME TABLE IF EXISTS EMPLOYEE TO employee;
+RENAME TABLES IF EXISTS TABLE11 to TABLE12, TABLE21 to TABLE22;
 #end
 #begin
 -- Truncate table


### PR DESCRIPTION
Solution for the unparseable DDLs in MariaDb

- Rename tables
- alter table ... convert to charset