### PR TITLE
debezium/dbz#1663 Optionally exclude client_id, username, commit_timestamp, start_timestamp tracking by configuration

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -306,7 +306,56 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withValidation(Field::isRequired)
             .withDescription("This controls whether the 'RS_ID' column values are tracked. " +
                     "When set to true (the default), the 'RS_ID' values are buffered and provided in events when available. " +
-                    "When set to false, the 'RS_ID' values are not buffered and can reduce the memory footprint.");
+                    "When set to false, the 'RS_ID' column is excluded from the LogMiner query and its values are not buffered, " +
+                    "reducing both the memory footprint and query bandwidth.");
+
+    public static final Field LOG_MINING_BUFFER_TRACK_CLIENT_ID = Field.create("log.mining.buffer.track.client_id")
+            .withDisplayName("Toggle whether the 'client_id' value is tracked and buffered")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(true)
+            .withValidation(Field::isRequired)
+            .withDescription("This controls whether the 'CLIENT_ID' column values are tracked. " +
+                    "When set to true (the default), the 'CLIENT_ID' values are buffered and provided in events when available. " +
+                    "When set to false, the 'CLIENT_ID' column is excluded from the LogMiner query and its values are not buffered, " +
+                    "reducing both the memory footprint and query bandwidth.");
+
+    public static final Field LOG_MINING_BUFFER_TRACK_USERNAME = Field.create("log.mining.buffer.track.username")
+            .withDisplayName("Toggle whether the 'username' value is tracked and buffered")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(true)
+            .withValidation(Field::isRequired)
+            .withDescription("This controls whether the 'USERNAME' column values are tracked. " +
+                    "When set to true (the default), the 'USERNAME' values are buffered and provided in events when available. " +
+                    "When set to false, the 'USERNAME' column is excluded from the LogMiner query and its values are not buffered, " +
+                    "reducing both the memory footprint and query bandwidth.");
+
+    public static final Field LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP = Field.create("log.mining.buffer.track.commit_timestamp")
+            .withDisplayName("Toggle whether the 'commit_timestamp' value is tracked and buffered")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(true)
+            .withValidation(Field::isRequired)
+            .withDescription("This controls whether the 'COMMIT_TIMESTAMP' column values are tracked. " +
+                    "When set to true (the default), the 'COMMIT_TIMESTAMP' values are buffered and provided in events when available. " +
+                    "When set to false, the 'COMMIT_TIMESTAMP' column is excluded from the LogMiner query and its values are not buffered, " +
+                    "reducing both the memory footprint and query bandwidth.");
+
+    public static final Field LOG_MINING_BUFFER_TRACK_START_TIMESTAMP = Field.create("log.mining.buffer.track.start_timestamp")
+            .withDisplayName("Toggle whether the 'start_timestamp' value is tracked and buffered")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(true)
+            .withValidation(Field::isRequired)
+            .withDescription("This controls whether the 'START_TIMESTAMP' column values are tracked. " +
+                    "When set to true (the default), the 'START_TIMESTAMP' values are buffered and provided in events when available. " +
+                    "When set to false, the 'START_TIMESTAMP' column is excluded from the LogMiner query and its values are not buffered, " +
+                    "reducing both the memory footprint and query bandwidth.");
 
     public static final Field LOG_MINING_BUFFER_TRANSACTION_EVENTS_THRESHOLD = Field.create("log.mining.buffer.transaction.events.threshold")
             .withDisplayName("The maximum number of events a transaction can have before being discarded.")
@@ -766,6 +815,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     ARCHIVE_DESTINATION_NAME,
                     LOG_MINING_BUFFER_TYPE,
                     LOG_MINING_BUFFER_TRACK_RS_ID,
+                    LOG_MINING_BUFFER_TRACK_CLIENT_ID,
+                    LOG_MINING_BUFFER_TRACK_USERNAME,
+                    LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP,
+                    LOG_MINING_BUFFER_TRACK_START_TIMESTAMP,
                     LOG_MINING_BUFFER_DROP_ON_STOP,
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_GLOBAL,
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_TRANSACTIONS,
@@ -891,6 +944,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final Integer logMiningMinimumLogCount;
     private final ArchiveDestinationNameResolver destinationNameResolver;
     private final boolean logMiningBufferTrackRsId;
+    private final boolean logMiningBufferTrackClientId;
+    private final boolean logMiningBufferTrackUsername;
+    private final boolean logMiningBufferTrackCommitTimestamp;
+    private final boolean logMiningBufferTrackStartTimestamp;
 
     private final String openLogReplicatorSource;
     private final String openLogReplicatorHostname;
@@ -977,6 +1034,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningSortAreaSize = config.getLong(LOG_MINING_SORT_AREA_SIZE);
         this.logMiningMinimumLogCount = config.getInteger(LOG_MINING_LOG_COUNT_MIN);
         this.logMiningBufferTrackRsId = config.getBoolean(LOG_MINING_BUFFER_TRACK_RS_ID);
+        this.logMiningBufferTrackClientId = config.getBoolean(LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        this.logMiningBufferTrackUsername = config.getBoolean(LOG_MINING_BUFFER_TRACK_USERNAME);
+        this.logMiningBufferTrackCommitTimestamp = config.getBoolean(LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP);
+        this.logMiningBufferTrackStartTimestamp = config.getBoolean(LOG_MINING_BUFFER_TRACK_START_TIMESTAMP);
 
         this.logMiningEhCacheConfiguration = config.subset("log.mining.buffer.ehcache", false);
 
@@ -1808,6 +1869,34 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public boolean isLogMiningBufferTrackRsId() {
         return logMiningBufferTrackRsId;
+    }
+
+    /**
+     * @return determines whether {@code CLIENT_ID} column values are buffered and tracked
+     */
+    public boolean isLogMiningBufferTrackClientId() {
+        return logMiningBufferTrackClientId;
+    }
+
+    /**
+     * @return determines whether {@code USERNAME} column values are buffered and tracked
+     */
+    public boolean isLogMiningBufferTrackUsername() {
+        return logMiningBufferTrackUsername;
+    }
+
+    /**
+     * @return determines whether {@code COMMIT_TIMESTAMP} column values are buffered and tracked
+     */
+    public boolean isLogMiningBufferTrackCommitTimestamp() {
+        return logMiningBufferTrackCommitTimestamp;
+    }
+
+    /**
+     * @return determines whether {@code START_TIMESTAMP} column values are buffered and tracked
+     */
+    public boolean isLogMiningBufferTrackStartTimestamp() {
+        return logMiningBufferTrackStartTimestamp;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
@@ -66,9 +66,7 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
             query.append("/*+ ORDERED USE_NL(R) */ ");
         }
 
-        query.append("SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, ")
-                .append("USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS, INFO, SSN, THREAD#, DATA_OBJ#, DATA_OBJV#, DATA_OBJD#, ")
-                .append("CLIENT_ID, START_SCN, COMMIT_SCN, START_TIMESTAMP, COMMIT_TIMESTAMP, SEQUENCE# ")
+        query.append(buildColumnList())
                 .append("FROM ")
                 .append(LOGMNR_CONTENTS_VIEW).append(" ");
 
@@ -77,6 +75,70 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
         }
 
         return query.append(!Strings.isNullOrEmpty(whereClause) ? "WHERE " + whereClause : "").toString();
