### PR TITLE
debezium/dbz#1421 Allow using record value and record header with row deletion

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -133,6 +133,17 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
                     continue;
                 }
 
+                if (record.isTombstone()) {
+                    switch (config.getPrimaryKeyMode()) {
+                        case RECORD_VALUE:
+                        case RECORD_HEADER: {
+                            LOGGER.debug("Tombstone skipped because primary.key.mode is {}.", config.getPrimaryKeyMode());
+                            progressListener.filtered();
+                            continue;
+                        }
+                    }
+                }
+
                 final Buffer upsertBufferToFlush = upsertBufferByTable.get(collectionId);
                 if (upsertBufferToFlush != null && !upsertBufferToFlush.isEmpty()) {
                     // When a delete event arrives, update buffer must be flushed to avoid losing the delete

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -712,14 +712,14 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private static int validateDeleteEnabled(Configuration config, Field field, ValidationOutput problems) {
         if (config.getBoolean(field)) {
             final PrimaryKeyMode primaryKeyMode = PrimaryKeyMode.parse(config.getString(PRIMARY_KEY_MODE));
-            
+
             // Allow RECORD_KEY, RECORD_VALUE, and RECORD_HEADER
             if (!PrimaryKeyMode.RECORD_KEY.equals(primaryKeyMode)
                     && !PrimaryKeyMode.RECORD_VALUE.equals(primaryKeyMode)
                     && !PrimaryKeyMode.RECORD_HEADER.equals(primaryKeyMode)) {
-                
+
                 LOGGER.error("When '{}' is set to 'true', the '{}' option must be set to '{}', '{}', or '{}'.",
-                        DELETE_ENABLED, PRIMARY_KEY_MODE, 
+                        DELETE_ENABLED, PRIMARY_KEY_MODE,
                         PrimaryKeyMode.RECORD_KEY.getValue(),
                         PrimaryKeyMode.RECORD_VALUE.getValue(),
                         PrimaryKeyMode.RECORD_HEADER.getValue());

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -712,13 +712,20 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private static int validateDeleteEnabled(Configuration config, Field field, ValidationOutput problems) {
         if (config.getBoolean(field)) {
             final PrimaryKeyMode primaryKeyMode = PrimaryKeyMode.parse(config.getString(PRIMARY_KEY_MODE));
-            if (!PrimaryKeyMode.RECORD_KEY.equals(primaryKeyMode)) {
-                LOGGER.error("When '{}' is set to 'true', the '{}' option must be set to '{}'.",
-                        DELETE_ENABLED, PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+            
+            // Allow RECORD_KEY, RECORD_VALUE, and RECORD_HEADER
+            if (!PrimaryKeyMode.RECORD_KEY.equals(primaryKeyMode)
+                    && !PrimaryKeyMode.RECORD_VALUE.equals(primaryKeyMode)
+                    && !PrimaryKeyMode.RECORD_HEADER.equals(primaryKeyMode)) {
+                
+                LOGGER.error("When '{}' is set to 'true', the '{}' option must be set to '{}', '{}', or '{}'.",
+                        DELETE_ENABLED, PRIMARY_KEY_MODE, 
+                        PrimaryKeyMode.RECORD_KEY.getValue(),
+                        PrimaryKeyMode.RECORD_VALUE.getValue(),
+                        PrimaryKeyMode.RECORD_HEADER.getValue());
                 return 1;
             }
         }
         return 0;
     }
-
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -66,14 +66,27 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
     }
 
     @Test
-    public void testNonDefaultDeleteEnabledPropertyWithPrimaryKeyModeNotRecordKey() {
+    public void testNonDefaultDeleteEnabledPropertyWithPrimaryKeyModeNone() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "none");
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        
+        assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
+                .isFalse();
+    }
+
+    @Test
+    public void testNonDefaultDeleteEnabledPropertyWithPrimaryKeyModeRecordValue() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "record_value");
 
         final JdbcSinkConnectorConfig config = getConfig(properties);
         assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
-                .isFalse();
+                .isTrue();
+        assertThat(config.isDeleteEnabled()).isTrue();
     }
 
     @Test
@@ -83,6 +96,18 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "record_key");
 
         final JdbcSinkConnectorConfig config = getConfig(properties);
+        assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
+                .isTrue();
+        assertThat(config.isDeleteEnabled()).isTrue();
+    }
+
+    @Test
+    public void testNonDefaultDeleteEnabledPropertyWithPrimaryKeyModeRecordHeader() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "record_header");
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
         assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
                 .isTrue();
         assertThat(config.isDeleteEnabled()).isTrue();

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -72,7 +72,7 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "none");
 
         final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
