### PR TITLE
DBZ-9668 Clarify Debezium Server documentation for signaling via source table channel

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -79,7 +79,7 @@ For example,
 +
 For more information about setting the `signal.data.collection` property, see the table of configuration properties for your connector.
 
-NOTE: If you use the `debezium.source.table.include.list` property, you do not need to include the signaling data collection in it. However, if you use the `debezium.source.column.include.list` property, you must include the signaling table columns (`id`, `type`, and `data`).
+NOTE: If you use the `table.include.list` property, you do not need to include the signaling data collection in it. However, if you use the `column.include.list` property, you must include the signaling table columns (`id`, `type`, and `data`).
 
 .Additional resources
 * xref:format-for-specifying-fully-qualified-names-for-data-collections[Formats for specifying fully qualified names for data collections].


### PR DESCRIPTION
Include notes in the signaling documentation to explicitly describe the required configuration for Debezium Server to work with the source signaling channel.

Fixes https://github.com/debezium/dbz/issues/1433