+    }
+
+    /**
+     * Builds the comma-separated list of columns for the SELECT clause. Optional tracking columns
+     * are included only when their corresponding configuration flag is enabled. When a tracking flag
+     * is disabled, the column is omitted from the query entirely, reducing query bandwidth.
+     *
+     * <p><strong>IMPORTANT:</strong> The column ordering here is the single source of truth for the
+     * LogMiner query projection. {@link LogMinerColumnIndexes#fromConfig(io.debezium.connector.oracle.OracleConnectorConfig)}
+     * mirrors this ordering exactly to pre-compute the 1-based JDBC {@link java.sql.ResultSet} ordinal
+     * for every column. Any change to column order, addition, or removal here <em>must</em> be
+     * reflected in {@link LogMinerColumnIndexes} and its tests.
+     *
+     * @return the column list string, ending with a trailing space
+     */
+    private String buildColumnList() {
+        final List<String> columns = new ArrayList<>();
+        // Mandatory columns (positions 1-9, always present)
+        columns.add("SCN");
+        columns.add("SQL_REDO");
+        columns.add("OPERATION_CODE");
+        columns.add("TIMESTAMP");
+        columns.add("XID");
+        columns.add("CSF");
+        columns.add("TABLE_NAME");
+        columns.add("SEG_OWNER");
+        columns.add("OPERATION");
+        // Optional column: USERNAME
+        if (connectorConfig.isLogMiningBufferTrackUsername()) {
+            columns.add("USERNAME");
+        }
+        // Mandatory columns
+        columns.add("ROW_ID");
+        columns.add("ROLLBACK");
+        // Optional column: RS_ID
+        if (connectorConfig.isLogMiningBufferTrackRsId()) {
+            columns.add("RS_ID");
+        }
+        // Mandatory columns
+        columns.add("STATUS");
+        columns.add("INFO");
+        columns.add("SSN");
+        columns.add("THREAD#");
+        columns.add("DATA_OBJ#");
+        columns.add("DATA_OBJV#");
+        columns.add("DATA_OBJD#");
+        // Optional column: CLIENT_ID
+        if (connectorConfig.isLogMiningBufferTrackClientId()) {
+            columns.add("CLIENT_ID");
+        }
+        // Mandatory columns
+        columns.add("START_SCN");
+        columns.add("COMMIT_SCN");
+        // Optional column: START_TIMESTAMP
+        if (connectorConfig.isLogMiningBufferTrackStartTimestamp()) {
+            columns.add("START_TIMESTAMP");
+        }
+        // Optional column: COMMIT_TIMESTAMP
+        if (connectorConfig.isLogMiningBufferTrackCommitTimestamp()) {
+            columns.add("COMMIT_TIMESTAMP");
+        }
+        // Mandatory column
+        columns.add("SEQUENCE#");
+        return String.join(", ", columns) + " ";
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
@@ -92,7 +92,8 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
      */
     private String buildColumnList() {
         final List<String> columns = new ArrayList<>();
-        // Mandatory columns (positions 1-9, always present)
+
+        // NOTE: Mandatory columns (positions 1-21, always present), and should be placed before optional columns
         columns.add("SCN");
         columns.add("SQL_REDO");
         columns.add("OPERATION_CODE");
@@ -102,18 +103,8 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
         columns.add("TABLE_NAME");
         columns.add("SEG_OWNER");
         columns.add("OPERATION");
-        // Optional column: USERNAME
-        if (connectorConfig.isLogMiningBufferTrackUsername()) {
-            columns.add("USERNAME");
-        }
-        // Mandatory columns
         columns.add("ROW_ID");
         columns.add("ROLLBACK");
-        // Optional column: RS_ID
-        if (connectorConfig.isLogMiningBufferTrackRsId()) {
-            columns.add("RS_ID");
-        }
-        // Mandatory columns
         columns.add("STATUS");
         columns.add("INFO");
         columns.add("SSN");
@@ -121,23 +112,27 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
         columns.add("DATA_OBJ#");
         columns.add("DATA_OBJV#");
         columns.add("DATA_OBJD#");
-        // Optional column: CLIENT_ID
-        if (connectorConfig.isLogMiningBufferTrackClientId()) {
-            columns.add("CLIENT_ID");
-        }
-        // Mandatory columns
         columns.add("START_SCN");
         columns.add("COMMIT_SCN");
-        // Optional column: START_TIMESTAMP
+        columns.add("SEQUENCE#");
+
+        // NOTE: Optional columns should be added here
         if (connectorConfig.isLogMiningBufferTrackStartTimestamp()) {
             columns.add("START_TIMESTAMP");
         }
-        // Optional column: COMMIT_TIMESTAMP
         if (connectorConfig.isLogMiningBufferTrackCommitTimestamp()) {
             columns.add("COMMIT_TIMESTAMP");
         }
-        // Mandatory column
-        columns.add("SEQUENCE#");
+        if (connectorConfig.isLogMiningBufferTrackRsId()) {
+            columns.add("RS_ID");
+        }
+        if (connectorConfig.isLogMiningBufferTrackUsername()) {
+            columns.add("USERNAME");
+        }
+        if (connectorConfig.isLogMiningBufferTrackClientId()) {
+            columns.add("CLIENT_ID");
+        }
+
         return String.join(", ", columns) + " ";
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -120,6 +120,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     private final XmlBeginParser xmlBeginParser;
     private final Tables.TableFilter tableFilter;
     private final List<String> archiveDestinationNames;
+    private final LogMinerColumnIndexes columnIndexes;
 
     private boolean sequenceUnavailable = false;
     private List<LogFile> currentLogFiles;
@@ -160,6 +161,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         this.xmlBeginParser = new XmlBeginParser();
         this.tableFilter = connectorConfig.getTableFilters().dataCollectionFilter();
         this.archiveDestinationNames = connectorConfig.getArchiveDestinationNameResolver().getDestinationNames(jdbcConnection);
+        this.columnIndexes = LogMinerColumnIndexes.fromConfig(connectorConfig);
     }
 
     @Override
@@ -412,7 +414,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             while (getContext().isRunning() && hasNextWithMetricsUpdate(resultSet)) {
                 getBatchMetrics().rowObserved();
 
-                final LogMinerEventRow event = LogMinerEventRow.fromResultSet(resultSet, schema, getConfig());
+                final LogMinerEventRow event = LogMinerEventRow.fromResultSet(resultSet, schema, columnIndexes);
                 processEvent(event);
             }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+
+/**
+ * Pre-computed JDBC {@link java.sql.ResultSet} column ordinals for the LogMiner query.
+ *
+ * <p>Five query columns are optional; when disabled they are omitted from the {@code SELECT},
+ * shifting every subsequent column's ordinal. This class resolves those shifts <em>once</em> at
+ * startup (via {@link #fromConfig}) rather than on every row.
+ *
+ * <p>Positions 1–9 are always present and exposed as {@code public static final} constants.
+ * Positions 10 onwards vary by configuration and are stored as instance fields, with {@code null}
+ * indicating the column is disabled.
+ *
+ * <p>The column ordering must exactly mirror {@link AbstractLogMinerQueryBuilder#buildColumnList()}.
+ *
+ * @author Debezium Authors
+ */
+public final class LogMinerColumnIndexes {
+
+    /** ResultSet ordinal for {@code SCN}. */
+    public static final int SCN = 1;
+    /** ResultSet ordinal for {@code SQL_REDO}. */
+    public static final int SQL_REDO = 2;
+    /** ResultSet ordinal for {@code OPERATION_CODE}. */
+    public static final int OPERATION_CODE = 3;
+    /** ResultSet ordinal for {@code TIMESTAMP} (the change timestamp). */
+    public static final int TIMESTAMP = 4;
+    /** ResultSet ordinal for {@code XID} (transaction identifier bytes). */
+    public static final int XID = 5;
+    /** ResultSet ordinal for {@code CSF} (continuation flag). */
+    public static final int CSF = 6;
+    /** ResultSet ordinal for {@code TABLE_NAME}. */
+    public static final int TABLE_NAME = 7;
+    /** ResultSet ordinal for {@code SEG_OWNER} (used as the tablespace / schema name). */
+    public static final int SEG_OWNER = 8;
+    /** ResultSet ordinal for {@code OPERATION}. */
+    public static final int OPERATION = 9;
+
+    private final ResultSetValueResolver[] resolvers;
+
+    private final String catalogName;
+
+    /** Ordinal for {@code USERNAME}, or {@code null} when username tracking is disabled. */
+    private final Integer usernameIndex;
+    /** Ordinal for {@code RS_ID}, or {@code null} when RS_ID tracking is disabled. */
+    private final Integer rsIdIndex;
+    /** Ordinal for {@code CLIENT_ID}, or {@code null} when client-ID tracking is disabled. */
+    private final Integer clientIdIndex;
+    /** Ordinal for {@code START_TIMESTAMP}, or {@code null} when start-timestamp tracking is disabled. */
+    private final Integer startTimestampIndex;
+    /** Ordinal for {@code COMMIT_TIMESTAMP}, or {@code null} when commit-timestamp tracking is disabled. */
+    private final Integer commitTimestampIndex;
+
+    private final int rowIdIndex;
+    private final int rollbackFlagIndex;
+    private final int statusIndex;
+    private final int infoIndex;
+    private final int ssnIndex;
+    private final int threadIndex;
+    private final int objectIdIndex;
+    private final int objectVersionIndex;
+    private final int dataObjectIdIndex;
+    private final int startScnIndex;
+    private final int commitScnIndex;
+    private final int sequenceIndex;
+
+    /**
+     * Computes all column ordinals from the given configuration flags.
+     *
+     * <p>The algorithm mirrors the column-list construction in
+     * {@link AbstractLogMinerQueryBuilder#buildColumnList()} exactly: walk the columns in order,
+     * assigning the next sequential 1-based position to each column that is included in the query.
+     */
+    private LogMinerColumnIndexes(String catalogName,
+                                  boolean trackUsername,
+                                  boolean trackRsId,
+                                  boolean trackClientId,
+                                  boolean trackStartTimestamp,
+                                  boolean trackCommitTimestamp) {
+        this.catalogName = catalogName;
+
+        int pos = OPERATION;
+
+        // Optional: USERNAME
+        if (trackUsername) {
+            usernameIndex = ++pos;
+        }
+        else {
+            usernameIndex = null;
+        }
+
+        // Mandatory: ROW_ID, ROLLBACK
+        rowIdIndex = ++pos;
+        rollbackFlagIndex = ++pos;
+
+        // Optional: RS_ID
+        if (trackRsId) {
+            rsIdIndex = ++pos;
+        }
+        else {
+            rsIdIndex = null;
+        }
+
+        // Mandatory block: STATUS … DATA_OBJD#
+        statusIndex = ++pos;
+        infoIndex = ++pos;
+        ssnIndex = ++pos;
+        threadIndex = ++pos;
+        objectIdIndex = ++pos;
+        objectVersionIndex = ++pos;
+        dataObjectIdIndex = ++pos;
+
+        // Optional: CLIENT_ID
+        if (trackClientId) {
+            clientIdIndex = ++pos;
+        }
+        else {
+            clientIdIndex = null;
+        }
+
+        // Mandatory: START_SCN, COMMIT_SCN
+        startScnIndex = ++pos;
+        commitScnIndex = ++pos;
+
+        // Optional: START_TIMESTAMP
+        if (trackStartTimestamp) {
+            startTimestampIndex = ++pos;
+        }
+        else {
+            startTimestampIndex = null;
+        }
+
+        // Optional: COMMIT_TIMESTAMP
+        if (trackCommitTimestamp) {
+            commitTimestampIndex = ++pos;
+        }
+        else {
+            commitTimestampIndex = null;
+        }
+
+        // Mandatory: SEQUENCE#
+        sequenceIndex = ++pos;
+
+        this.resolvers = LogMinerEventRow.buildResolvers(this);
+    }
+
+    /**
+     * Creates a {@link LogMinerColumnIndexes} instance for the given connector configuration.
+     * Call once at startup and reuse the returned instance for the lifetime of the streaming session.
+     *
+     * @param config the connector configuration, must not be {@code null}
+     * @return an immutable {@code LogMinerColumnIndexes}
+     */
+    public static LogMinerColumnIndexes fromConfig(OracleConnectorConfig config) {
+        return new LogMinerColumnIndexes(
+                config.getCatalogName(),
+                config.isLogMiningBufferTrackUsername(),
+                config.isLogMiningBufferTrackRsId(),
+                config.isLogMiningBufferTrackClientId(),
+                config.isLogMiningBufferTrackStartTimestamp(),
+                config.isLogMiningBufferTrackCommitTimestamp());
+    }
+
+    /**
+     * Applies each resolver in the pre-built array to {@code row}.
+     *
+     * @param row the target row being populated, never {@code null}
+     * @param rs  the current JDBC result set, never {@code null}
+     * @throws SQLException if the result set cannot be read
+     */
+    public void applyResolvers(LogMinerEventRow row, ResultSet rs) throws SQLException {
+        for (ResultSetValueResolver resolver : resolvers) {
+            resolver.resolve(row, rs);
+        }
+    }
+
+    /** For testing only: returns the number of {@link ResultSetValueResolver}s in the pre-built array. */
+    int getResolverCount() {
+        return resolvers.length;
+    }
+
+    /** Returns the catalog (database) name, used when constructing {@link io.debezium.relational.TableId}s. */
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code USERNAME}, or {@code null} if username tracking is disabled
+     * and the column is absent from the query.
+     */
+    public Integer getUsernameIndex() {
+        return usernameIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code ROW_ID}. */
+    public int getRowIdIndex() {
+        return rowIdIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code ROLLBACK}. */
+    public int getRollbackFlagIndex() {
+        return rollbackFlagIndex;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code RS_ID}, or {@code null} if RS-ID tracking is disabled
+     * and the column is absent from the query.
+     */
+    public Integer getRsIdIndex() {
+        return rsIdIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code STATUS}. */
+    public int getStatusIndex() {
+        return statusIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code INFO}. */
+    public int getInfoIndex() {
+        return infoIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code SSN}. */
+    public int getSsnIndex() {
+        return ssnIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code THREAD#}. */
+    public int getThreadIndex() {
+        return threadIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code DATA_OBJ#}. */
+    public int getObjectIdIndex() {
+        return objectIdIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code DATA_OBJV#}. */
+    public int getObjectVersionIndex() {
+        return objectVersionIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code DATA_OBJD#}. */
+    public int getDataObjectIdIndex() {
+        return dataObjectIdIndex;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code CLIENT_ID}, or {@code null} if client-ID tracking is
+     * disabled and the column is absent from the query.
+     */
+    public Integer getClientIdIndex() {
+        return clientIdIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code START_SCN}. */
+    public int getStartScnIndex() {
+        return startScnIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code COMMIT_SCN}. */
+    public int getCommitScnIndex() {
+        return commitScnIndex;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code START_TIMESTAMP}, or {@code null} if start-timestamp
+     * tracking is disabled and the column is absent from the query.
+     */
+    public Integer getStartTimestampIndex() {
+        return startTimestampIndex;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code COMMIT_TIMESTAMP}, or {@code null} if commit-timestamp
+     * tracking is disabled and the column is absent from the query.
+     */
+    public Integer getCommitTimestampIndex() {
+        return commitTimestampIndex;
+    }
+
+    /** Returns the 1-based ordinal for {@code SEQUENCE#}. */
+    public int getSequenceIndex() {
+        return sequenceIndex;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
@@ -18,8 +18,8 @@ import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
  * shifting every subsequent column's ordinal. This class resolves those shifts <em>once</em> at
  * startup (via {@link #fromConfig}) rather than on every row.
  *
- * <p>Positions 1–9 are always present and exposed as {@code public static final} constants.
- * Positions 10 onwards vary by configuration and are stored as instance fields, with {@code null}
+ * <p>Positions 1–21 are always present and exposed as {@code public static final} constants.
+ * Positions 22 onwards vary by configuration and are stored as instance fields, with {@code null}
  * indicating the column is disabled.
  *
  * <p>The column ordering must exactly mirror {@link AbstractLogMinerQueryBuilder#buildColumnList()}.
@@ -46,6 +46,30 @@ public final class LogMinerColumnIndexes {
     public static final int SEG_OWNER = 8;
     /** ResultSet ordinal for {@code OPERATION}. */
     public static final int OPERATION = 9;
+    /** ResultSet ordinal for {@code ROW_ID} */
+    public static final int ROW_ID = 10;
+    /** ResultSet ordinal for {@code ROLLBACK} */
+    public static final int ROLLBACK = 11;
+    /** ResultSet ordinal for {@code STATUS} */
+    public static final int STATUS = 12;
+    /** ResultSet ordinal for {@code INFO} */
+    public static final int INFO = 13;
+    /** ResultSet ordinal for {@code SSN} */
+    public static final int SSN = 14;
+    /** ResultSet ordinal for {@code THREAD#} */
+    public static final int THREAD = 15;
+    /** ResultSet ordinal for {@code DATA_OBJ#} */
+    public static final int DATA_OBJ = 16;
+    /** ResultSet ordinal for {@code DATA_OBJV#} */
+    public static final int DATA_OBJV = 17;
+    /** ResultSet ordinal for {@code DATA_OBJD#} */
+    public static final int DATA_OBJD = 18;
+    /** ResultSet ordinal for {@code START_SCN} */
+    public static final int START_SCN = 19;
+    /** ResultSet ordinal for {@code COMMIT_SCN} */
+    public static final int COMMIT_SCN = 20;
+    /** ResultSet ordinal for {@code SEQUENCE#} */
+    public static final int SEQUENCE = 21;
 
     private final ResultSetValueResolver[] resolvers;
 
@@ -62,19 +86,6 @@ public final class LogMinerColumnIndexes {
     /** Ordinal for {@code COMMIT_TIMESTAMP}, or {@code null} when commit-timestamp tracking is disabled. */
     private final Integer commitTimestampIndex;
 
-    private final int rowIdIndex;
-    private final int rollbackFlagIndex;
-    private final int statusIndex;
-    private final int infoIndex;
-    private final int ssnIndex;
-    private final int threadIndex;
-    private final int objectIdIndex;
-    private final int objectVersionIndex;
-    private final int dataObjectIdIndex;
-    private final int startScnIndex;
-    private final int commitScnIndex;
-    private final int sequenceIndex;
-
     /**
      * Computes all column ordinals from the given configuration flags.
      *
@@ -90,69 +101,15 @@ public final class LogMinerColumnIndexes {
                                   boolean trackCommitTimestamp) {
         this.catalogName = catalogName;
 
-        int pos = OPERATION;
+        int pos = SEQUENCE;
 
-        // Optional: USERNAME
-        if (trackUsername) {
-            usernameIndex = ++pos;
-        }
-        else {
-            usernameIndex = null;
-        }
+        startTimestampIndex = trackStartTimestamp ? ++pos : null;
+        commitTimestampIndex = trackCommitTimestamp ? ++pos : null;
+        rsIdIndex = trackRsId ? ++pos : null;
+        usernameIndex = trackUsername ? ++pos : null;
+        clientIdIndex = trackClientId ? ++pos : null;
 
-        // Mandatory: ROW_ID, ROLLBACK
-        rowIdIndex = ++pos;
-        rollbackFlagIndex = ++pos;
-
-        // Optional: RS_ID
-        if (trackRsId) {
-            rsIdIndex = ++pos;
-        }
-        else {
-            rsIdIndex = null;
-        }
-
-        // Mandatory block: STATUS … DATA_OBJD#
-        statusIndex = ++pos;
-        infoIndex = ++pos;
-        ssnIndex = ++pos;
-        threadIndex = ++pos;
-        objectIdIndex = ++pos;
-        objectVersionIndex = ++pos;
-        dataObjectIdIndex = ++pos;
-
-        // Optional: CLIENT_ID
-        if (trackClientId) {
-            clientIdIndex = ++pos;
-        }
-        else {
-            clientIdIndex = null;
-        }
-
-        // Mandatory: START_SCN, COMMIT_SCN
-        startScnIndex = ++pos;
-        commitScnIndex = ++pos;
-
-        // Optional: START_TIMESTAMP
-        if (trackStartTimestamp) {
-            startTimestampIndex = ++pos;
-        }
-        else {
-            startTimestampIndex = null;
-        }
-
-        // Optional: COMMIT_TIMESTAMP
-        if (trackCommitTimestamp) {
-            commitTimestampIndex = ++pos;
-        }
-        else {
-            commitTimestampIndex = null;
-        }
-
-        // Mandatory: SEQUENCE#
-        sequenceIndex = ++pos;
-
-        this.resolvers = LogMinerEventRow.buildResolvers(this);
+        this.resolvers = LogMinerEventRow.buildOptionalResolvers(this);
     }
 
     /**
@@ -203,16 +160,6 @@ public final class LogMinerColumnIndexes {
         return usernameIndex;
     }
 
-    /** Returns the 1-based ordinal for {@code ROW_ID}. */
-    public int getRowIdIndex() {
-        return rowIdIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code ROLLBACK}. */
-    public int getRollbackFlagIndex() {
-        return rollbackFlagIndex;
-    }
-
     /**
      * Returns the 1-based ordinal for {@code RS_ID}, or {@code null} if RS-ID tracking is disabled
      * and the column is absent from the query.
@@ -221,57 +168,12 @@ public final class LogMinerColumnIndexes {
         return rsIdIndex;
     }
 
-    /** Returns the 1-based ordinal for {@code STATUS}. */
-    public int getStatusIndex() {
-        return statusIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code INFO}. */
-    public int getInfoIndex() {
-        return infoIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code SSN}. */
-    public int getSsnIndex() {
-        return ssnIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code THREAD#}. */
-    public int getThreadIndex() {
-        return threadIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code DATA_OBJ#}. */
-    public int getObjectIdIndex() {
-        return objectIdIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code DATA_OBJV#}. */
-    public int getObjectVersionIndex() {
-        return objectVersionIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code DATA_OBJD#}. */
-    public int getDataObjectIdIndex() {
-        return dataObjectIdIndex;
-    }
-
     /**
      * Returns the 1-based ordinal for {@code CLIENT_ID}, or {@code null} if client-ID tracking is
      * disabled and the column is absent from the query.
      */
     public Integer getClientIdIndex() {
         return clientIdIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code START_SCN}. */
-    public int getStartScnIndex() {
-        return startScnIndex;
-    }
-
-    /** Returns the 1-based ordinal for {@code COMMIT_SCN}. */
-    public int getCommitScnIndex() {
-        return commitScnIndex;
     }
 
     /**
@@ -290,8 +192,4 @@ public final class LogMinerColumnIndexes {
         return commitTimestampIndex;
     }
 
-    /** Returns the 1-based ordinal for {@code SEQUENCE#}. */
-    public int getSequenceIndex() {
-        return sequenceIndex;
-    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/ResultSetValueResolver.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/ResultSetValueResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+
+/**
+ * Reads a single column value from a JDBC {@link ResultSet} into a {@link LogMinerEventRow} field.
+ *
+ * @author Debezium Authors
+ */
+@FunctionalInterface
+public interface ResultSetValueResolver {
+
+    /**
+     * Reads a value from {@code rs} and writes it to the appropriate field of {@code row}.
+     *
+     * @param row the target row being populated, never {@code null}
+     * @param rs  the current JDBC result set, never {@code null}
+     * @throws SQLException if the result set cannot be read
+     */
+    void resolve(LogMinerEventRow row, ResultSet rs) throws SQLException;
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
@@ -40,8 +40,8 @@ public class LogMinerEventRow {
     /* Allows for up to 100KB worth of SQL */
     private static final Integer MAX_SQL_CONTINUATIONS = 25;
 
-    // Column ordinals 1–9 are fixed and exposed as constants on LogMinerColumnIndexes.
-    // Column ordinals 10+ are pre-computed at startup by LogMinerColumnIndexes.fromConfig()
+    // Column ordinals 1–21 are fixed and exposed as constants on LogMinerColumnIndexes.
+    // Column ordinals 22+ are pre-computed at startup by LogMinerColumnIndexes.fromConfig()
     // because optional columns can be omitted from the SELECT, shifting all subsequent positions.
 
     private Scn scn;
@@ -186,71 +186,27 @@ public class LogMinerEventRow {
     /**
      * Builds the array of {@link ResultSetValueResolver} lambdas used by
      * {@link LogMinerColumnIndexes#applyResolvers} on every result-set row.
+     * <p>
      * Each lambda closes over a pre-computed JDBC ordinal; optional columns are excluded when
      * their index is {@code null}.
      *
      * @param indexes the pre-computed column ordinals, must not be {@code null}
      * @return an ordered array of resolvers
      */
-    public static ResultSetValueResolver[] buildResolvers(LogMinerColumnIndexes indexes) {
+    public static ResultSetValueResolver[] buildOptionalResolvers(LogMinerColumnIndexes indexes) {
         final List<ResultSetValueResolver> resolvers = new ArrayList<>();
+
         if (indexes.getUsernameIndex() != null) {
             final int pos = indexes.getUsernameIndex();
             resolvers.add((row, rs) -> row.userName = rs.getString(pos));
-        }
-        {
-            final int pos = indexes.getRowIdIndex();
-            resolvers.add((row, rs) -> row.rowId = rs.getString(pos));
-        }
-        {
-            final int pos = indexes.getRollbackFlagIndex();
-            resolvers.add((row, rs) -> row.rollbackFlag = rs.getInt(pos) == 1);
         }
         if (indexes.getRsIdIndex() != null) {
             final int pos = indexes.getRsIdIndex();
             resolvers.add((row, rs) -> row.rsId = trim(rs.getString(pos)));
         }
-        // getSqlRedo reads from fixed positions 2, 3, 6 and may call rs.next() for continuation rows.
-        resolvers.add((row, rs) -> row.redoSql = row.getSqlRedo(rs));
-        {
-            final int pos = indexes.getStatusIndex();
-            resolvers.add((row, rs) -> row.status = rs.getInt(pos));
-        }
-        {
-            final int pos = indexes.getInfoIndex();
-            resolvers.add((row, rs) -> row.info = rs.getString(pos));
-        }
-        {
-            final int pos = indexes.getSsnIndex();
-            resolvers.add((row, rs) -> row.ssn = rs.getLong(pos));
-        }
-        {
-            final int pos = indexes.getThreadIndex();
-            resolvers.add((row, rs) -> row.thread = rs.getInt(pos));
-        }
-        {
-            final int pos = indexes.getObjectIdIndex();
-            resolvers.add((row, rs) -> row.objectId = rs.getLong(pos));
-        }
-        {
-            final int pos = indexes.getObjectVersionIndex();
-            resolvers.add((row, rs) -> row.objectVersion = rs.getLong(pos));
-        }
-        {
-            final int pos = indexes.getDataObjectIdIndex();
-            resolvers.add((row, rs) -> row.dataObjectId = rs.getLong(pos));
-        }
         if (indexes.getClientIdIndex() != null) {
             final int pos = indexes.getClientIdIndex();
             resolvers.add((row, rs) -> row.clientId = rs.getString(pos));
-        }
-        {
-            final int pos = indexes.getStartScnIndex();
-            resolvers.add((row, rs) -> row.startScn = getScn(rs, pos));
-        }
-        {
-            final int pos = indexes.getCommitScnIndex();
-            resolvers.add((row, rs) -> row.commitScn = getScn(rs, pos));
         }
         if (indexes.getStartTimestampIndex() != null) {
             final int pos = indexes.getStartTimestampIndex();
@@ -260,10 +216,7 @@ public class LogMinerEventRow {
             final int pos = indexes.getCommitTimestampIndex();
             resolvers.add((row, rs) -> row.commitTime = getTime(rs, pos));
         }
-        {
-            final int pos = indexes.getSequenceIndex();
-            resolvers.add((row, rs) -> row.transactionSequence = rs.getLong(pos));
-        }
+
         return resolvers.toArray(new ResultSetValueResolver[0]);
     }
 
@@ -298,7 +251,7 @@ public class LogMinerEventRow {
     private void initializeFromResultSet(ResultSet resultSet, OracleDatabaseSchema schema,
                                          LogMinerColumnIndexes indexes)
             throws SQLException {
-        // Fixed positions 1–9: always present, never shift
+        // Fixed positions 1–21: always present, never shift
         this.scn = getScn(resultSet, LogMinerColumnIndexes.SCN);
         this.tableName = resultSet.getString(LogMinerColumnIndexes.TABLE_NAME);
         this.tablespaceName = resultSet.getString(LogMinerColumnIndexes.SEG_OWNER);
@@ -306,8 +259,26 @@ public class LogMinerEventRow {
         this.changeTime = getTime(resultSet, LogMinerColumnIndexes.TIMESTAMP);
         this.transactionId = getTransactionId(resultSet);
         this.operation = resultSet.getString(LogMinerColumnIndexes.OPERATION);
+        this.rowId = resultSet.getString(LogMinerColumnIndexes.ROW_ID);
+        this.rollbackFlag = resultSet.getInt(LogMinerColumnIndexes.ROLLBACK) == 1;
+        this.status = resultSet.getInt(LogMinerColumnIndexes.STATUS);
+        this.info = resultSet.getString(LogMinerColumnIndexes.INFO);
+        this.ssn = resultSet.getLong(LogMinerColumnIndexes.SSN);
+        this.thread = resultSet.getInt(LogMinerColumnIndexes.THREAD);
+        this.objectId = resultSet.getLong(LogMinerColumnIndexes.DATA_OBJ);
+        this.objectVersion = resultSet.getLong(LogMinerColumnIndexes.DATA_OBJV);
+        this.dataObjectId = resultSet.getLong(LogMinerColumnIndexes.DATA_OBJD);
+        this.startScn = getScn(resultSet, LogMinerColumnIndexes.START_SCN);
+        this.commitScn = getScn(resultSet, LogMinerColumnIndexes.COMMIT_SCN);
+        this.transactionSequence = resultSet.getLong(LogMinerColumnIndexes.SEQUENCE);
+
         // Variable positions and SQL redo: iterate over pre-built resolvers.
         indexes.applyResolvers(this, resultSet);
+
+        // Explicitly read sqlRedo at the end of all other columns
+        // getSqlRedo reads from fixed positions 2, 3, 6 and may call rs.next() for continuation rows.
+        this.redoSql = getSqlRedo(resultSet);
+
         if (this.tableName != null) {
             if (schema != null) {
                 this.tableId = schema.resolveTableId(indexes.getCatalogName(), tablespaceName, tableName);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
@@ -10,15 +10,18 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.LogMinerColumnIndexes;
+import io.debezium.connector.oracle.logminer.ResultSetValueResolver;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
@@ -37,32 +40,9 @@ public class LogMinerEventRow {
     /* Allows for up to 100KB worth of SQL */
     private static final Integer MAX_SQL_CONTINUATIONS = 25;
 
-    private static final int SCN = 1;
-    private static final int SQL_REDO = 2;
-    private static final int OPERATION_CODE = 3;
-    private static final int CHANGE_TIME = 4;
-    private static final int TX_ID = 5;
-    private static final int CSF = 6;
-    private static final int TABLE_NAME = 7;
-    private static final int TABLESPACE_NAME = 8;
-    private static final int OPERATION = 9;
-    private static final int USERNAME = 10;
-    private static final int ROW_ID = 11;
-    private static final int ROLLBACK_FLAG = 12;
-    private static final int RS_ID = 13;
-    private static final int STATUS = 14;
-    private static final int INFO = 15;
-    private static final int SSN = 16;
-    private static final int THREAD = 17;
-    private static final int OBJECT_ID = 18;
-    private static final int OBJECT_VERSION = 19;
-    private static final int OBJECT_DATA_ID = 20;
-    private static final int CLIENT_ID = 21;
-    private static final int START_SCN = 22;
-    private static final int COMMIT_SCN = 23;
-    private static final int START_TIMESTAMP = 24;
-    private static final int COMMIT_TIMESTAMP = 25;
-    private static final int SEQUENCE = 26;
+    // Column ordinals 1–9 are fixed and exposed as constants on LogMinerColumnIndexes.
+    // Column ordinals 10+ are pre-computed at startup by LogMinerColumnIndexes.fromConfig()
+    // because optional columns can be omitted from the SELECT, shifting all subsequent positions.
 
     private Scn scn;
     private TableId tableId;
@@ -204,93 +184,163 @@ public class LogMinerEventRow {
     }
 
     /**
-     * Returns a {@link LogMinerEventRow} instance based on the current row of the JDBC {@link ResultSet}.
+     * Builds the array of {@link ResultSetValueResolver} lambdas used by
+     * {@link LogMinerColumnIndexes#applyResolvers} on every result-set row.
+     * Each lambda closes over a pre-computed JDBC ordinal; optional columns are excluded when
+     * their index is {@code null}.
      *
-     * It's important to note that the instance returned by this method is never created as a new instance. The
-     * method uses an internal single instance that is initialized based on the values from the current row
-     * of the JDBC result-set to avoid creating lots of intermediate objects.
+     * @param indexes the pre-computed column ordinals, must not be {@code null}
+     * @return an ordered array of resolvers
+     */
+    public static ResultSetValueResolver[] buildResolvers(LogMinerColumnIndexes indexes) {
+        final List<ResultSetValueResolver> resolvers = new ArrayList<>();
+        if (indexes.getUsernameIndex() != null) {
+            final int pos = indexes.getUsernameIndex();
+            resolvers.add((row, rs) -> row.userName = rs.getString(pos));
+        }
+        {
+            final int pos = indexes.getRowIdIndex();
+            resolvers.add((row, rs) -> row.rowId = rs.getString(pos));
+        }
+        {
+            final int pos = indexes.getRollbackFlagIndex();
+            resolvers.add((row, rs) -> row.rollbackFlag = rs.getInt(pos) == 1);
+        }
+        if (indexes.getRsIdIndex() != null) {
+            final int pos = indexes.getRsIdIndex();
+            resolvers.add((row, rs) -> row.rsId = trim(rs.getString(pos)));
+        }
+        // getSqlRedo reads from fixed positions 2, 3, 6 and may call rs.next() for continuation rows.
+        resolvers.add((row, rs) -> row.redoSql = row.getSqlRedo(rs));
+        {
+            final int pos = indexes.getStatusIndex();
+            resolvers.add((row, rs) -> row.status = rs.getInt(pos));
+        }
+        {
+            final int pos = indexes.getInfoIndex();
+            resolvers.add((row, rs) -> row.info = rs.getString(pos));
+        }
+        {
+            final int pos = indexes.getSsnIndex();
+            resolvers.add((row, rs) -> row.ssn = rs.getLong(pos));
+        }
+        {
+            final int pos = indexes.getThreadIndex();
+            resolvers.add((row, rs) -> row.thread = rs.getInt(pos));
+        }
+        {
+            final int pos = indexes.getObjectIdIndex();
+            resolvers.add((row, rs) -> row.objectId = rs.getLong(pos));
+        }
+        {
+            final int pos = indexes.getObjectVersionIndex();
+            resolvers.add((row, rs) -> row.objectVersion = rs.getLong(pos));
+        }
+        {
+            final int pos = indexes.getDataObjectIdIndex();
+            resolvers.add((row, rs) -> row.dataObjectId = rs.getLong(pos));
+        }
+        if (indexes.getClientIdIndex() != null) {
+            final int pos = indexes.getClientIdIndex();
+            resolvers.add((row, rs) -> row.clientId = rs.getString(pos));
+        }
+        {
+            final int pos = indexes.getStartScnIndex();
+            resolvers.add((row, rs) -> row.startScn = getScn(rs, pos));
+        }
+        {
+            final int pos = indexes.getCommitScnIndex();
+            resolvers.add((row, rs) -> row.commitScn = getScn(rs, pos));
+        }
+        if (indexes.getStartTimestampIndex() != null) {
+            final int pos = indexes.getStartTimestampIndex();
+            resolvers.add((row, rs) -> row.startTime = getTime(rs, pos));
+        }
+        if (indexes.getCommitTimestampIndex() != null) {
+            final int pos = indexes.getCommitTimestampIndex();
+            resolvers.add((row, rs) -> row.commitTime = getTime(rs, pos));
+        }
+        {
+            final int pos = indexes.getSequenceIndex();
+            resolvers.add((row, rs) -> row.transactionSequence = rs.getLong(pos));
+        }
+        return resolvers.toArray(new ResultSetValueResolver[0]);
+    }
+
+    /**
+     * Returns a {@link LogMinerEventRow} instance based on the current row of the JDBC {@link ResultSet}.
      *
      * @param resultSet the result set to be read, should never be {@code null}
      * @param schema the relational schema, can be {@code null}
-     * @param connectorConfig the connector configuration, should not be {@code null}
+     * @param columnIndexes the pre-computed column ordinals for this query configuration,
+     *                      should not be {@code null}. Obtain via
+     *                      {@link LogMinerColumnIndexes#fromConfig(io.debezium.connector.oracle.OracleConnectorConfig)}
+     *                      once at startup.
      * @return a populated instance of a LogMinerEventRow object.
      * @throws SQLException if there was a problem reading the result set
      */
-    public static LogMinerEventRow fromResultSet(ResultSet resultSet, OracleDatabaseSchema schema, OracleConnectorConfig connectorConfig) throws SQLException {
+    public static LogMinerEventRow fromResultSet(ResultSet resultSet, OracleDatabaseSchema schema,
+                                                 LogMinerColumnIndexes columnIndexes)
+            throws SQLException {
         LogMinerEventRow row = new LogMinerEventRow();
-        row.initializeFromResultSet(resultSet, connectorConfig.getCatalogName(), schema, connectorConfig.isLogMiningBufferTrackRsId());
+        row.initializeFromResultSet(resultSet, schema, columnIndexes);
         return row;
     }
 
     /**
-     * Initializes the instance from the JDBC {@link ResultSet}.
+     * Initializes the instance from the JDBC {@link ResultSet} using pre-computed column ordinals.
      *
      * @param resultSet the result set to be read, should never be {@code null}
-     * @param catalogName the catalog name, should never be {@code null}
      * @param schema the relational schema, can be {@code null}
-     * @param trackRsId whether to track the rollback segment id
+     * @param indexes the pre-computed column ordinals, should not be {@code null}
      * @throws SQLException if there was a problem reading the result set
      */
-    private void initializeFromResultSet(ResultSet resultSet, String catalogName, OracleDatabaseSchema schema, boolean trackRsId) throws SQLException {
-        // Initialize the state from the result set
-        this.scn = getScn(resultSet, SCN);
-        this.tableName = resultSet.getString(TABLE_NAME);
-        this.tablespaceName = resultSet.getString(TABLESPACE_NAME);
-        this.eventType = EventType.from(resultSet.getInt(OPERATION_CODE));
-        this.changeTime = getTime(resultSet, CHANGE_TIME);
+    private void initializeFromResultSet(ResultSet resultSet, OracleDatabaseSchema schema,
+                                         LogMinerColumnIndexes indexes)
+            throws SQLException {
+        // Fixed positions 1–9: always present, never shift
+        this.scn = getScn(resultSet, LogMinerColumnIndexes.SCN);
+        this.tableName = resultSet.getString(LogMinerColumnIndexes.TABLE_NAME);
+        this.tablespaceName = resultSet.getString(LogMinerColumnIndexes.SEG_OWNER);
+        this.eventType = EventType.from(resultSet.getInt(LogMinerColumnIndexes.OPERATION_CODE));
+        this.changeTime = getTime(resultSet, LogMinerColumnIndexes.TIMESTAMP);
         this.transactionId = getTransactionId(resultSet);
-        this.operation = resultSet.getString(OPERATION);
-        this.userName = resultSet.getString(USERNAME);
-        this.rowId = resultSet.getString(ROW_ID);
-        this.rollbackFlag = resultSet.getInt(ROLLBACK_FLAG) == 1;
-        this.rsId = trackRsId ? trim(resultSet.getString(RS_ID)) : null;
-        this.redoSql = getSqlRedo(resultSet);
-        this.status = resultSet.getInt(STATUS);
-        this.info = resultSet.getString(INFO);
-        this.ssn = resultSet.getLong(SSN);
-        this.thread = resultSet.getInt(THREAD);
-        this.objectId = resultSet.getLong(OBJECT_ID);
-        this.objectVersion = resultSet.getLong(OBJECT_VERSION);
-        this.dataObjectId = resultSet.getLong(OBJECT_DATA_ID);
-        this.clientId = resultSet.getString(CLIENT_ID);
-        this.startScn = getScn(resultSet, START_SCN);
-        this.commitScn = getScn(resultSet, COMMIT_SCN);
-        this.startTime = getTime(resultSet, START_TIMESTAMP);
-        this.commitTime = getTime(resultSet, COMMIT_TIMESTAMP);
-        this.transactionSequence = resultSet.getLong(SEQUENCE);
+        this.operation = resultSet.getString(LogMinerColumnIndexes.OPERATION);
+        // Variable positions and SQL redo: iterate over pre-built resolvers.
+        indexes.applyResolvers(this, resultSet);
         if (this.tableName != null) {
             if (schema != null) {
-                this.tableId = schema.resolveTableId(catalogName, tablespaceName, tableName);
+                this.tableId = schema.resolveTableId(indexes.getCatalogName(), tablespaceName, tableName);
             }
             else {
-                this.tableId = new TableId(catalogName, tablespaceName, tableName);
+                this.tableId = new TableId(indexes.getCatalogName(), tablespaceName, tableName);
             }
         }
     }
 
-    private String getTransactionId(ResultSet rs) throws SQLException {
-        byte[] result = rs.getBytes(TX_ID);
+    private static String getTransactionId(ResultSet rs) throws SQLException {
+        byte[] result = rs.getBytes(LogMinerColumnIndexes.XID);
         return result != null ? HexConverter.convertToHexString(result) : null;
     }
 
-    private Instant getTime(ResultSet rs, int columnIndex) throws SQLException {
+    private static Instant getTime(ResultSet rs, int columnIndex) throws SQLException {
         final Timestamp result = rs.getTimestamp(columnIndex, UTC_CALENDAR);
         return result != null ? result.toInstant() : null;
     }
 
-    private Scn getScn(ResultSet rs, int columnIndex) throws SQLException {
+    private static Scn getScn(ResultSet rs, int columnIndex) throws SQLException {
         final String scn = rs.getString(columnIndex);
         return Strings.isNullOrEmpty(scn) ? Scn.NULL : Scn.valueOf(scn);
     }
 
     private String getSqlRedo(ResultSet rs) throws SQLException {
-        int csf = rs.getInt(CSF);
+        int csf = rs.getInt(LogMinerColumnIndexes.CSF);
         // 0 - indicates SQL_REDO is contained within the same row
         if (csf == 0) {
-            return rs.getString(SQL_REDO);
+            return rs.getString(LogMinerColumnIndexes.SQL_REDO);
         }
-        int operationCode = rs.getInt(OPERATION_CODE);
-        StringBuilder result = new StringBuilder(rs.getString(SQL_REDO));
+        int operationCode = rs.getInt(LogMinerColumnIndexes.OPERATION_CODE);
+        StringBuilder result = new StringBuilder(rs.getString(LogMinerColumnIndexes.SQL_REDO));
 
         long sqlLimitCounter = 0;
         // 1 - indicates that either SQL_REDO is greater than 4000 bytes in size and is continued in
@@ -324,9 +374,9 @@ public class LogMinerEventRow {
                 throw new LogMinerEventRowTooLargeException(tableName, sqlLimitCounter * 4000, scn);
             }
 
-            csf = rs.getInt(CSF);
-            operationCode = rs.getInt(OPERATION_CODE);
-            result.append(rs.getString(SQL_REDO));
+            csf = rs.getInt(LogMinerColumnIndexes.CSF);
+            operationCode = rs.getInt(LogMinerColumnIndexes.OPERATION_CODE);
+            result.append(rs.getString(LogMinerColumnIndexes.SQL_REDO));
         }
 
         return result.toString();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/AnyLogMinerAdapterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/AnyLogMinerAdapterIT.java
@@ -23,6 +23,7 @@ import io.debezium.connector.oracle.CommitScn;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.SourceInfo;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
@@ -125,6 +126,215 @@ public class AnyLogMinerAdapterIT extends AbstractAsyncEngineConnectorTest {
         }
         finally {
             TestHelper.dropTable(connection, "dbz9636");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void shouldTrackUsername() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.USERNAME_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.USERNAME_KEY)).isNotNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void shouldNotTrackUsername() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.USERNAME_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.USERNAME_KEY)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void shouldTrackCommitTimestamp() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.COMMIT_TIMESTAMP_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.COMMIT_TIMESTAMP_KEY)).isNotNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_UNBUFFERED, reason = "Buffered adapter populates commit_ts_ms from CHANGE_TIME regardless of tracking flag")
+    public void shouldNotTrackCommitTimestamp() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.COMMIT_TIMESTAMP_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.COMMIT_TIMESTAMP_KEY)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void shouldTrackStartTimestamp() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.START_TIMESTAMP_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.START_TIMESTAMP_KEY)).isNotNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_UNBUFFERED, reason = "Buffered adapter populates start_ts_ms from CHANGE_TIME regardless of tracking flag")
+    public void shouldNotTrackStartTimestamp() throws Exception {
+        TestHelper.dropTable(connection, "dbz1663");
+        try {
+            connection.execute("CREATE TABLE dbz1663 (id number(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1663");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1663")
+                    .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute("INSERT INTO dbz1663 (id,data) values (1, 'test')");
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> tableRecords = records.recordsForTopic("server1.DEBEZIUM.DBZ1663");
+            assertThat(tableRecords).hasSize(1);
+
+            VerifyRecord.isValidInsert(tableRecords.get(0), "ID", 1);
+
+            Struct source = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.SOURCE);
+            assertThat(source.schema().field(SourceInfo.START_TIMESTAMP_KEY)).isNotNull();
+            assertThat(source.get(SourceInfo.START_TIMESTAMP_KEY)).isNull();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1663");
         }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+
+/**
+ * Unit tests for {@link LogMinerColumnIndexes}.
+ *
+ * <p>These tests verify that the pre-computed column ordinals produced by
+ * {@link LogMinerColumnIndexes#fromConfig(OracleConnectorConfig)} align exactly with the column
+ * ordering defined in {@link AbstractLogMinerQueryBuilder#buildColumnList()}.
+ *
+ * <p>Fixed positions 1–9 are constants and never shift; they are tested here for completeness
+ * but would never regress unless changed deliberately. Positions 10+ can shift when optional
+ * columns are omitted via configuration flags, so every combination of omission is exercised.
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
+public class LogMinerColumnIndexesTest {
+
+    // Fixed column constant values
+
+    @Test
+    void fixedColumnConstantsShouldMatchExpectedOrdinals() {
+        assertThat(LogMinerColumnIndexes.SCN).isEqualTo(1);
+        assertThat(LogMinerColumnIndexes.SQL_REDO).isEqualTo(2);
+        assertThat(LogMinerColumnIndexes.OPERATION_CODE).isEqualTo(3);
+        assertThat(LogMinerColumnIndexes.TIMESTAMP).isEqualTo(4);
+        assertThat(LogMinerColumnIndexes.XID).isEqualTo(5);
+        assertThat(LogMinerColumnIndexes.CSF).isEqualTo(6);
+        assertThat(LogMinerColumnIndexes.TABLE_NAME).isEqualTo(7);
+        assertThat(LogMinerColumnIndexes.SEG_OWNER).isEqualTo(8);
+        assertThat(LogMinerColumnIndexes.OPERATION).isEqualTo(9);
+    }
+
+    // All optional columns enabled (baseline)
+
+    @Test
+    void allTrackingEnabledShouldProduceBaselineOrdinals() {
+        LogMinerColumnIndexes idx = fromDefaultConfig();
+
+        // Optional columns present
+        assertThat(idx.getUsernameIndex()).isEqualTo(10);
+        assertThat(idx.getRsIdIndex()).isEqualTo(13);
+        assertThat(idx.getClientIdIndex()).isEqualTo(21);
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(25);
+
+        // Mandatory columns at their full-set positions
+        assertThat(idx.getRowIdIndex()).isEqualTo(11);
+        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
+        assertThat(idx.getStatusIndex()).isEqualTo(14);
+        assertThat(idx.getInfoIndex()).isEqualTo(15);
+        assertThat(idx.getSsnIndex()).isEqualTo(16);
+        assertThat(idx.getThreadIndex()).isEqualTo(17);
+        assertThat(idx.getObjectIdIndex()).isEqualTo(18);
+        assertThat(idx.getObjectVersionIndex()).isEqualTo(19);
+        assertThat(idx.getDataObjectIdIndex()).isEqualTo(20);
+        assertThat(idx.getStartScnIndex()).isEqualTo(22);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(23);
+        assertThat(idx.getSequenceIndex()).isEqualTo(26);
+    }
+
+    // USERNAME disabled
+
+    @Test
+    void usernameDisabledShouldShiftSubsequentColumns() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false);
+
+        assertThat(idx.getUsernameIndex()).isNull();
+
+        // Columns after USERNAME each shift down by 1
+        assertThat(idx.getRowIdIndex()).isEqualTo(10);
+        assertThat(idx.getRollbackFlagIndex()).isEqualTo(11);
+        assertThat(idx.getRsIdIndex()).isEqualTo(12);
+        assertThat(idx.getStatusIndex()).isEqualTo(13);
+        assertThat(idx.getInfoIndex()).isEqualTo(14);
+        assertThat(idx.getSsnIndex()).isEqualTo(15);
+        assertThat(idx.getThreadIndex()).isEqualTo(16);
+        assertThat(idx.getObjectIdIndex()).isEqualTo(17);
+        assertThat(idx.getObjectVersionIndex()).isEqualTo(18);
+        assertThat(idx.getDataObjectIdIndex()).isEqualTo(19);
+        assertThat(idx.getClientIdIndex()).isEqualTo(20);
+        assertThat(idx.getStartScnIndex()).isEqualTo(21);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+    }
+
+    // RS_ID disabled
+
+    @Test
+    void rsIdDisabledShouldShiftColumnsAfterRollback() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false);
+
+        // Columns before RS_ID are unaffected
+        assertThat(idx.getUsernameIndex()).isEqualTo(10);
+        assertThat(idx.getRowIdIndex()).isEqualTo(11);
+        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
+        assertThat(idx.getRsIdIndex()).isNull();
+
+        // Everything from STATUS onwards shifts by 1
+        assertThat(idx.getStatusIndex()).isEqualTo(13);
+        assertThat(idx.getInfoIndex()).isEqualTo(14);
+        assertThat(idx.getSsnIndex()).isEqualTo(15);
+        assertThat(idx.getThreadIndex()).isEqualTo(16);
+        assertThat(idx.getObjectIdIndex()).isEqualTo(17);
+        assertThat(idx.getObjectVersionIndex()).isEqualTo(18);
+        assertThat(idx.getDataObjectIdIndex()).isEqualTo(19);
+        assertThat(idx.getClientIdIndex()).isEqualTo(20);
+        assertThat(idx.getStartScnIndex()).isEqualTo(21);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+    }
+
+    // CLIENT_ID disabled
+
+    @Test
+    void clientIdDisabledShouldShiftColumnsAfterDataObjectId() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false);
+
+        // Columns before CLIENT_ID are unaffected
+        assertThat(idx.getUsernameIndex()).isEqualTo(10);
+        assertThat(idx.getRowIdIndex()).isEqualTo(11);
+        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
+        assertThat(idx.getRsIdIndex()).isEqualTo(13);
+        assertThat(idx.getStatusIndex()).isEqualTo(14);
+        assertThat(idx.getInfoIndex()).isEqualTo(15);
+        assertThat(idx.getSsnIndex()).isEqualTo(16);
+        assertThat(idx.getThreadIndex()).isEqualTo(17);
+        assertThat(idx.getObjectIdIndex()).isEqualTo(18);
+        assertThat(idx.getObjectVersionIndex()).isEqualTo(19);
+        assertThat(idx.getDataObjectIdIndex()).isEqualTo(20);
+        assertThat(idx.getClientIdIndex()).isNull();
+
+        // Everything from START_SCN onwards shifts by 1
+        assertThat(idx.getStartScnIndex()).isEqualTo(21);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+    }
+
+    // START_TIMESTAMP disabled
+
+    @Test
+    void startTimestampDisabledShouldShiftCommitTimestampAndSequence() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false);
+
+        // All positions up to COMMIT_SCN are unaffected
+        assertThat(idx.getStartScnIndex()).isEqualTo(22);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(23);
+        assertThat(idx.getStartTimestampIndex()).isNull();
+
+        // COMMIT_TIMESTAMP and SEQUENCE each shift by 1
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+    }
+
+    // COMMIT_TIMESTAMP disabled
+
+    @Test
+    void commitTimestampDisabledShouldShiftSequence() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false);
+
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(24);
+        assertThat(idx.getCommitTimestampIndex()).isNull();
+        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+    }
+
+    // All optional columns disabled
+
+    @Test
+    void allOptionalColumnsDisabledShouldProduceMinimumPositions() {
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig()
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false)
+                        .build());
+        LogMinerColumnIndexes idx = LogMinerColumnIndexes.fromConfig(config);
+
+        // All optional indexes null
+        assertThat(idx.getUsernameIndex()).isNull();
+        assertThat(idx.getRsIdIndex()).isNull();
+        assertThat(idx.getClientIdIndex()).isNull();
+        assertThat(idx.getStartTimestampIndex()).isNull();
+        assertThat(idx.getCommitTimestampIndex()).isNull();
+
+        // Mandatory columns compressed to minimum positions (26 - 5 = 21 columns total)
+        assertThat(idx.getRowIdIndex()).isEqualTo(10);
+        assertThat(idx.getRollbackFlagIndex()).isEqualTo(11);
+        assertThat(idx.getStatusIndex()).isEqualTo(12);
+        assertThat(idx.getInfoIndex()).isEqualTo(13);
+        assertThat(idx.getSsnIndex()).isEqualTo(14);
+        assertThat(idx.getThreadIndex()).isEqualTo(15);
+        assertThat(idx.getObjectIdIndex()).isEqualTo(16);
+        assertThat(idx.getObjectVersionIndex()).isEqualTo(17);
+        assertThat(idx.getDataObjectIdIndex()).isEqualTo(18);
+        assertThat(idx.getStartScnIndex()).isEqualTo(19);
+        assertThat(idx.getCommitScnIndex()).isEqualTo(20);
+        assertThat(idx.getSequenceIndex()).isEqualTo(21);
+    }
+
+    // Resolver counts — verifies buildResolvers mirrors the column list
+
+    // 12 mandatory cols (rowId, rollback, status, info, ssn, thread, objectId, objectVersion,
+    // dataObjectId, startScn, commitScn, sequence) + 5 optional + 1 getSqlRedo = 18 total.
+    private static final int RESOLVER_COUNT_ALL_ENABLED = 18;
+    // With all 5 optional disabled: 18 - 5 = 13.
+    private static final int RESOLVER_COUNT_ALL_DISABLED = 13;
+    // With exactly one optional disabled: 18 - 1 = 17.
+    private static final int RESOLVER_COUNT_ONE_DISABLED = 17;
+
+    @Test
+    void allTrackingEnabledShouldProduceFullResolverArray() {
+        assertThat(fromDefaultConfig().getResolverCount()).isEqualTo(RESOLVER_COUNT_ALL_ENABLED);
+    }
+
+    @Test
+    void allOptionalColumnsDisabledShouldProduceMinimumResolverArray() {
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig()
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false)
+                        .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false)
+                        .build());
+        assertThat(LogMinerColumnIndexes.fromConfig(config).getResolverCount()).isEqualTo(RESOLVER_COUNT_ALL_DISABLED);
+    }
+
+    @Test
+    void usernameDisabledShouldReduceResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ONE_DISABLED);
+    }
+
+    @Test
+    void rsIdDisabledShouldReduceResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false)
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ONE_DISABLED);
+    }
+
+    @Test
+    void clientIdDisabledShouldReduceResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ONE_DISABLED);
+    }
+
+    @Test
+    void startTimestampDisabledShouldReduceResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false)
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ONE_DISABLED);
+    }
+
+    @Test
+    void commitTimestampDisabledShouldReduceResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false)
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ONE_DISABLED);
+    }
+
+    // Helpers
+
+    private static LogMinerColumnIndexes fromDefaultConfig() {
+        return LogMinerColumnIndexes.fromConfig(new OracleConnectorConfig(TestHelper.defaultConfig().build()));
+    }
+
+    private static LogMinerColumnIndexes fromConfig(io.debezium.config.Field field, Object value) {
+        return LogMinerColumnIndexes.fromConfig(
+                new OracleConnectorConfig(TestHelper.defaultConfig().with(field, value).build()));
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
@@ -20,14 +20,12 @@ import io.debezium.connector.oracle.util.TestHelper;
  * {@link LogMinerColumnIndexes#fromConfig(OracleConnectorConfig)} align exactly with the column
  * ordering defined in {@link AbstractLogMinerQueryBuilder#buildColumnList()}.
  *
- * <p>Fixed positions 1–9 are constants and never shift; they are tested here for completeness
+ * <p>Fixed positions 1–21 are constants and never shift; they are tested here for completeness
  * but would never regress unless changed deliberately. Positions 10+ can shift when optional
  * columns are omitted via configuration flags, so every combination of omission is exercised.
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
 public class LogMinerColumnIndexesTest {
-
-    // Fixed column constant values
 
     @Test
     void fixedColumnConstantsShouldMatchExpectedOrdinals() {
@@ -40,147 +38,81 @@ public class LogMinerColumnIndexesTest {
         assertThat(LogMinerColumnIndexes.TABLE_NAME).isEqualTo(7);
         assertThat(LogMinerColumnIndexes.SEG_OWNER).isEqualTo(8);
         assertThat(LogMinerColumnIndexes.OPERATION).isEqualTo(9);
+        assertThat(LogMinerColumnIndexes.ROW_ID).isEqualTo(10);
+        assertThat(LogMinerColumnIndexes.ROLLBACK).isEqualTo(11);
+        assertThat(LogMinerColumnIndexes.STATUS).isEqualTo(12);
+        assertThat(LogMinerColumnIndexes.INFO).isEqualTo(13);
+        assertThat(LogMinerColumnIndexes.SSN).isEqualTo(14);
+        assertThat(LogMinerColumnIndexes.THREAD).isEqualTo(15);
+        assertThat(LogMinerColumnIndexes.DATA_OBJ).isEqualTo(16);
+        assertThat(LogMinerColumnIndexes.DATA_OBJV).isEqualTo(17);
+        assertThat(LogMinerColumnIndexes.DATA_OBJD).isEqualTo(18);
+        assertThat(LogMinerColumnIndexes.START_SCN).isEqualTo(19);
+        assertThat(LogMinerColumnIndexes.COMMIT_SCN).isEqualTo(20);
+        assertThat(LogMinerColumnIndexes.SEQUENCE).isEqualTo(21);
     }
-
-    // All optional columns enabled (baseline)
 
     @Test
     void allTrackingEnabledShouldProduceBaselineOrdinals() {
         LogMinerColumnIndexes idx = fromDefaultConfig();
 
         // Optional columns present
-        assertThat(idx.getUsernameIndex()).isEqualTo(10);
-        assertThat(idx.getRsIdIndex()).isEqualTo(13);
-        assertThat(idx.getClientIdIndex()).isEqualTo(21);
-        assertThat(idx.getStartTimestampIndex()).isEqualTo(24);
-        assertThat(idx.getCommitTimestampIndex()).isEqualTo(25);
-
-        // Mandatory columns at their full-set positions
-        assertThat(idx.getRowIdIndex()).isEqualTo(11);
-        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
-        assertThat(idx.getStatusIndex()).isEqualTo(14);
-        assertThat(idx.getInfoIndex()).isEqualTo(15);
-        assertThat(idx.getSsnIndex()).isEqualTo(16);
-        assertThat(idx.getThreadIndex()).isEqualTo(17);
-        assertThat(idx.getObjectIdIndex()).isEqualTo(18);
-        assertThat(idx.getObjectVersionIndex()).isEqualTo(19);
-        assertThat(idx.getDataObjectIdIndex()).isEqualTo(20);
-        assertThat(idx.getStartScnIndex()).isEqualTo(22);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(23);
-        assertThat(idx.getSequenceIndex()).isEqualTo(26);
+        assertThat(idx.getStartTimestampIndex()).isEqualTo(22);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(23);
+        assertThat(idx.getRsIdIndex()).isEqualTo(24);
+        assertThat(idx.getUsernameIndex()).isEqualTo(25);
+        assertThat(idx.getClientIdIndex()).isEqualTo(26);
     }
-
-    // USERNAME disabled
 
     @Test
     void usernameDisabledShouldShiftSubsequentColumns() {
         LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false);
 
-        assertThat(idx.getUsernameIndex()).isNull();
-
         // Columns after USERNAME each shift down by 1
-        assertThat(idx.getRowIdIndex()).isEqualTo(10);
-        assertThat(idx.getRollbackFlagIndex()).isEqualTo(11);
-        assertThat(idx.getRsIdIndex()).isEqualTo(12);
-        assertThat(idx.getStatusIndex()).isEqualTo(13);
-        assertThat(idx.getInfoIndex()).isEqualTo(14);
-        assertThat(idx.getSsnIndex()).isEqualTo(15);
-        assertThat(idx.getThreadIndex()).isEqualTo(16);
-        assertThat(idx.getObjectIdIndex()).isEqualTo(17);
-        assertThat(idx.getObjectVersionIndex()).isEqualTo(18);
-        assertThat(idx.getDataObjectIdIndex()).isEqualTo(19);
-        assertThat(idx.getClientIdIndex()).isEqualTo(20);
-        assertThat(idx.getStartScnIndex()).isEqualTo(21);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
-        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
-        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
-        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+        assertThat(idx.getUsernameIndex()).isNull();
+        assertThat(idx.getClientIdIndex()).isEqualTo(25);
     }
-
-    // RS_ID disabled
 
     @Test
     void rsIdDisabledShouldShiftColumnsAfterRollback() {
         LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false);
 
         // Columns before RS_ID are unaffected
-        assertThat(idx.getUsernameIndex()).isEqualTo(10);
-        assertThat(idx.getRowIdIndex()).isEqualTo(11);
-        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
         assertThat(idx.getRsIdIndex()).isNull();
-
-        // Everything from STATUS onwards shifts by 1
-        assertThat(idx.getStatusIndex()).isEqualTo(13);
-        assertThat(idx.getInfoIndex()).isEqualTo(14);
-        assertThat(idx.getSsnIndex()).isEqualTo(15);
-        assertThat(idx.getThreadIndex()).isEqualTo(16);
-        assertThat(idx.getObjectIdIndex()).isEqualTo(17);
-        assertThat(idx.getObjectVersionIndex()).isEqualTo(18);
-        assertThat(idx.getDataObjectIdIndex()).isEqualTo(19);
-        assertThat(idx.getClientIdIndex()).isEqualTo(20);
-        assertThat(idx.getStartScnIndex()).isEqualTo(21);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
-        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
-        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
-        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+        assertThat(idx.getUsernameIndex()).isEqualTo(24);
+        assertThat(idx.getClientIdIndex()).isEqualTo(25);
     }
-
-    // CLIENT_ID disabled
 
     @Test
     void clientIdDisabledShouldShiftColumnsAfterDataObjectId() {
         LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false);
 
         // Columns before CLIENT_ID are unaffected
-        assertThat(idx.getUsernameIndex()).isEqualTo(10);
-        assertThat(idx.getRowIdIndex()).isEqualTo(11);
-        assertThat(idx.getRollbackFlagIndex()).isEqualTo(12);
-        assertThat(idx.getRsIdIndex()).isEqualTo(13);
-        assertThat(idx.getStatusIndex()).isEqualTo(14);
-        assertThat(idx.getInfoIndex()).isEqualTo(15);
-        assertThat(idx.getSsnIndex()).isEqualTo(16);
-        assertThat(idx.getThreadIndex()).isEqualTo(17);
-        assertThat(idx.getObjectIdIndex()).isEqualTo(18);
-        assertThat(idx.getObjectVersionIndex()).isEqualTo(19);
-        assertThat(idx.getDataObjectIdIndex()).isEqualTo(20);
         assertThat(idx.getClientIdIndex()).isNull();
-
-        // Everything from START_SCN onwards shifts by 1
-        assertThat(idx.getStartScnIndex()).isEqualTo(21);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(22);
-        assertThat(idx.getStartTimestampIndex()).isEqualTo(23);
-        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
-        assertThat(idx.getSequenceIndex()).isEqualTo(25);
     }
-
-    // START_TIMESTAMP disabled
 
     @Test
     void startTimestampDisabledShouldShiftCommitTimestampAndSequence() {
         LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false);
 
-        // All positions up to COMMIT_SCN are unaffected
-        assertThat(idx.getStartScnIndex()).isEqualTo(22);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(23);
+        // All positions up to START_TIMESTAMP are unaffected
         assertThat(idx.getStartTimestampIndex()).isNull();
-
-        // COMMIT_TIMESTAMP and SEQUENCE each shift by 1
-        assertThat(idx.getCommitTimestampIndex()).isEqualTo(24);
-        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+        assertThat(idx.getCommitTimestampIndex()).isEqualTo(22);
+        assertThat(idx.getRsIdIndex()).isEqualTo(23);
+        assertThat(idx.getUsernameIndex()).isEqualTo(24);
+        assertThat(idx.getClientIdIndex()).isEqualTo(25);
     }
-
-    // COMMIT_TIMESTAMP disabled
 
     @Test
     void commitTimestampDisabledShouldShiftSequence() {
         LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false);
 
-        assertThat(idx.getStartTimestampIndex()).isEqualTo(24);
+        // All positions up to COMMIT_TIMESTAMP are unaffected
         assertThat(idx.getCommitTimestampIndex()).isNull();
-        assertThat(idx.getSequenceIndex()).isEqualTo(25);
+        assertThat(idx.getRsIdIndex()).isEqualTo(23);
+        assertThat(idx.getUsernameIndex()).isEqualTo(24);
+        assertThat(idx.getClientIdIndex()).isEqualTo(25);
     }
-
-    // All optional columns disabled
 
     @Test
     void allOptionalColumnsDisabledShouldProduceMinimumPositions() {
@@ -194,37 +126,19 @@ public class LogMinerColumnIndexesTest {
                         .build());
         LogMinerColumnIndexes idx = LogMinerColumnIndexes.fromConfig(config);
 
-        // All optional indexes null
+        // All optional indexes null, all fixed columns are unaffected
         assertThat(idx.getUsernameIndex()).isNull();
         assertThat(idx.getRsIdIndex()).isNull();
         assertThat(idx.getClientIdIndex()).isNull();
         assertThat(idx.getStartTimestampIndex()).isNull();
         assertThat(idx.getCommitTimestampIndex()).isNull();
-
-        // Mandatory columns compressed to minimum positions (26 - 5 = 21 columns total)
-        assertThat(idx.getRowIdIndex()).isEqualTo(10);
-        assertThat(idx.getRollbackFlagIndex()).isEqualTo(11);
-        assertThat(idx.getStatusIndex()).isEqualTo(12);
-        assertThat(idx.getInfoIndex()).isEqualTo(13);
-        assertThat(idx.getSsnIndex()).isEqualTo(14);
-        assertThat(idx.getThreadIndex()).isEqualTo(15);
-        assertThat(idx.getObjectIdIndex()).isEqualTo(16);
-        assertThat(idx.getObjectVersionIndex()).isEqualTo(17);
-        assertThat(idx.getDataObjectIdIndex()).isEqualTo(18);
-        assertThat(idx.getStartScnIndex()).isEqualTo(19);
-        assertThat(idx.getCommitScnIndex()).isEqualTo(20);
-        assertThat(idx.getSequenceIndex()).isEqualTo(21);
     }
 
     // Resolver counts — verifies buildResolvers mirrors the column list
 
-    // 12 mandatory cols (rowId, rollback, status, info, ssn, thread, objectId, objectVersion,
-    // dataObjectId, startScn, commitScn, sequence) + 5 optional + 1 getSqlRedo = 18 total.
-    private static final int RESOLVER_COUNT_ALL_ENABLED = 18;
-    // With all 5 optional disabled: 18 - 5 = 13.
-    private static final int RESOLVER_COUNT_ALL_DISABLED = 13;
-    // With exactly one optional disabled: 18 - 1 = 17.
-    private static final int RESOLVER_COUNT_ONE_DISABLED = 17;
+    private static final int RESOLVER_COUNT_ALL_ENABLED = 5;
+    private static final int RESOLVER_COUNT_ALL_DISABLED = 0;
+    private static final int RESOLVER_COUNT_ONE_DISABLED = RESOLVER_COUNT_ALL_ENABLED - 1;
 
     @Test
     void allTrackingEnabledShouldProduceFullResolverArray() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
@@ -51,7 +51,7 @@ public class LogMinerEventRowTest {
     void testChangeTime() throws Exception {
         when(resultSet.getTimestamp(eq(4), any(Calendar.class))).thenReturn(new Timestamp(1000L));
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getChangeTime()).isEqualTo(Instant.ofEpochMilli(1000L));
 
         when(resultSet.getTimestamp(eq(4), any(Calendar.class))).thenThrow(SQLException.class);
@@ -64,7 +64,7 @@ public class LogMinerEventRowTest {
     void testEventType() throws Exception {
         when(resultSet.getInt(3)).thenReturn(EventType.UPDATE.getValue());
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getEventType()).isEqualTo(EventType.UPDATE);
         verify(resultSet).getInt(3);
 
@@ -78,7 +78,7 @@ public class LogMinerEventRowTest {
     void testTableName() throws Exception {
         when(resultSet.getString(7)).thenReturn("TABLENAME");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getTableName()).isEqualTo("TABLENAME");
         verify(resultSet).getString(7);
 
@@ -92,7 +92,7 @@ public class LogMinerEventRowTest {
     void testTablespaceName() throws Exception {
         when(resultSet.getString(8)).thenReturn("DEBEZIUM");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getTablespaceName()).isEqualTo("DEBEZIUM");
         verify(resultSet).getString(8);
 
@@ -106,7 +106,7 @@ public class LogMinerEventRowTest {
     void testScn() throws Exception {
         when(resultSet.getString(1)).thenReturn("12345");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getScn()).isEqualTo(Scn.valueOf(12345L));
         verify(resultSet).getString(1);
 
@@ -120,7 +120,7 @@ public class LogMinerEventRowTest {
     void testTransactionId() throws Exception {
         when(resultSet.getBytes(5)).thenReturn("tr_id".getBytes(StandardCharsets.UTF_8));
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getTransactionId()).isEqualToIgnoringCase("74725F6964");
         verify(resultSet).getBytes(5);
 
@@ -135,7 +135,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getString(8)).thenReturn("SCHEMA");
         when(resultSet.getString(7)).thenReturn("TABLE");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getTableId().toString()).isEqualTo(TestHelper.getDatabaseName() + ".SCHEMA.TABLE");
         verify(resultSet).getString(8);
 
@@ -149,7 +149,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getString(8)).thenReturn("Schema");
         when(resultSet.getString(7)).thenReturn("table");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getTableId().toString()).isEqualTo(TestHelper.getDatabaseName() + ".Schema.table");
         verify(resultSet).getString(8);
 
@@ -162,7 +162,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getInt(6)).thenReturn(0);
         when(resultSet.getString(2)).thenReturn("short_sql");
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getRedoSql()).isEqualTo("short_sql");
         verify(resultSet).getInt(6);
         verify(resultSet).getString(2);
@@ -170,7 +170,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getInt(6)).thenReturn(1).thenReturn(0);
         when(resultSet.getString(2)).thenReturn("long").thenReturn("_sql");
 
-        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getRedoSql()).isEqualTo("long_sql");
         verify(resultSet, times(3)).getInt(6);
         verify(resultSet, times(3)).getString(2);
@@ -181,7 +181,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getString(2)).thenReturn(new String(chars));
         when(resultSet.getInt(6)).thenReturn(1, 1, 1, 1, 1, 1, 1, 1, 1, 0);
 
-        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getRedoSql().length()).isEqualTo(40_000);
         verify(resultSet, times(13)).getInt(6);
         verify(resultSet, times(13)).getString(2);
@@ -189,7 +189,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getInt(6)).thenReturn(0);
         when(resultSet.getString(2)).thenReturn(null);
 
-        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getRedoSql()).isNull();
         verify(resultSet, times(14)).getInt(6);
         verify(resultSet, times(14)).getString(2);
@@ -210,7 +210,7 @@ public class LogMinerEventRowTest {
         when(resultSet.getLong(19)).thenReturn(20L);
         when(resultSet.getLong(20)).thenReturn(2345678901L);
 
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultConfig());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getObjectId()).isEqualTo(1234567890L);
         assertThat(row.getObjectVersion()).isEqualTo(20L);
         assertThat(row.getDataObjectId()).isEqualTo(2345678901L);
@@ -219,13 +219,159 @@ public class LogMinerEventRowTest {
         verify(resultSet).getLong(20);
     }
 
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldTrackUsernameWhenEnabled() throws Exception {
+        when(resultSet.getString(10)).thenReturn("testuser");
+
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
+        assertThat(row.getUserName()).isEqualTo("testuser");
+        verify(resultSet).getString(10);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldNotTrackUsernameWhenDisabled() throws Exception {
+        when(resultSet.getString(10)).thenReturn("testuser");
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getUserName()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldTrackClientIdWhenEnabled() throws Exception {
+        when(resultSet.getString(21)).thenReturn("testclient");
+
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
+        assertThat(row.getClientId()).isEqualTo("testclient");
+        verify(resultSet).getString(21);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldNotTrackClientIdWhenDisabled() throws Exception {
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getClientId()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldTrackCommitTimestampWhenEnabled() throws Exception {
+        when(resultSet.getTimestamp(eq(25), any(Calendar.class))).thenReturn(new Timestamp(2000L));
+
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
+        assertThat(row.getCommitTime()).isEqualTo(Instant.ofEpochMilli(2000L));
+        verify(resultSet).getTimestamp(eq(25), any(Calendar.class));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldNotTrackCommitTimestampWhenDisabled() throws Exception {
+        when(resultSet.getTimestamp(eq(25), any(Calendar.class))).thenReturn(new Timestamp(2000L));
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getCommitTime()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldTrackStartTimestampWhenEnabled() throws Exception {
+        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(3000L));
+
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
+        assertThat(row.getStartTime()).isEqualTo(Instant.ofEpochMilli(3000L));
+        verify(resultSet).getTimestamp(eq(24), any(Calendar.class));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldNotTrackStartTimestampWhenDisabled() throws Exception {
+        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(3000L));
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getStartTime()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldShiftRowIdOrdinalWhenUsernameNotTracked() throws Exception {
+        // When USERNAME is excluded from the SELECT, ROW_ID shifts from position 11 to 10
+        when(resultSet.getString(10)).thenReturn("shifted-row-id");
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getRowId()).isEqualTo("shifted-row-id");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldShiftStatusOrdinalWhenRsIdNotTracked() throws Exception {
+        // When RS_ID is excluded from the SELECT, STATUS shifts from position 14 to 13
+        when(resultSet.getInt(13)).thenReturn(2);
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.hasErrorStatus()).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldShiftStartScnOrdinalWhenClientIdNotTracked() throws Exception {
+        // When CLIENT_ID is excluded from the SELECT, START_SCN shifts from position 22 to 21
+        when(resultSet.getString(21)).thenReturn("54321");
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getStartScn()).isEqualTo(Scn.valueOf(54321L));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldShiftCommitTimestampOrdinalWhenStartTimestampNotTracked() throws Exception {
+        // When START_TIMESTAMP is excluded from the SELECT, COMMIT_TIMESTAMP shifts from position 25 to 24
+        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(9999L));
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getCommitTime()).isEqualTo(Instant.ofEpochMilli(9999L));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    void shouldShiftSequenceOrdinalWhenCommitTimestampNotTracked() throws Exception {
+        // When COMMIT_TIMESTAMP is excluded from the SELECT, SEQUENCE# shifts from position 26 to 25
+        when(resultSet.getLong(25)).thenReturn(42L);
+
+        OracleConnectorConfig config = new OracleConnectorConfig(
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false).build());
+        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
+        assertThat(row.getTransactionSequence()).isEqualTo(42L);
+    }
+
     private static OracleConnectorConfig defaultConfig() {
         return new OracleConnectorConfig(TestHelper.defaultConfig().build());
     }
 
+    private static LogMinerColumnIndexes defaultIndexes() {
+        return LogMinerColumnIndexes.fromConfig(defaultConfig());
+    }
+
     private static <T extends Throwable, R> void assertThrows(ResultSet rs, Class<T> throwAs) {
         try {
-            LogMinerEventRow.fromResultSet(rs, null, defaultConfig());
+            LogMinerEventRow.fromResultSet(rs, null, defaultIndexes());
             fail("Should have thrown a " + throwAs.getSimpleName());
         }
         catch (Throwable t) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerEventRowTest.java
@@ -206,33 +206,33 @@ public class LogMinerEventRowTest {
     @Test
     @FixFor("DBZ-3401")
     public void testObjectIdAndVersionDetails() throws Exception {
-        when(resultSet.getLong(18)).thenReturn(1234567890L);
-        when(resultSet.getLong(19)).thenReturn(20L);
-        when(resultSet.getLong(20)).thenReturn(2345678901L);
+        when(resultSet.getLong(16)).thenReturn(1234567890L);
+        when(resultSet.getLong(17)).thenReturn(20L);
+        when(resultSet.getLong(18)).thenReturn(2345678901L);
 
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getObjectId()).isEqualTo(1234567890L);
         assertThat(row.getObjectVersion()).isEqualTo(20L);
         assertThat(row.getDataObjectId()).isEqualTo(2345678901L);
+        verify(resultSet).getLong(16);
+        verify(resultSet).getLong(17);
         verify(resultSet).getLong(18);
-        verify(resultSet).getLong(19);
-        verify(resultSet).getLong(20);
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldTrackUsernameWhenEnabled() throws Exception {
-        when(resultSet.getString(10)).thenReturn("testuser");
+        when(resultSet.getString(25)).thenReturn("testuser");
 
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getUserName()).isEqualTo("testuser");
-        verify(resultSet).getString(10);
+        verify(resultSet).getString(25);
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldNotTrackUsernameWhenDisabled() throws Exception {
-        when(resultSet.getString(10)).thenReturn("testuser");
+        when(resultSet.getString(25)).thenReturn("testuser");
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false).build());
@@ -243,11 +243,11 @@ public class LogMinerEventRowTest {
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldTrackClientIdWhenEnabled() throws Exception {
-        when(resultSet.getString(21)).thenReturn("testclient");
+        when(resultSet.getString(26)).thenReturn("testclient");
 
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getClientId()).isEqualTo("testclient");
-        verify(resultSet).getString(21);
+        verify(resultSet).getString(26);
     }
 
     @Test
@@ -262,17 +262,17 @@ public class LogMinerEventRowTest {
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldTrackCommitTimestampWhenEnabled() throws Exception {
-        when(resultSet.getTimestamp(eq(25), any(Calendar.class))).thenReturn(new Timestamp(2000L));
+        when(resultSet.getTimestamp(eq(23), any(Calendar.class))).thenReturn(new Timestamp(2000L));
 
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getCommitTime()).isEqualTo(Instant.ofEpochMilli(2000L));
-        verify(resultSet).getTimestamp(eq(25), any(Calendar.class));
+        verify(resultSet).getTimestamp(eq(23), any(Calendar.class));
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldNotTrackCommitTimestampWhenDisabled() throws Exception {
-        when(resultSet.getTimestamp(eq(25), any(Calendar.class))).thenReturn(new Timestamp(2000L));
+        when(resultSet.getTimestamp(eq(23), any(Calendar.class))).thenReturn(new Timestamp(2000L));
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false).build());
@@ -283,17 +283,17 @@ public class LogMinerEventRowTest {
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldTrackStartTimestampWhenEnabled() throws Exception {
-        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(3000L));
+        when(resultSet.getTimestamp(eq(22), any(Calendar.class))).thenReturn(new Timestamp(3000L));
 
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, defaultIndexes());
         assertThat(row.getStartTime()).isEqualTo(Instant.ofEpochMilli(3000L));
-        verify(resultSet).getTimestamp(eq(24), any(Calendar.class));
+        verify(resultSet).getTimestamp(eq(22), any(Calendar.class));
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldNotTrackStartTimestampWhenDisabled() throws Exception {
-        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(3000L));
+        when(resultSet.getTimestamp(eq(22), any(Calendar.class))).thenReturn(new Timestamp(3000L));
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false).build());
@@ -303,62 +303,50 @@ public class LogMinerEventRowTest {
 
     @Test
     @FixFor("debezium/dbz#1663")
-    void shouldShiftRowIdOrdinalWhenUsernameNotTracked() throws Exception {
-        // When USERNAME is excluded from the SELECT, ROW_ID shifts from position 11 to 10
-        when(resultSet.getString(10)).thenReturn("shifted-row-id");
+    void shouldShiftClientIdOrdinalWhenUsernameNotTracked() throws Exception {
+        // When USERNAME is excluded from the SELECT, CLIENT_ID shifts from position 26 to 25
+        when(resultSet.getString(25)).thenReturn("shifted-client-id");
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false).build());
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
-        assertThat(row.getRowId()).isEqualTo("shifted-row-id");
+        assertThat(row.getClientId()).isEqualTo("shifted-client-id");
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
-    void shouldShiftStatusOrdinalWhenRsIdNotTracked() throws Exception {
-        // When RS_ID is excluded from the SELECT, STATUS shifts from position 14 to 13
-        when(resultSet.getInt(13)).thenReturn(2);
+    void shouldShiftUserNameOrdinalWhenRsIdNotTracked() throws Exception {
+        // When RS_ID is excluded from the SELECT, USERNAME shifts from position 25 to 24
+        when(resultSet.getString(24)).thenReturn("shifted-username");
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, false).build());
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
-        assertThat(row.hasErrorStatus()).isTrue();
+        assertThat(row.getUserName()).isEqualTo("shifted-username");
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
-    void shouldShiftStartScnOrdinalWhenClientIdNotTracked() throws Exception {
-        // When CLIENT_ID is excluded from the SELECT, START_SCN shifts from position 22 to 21
-        when(resultSet.getString(21)).thenReturn("54321");
+    void shouldShiftRsIdOrdinalWhenCommitTimestampNotTracked() throws Exception {
+        // When COMMIT_TIMESTAMP is excluded from the SELECT, RS_ID shifts from position 24 to 23
+        when(resultSet.getString(23)).thenReturn("rs-id");
 
         OracleConnectorConfig config = new OracleConnectorConfig(
-                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false).build());
+                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false).build());
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
-        assertThat(row.getStartScn()).isEqualTo(Scn.valueOf(54321L));
+        assertThat(row.getRsId()).isEqualTo("rs-id");
     }
 
     @Test
     @FixFor("debezium/dbz#1663")
     void shouldShiftCommitTimestampOrdinalWhenStartTimestampNotTracked() throws Exception {
-        // When START_TIMESTAMP is excluded from the SELECT, COMMIT_TIMESTAMP shifts from position 25 to 24
-        when(resultSet.getTimestamp(eq(24), any(Calendar.class))).thenReturn(new Timestamp(9999L));
+        // When START_TIMESTAMP is excluded from the SELECT, COMMIT_TIMESTAMP shifts from position 23 to 22
+        when(resultSet.getTimestamp(eq(22), any(Calendar.class))).thenReturn(new Timestamp(9999L));
 
         OracleConnectorConfig config = new OracleConnectorConfig(
                 TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, false).build());
         LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
         assertThat(row.getCommitTime()).isEqualTo(Instant.ofEpochMilli(9999L));
-    }
-
-    @Test
-    @FixFor("debezium/dbz#1663")
-    void shouldShiftSequenceOrdinalWhenCommitTimestampNotTracked() throws Exception {
-        // When COMMIT_TIMESTAMP is excluded from the SELECT, SEQUENCE# shifts from position 26 to 25
-        when(resultSet.getLong(25)).thenReturn(42L);
-
-        OracleConnectorConfig config = new OracleConnectorConfig(
-                TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, false).build());
-        LogMinerEventRow row = LogMinerEventRow.fromResultSet(resultSet, null, LogMinerColumnIndexes.fromConfig(config));
-        assertThat(row.getTransactionSequence()).isEqualTo(42L);
     }
 
     private static OracleConnectorConfig defaultConfig() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -52,11 +52,6 @@ import io.debezium.util.Strings;
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
 public class LogMinerQueryBuilderTest {
 
-    private static final String LOG_MINER_QUERY_BASE = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS, INFO, SSN, " +
-            "THREAD#, DATA_OBJ#, DATA_OBJV#, DATA_OBJD#, CLIENT_ID, START_SCN, COMMIT_SCN, " +
-            "START_TIMESTAMP, COMMIT_TIMESTAMP, SEQUENCE# FROM V$LOGMNR_CONTENTS WHERE ";
-
     @Test
     void testLogMinerQueryFilterNone() {
         testLogMinerQueryFilterMode(LogMiningQueryFilterMode.NONE);
@@ -118,6 +113,47 @@ public class LogMinerQueryBuilderTest {
         assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START, false).build());
     }
 
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithUsernameNotTracked() {
+        assertQuery(new ConfigBuilder().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, "false"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithRsIdNotTracked() {
+        assertQuery(new ConfigBuilder().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, "false"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithClientIdNotTracked() {
+        assertQuery(new ConfigBuilder().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, "false"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithStartTimestampNotTracked() {
+        assertQuery(new ConfigBuilder().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, "false"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithCommitTimestampNotTracked() {
+        assertQuery(new ConfigBuilder().with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, "false"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1663")
+    public void testLogMinerQueryWithAllOptionalColumnsNotTracked() {
+        assertQuery(new ConfigBuilder()
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, "false")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_RS_ID, "false")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, "false")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_START_TIMESTAMP, "false")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP, "false"));
+    }
+
     private void testLogMinerQueryFilterMode(LogMiningQueryFilterMode mode) {
         // Default configuration
         assertQuery(getBuilderForMode(mode));
@@ -176,10 +212,51 @@ public class LogMinerQueryBuilderTest {
         assertThat(new BufferedLogMinerQueryBuilder(config).getQuery()).isEqualTo(getBufferedQuery(config));
     }
 
+    private String buildSelectColumns(OracleConnectorConfig config) {
+        final List<String> columns = new ArrayList<>();
+        columns.add("SCN");
+        columns.add("SQL_REDO");
+        columns.add("OPERATION_CODE");
+        columns.add("TIMESTAMP");
+        columns.add("XID");
+        columns.add("CSF");
+        columns.add("TABLE_NAME");
+        columns.add("SEG_OWNER");
+        columns.add("OPERATION");
+        if (config.isLogMiningBufferTrackUsername()) {
+            columns.add("USERNAME");
+        }
+        columns.add("ROW_ID");
+        columns.add("ROLLBACK");
+        if (config.isLogMiningBufferTrackRsId()) {
+            columns.add("RS_ID");
+        }
+        columns.add("STATUS");
+        columns.add("INFO");
+        columns.add("SSN");
+        columns.add("THREAD#");
+        columns.add("DATA_OBJ#");
+        columns.add("DATA_OBJV#");
+        columns.add("DATA_OBJD#");
+        if (config.isLogMiningBufferTrackClientId()) {
+            columns.add("CLIENT_ID");
+        }
+        columns.add("START_SCN");
+        columns.add("COMMIT_SCN");
+        if (config.isLogMiningBufferTrackStartTimestamp()) {
+            columns.add("START_TIMESTAMP");
+        }
+        if (config.isLogMiningBufferTrackCommitTimestamp()) {
+            columns.add("COMMIT_TIMESTAMP");
+        }
+        columns.add("SEQUENCE#");
+        return String.join(", ", columns) + " ";
+    }
+
     private String getBufferedQuery(OracleConnectorConfig config) {
         final String operationDdlPredicate = " OR (OPERATION_CODE = 5 AND INFO NOT LIKE 'INTERNAL DDL%')";
 
-        String query = LOG_MINER_QUERY_BASE;
+        String query = "SELECT " + buildSelectColumns(config) + "FROM V$LOGMNR_CONTENTS WHERE ";
 
         query += "SCN > ? AND SCN <= ?";
         query += getPdbPredicate(config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -214,6 +214,7 @@ public class LogMinerQueryBuilderTest {
 
     private String buildSelectColumns(OracleConnectorConfig config) {
         final List<String> columns = new ArrayList<>();
+        // Mandatory first
         columns.add("SCN");
         columns.add("SQL_REDO");
         columns.add("OPERATION_CODE");
@@ -223,14 +224,8 @@ public class LogMinerQueryBuilderTest {
         columns.add("TABLE_NAME");
         columns.add("SEG_OWNER");
         columns.add("OPERATION");
-        if (config.isLogMiningBufferTrackUsername()) {
-            columns.add("USERNAME");
-        }
         columns.add("ROW_ID");
         columns.add("ROLLBACK");
-        if (config.isLogMiningBufferTrackRsId()) {
-            columns.add("RS_ID");
-        }
         columns.add("STATUS");
         columns.add("INFO");
         columns.add("SSN");
@@ -238,18 +233,27 @@ public class LogMinerQueryBuilderTest {
         columns.add("DATA_OBJ#");
         columns.add("DATA_OBJV#");
         columns.add("DATA_OBJD#");
-        if (config.isLogMiningBufferTrackClientId()) {
-            columns.add("CLIENT_ID");
-        }
         columns.add("START_SCN");
         columns.add("COMMIT_SCN");
+        columns.add("SEQUENCE#");
+
+        // Optional added at the end
         if (config.isLogMiningBufferTrackStartTimestamp()) {
             columns.add("START_TIMESTAMP");
         }
         if (config.isLogMiningBufferTrackCommitTimestamp()) {
             columns.add("COMMIT_TIMESTAMP");
         }
-        columns.add("SEQUENCE#");
+        if (config.isLogMiningBufferTrackRsId()) {
+            columns.add("RS_ID");
+        }
+        if (config.isLogMiningBufferTrackUsername()) {
+            columns.add("USERNAME");
+        }
+        if (config.isLogMiningBufferTrackClientId()) {
+            columns.add("CLIENT_ID");
+        }
+
         return String.join(", ", columns) + " ";
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
@@ -376,7 +376,7 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
             Mockito.when(rs.getTimestamp(eq(4), any(Calendar.class))).thenReturn(Timestamp.valueOf(LocalDateTime.now()));
             Mockito.when(rs.getString(7)).thenReturn("ABC");
             Mockito.when(rs.getString(8)).thenReturn("DEBEZIUM");
-            Mockito.when(rs.getString(11)).thenReturn("AAAAAAAAAAAAAAAAAB");
+            Mockito.when(rs.getString(10)).thenReturn("AAAAAAAAAAAAAAAAAB");
 
             final PreparedStatement ps = Mockito.mock(PreparedStatement.class);
             Mockito.when(ps.executeQuery()).thenReturn(rs);

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4366,6 +4366,34 @@ endif::community[]
 When enabled, the transaction buffer will store rollback segment information for all change events, populating the value in the event's `source` information block.
 When disabled, the transaction buffer will not store the information, reducing the memory footprint, and excluding the field in the event's `source` information block.
 
+|[[oracle-property-log-mining-buffer-track-client-id]]<<oracle-property-log-mining-buffer-track-client-id, `+log.mining.buffer.track.client_id+`>>
+|`true`
+|Specifies whether the client identifier (`CLIENT_ID`) values are provided in change events.
+
+When enabled, the transaction buffer will store client identifier information for all change events, populating the value in the event's `source` information block.
+When disabled, the transaction buffer will not store the information, reducing the memory footprint, and the field will be excluded from the event's `source` information block.
+
+|[[oracle-property-log-mining-buffer-track-username]]<<oracle-property-log-mining-buffer-track-username, `+log.mining.buffer.track.username+`>>
+|`true`
+|Specifies whether the username (`USERNAME`) values are provided in change events.
+
+When enabled, the transaction buffer will store username information for all change events, populating the value in the event's `source` information block.
+When disabled, the transaction buffer will not store the information, reducing the memory footprint, and the field will be excluded from the event's `source` information block.
+
+|[[oracle-property-log-mining-buffer-track-commit-timestamp]]<<oracle-property-log-mining-buffer-track-commit-timestamp, `+log.mining.buffer.track.commit_timestamp+`>>
+|`true`
+|Specifies whether the commit timestamp (`COMMIT_TIMESTAMP`) values are provided in change events.
+
+When enabled, the transaction buffer will store commit timestamp information for all change events, populating the value in the event's `source` information block.
+When disabled, the transaction buffer will not store the information, reducing the memory footprint, and the field will be excluded from the event's `source` information block.
+
+|[[oracle-property-log-mining-buffer-track-start-timestamp]]<<oracle-property-log-mining-buffer-track-start-timestamp, `+log.mining.buffer.track.start_timestamp+`>>
+|`true`
+|Specifies whether the start timestamp (`START_TIMESTAMP`) values are provided in change events.
+
+When enabled, the transaction buffer will store start timestamp information for all change events, populating the value in the event's `source` information block.
+When disabled, the transaction buffer will not store the information, reducing the memory footprint, and the field will be excluded from the event's `source` information block.
+
 |[[oracle-property-log-mining-buffer-transaction-events-threshold]]<<oracle-property-log-mining-buffer-transaction-events-threshold, `+log.mining.buffer.transaction.events.threshold+`>>
 |`0`
 |The maximum number of events a transaction is capable of having in the transaction buffer.


### PR DESCRIPTION
Fixes debezium/dbz#1663

## Description
Relates to this conversation [here](https://debezium.zulipchat.com/#narrow/channel/348250-community-oracle/topic/ROWID.20based.20snapshot.20for.20oracle)

The goal here is to allow a user to optionally exclude certain metadata columns.  This means excluding it from the source_info block as well as the V$LOGMNR_CONTENTS query.  The goal of the PR is to prevent the need for a hardcoded list by using a new ResultSetValueResolver.  For every row fetched, it simply loops through this pre-built array to map the ResultSet values into the LogMinerEventRow

I've currently focused on implementing this for metadata columns that appear to be the most impactful from my own testing.  I've found removing all of the optional columns leads to ~3% performance improvement.  I've also done testing vs current main branch and I don't believe I've added any overhead to the existing process.

Note:  This has also been added for RS_ID and essentially replaces the optional removal process that was implemented there.  Let me know if that's going to be a problem...

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ x] One feature/change per PR unless tightly coupled
- [ x] Do a rebase on upstream `main`