-        
+
         assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
                 .isFalse();
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -71,7 +71,7 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
         properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "none");
 
-        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcSinkConnectorConfig config = getConfig(properties);
 
         assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
                 .isFalse();
@@ -107,7 +107,7 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
         properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, "record_header");
 
-        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcSinkConnectorConfig config = getConfig(properties);
         assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.DELETE_ENABLED_FIELD, JdbcSinkConnectorConfig.PRIMARY_KEY_MODE_FIELD), LOGGER::error))
                 .isTrue();
         assertThat(config.isDeleteEnabled()).isTrue();

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
@@ -117,6 +117,71 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-9583")
+    public void testShouldDeleteRowWhenDeletesEnabledUsingRecordValuePrimaryKeyMode(SinkRecordFactory factory) {
+        // A flattened delete event carries no value, so the primary key can only be
+        // resolved from the record value for a full change event.
+        if (factory.isFlattened()) {
+            return;
+        }
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecord(topicName, config);
+        consume(createRecord);
+        consume(factory.deleteRecord(topicName, config));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
+        tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
+        getSink().assertColumnType(tableAssert, "name", ValueType.TEXT);
+        getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-9583")
+    public void testShouldDeleteRowWhenDeletesEnabledUsingRecordHeaderPrimaryKeyMode(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_HEADER.getValue());
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecord(topicName, config);
+        createRecord.getOriginalKafkaRecord().headers().addInt("id", 1);
+        consume(createRecord);
+
+        final JdbcKafkaSinkRecord deleteRecord = factory.deleteRecord(topicName, config);
+        deleteRecord.getOriginalKafkaRecord().headers().addInt("id", 1);
+        consume(deleteRecord);
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
+        tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
+        getSink().assertColumnType(tableAssert, "name", ValueType.TEXT);
+        getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
     public void testShouldHandleRowDeletionWhenRowDoesNotExist(SinkRecordFactory factory) {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
@@ -182,6 +182,72 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#1421")
+    public void testTombstoneShouldBeSkippedWhenUsingRecordValuePrimaryKeyMode(SinkRecordFactory factory) {
+        if (factory.isFlattened()) {
+            return;
+        }
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecord(topicName, config);
+        consume(createRecord);
+        consume(factory.deleteRecord(topicName, config));
+        consume(factory.tombstoneRecord(topicName, config));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
+        tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
+        getSink().assertColumnType(tableAssert, "name", ValueType.TEXT);
+        getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#1421")
+    public void testTombstoneShouldBeSkippedWhenUsingRecordHeaderPrimaryKeyMode(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_HEADER.getValue());
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecord(topicName, config);
+        createRecord.getOriginalKafkaRecord().headers().addInt("id", 1);
+        consume(createRecord);
+
+        final JdbcKafkaSinkRecord deleteRecord = factory.deleteRecord(topicName, config);
+        deleteRecord.getOriginalKafkaRecord().headers().addInt("id", 1);
+        consume(deleteRecord);
+
+        consume(factory.tombstoneRecord(topicName, config));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(createRecord));
+        tableAssert.exists().hasNumberOfRows(0).hasNumberOfColumns(3);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER);
+        getSink().assertColumnType(tableAssert, "name", ValueType.TEXT);
+        getSink().assertColumnType(tableAssert, "nick_name$", ValueType.TEXT);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
     public void testShouldHandleRowDeletionWhenRowDoesNotExist(SinkRecordFactory factory) {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkDeleteEnabledTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-9583")
+    @FixFor("debezium/dbz#1421")
     public void testShouldDeleteRowWhenDeletesEnabledUsingRecordValuePrimaryKeyMode(SinkRecordFactory factory) {
         // A flattened delete event carries no value, so the primary key can only be
         // resolved from the record value for a full change event.
@@ -151,7 +151,7 @@ public abstract class AbstractJdbcSinkDeleteEnabledTest extends AbstractJdbcSink
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-9583")
+    @FixFor("debezium/dbz#1421")
     public void testShouldDeleteRowWhenDeletesEnabledUsingRecordHeaderPrimaryKeyMode(SinkRecordFactory factory) {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());

--- a/debezium-sink/src/main/java/io/debezium/bindings/kafka/KafkaDebeziumSinkRecord.java
+++ b/debezium-sink/src/main/java/io/debezium/bindings/kafka/KafkaDebeziumSinkRecord.java
@@ -345,6 +345,10 @@ public class KafkaDebeziumSinkRecord implements DebeziumSinkRecord {
             }
             case RECORD_VALUE -> {
                 final Struct payload = getPayload();
+                if (payload == null) {
+                    throw new ConnectException("Cannot extract primary key from a null record value");
+                }
+
                 final Schema valueSchema = payload.schema();
                 if (valueSchema != null && Schema.Type.STRUCT.equals(valueSchema.type())) {
                     return filterFields(payload, topicName(), allowedPrimaryKeyFields, fieldsFilter);

--- a/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
@@ -97,6 +97,16 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
                 }
             }
 
+            if (record.isTombstone()) {
+                switch (config.getPrimaryKeyMode()) {
+                    case RECORD_VALUE:
+                    case RECORD_HEADER: {
+                        LOGGER.debug("Tombstone skipped because primary.key.mode is {}.", config.getPrimaryKeyMode());
+                        continue;
+                    }
+                }
+            }
+
             buffer.enqueue(collectionId, record);
         }
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1770,7 +1770,7 @@ Use with caution where strong data consistency is required.
 |[[jdbc-property-delete-enabled]]<<jdbc-property-delete-enabled, `+delete.enabled+`>>
 |`false`
 |Specifies whether the connector processes `DELETE` or _tombstone_ events and removes the corresponding row from the database.
-Use of this option requires that you set the xref:jdbc-property-primary-key-mode[`primary.key.mode`] to `record.key`, `record.value` or `record.header`.
+Use of this option requires that you set the xref:jdbc-property-primary-key-mode[`primary.key.mode`] to `record_key`, `record_value` or `record_header`.
 
 |[[jdbc-property-truncate-enabled]]<<jdbc-property-truncate-enabled, `+truncate.enabled+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1770,7 +1770,7 @@ Use with caution where strong data consistency is required.
 |[[jdbc-property-delete-enabled]]<<jdbc-property-delete-enabled, `+delete.enabled+`>>
 |`false`
 |Specifies whether the connector processes `DELETE` or _tombstone_ events and removes the corresponding row from the database.
-Use of this option requires that you set the xref:jdbc-property-primary-key-mode[`primary.key.mode`] to `record.key`.
+Use of this option requires that you set the xref:jdbc-property-primary-key-mode[`primary.key.mode`] to `record.key`, `record.value` or `record.header`.
 
 |[[jdbc-property-truncate-enabled]]<<jdbc-property-truncate-enabled, `+truncate.enabled+`>>
 |`false`


### PR DESCRIPTION

As described on the issue, the JDBC sink connector currently only supports deletion if the connector configuration has set the {{primary.key.mode}} to {{record_key}}.

We thought that a better approach would be to let the user delete the connector configuration when the {{primary.key.mode}} has the {{record_value}}, {{record_header}} or {{record_key}} defined. 

In this PR we have changed the JDBC Sink Connector Configuration logic, so It allows the new logic. We have also adapted the corresponding test logic and the documentation regarding the connector's new logic.

I have ensured that the new logic passes the tests, and ran the linting and formatting before submitting this PR.

Fixes debezium/dbz#1421