### PR TITLE
debezium/dbz#1557 Keep OTel span scope active during format conversion

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
@@ -124,7 +124,8 @@ public class MongoEventRouterConfigDefinition {
         Field.group(
                 config,
                 "Tracing",
-                ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD, ActivateTracingSpan.TRACING_OPERATION_NAME, ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED);
+                ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD, ActivateTracingSpan.TRACING_OPERATION_NAME, ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED,
+                ActivateTracingSpan.TRACING_KEEP_SCOPE_ACTIVE);
         return config;
     }
 }

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -28,6 +28,10 @@
       <version>1.1.0</version>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${version.maven}</version>

--- a/debezium-transforms/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-transforms/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -327,7 +327,8 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Tracing",
-                ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD, ActivateTracingSpan.TRACING_OPERATION_NAME, ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED);
+                ActivateTracingSpan.TRACING_SPAN_CONTEXT_FIELD, ActivateTracingSpan.TRACING_OPERATION_NAME, ActivateTracingSpan.TRACING_CONTEXT_FIELD_REQUIRED,
+                ActivateTracingSpan.TRACING_KEEP_SCOPE_ACTIVE);
         return config;
     }
 


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/1557

## Description

When using Debezium with OpenTelemetry tracing and a schema registry (Apicurio, Confluent), HTTP calls made by format converters to register/fetch schemas are **not included in the distributed trace**. The root cause is in `TracingSpanUtil.traceRecord()` — the span scope is closed via try-with-resources before the method returns, so downstream components have no active thread-local trace context.

This PR adds an optional `tracing.keep.scope.active` configuration property (default `false`) to the `ActivateTracingSpan` SMT. When enabled, the OTel span scope remains active after `apply()` returns, allowing the OTel Java Agent to automatically instrument downstream HTTP calls (e.g. schema registry requests) as child spans of the CDC trace.

### Changes

- **`TracingSpanUtil`**: Added `TracingResult<R>` inner class and `traceRecordKeepingScope()` method that creates the same tracing structure as `traceRecord()` but does not close the scope or end the span, returning them for the caller to manage
- **`ActivateTracingSpan`**: Added `tracing.keep.scope.active` boolean config field. When enabled, `apply()` delegates to `traceRecordKeepingScope()` and stores the active span/scope. The previous scope is automatically cleaned up on the next `apply()` call or on `close()`
- **`EventRouterConfigDefinition`** / **`MongoEventRouterConfigDefinition`**: Added the new field to the "Tracing" config group
- **`ActivateTracingSpanTest`**: Added two new tests verifying that the span context remains active after `apply()` and that the previous scope is properly cleaned up on subsequent calls

### Default behavior is unchanged

When `tracing.keep.scope.active` is not set (or set to `false`), the existing `traceRecord()` code path is used with no behavioral change.

## Test plan
- [x] Two new unit tests added to `ActivateTracingSpanTest`
- [x] All 5 tracing tests pass (3 existing + 2 new)
- [x] Code formatting verified (`mvn process-sources` — 0 files changed)