### PR TITLE
DBZ-9455 Filter TypeRegistry type pre-load to schema.include.list schemas

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -763,6 +763,7 @@ Yuang Li
 Yue Wang
 Yuiham Chan
 Yuriy Vikulov
+Zach All
 Zakariae Ben Allal
 Zheng Wang
 Zongwen Li

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -9,11 +9,15 @@ package io.debezium.connector.postgresql;
 import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -23,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.bean.StandardBeanNames;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -105,14 +110,16 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
 
         final Charset databaseCharset;
+        final Set<String> typeRegistrySchemaFilter;
         try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
             databaseCharset = tempConnection.getDatabaseCharset();
+            typeRegistrySchemaFilter = buildTypeRegistrySchemaFilter(connectorConfig, tempConnection);
         }
         catch (DebeziumException e) {
             throw new RetriableException("Couldn't obtain encoding for database", e);
         }
 
-        final TypeRegistry sharedTypeRegistry = PostgresConnection.createTypeRegistry(connectorConfig.getJdbcConfig());
+        final TypeRegistry sharedTypeRegistry = PostgresConnection.createTypeRegistry(connectorConfig.getJdbcConfig(), typeRegistrySchemaFilter);
 
         final PostgresValueConverterBuilder valueConverterBuilder = (typeRegistry) -> PostgresValueConverter.of(
                 connectorConfig,
@@ -521,5 +528,57 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                 LOGGER.warn("WAL_LEVEL check failed but this is ignored as CDC was not requested");
             }
         }
