### PR TITLE
DBZ-9683 prefer wallTime over clusterTime for source.ts_ms

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -285,6 +285,11 @@ public final class SourceInfo extends BaseSourceInfo {
 
     @Override
     protected Instant timestamp() {
+        // Prefer wallTime (actual database change time) over clusterTime when available (version 6.0 and onwards)
+        if (wallTime != 0L) {
+            return Instant.ofEpochMilli(wallTime);
+        }
+        // Fall back to position timestamp (clusterTime)
         var time = position().getTime();
         return (time == -1) ? null : Instant.ofEpochSecond(time);
     }


### PR DESCRIPTION
## Summary

This PR updates the MongoDB connector to use `wallTime` instead of `clusterTime` for `source.ts_ms` in change stream events when available (MongoDB 6.0+).

According to Debezium documentation, `source.ts_ms` should indicate "the time that the change was made in the database." Using `wallTime` provides:
- **Documentation alignment**: `wallTime` correctly represents "the time that the change was made in the database" as defined in the Debezium documentation, whereas `clusterTime` is a logical oplog timestamp that may not match the actual operation time
- **Accurate lag calculation**: `ts_ms - source.ts_ms` now reflects the actual time between database operation and Debezium processing.

## Changes

- Modified `SourceInfo.timestamp()` to prefer `wallTime` (actual database operation time) over `clusterTime` (logical oplog timestamp)
- Falls back to `clusterTime` when `wallTime` is not available (MongoDB < 6.0 or when not provided)
- Added test cases to verify the preference logic and fallback behavior
