### PR TITLE
DBZ-9533 Always include incremental snapshot offset when the snapshot is in progress

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -20,7 +20,6 @@ import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.relational.TableId;
 import io.debezium.spi.schema.DataCollectionId;
-import io.debezium.util.Collect;
 
 public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9533

SQL Server connector is restarted while it is doing an incremental snapshot. There is a chance that **incremental_snapshot_collections** metadata is not included in the connector offset. This PR ensures the incremental snapshot related metadata is alway included as long as the snapshot is not finished.  And the PR applied similar offset management used in [PostgresOffsetContext.getOffset ](https://github.com/debezium/debezium/blob/ec4ddb0946de6f99befdb353401440f8848c9b0f/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java#L75C27-L75C36  )