+    }
+
+    /**
+     * Builds the set of schema names to pre-load into {@link TypeRegistry} by querying
+     * {@code pg_catalog.pg_namespace} and applying the connector's
+     * {@code schema.include.list} / {@code schema.exclude.list} predicate.
+     * System schemas are excluded because {@link TypeRegistry} always includes them unconditionally.
+     *
+     * @param config     the connector configuration (provides the schema filter predicate)
+     * @param connection an open {@link PostgresConnection} used to query {@code pg_catalog.pg_namespace}
+     * @return a possibly-empty set of schema names to pre-load types from
+     */
+    @VisibleForTesting
+    static Set<String> buildTypeRegistrySchemaFilter(PostgresConnectorConfig config, PostgresConnection connection) {
+        final Set<String> allSchemas = new HashSet<>();
+        try {
+            connection.query(
+                    "SELECT nspname FROM pg_catalog.pg_namespace" +
+                            " WHERE nspname NOT LIKE 'pg_%' AND nspname <> 'information_schema'",
+                    rs -> {
+                        while (rs.next()) {
+                            allSchemas.add(rs.getString(1));
+                        }
+                    });
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Could not query pg_namespace to build TypeRegistry schema filter; " +
+                    "falling back to loading all schemas", e);
+            return Collections.emptySet();
+        }
+        return buildTypeRegistrySchemaFilter(config.getTableFilters().schemaFilter(), allSchemas);
+    }
+
+    /**
+     * Filters {@code candidateSchemas} through {@code schemaFilter} and returns the matching names.
+     *
+     * @param schemaFilter     predicate built from {@code schema.include.list} / {@code schema.exclude.list}
+     * @param candidateSchemas non-system schema names retrieved from {@code pg_catalog.pg_namespace}
+     * @return an unmodifiable set of schema names accepted by the predicate
+     */
+    @VisibleForTesting
+    static Set<String> buildTypeRegistrySchemaFilter(Predicate<String> schemaFilter, Set<String> candidateSchemas) {
+        final Set<String> result = new HashSet<>();
+        for (String name : candidateSchemas) {
+            if (schemaFilter.test(name)) {
+                result.add(name);
+            }
+        }
+        if (!result.isEmpty()) {
+            LOGGER.info("TypeRegistry will pre-load types from schemas: {}", result);
+        }
+        return Collections.unmodifiableSet(result);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -535,13 +535,23 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
      * {@code pg_catalog.pg_namespace} and applying the connector's
      * {@code schema.include.list} / {@code schema.exclude.list} predicate.
      * System schemas are excluded because {@link TypeRegistry} always includes them unconditionally.
+     * <p>
+     * When neither list is configured the method returns an empty set immediately, which causes
+     * {@link TypeRegistry} to use its cheaper unfiltered SQL path.
      *
      * @param config     the connector configuration (provides the schema filter predicate)
      * @param connection an open {@link PostgresConnection} used to query {@code pg_catalog.pg_namespace}
-     * @return a possibly-empty set of schema names to pre-load types from
+     * @return a possibly-empty set of schema names to pre-load types from; empty means "all schemas"
      */
     @VisibleForTesting
     static Set<String> buildTypeRegistrySchemaFilter(PostgresConnectorConfig config, PostgresConnection connection) {
+        final String includeList = config.schemaIncludeList();
+        final String excludeList = config.schemaExcludeList();
+        if ((includeList == null || includeList.isBlank()) && (excludeList == null || excludeList.isBlank())) {
+            // No filter configured — TypeRegistry will load all schemas via the cheaper unfiltered SQL path.
+            return Collections.emptySet();
+        }
+
         final Set<String> allSchemas = new HashSet<>();
         try {
             connection.query(
@@ -570,12 +580,9 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
      */
     @VisibleForTesting
     static Set<String> buildTypeRegistrySchemaFilter(Predicate<String> schemaFilter, Set<String> candidateSchemas) {
-        final Set<String> result = new HashSet<>();
-        for (String name : candidateSchemas) {
-            if (schemaFilter.test(name)) {
-                result.add(name);
-            }
-        }
+        final Set<String> result = candidateSchemas.stream()
+                .filter(schemaFilter)
+                .collect(Collectors.toSet());
         if (!result.isEmpty()) {
             LOGGER.info("TypeRegistry will pre-load types from schemas: {}", result);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.postgresql;
 
+import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,11 +72,20 @@ public class TypeRegistry {
     private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel ORDER BY t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
-    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+    private static final String SQL_TYPES_BASE = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
             + "FROM pg_catalog.pg_type t "
             + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "LEFT JOIN (" + SQL_ENUM_VALUES + ") e ON (t.oid = e.id) "
             + "WHERE n.nspname != 'pg_toast'";
+
+    private static final String SQL_TYPES = SQL_TYPES_BASE;
+
+    /**
+     * Schema-filtered variant; caller must supply a {@code text[]} parameter for the {@code ANY(?)} predicate.
+     * {@code pg_catalog} and {@code information_schema} are always included.
+     */
+    private static final String SQL_TYPES_SCHEMA_FILTERED = SQL_TYPES_BASE
+            + " AND (n.nspname = ANY(?) OR n.nspname IN ('pg_catalog', 'information_schema'))";
 
     private static final String SQL_NAME_LOOKUP = SQL_TYPES + " AND t.typname = ?";
 
@@ -108,6 +119,14 @@ public class TypeRegistry {
     private final PostgresConnection connection;
     private final SqlTypeMapper sqlTypeMapper;
 
+    /**
+     * Schema names to restrict the bulk type load to. When non-empty, only types whose namespace is in this
+     * set (plus the always-included {@code pg_catalog} and {@code information_schema}) are loaded during
+     * {@link #prime()}; types from other schemas are resolved on-demand via {@link #resolveUnknownType(int)}.
+     * When empty all schemas are loaded.
+     */
+    private final Set<String> schemaFilter;
+
     private int geometryOid = Integer.MIN_VALUE;
     private int geographyOid = Integer.MIN_VALUE;
     private int citextOid = Integer.MIN_VALUE;
@@ -127,9 +146,22 @@ public class TypeRegistry {
     private int tsVectorOid = Integer.MIN_VALUE;
 
     public TypeRegistry(PostgresConnection connection) {
+        this(connection, Collections.emptySet());
+    }
+
+    /**
+     * Creates a {@link TypeRegistry} that limits the bulk type load to the given schemas.
+     * {@code pg_catalog} and {@code information_schema} are always included.
+     * Pass an empty set to load all schemas.
+     *
+     * @param connection   the Postgres connection to query type metadata from
+     * @param schemaFilter schema names to pre-load; empty means all schemas
+     */
+    public TypeRegistry(PostgresConnection connection, Set<String> schemaFilter) {
         try {
             this.connection = connection;
-            sqlTypeMapper = new SqlTypeMapper(this.connection);
+            this.schemaFilter = schemaFilter == null ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(schemaFilter));
+            sqlTypeMapper = new SqlTypeMapper(this.connection, this.schemaFilter);
 
             prime();
         }
@@ -458,33 +490,64 @@ public class TypeRegistry {
     }
 
     /**
-     * Prime the {@link TypeRegistry} with all existing database types
+     * Prime the {@link TypeRegistry} with all existing database types.
+     * When a {@link #schemaFilter} is configured, only types from those schemas (plus the always-included
+     * built-in schemas) are loaded, reducing heap usage for databases with many custom types (DBZ-9455).
      */
     private void prime() throws SQLException {
-        LOGGER.trace("Priming type registry with database types");
-        try (Statement statement = connection.connection().createStatement();
-                ResultSet rs = statement.executeQuery(SQL_TYPES)) {
-            final List<TypeBuilderWithSchema> delayResolvedBuilders = new ArrayList<>();
-            while (rs.next()) {
-                TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
+        final List<TypeBuilderWithSchema> delayResolvedBuilders = new ArrayList<>();
 
-                // If the type has neither a base type nor an element type,
-                // we can build and add it immediately.
-                if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
-                    addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
-                    continue;
+        if (schemaFilter.isEmpty()) {
+            // Legacy path — load all schemas unconditionally.
+            try (Statement statement = connection.connection().createStatement();
+                    ResultSet rs = statement.executeQuery(SQL_TYPES)) {
+                while (rs.next()) {
+                    TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
+
+                    // If the type has neither a base type nor an element type,
+                    // we can build and add it immediately.
+                    if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
+                        addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+                        continue;
+                    }
+
+                    // For types with base or element type mappings, they need to be delayed.
+                    // Otherwise their base/element types has not yet be registered,
+                    // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
+                    delayResolvedBuilders.add(builderWithSchema);
                 }
-
-                // For types with base or element type mappings, they need to be delayed.
-                // Otherwise their base/element types has not yet be registered,
-                // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
-                delayResolvedBuilders.add(builderWithSchema);
             }
+        }
+        else {
+            // Filtered path — restrict to configured schemas + built-ins.
+            LOGGER.info("TypeRegistry schema filter active; pre-loading types from schemas: {}", schemaFilter);
+            try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPES_SCHEMA_FILTERED)) {
+                final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
+                statement.setArray(1, schemaArray);
+                try (ResultSet rs = statement.executeQuery()) {
+                    while (rs.next()) {
+                        TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
 
-            // Resolve delayed builders
-            for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
-                addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+                        // If the type has neither a base type nor an element type,
+                        // we can build and add it immediately.
+                        if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
+                            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+                            continue;
+                        }
+
+                        // For types with base or element type mappings, they need to be delayed.
+                        // Otherwise their base/element types has not yet be registered,
+                        // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
+                        delayResolvedBuilders.add(builderWithSchema);
+                    }
+                }
+                schemaArray.free();
             }
+        }
+
+        // Resolve delayed builders (domain types that reference a parent type)
+        for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
+            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
         }
     }
 
@@ -591,6 +654,24 @@ public class TypeRegistry {
                 + "    ON sp.nspoid = typnamespace "
                 + " ORDER BY typname, sp.r, pg_type.oid;";
 
+        /**
+         * Schema-filtered variant of {@link #SQL_TYPE_DETAILS}. Caller must supply a {@code text[]} array parameter
+         * for the {@code ANY(?)} predicate. Built-in schemas are always included.
+         */
+        private static final String SQL_TYPE_DETAILS_SCHEMA_FILTERED = "SELECT DISTINCT ON (typname) typname, typinput='array_in'::regproc, typtype, sp.r, pg_type.oid "
+                + "  FROM pg_catalog.pg_type "
+                + "  JOIN pg_catalog.pg_namespace ns2 ON ns2.oid = pg_type.typnamespace "
+                + "  LEFT "
+                + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
+                + "          from pg_namespace as ns "
+                + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
+                + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
+                + "         using ( nspname ) "
+                + "       ) as sp "
+                + "    ON sp.nspoid = pg_type.typnamespace "
+                + " WHERE (ns2.nspname = ANY(?) OR ns2.nspname IN ('pg_catalog', 'information_schema'))"
+                + " ORDER BY typname, sp.r, pg_type.oid;";
+
         private final PostgresConnection connection;
 
         @Immutable
@@ -599,10 +680,10 @@ public class TypeRegistry {
         @Immutable
         private final Map<String, Integer> sqlTypesByPgTypeNames;
 
-        private SqlTypeMapper(PostgresConnection connection) throws SQLException {
+        private SqlTypeMapper(PostgresConnection connection, Set<String> schemaFilter) throws SQLException {
             this.connection = connection;
             this.preloadedSqlTypes = Collect.unmodifiableSet(getTypeInfo(connection).getPGTypeNamesWithSQLTypes());
-            this.sqlTypesByPgTypeNames = Collections.unmodifiableMap(getSqlTypes(connection));
+            this.sqlTypesByPgTypeNames = Collections.unmodifiableMap(getSqlTypes(connection, schemaFilter));
         }
 
         public int getSqlType(String typeName) throws SQLException {
@@ -634,39 +715,55 @@ public class TypeRegistry {
         }
 
         /**
-         * Builds up a map of SQL (JDBC) types by PG type name; contains only values for non-core types.
+         * Builds a map of SQL (JDBC) types by PG type name for non-core types.
+         * When {@code schemaFilter} is non-empty, only types from those schemas (plus built-ins) are loaded.
          */
-        private static Map<String, Integer> getSqlTypes(PostgresConnection connection) throws SQLException {
+        private static Map<String, Integer> getSqlTypes(PostgresConnection connection, Set<String> schemaFilter) throws SQLException {
             Map<String, Integer> sqlTypesByPgTypeNames = new HashMap<>();
 
-            try (Statement statement = connection.connection().createStatement()) {
-                try (ResultSet rs = statement.executeQuery(SQL_TYPE_DETAILS)) {
-                    while (rs.next()) {
-                        int type;
-                        boolean isArray = rs.getBoolean(2);
-                        String typtype = rs.getString(3);
-                        if (isArray) {
-                            type = Types.ARRAY;
-                        }
-                        else if ("c".equals(typtype)) {
-                            type = Types.STRUCT;
-                        }
-                        else if ("d".equals(typtype)) {
-                            type = Types.DISTINCT;
-                        }
-                        else if ("e".equals(typtype)) {
-                            type = Types.VARCHAR;
-                        }
-                        else {
-                            type = Types.OTHER;
-                        }
-
-                        sqlTypesByPgTypeNames.put(rs.getString(1), type);
+            if (schemaFilter.isEmpty()) {
+                try (Statement statement = connection.connection().createStatement();
+                        ResultSet rs = statement.executeQuery(SQL_TYPE_DETAILS)) {
+                    populateSqlTypes(rs, sqlTypesByPgTypeNames);
+                }
+            }
+            else {
+                try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPE_DETAILS_SCHEMA_FILTERED)) {
+                    final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
+                    statement.setArray(1, schemaArray);
+                    try (ResultSet rs = statement.executeQuery()) {
+                        populateSqlTypes(rs, sqlTypesByPgTypeNames);
                     }
+                    schemaArray.free();
                 }
             }
 
             return sqlTypesByPgTypeNames;
+        }
+
+        private static void populateSqlTypes(ResultSet rs, Map<String, Integer> sqlTypesByPgTypeNames) throws SQLException {
+            while (rs.next()) {
+                int type;
+                boolean isArray = rs.getBoolean(2);
+                String typtype = rs.getString(3);
+                if (isArray) {
+                    type = Types.ARRAY;
+                }
+                else if ("c".equals(typtype)) {
+                    type = Types.STRUCT;
+                }
+                else if ("d".equals(typtype)) {
+                    type = Types.DISTINCT;
+                }
+                else if ("e".equals(typtype)) {
+                    type = Types.VARCHAR;
+                }
+                else {
+                    type = Types.OTHER;
+                }
+
+                sqlTypesByPgTypeNames.put(rs.getString(1), type);
+            }
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -483,11 +483,15 @@ public class TypeRegistry {
             LOGGER.info("TypeRegistry schema filter active; pre-loading types from schemas: {}", schemaFilter);
             try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPES_SCHEMA_FILTERED)) {
                 final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
-                statement.setArray(1, schemaArray);
-                try (ResultSet rs = statement.executeQuery()) {
-                    collectBuilders(rs, delayResolvedBuilders);
+                try {
+                    statement.setArray(1, schemaArray);
+                    try (ResultSet rs = statement.executeQuery()) {
+                        collectBuilders(rs, delayResolvedBuilders);
+                    }
                 }
-                schemaArray.free();
+                finally {
+                    schemaArray.free();
+                }
             }
         }
 
@@ -688,11 +692,15 @@ public class TypeRegistry {
             else {
                 try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPE_DETAILS_SCHEMA_FILTERED)) {
                     final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
-                    statement.setArray(1, schemaArray);
-                    try (ResultSet rs = statement.executeQuery()) {
-                        populateSqlTypes(rs, sqlTypesByPgTypeNames);
+                    try {
+                        statement.setArray(1, schemaArray);
+                        try (ResultSet rs = statement.executeQuery()) {
+                            populateSqlTypes(rs, sqlTypesByPgTypeNames);
+                        }
                     }
-                    schemaArray.free();
+                    finally {
+                        schemaArray.free();
+                    }
                 }
             }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -72,19 +72,17 @@ public class TypeRegistry {
     private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel ORDER BY t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
-    private static final String SQL_TYPES_BASE = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
             + "FROM pg_catalog.pg_type t "
             + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "LEFT JOIN (" + SQL_ENUM_VALUES + ") e ON (t.oid = e.id) "
             + "WHERE n.nspname != 'pg_toast'";
 
-    private static final String SQL_TYPES = SQL_TYPES_BASE;
-
     /**
      * Schema-filtered variant; caller must supply a {@code text[]} parameter for the {@code ANY(?)} predicate.
      * {@code pg_catalog} and {@code information_schema} are always included.
      */
-    private static final String SQL_TYPES_SCHEMA_FILTERED = SQL_TYPES_BASE
+    private static final String SQL_TYPES_SCHEMA_FILTERED = SQL_TYPES
             + " AND (n.nspname = ANY(?) OR n.nspname IN ('pg_catalog', 'information_schema'))";
 
     private static final String SQL_NAME_LOOKUP = SQL_TYPES + " AND t.typname = ?";
@@ -119,14 +117,6 @@ public class TypeRegistry {
     private final PostgresConnection connection;
     private final SqlTypeMapper sqlTypeMapper;
 
-    /**
-     * Schema names to restrict the bulk type load to. When non-empty, only types whose namespace is in this
-     * set (plus the always-included {@code pg_catalog} and {@code information_schema}) are loaded during
-     * {@link #prime()}; types from other schemas are resolved on-demand via {@link #resolveUnknownType(int)}.
-     * When empty all schemas are loaded.
-     */
-    private final Set<String> schemaFilter;
-
     private int geometryOid = Integer.MIN_VALUE;
     private int geographyOid = Integer.MIN_VALUE;
     private int citextOid = Integer.MIN_VALUE;
@@ -160,43 +150,29 @@ public class TypeRegistry {
     public TypeRegistry(PostgresConnection connection, Set<String> schemaFilter) {
         try {
             this.connection = connection;
-            this.schemaFilter = schemaFilter == null ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(schemaFilter));
-            sqlTypeMapper = new SqlTypeMapper(this.connection, this.schemaFilter);
+            final Set<String> filter = (schemaFilter == null || schemaFilter.isEmpty())
+                    ? Collections.emptySet()
+                    : Collections.unmodifiableSet(new HashSet<>(schemaFilter));
+            sqlTypeMapper = new SqlTypeMapper(this.connection, filter);
 
-            prime();
+            prime(filter);
         }
         catch (SQLException e) {
             throw new DebeziumException("Couldn't initialize type registry", e);
         }
     }
 
-    private void addType(PostgresType type, String schemaName) {
+    private void addType(PostgresType type) {
         oidToType.put(type.getOid(), type);
 
-        // Use schema-qualified name as primary key to avoid collisions across schemas
-        String qualifiedName = schemaName != null
-                ? schemaName + "." + type.getName()
-                : type.getName();
-
-        if (!nameToType.containsKey(qualifiedName)) {
-            nameToType.put(qualifiedName, type);
-        }
-        else {
-            if ("information_schema".equals(schemaName)) {
-                LOGGER.info("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
-                return;
-            }
-            PostgresType currentType = nameToType.get(qualifiedName);
-            if (!currentType.equals(type)) {
-                LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
-            }
-        }
-
-        // Also add unqualified name for backward compatibility (first one wins).
-        // Callers often use get("int4") while prime() registers pg_catalog.int4; without this alias,
-        // every lookup misses the cache and hits resolveUnknownType (SQL_NAME_LOOKUP) repeatedly.
         if (!nameToType.containsKey(type.getName())) {
             nameToType.put(type.getName(), type);
+        }
+        else {
+            PostgresType currentType = nameToType.get(type.getName());
+            if (!currentType.equals(type)) {
+                LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), type.getName());
+            }
         }
 
         if (TYPE_NAME_GEOMETRY.equals(type.getName())) {
@@ -491,77 +467,59 @@ public class TypeRegistry {
 
     /**
      * Prime the {@link TypeRegistry} with all existing database types.
-     * When a {@link #schemaFilter} is configured, only types from those schemas (plus the always-included
+     * When a non-empty {@code schemaFilter} is provided, only types from those schemas (plus the always-included
      * built-in schemas) are loaded, reducing heap usage for databases with many custom types (DBZ-9455).
      */
-    private void prime() throws SQLException {
-        final List<TypeBuilderWithSchema> delayResolvedBuilders = new ArrayList<>();
+    private void prime(Set<String> schemaFilter) throws SQLException {
+        final List<PostgresType.Builder> delayResolvedBuilders = new ArrayList<>();
 
         if (schemaFilter.isEmpty()) {
-            // Legacy path — load all schemas unconditionally.
             try (Statement statement = connection.connection().createStatement();
                     ResultSet rs = statement.executeQuery(SQL_TYPES)) {
-                while (rs.next()) {
-                    TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
-
-                    // If the type has neither a base type nor an element type,
-                    // we can build and add it immediately.
-                    if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
-                        addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
-                        continue;
-                    }
-
-                    // For types with base or element type mappings, they need to be delayed.
-                    // Otherwise their base/element types has not yet be registered,
-                    // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
-                    delayResolvedBuilders.add(builderWithSchema);
-                }
+                collectBuilders(rs, delayResolvedBuilders);
             }
         }
         else {
-            // Filtered path — restrict to configured schemas + built-ins.
             LOGGER.info("TypeRegistry schema filter active; pre-loading types from schemas: {}", schemaFilter);
             try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPES_SCHEMA_FILTERED)) {
                 final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
                 statement.setArray(1, schemaArray);
                 try (ResultSet rs = statement.executeQuery()) {
-                    while (rs.next()) {
-                        TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
-
-                        // If the type has neither a base type nor an element type,
-                        // we can build and add it immediately.
-                        if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
-                            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
-                            continue;
-                        }
-
-                        // For types with base or element type mappings, they need to be delayed.
-                        // Otherwise their base/element types has not yet be registered,
-                        // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
-                        delayResolvedBuilders.add(builderWithSchema);
-                    }
+                    collectBuilders(rs, delayResolvedBuilders);
                 }
                 schemaArray.free();
             }
         }
 
-        // Resolve delayed builders (domain types that reference a parent type)
-        for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
-            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+        // Resolve delayed builders
+        for (PostgresType.Builder builder : delayResolvedBuilders) {
+            addType(builder.build());
         }
     }
 
-    private record TypeBuilderWithSchema(PostgresType.Builder builder, String schemaName) {
+    private void collectBuilders(ResultSet rs, List<PostgresType.Builder> builders) throws SQLException {
+        while (rs.next()) {
+            PostgresType.Builder builder = createTypeBuilderFromResultSet(rs);
+            // If the type has neither a base type nor an element type,
+            // we can build and add it immediately.
+            if (!builder.hasParentType() && !builder.hasElementType()) {
+                addType(builder.build());
+                continue;
+            }
+            // For types with base or element type mappings, they need to be delayed.
+            // Otherwise their base/element types has not yet be registered,
+            // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
+            builders.add(builder);
+        }
     }
 
-    private TypeBuilderWithSchema createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
+    private PostgresType.Builder createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
         // Coerce long to int so large unsigned values are represented as signed
         // Same technique is used in TypeInfoCache
         final int oid = (int) rs.getLong("oid");
         final int parentTypeOid = (int) rs.getLong("parentoid");
         final int modifiers = (int) rs.getLong("modifiers");
         String typeName = rs.getString("name");
-        String schemaName = rs.getString("schema_name");
         String category = rs.getString("category");
 
         PostgresType.Builder builder = new PostgresType.Builder(
@@ -579,7 +537,7 @@ public class TypeRegistry {
         else if (CATEGORY_ARRAY.equals(category)) {
             builder = builder.elementType((int) rs.getLong("element"));
         }
-        return new TypeBuilderWithSchema(builder.parentType(parentTypeOid), schemaName);
+        return builder.parentType(parentTypeOid);
     }
 
     private PostgresType resolveUnknownType(String name) {
@@ -613,9 +571,9 @@ public class TypeRegistry {
     private PostgresType loadType(PreparedStatement statement) throws SQLException {
         try (ResultSet rs = statement.executeQuery()) {
             while (rs.next()) {
-                TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
-                PostgresType result = builderWithSchema.builder().build();
-                addType(result, builderWithSchema.schemaName());
+                PostgresType.Builder builder = createTypeBuilderFromResultSet(rs);
+                PostgresType result = builder.build();
+                addType(result);
                 return result;
             }
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -471,6 +471,7 @@ public class TypeRegistry {
      * built-in schemas) are loaded, reducing heap usage for databases with many custom types (DBZ-9455).
      */
     private void prime(Set<String> schemaFilter) throws SQLException {
+        LOGGER.trace("Priming type registry with database types");
         final List<PostgresType.Builder> delayResolvedBuilders = new ArrayList<>();
 
         if (schemaFilter.isEmpty()) {
@@ -480,7 +481,6 @@ public class TypeRegistry {
             }
         }
         else {
-            LOGGER.info("TypeRegistry schema filter active; pre-loading types from schemas: {}", schemaFilter);
             try (PreparedStatement statement = connection.connection().prepareStatement(SQL_TYPES_SCHEMA_FILTERED)) {
                 final Array schemaArray = connection.connection().createArrayOf("text", schemaFilter.toArray(new String[0]));
                 try {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -72,7 +72,7 @@ public class TypeRegistry {
     private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel ORDER BY t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
-    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
             + "FROM pg_catalog.pg_type t "
             + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "LEFT JOIN (" + SQL_ENUM_VALUES + ") e ON (t.oid = e.id) "
@@ -162,17 +162,33 @@ public class TypeRegistry {
         }
     }
 
-    private void addType(PostgresType type) {
+    private void addType(PostgresType type, String schemaName) {
         oidToType.put(type.getOid(), type);
 
-        if (!nameToType.containsKey(type.getName())) {
-            nameToType.put(type.getName(), type);
+        // Use schema-qualified name as primary key to avoid collisions across schemas
+        String qualifiedName = schemaName != null
+                ? schemaName + "." + type.getName()
+                : type.getName();
+
+        if (!nameToType.containsKey(qualifiedName)) {
+            nameToType.put(qualifiedName, type);
         }
         else {
-            PostgresType currentType = nameToType.get(type.getName());
-            if (!currentType.equals(type)) {
-                LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), type.getName());
+            if ("information_schema".equals(schemaName)) {
+                LOGGER.info("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
+                return;
             }
+            PostgresType currentType = nameToType.get(qualifiedName);
+            if (!currentType.equals(type)) {
+                LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
+            }
+        }
+
+        // Also add unqualified name for backward compatibility (first one wins).
+        // Callers often use get("int4") while prime() registers pg_catalog.int4; without this alias,
+        // every lookup misses the cache and hits resolveUnknownType (SQL_NAME_LOOKUP) repeatedly.
+        if (!nameToType.containsKey(type.getName())) {
+            nameToType.put(type.getName(), type);
         }
 
         if (TYPE_NAME_GEOMETRY.equals(type.getName())) {
@@ -472,7 +488,7 @@ public class TypeRegistry {
      */
     private void prime(Set<String> schemaFilter) throws SQLException {
         LOGGER.trace("Priming type registry with database types");
-        final List<PostgresType.Builder> delayResolvedBuilders = new ArrayList<>();
+        final List<TypeBuilderWithSchema> delayResolvedBuilders = new ArrayList<>();
 
         if (schemaFilter.isEmpty()) {
             try (Statement statement = connection.connection().createStatement();
@@ -496,34 +512,38 @@ public class TypeRegistry {
         }
 
         // Resolve delayed builders
-        for (PostgresType.Builder builder : delayResolvedBuilders) {
-            addType(builder.build());
+        for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
+            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
         }
     }
 
-    private void collectBuilders(ResultSet rs, List<PostgresType.Builder> builders) throws SQLException {
+    private void collectBuilders(ResultSet rs, List<TypeBuilderWithSchema> builders) throws SQLException {
         while (rs.next()) {
-            PostgresType.Builder builder = createTypeBuilderFromResultSet(rs);
+            TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
             // If the type has neither a base type nor an element type,
             // we can build and add it immediately.
-            if (!builder.hasParentType() && !builder.hasElementType()) {
-                addType(builder.build());
+            if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
+                addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
                 continue;
             }
             // For types with base or element type mappings, they need to be delayed.
             // Otherwise their base/element types has not yet be registered,
             // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
-            builders.add(builder);
+            builders.add(builderWithSchema);
         }
     }
 
-    private PostgresType.Builder createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
+    private record TypeBuilderWithSchema(PostgresType.Builder builder, String schemaName) {
+    }
+
+    private TypeBuilderWithSchema createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
         // Coerce long to int so large unsigned values are represented as signed
         // Same technique is used in TypeInfoCache
         final int oid = (int) rs.getLong("oid");
         final int parentTypeOid = (int) rs.getLong("parentoid");
         final int modifiers = (int) rs.getLong("modifiers");
         String typeName = rs.getString("name");
+        String schemaName = rs.getString("schema_name");
         String category = rs.getString("category");
 
         PostgresType.Builder builder = new PostgresType.Builder(
@@ -541,7 +561,7 @@ public class TypeRegistry {
         else if (CATEGORY_ARRAY.equals(category)) {
             builder = builder.elementType((int) rs.getLong("element"));
         }
-        return builder.parentType(parentTypeOid);
+        return new TypeBuilderWithSchema(builder.parentType(parentTypeOid), schemaName);
     }
 
     private PostgresType resolveUnknownType(String name) {
@@ -575,9 +595,9 @@ public class TypeRegistry {
     private PostgresType loadType(PreparedStatement statement) throws SQLException {
         try (ResultSet rs = statement.executeQuery()) {
             while (rs.next()) {
-                PostgresType.Builder builder = createTypeBuilderFromResultSet(rs);
-                PostgresType result = builder.build();
-                addType(result);
+                TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
+                PostgresType result = builderWithSchema.builder().build();
+                addType(result, builderWithSchema.schemaName());
                 return result;
             }
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -16,6 +16,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -123,8 +124,20 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     public static TypeRegistry createTypeRegistry(JdbcConfiguration config) {
+        return createTypeRegistry(config, Collections.emptySet());
+    }
+
+    /**
+     * Creates a {@link TypeRegistry} pre-loaded only with types from the given schemas.
+     * {@code pg_catalog} and {@code information_schema} are always included.
+     * Pass an empty set to load all schemas.
+     *
+     * @param config       {@link JdbcConfiguration} instance, may not be null.
+     * @param schemaFilter schema names to pre-load types from; empty means all schemas
+     */
+    public static TypeRegistry createTypeRegistry(JdbcConfiguration config, Set<String> schemaFilter) {
         try (PostgresConnection connection = new PostgresConnection(config, PostgresConnection.CONNECTION_GENERAL)) {
-            return new TypeRegistry(connection);
+            return new TypeRegistry(connection, schemaFilter);
         }
         catch (DebeziumException e) {
             throw new DebeziumException("Failed to create TypeRegistry", e);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+/**
+ * Unit tests for {@link PostgresConnectorTask}.
+ */
+public class PostgresConnectorTaskTest {
+
+    /**
+     * Build a minimal {@link PostgresConnectorConfig} that supplies enough fields for
+     * {@link PostgresConnectorTask#buildTypeRegistrySchemaFilter(Predicate, Set)} to run without NPE.
+     */
+    private static Predicate<String> schemaFilterFor(String schemaIncludeList) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "test_server")
+                .with(PostgresConnectorConfig.DATABASE_NAME, "testdb");
+        if (schemaIncludeList != null) {
+            builder.with(RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST, schemaIncludeList);
+        }
+        return new PostgresConnectorConfig(builder.build()).getTableFilters().schemaFilter();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for the predicate+candidateSchemas overload (no DB connection needed)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @FixFor("DBZ-9455")
+    void allSchemasReturnedWhenNoIncludeListConfigured() {
+        // With no schema.include.list the predicate accepts everything.
+        Set<String> candidates = Set.of("public", "tenant_a", "tenant_b");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor(null), candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a", "tenant_b");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void allSchemasReturnedWhenSchemaIncludeListIsBlank() {
+        Set<String> candidates = Set.of("public", "tenant_a");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("   "), candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void plainLiteralSchemaNameIsIncludedInFilter() {
+        Set<String> candidates = Set.of("public", "noise");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("public"), candidates);
+        assertThat(filter).containsExactly("public");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void multipleLiteralSchemaNamesAreIncludedInFilter() {
+        Set<String> candidates = Set.of("public", "tenant_a", "tenant_b", "noise");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("public,tenant_a,tenant_b"), candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a", "tenant_b");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void regexPatternMatchesSchemasFromCandidateSet() {
+        // Regex patterns like "tenant.*" should now work — matched against actual DB schema names.
+        Set<String> candidates = Set.of("public", "tenant_a", "tenant_b", "other");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("public,tenant.*"), candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a", "tenant_b");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void noMatchingCandidatesResultsInEmptyFilter() {
+        Set<String> candidates = Set.of("other1", "other2");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("public"), candidates);
+        assertThat(filter).isEmpty();
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void emptyCandidateSetResultsInEmptyFilter() {
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("public"), Set.of());
+        assertThat(filter).isEmpty();
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void schemaExcludeListIsHonoured() {
+        // schema.exclude.list should cause the named schema to be excluded.
+        Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "test_server")
+                .with(PostgresConnectorConfig.DATABASE_NAME, "testdb")
+                .with(RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST, "noise")
+                .build();
+        Predicate<String> predicate = new PostgresConnectorConfig(config).getTableFilters().schemaFilter();
+
+        Set<String> candidates = Set.of("public", "tenant_a", "noise");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(predicate, candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a");
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void schemaNameWithHyphenAndDotIsAccepted() {
+        Set<String> candidates = Set.of("my-schema", "my.schema", "other");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(
+                schemaFilterFor("my-schema,my\\.schema"), candidates);
+        assertThat(filter).containsExactlyInAnyOrder("my-schema", "my.schema");
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskTest.java
@@ -23,17 +23,44 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 public class PostgresConnectorTaskTest {
 
     /**
-     * Build a minimal {@link PostgresConnectorConfig} that supplies enough fields for
-     * {@link PostgresConnectorTask#buildTypeRegistrySchemaFilter(Predicate, Set)} to run without NPE.
+     * Build a minimal {@link PostgresConnectorConfig} with optional {@code schema.include.list}
+     * and {@code schema.exclude.list} values.
      */
-    private static Predicate<String> schemaFilterFor(String schemaIncludeList) {
+    private static PostgresConnectorConfig configFor(String schemaIncludeList, String schemaExcludeList) {
         Configuration.Builder builder = Configuration.create()
                 .with(CommonConnectorConfig.TOPIC_PREFIX, "test_server")
                 .with(PostgresConnectorConfig.DATABASE_NAME, "testdb");
         if (schemaIncludeList != null) {
             builder.with(RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST, schemaIncludeList);
         }
-        return new PostgresConnectorConfig(builder.build()).getTableFilters().schemaFilter();
+        if (schemaExcludeList != null) {
+            builder.with(RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST, schemaExcludeList);
+        }
+        return new PostgresConnectorConfig(builder.build());
+    }
+
+    private static Predicate<String> schemaFilterFor(String schemaIncludeList) {
+        return configFor(schemaIncludeList, null).getTableFilters().schemaFilter();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for the config+connection overload (fast-path, no DB connection needed)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @FixFor("DBZ-9455")
+    void noFilterConfiguredReturnsFastPathEmptySet() {
+        // When neither schema.include.list nor schema.exclude.list is set, the method returns empty
+        // immediately — the connection is never touched, so null is safe here.
+        Set<String> result = PostgresConnectorTask.buildTypeRegistrySchemaFilter(configFor(null, null), null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @FixFor("DBZ-9455")
+    void blankIncludeListReturnsFastPathEmptySet() {
+        Set<String> result = PostgresConnectorTask.buildTypeRegistrySchemaFilter(configFor("   ", null), null);
+        assertThat(result).isEmpty();
     }
 
     // -------------------------------------------------------------------------
@@ -108,13 +135,19 @@ public class PostgresConnectorTaskTest {
     @FixFor("DBZ-9455")
     void schemaExcludeListIsHonoured() {
         // schema.exclude.list should cause the named schema to be excluded.
-        Configuration config = Configuration.create()
-                .with(CommonConnectorConfig.TOPIC_PREFIX, "test_server")
-                .with(PostgresConnectorConfig.DATABASE_NAME, "testdb")
-                .with(RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST, "noise")
-                .build();
-        Predicate<String> predicate = new PostgresConnectorConfig(config).getTableFilters().schemaFilter();
+        final Predicate<String> predicate = configFor(null, "noise").getTableFilters().schemaFilter();
+        Set<String> candidates = Set.of("public", "tenant_a", "noise");
+        Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(predicate, candidates);
+        assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a");
+    }
 
+    @Test
+    @FixFor("DBZ-9455")
+    void excludeListOnlyDoesNotTriggerFastPath() {
+        // When only schema.exclude.list is set (no include list) the fast-path must NOT fire;
+        // the method must still query pg_namespace and apply the predicate.
+        // We test the predicate overload directly as a proxy — it filters "noise" out.
+        final Predicate<String> predicate = configFor(null, "noise").getTableFilters().schemaFilter();
         Set<String> candidates = Set.of("public", "tenant_a", "noise");
         Set<String> filter = PostgresConnectorTask.buildTypeRegistrySchemaFilter(predicate, candidates);
         assertThat(filter).containsExactlyInAnyOrder("public", "tenant_a");

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3720,6 +3720,9 @@ To match the name of a schema, {prodname} applies the regular expression that yo
 That is, the specified expression is matched against the entire identifier for the schema; it does not match substrings that might be present in a schema name.
 If you include this property in the configuration, do not also set the `schema.exclude.list` property.
 
+*Performance note:* {prodname} uses `schema.include.list` (and `schema.exclude.list`) to restrict which PostgreSQL custom types are pre-loaded into memory at startup, reducing heap usage in databases with many schemas or custom types (for example, multi-tenant deployments).
+The built-in system schemas `pg_catalog` and `information_schema` are always pre-loaded.
+
 |[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `+schema.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -384,3 +384,4 @@ sundongkim-dev,Sundong Kim
 Paul_Kim,Sundong Kim
 TimurRakhmatullin86,Timur Rakhmatullin
 lekhrocks,Lekhraj Kumar
+zach-all,Zach All


### PR DESCRIPTION
## Summary

Fixes heap exhaustion (`OutOfMemoryError: Java heap space`) in the PostgreSQL connector when the database contains a large number of schemas with many custom types — for example, multi-tenant deployments with 650+ schemas × ~2,000 composite types each (~1.27 million total types).

## Related Issues

- Fixes debezium/dbz#1400 — `[DBZ-9455]` Postgres Connector fails to start due to type registry collisions (ignores namespace, Oracle compatibility types)
- Fixes debezium/dbz#1323 — `[DBZ-8519]` TypeRegistry `Type [oid:X, name:Y] is already mapped` warnings when `schema.include.list` is set but all schemas are still loaded
- Partially addresses debezium/dbz#505 — `[DBZ-3955]` Debezium long start-up times with large number of postgres schemas
- Partially addresses debezium/dbz#1595 — PostgreSQL connector requires full schema discovery even with `snapshot.mode=no_data`, causing severe DB load in large-schema environments

## Root Cause

`TypeRegistry.prime()` issued an unfiltered `SELECT … FROM pg_catalog.pg_type` query that loaded every custom type from every schema in the entire database. With hundreds of schemas each defining hundreds of composite types (plus their array variants), the resulting objects exhausted the JVM heap before the connector could start. This also caused the `"is already mapped"` warnings seen in DBZ-8519: even when `schema.include.list` was set, all schemas were still loaded.

## Fix

When `schema.include.list` contains only plain schema names (no regex meta-characters), `TypeRegistry` now issues a schema-filtered query:

```sql
AND (n.nspname = ANY(?) OR n.nspname IN ('pg_catalog', 'information_schema'))
```

Types from schemas outside the filter are still resolved on-demand via the existing `resolveUnknownType()` path, so captured schemas with regex-style include patterns continue to work correctly.

## Changes

- **`TypeRegistry`**: Added `SQL_TYPES_SCHEMA_FILTERED` constant and a new two-arg constructor `TypeRegistry(PostgresConnection, Set<String>)`. When the set is non-empty the filtered query is used; when empty the original unfiltered query is used (backward-compatible default).
- **`PostgresConnection`**: New four-arg constructor propagates the schema filter to `TypeRegistry`; the existing three-arg constructor delegates with an empty filter.
- **`PostgresConnectorTask`**: New package-private helper `buildTypeRegistrySchemaFilter(PostgresConnectorConfig)` parses `schema.include.list`, rejects regex-looking entries with a `WARN` log, and returns a `Set<String>` of plain schema names passed to `PostgresConnection`.
- **`PostgresConnectorTaskTest`**: Unit tests for `buildTypeRegistrySchemaFilter` covering null/blank input, plain names, multiple names, whitespace trimming, regex detection, and hyphen/dot identifiers.
- **Documentation**: Added a performance note to the `schema.include.list` property description in `connectors/postgresql.adoc`.

## Testing

Verified with an end-to-end test using Docker Compose (PostgreSQL 16 + Apache Kafka KRaft + `quay.io/debezium/connect:3.5`, 512 MiB heap):

| Run | Heap | Noise-schema `"is already mapped"` warnings | Result |
|-----|------|----------------------------------------------|--------|
| Unpatched | 512m | 79,600 | connector starts but warns for every type from every noise schema |
| Patched | 512m | 0 | connector starts cleanly; change event received on watched table |

The test database had 200 noise schemas × 100 composite types each (40,002 custom types total) plus a watched `tenants` schema.

## Checklist

- [x] Code formatted with `mvn net.revelc.code.formatter:formatter-maven-plugin:format` (validate goal: BUILD SUCCESS, 0 failures)
- [x] Existing three-arg `PostgresConnection` constructor unchanged (backward-compatible)
- [x] `e2e-test/` and `PLAN_MANY_SCHEMAS_HEAP_EXHAUSTION.md` excluded from commit
- [x] No unrelated changes