### PR TITLE
DBZ-9504 Always return NoOpLineageEmitter when open lineage integration not enabled

### DIFF
--- a/debezium-openlineage/debezium-openlineage-api/src/main/java/io/debezium/openlineage/DebeziumOpenLineageEmitter.java
+++ b/debezium-openlineage/debezium-openlineage-api/src/main/java/io/debezium/openlineage/DebeziumOpenLineageEmitter.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.openlineage;
 
+import static io.debezium.openlineage.OpenLineageConfig.OPEN_LINEAGE_INTEGRATION_ENABLED;
+
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -43,6 +45,8 @@ public class DebeziumOpenLineageEmitter {
     // Thread-safe map to store emitters per connector
     private static final ConcurrentHashMap<String, LineageEmitter> emitters = new ConcurrentHashMap<>();
 
+    private static final NoOpLineageEmitter noOpLineageEmitter = new NoOpLineageEmitter();
+
     /**
      * Initializes the lineage emitter with the given configuration for a specific connector.
      * <p>
@@ -71,6 +75,9 @@ public class DebeziumOpenLineageEmitter {
      * @param connectorContext The connector context
      */
     public static void init(ConnectorContext connectorContext) {
+        if (isOpenLineageDisabled(connectorContext)) {
+            return;
+        }
 
         LOGGER.debug("Calling init for connector with context {}", connectorContext);
 
@@ -170,11 +177,19 @@ public class DebeziumOpenLineageEmitter {
     }
 
     private static LineageEmitter getEmitter(ConnectorContext connectorContext) {
+        if (isOpenLineageDisabled(connectorContext)) {
+            return noOpLineageEmitter;
+        }
+
         LineageEmitter emitter = emitters.get(connectorContext.toEmitterKey());
         LOGGER.debug("Available emitters {}", emitters);
         if (emitter == null) {
             throw new IllegalStateException("DebeziumOpenLineageEmitter not initialized for connector " + connectorContext + ". Call init() first.");
         }
         return emitter;
+    }
+
+    private static boolean isOpenLineageDisabled(ConnectorContext connectorContext) {
+        return !Boolean.parseBoolean(connectorContext.config().get(OPEN_LINEAGE_INTEGRATION_ENABLED));
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9504

Despite that debezium would expect topic.prefix to be unique for each connector, there are at least two issues with the introduction of open lineage integration. 

1. It's a bit invasive that it touches all connectors main execution path and despite there is the default option to not enable open lineage integration, it still makes a lot of debezium users feels this new feature (by creating emitters and get emitters and throw exceptions if can't get the emitter). And as discussed in [#community-db2 > DebeziumOpenLineageEmitter not initialized for connector @ 💬](https://debezium.zulipchat.com/#narrow/channel/348103-community-db2/topic/DebeziumOpenLineageEmitter.20not.20initialized.20for.20connector/near/546845894), I think we should make this feature not so invasive by properly honor the enabled flag. 
2. When exception is thrown, because the ConnectorContext is a record and contains the whole connector config, the exception will print out all the sensitive information such as DB connection string, password, etc. 

There are multiple ways to address this problem:
1. Similar to JMX metrics, where the metric name will consist of the tags as well which gives debezium users a lot of flexibility to work around of similar issue. (As a side note, I generally feel we shouldn't rely on topic.prefix as the only unique thing for connector, if we need such a unique property, we should introduce one rather than rely on topic.prefix which also has impact on how the event looks like in the payload). So, if we include open lineage tags as part of emitter key, the uniqueness can also be resolved. 
2. This PR to always use NoOpLineageEmitter when open lineage integration not enabled

This could be considered just as a starting point, as we would like to get this resolved ASAP. Open to further discussions as this PR is just one way to resolve these issues. 