### PR TITLE
Add CockroachDB connector documentation

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -78,6 +78,7 @@ asciidoc:
     link-spanner-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-spanner&v=LATEST&c=plugin&e=tar.gz'
     link-jdbc-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-jdbc&v=LATEST&c=plugin&e=tar.gz'
     link-informix-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-informix&v=LATEST&c=plugin&e=tar.gz'
+    link-cockroachdb-connector: 'connectors/cockroachdb.adoc'
     link-cockroachdb-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-cockroachdb&v=LATEST&c=plugin&e=tar.gz'
     link-server-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-server-dist&v=LATEST&e=tar.gz'
     link-kafka-docs: 'https://kafka.apache.org/documentation'

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -24,6 +24,7 @@
 ** xref:connectors/vitess.adoc[Vitess]
 ** xref:connectors/spanner.adoc[Spanner]
 ** xref:connectors/informix.adoc[Informix]
+** xref:connectors/cockroachdb.adoc[CockroachDB]
 * Sink Connectors
 ** xref:connectors/index-sink.adoc[Overview]
 ** xref:connectors/jdbc.adoc[JDBC]

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -31,6 +31,7 @@ When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-
 
 Signaling is available for use with the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 * MongoDB
@@ -87,6 +88,7 @@ For more information about setting the `signal.data.collection` property, see th
 === Formats for specifying fully qualified names for data collections
 
 [horizontal]
+CockroachDB:: `_<databaseName>_._<schemaName>_._<tableName>_`
 Db2:: `_<schemaName>_._<tableName>_`
 MariaDB:: `_<databaseName>_._<tableName>_`
 MongoDB:: `_<databaseName>_._<collectionName>_`
@@ -518,6 +520,7 @@ You can initiate ad hoc snapshots at any time.
 
 Ad hoc snapshots are available for the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 * MongoDB
@@ -568,6 +571,7 @@ For more information about ad hoc snapshots, see the _Snapshots_ topic in the do
 
 .Additional resources
 
+* {link-prefix}:{link-cockroachdb-connector}#cockroachdb-incremental-snapshots[CockroachDB connector incremental snapshots]
 * {link-prefix}:{link-db2-connector}#debezium-db2-incremental-snapshots[Db2 connector incremental snapshots]
 * {link-prefix}:{link-mongodb-connector}#debezium-mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
 * {link-prefix}:{link-mysql-connector}#debezium-mysql-incremental-snapshots[MySQL connector incremental snapshots]
@@ -584,6 +588,7 @@ After processing the signal, the connector will stop the current in-progress sna
 
 You can stop ad hoc snapshots for the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 * MongoDB
@@ -642,6 +647,7 @@ Therefor it's not possible to specify the data collection as the snapshot proces
 
 You can pause incremental snapshots for the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 * MongoDB
@@ -675,6 +681,7 @@ After processing the signal, the connector will resume previously paused snapsho
 
 You can resume incremental snapshots for the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 * MongoDB
@@ -704,6 +711,7 @@ For more information about incremental snapshots, see the _Snapshots_ topic in t
 
 .Additional resources
 
+* {link-prefix}:{link-cockroachdb-connector}#cockroachdb-incremental-snapshots[CockroachDB connector incremental snapshots]
 * {link-prefix}:{link-db2-connector}#debezium-db2-incremental-snapshots[Db2 connector incremental snapshots]
 * {link-prefix}:{link-mongodb-connector}#debezium-mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
 * {link-prefix}:{link-mysql-connector}#debezium-mysql-incremental-snapshots[MySQL connector incremental snapshots]
@@ -724,6 +732,7 @@ You can initiate ad hoc blocking snapshots at any time.
 
 Blocking snapshots are available for the following {prodname} connectors:
 
+* CockroachDB
 * Db2
 * MariaDB
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -31,7 +31,9 @@ When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-
 
 Signaling is available for use with the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 * MongoDB
@@ -88,7 +90,9 @@ For more information about setting the `signal.data.collection` property, see th
 === Formats for specifying fully qualified names for data collections
 
 [horizontal]
+ifdef::community[]
 CockroachDB:: `_<databaseName>_._<schemaName>_._<tableName>_`
+endif::community[]
 Db2:: `_<schemaName>_._<tableName>_`
 MariaDB:: `_<databaseName>_._<tableName>_`
 MongoDB:: `_<databaseName>_._<collectionName>_`
@@ -520,7 +524,9 @@ You can initiate ad hoc snapshots at any time.
 
 Ad hoc snapshots are available for the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 * MongoDB
@@ -588,7 +594,9 @@ After processing the signal, the connector will stop the current in-progress sna
 
 You can stop ad hoc snapshots for the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 * MongoDB
@@ -647,7 +655,9 @@ Therefor it's not possible to specify the data collection as the snapshot proces
 
 You can pause incremental snapshots for the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 * MongoDB
@@ -681,7 +691,9 @@ After processing the signal, the connector will resume previously paused snapsho
 
 You can resume incremental snapshots for the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 * MongoDB
@@ -732,7 +744,9 @@ You can initiate ad hoc blocking snapshots at any time.
 
 Blocking snapshots are available for the following {prodname} connectors:
 
+ifdef::community[]
 * CockroachDB
+endif::community[]
 * Db2
 * MariaDB
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -723,7 +723,9 @@ For more information about incremental snapshots, see the _Snapshots_ topic in t
 
 .Additional resources
 
+ifdef::community[]
 * {link-prefix}:{link-cockroachdb-connector}#cockroachdb-incremental-snapshots[CockroachDB connector incremental snapshots]
