### PR TITLE
DBZ-9504 No-op emitter is not forced for context created from headers

### DIFF
--- a/debezium-openlineage/debezium-openlineage-api/src/main/java/io/debezium/openlineage/DebeziumOpenLineageEmitter.java
+++ b/debezium-openlineage/debezium-openlineage-api/src/main/java/io/debezium/openlineage/DebeziumOpenLineageEmitter.java
@@ -190,6 +190,7 @@ public class DebeziumOpenLineageEmitter {
     }
 
     private static boolean isOpenLineageDisabled(ConnectorContext connectorContext) {
-        return !Boolean.parseBoolean(connectorContext.config().get(OPEN_LINEAGE_INTEGRATION_ENABLED));
+        // If config is null, it means that context was created from headers, so we assume OpenLineage is enabled
+        return connectorContext.config() != null && !Boolean.parseBoolean(connectorContext.config().get(OPEN_LINEAGE_INTEGRATION_ENABLED));
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9504

Prevents NPE for contexts created from headers