### PR TITLE
DBZ-9681-Debezium Oracle connector fails to parse Oracle database version

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -159,7 +159,7 @@ public class OracleConnection extends JdbcConnection {
             try {
                 // Oracle 18.1 introduced BANNER_FULL as the new column rather than BANNER
                 // This column uses a different format than the legacy BANNER.
-                versionStr = queryAndMap("SELECT BANNER_FULL FROM V$VERSION WHERE BANNER_FULL LIKE 'Oracle Database%'", (rs) -> {
+                versionStr = queryAndMap("SELECT VERSION_FULL FROM V$INSTANCE", (rs) -> {
                     if (rs.next()) {
                         return rs.getString(1);
                     }
@@ -168,8 +168,8 @@ public class OracleConnection extends JdbcConnection {
             }
             catch (SQLException e) {
                 // exception ignored
-                if (e.getMessage().contains("ORA-00904: \"BANNER_FULL\"")) {
-                    LOGGER.debug("BANNER_FULL column not in V$VERSION, using BANNER column as fallback");
+                if (e.getMessage().contains("ORA-00904: \"VERSION_FULL\"")) {
+                    LOGGER.debug("VERSION_FULL column not in V$INSTANCE, using VERSION column as fallback");
                     versionStr = null;
                 }
                 else {
@@ -180,7 +180,7 @@ public class OracleConnection extends JdbcConnection {
             // For databases prior to 18.1, a SQLException will be thrown due to BANNER_FULL not being a column and
             // this will cause versionStr to remain null, use fallback column BANNER for versions prior to 18.1.
             if (versionStr == null) {
-                versionStr = queryAndMap("SELECT BANNER FROM V$VERSION WHERE BANNER LIKE 'Oracle Database%'", (rs) -> {
+                versionStr = queryAndMap("SELECT VERSION FROM V$INSTANCE", (rs) -> {
                     if (rs.next()) {
                         return rs.getString(1);
                     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -88,7 +88,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         jdbcConnection = connectionFactory.mainConnection();
 
-        LOGGER.info("Database Version: {}", jdbcConnection.getOracleVersion().getBanner());
+        LOGGER.info("Database Version: {}", jdbcConnection.getOracleVersion().getVersion());
 
         final boolean extendedStringsSupported = jdbcConnection.hasExtendedStringSupport();
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseVersion.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseVersion.java
@@ -8,8 +8,6 @@ package io.debezium.connector.oracle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.debezium.annotation.VisibleForTesting;
-
 /**
  * Represents the Oracle database version.
  *
@@ -17,27 +15,22 @@ import io.debezium.annotation.VisibleForTesting;
  */
 public class OracleDatabaseVersion {
     private final static Pattern VERSION_PATTERN = Pattern
-            .compile("(?:.*)(?:Release )([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:.*)");
-    private final static Pattern VERSION_18_1_PATTERN = Pattern
-            .compile("^Oracle Database.*(?:\\r\\n|\\r|\\n)^(?:Version )([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)", Pattern.MULTILINE);
-
-    @VisibleForTesting
-    public static final OracleDatabaseVersion VERSION_19_3 = new OracleDatabaseVersion(19, 3, 0, 0, 0, "");
+            .compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)$");
 
     private final int major;
     private final int maintenance;
     private final int appServer;
     private final int component;
     private final int platform;
-    private final String banner;
+    private final String version;
 
-    private OracleDatabaseVersion(int major, int maintenance, int appServer, int component, int platform, String banner) {
+    private OracleDatabaseVersion(int major, int maintenance, int appServer, int component, int platform, String version) {
         this.major = major;
         this.maintenance = maintenance;
         this.appServer = appServer;
         this.component = component;
         this.platform = platform;
-        this.banner = banner;
+        this.version = version;
     }
 
     public int getMajor() {
@@ -60,8 +53,8 @@ public class OracleDatabaseVersion {
         return platform;
     }
 
-    public String getBanner() {
-        return banner;
+    public String getVersion() {
+        return version;
     }
 
     @Override
@@ -72,17 +65,14 @@ public class OracleDatabaseVersion {
     /**
      * Parse the Oracle database version banner.
      *
-     * @param banner the banner text
+     * @param version the banner text
      * @return the parsed OracleDatabaseVersion.
      * @throws RuntimeException if the version banner string cannot be parsed
      */
-    public static OracleDatabaseVersion parse(String banner) {
-        Matcher matcher = VERSION_18_1_PATTERN.matcher(banner);
+    public static OracleDatabaseVersion parse(String version) {
+        Matcher matcher = VERSION_PATTERN.matcher(version);
         if (!matcher.matches()) {
-            matcher = VERSION_PATTERN.matcher(banner);
-            if (!matcher.matches()) {
-                throw new RuntimeException("Failed to resolve Oracle database version: '" + banner + "'");
-            }
+            throw new RuntimeException("Failed to resolve Oracle database version: '" + version + "'");
         }
 
         int major = Integer.parseInt(matcher.group(1));
@@ -91,6 +81,6 @@ public class OracleDatabaseVersion {
         int component = Integer.parseInt(matcher.group(4));
         int platform = Integer.parseInt(matcher.group(5));
 
-        return new OracleDatabaseVersion(major, maintenance, app, component, platform, banner);
+        return new OracleDatabaseVersion(major, maintenance, app, component, platform, version);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDatabaseVersionTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDatabaseVersionTest.java
@@ -9,8 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-import io.debezium.doc.FixFor;
-
 /**
  * Test paring of various Oracle version strings.
  *
@@ -19,63 +17,14 @@ import io.debezium.doc.FixFor;
 public class OracleDatabaseVersionTest {
 
     @Test
-    @FixFor("DBZ-7257")
-    public void shouldParseOracle11g() throws Exception {
-        String banner = "Oracle Database 11g Enterprise Edition Release 11.2.0.4.0 - 64bit Production";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 11, 2, 0, 4, 0, banner);
+    public void shouldParseOracleVersion() {
+        String version = "23.4.0.23.10";
+        OracleDatabaseVersion oracleDatabaseVersion = OracleDatabaseVersion.parse(version);
+        assertThat(oracleDatabaseVersion.getMajor()).isEqualTo(23);
+        assertThat(oracleDatabaseVersion.getMaintenance()).isEqualTo(4);
+        assertThat(oracleDatabaseVersion.getAppServer()).isEqualTo(0);
+        assertThat(oracleDatabaseVersion.getComponent()).isEqualTo(23);
+        assertThat(oracleDatabaseVersion.getPlatform()).isEqualTo(10);
+        assertThat(oracleDatabaseVersion.getVersion()).isEqualTo(version);
     }
-
-    @Test
-    @FixFor("DBZ-7257")
-    public void shouldParseOracle12c() throws Exception {
-        String banner = "Oracle Database 12c Enterprise Edition Release 12.1.0.2.0 - 64bit Production";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 12, 1, 0, 2, 0, banner);
-    }
-
-    @Test
-    public void shouldParseOracle19c() throws Exception {
-        String banner = "Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production\nVersion 19.3.0.0.0";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 19, 3, 0, 0, 0, banner);
-    }
-
-    @Test
-    public void shouldParseOracle21c() throws Exception {
-        String banner = "Oracle Database 21c Express Edition Release 21.0.0.0.0 - Production\nVersion 21.3.0.0.0";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 21, 3, 0, 0, 0, banner);
-    }
-
-    @Test
-    public void shouldParseOracle23cFree() throws Exception {
-        String banner = "Oracle Database 23c Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free\nVersion 23.3.0.23.09";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 23, 3, 0, 23, 9, banner);
-    }
-
-    @Test
-    public void shouldParseOracle23c() throws Exception {
-        String banner = "Oracle Database 23c Enterprise Edition Release 23.0.0.0.0\nVersion 23.4.0.23.10";
-        OracleDatabaseVersion version = OracleDatabaseVersion.parse(banner);
-        assertOracleVersion(version, 23, 4, 0, 23, 10, banner);
-    }
-
-    private void assertOracleVersion(
-                                     OracleDatabaseVersion actual,
-                                     int expectedMajor,
-                                     int expectedMaintenance,
-                                     int expectedAppServer,
-                                     int expectedComponent,
-                                     int expectedPlatform,
-                                     String expectedBanner) {
-        assertThat(actual.getMajor()).isEqualTo(expectedMajor);
-        assertThat(actual.getMaintenance()).isEqualTo(expectedMaintenance);
-        assertThat(actual.getAppServer()).isEqualTo(expectedAppServer);
-        assertThat(actual.getComponent()).isEqualTo(expectedComponent);
-        assertThat(actual.getPlatform()).isEqualTo(expectedPlatform);
-        assertThat(actual.getBanner()).isEqualTo(expectedBanner);
-    }
-
 }


### PR DESCRIPTION
## External Links
[DBZ-9681](https://issues.redhat.com/browse/DBZ-9681)

## Description
The change fixes the bug in validating Oracle database version in Oracle Connector. The existing query for validating Oracle connection used V$VERSION view that had version in full banner string and each version has a different format for this banner string, for which there are regex patterns to match and extract each segment of database version.

However, the newer versions have below banner that does not match any of the existing regex:
```
SQL> select banner_full from V$VERSION;

BANNER_FULL
--------------------------------------------------------------------------------
Oracle AI Database 26ai Free Release 23.26.0.0.0 - Develop, Learn, and Run for F
ree
Version 23.26.0.0.0

```
The change queries from V$INSTANCE instead that does not need to parse the banner like above but VERSION string which adheres by the 5 segment version format -
example - 23.26.0.0.0