+endif::community[]
 * {link-prefix}:{link-db2-connector}#debezium-db2-incremental-snapshots[Db2 connector incremental snapshots]
 * {link-prefix}:{link-mongodb-connector}#debezium-mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
 * {link-prefix}:{link-mysql-connector}#debezium-mysql-incremental-snapshots[MySQL connector incremental snapshots]

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1,0 +1,1190 @@
+// Category: debezium-using
+// Type: assembly
+[id="debezium-connector-for-cockroachdb"]
+= {prodname} connector for CockroachDB
+:context: CockroachDB
+:mbean-name: {context}
+:toc:
+:toc-placement: macro
+:linkattrs:
+:icons: font
+:source-highlighter: highlight.js
+:connector-name: CockroachDB
+
+toc::[]
+
+{prodname}'s CockroachDB connector captures row-level changes from a link:https://www.cockroachlabs.com/docs/stable/changefeed-messages[CockroachDB enriched changefeed] and streams them into Kafka topics.
+
+CockroachDB link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeeds] watch a database's data changes -- inserts, updates, deletes -- in near-real-time.
+The connector creates a link:https://www.cockroachlabs.com/docs/stable/create-changefeed[changefeed] that publishes events to an intermediate Kafka cluster, then consumes those events, transforms them into the standard {prodname} envelope format, and produces them to the output Kafka topics that downstream consumers subscribe to.
+
+[NOTE]
+====
+The CockroachDB connector is an incubating connector.
+An incubating connector is one that has been released for preview purposes and is subject to changes that may not always be backward compatible.
+====
+
+// Type: concept
+// Title: Overview of {prodname} CockroachDB connector
+// ModuleID: overview-of-debezium-cockroachdb-connector
+[[cockroachdb-overview]]
+== Overview
+
+CockroachDB is a distributed SQL database that provides link:https://www.cockroachlabs.com/docs/stable/architecture/overview[strong consistency], horizontal scalability, and survivability.
+Unlike traditional databases that rely on a write-ahead log (WAL) for change data capture, CockroachDB provides a native link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeed mechanism] that streams row-level changes directly from the storage layer.
+
+The {prodname} CockroachDB connector leverages this native changefeed capability.
+The connector produces a change event for every row-level insert, update, and delete operation that was captured and sends change event records for each table to a separate Kafka topic.
+Client applications read the Kafka topics that correspond to the database tables of interest and can react to every row-level event they receive from those topics.
+
+The connector is tolerant of failures.
+As the connector reads changes and produces events, it records the last resolved timestamp processed.
+If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues streaming records from where it last left off.
+
+// Type: assembly
+// ModuleID: how-debezium-cockroachdb-connectors-work
+// Title: How {prodname} CockroachDB connectors work
+[[how-the-cockroachdb-connector-works]]
+== How the connector works
+
+To optimally configure and run a {prodname} CockroachDB connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
+
+// Type: concept
+// ModuleID: cockroachdb-connector-architecture
+// Title: {prodname} CockroachDB connector architecture
+[[cockroachdb-architecture]]
+=== Architecture
+
+The CockroachDB connector uses a two-stage Kafka architecture:
+
+1. **CockroachDB changefeed -> Intermediate Kafka**: The connector creates a single CockroachDB changefeed covering all configured tables (`CREATE CHANGEFEED FOR table1, table2, ...`) with the `enriched` envelope format.
+CockroachDB automatically routes events to per-table Kafka topics in the intermediate cluster.
+The enriched format includes both schema metadata and the full before/after row state.
+
+2. **Intermediate Kafka -> {prodname} -> Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer, routes each event to the correct table based on the topic name, transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields), and produces them to the final output Kafka topics.
+
+This architecture allows the connector to leverage CockroachDB's native, highly-available changefeed infrastructure for capture reliability, while providing the standard {prodname} event format that downstream consumers expect.
+Using a single multi-table changefeed is the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended approach] to stay within CockroachDB's limit of approximately 80 changefeed jobs per cluster.
+
+// Type: concept
+// ModuleID: cockroachdb-snapshots
+// Title: How {prodname} CockroachDB connectors perform snapshots
+[[cockroachdb-snapshots]]
+=== Snapshots
+
+CockroachDB changefeeds natively support an link:https://www.cockroachlabs.com/docs/stable/create-changefeed#initial-scan[`initial_scan`] option that backfills all existing rows before streaming ongoing changes.
+The {prodname} CockroachDB connector maps its `snapshot.mode` configuration to the CockroachDB `initial_scan` changefeed option, so there is no separate JDBC-based snapshot phase.
+
+During the initial scan phase, all events are marked with `op=r` (read) to distinguish them from ongoing change events.
+Once the initial scan completes and the changefeed transitions to streaming, events are marked with the appropriate operation type (`c` for create, `u` for update, `d` for delete).
+
+The following table shows how each `snapshot.mode` maps to the CockroachDB `initial_scan` option:
+
+.Snapshot mode to initial_scan mapping
+[cols="30%a,20%a,50%a",options="header"]
+|===
+|Snapshot mode
+|initial_scan value
+|Description
+
+|`initial` (default)
+|`yes` on first start, `no` on restart
+|On first start (no prior offset), backfills all existing rows.
+On restart with an existing offset, resumes streaming from the stored cursor.
+
+|`always`
+|`yes`
+|Always backfills all existing rows, even on restart.
+
+|`initial_only`
+|`only`
+|Backfills all existing rows, then the connector stops.
+Useful for one-time data migration.
+
+|`no_data` / `never`
+|`no`
+|Skips the initial scan entirely.
+Only ongoing changes after the changefeed is created are captured.
+
+|`when_needed`
+|`yes` on first start, `no` on restart
+|Same as `initial`, but also re-snapshots if the stored offset is no longer valid.
+|===
+
+// Type: concept
+// ModuleID: how-debezium-cockroachdb-connectors-stream-change-event-records
+// Title: How {prodname} CockroachDB connectors stream change event records
+[[cockroachdb-streaming-changes]]
+=== Streaming changes
+
+After any initial scan completes, the CockroachDB connector streams changes continuously.
+When a row-level change occurs in CockroachDB, the changefeed writes a corresponding event to the intermediate Kafka topic.
+The connector consumes these events, transforms them into {prodname} change events, and forwards them to the output Kafka topics.
+
+CockroachDB changefeeds emit link:https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages[resolved timestamp messages] at a configurable interval.
+These messages indicate that all changes up to that timestamp have been emitted.
+The connector uses resolved timestamps for offset tracking, so that on restart it can create a new changefeed with a `cursor` pointing to the last resolved timestamp, ensuring no events are missed.
+
+When the connector receives changes it transforms the events into {prodname} _read_, _create_, _update_, or _delete_ events.
+The connector forwards these change events in records to the Kafka Connect framework, which is running in the same process.
+The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
+
+Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic.
+The offset indicates source-specific position information that {prodname} includes with each event.
+For the CockroachDB connector, the last resolved timestamp is the offset.
+
+When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector.
+When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset.
+
+// Type: concept
+// ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
+// Title: Default names of Kafka topics that receive {prodname} CockroachDB change event records
+[[cockroachdb-topic-names]]
+=== Topic names
+
+The CockroachDB connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic.
+By default, the Kafka topic name is _topicPrefix_._schemaName_._tableName_ where:
+
+* _topicPrefix_ is the topic prefix as specified by the `topic.prefix` connector configuration property.
+* _schemaName_ is the name of the database schema (default: `public`).
+* _tableName_ is the name of the database table in which the operation occurred.
+
+For example, suppose that `cockroachdb` is the topic prefix for a connector that is capturing changes from a database that contains two tables: `orders` and `customers`.
+The connector would stream records to these two Kafka topics:
+
+* `cockroachdb.public.orders`
+* `cockroachdb.public.customers`
+
+The connector applies similar naming conventions as other {prodname} connectors, and supports the standard topic naming strategies.
+
+// Type: assembly
+// ModuleID: descriptions-of-debezium-cockroachdb-connector-data-change-events
+// Title: Descriptions of {prodname} CockroachDB connector data change events
+[[cockroachdb-events]]
+== Data change events
+
+The {prodname} CockroachDB connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation.
+Each event contains a key and a value.
+The key and value are separate documents.
+The structure of the key and the value depends on the table that was changed.
+
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_.
+However, the structure of these events may change over time, which can be difficult for consumers to handle.
+To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry.
+This makes each event self-contained.
+
+The following skeleton JSON documents show the basic structure for the key and value documents.
+However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of the key and value documents.
+A `schema` field is in a change event key or change event value only when you configure the converter to produce it.
+Likewise, the event key and event payload are present only if you configure a converter to produce it.
+If you use the JSON converter and you configure it to produce schemas, change events have this structure:
+
+[source,json,index=0]
+----
+// Key
+{
+ "schema": { // <1>
+   ...
+  },
+ "payload": { // <2>
+   ...
+ }
+}
+
+// Value
+{
+ "schema": { // <3>
+   ...
+ },
+ "payload": { // <4>
+   ...
+ }
+}
+----
+
+.Overview of change event basic content
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The first `schema` field is part of the event key.
+It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion.
+In other words, the first `schema` field describes the structure of the primary key.
+
+|2
+|`payload`
+|The first `payload` field is part of the event key.
+It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
+
+|3
+|`schema`
+|The second `schema` field is part of the event value.
+It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion.
+In other words, the second `schema` describes the structure of the row that was changed.
+Typically, this schema contains nested schemas.
+
+|4
+|`payload`
+|The second `payload` field is part of the event value.
+It has the structure described by the previous `schema` field and it contains the actual data for the row that was changed.
+
+|===
+
+The default behavior is that the connector streams change event records to xref:cockroachdb-topic-names[topics with names that are the same as the event's originating table].
+
+// Type: concept
+// ModuleID: about-keys-in-debezium-cockroachdb-change-events
+// Title: About keys in {prodname} CockroachDB change events
+[[cockroachdb-change-events-key]]
+=== Change event keys
+
+For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created.
+
+Consider an `orders` table defined in the `defaultdb` database and the example of a change event key for that table.
+
+.Example table
+[source,sql,indent=0]
+----
+CREATE TABLE orders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_name STRING NOT NULL,
+  amount DECIMAL NOT NULL,
+  status STRING DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT now()
+);
+----
+
+.Example change event key
+Every change event for the `orders` table while it has this definition has the same key structure, which in JSON looks like this:
+
+[source,json,indent=0]
+----
+{
+  "schema": {
+    "type": "struct",
+    "name": "cockroachdb.public.orders.Key",
+    "optional": false,
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "id"
+      }
+    ]
+  },
+  "payload": {
+    "id": "5f8a1c2e-3b4d-4e6f-8a9b-1c2d3e4f5a6b"
+  }
+}
+----
+
+// Type: concept
+// ModuleID: about-values-in-debezium-cockroachdb-change-events
+// Title: About values in {prodname} CockroachDB change events
+[[cockroachdb-change-events-value]]
+=== Change event values
+
+Consider the same sample table that was used to show an example of a change event key:
+
+[source,sql,indent=0]
+----
+CREATE TABLE orders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_name STRING NOT NULL,
+  amount DECIMAL NOT NULL,
+  status STRING DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT now()
+);
+----
+
+// Type: continue
+[[cockroachdb-create-events]]
+=== _create_ events
+
+The following example shows the value portion of a change event that the connector generates for an operation that inserts data in the `orders` table:
+
+[source,json,options="nowrap",indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": null, // <1>
+        "after": { // <2>
+            "id": "5f8a1c2e-3b4d-4e6f-8a9b-1c2d3e4f5a6b",
+            "customer_name": "Alice",
+            "amount": "99.99",
+            "status": "pending",
+            "created_at": "2026-01-15T10:30:00"
+        },
+        "source": { // <3>
+            "version": "{debezium-version}",
+            "connector": "cockroachdb",
+            "name": "cockroachdb_connector",
+            "ts_ms": 1705312200000,
+            "ts_us": 1705312200000000,
+            "ts_ns": 1705312200000000000,
+            "snapshot": "false",
+            "db": "defaultdb",
+            "sequence": "[]",
+            "schema": "public",
+            "table": "orders",
+            "cluster": "cockroachdb_connector",
+            "resolved_ts": null,
+            "ts_hlc": null
+        },
+        "op": "c", // <4>
+        "ts_ms": 1705312200123, // <5>
+        "ts_us": 1705312200123456,
+        "ts_ns": 1705312200123456789
+    }
+}
+----
+
+.Descriptions of _create_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`before`
+a|An optional field that specifies the state of the row before the event occurred.
+When the `op` field is `c` for create, the `before` field is `null` since this change event is for new content.
+
+|2
+|`after`
+|An optional field that specifies the state of the row after the event occurred.
+In this example, the `after` field contains the values of the new row's `id`, `customer_name`, `amount`, `status`, and `created_at` columns.
+
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event.
+This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction.
+The source metadata includes:
+
+* {prodname} version
+* Connector type and name
+* Database and table that contains the new row
+* Whether the event was part of a snapshot (initial scan)
+* The schema name
+* The logical cluster name
+* The resolved timestamp (for consistency tracking)
+* The Hybrid Logical Clock (HLC) timestamp (CockroachDB's internal timestamp format)
+
+|4
+|`op`
+a|Mandatory string that describes the type of operation that caused the connector to generate the event.
+In this example, `c` indicates that the operation created a row.
+Valid values are:
+
+* `r` = read (initial scan / snapshot)
+* `c` = create
+* `u` = update
+* `d` = delete
+
+|5
+|`ts_ms`, `ts_us`, `ts_ns`
+a|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|===
+
+// Type: continue
+[[cockroachdb-update-events]]
+=== _update_ events
+
+The value of a change event for an update in the sample `orders` table has the same schema as a _create_ event for that table.
+Likewise, the event value's payload has the same structure.
+However, the event value payload contains different values in an _update_ event.
+Here is an example of a change event value in an event that the connector generates for an update in the `orders` table:
+
+[source,json,indent=0,options="nowrap",subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": null, // <1>
+        "after": { // <2>
+            "id": "5f8a1c2e-3b4d-4e6f-8a9b-1c2d3e4f5a6b",
+            "customer_name": "Alice",
+            "amount": "99.99",
+            "status": "shipped",
+            "created_at": "2026-01-15T10:30:00"
+        },
+        "source": { // <3>
+            "version": "{debezium-version}",
+            "connector": "cockroachdb",
+            "name": "cockroachdb_connector",
+            "ts_ms": 1705312500000,
+            "ts_us": 1705312500000000,
+            "ts_ns": 1705312500000000000,
+            "snapshot": "false",
+            "db": "defaultdb",
+            "sequence": "[]",
+            "schema": "public",
+            "table": "orders",
+            "cluster": "cockroachdb_connector",
+            "resolved_ts": null,
+            "ts_hlc": null
+        },
+        "op": "u", // <4>
+        "ts_ms": 1705312500123,
+        "ts_us": 1705312500123456,
+        "ts_ns": 1705312500123456789
+    }
+}
+----
+
+.Descriptions of _update_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`before`
+a|An optional field that contains the state of the row before the update.
+By default, CockroachDB changefeeds do not include the `before` state unless the `diff` changefeed option is enabled (`cockroachdb.changefeed.include.diff=true`).
+When `diff` is not enabled, this field is `null`.
+
+|2
+|`after`
+|An optional field that specifies the state of the row after the event occurred.
+In this example, the `status` value has been changed to `shipped`.
+
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event.
+The `source` field structure has the same fields as in a _create_ event, but some values are different.
+
+|4
+|`op`
+a|Mandatory string that describes the type of operation.
+In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|===
+
+[NOTE]
+====
+To include the `before` state in update events, set `cockroachdb.changefeed.include.diff` to `true` in the connector configuration.
+This enables the CockroachDB changefeed `diff` option, which includes the previous row state.
+====
+
+[[cockroachdb-delete-events]]
+=== _delete_ events
+
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table.
+The `payload` portion in a _delete_ event for the sample `orders` table looks like this:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": null,
+        "after": null, // <1>
+        "source": { // <2>
+            "version": "{debezium-version}",
+            "connector": "cockroachdb",
+            "name": "cockroachdb_connector",
+            "ts_ms": 1705312800000,
+            "ts_us": 1705312800000000,
+            "ts_ns": 1705312800000000000,
+            "snapshot": "false",
+            "db": "defaultdb",
+            "sequence": "[]",
+            "schema": "public",
+            "table": "orders",
+            "cluster": "cockroachdb_connector",
+            "resolved_ts": null,
+            "ts_hlc": null
+        },
+        "op": "d", // <3>
+        "ts_ms": 1705312800123,
+        "ts_us": 1705312800123456,
+        "ts_ns": 1705312800123456789
+    }
+}
+----
+
+.Descriptions of _delete_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`after`
+|The `after` field is `null`, signifying that the row no longer exists.
+
+|2
+|`source`
+a|Mandatory field that describes the source metadata for the event.
+In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table.
+
+|3
+|`op`
+a|Mandatory string that describes the type of operation.
+The `op` field value is `d`, signifying that this row was deleted.
+
+|===
+
+A _delete_ change event record provides a consumer with the information it needs to process the removal of this row.
+
+CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
+Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
+This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
+
+// Type: continue
+[[cockroachdb-tombstone-events]]
+.Tombstone events
+When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key.
+However, for Kafka to remove all messages that have that same key, the message value must be `null`.
+To make this possible, the connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
+
+// Type: reference
+// ModuleID: how-debezium-cockroachdb-connectors-map-data-types
+// Title: How {prodname} CockroachDB connectors map data types
+[[cockroachdb-data-types]]
+== Data type mappings
+
+The CockroachDB connector represents changes to rows with events that are structured like the table in which the row exists.
+The event contains a field for each column value.
+How that value is represented in the event depends on the CockroachDB data type of the column.
+This section describes these mappings.
+
+[id="cockroachdb-types"]
+=== CockroachDB types
+
+.Mappings for CockroachDB data types
+[cols="30%a,20%a,50%a",options="header"]
+|===
+|CockroachDB data type
+|Kafka Connect schema type
+|Notes
+
+|`BOOL`, `BOOLEAN`
+|`BOOLEAN`
+|
+
+|`INT2`, `SMALLINT`
+|`INT16`
+|
+
+|`INT4`, `INT`, `INTEGER`
+|`INT32`
+|
+
+|`INT8`, `BIGINT`, `SERIAL`
+|`INT64`
+|
+
+|`FLOAT4`, `REAL`
+|`FLOAT32`
+|
+
+|`FLOAT8`, `DOUBLE PRECISION`, `FLOAT`
+|`FLOAT64`
+|
+
+|`NUMERIC`, `DECIMAL`, `DEC`
+|`STRING`
+|Represented as string to preserve arbitrary precision.
+
+|`STRING`, `VARCHAR`, `CHAR`, `CHARACTER VARYING`, `TEXT`
+|`STRING`
+|
+
+|`UUID`
+|`STRING`
+|Represented as the standard UUID string format.
+
+|`BYTES`, `BYTEA`, `BLOB`
+|`BYTES`
+|
+
+|`DATE`
+|`STRING`
+|ISO-8601 date format.
+
+|`TIME`, `TIMETZ`
+|`STRING`
+|ISO-8601 time format.
+
+|`TIMESTAMP`, `TIMESTAMPTZ`
+|`STRING`
+|ISO-8601 timestamp format.
+
+|`INTERVAL`
+|`STRING`
+|CockroachDB interval format.
+
+|`JSONB`, `JSON`
+|`STRING` (Json logical type)
+|Represented as a JSON string using the {prodname} `Json` logical type.
+
+|`INET`
+|`STRING`
+|IP address string.
+
+|`BIT`, `VARBIT`
+|`STRING`
+|Bit string representation.
+
+|`ARRAY`
+|`STRING`
+|JSON array format.
+
+|`ENUM`
+|`STRING`
+|Enum label string.
+
+|`GEOMETRY`, `GEOGRAPHY`
+|`STRING`
+|GeoJSON or WKT format.
+
+|`VECTOR`
+|`ARRAY` of `FLOAT64` (DoubleVector)
+|pgvector-compatible type (CockroachDB 24.2+).
+Uses the {prodname} `DoubleVector` logical type.
+|===
+
+// Type: assembly
+// ModuleID: setting-up-cockroachdb-for-debezium
+// Title: Setting up CockroachDB for {prodname}
+[[setting-up-cockroachdb]]
+== Setting up CockroachDB
+
+Before deploying the {prodname} CockroachDB connector, verify the following prerequisites:
+
+.Prerequisites
+
+* **CockroachDB**: The connector requires CockroachDB with support for sink-based changefeeds.
+All changefeed features are available in all CockroachDB editions without an enterprise license.
+
+* **Changefeed permissions**: The database user configured for the connector must have the `CHANGEFEED` privilege on the target tables (CockroachDB v22.2+), or be an `admin` user.
++
+[source,sql]
+----
+-- Grant changefeed privilege to a specific user
+GRANT CHANGEFEED ON TABLE orders TO myuser;
+
+-- Or grant on all tables in a database
+GRANT CHANGEFEED ON ALL TABLES IN DATABASE defaultdb TO myuser;
+----
+
+* **Intermediate Kafka cluster**: The connector requires a Kafka cluster where CockroachDB will publish changefeed events.
+This can be the same Kafka cluster used by Kafka Connect, or a separate one.
+
+* **Network connectivity**: The CockroachDB cluster must be able to reach the intermediate Kafka cluster to publish changefeed events.
+The Kafka Connect worker must be able to reach both the CockroachDB cluster (for JDBC) and the intermediate Kafka cluster (for consuming changefeed events).
+
+// Type: assembly
+// ModuleID: deploying-and-managing-debezium-cockroachdb-connectors
+// Title: Deploying and managing {prodname} CockroachDB connectors
+[[cockroachdb-deploying-a-connector]]
+== Deployment
+
+With link:http://kafka.apache.org/[Kafka] and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} CockroachDB connector are to download the connector's plug-in archive, extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
+You then need to restart your Kafka Connect process to pick up the new JAR files.
+
+If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Kafka and Kafka Connect.
+You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
+
+[IMPORTANT]
+====
+The {prodname} container images that you obtain from `quay.io` do not undergo rigorous testing or security analysis, and are provided for testing and evaluation purposes only.
+These images are not intended for use in production environments.
+To mitigate risk in production deployments, deploy only containers that are actively maintained by trusted vendors, and thoroughly tested for potential vulnerabilities.
+====
+
+// Type: concept
+// ModuleID: debezium-cockroachdb-connector-configuration-example
+// Title: {prodname} CockroachDB connector configuration example
+[[cockroachdb-example-configuration]]
+=== Connector configuration example
+
+Following is an example of the configuration for a CockroachDB connector that connects to a CockroachDB cluster and captures changes from all tables in the `public` schema of the `defaultdb` database.
+
+[source,json]
+----
+{
+  "name": "cockroachdb-connector",  // <1>
+  "config": {
+    "connector.class": "io.debezium.connector.cockroachdb.CockroachDBConnector", // <2>
+    "database.hostname": "cockroachdb-host", // <3>
+    "database.port": "26257", // <4>
+    "database.user": "myuser", // <5>
+    "database.password": "mypassword", // <6>
+    "database.dbname": "defaultdb", // <7>
+    "topic.prefix": "cockroachdb", // <8>
+    "cockroachdb.changefeed.sink.uri": "kafka://kafka-broker:9092", // <9>
+    "cockroachdb.changefeed.envelope": "enriched", // <10>
+    "snapshot.mode": "initial", // <11>
+    "tasks.max": "1" // <12>
+  }
+}
+----
+<1> The name of the connector when registered with a Kafka Connect service.
+<2> The name of this CockroachDB connector class.
+<3> The address of the CockroachDB host.
+<4> The port number of the CockroachDB server (default: 26257).
+<5> The name of the CockroachDB user.
+<6> The password of the CockroachDB user.
+<7> The name of the CockroachDB database to connect to.
+<8> The topic prefix for Kafka topics that the connector writes to.
+<9> The URI of the Kafka cluster where CockroachDB will publish changefeed events.
+<10> The changefeed envelope format (`enriched` includes schema metadata).
+<11> The snapshot mode; `initial` backfills existing rows on first start.
+<12> The maximum number of tasks.
+
+See the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] that can be specified in these configurations.
+
+// Type: procedure
+// ModuleID: adding-debezium-cockroachdb-connector-configuration-to-kafka-connect
+// Title: Adding {prodname} CockroachDB connector configuration to Kafka Connect
+[[cockroachdb-adding-connector-configuration]]
+=== Adding connector configuration
+
+To start running a CockroachDB connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
+
+.Prerequisites
+
+* CockroachDB is running and accessible.
+
+* The intermediate Kafka cluster is running and accessible from the CockroachDB cluster.
+
+* The CockroachDB connector is installed.
+
+.Procedure
+
+. Create a configuration for the CockroachDB connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
++
+For example:
++
+[source,bash]
+----
+curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" \
+  http://localhost:8083/connectors/ -d @connector-config.json
+----
+
+.Results
+
+When the connector starts, it connects to the CockroachDB database, creates a changefeed, and starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+
+// Type: assembly
+// ModuleID: monitoring-debezium-cockroachdb-connector-performance
+// Title: Monitoring {prodname} CockroachDB connector performance
+[[cockroachdb-monitoring]]
+=== Monitoring
+
+The {prodname} CockroachDB connector provides the built-in support for JMX metrics that Kafka and Kafka Connect provide, plus streaming metrics.
+
+* xref:cockroachdb-streaming-metrics[Streaming metrics] provide information about connector operations when the connector is capturing changes and streaming change event records.
+
+xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+// Type: concept
+// ModuleID: monitoring-debezium-cockroachdb-connectors-customized-mbean-names
+// Title: Customized names for CockroachDB connector MBean objects
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
+
+// Type: reference
+// ModuleID: monitoring-debezium-cockroachdb-connector-record-streaming
+// Title: Monitoring {prodname} CockroachDB connector record streaming
+[[cockroachdb-streaming-metrics]]
+==== Streaming metrics
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-streaming]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
+
+// Type: reference
+// ModuleID: descriptions-of-debezium-cockroachdb-connector-configuration-properties
+// Title: Description of {prodname} CockroachDB connector configuration properties
+[[cockroachdb-connector-properties]]
+=== Connector configuration properties
+
+The {prodname} CockroachDB connector has many configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
+
+* xref:cockroachdb-required-configuration-properties[Required configuration properties]
+* xref:cockroachdb-connection-configuration-properties[Connection configuration properties]
+* xref:cockroachdb-changefeed-configuration-properties[Changefeed configuration properties]
+* xref:cockroachdb-connector-configuration-properties[Connector configuration properties]
+* xref:cockroachdb-advanced-configuration-properties[Advanced configuration properties]
+
+[id="cockroachdb-required-configuration-properties"]
+The following configuration properties are _required_ unless a default value is available.
+
+.Required connector configuration properties
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[cockroachdb-property-name]]<<cockroachdb-property-name, `+name+`>>
+|No default
+|Unique name for the connector.
+Attempting to register again with the same name will fail.
+This property is required by all Kafka Connect connectors.
+
+|[[cockroachdb-property-connector-class]]<<cockroachdb-property-connector-class, `+connector.class+`>>
+|No default
+|The name of the Java class for the connector.
+Always use a value of `io.debezium.connector.cockroachdb.CockroachDBConnector` for the CockroachDB connector.
+
+|[[cockroachdb-property-tasks-max]]<<cockroachdb-property-tasks-max, `+tasks.max+`>>
+|`1`
+|The maximum number of tasks that should be created for this connector.
+
+|[[cockroachdb-property-hostname]]<<cockroachdb-property-hostname, `+database.hostname+`>>
+|No default
+|IP address or hostname of the CockroachDB database server.
+
+|[[cockroachdb-property-port]]<<cockroachdb-property-port, `+database.port+`>>
+|`26257`
+|Integer port number of the CockroachDB database server.
+The CockroachDB default SQL port is 26257.
+
+|[[cockroachdb-property-user]]<<cockroachdb-property-user, `+database.user+`>>
+|No default
+|Name of the CockroachDB database user for connecting to the database.
+
+|[[cockroachdb-property-password]]<<cockroachdb-property-password, `+database.password+`>>
+|No default
+|Password of the CockroachDB database user for connecting to the database.
+
+|[[cockroachdb-property-dbname]]<<cockroachdb-property-dbname, `+database.dbname+`>>
+|No default
+|The name of the CockroachDB database from which to stream changes.
+
+|[[cockroachdb-property-topic-prefix]]<<cockroachdb-property-topic-prefix, `+topic.prefix+`>>
+|No default
+|Topic prefix that provides a namespace for the particular CockroachDB database server or cluster.
+The topic prefix should be unique across all other connectors, since it is used as the prefix for all Kafka topic names that receive events emitted by this connector.
+Only alphanumeric characters, hyphens, dots, and underscores must be used in the topic prefix.
+
+|[[cockroachdb-property-sink-uri]]<<cockroachdb-property-sink-uri, `+cockroachdb.changefeed.sink.uri+`>>
+|No default
+|The URI for the intermediate Kafka cluster where CockroachDB publishes changefeed events.
+Format: `kafka://host:port`.
+This is a required property.
+
+|===
+
+[id="cockroachdb-connection-configuration-properties"]
+The following properties configure the JDBC connection to the CockroachDB database.
+
+.Connection configuration properties
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[cockroachdb-property-sslmode]]<<cockroachdb-property-sslmode, `+database.sslmode+`>>
+|`prefer`
+|Whether to use an encrypted connection to CockroachDB.
+Options include: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
+See the link:https://www.cockroachlabs.com/docs/stable/authentication[CockroachDB authentication docs] for details.
+
+|[[cockroachdb-property-sslrootcert]]<<cockroachdb-property-sslrootcert, `+database.sslrootcert+`>>
+|No default
+|File containing the root certificate(s) against which the server is validated.
+
+|[[cockroachdb-property-sslcert]]<<cockroachdb-property-sslcert, `+database.sslcert+`>>
+|No default
+|File containing the SSL certificate for the client.
+
+|[[cockroachdb-property-sslkey]]<<cockroachdb-property-sslkey, `+database.sslkey+`>>
+|No default
+|File containing the SSL private key for the client.
+
+|[[cockroachdb-property-sslpassword]]<<cockroachdb-property-sslpassword, `+database.sslpassword+`>>
+|No default
+|Password to access the client private key from the file specified by `database.sslkey`.
+
+|[[cockroachdb-property-tcp-keepalive]]<<cockroachdb-property-tcp-keepalive, `+database.tcpKeepAlive+`>>
+|`true`
+|Enable or disable TCP keep-alive probe to avoid dropping TCP connections.
+
+|[[cockroachdb-property-on-connect-statements]]<<cockroachdb-property-on-connect-statements, `+database.on.connect.statements+`>>
+|No default
+|A semicolon-separated list of SQL statements to be executed when a JDBC connection to the database is established.
+Use doubled semicolons (`;;`) to use a semicolon as a character and not as a delimiter.
+
+|[[cockroachdb-property-connection-timeout]]<<cockroachdb-property-connection-timeout, `+connection.timeout.ms+`>>
+|`30000`
+|How long to wait for a connection to be established, in milliseconds.
+
+|[[cockroachdb-property-connection-retry-delay]]<<cockroachdb-property-connection-retry-delay, `+connection.retry.delay.ms+`>>
+|`1000`
+|Base delay in milliseconds between connection retry attempts.
+The actual delay is multiplied by the attempt number (linear backoff).
+
+|[[cockroachdb-property-connection-max-retries]]<<cockroachdb-property-connection-max-retries, `+connection.max.retries+`>>
+|`3`
+|Maximum number of connection retry attempts before giving up.
+
+|[[cockroachdb-property-connection-validation-timeout]]<<cockroachdb-property-connection-validation-timeout, `+connection.validation.timeout.seconds+`>>
+|`5`
+|Timeout in seconds for validating that an existing JDBC connection is still usable.
+
+|[[cockroachdb-property-skip-permission-check]]<<cockroachdb-property-skip-permission-check, `+cockroachdb.skip.permission.check+`>>
+|`false`
+|Whether to skip the changefeed permission validation during connection.
+Set to `true` when the user is a superadmin or permissions are managed externally.
+
+|===
+
+[id="cockroachdb-changefeed-configuration-properties"]
+The following properties configure the CockroachDB changefeed behavior.
+
+.Changefeed configuration properties
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[cockroachdb-property-envelope]]<<cockroachdb-property-envelope, `+cockroachdb.changefeed.envelope+`>>
+|`enriched`
+|The envelope type for changefeed events.
+Options: `enriched` (includes schema metadata), `wrapped`, `bare`.
+The `enriched` format is recommended as it provides full schema information.
+
+|[[cockroachdb-property-resolved-interval]]<<cockroachdb-property-resolved-interval, `+cockroachdb.changefeed.resolved.interval+`>>
+|`10s`
+|The interval for resolved timestamp messages.
+Format: `10s`, `1m`, etc.
+Resolved timestamps are used for offset tracking.
+
+|[[cockroachdb-property-include-updated]]<<cockroachdb-property-include-updated, `+cockroachdb.changefeed.include.updated+`>>
+|`false`
+|Whether to include information about which columns were updated in UPDATE events.
+
+|[[cockroachdb-property-include-diff]]<<cockroachdb-property-include-diff, `+cockroachdb.changefeed.include.diff+`>>
+|`false`
+|Whether to include before/after diff information in changefeed events.
+When enabled, UPDATE events include the previous row state in the `before` field.
+
+|[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
+|`source,schema`
+|Comma-separated list of properties to include in the enriched envelope: `source`, `schema`, `mvcc`.
+
+|[[cockroachdb-property-cursor]]<<cockroachdb-property-cursor, `+cockroachdb.changefeed.cursor+`>>
+|`now`
+|The cursor position to start the changefeed from.
+Use `now` for current time or a specific timestamp.
+On restart with a stored offset, the connector uses the stored resolved timestamp instead of this value.
+
+|[[cockroachdb-property-batch-size]]<<cockroachdb-property-batch-size, `+cockroachdb.changefeed.batch.size+`>>
+|`1000`
+|The batch size for changefeed processing.
+
+|[[cockroachdb-property-poll-interval]]<<cockroachdb-property-poll-interval, `+cockroachdb.changefeed.poll.interval.ms+`>>
+|`100`
+|The poll interval in milliseconds for changefeed processing.
+
+|[[cockroachdb-property-sink-type]]<<cockroachdb-property-sink-type, `+cockroachdb.changefeed.sink.type+`>>
+|`kafka`
+|The type of sink for changefeed events.
+Currently supported: `kafka`.
+
+|[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
+|_empty_
+|Prefix for changefeed topic names in the intermediate Kafka cluster.
+For multi-tenant deployments, consider using a unique prefix per tenant.
+
+|[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
+|No default
+|Additional options for the sink in `key=value` format, comma-separated.
+
+|[[cockroachdb-property-kafka-consumer-group-prefix]]<<cockroachdb-property-kafka-consumer-group-prefix, `+cockroachdb.changefeed.kafka.consumer.group.prefix+`>>
+|`cockroachdb-connector`
+|Prefix for the Kafka consumer group ID used when consuming changefeed events from the intermediate Kafka cluster.
+The full group ID is `{prefix}-{table_name}`.
+
+|[[cockroachdb-property-kafka-poll-timeout]]<<cockroachdb-property-kafka-poll-timeout, `+cockroachdb.changefeed.kafka.poll.timeout.ms+`>>
+|`100`
+|Maximum time in milliseconds to block in each Kafka consumer `poll()` call when consuming from the intermediate Kafka cluster.
+
+|[[cockroachdb-property-kafka-auto-offset-reset]]<<cockroachdb-property-kafka-auto-offset-reset, `+cockroachdb.changefeed.kafka.auto.offset.reset+`>>
+|`earliest`
+|What to do when there is no initial offset in the intermediate Kafka cluster.
+Options: `earliest` (start from beginning), `latest` (start from end).
+
+|===
+
+[id="cockroachdb-connector-configuration-properties"]
+The following properties configure the connector's snapshot and schema behavior.
+
+.Connector configuration properties
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[cockroachdb-property-snapshot-mode]]<<cockroachdb-property-snapshot-mode, `+snapshot.mode+`>>
+|`initial`
+|The criteria for running a snapshot upon startup of the connector.
+CockroachDB uses native changefeed `initial_scan` to backfill existing rows.
+See xref:cockroachdb-snapshots[Snapshots] for details on how each mode maps to CockroachDB's `initial_scan` option.
+Options: `always`, `initial`, `initial_only`, `no_data`, `never`, `when_needed`, `configuration_based`, `custom`.
+
+|[[cockroachdb-property-snapshot-isolation-mode]]<<cockroachdb-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
+|`serializable`
+|Controls which transaction isolation level is used.
+Options: `serializable` (CockroachDB default), `read_committed`.
+
+|[[cockroachdb-property-snapshot-locking-mode]]<<cockroachdb-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
+|`none`
+|Controls how the connector holds locks on tables while performing the schema snapshot.
+Options: `shared`, `none`, `custom`.
+CockroachDB's changefeed-based snapshot does not require table locks, so `none` is the default and recommended setting.
+
+|[[cockroachdb-property-schema-name]]<<cockroachdb-property-schema-name, `+cockroachdb.schema.name+`>>
+|`public`
+|The schema name to use for changefeed operations.
+
+|[[cockroachdb-property-read-only]]<<cockroachdb-property-read-only, `+read.only+`>>
+|`false`
+|Switches the connector to use alternative methods to deliver signals to {prodname} instead of writing to the signaling table.
+
+|[[cockroachdb-property-status-update-interval]]<<cockroachdb-property-status-update-interval, `+status.update.interval.ms+`>>
+|`10000`
+|How often to send status updates to the server in milliseconds.
+
+|===
+
+[id="cockroachdb-advanced-configuration-properties"]
+The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
+
+.Advanced connector configuration properties
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[cockroachdb-property-schema-name-adjustment-mode]]<<cockroachdb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|`none`
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector.
+Possible settings: `none`, `avro`, `avro_unicode`.
+
+|[[cockroachdb-property-field-name-adjustment-mode]]<<cockroachdb-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
+|`none`
+|Specifies how field names should be adjusted for compatibility with the message converter used by the connector.
+Possible settings: `none`, `avro`, `avro_unicode`.
+See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+
+|[[cockroachdb-property-unavailable-value-placeholder]]<<cockroachdb-property-unavailable-value-placeholder, `+unavailable.value.placeholder+`>>
+|`__debezium_unavailable_value`
+|Placeholder for unavailable values (e.g. for toasted columns).
+
+|===
+
+// Type: assembly
+// ModuleID: how-debezium-cockroachdb-connectors-handle-faults-and-problems
+// Title: How {prodname} CockroachDB connectors handle faults and problems
+[[cockroachdb-when-things-go-wrong]]
+== Behavior when things go wrong
+
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event.
+When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record.
+
+If a fault does happen then the system does not lose any events.
+However, while it is recovering from the fault, it might repeat some change events.
+In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
+
+The rest of this section describes how {prodname} handles various kinds of faults and problems.
+
+[id="cockroachdb-connector-configuration-and-startup-errors"]
+=== Configuration and startup errors
+
+In the following situations, the connector fails when trying to start, reports an error or exception in the log, and stops running:
+
+* The connector's configuration is invalid.
+* The connector cannot successfully connect to CockroachDB by using the specified connection parameters.
+* The connector cannot create a changefeed because the user lacks the required `CHANGEFEED` privilege.
+
+In these cases, the error message has details about the problem and possibly a suggested workaround.
+After you correct the configuration or address the CockroachDB problem, restart the connector.
+
+[id="cockroachdb-becomes-unavailable"]
+=== CockroachDB becomes unavailable
+
+When the connector is running, the CockroachDB cluster could become unavailable for any number of reasons.
+Because CockroachDB is a distributed database, individual node failures are handled transparently by the cluster.
+If the entire cluster becomes unavailable, the changefeed will stop producing events.
+When the cluster recovers, the connector will resume from the last stored offset.
+
+The connector includes retry logic with configurable parameters (`connection.max.retries`, `connection.retry.delay.ms`) for handling transient connection failures, including CockroachDB-specific errors like serialization failures (SQL state 40001) and connection errors (SQL state 08xxx).
+
+[id="cockroachdb-kafka-connect-process-stops-gracefully"]
+=== Kafka Connect process stops gracefully
+
+Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully.
+Prior to shutting down that process, Kafka Connect migrates the process's connector tasks to another Kafka Connect process in that group.
+The new connector tasks start processing exactly where the prior tasks stopped.
+There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
+
+[id="cockroachdb-kafka-connect-process-crashes"]
+=== Kafka Connect process crashes
+
+If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminate without recording their most recently processed offsets.
+When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes.
+However, CockroachDB connectors resume from the last offset that was _recorded_ by the earlier processes.
+This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash.
+The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
+
+Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events.
+
+[id="cockroachdb-kafka-becomes-unavailable"]
+=== Kafka becomes unavailable
+
+As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API.
+Periodically, at a frequency that you specify in the Kafka Connect configuration, Kafka Connect records the latest offset that appears in those change events.
+If the Kafka brokers become unavailable, the Kafka Connect process that is running the connectors repeatedly tries to reconnect to the Kafka brokers.
+In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
+
+[id="cockroachdb-connector-is-stopped-for-a-duration"]
+=== Connector is stopped for a duration
+
+If the connector is gracefully stopped, the database can continue to be used.
+When the connector restarts, it resumes streaming changes where it left off.
+That is, it generates change event records for all database changes that were made while the connector was stopped.
+
+Note that CockroachDB's link:https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection TTL] (default: 4 hours) limits how far back in time a changefeed can be started.
+If the connector is stopped for longer than the GC TTL, the stored offset may no longer be valid.
+In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when the offset has expired.
+
+// Type: assembly
+// ModuleID: debezium-cockroachdb-limitations
+// Title: Current Limitations
+[[cockroachdb-limitations]]
+== Limitations
+
+* **Multi-table changefeed**: The connector creates a single changefeed for all configured tables and consumes all per-table Kafka topics concurrently in a single KafkaConsumer.
+This is the recommended approach to minimize the number of changefeed jobs on the CockroachDB cluster.
+
+* **No incremental snapshots**: The connector does not yet support signal-based incremental snapshots (see link:https://github.com/debezium/dbz/issues/1630[debezium/dbz#1630]).
+
+* **No schema evolution detection**: The connector does not currently detect schema changes automatically.
+If you alter a table's schema, you must restart the connector to pick up the changes (see link:https://github.com/debezium/dbz/issues/1629[debezium/dbz#1629]).
+
+* **Kafka sink only**: The connector currently only supports Kafka as the intermediate changefeed sink.
+Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).
+
+* **Before state in updates**: CockroachDB changefeeds do not include the previous row state by default.
+To get the `before` field in update events, enable the `diff` changefeed option via `cockroachdb.changefeed.include.diff=true`.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -137,6 +137,24 @@ When Kafka Connect gracefully shuts down, it stops the connectors, flushes all e
 When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset.
 
 // Type: concept
+// ModuleID: cockroachdb-heartbeats
+// Title: How the CockroachDB connector uses heartbeats
+[[cockroachdb-heartbeats]]
+=== Heartbeats
+
+CockroachDB changefeed link:https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages[resolved timestamps] serve as natural heartbeats.
+When the connector receives a resolved timestamp, it:
+
+1. Updates the stored offset cursor to the resolved timestamp value.
+2. Dispatches a {prodname} heartbeat event to advance Kafka Connect offsets.
+
+This ensures that offsets advance even during idle periods when no data changes occur.
+Without offset advancement, monitoring systems might report the connector as stuck, and CockroachDB protected timestamps could accumulate, preventing garbage collection.
+
+To enable {prodname} heartbeat records on the `__debezium-heartbeat.<topic.prefix>` Kafka topic, set `heartbeat.interval.ms` to a value greater than `0` (in milliseconds).
+The `cockroachdb.changefeed.resolved.interval` property controls how frequently CockroachDB emits resolved timestamps (default: `10s`).
+
+// Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
 // Title: Default names of Kafka topics that receive {prodname} CockroachDB change event records
 [[cockroachdb-topic-names]]
@@ -1091,6 +1109,13 @@ See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |[[cockroachdb-property-unavailable-value-placeholder]]<<cockroachdb-property-unavailable-value-placeholder, `+unavailable.value.placeholder+`>>
 |`__debezium_unavailable_value`
 |Placeholder for unavailable values (e.g. for toasted columns).
+
+|[[cockroachdb-property-heartbeat-interval]]<<cockroachdb-property-heartbeat-interval, `+heartbeat.interval.ms+`>>
+|`0`
+|Controls the interval (in milliseconds) at which the connector emits heartbeat records to the `__debezium-heartbeat.<topic.prefix>` Kafka topic.
+Set to `0` (the default) to disable heartbeat records.
+Even when disabled, resolved timestamps still advance the connector's internal offsets.
+See xref:cockroachdb-heartbeats[Heartbeats] for details.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -171,6 +171,58 @@ CockroachDB changefeeds handle schema changes natively by performing a _backfill
 This means no events are lost during the transition, and downstream consumers see the new columns as soon as the backfill completes.
 
 // Type: concept
+// ModuleID: cockroachdb-incremental-snapshots
+// Title: Incremental snapshots
+[[cockroachdb-incremental-snapshots]]
+=== Incremental snapshots
+
+The CockroachDB connector supports {prodname} {link-prefix}:{link-signalling}#debezium-signaling-incremental-snapshots[signal-based incremental snapshots].
+An incremental snapshot re-reads existing rows from one or more tables and emits them as `op=r` (read) events, while the connector continues to capture ongoing changes without interruption.
+
+To use incremental snapshots:
+
+. Create a signaling table in CockroachDB:
++
+[source,sql]
+----
+CREATE TABLE debezium_signal (
+    id STRING PRIMARY KEY,
+    type STRING NOT NULL,
+    data STRING
+);
+----
+
+. Add the signaling table to the connector configuration:
++
+[source,json]
+----
+{
+    "signal.data.collection": "mydb.public.debezium_signal",
+    "table.include.list": "public.my_table,public.debezium_signal"
+}
+----
++
+The signaling table must be included in `table.include.list` so the changefeed delivers signal events to the connector.
+
+. To trigger an incremental snapshot, insert a signal row:
++
+[source,sql]
+----
+INSERT INTO debezium_signal (id, type, data) VALUES
+    ('snap-1', 'execute-snapshot',
+     '{"data-collections": ["mydb.public.my_table"]}');
+----
+
+The connector re-reads all rows from the specified table(s) and emits them as `op=r` events.
+You can use incremental snapshots to:
+
+* Re-populate a downstream consumer that lost data.
+* Backfill a newly added sink or topic.
+* Verify source-target consistency by re-snapshotting and comparing.
+
+For more information about signaling, see {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
+
+// Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
 // Title: Default names of Kafka topics that receive {prodname} CockroachDB change event records
 [[cockroachdb-topic-names]]
@@ -1218,8 +1270,6 @@ In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when 
 
 * **Multi-table changefeed**: The connector creates a single changefeed for all configured tables and consumes all per-table Kafka topics concurrently in a single KafkaConsumer.
 This is the recommended approach to minimize the number of changefeed jobs on the CockroachDB cluster.
-
-* **No incremental snapshots**: The connector does not yet support signal-based incremental snapshots (see link:https://github.com/debezium/dbz/issues/1630[debezium/dbz#1630]).
 
 * **Kafka sink only**: The connector currently only supports Kafka as the intermediate changefeed sink.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -750,12 +750,22 @@ Before deploying the {prodname} CockroachDB connector, verify the following prer
 * **CockroachDB**: The connector requires CockroachDB with support for sink-based changefeeds.
 All changefeed features are available in all CockroachDB editions without an enterprise license.
 
-* **Changefeed permissions**: The database user configured for the connector must have the `CHANGEFEED` privilege on the target tables (CockroachDB v22.2+), or be an `admin` user.
+* **Changefeed permissions**: The database user configured for the connector must have one of the following:
+** The `CHANGEFEED` privilege on the target tables (CockroachDB v22.2+)
+** The `ALL` privilege on the target tables
+** Membership in the `admin` role
++
+Additionally, grant `VIEWCLUSTERSETTING` so the connector can verify that `kv.rangefeed.enabled` is set to `true` (a prerequisite for changefeeds).
+CockroachDB validates changefeed privileges at `CREATE CHANGEFEED` time and returns accurate, version-specific error messages if the user lacks sufficient permissions.
 +
 [source,sql]
 ----
+-- Enable rangefeeds (required cluster-wide setting)
+SET CLUSTER SETTING kv.rangefeed.enabled = true;
+
 -- Grant changefeed privilege to a specific user
 GRANT CHANGEFEED ON TABLE orders TO myuser;
+GRANT VIEWCLUSTERSETTING TO myuser;
 
 -- Or grant on all tables in a database
 GRANT CHANGEFEED ON ALL TABLES IN DATABASE defaultdb TO myuser;
@@ -1025,11 +1035,6 @@ The actual delay is multiplied by the attempt number (linear backoff).
 |`5`
 |Timeout in seconds for validating that an existing JDBC connection is still usable.
 
-|[[cockroachdb-property-skip-permission-check]]<<cockroachdb-property-skip-permission-check, `+cockroachdb.skip.permission.check+`>>
-|`false`
-|Whether to skip the changefeed permission validation during connection.
-Set to `true` when the user is a superadmin or permissions are managed externally.
-
 |===
 
 [id="cockroachdb-changefeed-configuration-properties"]
@@ -1089,6 +1094,7 @@ Currently supported: `kafka`.
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
 |Prefix for changefeed topic names in the intermediate Kafka cluster.
+If empty, defaults to the value of `topic.prefix`.
 For multi-tenant deployments, consider using a unique prefix per tenant.
 
 |[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
@@ -1097,8 +1103,8 @@ For multi-tenant deployments, consider using a unique prefix per tenant.
 
 |[[cockroachdb-property-kafka-consumer-group-prefix]]<<cockroachdb-property-kafka-consumer-group-prefix, `+cockroachdb.changefeed.kafka.consumer.group.prefix+`>>
 |`cockroachdb-connector`
-|Prefix for the Kafka consumer group ID used when consuming changefeed events from the intermediate Kafka cluster.
-The full group ID is `{prefix}-{table_name}`.
+|Kafka consumer group ID used when consuming changefeed events from the intermediate Kafka cluster.
+Should be unique per connector instance when multiple connectors share the same intermediate Kafka cluster.
 
 |[[cockroachdb-property-kafka-poll-timeout]]<<cockroachdb-property-kafka-poll-timeout, `+cockroachdb.changefeed.kafka.poll.timeout.ms+`>>
 |`100`
@@ -1209,7 +1215,7 @@ In the following situations, the connector fails when trying to start, reports a
 
 * The connector's configuration is invalid.
 * The connector cannot successfully connect to CockroachDB by using the specified connection parameters.
-* The connector cannot create a changefeed because the user lacks the required `CHANGEFEED` privilege.
+* The connector cannot create a changefeed because the user lacks sufficient privileges (`CHANGEFEED`, `ALL`, or `admin` role membership).
 
 In these cases, the error message has details about the problem and possibly a suggested workaround.
 After you correct the configuration or address the CockroachDB problem, restart the connector.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -155,6 +155,22 @@ To enable {prodname} heartbeat records on the `__debezium-heartbeat.<topic.prefi
 The `cockroachdb.changefeed.resolved.interval` property controls how frequently CockroachDB emits resolved timestamps (default: `10s`).
 
 // Type: concept
+// ModuleID: cockroachdb-schema-evolution
+// Title: How the CockroachDB connector handles schema evolution
+[[cockroachdb-schema-evolution]]
+=== Schema evolution
+
+The connector automatically detects DDL changes such as `ALTER TABLE ADD COLUMN`, `DROP COLUMN`, and `RENAME COLUMN` without requiring a restart.
+When an incoming changefeed event contains fields that do not match the registered table schema, the connector:
+
+1. Detects the mismatch by comparing event field names against registered column names.
+2. Re-queries `information_schema` to retrieve the updated table definition.
+3. Refreshes the internal schema and continues processing with the new column layout.
+
+CockroachDB changefeeds handle schema changes natively by performing a _backfill_ -- re-emitting all existing rows with the updated schema.
+This means no events are lost during the transition, and downstream consumers see the new columns as soon as the backfill completes.
+
+// Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
 // Title: Default names of Kafka topics that receive {prodname} CockroachDB change event records
 [[cockroachdb-topic-names]]
@@ -1204,9 +1220,6 @@ In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when 
 This is the recommended approach to minimize the number of changefeed jobs on the CockroachDB cluster.
 
 * **No incremental snapshots**: The connector does not yet support signal-based incremental snapshots (see link:https://github.com/debezium/dbz/issues/1630[debezium/dbz#1630]).
-
-* **No schema evolution detection**: The connector does not currently detect schema changes automatically.
-If you alter a table's schema, you must restart the connector to pick up the changes (see link:https://github.com/debezium/dbz/issues/1629[debezium/dbz#1629]).
 
 * **Kafka sink only**: The connector currently only supports Kafka as the intermediate changefeed sink.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1290,6 +1290,55 @@ Note that CockroachDB's link:https://www.cockroachlabs.com/docs/stable/configure
 If the connector is stopped for longer than the GC TTL, the stored offset may no longer be valid.
 In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when the offset has expired.
 
+[id="cockroachdb-debugging"]
+=== Enabling debug logging
+
+To diagnose connector behavior, enable `DEBUG` (or `TRACE`) logging for one or more of the connector's loggers in the Kafka Connect worker's logging configuration.
+The connector uses SLF4J, so the standard `connect-log4j.properties` mechanism (or the runtime `/admin/loggers` REST endpoint) controls the level.
+
+The most useful logger names for triage are:
+
+[cols="50%a,50%a",options="header"]
+|===
+|Logger
+|What it traces
+
+|`io.debezium.connector.cockroachdb`
+|Top-level connector lifecycle: task start/stop, configuration, signal processing.
+
+|`io.debezium.connector.cockroachdb.CockroachDBSchema`
+|Schema discovery (which tables and schemas were found, which were filtered out by `schema.include.list` / `table.include.list`), and per-table refresh on schema change.
+
+|`io.debezium.connector.cockroachdb.CockroachDBStreamingChangeEventSource`
+|Changefeed query construction, per-event dispatch, resolved-timestamp progression, and Kafka consumer wiring.
+
+|`io.debezium.connector.cockroachdb.CockroachDBSnapshotChangeEventSource`
+|Snapshot decisions and delegation to CockroachDB's `initial_scan` mode.
+
+|`io.debezium.connector.cockroachdb.CockroachDBDefaultValueConverter`
+|Parsing of column `DEFAULT` expressions; logs at `DEBUG` when a default expression cannot be mapped to the column's Java type.
+
+|`io.debezium.connector.cockroachdb.connection.CockroachDBConnection`
+|JDBC connection attempts, retries, and successful connects.
+|===
+
+For example, to enable schema-discovery and streaming traces, add the following to `connect-log4j.properties`:
+
+[source,properties]
+----
+log4j.logger.io.debezium.connector.cockroachdb.CockroachDBSchema=DEBUG
+log4j.logger.io.debezium.connector.cockroachdb.CockroachDBStreamingChangeEventSource=DEBUG
+----
+
+Or set the levels at runtime against a running Kafka Connect worker:
+
+[source,bash]
+----
+curl -X PUT -H "Content-Type: application/json" \
+    --data '{"level":"DEBUG"}' \
+    http://localhost:8083/admin/loggers/io.debezium.connector.cockroachdb
+----
+
 // Type: assembly
 // ModuleID: debezium-cockroachdb-limitations
 // Title: Current Limitations

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -737,6 +737,15 @@ This section describes these mappings.
 Uses the {prodname} `DoubleVector` logical type.
 |===
 
+[id="cockroachdb-default-values"]
+=== Default values
+
+When a CockroachDB column is created with a `DEFAULT` clause, the connector parses the JDBC-reported default expression into the Java type that matches the column's Kafka Connect schema, and sets it as the schema default for that field.
+CockroachDB annotates default expressions with a CRDB-specific `:::TYPE` suffix (for example, `0:::INT8`, `'PENDING':::STRING`, `'[1.0,2.0,3.0]':::VECTOR`); the connector strips this annotation, unwraps quoted literals, and converts the value to the column's Java type.
+
+Function-generated defaults such as `current_timestamp()`, `gen_random_uuid()`, `now()`, and `unique_rowid()` are not evaluated by the connector.
+For these columns, the connector omits the default from the schema so that CockroachDB computes the value at insert time.
+
 // Type: assembly
 // ModuleID: setting-up-cockroachdb-for-debezium
 // Title: Setting up CockroachDB for {prodname}

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -836,6 +836,45 @@ GRANT CHANGEFEED ON ALL TABLES IN DATABASE defaultdb TO myuser;
 +
 Granting `VIEWCLUSTERSETTING` lets the connector verify that `kv.rangefeed.enabled` is set to `true`, which is a prerequisite for changefeeds.
 
+// Type: concept
+// ModuleID: securing-the-changefeed-sink
+
+[id="cockroachdb-securing-the-changefeed-sink"]
+== Securing the changefeed sink
+
+When the changefeed sink requires TLS, or mutual TLS (mTLS), the connector can read PEM files from disk and inject the base64-encoded material into the sink URI at startup.
+This avoids the need to base64-encode certificates by hand and paste large strings into the connector configuration.
+
+Set any combination of the following properties:
+
+`+cockroachdb.changefeed.sink.tls.ca.cert.file+`::
+Path to a PEM-encoded CA certificate that verifies the sink broker's certificate.
+
+`+cockroachdb.changefeed.sink.tls.client.cert.file+`::
+Path to a PEM-encoded client certificate used for mutual TLS to the sink.
+
+`+cockroachdb.changefeed.sink.tls.client.key.file+`::
+Path to a PEM-encoded client private key used for mutual TLS to the sink.
+
+For each property that is set, the connector reads the file, validates that it is readable and non-empty, base64-encodes the contents, URL-encodes the result, and appends a corresponding query parameter to `cockroachdb.changefeed.sink.uri` in the form expected by the configured sink type.
+For the Kafka sink, the appended parameters are `ca_cert=...`, `client_cert=...`, `client_key=...`, and `tls_enabled=true` (added automatically whenever any of the three TLS file options is set).
+File-based values overwrite any same-named query parameter that was already present inline in the sink URI.
+
+.Example configuration for a Kafka sink secured with mTLS
+[source,json]
+----
+{
+  "cockroachdb.changefeed.sink.type": "kafka",
+  "cockroachdb.changefeed.sink.uri": "kafka://kafka.example.com:9093",
+  "cockroachdb.changefeed.sink.tls.ca.cert.file": "/etc/kafka/secrets/ca.pem",
+  "cockroachdb.changefeed.sink.tls.client.cert.file": "/etc/kafka/secrets/client.pem",
+  "cockroachdb.changefeed.sink.tls.client.key.file": "/etc/kafka/secrets/client-key.pem"
+}
+----
+
+The connector validates each configured file path at startup and fails fast if the file does not exist, is unreadable, or is empty.
+Currently only the Kafka sink consumes these TLS parameters; for other sink types the sink URI passes through unchanged.
+
 // Type: assembly
 // ModuleID: deploying-and-managing-debezium-cockroachdb-connectors
 
@@ -1173,6 +1212,28 @@ For multi-tenant deployments, consider using a unique prefix per tenant.
 |[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
 |No default
 |Additional options for the sink in `key=value` format, comma-separated.
+
+|[[cockroachdb-property-sink-tls-ca-cert-file]]<<cockroachdb-property-sink-tls-ca-cert-file, `+cockroachdb.changefeed.sink.tls.ca.cert.file+`>>
+|No default
+|Path to a PEM-encoded CA certificate file used to verify the changefeed sink server's certificate.
+When set, the connector reads the file, base64-encodes the contents, and appends the CA certificate to the sink URI in the form expected by the configured sink type (for example, `ca_cert=...` for Kafka sinks).
+Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
+See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
+
+|[[cockroachdb-property-sink-tls-client-cert-file]]<<cockroachdb-property-sink-tls-client-cert-file, `+cockroachdb.changefeed.sink.tls.client.cert.file+`>>
+|No default
+|Path to a PEM-encoded client certificate file used for mutual TLS to the changefeed sink.
+When set, the connector reads the file, base64-encodes the contents, and appends the client certificate to the sink URI in the form expected by the configured sink type (for example, `client_cert=...` for Kafka sinks).
+Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
+See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
+
+|[[cockroachdb-property-sink-tls-client-key-file]]<<cockroachdb-property-sink-tls-client-key-file, `+cockroachdb.changefeed.sink.tls.client.key.file+`>>
+|No default
+|Path to a PEM-encoded client private key file used for mutual TLS to the changefeed sink.
+When set, the connector reads the file, base64-encodes the contents, and appends the client key to the sink URI in the form expected by the configured sink type (for example, `client_key=...` for Kafka sinks).
+Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
+Setting any of the three sink TLS file options also implies `tls_enabled=true` on the sink URI.
+See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
 
 |[[cockroachdb-property-kafka-consumer-group-prefix]]<<cockroachdb-property-kafka-consumer-group-prefix, `+cockroachdb.changefeed.kafka.consumer.group.prefix+`>>
 |`cockroachdb-connector`

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -137,6 +137,42 @@ When Kafka Connect gracefully shuts down, it stops the connectors, flushes all e
 When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset.
 
 // Type: concept
+// ModuleID: cockroachdb-reusing-an-existing-changefeed
+
+[[cockroachdb-reusing-an-existing-changefeed]]
+=== Reusing an existing changefeed
+
+By default, the connector creates and manages its own CockroachDB changefeed.
+Before it creates a changefeed, the connector checks whether a running changefeed already covers the configured tables.
+If a matching changefeed is found, the connector skips creation and consumes from the existing changefeed instead.
+This behavior keeps connector restarts idempotent and avoids creating duplicate changefeed jobs on the cluster.
+It also lets an operator pre-provision a changefeed that the connector then attaches to.
+
+A changefeed is considered a match only when both of the following are true for the running changefeed job:
+
+* Its description includes the fully-qualified name of each configured table.
+* Its description includes the `topic_prefix` that the connector expects, which is the value of xref:cockroachdb-property-sink-topic-prefix[`cockroachdb.changefeed.sink.topic.prefix`], or the value of xref:cockroachdb-property-topic-prefix[`topic.prefix`] when no sink topic prefix is set.
+
+For the connector to consume the existing changefeed correctly, the changefeed must publish to Kafka topics whose names match the topics that the connector subscribes to, in the format `_topicPrefix_._database_._schema_._table_`.
+To produce that topic layout, and to emit events in the structure that the connector expects, create the changefeed with the following options:
+
+`full_table_name`:: Required so that CockroachDB names topics in `_database_._schema_._table_` form.
+`topic_prefix='_prefix_.'`:: Required, and must equal the connector's topic prefix described in the preceding list. Note the trailing dot.
+`envelope='enriched'`:: Required. The connector consumes the enriched envelope.
+`enriched_properties`:: Must match the value of xref:cockroachdb-property-enriched-properties[`cockroachdb.changefeed.enriched.properties`] (default `source,schema`).
+`format='json'`:: Required. The connector consumes JSON-encoded changefeed messages.
+`diff`, `updated`, `resolved`:: Set these to match the connector configuration so that before-images, update markers, and resolved timestamps are available.
+
+If any of these conditions is not met, the connector does not recognize the existing changefeed and creates its own.
+A changefeed created with a different `topic_prefix`, without `full_table_name`, or with a different envelope or set of enriched properties is not reused, even if it captures the same tables.
+
+[NOTE]
+====
+For most deployments, the simplest approach is to let the connector create and manage the changefeed.
+Reuse an existing changefeed only when you have a specific reason to do so, such as preserving an existing cursor position or a custom partitioning scheme.
+====
+
+// Type: concept
 // ModuleID: cockroachdb-heartbeats
 
 [[cockroachdb-heartbeats]]

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1295,6 +1295,13 @@ Should be unique per connector instance when multiple connectors share the same 
 |What to do when there is no initial offset in the intermediate Kafka cluster.
 Options: `earliest` (start from beginning), `latest` (start from end).
 
+|[[cockroachdb-property-kafka-consumer-override]]<<cockroachdb-property-kafka-consumer-override, `+cockroachdb.changefeed.kafka.consumer.override.*+`>>
+|No default
+|Properties under this prefix are passed verbatim to the connector's changefeed consumer (a standard Kafka client), with the prefix stripped.
+For example, `cockroachdb.changefeed.kafka.consumer.override.security.protocol=SSL` sets the consumer's `security.protocol`.
+Use this to configure SASL, custom trust or key stores (PEM or JKS), or to override any setting.
+When `cockroachdb.changefeed.sink.tls.*` is set, the consumer's SSL is derived automatically from those PEM files (the CA becomes the consumer's PEM truststore, and the client certificate and key become its PEM keystore), so this passthrough is only needed for additional or different settings.
+
 |===
 
 [id="cockroachdb-connector-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1215,6 +1215,9 @@ When enabled, UPDATE events include the previous row state in the `before` field
 |[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
 |`source,schema`
 |Comma-separated list of properties to include in the enriched envelope: `source`, `schema`, `mvcc`.
+The connector requires only `source`, which it uses to identify the originating table for each event.
+The connector does not read the `schema` property; it infers the event schema from the message payload and from the table metadata that it discovers over JDBC.
+The default includes `schema` for completeness, but you can set this property to `source` alone to reduce the size of each changefeed message.
 
 |[[cockroachdb-property-cursor]]<<cockroachdb-property-cursor, `+cockroachdb.changefeed.cursor+`>>
 |`now`

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -992,9 +992,6 @@ include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[levelo
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
-// Type: reference
-// ModuleID: descriptions-of-debezium-cockroachdb-connector-configuration-properties
-// Title: Description of {prodname} CockroachDB connector configuration properties
 [[cockroachdb-connector-properties]]
 === Connector configuration properties
 
@@ -1142,7 +1139,7 @@ The following properties configure the CockroachDB changefeed behavior.
 |[[cockroachdb-property-resolved-interval]]<<cockroachdb-property-resolved-interval, `+cockroachdb.changefeed.resolved.interval+`>>
 |`10s`
 |The interval for resolved timestamp messages.
-Format: `10s`, `1m`, etc.
+Format: `10s`, `1m`, and so on.
 Resolved timestamps are used for offset tracking.
 
 |[[cockroachdb-property-include-updated]]<<cockroachdb-property-include-updated, `+cockroachdb.changefeed.include.updated+`>>
@@ -1156,12 +1153,12 @@ When enabled, UPDATE events include the previous row state in the `before` field
 
 |[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
 |`source`
-|Comma-separated enriched envelope properties, passed through verbatim to the CockroachDB `CREATE CHANGEFEED` statement.
+|Comma-separated list of enriched envelope properties, passed through verbatim to the CockroachDB `CREATE CHANGEFEED` statement.
 The connector always uses the enriched envelope, so this applies to every changefeed it creates.
 CockroachDB owns the set of valid values, currently `source` and `schema`, and validates them when the changefeed is created.
 The connector derives the schema of each event from the table metadata that it discovers over JDBC, and it identifies each event's table from the topic on which the event arrives.
 The connector does not read the `schema` block, which duplicates information that it already has; `schema` is accepted and passed through for other consumers of the intermediate topics, but it is not used by the connector.
-The default is `source` because that block identifies the originating database, schema, table, and commit timestamp.
+The default value is `source` because that block identifies the originating database, schema, table, and commit timestamp.
 This information is useful when you inspect the intermediate topics or when other tools also consume them.
 
 |[[cockroachdb-property-cursor]]<<cockroachdb-property-cursor, `+cockroachdb.changefeed.cursor+`>>
@@ -1197,7 +1194,8 @@ The default of `0` places all configured tables in one changefeed.
 Set the value to a positive number to instruct the connector to split captured tables into multiple changefeeds.
 The specified value sets the maximum number of tables in each resulting changefeed.
 Split captured tables into multiple changefeeds if CockroachDB returns a warning about the high number of tables that a changefeed watches.
-Smaller values reduce coupling but create more changefeed jobs, so balance this against CockroachDB's recommended limit on the number of changefeed jobs per cluster.
+Smaller values reduce coupling but create more changefeed jobs.
+Specify a value that optimizes performance while honoring CockroachDB recommendations for limiting the number of changefeed jobs per cluster.
 
 |[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
 |No default value
@@ -1337,9 +1335,6 @@ For more information, see xref:cockroachdb-heartbeats[Heartbeats] .
 
 |===
 
-// Type: assembly
-// ModuleID: how-debezium-cockroachdb-connectors-handle-faults-and-problems
-// Title: How {prodname} CockroachDB connectors handle faults and problems
 [[cockroachdb-when-things-go-wrong]]
 == Behavior when things go wrong
 
@@ -1385,7 +1380,7 @@ There is a short delay in processing while the connector tasks are stopped grace
 [id="cockroachdb-kafka-connect-process-crashes"]
 === Kafka Connect process crashes
 
-If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminate without recording their most recently processed offsets.
+If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminates without recording the most recently processed offsets.
 When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes.
 However, CockroachDB connectors resume from the last offset that was _recorded_ by the earlier processes.
 This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash.
@@ -1461,14 +1456,11 @@ curl -X PUT -H "Content-Type: application/json" \
     http://localhost:8083/admin/loggers/io.debezium.connector.cockroachdb
 ----
 
-// Type: assembly
-// ModuleID: debezium-cockroachdb-limitations
-// Title: Current Limitations
 [[cockroachdb-limitations]]
 == Limitations
 
-* **Kafka sink only**: The connector currently only supports Kafka as the intermediate changefeed sink.
+Kafka sink only:: The connector currently only supports Kafka as the intermediate changefeed sink.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).
 
-* **Before state in updates**: CockroachDB changefeeds do not include the previous row state by default.
+Before state in updates:: By default, CockroachDB changefeeds do not include the previous row state.
 To include the `before` field in update events, set `cockroachdb.changefeed.include.diff=true` to enable the `diff` changefeed option.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -826,10 +826,10 @@ For these columns, the connector omits the default from the schema so that Cockr
 [[setting-up-cockroachdb]]
 == Setting up CockroachDB
 
-Before you deploy the {prodname} CockroachDB connector, complete the following tasks in your CockroachDB environment:
-
-* Verify that the required components, user account, and connectivity are available.
-* Grant the changefeed permissions that the connector requires.
+Before you deploy the {prodname} CockroachDB connector, prepare your CockroachDB environment so that the connector can create and read changefeeds.
+At a high level, ensure that the required components and connectivity are in place, enable rangefeeds on the cluster, and grant the database user that the connector uses the privileges that changefeeds require.
+The prerequisites that follow describe what must be available before you begin.
+For the commands that enable rangefeeds and grant the required privileges, see xref:cockroachdb-grant-changefeed-permissions[Granting changefeed permissions].
 
 .Prerequisites
 

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -164,7 +164,7 @@ To produce that topic layout, and to emit events in the structure that the conne
 `diff`, `updated`, `resolved`:: Set these to match the connector configuration so that before-images, update markers, and resolved timestamps are available.
 
 If any of these conditions is not met, the connector does not recognize the existing changefeed and creates its own.
-A changefeed created with a different `topic_prefix`, without `full_table_name`, or with a different envelope is not reused, even if it captures the same tables.
+A changefeed created with a different `topic_prefix` or without `full_table_name` is not recognized as a match, and the connector creates its own. If a running changefeed does match the connector's topic prefix and tables but was created with an envelope other than `enriched`, the connector cannot consume it: it fails to start with an error asking you to recreate that changefeed with `envelope='enriched'` or to use a different topic prefix.
 
 [NOTE]
 ====
@@ -966,9 +966,8 @@ The following example shows a possible configuration for a CockroachDB connector
     "database.dbname": "defaultdb", // <7>
     "topic.prefix": "cockroachdb", // <8>
     "cockroachdb.changefeed.sink.uri": "kafka://kafka-broker:9092", // <9>
-    "cockroachdb.changefeed.envelope": "enriched", // <10>
-    "snapshot.mode": "initial", // <11>
-    "tasks.max": "1" // <12>
+    "snapshot.mode": "initial", // <10>
+    "tasks.max": "1" // <11>
   }
 }
 ----
@@ -981,9 +980,8 @@ The following example shows a possible configuration for a CockroachDB connector
 <7> The name of the CockroachDB database to connect to.
 <8> The topic prefix for Kafka topics that the connector writes to.
 <9> The URI of the Kafka cluster where CockroachDB will publish changefeed events.
-<10> The changefeed envelope format (`enriched` includes schema metadata).
-<11> The snapshot mode; `initial` backfills existing rows on first start.
-<12> The maximum number of tasks.
+<10> The snapshot mode; `initial` backfills existing rows on first start.
+<11> The maximum number of tasks.
 
 For more information about the properties that you can specify in the connector configuration, see the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] .
 
@@ -1198,12 +1196,6 @@ The following properties configure the CockroachDB changefeed behavior.
 |Default
 |Description
 
-|[[cockroachdb-property-envelope]]<<cockroachdb-property-envelope, `+cockroachdb.changefeed.envelope+`>>
-|`enriched`
-|The envelope type for changefeed events.
-Options: `enriched` (includes schema metadata), `wrapped`, `bare`.
-The `enriched` format is recommended as it provides full schema information.
-
 |[[cockroachdb-property-resolved-interval]]<<cockroachdb-property-resolved-interval, `+cockroachdb.changefeed.resolved.interval+`>>
 |`10s`
 |The interval for resolved timestamp messages.
@@ -1221,7 +1213,8 @@ When enabled, UPDATE events include the previous row state in the `before` field
 
 |[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
 |`source`
-|Comma-separated enriched envelope properties, passed through verbatim to the CockroachDB `CREATE CHANGEFEED` statement (applies only when xref:cockroachdb-property-envelope[`cockroachdb.changefeed.envelope`] is `enriched`).
+|Comma-separated enriched envelope properties, passed through verbatim to the CockroachDB `CREATE CHANGEFEED` statement.
+The connector always uses the enriched envelope, so this applies to every changefeed it creates.
 CockroachDB owns the set of valid values, currently `source` and `schema`, and validates them when the changefeed is created.
 The connector derives the schema of each event from the table metadata that it discovers over JDBC, and it identifies each event's table from the topic on which the event arrives.
 It therefore does not read the `schema` block, which duplicates information the connector already has; `schema` is accepted and passed through for other consumers of the intermediate topics but is not used by the connector.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1145,9 +1145,22 @@ Options: `serializable` (CockroachDB default), `read_committed`.
 Options: `shared`, `none`, `custom`.
 CockroachDB's changefeed-based snapshot does not require table locks, so `none` is the default and recommended setting.
 
-|[[cockroachdb-property-schema-name]]<<cockroachdb-property-schema-name, `+cockroachdb.schema.name+`>>
-|`public`
-|The schema name to use for changefeed operations.
+|[[cockroachdb-property-schema-include-list]]<<cockroachdb-property-schema-include-list, `+schema.include.list+`>>
+|No default
+|An optional, comma-separated list of regular expressions that match names of schemas for which you want to capture changes.
+Any schema name not included in `schema.include.list` is excluded from having its changes captured.
+By default, the connector captures changes in all non-system schemas.
+To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+That is, the specified expression is matched against the entire name string of the schema; it does not match substrings that might be present in a schema name.
+If you include this property in the configuration, do not also set the `schema.exclude.list` property.
+
+|[[cockroachdb-property-schema-exclude-list]]<<cockroachdb-property-schema-exclude-list, `+schema.exclude.list+`>>
+|No default
+|An optional, comma-separated list of regular expressions that match names of schemas for which you do _not_ want to capture changes.
+Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas.
+To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+That is, the specified expression is matched against the entire name string of the schema; it does not match substrings that might be present in a schema name.
+If you include this property in the configuration, do not also set the `schema.include.list` property.
 
 |[[cockroachdb-property-read-only]]<<cockroachdb-property-read-only, `+read.only+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -233,10 +233,6 @@ INSERT INTO debezium_signal (id, type, data) VALUES
 ----
 
 The connector re-reads all rows from the specified table(s) and emits them as `op=r` events.
-You can use incremental snapshots to:
-
-* Re-populate a downstream consumer that lost data.
-* Backfill a newly added sink or topic.
 
 For more information about signaling, see {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
 

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -980,7 +980,7 @@ When the connector starts, it connects to the CockroachDB database, creates a ch
 [[cockroachdb-monitoring]]
 === Monitoring
 
-The {prodname} CockroachDB connector includes built-in support for both the JMX metrics that Kafka and Kafka Connect provide, as well as cockroachdb-streaming-metrics[streaming metrics] that provide insights into connector behavior during the capture and streaming of change event records.
+The {prodname} CockroachDB connector includes built-in support for both the JMX metrics that Kafka and Kafka Connect provide, as well as xref:cockroachdb-snapshot-metrics[snapshot metrics] and xref:cockroachdb-streaming-metrics[streaming metrics] that provide insights into connector behavior during the initial scan and during the capture and streaming of change event records.
 
 
 
@@ -990,6 +990,17 @@ The {prodname} CockroachDB connector includes built-in support for both the JMX 
 === Customized MBean names
 
 include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
+
+[[cockroachdb-snapshot-metrics]]
+==== Snapshot metrics
+
+The connector backfills existing rows through the CockroachDB changefeed `initial_scan` and drives the standard snapshot lifecycle around it, so the snapshot metrics are populated during the initial scan.
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-snapshot]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
 
 [[cockroachdb-streaming-metrics]]
 ==== Streaming metrics

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -64,7 +64,9 @@ The enriched format includes both schema metadata and the full before and after 
 2. **Intermediate Kafka to {prodname} to Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer; routes each event to the correct table based on the topic name; transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields); and produces them to the final output Kafka topics.
 
 This architecture allows the connector to leverage CockroachDB's native, highly-available changefeed infrastructure for capture reliability, while providing the standard {prodname} event format that downstream consumers expect.
-Using a single multi-table changefeed is the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended approach] to stay within CockroachDB's limit of approximately 80 changefeed jobs per cluster.
+By default the connector consolidates all configured tables into a single changefeed, which keeps it to one changefeed job and helps stay within CockroachDB's link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended limit] on the number of changefeeds per cluster (approximately 80 at the time of writing).
+CockroachDB also link:https://www.cockroachlabs.com/docs/stable/changefeed-best-practices[advises against] watching very many tables with a single changefeed, because their performance becomes coupled.
+For large table counts, set xref:cockroachdb-property-max-tables-per-changefeed[`cockroachdb.changefeed.max.tables.per.changefeed`] to split the tables across several changefeeds, or run multiple connector instances that each capture a related subset of the tables.
 
 // Type: concept
 // ModuleID: cockroachdb-snapshots
@@ -1241,9 +1243,17 @@ Currently supported: `kafka`.
 
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
-|Prefix for changefeed topic names in the intermediate Kafka cluster.
-If empty, defaults to the value of `topic.prefix`.
-For multi-tenant deployments, consider using a unique prefix per tenant.
+|Prefix prepended to the intermediate changefeed topic names.
+The connector uses the value verbatim, so the resulting topics are named `_prefix__database_._schema_._table_`.
+Include your own separator if you want one: for example, `crdb.` yields `crdb.mydb.public.orders`, and `env-prod-` yields `env-prod-mydb.public.orders`.
+If empty, defaults to the value of `topic.prefix` followed by a dot.
+
+|[[cockroachdb-property-max-tables-per-changefeed]]<<cockroachdb-property-max-tables-per-changefeed, `+cockroachdb.changefeed.max.tables.per.changefeed+`>>
+|`0`
+|Maximum number of tables to include in a single CockroachDB changefeed.
+The default of `0` places all configured tables in one changefeed.
+When set to a positive value, the connector splits the captured tables into multiple changefeeds of at most this many tables each, to avoid the performance coupling that CockroachDB warns about when one changefeed watches very many tables.
+Smaller values reduce coupling but create more changefeed jobs, so balance this against CockroachDB's recommended limit on the number of changefeed jobs per cluster.
 
 |[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
 |No default
@@ -1505,9 +1515,6 @@ curl -X PUT -H "Content-Type: application/json" \
 // Title: Current Limitations
 [[cockroachdb-limitations]]
 == Limitations
-
-* **Multi-table changefeed**: The connector creates a single changefeed for all configured tables and consumes all per-table Kafka topics concurrently in a single KafkaConsumer.
-This is the recommended approach to minimize the number of changefeed jobs on the CockroachDB cluster.
 
 * **Kafka sink only**: The connector currently only supports Kafka as the intermediate changefeed sink.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1244,47 +1244,49 @@ Currently supported: `kafka`.
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
 |Prefix prepended to the intermediate changefeed topic names.
-The connector uses the value verbatim, so the resulting topics are named `_prefix__database_._schema_._table_`.
+The connector uses the exact prefix string that you specify, so the resulting topics are named `_prefix__database_._schema_._table_`.
 Include your own separator if you want one: for example, `crdb.` yields `crdb.mydb.public.orders`, and `env-prod-` yields `env-prod-mydb.public.orders`.
-If empty, defaults to the value of `topic.prefix` followed by a dot.
+If you do not supply a value for this property, the connector defaults to using the value of `topic.prefix` followed by a dot.
 
 |[[cockroachdb-property-max-tables-per-changefeed]]<<cockroachdb-property-max-tables-per-changefeed, `+cockroachdb.changefeed.max.tables.per.changefeed+`>>
 |`0`
 |Maximum number of tables to include in a single CockroachDB changefeed.
 The default of `0` places all configured tables in one changefeed.
-When set to a positive value, the connector splits the captured tables into multiple changefeeds of at most this many tables each, to avoid the performance coupling that CockroachDB warns about when one changefeed watches very many tables.
+Set the value to a positive number to instruct the connector to split captured tables into multiple changefeeds.
+The specified value sets the maximum number of tables in each resulting changefeed.
+Split captured tables into multiple changefeeds if CockroachDB returns a warning about the high number of tables that a changefeed watches.
 Smaller values reduce coupling but create more changefeed jobs, so balance this against CockroachDB's recommended limit on the number of changefeed jobs per cluster.
 
 |[[cockroachdb-property-sink-options]]<<cockroachdb-property-sink-options, `+cockroachdb.changefeed.sink.options+`>>
-|No default
-|Additional options for the sink in `key=value` format, comma-separated.
+|No default value
+|A comma-separated list of additional options for the sink in `key=value` format.
 
 |[[cockroachdb-property-sink-tls-ca-cert-file]]<<cockroachdb-property-sink-tls-ca-cert-file, `+cockroachdb.changefeed.sink.tls.ca.cert.file+`>>
 |No default
-|Path to a PEM-encoded CA certificate file used to verify the changefeed sink server's certificate.
-When set, the connector reads the file, base64-encodes the contents, and appends the CA certificate to the sink URI in the form expected by the configured sink type (for example, `ca_cert=...` for Kafka sinks).
-Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
-See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
+|Path to a PEM-encoded CA certificate file that the connector uses to verify the certificate of the changefeed sink server.
+When you set this property, the connector reads the file, base64-encodes the contents, and appends the CA certificate to the sink URI in the form expected by the configured sink type (for example, `ca_cert=...` for Kafka sinks).
+The specified value overrides any equivalent query parameter that is present in `cockroachdb.changefeed.sink.uri`.
+For more information, see xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
 
 |[[cockroachdb-property-sink-tls-client-cert-file]]<<cockroachdb-property-sink-tls-client-cert-file, `+cockroachdb.changefeed.sink.tls.client.cert.file+`>>
 |No default
 |Path to a PEM-encoded client certificate file used for mutual TLS to the changefeed sink.
-When set, the connector reads the file, base64-encodes the contents, and appends the client certificate to the sink URI in the form expected by the configured sink type (for example, `client_cert=...` for Kafka sinks).
-Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
-See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
+When this property is set, the connector reads the file, base64-encodes the contents, and appends the client certificate to the sink URI in the form expected by the configured sink type (for example, `client_cert=...` for Kafka sinks).
+The specified value overrides any equivalent query parameter that is present in `cockroachdb.changefeed.sink.uri`.
+For more information, see xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
 
 |[[cockroachdb-property-sink-tls-client-key-file]]<<cockroachdb-property-sink-tls-client-key-file, `+cockroachdb.changefeed.sink.tls.client.key.file+`>>
 |No default
 |Path to a PEM-encoded client private key file used for mutual TLS to the changefeed sink.
 When set, the connector reads the file, base64-encodes the contents, and appends the client key to the sink URI in the form expected by the configured sink type (for example, `client_key=...` for Kafka sinks).
-Overrides any equivalent query parameter already present in `cockroachdb.changefeed.sink.uri`.
+The specified value overrides any equivalent query parameter that is present in `cockroachdb.changefeed.sink.uri`.
 Setting any of the three sink TLS file options also implies `tls_enabled=true` on the sink URI.
-See xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
+For more information, see xref:cockroachdb-securing-the-changefeed-sink[Securing the changefeed sink].
 
 |[[cockroachdb-property-kafka-consumer-group-prefix]]<<cockroachdb-property-kafka-consumer-group-prefix, `+cockroachdb.changefeed.kafka.consumer.group.prefix+`>>
 |`cockroachdb-connector`
 |Kafka consumer group ID used when consuming changefeed events from the intermediate Kafka cluster.
-Should be unique per connector instance when multiple connectors share the same intermediate Kafka cluster.
+If multiple connectors share the same intermediate Kafka cluster, specify a value that is unique for the connector instance.
 
 |[[cockroachdb-property-kafka-poll-timeout]]<<cockroachdb-property-kafka-poll-timeout, `+cockroachdb.changefeed.kafka.poll.timeout.ms+`>>
 |`100`
@@ -1292,12 +1294,12 @@ Should be unique per connector instance when multiple connectors share the same 
 
 |[[cockroachdb-property-kafka-auto-offset-reset]]<<cockroachdb-property-kafka-auto-offset-reset, `+cockroachdb.changefeed.kafka.auto.offset.reset+`>>
 |`earliest`
-|What to do when there is no initial offset in the intermediate Kafka cluster.
-Options: `earliest` (start from beginning), `latest` (start from end).
+|Specifies where the connector begins processing when it does not detect an initial offset in the intermediate Kafka cluster.
+Specify one of the following options: `earliest` (start from beginning), `latest` (start from end).
 
 |[[cockroachdb-property-kafka-consumer-override]]<<cockroachdb-property-kafka-consumer-override, `+cockroachdb.changefeed.kafka.consumer.override.*+`>>
 |No default
-|Properties under this prefix are passed verbatim to the connector's changefeed consumer (a standard Kafka client), with the prefix stripped.
+|Properties with this prefix are passed as-is to the connector's changefeed consumer (a standard Kafka client), with the prefix stripped.
 For example, `cockroachdb.changefeed.kafka.consumer.override.security.protocol=SSL` sets the consumer's `security.protocol`.
 Use this to configure SASL, custom trust or key stores (PEM or JKS), or to override any setting.
 When `cockroachdb.changefeed.sink.tls.*` is set, the consumer's SSL is derived automatically from those PEM files (the CA becomes the consumer's PEM truststore, and the client certificate and key become its PEM keystore), so this passthrough is only needed for additional or different settings.
@@ -1305,7 +1307,7 @@ When `cockroachdb.changefeed.sink.tls.*` is set, the consumer's SSL is derived a
 |===
 
 [id="cockroachdb-connector-configuration-properties"]
-The following properties configure the connector's snapshot and schema behavior.
+Set the following properties to configure the connector's snapshot and schema behavior.
 
 .Connector configuration properties
 [cols="30%a,25%a,45%a",options="header"]
@@ -1316,21 +1318,21 @@ The following properties configure the connector's snapshot and schema behavior.
 
 |[[cockroachdb-property-snapshot-mode]]<<cockroachdb-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
-|The criteria for running a snapshot upon startup of the connector.
+|Specifies the criteria for running a snapshot when the connector starts.
 CockroachDB uses native changefeed `initial_scan` to backfill existing rows.
-See xref:cockroachdb-snapshots[Snapshots] for details on how each mode maps to CockroachDB's `initial_scan` option.
-Options: `always`, `initial`, `initial_only`, `no_data`, `never`, `when_needed`, `configuration_based`, `custom`.
+For details about how each snapshot mode maps to the CockroachDB `initial_scan` option, see  xref:cockroachdb-snapshots[Snapshots].
+Set one of the following options: `always`, `initial`, `initial_only`, `no_data`, `never`, `when_needed`, `configuration_based`, `custom`.
 
 |[[cockroachdb-property-snapshot-isolation-mode]]<<cockroachdb-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |`serializable`
-|Controls which transaction isolation level is used.
-Options: `serializable` (CockroachDB default), `read_committed`.
+|Specifies the transaction isolation level that the connector uses.
+Set one of the following options: `serializable` (CockroachDB default), `read_committed`.
 
 |[[cockroachdb-property-snapshot-locking-mode]]<<cockroachdb-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |`none`
-|Controls how the connector holds locks on tables while performing the schema snapshot.
-Options: `shared`, `none`, `custom`.
-CockroachDB's changefeed-based snapshot does not require table locks, so `none` is the default and recommended setting.
+|Specifies how the connector holds locks on tables when it performs a schema snapshot.
+Set one of the following options: `shared`, `none`, `custom`.
+Because changefeed-based snapshots in CockroachDB do not require table locks, the default and recommended setting is `none`.
 
 |[[cockroachdb-property-schema-include-list]]<<cockroachdb-property-schema-include-list, `+schema.include.list+`>>
 |No default
@@ -1351,11 +1353,11 @@ If you include this property in the configuration, do not also set the `schema.i
 
 |[[cockroachdb-property-read-only]]<<cockroachdb-property-read-only, `+read.only+`>>
 |`false`
-|Switches the connector to use alternative methods to deliver signals to {prodname} instead of writing to the signaling table.
+|Specifies whether the connector uses alternative methods to deliver signals to {prodname} instead of writing to the signaling table.
 
 |[[cockroachdb-property-status-update-interval]]<<cockroachdb-property-status-update-interval, `+status.update.interval.ms+`>>
 |`10000`
-|How often to send status updates to the server in milliseconds.
+|Specifies the interval, in milliseconds, at which the connector sends status updates to the server.
 
 |===
 
@@ -1371,25 +1373,25 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[cockroachdb-property-schema-name-adjustment-mode]]<<cockroachdb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
 |`none`
-|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector.
-Possible settings: `none`, `avro`, `avro_unicode`.
+|Specifies how to adjust schema names for compatibility with the message converter that the connector uses.
+Set one of the following options: `none`, `avro`, `avro_unicode`.
 
 |[[cockroachdb-property-field-name-adjustment-mode]]<<cockroachdb-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
 |`none`
-|Specifies how field names should be adjusted for compatibility with the message converter used by the connector.
-Possible settings: `none`, `avro`, `avro_unicode`.
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+|Specifies how to adjust field names for compatibility with the message converter that the connector uses.
+Set one of the following options: `none`, `avro`, `avro_unicode`.
+For details, see {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming].
 
 |[[cockroachdb-property-unavailable-value-placeholder]]<<cockroachdb-property-unavailable-value-placeholder, `+unavailable.value.placeholder+`>>
 |`__debezium_unavailable_value`
-|Placeholder for unavailable values (e.g. for toasted columns).
+|Placeholder for unavailable values (for example, for toasted columns).
 
 |[[cockroachdb-property-heartbeat-interval]]<<cockroachdb-property-heartbeat-interval, `+heartbeat.interval.ms+`>>
 |`0`
-|Controls the interval (in milliseconds) at which the connector emits heartbeat records to the `__debezium-heartbeat.<topic.prefix>` Kafka topic.
+|Specifies the interval, in milliseconds, at which the connector emits heartbeat records to the `__debezium-heartbeat.<topic.prefix>` Kafka topic.
 Set to `0` (the default) to disable heartbeat records.
 Even when disabled, resolved timestamps still advance the connector's internal offsets.
-See xref:cockroachdb-heartbeats[Heartbeats] for details.
+For more information, see xref:cockroachdb-heartbeats[Heartbeats] .
 
 |===
 
@@ -1400,10 +1402,10 @@ See xref:cockroachdb-heartbeats[Heartbeats] for details.
 == Behavior when things go wrong
 
 {prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event.
-When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record.
+When the system is operating normally and is managed carefully, {prodname} provides _exactly once_ delivery of every change event record.
 
-If a fault does happen then the system does not lose any events.
-However, while it is recovering from the fault, it might repeat some change events.
+If a fault occurs, the system is designed to prevent the loss of any events.
+However, while it is recovering from a fault, it might repeat some change events.
 In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
 
 The rest of this section describes how {prodname} handles various kinds of faults and problems.
@@ -1411,7 +1413,7 @@ The rest of this section describes how {prodname} handles various kinds of fault
 [id="cockroachdb-connector-configuration-and-startup-errors"]
 === Configuration and startup errors
 
-In the following situations, the connector fails when trying to start, reports an error or exception in the log, and stops running:
+In the following situations, the connector fails when trying to start, reports an error or exception in the log, and then stops running:
 
 * The connector's configuration is invalid.
 * The connector cannot successfully connect to CockroachDB by using the specified connection parameters.
@@ -1424,9 +1426,9 @@ After you correct the configuration or address the CockroachDB problem, restart 
 === CockroachDB becomes unavailable
 
 When the connector is running, the CockroachDB cluster could become unavailable for any number of reasons.
-Because CockroachDB is a distributed database, individual node failures are handled transparently by the cluster.
-If the entire cluster becomes unavailable, the changefeed will stop producing events.
-When the cluster recovers, the connector will resume from the last stored offset.
+Because CockroachDB is a distributed database, the cluster automatically handles individual node failures.
+If the entire cluster becomes unavailable, the changefeed stops producing events.
+After the cluster recovers, the connector resumes processing from the last stored offset.
 
 The connector includes retry logic with configurable parameters (`connection.max.retries`, `connection.retry.delay.ms`) for handling transient connection failures, including CockroachDB-specific errors like serialization failures (SQL state 40001) and connection errors (SQL state 08xxx).
 
@@ -1458,14 +1460,14 @@ If the Kafka brokers become unavailable, the Kafka Connect process that is runni
 In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
 
 [id="cockroachdb-connector-is-stopped-for-a-duration"]
-=== Connector is stopped for a duration
+=== Connector is stopped for an extended period
 
 If the connector is gracefully stopped, the database can continue to be used.
 When the connector restarts, it resumes streaming changes where it left off.
 That is, it generates change event records for all database changes that were made while the connector was stopped.
 
-Note that CockroachDB's link:https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection TTL] (default: 4 hours) limits how far back in time a changefeed can be started.
-If the connector is stopped for longer than the GC TTL, the stored offset may no longer be valid.
+The CockroachDB link:https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection TTL] (default: 4 hours) limits how far back in time a changefeed can be started.
+If the connector is stopped for longer than the configured TTL interval, the stored offset may no longer be valid.
 In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when the offset has expired.
 
 [id="cockroachdb-debugging"]
@@ -1474,7 +1476,7 @@ In this case, use `snapshot.mode=when_needed` to automatically re-snapshot when 
 To diagnose connector behavior, enable `DEBUG` (or `TRACE`) logging for one or more of the connector's loggers in the Kafka Connect worker's logging configuration.
 The connector uses SLF4J, so the standard `connect-log4j.properties` mechanism (or the runtime `/admin/loggers` REST endpoint) controls the level.
 
-The most useful logger names for triage are:
+The following table list the most useful logger names for triage.
 
 [cols="50%a,50%a",options="header"]
 |===
@@ -1491,7 +1493,7 @@ The most useful logger names for triage are:
 |Changefeed query construction, per-event dispatch, resolved-timestamp progression, and Kafka consumer wiring.
 
 |`io.debezium.connector.cockroachdb.CockroachDBSnapshotChangeEventSource`
-|Snapshot decisions and delegation to CockroachDB's `initial_scan` mode.
+|Snapshot decisions and delegation to the CockroachDB `initial_scan` mode.
 
 |`io.debezium.connector.cockroachdb.CockroachDBDefaultValueConverter`
 |Parsing of column `DEFAULT` expressions; logs at `DEBUG` when a default expression cannot be mapped to the column's Java type.
@@ -1527,4 +1529,4 @@ curl -X PUT -H "Content-Type: application/json" \
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).
 
 * **Before state in updates**: CockroachDB changefeeds do not include the previous row state by default.
-To get the `before` field in update events, enable the `diff` changefeed option via `cockroachdb.changefeed.include.diff=true`.
+To include the `before` field in update events, set `cockroachdb.changefeed.include.diff=true` to enable the `diff` changefeed option.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -729,16 +729,24 @@ The following data type mappings are applied for CockroachDB data:
 |
 
 |`DATE`
-|`STRING`
-|ISO-8601 date format.
+|`INT32` (`io.debezium.time.Date` logical type)
+|Number of days since the epoch.
 
-|`TIME`, `TIMETZ`
-|`STRING`
-|ISO-8601 time format.
+|`TIME`
+|`INT64` (`io.debezium.time.MicroTime` logical type)
+|Number of microseconds since midnight.
 
-|`TIMESTAMP`, `TIMESTAMPTZ`
-|`STRING`
-|ISO-8601 timestamp format.
+|`TIMETZ`
+|`STRING` (`io.debezium.time.ZonedTime` logical type)
+|Offset-qualified ISO-8601 time (for example `14:36:34.873+02:00`).
+
+|`TIMESTAMP`
+|`INT64` (`io.debezium.time.MicroTimestamp` logical type)
+|Number of microseconds since the epoch, interpreted as UTC.
+
+|`TIMESTAMPTZ`
+|`STRING` (`io.debezium.time.ZonedTimestamp` logical type)
+|Offset-qualified ISO-8601 timestamp (for example `2026-06-15T14:36:34.873Z`).
 
 |`INTERVAL`
 |`STRING`

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1,4 +1,3 @@
-// Category: debezium-using
 
 [id="debezium-connector-for-cockroachdb"]
 = {prodname} connector for CockroachDB
@@ -15,7 +14,7 @@ toc::[]
 
 The {prodname} CockroachDB connector captures row-level changes from a link:https://www.cockroachlabs.com/docs/stable/changefeed-messages[CockroachDB enriched changefeed] and streams them into Kafka topics.
 
-CockroachDB link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeeds] detect  data changes in the database -- inserts, updates, deletes -- in near-real-time.
+CockroachDB link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeeds] detects data changes in the database -- inserts, updates, and deletes -- in near-real-time.
 The connector creates a link:https://www.cockroachlabs.com/docs/stable/create-changefeed[changefeed] that publishes events to an intermediate Kafka cluster, then consumes those events, transforms them into the standard {prodname} envelope format, and produces them to the output Kafka topics that downstream consumers subscribe to.
 
 [NOTE]
@@ -23,9 +22,6 @@ The connector creates a link:https://www.cockroachlabs.com/docs/stable/create-ch
 The CockroachDB connector is an incubating connector.
 An incubating connector is one that has been released for preview purposes and is subject to changes that may not always be backward compatible.
 ====
-
-// Type: concept
-// Title: Overview of {prodname} CockroachDB connector
 
 [[cockroachdb-overview]]
 == Overview
@@ -41,16 +37,10 @@ The connector is tolerant of failures.
 As the connector reads changes and produces events, it records the last resolved timestamp it processes.
 If the connector stops for any reason (including communication failures, network problems, or crashes), after the connector restarts, it resumes streaming from the last record that it processed.
 
-// Type: assembly
-// ModuleID: how-debezium-cockroachdb-connectors-work
-
 [[how-the-cockroachdb-connector-works]]
 == How the connector works
 
 To optimally configure and run a {prodname} CockroachDB connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
-
-// Type: concept
-// ModuleID: cockroachdb-connector-architecture
 
 [[cockroachdb-architecture]]
 === Architecture
@@ -63,13 +53,11 @@ The enriched format includes both schema metadata and the full before and after 
 
 2. **Intermediate Kafka to {prodname} to Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer; routes each event to the correct table based on the topic name; transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields); and produces them to the final output Kafka topics.
 
-This architecture allows the connector to leverage CockroachDB's native, highly-available changefeed infrastructure for capture reliability, while providing the standard {prodname} event format that downstream consumers expect.
-By default the connector consolidates all configured tables into a single changefeed, which keeps it to one changefeed job and helps stay within CockroachDB's link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended limit] on the number of changefeeds per cluster (approximately 80 at the time of writing).
-CockroachDB also link:https://www.cockroachlabs.com/docs/stable/changefeed-best-practices[advises against] watching very many tables with a single changefeed, because their performance becomes coupled.
-For large table counts, set xref:cockroachdb-property-max-tables-per-changefeed[`cockroachdb.changefeed.max.tables.per.changefeed`] to split the tables across several changefeeds, or run multiple connector instances that each capture a related subset of the tables.
-
-// Type: concept
-// ModuleID: cockroachdb-snapshots
+By using this architecture the connector can leverage the native, highly-available changefeed infrastructure of CockroachDB to reliably capture data and provide it to downstream consumers in the standard {prodname} event format.
+By default, the connector consolidates all configured tables into a single changefeed.
+By consolidating data in a single changefeed job, the connector conforms to the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended limit] on the number of changefeeds per CockroachDB cluster (approximately 80 at the time of writing).
+To improve throughput and prevent performance coupling, CockroachDB link:https://www.cockroachlabs.com/docs/stable/changefeed-best-practices[best practices] advise against using a single changefeed to monitor a large number of tables.
+In environments with large table counts, consider setting xref:cockroachdb-property-max-tables-per-changefeed[`cockroachdb.changefeed.max.tables.per.changefeed`] to split the tables across several changefeeds, or running multiple connector instances so that each connector captures a related subset of the tables.
 
 [[cockroachdb-snapshots]]
 === Snapshots
@@ -77,7 +65,7 @@ For large table counts, set xref:cockroachdb-property-max-tables-per-changefeed[
 CockroachDB changefeeds natively support an link:https://www.cockroachlabs.com/docs/stable/create-changefeed#initial-scan[`initial_scan`] option that backfills all existing rows before streaming ongoing changes.
 The {prodname} CockroachDB connector maps its `snapshot.mode` configuration to the CockroachDB `initial_scan` changefeed option, so the connector does not require a separate JDBC-based snapshot phase.
 
-During the initial scan phase, captured events are marked `op=r` (read) to distinguish them from ongoing change events.
+During the initial scan phase, captured events are marked `op=r` to designate a read operation, which distinguishes snapshot events from ongoing change events.
 After the initial scan completes and the changefeed transitions to streaming, events are marked with the appropriate operation type (`c` for create, `u` for update, `d` for delete).
 
 The following table shows how each `snapshot.mode` maps to the CockroachDB `initial_scan` option:
@@ -113,9 +101,6 @@ Only ongoing changes after the changefeed is created are captured.
 |Same as `initial`, but if the stored offset is no longer valid, the connector performs a new initial snapshot.
 |===
 
-// Type: concept
-// ModuleID: how-debezium-cockroachdb-connectors-stream-change-event-records
-
 [[cockroachdb-streaming-changes]]
 === Streaming changes
 
@@ -138,9 +123,6 @@ For the CockroachDB connector, the last resolved timestamp is the offset.
 When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector.
 When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset.
 
-// Type: concept
-// ModuleID: cockroachdb-reusing-an-existing-changefeed
-
 [[cockroachdb-reusing-an-existing-changefeed]]
 === Reusing an existing changefeed
 
@@ -159,14 +141,18 @@ For the connector to consume the existing changefeed correctly, the changefeed m
 To produce that topic layout, and to emit events in the structure that the connector expects, create the changefeed with the following options:
 
 `full_table_name`:: Required so that CockroachDB names topics in `_database_._schema_._table_` form.
-`topic_prefix='_prefix_.'`:: Required, and must equal the connector's topic prefix described in the preceding list. Note the trailing dot.
+`topic_prefix='_prefix_.'`:: Required, and must equal the connector's topic prefix described in the preceding list. 
+The specified prefix must include a trailing dot (`.`).
 `envelope='enriched'`:: Required. The connector consumes the enriched envelope.
-`enriched_properties`:: Optional. The connector reads the base enriched fields (`op`, `ts_ns`, `after`, and `before` when `diff` is set), so it does not require any enriched property to consume the feed. Including `source` (the connector default) is recommended so that the intermediate topics carry origin and commit-time metadata.
+`enriched_properties`:: Optional. The connector reads the base enriched fields (`op`, `ts_ns`, `after`, and `before` when `diff` is set), so it does not require any enriched property to consume the feed. 
+The default value,  `source` ensures that intermediate topics include origin and commit-time metadata.
 `format='json'`:: Required. The connector consumes JSON-encoded changefeed messages.
 `diff`, `updated`, `resolved`:: Set these to match the connector configuration so that before-images, update markers, and resolved timestamps are available.
 
 If any of these conditions is not met, the connector does not recognize the existing changefeed and creates its own.
-A changefeed created with a different `topic_prefix` or without `full_table_name` is not recognized as a match, and the connector creates its own. If a running changefeed does match the connector's topic prefix and tables but was created with an envelope other than `enriched`, the connector cannot consume it: it fails to start with an error asking you to recreate that changefeed with `envelope='enriched'` or to use a different topic prefix.
+A changefeed created with a different `topic_prefix` or without `full_table_name` is not recognized as a match, and the connector creates its own. 
+If a running changefeed matches the connector's topic prefix and tables, but it was created with an envelope other than `enriched`, the connector cannot consume it.
+The connector then fails to start and returns an error stating that you must recreate that changefeed with `envelope='enriched'` or else use a different topic prefix.
 
 [NOTE]
 ====
@@ -174,8 +160,6 @@ For most deployments, the simplest approach is to let the connector create and m
 Reuse an existing changefeed only when you have a specific reason to do so, such as preserving an existing cursor position or a custom partitioning scheme.
 ====
 
-// Type: concept
-// ModuleID: cockroachdb-heartbeats
 
 [[cockroachdb-heartbeats]]
 === Heartbeats
@@ -186,14 +170,11 @@ When the connector receives a resolved timestamp, it performs the following oper
 1. Updates the stored offset cursor to the resolved timestamp value.
 2. Dispatches a {prodname} heartbeat event to advance Kafka Connect offsets.
 
-This ensures that offsets advance even during idle periods when no data changes occur.
+By emitting heartbeat messages the connector helps to ensure that offsets advance even during idle periods in which no data changes occur.
 When offsets fail to advance, monitoring systems might report that the connector is unresponsive, which can cause CockroachDB protected timestamps to accumulate, preventing garbage collection.
 
 To enable {prodname} heartbeat records on the `__debezium-heartbeat.<topic.prefix>` Kafka topic, set `heartbeat.interval.ms` to a value greater than `0` (in milliseconds).
 The `cockroachdb.changefeed.resolved.interval` property controls how frequently CockroachDB emits resolved timestamps (default: `10s`).
-
-// Type: concept
-// ModuleID: cockroachdb-schema-evolution
 
 [[cockroachdb-schema-evolution]]
 === Schema evolution
@@ -216,9 +197,6 @@ It does not maintain a database history and does not emit DDL change events to a
 The schema that the connector uses comes from its own JDBC discovery of the table, not from the `schema` block in the changefeed message, so schema changes are handled even when xref:cockroachdb-property-enriched-properties[`cockroachdb.changefeed.enriched.properties`] is set to `source` alone.
 ====
 
-// Type: concept
-// ModuleID: cockroachdb-incremental-snapshots
-
 [[cockroachdb-incremental-snapshots]]
 === Incremental snapshots
 
@@ -227,7 +205,7 @@ An incremental snapshot re-reads existing rows from one or more tables and emits
 
 You can use incremental snapshots to perform the following tasks:
 
-* Re-populate a downstream consumer that lost data.
+* Repopulate a downstream consumer that lost data.
 * Backfill a newly added sink or topic.
 * Verify source-target consistency by re-snapshotting and comparing.
 
@@ -277,17 +255,14 @@ INSERT INTO debezium_signal (id, type, data) VALUES
      '{"data-collections": ["mydb.public.my_table"]}');
 ----
 
-The connector re-reads all rows from the specified table(s) and emits them as `op=r` events.
+The connector rereads all rows from the specified tables and emits them as `op=r` events.
 
 For more information about signaling, see {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
-
-// Type: concept
-// ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
 
 [[cockroachdb-topic-names]]
 === Topic names
 
-The CockroachDB connector all data change events for a table (insert, update, and delete) to a Kafka topic that is dedicated to that table.
+The CockroachDB connector emits all data change events for a table (insert, update, and delete) to a Kafka topic that is dedicated to that table.
 By default, the Kafka topic name is _topicPrefix_._schemaName_._tableName_ where:
 
 * _topicPrefix_ is the topic prefix as specified by the xref:cockroachdb-property-topic-prefix[`topic.prefix`] connector configuration property.
@@ -302,9 +277,6 @@ The connector would stream records to the following two Kafka topics:
 
 The connector applies naming conventions that are similar to those used by other {prodname} connectors, and it supports the standard topic naming strategies.
 
-// Type: assembly
-// ModuleID: descriptions-of-debezium-cockroachdb-connector-data-change-events
-
 [[cockroachdb-events]]
 == Data change events
 
@@ -315,11 +287,11 @@ The structure of the key and the value depends on the table that was changed.
 
 {prodname} and Kafka Connect are designed around _continuous streams of event messages_.
 However, the structure of these events may change over time, which can be difficult for consumers to handle.
-To help consumers adapt to structural volatility, the connector emits self-contained events; that is, each event message contains either the schema for its content.
-Or in environments  that use a schema registry, each message contains a schema ID that a consumer can use to obtain the schema from the registry.
+To help consumers adapt to structural volatility, the connector emits self-contained events.
+That is, each event message either contains the schema for its content , or in environments  that use a schema registry, each message contains a schema ID that a consumer can use to obtain the schema from the registry.
 
 
-The following skeleton JSON documents show the basic structure for the key and value documents.
+The following skeleton JSON documents show the basic structure of the key and value fields in an event message.
 However, the exact representation of the key and value documents depends on how you configure the Kafka Connect converter that you use in your application.
 A `schema` field is present a change event key or change event value only if you configure the converter to produce it.
 Likewise, the event key and event payload are present only if you configure a converter to produce it.
@@ -380,9 +352,6 @@ It has the structure described by the previous `schema` field and it contains th
 
 The default xref: xref:cockroachdb-topic-names[topic naming behavior] results in the connector streaming change event records to a topic whose name matches the name of the table that the event describes.
 
-// Type: concept
-// ModuleID: about-keys-in-debezium-cockroachdb-change-events
-
 [[cockroachdb-change-events-key]]
 === Change event keys
 
@@ -403,7 +372,7 @@ CREATE TABLE orders (
 ----
 
 .Example change event key
-Based on the preceding definition of the `orders` table, the key structure for every change event for the table is the same key structure. 
+Based on the preceding definition of the `orders` table, every change event for the table uses the same key structure. 
 The following JSON represents this key structure:
 
 [source,json,indent=0]
@@ -426,9 +395,6 @@ The following JSON represents this key structure:
   }
 }
 ----
-
-// Type: concept
-// ModuleID: about-values-in-debezium-cockroachdb-change-events
 
 [[cockroachdb-change-events-value]]
 === Change event values
@@ -521,7 +487,8 @@ The source metadata includes:
 * The schema name
 * The logical cluster name
 * The resolved timestamp (for consistency tracking)
-* The Hybrid Logical Clock (HLC) timestamp (CockroachDB's internal timestamp format)
+* The Hybrid Logical Clock (HLC) timestamp. 
+HLC is the internal timestamp format for CockroachDB.
 
 |4
 |`op`
@@ -537,8 +504,8 @@ Valid values are:
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
 |Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task.  +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task. 
+ 
 In the `source` object, `ts_ms` indicates the time that the change was made in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
@@ -548,7 +515,7 @@ By comparing the value for `payload.source.ts_ms` with the value for `payload.ts
 [[cockroachdb-update-events]]
 === _update_ events
 
-The value of a change event for an update in the sample `orders` table has the same schema as a _create_ event for that table.
+The value portion of a an event record for an update event in the sample `orders` table has the same schema as a _create_ event for that table.
 Likewise, the event value's payload has the same structure.
 However, the event value payload contains different values in an _update_ event.
 The following example shows the JSON for the value portion of a change event that the connector generates for an update in the `orders` table:
@@ -628,9 +595,9 @@ To include the `before` state for a row in update events, enable the CockroachDB
 === _delete_ events
 
 The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table.
-A delete_ change event record provides a consumer with the information that it needs to process the removal of a row.
+A _delete_ change event record provides a consumer with the information that it needs to process the removal of a row.
 
-The {prodname} CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
+{prodname} CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
 Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
 Removing older messages lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
@@ -690,19 +657,15 @@ The `op` field value is `d`, signifying that this row was deleted.
 
 A _delete_ change event record provides a consumer with the information it needs to process the removal of this row.
 
-CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
-Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
 
 
 
 [[cockroachdb-tombstone-events]]
-.Tombstone events
+=== Tombstone events
+
 When you delete a row, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key.
 However, for Kafka to remove all messages that have that same key, the message value must be `null`.
 To make this possible, the connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
-
-// Type: reference
-// ModuleID: how-debezium-cockroachdb-connectors-map-data-types
 
 [[cockroachdb-data-types]]
 == Data type mappings
@@ -815,13 +778,11 @@ Uses the {prodname} `DoubleVector` logical type.
 === Default values
 
 When a CockroachDB column is created with a `DEFAULT` clause, the connector parses the JDBC-reported default expression into the Java type that matches the column's Kafka Connect schema, and sets it as the schema default for that field.
-CockroachDB annotates default expressions with a CRDB-specific `:::TYPE` suffix (for example, `0:::INT8`, `'PENDING':::STRING`, `'[1.0,2.0,3.0]':::VECTOR`); the connector strips this annotation, unwraps quoted literals, and converts the value to the column's Java type.
+CockroachDB annotates default expressions with a CockroachDB-specific `:::TYPE` suffix (for example, `0:::INT8`, `'PENDING':::STRING`, `'[1.0,2.0,3.0]':::VECTOR`).
+The connector strips this annotation, unwraps quoted literals, and converts the value to the column's Java type.
 
 Function-generated defaults such as `current_timestamp()`, `gen_random_uuid()`, `now()`, and `unique_rowid()` are not evaluated by the connector.
 For these columns, the connector omits the default from the schema so that CockroachDB computes the value at insert time.
-
-// Type: assembly
-// ModuleID: setting-up-cockroachdb-for-debezium
 
 [[setting-up-cockroachdb]]
 == Setting up CockroachDB
@@ -829,7 +790,7 @@ For these columns, the connector omits the default from the schema so that Cockr
 Before you deploy the {prodname} CockroachDB connector, prepare your CockroachDB environment so that the connector can create and read changefeeds.
 At a high level, ensure that the required components and connectivity are in place, enable rangefeeds on the cluster, and grant the database user that the connector uses the privileges that changefeeds require.
 The prerequisites that follow describe what must be available before you begin.
-For the commands that enable rangefeeds and grant the required privileges, see xref:cockroachdb-grant-changefeed-permissions[Granting changefeed permissions].
+For information about enabling rangefeeds and granting the required privileges, see xref:cockroachdb-grant-changefeed-permissions[Granting changefeed permissions].
 
 .Prerequisites
 
@@ -877,8 +838,6 @@ GRANT CHANGEFEED ON ALL TABLES IN DATABASE defaultdb TO myuser;
 +
 Granting `VIEWCLUSTERSETTING` lets the connector verify that `kv.rangefeed.enabled` is set to `true`, which is a prerequisite for changefeeds.
 
-// Type: concept
-// ModuleID: securing-the-changefeed-sink
 [id="cockroachdb-securing-the-changefeed-sink"]
 == Securing the changefeed sink
 
@@ -915,15 +874,12 @@ File-based values overwrite any same-named query parameter that is already prese
 The connector validates each configured file path at startup and fails fast if the file does not exist, is unreadable, or is empty.
 Currently only the Kafka sink consumes these TLS parameters; for other sink types the sink URI passes through unchanged.
 
-// Type: assembly
-// ModuleID: deploying-and-managing-debezium-cockroachdb-connectors
-
 [[cockroachdb-deploying-a-connector]]
 == Deployment
 
 To deploy a {prodname} CockroachDB connector you obtain the connector plug-in files archive, add the JAR files to your Kafka Connect environment, and then edit the `plugin.path` configuration to reference the location of the files.
 
-If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Kafka and Kafka Connect.
+If you are working with immutable containers, see link:https://quay.io/organization/debezium[the {prodname} container images] for Kafka and Kafka Connect.
 
 [IMPORTANT]
 ====
@@ -946,8 +902,6 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 5. xref:cockroachdb-example-configuration[Configure the connector] and xref:cockroachdb-adding-connector-configuration[add the configuration] to your Kafka Connect cluster.
 6. Restart the Kafka Connect process so that it picks up the new JAR files.
 
-// Type: concept
-// ModuleID: debezium-cockroachdb-connector-configuration-example
 [[cockroachdb-example-configuration]]
 === Connector configuration example
 
@@ -985,8 +939,6 @@ The following example shows a possible configuration for a CockroachDB connector
 
 For more information about the properties that you can specify in the connector configuration, see the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] .
 
-// Type: procedure
-// ModuleID: adding-debezium-cockroachdb-connector-configuration-to-kafka-connect
 [[cockroachdb-adding-connector-configuration]]
 === Adding connector configuration
 
@@ -1019,28 +971,20 @@ curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" 
 
 When the connector starts, it connects to the CockroachDB database, creates a changefeed, and starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
-// Type: assembly
-// ModuleID: monitoring-debezium-cockroachdb-connector-performance
 [[cockroachdb-monitoring]]
 === Monitoring
 
-The {prodname} CockroachDB connector includes built-in support for both the JMX metrics that Kafka and Kafka Connect provide, as well as cockroachdb-streaming-metrics[streaming metrics] that provide insights into connector behavior during the captures and streaming of change event records.
+The {prodname} CockroachDB connector includes built-in support for both the JMX metrics that Kafka and Kafka Connect provide, as well as cockroachdb-streaming-metrics[streaming metrics] that provide insights into connector behavior during the capture and streaming of change event records.
 
 
 
 .Additional resources
 * xref:{link-debezium-monitoring}#monitoring-debezium[Using JMX to expose metrics ({prodname} monitoring documentation)^] .
 
-// Type: concept
-// ModuleID: monitoring-debezium-cockroachdb-connectors-customized-mbean-names
-// Title: Customized names for CockroachDB connector MBean objects
 === Customized MBean names
 
 include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
 
-// Type: reference
-// ModuleID: monitoring-debezium-cockroachdb-connector-record-streaming
-// Title: Monitoring {prodname} CockroachDB connector record streaming
 [[cockroachdb-streaming-metrics]]
 ==== Streaming metrics
 

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -193,7 +193,7 @@ To enable the connector to use incremental snapshots, you must create a signalin
 
 .Procedure
 
-1.  Create a signaling table in CockroachDB by issuing the following SQL command:
+1. Create a signaling table in CockroachDB by issuing the following SQL command:
 +
 [source,sql]
 ----
@@ -214,9 +214,16 @@ CREATE TABLE debezium_signal (
 }
 ----
 +
-You must include the signaling table in the  `table.include.list` so that the changefeed can deliver signal events to the connector.
+You must include the signaling table in the `table.include.list` so that the changefeed can deliver signal events to the connector.
 
-. To trigger an incremental snapshot, insert a signal row:
+[id="cockroachdb-trigger-an-incremental-snapshot"]
+==== Trigger an incremental snapshot
+
+You trigger an incremental snapshot by inserting a row in the connector's signaling table.
+
+.Procedure
+
+* Run a SQL command that uses the following format to add a row to the signaling table to trigger an incremental snapshot:
 +
 [source,sql]
 ----
@@ -230,7 +237,6 @@ You can use incremental snapshots to:
 
 * Re-populate a downstream consumer that lost data.
 * Backfill a newly added sink or topic.
-
 
 For more information about signaling, see {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
 
@@ -779,20 +785,41 @@ For these columns, the connector omits the default from the schema so that Cockr
 [[setting-up-cockroachdb]]
 == Setting up CockroachDB
 
-Before deploying the {prodname} CockroachDB connector, verify the following prerequisites:
+Before you deploy the {prodname} CockroachDB connector, complete the following tasks in your CockroachDB environment:
+
+* Verify that the required components, user account, and connectivity are available.
+* Grant the changefeed permissions that the connector requires.
 
 .Prerequisites
 
-* **CockroachDB**: The connector requires CockroachDB with support for sink-based changefeeds.
-All changefeed features are available in all CockroachDB editions without an enterprise license.
+CockroachDB cluster::
+A CockroachDB cluster that supports sink-based changefeeds.
+All changefeed features are available in every CockroachDB edition without an enterprise license.
 
-* **Changefeed permissions**: The database user configured for the connector must have one of the following:
-** The `CHANGEFEED` privilege on the target tables (CockroachDB v22.2+)
-** The `ALL` privilege on the target tables
-** Membership in the `admin` role
+Intermediate Kafka cluster::
+A Kafka cluster where CockroachDB publishes changefeed events.
+This can be the same Kafka cluster that Kafka Connect uses, or a separate one.
+
+Network connectivity::
+The CockroachDB cluster must be able to reach the intermediate Kafka cluster to publish changefeed events.
+The Kafka Connect worker must be able to reach both the CockroachDB cluster (for JDBC) and the intermediate Kafka cluster (for consuming changefeed events).
+
+Changefeed user account::
+A CockroachDB user that has one of the following privileges on the target tables:
 +
-Additionally, grant `VIEWCLUSTERSETTING` so the connector can verify that `kv.rangefeed.enabled` is set to `true` (a prerequisite for changefeeds).
+* The `CHANGEFEED` privilege (CockroachDB v22.2+)
+* The `ALL` privilege
+* Membership in the `admin` role
+
+[id="cockroachdb-grant-changefeed-permissions"]
+=== Granting changefeed permissions
+
+Enable cluster-wide rangefeeds and grant the necessary privileges to the database user that the connector uses.
 CockroachDB validates changefeed privileges at `CREATE CHANGEFEED` time and returns accurate, version-specific error messages if the user lacks sufficient permissions.
+
+.Procedure
+
+* As a CockroachDB admin user, run the following SQL commands:
 +
 [source,sql]
 ----
@@ -806,12 +833,8 @@ GRANT VIEWCLUSTERSETTING TO myuser;
 -- Or grant on all tables in a database
 GRANT CHANGEFEED ON ALL TABLES IN DATABASE defaultdb TO myuser;
 ----
-
-* **Intermediate Kafka cluster**: The connector requires a Kafka cluster where CockroachDB will publish changefeed events.
-This can be the same Kafka cluster used by Kafka Connect, or a separate one.
-
-* **Network connectivity**: The CockroachDB cluster must be able to reach the intermediate Kafka cluster to publish changefeed events.
-The Kafka Connect worker must be able to reach both the CockroachDB cluster (for JDBC) and the intermediate Kafka cluster (for consuming changefeed events).
++
+Granting `VIEWCLUSTERSETTING` lets the connector verify that `kv.rangefeed.enabled` is set to `true`, which is a prerequisite for changefeeds.
 
 // Type: assembly
 // ModuleID: deploying-and-managing-debezium-cockroachdb-connectors
@@ -839,21 +862,10 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 
 1. Download the archive file to a temporary directory.
 2. Copy the downloaded file to a directory in your Kafka Connect environment, for example, `/usr/local/share/kafka/plugins`.
-4.  Extract the JAR file into the directory and then remove the downloaded archive file.
-5. Add an entry for the directory with the JAR files to the [Kafka Connect plugin.path](https://kafka.apache.org/documentation/#connectconfigs).
-6. xref:cockroachdb-example-configuration[Configure the connector] and xref:cockroachdb-adding-connector-configuration[add the configuration] to your Kafka Connect cluster.
-7. Restart the Kafka Connect process so that it picks up the new JAR files.
-
-
-If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Kafka and Kafka Connect.
-
-
-[IMPORTANT]
-====
-The {prodname} container images that you obtain from `quay.io` do not undergo rigorous testing or security analysis, and are provided for testing and evaluation purposes only.
-These images are not intended for use in production environments.
-To mitigate risk in production deployments, deploy only containers that are actively maintained by trusted vendors, and thoroughly tested for potential vulnerabilities.
-====
+3. Extract the JAR file into the directory and then remove the downloaded archive file.
+4. Add an entry for the directory with the JAR files to the link:https://kafka.apache.org/documentation/#connectconfigs[Kafka Connect `plugin.path`].
+5. xref:cockroachdb-example-configuration[Configure the connector] and xref:cockroachdb-adding-connector-configuration[add the configuration] to your Kafka Connect cluster.
+6. Restart the Kafka Connect process so that it picks up the new JAR files.
 
 // Type: concept
 // ModuleID: debezium-cockroachdb-connector-configuration-example

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -159,12 +159,12 @@ To produce that topic layout, and to emit events in the structure that the conne
 `full_table_name`:: Required so that CockroachDB names topics in `_database_._schema_._table_` form.
 `topic_prefix='_prefix_.'`:: Required, and must equal the connector's topic prefix described in the preceding list. Note the trailing dot.
 `envelope='enriched'`:: Required. The connector consumes the enriched envelope.
-`enriched_properties`:: Must match the value of xref:cockroachdb-property-enriched-properties[`cockroachdb.changefeed.enriched.properties`] (default `source,schema`).
+`enriched_properties`:: Optional. The connector reads the base enriched fields (`op`, `ts_ns`, `after`, and `before` when `diff` is set), so it does not require any enriched property to consume the feed. Including `source` (the connector default) is recommended so that the intermediate topics carry origin and commit-time metadata.
 `format='json'`:: Required. The connector consumes JSON-encoded changefeed messages.
 `diff`, `updated`, `resolved`:: Set these to match the connector configuration so that before-images, update markers, and resolved timestamps are available.
 
 If any of these conditions is not met, the connector does not recognize the existing changefeed and creates its own.
-A changefeed created with a different `topic_prefix`, without `full_table_name`, or with a different envelope or set of enriched properties is not reused, even if it captures the same tables.
+A changefeed created with a different `topic_prefix`, without `full_table_name`, or with a different envelope is not reused, even if it captures the same tables.
 
 [NOTE]
 ====
@@ -204,8 +204,15 @@ When an incoming changefeed event contains fields that do not match the register
 3. Refreshes the internal schema and continues processing the table based on the adjusted column layout.
 
 CockroachDB changefeeds handle schema changes natively by performing a _backfill_ operation in which the Schema Change Manager re-emits all existing rows with the updated schema.
-A backfill ensures that no events are lost during the schema transition.  
+A backfill ensures that no events are lost during the schema transition.
 After a backfill completes, the refreshed columns are immediately available to downstream consumers.
+
+[NOTE]
+====
+The connector adapts the schema of the change events that it emits, so that the records on the output topics always reflect the current table structure.
+It does not maintain a database history and does not emit DDL change events to a separate schema change topic.
+The schema that the connector uses comes from its own JDBC discovery of the table, not from the `schema` block in the changefeed message, so schema changes are handled even when xref:cockroachdb-property-enriched-properties[`cockroachdb.changefeed.enriched.properties`] is set to `source` alone.
+====
 
 // Type: concept
 // ModuleID: cockroachdb-incremental-snapshots
@@ -1213,11 +1220,12 @@ Resolved timestamps are used for offset tracking.
 When enabled, UPDATE events include the previous row state in the `before` field.
 
 |[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
-|`source,schema`
-|Comma-separated list of properties to include in the enriched envelope: `source`, `schema`, `mvcc`.
-The connector requires only `source`, which it uses to identify the originating table for each event.
-The connector does not read the `schema` property; it infers the event schema from the message payload and from the table metadata that it discovers over JDBC.
-The default includes `schema` for completeness, but you can set this property to `source` alone to reduce the size of each changefeed message.
+|`source`
+|Comma-separated enriched envelope properties, passed through verbatim to the CockroachDB `CREATE CHANGEFEED` statement (applies only when xref:cockroachdb-property-envelope[`cockroachdb.changefeed.envelope`] is `enriched`).
+CockroachDB owns the set of valid values, currently `source` and `schema`, and validates them when the changefeed is created.
+The connector derives the schema of each event from the table metadata that it discovers over JDBC, and it identifies each event's table from the topic on which the event arrives.
+It therefore does not read the `schema` block, which duplicates information the connector already has; `schema` is accepted and passed through for other consumers of the intermediate topics but is not used by the connector.
+The default is `source` because that block carries the originating database, schema, table, and commit timestamp, which is useful when you inspect the intermediate topics or when other tools also consume them.
 
 |[[cockroachdb-property-cursor]]<<cockroachdb-property-cursor, `+cockroachdb.changefeed.cursor+`>>
 |`now`

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -879,12 +879,11 @@ Granting `VIEWCLUSTERSETTING` lets the connector verify that `kv.rangefeed.enabl
 
 // Type: concept
 // ModuleID: securing-the-changefeed-sink
-
 [id="cockroachdb-securing-the-changefeed-sink"]
 == Securing the changefeed sink
 
-When the changefeed sink requires TLS, or mutual TLS (mTLS), the connector can read PEM files from disk and inject the base64-encoded material into the sink URI at startup.
-This avoids the need to base64-encode certificates by hand and paste large strings into the connector configuration.
+When a changefeed sink requires TLS, or mutual TLS (mTLS), the connector can read PEM files from disk and inject the base64-encoded material into the sink URI at startup.
+This method of securing the sink connection avoids the need to base64-encode certificates by hand and paste large strings into the connector configuration.
 
 Set any combination of the following properties:
 
@@ -899,7 +898,7 @@ Path to a PEM-encoded client private key used for mutual TLS to the sink.
 
 For each property that is set, the connector reads the file, validates that it is readable and non-empty, base64-encodes the contents, URL-encodes the result, and appends a corresponding query parameter to `cockroachdb.changefeed.sink.uri` in the form expected by the configured sink type.
 For the Kafka sink, the appended parameters are `ca_cert=...`, `client_cert=...`, `client_key=...`, and `tls_enabled=true` (added automatically whenever any of the three TLS file options is set).
-File-based values overwrite any same-named query parameter that was already present inline in the sink URI.
+File-based values overwrite any same-named query parameter that is already present inline in the sink URI.
 
 .Example configuration for a Kafka sink secured with mTLS
 [source,json]
@@ -949,7 +948,6 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 
 // Type: concept
 // ModuleID: debezium-cockroachdb-connector-configuration-example
-
 [[cockroachdb-example-configuration]]
 === Connector configuration example
 
@@ -989,12 +987,11 @@ For more information about the properties that you can specify in the connector 
 
 // Type: procedure
 // ModuleID: adding-debezium-cockroachdb-connector-configuration-to-kafka-connect
-
 [[cockroachdb-adding-connector-configuration]]
 === Adding connector configuration
 
-You edit the  CockroachDB connector configuration to specify how you want the connector to behave.
-After you finalize the configuration, you use the Kafka Connect API to apply the configuration to the  cluster.
+Edit the CockroachDB connector configuration to specify how you want the connector to behave.
+After you finalize the configuration, use the Kafka Connect API to apply the configuration to the cluster.
 
 .Prerequisites
 
@@ -1024,7 +1021,6 @@ When the connector starts, it connects to the CockroachDB database, creates a ch
 
 // Type: assembly
 // ModuleID: monitoring-debezium-cockroachdb-connector-performance
-
 [[cockroachdb-monitoring]]
 === Monitoring
 
@@ -1033,7 +1029,7 @@ The {prodname} CockroachDB connector includes built-in support for both the JMX 
 
 
 .Additional resources
-* xref:{link-debezium-monitoring}#monitoring-debezium[Using JMX to expose metrics({prodname} monitoring documentation)^] .
+* xref:{link-debezium-monitoring}#monitoring-debezium[Using JMX to expose metrics ({prodname} monitoring documentation)^] .
 
 // Type: concept
 // ModuleID: monitoring-debezium-cockroachdb-connectors-customized-mbean-names
@@ -1081,7 +1077,8 @@ The following configuration properties are _required_ unless a default value is 
 |[[cockroachdb-property-name]]<<cockroachdb-property-name, `+name+`>>
 |No default
 |Unique name for the connector.
-Attempting to register again with the same name will fail.
+The name that you use to register a connector name must be unique.
+Registration fails if you reuse a connector name.
 This property is required by all Kafka Connect connectors.
 
 |[[cockroachdb-property-connector-class]]<<cockroachdb-property-connector-class, `+connector.class+`>>
@@ -1091,7 +1088,7 @@ Always use a value of `io.debezium.connector.cockroachdb.CockroachDBConnector` f
 
 |[[cockroachdb-property-tasks-max]]<<cockroachdb-property-tasks-max, `+tasks.max+`>>
 |`1`
-|The maximum number of tasks that should be created for this connector.
+|The maximum number of tasks that the connector can create.
 
 |[[cockroachdb-property-hostname]]<<cockroachdb-property-hostname, `+database.hostname+`>>
 |No default
@@ -1140,21 +1137,21 @@ The following properties configure the JDBC connection to the CockroachDB databa
 
 |[[cockroachdb-property-sslmode]]<<cockroachdb-property-sslmode, `+database.sslmode+`>>
 |`prefer`
-|Whether to use an encrypted connection to CockroachDB.
-Options include: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
+|Specifies whether {prodname} establishes an encrypted connection to CockroachDB.
+Set one of the following options: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
 See the link:https://www.cockroachlabs.com/docs/stable/authentication[CockroachDB authentication docs] for details.
 
 |[[cockroachdb-property-sslrootcert]]<<cockroachdb-property-sslrootcert, `+database.sslrootcert+`>>
 |No default
-|File containing the root certificate(s) against which the server is validated.
+|File that contains the trusted root certificates for validating the database server.
 
 |[[cockroachdb-property-sslcert]]<<cockroachdb-property-sslcert, `+database.sslcert+`>>
 |No default
-|File containing the SSL certificate for the client.
+|File that contains the SSL certificate for the client.
 
 |[[cockroachdb-property-sslkey]]<<cockroachdb-property-sslkey, `+database.sslkey+`>>
 |No default
-|File containing the SSL private key for the client.
+|File that contains the SSL private key for the client.
 
 |[[cockroachdb-property-sslpassword]]<<cockroachdb-property-sslpassword, `+database.sslpassword+`>>
 |No default
@@ -1162,7 +1159,7 @@ See the link:https://www.cockroachlabs.com/docs/stable/authentication[CockroachD
 
 |[[cockroachdb-property-tcp-keepalive]]<<cockroachdb-property-tcp-keepalive, `+database.tcpKeepAlive+`>>
 |`true`
-|Enable or disable TCP keep-alive probe to avoid dropping TCP connections.
+|Specifies whether to enable TCP keep-alive probes to avoid dropping TCP connections.
 
 |[[cockroachdb-property-on-connect-statements]]<<cockroachdb-property-on-connect-statements, `+database.on.connect.statements+`>>
 |No default
@@ -1171,7 +1168,7 @@ Use doubled semicolons (`;;`) to use a semicolon as a character and not as a del
 
 |[[cockroachdb-property-connection-timeout]]<<cockroachdb-property-connection-timeout, `+connection.timeout.ms+`>>
 |`30000`
-|How long to wait for a connection to be established, in milliseconds.
+|Specifies the time, in milliseconds, that the connector waits for a connection to be established with the database.
 
 |[[cockroachdb-property-connection-retry-delay]]<<cockroachdb-property-connection-retry-delay, `+connection.retry.delay.ms+`>>
 |`1000`
@@ -1180,7 +1177,7 @@ The actual delay is multiplied by the attempt number (linear backoff).
 
 |[[cockroachdb-property-connection-max-retries]]<<cockroachdb-property-connection-max-retries, `+connection.max.retries+`>>
 |`3`
-|Maximum number of connection retry attempts before giving up.
+|Maximum number of times that the connector retries the connection before it abandons the attempt.
 
 |[[cockroachdb-property-connection-validation-timeout]]<<cockroachdb-property-connection-validation-timeout, `+connection.validation.timeout.seconds+`>>
 |`5`
@@ -1206,11 +1203,11 @@ Resolved timestamps are used for offset tracking.
 
 |[[cockroachdb-property-include-updated]]<<cockroachdb-property-include-updated, `+cockroachdb.changefeed.include.updated+`>>
 |`false`
-|Whether to include information about which columns were updated in UPDATE events.
+|Specifies whether UPDATE events include information about which columns were updated.
 
 |[[cockroachdb-property-include-diff]]<<cockroachdb-property-include-diff, `+cockroachdb.changefeed.include.diff+`>>
 |`false`
-|Whether to include before/after diff information in changefeed events.
+|Specifies whether to include before and after diff information in changefeed events.
 When enabled, UPDATE events include the previous row state in the `before` field.
 
 |[[cockroachdb-property-enriched-properties]]<<cockroachdb-property-enriched-properties, `+cockroachdb.changefeed.enriched.properties+`>>
@@ -1219,14 +1216,15 @@ When enabled, UPDATE events include the previous row state in the `before` field
 The connector always uses the enriched envelope, so this applies to every changefeed it creates.
 CockroachDB owns the set of valid values, currently `source` and `schema`, and validates them when the changefeed is created.
 The connector derives the schema of each event from the table metadata that it discovers over JDBC, and it identifies each event's table from the topic on which the event arrives.
-It therefore does not read the `schema` block, which duplicates information the connector already has; `schema` is accepted and passed through for other consumers of the intermediate topics but is not used by the connector.
-The default is `source` because that block carries the originating database, schema, table, and commit timestamp, which is useful when you inspect the intermediate topics or when other tools also consume them.
+The connector does not read the `schema` block, which duplicates information that it already has; `schema` is accepted and passed through for other consumers of the intermediate topics, but it is not used by the connector.
+The default is `source` because that block identifies the originating database, schema, table, and commit timestamp.
+This information is useful when you inspect the intermediate topics or when other tools also consume them.
 
 |[[cockroachdb-property-cursor]]<<cockroachdb-property-cursor, `+cockroachdb.changefeed.cursor+`>>
 |`now`
 |The cursor position to start the changefeed from.
-Use `now` for current time or a specific timestamp.
-On restart with a stored offset, the connector uses the stored resolved timestamp instead of this value.
+Use `now` to start from the current time or specify an absolute timestamp.
+When the connector restarts from a stored offset, it uses the stored resolved timestamp instead of this value.
 
 |[[cockroachdb-property-batch-size]]<<cockroachdb-property-batch-size, `+cockroachdb.changefeed.batch.size+`>>
 |`1000`
@@ -1243,7 +1241,7 @@ Currently supported: `kafka`.
 
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
-|Prefix prepended to the intermediate changefeed topic names.
+|String that the connector prefixes to intermediate changefeed topic names.
 The connector uses the exact prefix string that you specify, so the resulting topics are named `_prefix__database_._schema_._table_`.
 Include your own separator if you want one: for example, `crdb.` yields `crdb.mydb.public.orders`, and `env-prod-` yields `env-prod-mydb.public.orders`.
 If you do not supply a value for this property, the connector defaults to using the value of `topic.prefix` followed by a dot.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1,4 +1,3 @@
-
 [id="debezium-connector-for-cockroachdb"]
 = {prodname} connector for CockroachDB
 :context: CockroachDB
@@ -104,7 +103,7 @@ Only ongoing changes after the changefeed is created are captured.
 [[cockroachdb-streaming-changes]]
 === Streaming changes
 
-After any initial scan completes, the CockroachDB connector streams changes continuously.
+After an initial scan completes, the CockroachDB connector streams changes continuously.
 When a row-level change occurs in CockroachDB, the changefeed writes a corresponding event to the intermediate Kafka topic.
 The connector consumes these events, transforms them into {prodname} change events, and forwards them to the output Kafka topics.
 
@@ -112,11 +111,11 @@ CockroachDB changefeeds emit link:https://www.cockroachlabs.com/docs/stable/chan
 These messages indicate that all changes up to that timestamp have been emitted.
 The connector uses resolved timestamps for offset tracking, so that on restart it can create a new changefeed with a `cursor` pointing to the last resolved timestamp, ensuring that it does not miss any events.
 
-When the connector receives changes it transforms the events into {prodname} _read_, _create_, _update_, or _delete_ events.
-The connector forwards these change events in records to the Kafka Connect framework, which is running in the same process.
+When the connector receives changes it transforms the events into {prodname} _read_, _create_, _update_, or _delete_ event records.
+The connector forwards these change records to the Kafka Connect framework, which is running in the same process.
 The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
 
-Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic.
+Periodically, Kafka Connect writes the most recent _offset_ to another Kafka topic.
 The offset indicates source-specific position information that {prodname} includes with each event.
 For the CockroachDB connector, the last resolved timestamp is the offset.
 
@@ -785,7 +784,7 @@ Uses the {prodname} `DoubleVector` logical type.
 [id="cockroachdb-default-values"]
 === Default values
 
-When a CockroachDB column is created with a `DEFAULT` clause, the connector parses the JDBC-reported default expression into the Java type that matches the column's Kafka Connect schema, and sets it as the schema default for that field.
+When a CockroachDB column specifies a `DEFAULT` clause, the connector parses the JDBC-reported default expression into the Java type that matches the column's Kafka Connect schema, and sets it as the schema default for that field.
 CockroachDB annotates default expressions with a CockroachDB-specific `:::TYPE` suffix (for example, `0:::INT8`, `'PENDING':::STRING`, `'[1.0,2.0,3.0]':::VECTOR`).
 The connector strips this annotation, unwraps quoted literals, and converts the value to the column's Java type.
 
@@ -797,7 +796,6 @@ For these columns, the connector omits the default from the schema so that Cockr
 
 Before you deploy the {prodname} CockroachDB connector, prepare your CockroachDB environment so that the connector can create and read changefeeds.
 At a high level, ensure that the required components and connectivity are in place, enable rangefeeds on the cluster, and grant the database user that the connector uses the privileges that changefeeds require.
-The prerequisites that follow describe what must be available before you begin.
 For information about enabling rangefeeds and granting the required privileges, see xref:cockroachdb-grant-changefeed-permissions[Granting changefeed permissions].
 
 .Prerequisites
@@ -811,8 +809,8 @@ A Kafka cluster where CockroachDB publishes changefeed events.
 This can be the same Kafka cluster that Kafka Connect uses, or a separate one.
 
 Network connectivity::
-The CockroachDB cluster must be able to reach the intermediate Kafka cluster to publish changefeed events.
-The Kafka Connect worker must be able to reach both the CockroachDB cluster (for JDBC) and the intermediate Kafka cluster (for consuming changefeed events).
+The CockroachDB cluster must be able to connect to the intermediate Kafka cluster to publish changefeed events.
+The Kafka Connect worker must be able to read from both the CockroachDB cluster (for JDBC) and the intermediate Kafka cluster (for consuming changefeed events).
 
 Changefeed user account::
 A CockroachDB user that has one of the following privileges on the target tables:
@@ -849,10 +847,10 @@ Granting `VIEWCLUSTERSETTING` lets the connector verify that `kv.rangefeed.enabl
 [id="cockroachdb-securing-the-changefeed-sink"]
 == Securing the changefeed sink
 
-When a changefeed sink requires TLS, or mutual TLS (mTLS), the connector can read PEM files from disk and inject the base64-encoded material into the sink URI at startup.
-This method of securing the sink connection avoids the need to base64-encode certificates by hand and paste large strings into the connector configuration.
+When a changefeed sink uses TLS or mutual TLS (mTLS), the connector can load PEM files from disk and automatically add their base64-encoded contents to the sink URI at startup. 
+This automatic injection removes the need to manually copy large, encoded certificate strings into the connector configuration.
 
-Set any combination of the following properties:
+Set one or more of the following properties to specify the mechanism that the connector uses to encrypt sink connections:
 
 `+cockroachdb.changefeed.sink.tls.ca.cert.file+`::
 Path to a PEM-encoded CA certificate that verifies the sink broker's certificate.
@@ -941,14 +939,14 @@ The following example shows a possible configuration for a CockroachDB connector
 <6> The password of the CockroachDB user.
 <7> The name of the CockroachDB database to connect to.
 <8> The topic prefix for Kafka topics that the connector writes to.
-<9> The URI of the Kafka cluster where CockroachDB will publish changefeed events.
+<9> The URI of the Kafka cluster where CockroachDB publishes changefeed events.
 <10> The snapshot mode; `initial` backfills existing rows on first start.
 <11> The maximum number of tasks.
 
 For more information about the properties that you can specify in the connector configuration, see the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] .
 
 [[cockroachdb-adding-connector-configuration]]
-=== Adding connector configuration
+=== Adding the connector configuration
 
 Edit the CockroachDB connector configuration to specify how you want the connector to behave.
 After you finalize the configuration, use the Kafka Connect API to apply the configuration to the cluster.
@@ -1074,9 +1072,9 @@ This is a required property.
 
 |===
 
-[id="cockroachdb-connection-configuration-properties"]
 The following properties configure the JDBC connection to the CockroachDB database.
 
+[id="cockroachdb-connection-configuration-properties"]
 .Connection configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
@@ -1112,8 +1110,8 @@ See the link:https://www.cockroachlabs.com/docs/stable/authentication[CockroachD
 
 |[[cockroachdb-property-on-connect-statements]]<<cockroachdb-property-on-connect-statements, `+database.on.connect.statements+`>>
 |No default
-|A semicolon-separated list of SQL statements to be executed when a JDBC connection to the database is established.
-Use doubled semicolons (`;;`) to use a semicolon as a character and not as a delimiter.
+|Specifies a semicolon-separated list of SQL statements that the connector runs when it establishes a JDBC connection.
+Use double semicolons (;;) to specify a literal semicolon instead of treating it as a separator.
 
 |[[cockroachdb-property-connection-timeout]]<<cockroachdb-property-connection-timeout, `+connection.timeout.ms+`>>
 |`30000`
@@ -1134,9 +1132,10 @@ The actual delay is multiplied by the attempt number (linear backoff).
 
 |===
 
-[id="cockroachdb-changefeed-configuration-properties"]
+
 The following properties configure the CockroachDB changefeed behavior.
 
+[id="cockroachdb-changefeed-configuration-properties"]
 .Changefeed configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
@@ -1254,9 +1253,9 @@ When `cockroachdb.changefeed.sink.tls.*` is set, the consumer's SSL is derived a
 
 |===
 
-[id="cockroachdb-connector-configuration-properties"]
 Set the following properties to configure the connector's snapshot and schema behavior.
 
+[id="cockroachdb-connector-configuration-properties"]
 .Connector configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
@@ -1309,9 +1308,10 @@ If you include this property in the configuration, do not also set the `schema.i
 
 |===
 
-[id="cockroachdb-advanced-configuration-properties"]
+
 The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
 
+[id="cockroachdb-advanced-configuration-properties"]
 .Advanced connector configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1,5 +1,5 @@
 // Category: debezium-using
-// Type: assembly
+
 [id="debezium-connector-for-cockroachdb"]
 = {prodname} connector for CockroachDB
 :context: CockroachDB
@@ -13,9 +13,9 @@
 
 toc::[]
 
-{prodname}'s CockroachDB connector captures row-level changes from a link:https://www.cockroachlabs.com/docs/stable/changefeed-messages[CockroachDB enriched changefeed] and streams them into Kafka topics.
+The {prodname} CockroachDB connector captures row-level changes from a link:https://www.cockroachlabs.com/docs/stable/changefeed-messages[CockroachDB enriched changefeed] and streams them into Kafka topics.
 
-CockroachDB link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeeds] watch a database's data changes -- inserts, updates, deletes -- in near-real-time.
+CockroachDB link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeeds] detect  data changes in the database -- inserts, updates, deletes -- in near-real-time.
 The connector creates a link:https://www.cockroachlabs.com/docs/stable/create-changefeed[changefeed] that publishes events to an intermediate Kafka cluster, then consumes those events, transforms them into the standard {prodname} envelope format, and produces them to the output Kafka topics that downstream consumers subscribe to.
 
 [NOTE]
@@ -26,7 +26,7 @@ An incubating connector is one that has been released for preview purposes and i
 
 // Type: concept
 // Title: Overview of {prodname} CockroachDB connector
-// ModuleID: overview-of-debezium-cockroachdb-connector
+
 [[cockroachdb-overview]]
 == Overview
 
@@ -34,16 +34,16 @@ CockroachDB is a distributed SQL database that provides link:https://www.cockroa
 Unlike traditional databases that rely on a write-ahead log (WAL) for change data capture, CockroachDB provides a native link:https://www.cockroachlabs.com/docs/stable/change-data-capture-overview[changefeed mechanism] that streams row-level changes directly from the storage layer.
 
 The {prodname} CockroachDB connector leverages this native changefeed capability.
-The connector produces a change event for every row-level insert, update, and delete operation that was captured and sends change event records for each table to a separate Kafka topic.
-Client applications read the Kafka topics that correspond to the database tables of interest and can react to every row-level event they receive from those topics.
+The connector produces a change event for every row-level insert, update, and delete operation that it captures and sends change event records for each table to a separate Kafka topic.
+Client applications read the Kafka topics that correspond to the database tables of interest and can react to each row-level event that they receive from those topics.
 
 The connector is tolerant of failures.
-As the connector reads changes and produces events, it records the last resolved timestamp processed.
-If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues streaming records from where it last left off.
+As the connector reads changes and produces events, it records the last resolved timestamp it processes.
+If the connector stops for any reason (including communication failures, network problems, or crashes), after the connector restarts, it resumes streaming from the last record that it processed.
 
 // Type: assembly
 // ModuleID: how-debezium-cockroachdb-connectors-work
-// Title: How {prodname} CockroachDB connectors work
+
 [[how-the-cockroachdb-connector-works]]
 == How the connector works
 
@@ -51,32 +51,32 @@ To optimally configure and run a {prodname} CockroachDB connector, it is helpful
 
 // Type: concept
 // ModuleID: cockroachdb-connector-architecture
-// Title: {prodname} CockroachDB connector architecture
+
 [[cockroachdb-architecture]]
 === Architecture
 
 The CockroachDB connector uses a two-stage Kafka architecture:
 
-1. **CockroachDB changefeed -> Intermediate Kafka**: The connector creates a single CockroachDB changefeed covering all configured tables (`CREATE CHANGEFEED FOR table1, table2, ...`) with the `enriched` envelope format.
+1. **CockroachDB changefeed to Intermediate Kafka**: The connector creates a single CockroachDB changefeed that uses the `enriched` envelope format for all configured tables (`CREATE CHANGEFEED FOR table1, table2, ...`)
 CockroachDB automatically routes events to per-table Kafka topics in the intermediate cluster.
-The enriched format includes both schema metadata and the full before/after row state.
+The enriched format includes both schema metadata and the full before and after row states.
 
-2. **Intermediate Kafka -> {prodname} -> Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer, routes each event to the correct table based on the topic name, transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields), and produces them to the final output Kafka topics.
+2. **Intermediate Kafka to {prodname} to Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer; routes each event to the correct table based on the topic name; transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields); and produces them to the final output Kafka topics.
 
 This architecture allows the connector to leverage CockroachDB's native, highly-available changefeed infrastructure for capture reliability, while providing the standard {prodname} event format that downstream consumers expect.
 Using a single multi-table changefeed is the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended approach] to stay within CockroachDB's limit of approximately 80 changefeed jobs per cluster.
 
 // Type: concept
 // ModuleID: cockroachdb-snapshots
-// Title: How {prodname} CockroachDB connectors perform snapshots
+
 [[cockroachdb-snapshots]]
 === Snapshots
 
 CockroachDB changefeeds natively support an link:https://www.cockroachlabs.com/docs/stable/create-changefeed#initial-scan[`initial_scan`] option that backfills all existing rows before streaming ongoing changes.
-The {prodname} CockroachDB connector maps its `snapshot.mode` configuration to the CockroachDB `initial_scan` changefeed option, so there is no separate JDBC-based snapshot phase.
+The {prodname} CockroachDB connector maps its `snapshot.mode` configuration to the CockroachDB `initial_scan` changefeed option, so the connector does not require a separate JDBC-based snapshot phase.
 
-During the initial scan phase, all events are marked with `op=r` (read) to distinguish them from ongoing change events.
-Once the initial scan completes and the changefeed transitions to streaming, events are marked with the appropriate operation type (`c` for create, `u` for update, `d` for delete).
+During the initial scan phase, captured events are marked `op=r` (read) to distinguish them from ongoing change events.
+After the initial scan completes and the changefeed transitions to streaming, events are marked with the appropriate operation type (`c` for create, `u` for update, `d` for delete).
 
 The following table shows how each `snapshot.mode` maps to the CockroachDB `initial_scan` option:
 
@@ -89,16 +89,16 @@ The following table shows how each `snapshot.mode` maps to the CockroachDB `init
 
 |`initial` (default)
 |`yes` on first start, `no` on restart
-|On first start (no prior offset), backfills all existing rows.
-On restart with an existing offset, resumes streaming from the stored cursor.
+|On first start (no prior offset), the snapshot backfills all existing rows.
+On restart with an existing offset, streaming resumes from the stored cursor.
 
 |`always`
 |`yes`
-|Always backfills all existing rows, even on restart.
+|The snapshot always backfills all existing rows, even on restart.
 
 |`initial_only`
 |`only`
-|Backfills all existing rows, then the connector stops.
+|The snapshot backfills all existing rows, then the connector stops.
 Useful for one-time data migration.
 
 |`no_data` / `never`
@@ -108,12 +108,12 @@ Only ongoing changes after the changefeed is created are captured.
 
 |`when_needed`
 |`yes` on first start, `no` on restart
-|Same as `initial`, but also re-snapshots if the stored offset is no longer valid.
+|Same as `initial`, but if the stored offset is no longer valid, the connector performs a new initial snapshot.
 |===
 
 // Type: concept
 // ModuleID: how-debezium-cockroachdb-connectors-stream-change-event-records
-// Title: How {prodname} CockroachDB connectors stream change event records
+
 [[cockroachdb-streaming-changes]]
 === Streaming changes
 
@@ -123,7 +123,7 @@ The connector consumes these events, transforms them into {prodname} change even
 
 CockroachDB changefeeds emit link:https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages[resolved timestamp messages] at a configurable interval.
 These messages indicate that all changes up to that timestamp have been emitted.
-The connector uses resolved timestamps for offset tracking, so that on restart it can create a new changefeed with a `cursor` pointing to the last resolved timestamp, ensuring no events are missed.
+The connector uses resolved timestamps for offset tracking, so that on restart it can create a new changefeed with a `cursor` pointing to the last resolved timestamp, ensuring that it does not miss any events.
 
 When the connector receives changes it transforms the events into {prodname} _read_, _create_, _update_, or _delete_ events.
 The connector forwards these change events in records to the Kafka Connect framework, which is running in the same process.
@@ -138,50 +138,62 @@ When Kafka Connect restarts, it reads the last recorded offset for each connecto
 
 // Type: concept
 // ModuleID: cockroachdb-heartbeats
-// Title: How the CockroachDB connector uses heartbeats
+
 [[cockroachdb-heartbeats]]
 === Heartbeats
 
-CockroachDB changefeed link:https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages[resolved timestamps] serve as natural heartbeats.
-When the connector receives a resolved timestamp, it:
+link:https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages[Resolved timestamps] in the CockroachDB changefeed serve as natural heartbeats.
+When the connector receives a resolved timestamp, it performs the following operations:
 
 1. Updates the stored offset cursor to the resolved timestamp value.
 2. Dispatches a {prodname} heartbeat event to advance Kafka Connect offsets.
 
 This ensures that offsets advance even during idle periods when no data changes occur.
-Without offset advancement, monitoring systems might report the connector as stuck, and CockroachDB protected timestamps could accumulate, preventing garbage collection.
+When offsets fail to advance, monitoring systems might report that the connector is unresponsive, which can cause CockroachDB protected timestamps to accumulate, preventing garbage collection.
 
 To enable {prodname} heartbeat records on the `__debezium-heartbeat.<topic.prefix>` Kafka topic, set `heartbeat.interval.ms` to a value greater than `0` (in milliseconds).
 The `cockroachdb.changefeed.resolved.interval` property controls how frequently CockroachDB emits resolved timestamps (default: `10s`).
 
 // Type: concept
 // ModuleID: cockroachdb-schema-evolution
-// Title: How the CockroachDB connector handles schema evolution
+
 [[cockroachdb-schema-evolution]]
 === Schema evolution
 
 The connector automatically detects DDL changes such as `ALTER TABLE ADD COLUMN`, `DROP COLUMN`, and `RENAME COLUMN` without requiring a restart.
-When an incoming changefeed event contains fields that do not match the registered table schema, the connector:
+When an incoming changefeed event contains fields that do not match the registered table schema, the connector adapts the schema by performing the following tasks:
 
 1. Detects the mismatch by comparing event field names against registered column names.
 2. Re-queries `information_schema` to retrieve the updated table definition.
-3. Refreshes the internal schema and continues processing with the new column layout.
+3. Refreshes the internal schema and continues processing the table based on the adjusted column layout.
 
-CockroachDB changefeeds handle schema changes natively by performing a _backfill_ -- re-emitting all existing rows with the updated schema.
-This means no events are lost during the transition, and downstream consumers see the new columns as soon as the backfill completes.
+CockroachDB changefeeds handle schema changes natively by performing a _backfill_ operation in which the Schema Change Manager re-emits all existing rows with the updated schema.
+A backfill ensures that no events are lost during the schema transition.  
+After a backfill completes, the refreshed columns are immediately available to downstream consumers.
 
 // Type: concept
 // ModuleID: cockroachdb-incremental-snapshots
-// Title: Incremental snapshots
+
 [[cockroachdb-incremental-snapshots]]
 === Incremental snapshots
 
 The CockroachDB connector supports {prodname} {link-prefix}:{link-signalling}#debezium-signaling-incremental-snapshots[signal-based incremental snapshots].
 An incremental snapshot re-reads existing rows from one or more tables and emits them as `op=r` (read) events, while the connector continues to capture ongoing changes without interruption.
 
-To use incremental snapshots:
+You can use incremental snapshots to perform the following tasks:
 
-. Create a signaling table in CockroachDB:
+* Re-populate a downstream consumer that lost data.
+* Backfill a newly added sink or topic.
+* Verify source-target consistency by re-snapshotting and comparing.
+
+[id="cockroachdb-prepare-to-use-incremental-snapshots"]
+==== Prepare to use incremental snapshots
+
+To enable the connector to use incremental snapshots, you must create a signaling table and then update the connector configuration to recognize the signaling table.
+
+.Procedure
+
+1.  Create a signaling table in CockroachDB by issuing the following SQL command:
 +
 [source,sql]
 ----
@@ -192,7 +204,7 @@ CREATE TABLE debezium_signal (
 );
 ----
 
-. Add the signaling table to the connector configuration:
+2. Add the following properties to the connector configuration to reference the signaling table:
 +
 [source,json]
 ----
@@ -202,7 +214,7 @@ CREATE TABLE debezium_signal (
 }
 ----
 +
-The signaling table must be included in `table.include.list` so the changefeed delivers signal events to the connector.
+You must include the signaling table in the  `table.include.list` so that the changefeed can deliver signal events to the connector.
 
 . To trigger an incremental snapshot, insert a signal row:
 +
@@ -218,34 +230,34 @@ You can use incremental snapshots to:
 
 * Re-populate a downstream consumer that lost data.
 * Backfill a newly added sink or topic.
-* Verify source-target consistency by re-snapshotting and comparing.
+
 
 For more information about signaling, see {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-cockroachdb-change-event-records
-// Title: Default names of Kafka topics that receive {prodname} CockroachDB change event records
+
 [[cockroachdb-topic-names]]
 === Topic names
 
-The CockroachDB connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic.
+The CockroachDB connector all data change events for a table (insert, update, and delete) to a Kafka topic that is dedicated to that table.
 By default, the Kafka topic name is _topicPrefix_._schemaName_._tableName_ where:
 
-* _topicPrefix_ is the topic prefix as specified by the `topic.prefix` connector configuration property.
+* _topicPrefix_ is the topic prefix as specified by the xref:cockroachdb-property-topic-prefix[`topic.prefix`] connector configuration property.
 * _schemaName_ is the name of the database schema (default: `public`).
 * _tableName_ is the name of the database table in which the operation occurred.
 
-For example, suppose that `cockroachdb` is the topic prefix for a connector that is capturing changes from a database that contains two tables: `orders` and `customers`.
-The connector would stream records to these two Kafka topics:
+For example, suppose that `cockroachdb` is the topic prefix for a connector that captures changes from a database that contains two tables: `orders` and `customers`.
+The connector would stream records to the following two Kafka topics:
 
 * `cockroachdb.public.orders`
 * `cockroachdb.public.customers`
 
-The connector applies similar naming conventions as other {prodname} connectors, and supports the standard topic naming strategies.
+The connector applies naming conventions that are similar to those used by other {prodname} connectors, and it supports the standard topic naming strategies.
 
 // Type: assembly
 // ModuleID: descriptions-of-debezium-cockroachdb-connector-data-change-events
-// Title: Descriptions of {prodname} CockroachDB connector data change events
+
 [[cockroachdb-events]]
 == Data change events
 
@@ -256,14 +268,15 @@ The structure of the key and the value depends on the table that was changed.
 
 {prodname} and Kafka Connect are designed around _continuous streams of event messages_.
 However, the structure of these events may change over time, which can be difficult for consumers to handle.
-To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry.
-This makes each event self-contained.
+To help consumers adapt to structural volatility, the connector emits self-contained events; that is, each event message contains either the schema for its content.
+Or in environments  that use a schema registry, each message contains a schema ID that a consumer can use to obtain the schema from the registry.
+
 
 The following skeleton JSON documents show the basic structure for the key and value documents.
-However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of the key and value documents.
-A `schema` field is in a change event key or change event value only when you configure the converter to produce it.
+However, the exact representation of the key and value documents depends on how you configure the Kafka Connect converter that you use in your application.
+A `schema` field is present a change event key or change event value only if you configure the converter to produce it.
 Likewise, the event key and event payload are present only if you configure a converter to produce it.
-If you use the JSON converter and you configure it to produce schemas, change events have this structure:
+If you use the JSON converter and you configure it to produce schemas, change events have the following structure:
 
 [source,json,index=0]
 ----
@@ -318,17 +331,17 @@ It has the structure described by the previous `schema` field and it contains th
 
 |===
 
-The default behavior is that the connector streams change event records to xref:cockroachdb-topic-names[topics with names that are the same as the event's originating table].
+The default xref: xref:cockroachdb-topic-names[topic naming behavior] results in the connector streaming change event records to a topic whose name matches the name of the table that the event describes.
 
 // Type: concept
 // ModuleID: about-keys-in-debezium-cockroachdb-change-events
-// Title: About keys in {prodname} CockroachDB change events
+
 [[cockroachdb-change-events-key]]
 === Change event keys
 
-For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created.
+The change event key for a table contains fields for each column that was present in the table's primary key at the time the event was created.
 
-Consider an `orders` table defined in the `defaultdb` database and the example of a change event key for that table.
+For example, consider the following definition for an `orders` table in the `defaultdb` database:
 
 .Example table
 [source,sql,indent=0]
@@ -343,7 +356,8 @@ CREATE TABLE orders (
 ----
 
 .Example change event key
-Every change event for the `orders` table while it has this definition has the same key structure, which in JSON looks like this:
+Based on the preceding definition of the `orders` table, the key structure for every change event for the table is the same key structure. 
+The following JSON represents this key structure:
 
 [source,json,indent=0]
 ----
@@ -368,11 +382,11 @@ Every change event for the `orders` table while it has this definition has the s
 
 // Type: concept
 // ModuleID: about-values-in-debezium-cockroachdb-change-events
-// Title: About values in {prodname} CockroachDB change events
+
 [[cockroachdb-change-events-value]]
 === Change event values
 
-Consider the same sample table that was used to show an example of a change event key:
+Consider the same sample `orders` table that was used in the xref:cockroachdb-change-events-key[change event key example]:
 
 [source,sql,indent=0]
 ----
@@ -384,8 +398,12 @@ CREATE TABLE orders (
   created_at TIMESTAMP DEFAULT now()
 );
 ----
+Based on the preceding `orders` table definition, the following examples show representative structures for the following types of change event values:
 
-// Type: continue
+* xref:cockroachdb-create-events[_create_ event values]
+* xref:cockroachdb-update-events[_update_ event values]
+* xref:cockroachdb-delete-events[_delete_ event values]
+
 [[cockroachdb-create-events]]
 === _create_ events
 
@@ -429,7 +447,7 @@ The following example shows the value portion of a change event that the connect
 ----
 
 .Descriptions of _create_ event value fields
-[cols="1,2,7",options="header"]
+[cols="1,2a,7a",options="header"]
 |===
 |Item |Field name |Description
 
@@ -445,7 +463,7 @@ In this example, the `after` field contains the values of the new row's `id`, `c
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event.
+|Mandatory field that describes the source metadata for the event.
 This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction.
 The source metadata includes:
 
@@ -471,7 +489,7 @@ Valid values are:
 
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
-a|Optional field that displays the time at which the connector processed the event.
+|Optional field that displays the time at which the connector processed the event.
 The time is based on the system clock in the JVM running the Kafka Connect task.  +
  +
 In the `source` object, `ts_ms` indicates the time that the change was made in the database.
@@ -479,14 +497,14 @@ By comparing the value for `payload.source.ts_ms` with the value for `payload.ts
 
 |===
 
-// Type: continue
+
 [[cockroachdb-update-events]]
 === _update_ events
 
 The value of a change event for an update in the sample `orders` table has the same schema as a _create_ event for that table.
 Likewise, the event value's payload has the same structure.
 However, the event value payload contains different values in an _update_ event.
-Here is an example of a change event value in an event that the connector generates for an update in the `orders` table:
+The following example shows the JSON for the value portion of a change event that the connector generates for an update in the `orders` table:
 
 [source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
@@ -526,13 +544,13 @@ Here is an example of a change event value in an event that the connector genera
 ----
 
 .Descriptions of _update_ event value fields
-[cols="1,2,7",options="header"]
+[cols="1,2,7a",options="header"]
 |===
 |Item |Field name |Description
 
 |1
 |`before`
-a|An optional field that contains the state of the row before the update.
+|An optional field that contains the state of the row before the update.
 By default, CockroachDB changefeeds do not include the `before` state unless the `diff` changefeed option is enabled (`cockroachdb.changefeed.include.diff=true`).
 When `diff` is not enabled, this field is `null`.
 
@@ -543,7 +561,7 @@ In this example, the `status` value has been changed to `shipped`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event.
+|Mandatory field that describes the source metadata for the event.
 The `source` field structure has the same fields as in a _create_ event, but some values are different.
 
 |4
@@ -556,14 +574,20 @@ In an _update_ event value, the `op` field value is `u`, signifying that this ro
 [NOTE]
 ====
 To include the `before` state in update events, set `cockroachdb.changefeed.include.diff` to `true` in the connector configuration.
-This enables the CockroachDB changefeed `diff` option, which includes the previous row state.
+To include the `before` state for a row in update events, enable the CockroachDB changefeed `diff` option by setting `cockroachdb.changefeed.include.diff` to `true` in the connector configuration.
 ====
 
 [[cockroachdb-delete-events]]
 === _delete_ events
 
 The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table.
-The `payload` portion in a _delete_ event for the sample `orders` table looks like this:
+A delete_ change event record provides a consumer with the information that it needs to process the removal of a row.
+
+The {prodname} CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
+Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
+Removing older messages lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
+
+The following example shows the JSON for the `payload` portion of a change event that the connector generates for a delete event in the `orders` table:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -597,7 +621,7 @@ The `payload` portion in a _delete_ event for the sample `orders` table looks li
 ----
 
 .Descriptions of _delete_ event value fields
-[cols="1,2,7",options="header"]
+[cols="1,2,7a",options="header"]
 |===
 |Item |Field name |Description
 
@@ -607,12 +631,12 @@ The `payload` portion in a _delete_ event for the sample `orders` table looks li
 
 |2
 |`source`
-a|Mandatory field that describes the source metadata for the event.
+|Mandatory field that describes the source metadata for the event.
 In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table.
 
 |3
 |`op`
-a|Mandatory string that describes the type of operation.
+|Mandatory string that describes the type of operation.
 The `op` field value is `d`, signifying that this row was deleted.
 
 |===
@@ -621,25 +645,28 @@ A _delete_ change event record provides a consumer with the information it needs
 
 CockroachDB connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
 Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
-This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
-// Type: continue
+
+
 [[cockroachdb-tombstone-events]]
 .Tombstone events
-When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key.
+When you delete a row, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key.
 However, for Kafka to remove all messages that have that same key, the message value must be `null`.
 To make this possible, the connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
 
 // Type: reference
 // ModuleID: how-debezium-cockroachdb-connectors-map-data-types
-// Title: How {prodname} CockroachDB connectors map data types
+
 [[cockroachdb-data-types]]
 == Data type mappings
 
 The CockroachDB connector represents changes to rows with events that are structured like the table in which the row exists.
 The event contains a field for each column value.
-How that value is represented in the event depends on the CockroachDB data type of the column.
-This section describes these mappings.
+The way in which {prodname} represents values in the event record depends on the data type of the CockroachDB column.
+The following data type mappings are applied for CockroachDB data:
+
+* xref:cockroachdb-types[Mappings for CockroachDB data types]
+
 
 [id="cockroachdb-types"]
 === CockroachDB types
@@ -748,7 +775,7 @@ For these columns, the connector omits the default from the schema so that Cockr
 
 // Type: assembly
 // ModuleID: setting-up-cockroachdb-for-debezium
-// Title: Setting up CockroachDB for {prodname}
+
 [[setting-up-cockroachdb]]
 == Setting up CockroachDB
 
@@ -788,15 +815,38 @@ The Kafka Connect worker must be able to reach both the CockroachDB cluster (for
 
 // Type: assembly
 // ModuleID: deploying-and-managing-debezium-cockroachdb-connectors
-// Title: Deploying and managing {prodname} CockroachDB connectors
+
 [[cockroachdb-deploying-a-connector]]
 == Deployment
 
-With link:http://kafka.apache.org/[Kafka] and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} CockroachDB connector are to download the connector's plug-in archive, extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-You then need to restart your Kafka Connect process to pick up the new JAR files.
+To deploy a {prodname} CockroachDB connector you obtain the connector plug-in files archive, add the JAR files to your Kafka Connect environment, and then edit the `plugin.path` configuration to reference the location of the files.
 
 If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Kafka and Kafka Connect.
+
+[IMPORTANT]
+====
+The {prodname} container images that you obtain from `quay.io` do not undergo rigorous testing or security analysis, and are provided for testing and evaluation purposes only.
+These images are not intended for use in production environments.
+To mitigate risk in production deployments, deploy only containers that are actively maintained by trusted vendors, and thoroughly tested for potential vulnerabilities.
+====
+
 You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
+
+.Prerequisites
+* link:http://kafka.apache.org/[Kafka] and {link-kafka-docs}.html#connect[Kafka Connect] are deployed and running.
+ 
+.Procedure
+
+1. Download the archive file to a temporary directory.
+2. Copy the downloaded file to a directory in your Kafka Connect environment, for example, `/usr/local/share/kafka/plugins`.
+4.  Extract the JAR file into the directory and then remove the downloaded archive file.
+5. Add an entry for the directory with the JAR files to the [Kafka Connect plugin.path](https://kafka.apache.org/documentation/#connectconfigs).
+6. xref:cockroachdb-example-configuration[Configure the connector] and xref:cockroachdb-adding-connector-configuration[add the configuration] to your Kafka Connect cluster.
+7. Restart the Kafka Connect process so that it picks up the new JAR files.
+
+
+If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Kafka and Kafka Connect.
+
 
 [IMPORTANT]
 ====
@@ -807,11 +857,11 @@ To mitigate risk in production deployments, deploy only containers that are acti
 
 // Type: concept
 // ModuleID: debezium-cockroachdb-connector-configuration-example
-// Title: {prodname} CockroachDB connector configuration example
+
 [[cockroachdb-example-configuration]]
 === Connector configuration example
 
-Following is an example of the configuration for a CockroachDB connector that connects to a CockroachDB cluster and captures changes from all tables in the `public` schema of the `defaultdb` database.
+The following example shows a possible configuration for a CockroachDB connector that connects to a CockroachDB cluster and captures changes from all tables in the `public` schema of the `defaultdb` database.
 
 [source,json]
 ----
@@ -845,15 +895,16 @@ Following is an example of the configuration for a CockroachDB connector that co
 <11> The snapshot mode; `initial` backfills existing rows on first start.
 <12> The maximum number of tasks.
 
-See the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] that can be specified in these configurations.
+For more information about the properties that you can specify in the connector configuration, see the xref:cockroachdb-connector-properties[complete list of CockroachDB connector properties] .
 
 // Type: procedure
 // ModuleID: adding-debezium-cockroachdb-connector-configuration-to-kafka-connect
-// Title: Adding {prodname} CockroachDB connector configuration to Kafka Connect
+
 [[cockroachdb-adding-connector-configuration]]
 === Adding connector configuration
 
-To start running a CockroachDB connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
+You edit the  CockroachDB connector configuration to specify how you want the connector to behave.
+After you finalize the configuration, you use the Kafka Connect API to apply the configuration to the  cluster.
 
 .Prerequisites
 
@@ -865,9 +916,9 @@ To start running a CockroachDB connector, create a connector configuration and a
 
 .Procedure
 
-. Create a configuration for the CockroachDB connector.
+. xref:cockroachdb-example-configuration[Create the configuration for the CockroachDB connector].
 
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to submit a `POST` request that applies the JSON for the connector configuration to the Kafka Connect cluster.
 +
 For example:
 +
@@ -883,15 +934,16 @@ When the connector starts, it connects to the CockroachDB database, creates a ch
 
 // Type: assembly
 // ModuleID: monitoring-debezium-cockroachdb-connector-performance
-// Title: Monitoring {prodname} CockroachDB connector performance
+
 [[cockroachdb-monitoring]]
 === Monitoring
 
-The {prodname} CockroachDB connector provides the built-in support for JMX metrics that Kafka and Kafka Connect provide, plus streaming metrics.
+The {prodname} CockroachDB connector includes built-in support for both the JMX metrics that Kafka and Kafka Connect provide, as well as cockroachdb-streaming-metrics[streaming metrics] that provide insights into connector behavior during the captures and streaming of change event records.
 
-* xref:cockroachdb-streaming-metrics[Streaming metrics] provide information about connector operations when the connector is capturing changes and streaming change event records.
 
-xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+
+.Additional resources
+* xref:{link-debezium-monitoring}#monitoring-debezium[Using JMX to expose metrics({prodname} monitoring documentation)^] .
 
 // Type: concept
 // ModuleID: monitoring-debezium-cockroachdb-connectors-customized-mbean-names

--- a/documentation/modules/ROOT/pages/connectors/index.adoc
+++ b/documentation/modules/ROOT/pages/connectors/index.adoc
@@ -16,6 +16,7 @@ We currently have the following connectors:
 * xref:connectors/vitess.adoc[Vitess] (Incubating)
 * xref:connectors/spanner.adoc[Spanner]
 * xref:connectors/informix.adoc[Informix] (Incubating)
+* xref:connectors/cockroachdb.adoc[CockroachDB] (Incubating)
 
 [NOTE]
 ====


### PR DESCRIPTION
Add comprehensive documentation for the Debezium CockroachDB connector to the official documentation site at https://debezium.io/documentation/.

## Changes

- **New file**: `documentation/modules/ROOT/pages/connectors/cockroachdb.adoc` (1188 lines)
- **Modified**: `documentation/modules/ROOT/pages/connectors/index.adoc` -- added CockroachDB (Incubating) to the connector list
- **Modified**: `documentation/modules/ROOT/nav.adoc` -- added CockroachDB to the navigation

## Documentation covers

- Overview and architecture (two-stage Kafka pipeline with enriched changefeeds)
- Snapshot support via CockroachDB native `initial_scan` (all snapshot modes mapped)
- Streaming changes with resolved timestamp offset tracking
- Topic naming conventions
- Data change events with full JSON examples (create, update, delete)
- Data type mappings (25+ CockroachDB types including VECTOR)
- CockroachDB setup prerequisites (permissions, intermediate Kafka, network)
- Deployment and connector configuration example
- Monitoring (JMX MBeans, streaming metrics)
- All configuration properties organized into 5 tables (required, connection, changefeed, connector, advanced)
- Fault handling (CockroachDB unavailability, Kafka Connect crashes, GC TTL)
- Current limitations with links to GitHub issues for planned features

Modeled after the existing Spanner connector documentation.

Related: https://github.com/debezium/debezium-connector-cockroachdb

Fixes https://github.com/debezium/dbz/issues/1633