### PR TITLE
DBZ-9661 LogMiner to always exclude tables prefixed `MLOG$`

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
@@ -157,12 +157,10 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
 
         final LogMiningQueryFilterMode queryFilterMode = connectorConfig.getLogMiningQueryFilterMode();
         if (LogMiningQueryFilterMode.NONE.equals(queryFilterMode)) {
-            // No filters get applied
-            return EMPTY;
+            return "(TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'MLOG$%')";
         }
         else if (Strings.isNullOrEmpty(includeList) && Strings.isNullOrEmpty(excludeList)) {
-            // No table filters provided, nothing to apply
-            return EMPTY;
+            return "(TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'MLOG$%')";
         }
         else if (LogMiningQueryFilterMode.IN.equals(queryFilterMode)) {
             final List<String> includeTableList = getTableIncludeExcludeListAsInValueList(includeList);
@@ -173,6 +171,10 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
             predicate.append("(TABLE_NAME IS NULL OR ");
             if (connectorConfig.getLogMiningStrategy() == OracleConnectorConfig.LogMiningStrategy.HYBRID) {
                 predicate.append("TABLE_NAME LIKE '").append(UNKNOWN_TABLE_NAME_PREFIX).append("%' OR ");
+            }
+
+            if (includeTableList.isEmpty()) {
+                predicate.append("TABLE_NAME NOT LIKE 'MLOG$%' OR ");
             }
 
             getSignalDataCollectionId(connectorConfig).ifPresent(signalTableId -> {
@@ -206,6 +208,10 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
             predicate.append("(TABLE_NAME IS NULL OR ");
             if (connectorConfig.getLogMiningStrategy() == OracleConnectorConfig.LogMiningStrategy.HYBRID) {
                 predicate.append("TABLE_NAME LIKE '").append(UNKNOWN_TABLE_NAME_PREFIX).append("%' OR ");
+            }
+
+            if (includeTableList.isEmpty()) {
+                predicate.append("TABLE_NAME NOT LIKE 'MLOG$%' OR ");
             }
 
             getSignalDataCollectionId(connectorConfig).ifPresent(signalTableId -> {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -314,7 +314,7 @@ public class LogMinerQueryBuilderTest {
         final String excludeList = config.tableExcludeList();
         if (config.getLogMiningQueryFilterMode().equals(LogMiningQueryFilterMode.NONE) ||
                 (Strings.isNullOrEmpty(includeList) && Strings.isNullOrEmpty(excludeList))) {
-            return "";
+            return " AND (TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'MLOG$%')";
         }
         else if (config.getLogMiningQueryFilterMode().equals(LogMiningQueryFilterMode.IN)) {
             // Use IN-clauses
@@ -326,10 +326,17 @@ public class LogMinerQueryBuilderTest {
                 inClause = getIn(fieldName, getTableIncludeOrExclude(excludeList, false), true, true);
             }
             final String signalDataClause = getSignalDataCollectionTableClause(config);
+
+            String result = " AND (TABLE_NAME IS NULL OR ";
             if (config.getLogMiningStrategy() == OracleConnectorConfig.LogMiningStrategy.HYBRID) {
-                return " AND (TABLE_NAME IS NULL OR TABLE_NAME LIKE 'OBJ#%' OR " + signalDataClause + inClause + ")";
+                result += "TABLE_NAME LIKE 'OBJ#% OR ";
             }
-            return " AND (TABLE_NAME IS NULL OR " + signalDataClause + inClause + ")";
+
+            if (Strings.isNullOrEmpty(includeList)) {
+                result += "TABLE_NAME NOT LIKE 'MLOG$%' OR ";
+            }
+
+            return result + signalDataClause + inClause + ")";
         }
         else {
             // Regular Expressions
@@ -341,10 +348,17 @@ public class LogMinerQueryBuilderTest {
                 regExpLikeClause = getRegexpLike(fieldName, getTableIncludeOrExclude(excludeList, true), true);
             }
             final String signalDataClause = getSignalDataCollectionTableClause(config);
+
+            String result = " AND (TABLE_NAME IS NULL OR ";
             if (config.getLogMiningStrategy() == OracleConnectorConfig.LogMiningStrategy.HYBRID) {
-                return " AND (TABLE_NAME IS NULL OR TABLE_NAME LIKE 'OBJ#%' OR " + signalDataClause + regExpLikeClause + ")";
+                result += "TABLE_NAME LIKE 'OBJ#%' OR ";
             }
-            return " AND (TABLE_NAME IS NULL OR " + signalDataClause + regExpLikeClause + ")";
+
+            if (Strings.isNullOrEmpty(includeList)) {
+                result += "TABLE_NAME NOT LIKE 'MLOG$%' OR ";
+            }
+
+            return result + signalDataClause + regExpLikeClause + ")";
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9661

When refreshing a materialized view, Oracle uses `MLOG$%` (materialized view log) tables to track the changes that will eventually be placed into the materialized view. In an effort to optimize the LogMiner data fetch, when the query filter mode is not set or an exclude list is specified, the query will now always exclude such log tables by default.
