### PR TITLE
#1500 Preserve table.include.list order during PostgreSQL snapshot

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -569,7 +569,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         return capturedTables
                 .stream()
-                // Don't sort here - preserve the order from table.include.list patterns
+                .sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -569,7 +569,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         return capturedTables
                 .stream()
-                .sorted()
+                // Don't sort here - preserve the order from table.include.list patterns
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -321,7 +321,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 .sorted();
     }
 
-    private Set<TableId> addSignalingCollectionAndSort(Set<TableId> capturedTables) {
+    protected Set<TableId> addSignalingCollectionAndSort(Set<TableId> capturedTables) {
 
         String tableIncludeList = connectorConfig.tableIncludeList();
         List<String> signalingDataCollections = connectorConfig.getSignalingDataCollectionIds();
@@ -374,7 +374,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         ctx.capturedSchemaTables = snapshottingTask.isOnDemand() ? ctx.capturedTables
                 : capturedSchemaTables
                         .stream()
-                        // Don't re-sort here - preserve the order from table.include.list patterns
+                        .sorted()
                         .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -374,7 +374,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         ctx.capturedSchemaTables = snapshottingTask.isOnDemand() ? ctx.capturedTables
                 : capturedSchemaTables
                         .stream()
-                        .sorted()
+                        // Don't re-sort here - preserve the order from table.include.list patterns
                         .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1500

Removes global alphabetical sorting of tables during snapshot while preserving alphabetical sorting within each pattern match from table.include.list.

Changes:
- PostgreSQL connector: Remove global .sorted() in determineCapturedTables()
- Core: Remove .sorted() for capturedSchemaTables (line 377)
- Core: Keep .sorted() in toTableIds() for within-pattern sorting (line 321)
- Tests: Add a few comprehensive tests for table ordering scenarios