### PR TITLE
debezium/dbz#1726 Order by primary key when ROWID pseudocolumn is used as surrogate key

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -52,25 +52,33 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
 
     @Override
     public String buildChunkQuery(IncrementalSnapshotContext<T> context, Table table, int limit, Optional<String> additionalCondition) {
+        final Optional<Object[]> upperBound = getChunkUpperBound(context);
+        final List<Column> queryColumns = getQueryColumns(context, table);
         String condition = null;
         // Add condition when this is not the first query
         if (context.isNonInitialChunk()) {
-            final Object[] maximumKey = context.maximumKey().get();
             final Object[] chunkEndPosition = context.chunkEndPosititon();
             final StringBuilder sql = new StringBuilder();
             // Window boundaries
             addLowerBound(context, table, chunkEndPosition, sql);
             // Table boundaries
-            sql.append(" AND ");
-            addUpperBound(context, table, maximumKey, sql);
+            if (upperBound.isPresent()) {
+                sql.append(" AND ");
+                addUpperBound(context, table, upperBound.get(), sql);
+            }
             condition = sql.toString();
         }
-        final List<Column> queryColumns = getQueryColumns(context, table);
+        else if (upperBound.isPresent()) {
+            final StringBuilder sql = new StringBuilder();
+            addUpperBound(context, table, upperBound.get(), sql);
+            condition = sql.toString();
+        }
+        final List<Column> orderByColumns = getOrderByColumns(context, table);
         if (jdbcConnection.nullsSortLast().isEmpty() && queryColumns.stream().anyMatch(Column::isOptional)) {
             // You need to override nullsSortLast on JdbcConnection for your connector if you want to be able to chunk based on nullable columns.
             throw new UnsupportedOperationException("The sort order of NULL values in the incremental snapshot key is unknown.");
         }
-        final String orderBy = queryColumns.stream()
+        final String orderBy = orderByColumns.stream()
                 .map(c -> jdbcConnection.quoteIdentifier(c.name()))
                 .collect(Collectors.joining(", "));
         return jdbcConnection.buildSelectWithRowLimits(table.id(),
@@ -196,14 +204,19 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     public PreparedStatement readTableChunkStatement(IncrementalSnapshotContext<T> context, Table table, String sql) throws SQLException {
         final PreparedStatement statement = jdbcConnection.readTablePreparedStatement(connectorConfig, sql,
                 OptionalLong.empty());
+        final Optional<Object[]> upperBound = getChunkUpperBound(context);
         if (context.isNonInitialChunk()) {
-            final Object[] maximumKey = context.maximumKey().get();
             final Object[] chunkEndPosition = context.chunkEndPosititon();
             final List<Column> queryColumns = getQueryColumns(context, table);
 
-            // Fill lower-bound (chunk end) and upper-bound (maximum key) placeholders
             int pos = CascadingOrBoundaryConditions.bindTriangularParamsSkipNulls(statement, queryColumns, chunkEndPosition, 1, jdbcConnection);
-            CascadingOrBoundaryConditions.bindTriangularParamsSkipNulls(statement, queryColumns, maximumKey, pos, jdbcConnection);
+            if (upperBound.isPresent()) {
+                CascadingOrBoundaryConditions.bindTriangularParamsSkipNulls(statement, queryColumns, upperBound.get(), pos, jdbcConnection);
+            }
+        }
+        else if (upperBound.isPresent()) {
+            final List<Column> queryColumns = getQueryColumns(context, table);
+            CascadingOrBoundaryConditions.bindTriangularParamsSkipNulls(statement, queryColumns, upperBound.get(), 1, jdbcConnection);
         }
         return statement;
     }
@@ -223,8 +236,26 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
         return Optional.empty();
     }
 
-    private KeyMapper getKeyMapper() {
-        return connectorConfig.getKeyMapper() == null ? table -> table.primaryKeyColumns() : connectorConfig.getKeyMapper();
+    protected KeyMapper getKeyMapper() {
+        return connectorConfig.getKeyMapper() == null ? Table::primaryKeyColumns : connectorConfig.getKeyMapper();
+    }
+
+    /**
+     * Returns the upper bound for chunk queries.
+     * <p>
+     * Defaults to the maximum key for non-initial chunks. Subclasses may return a precomputed boundary to constrain earlier chunks.
+     */
+    protected Optional<Object[]> getChunkUpperBound(IncrementalSnapshotContext<T> context) {
+        return context.isNonInitialChunk() ? context.maximumKey() : Optional.empty();
+    }
+
+    /**
+     * Returns the columns for the ORDER BY clause of a chunk query.
+     * <p>
+     * Defaults to the chunking columns. Override when result ordering should differ from chunk boundaries.
+     */
+    protected List<Column> getOrderByColumns(IncrementalSnapshotContext<T> context, Table table) {
+        return getQueryColumns(context, table);
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -693,7 +693,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             else {
                 progressListener.currentChunk(partition, context.currentChunkId(), firstKey, lastKey, context.maximumKey().orElse(null));
             }
-            context.nextChunkPosition(lastKey);
+            context.nextChunkPosition(chunkQueryBuilder.resolveChunkEndPosition(context, currentTable, lastKey));
             if (lastRow != null) {
                 LOGGER.debug("\t Next window will resume from {}", (Object) context.chunkEndPosititon());
             }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/ChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/ChunkQueryBuilder.java
@@ -52,4 +52,18 @@ public interface ChunkQueryBuilder<T extends DataCollectionId> {
     default Table prepareTable(IncrementalSnapshotContext<T> context, Table table) {
         return table;
     }
+
+    /**
+     * Resolves the chunk-end position for the next chunk.
+     * <p>
+     * Defaults to {@code lastRowKey}. Implementations may return a separately computed boundary when chunk ordering differs from result ordering.
+     *
+     * @param context the current incremental snapshot context
+     * @param table the table being snapshotted
+     * @param lastRowKey the key from the last row of the current chunk
+     * @return the key to use as the next chunk start position
+     */
+    default Object[] resolveChunkEndPosition(IncrementalSnapshotContext<T> context, Table table, Object[] lastRowKey) {
+        return lastRowKey;
+    }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/PhysicalRowIdentifierChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/PhysicalRowIdentifierChunkQueryBuilder.java
@@ -5,11 +5,20 @@
  */
 package io.debezium.pipeline.source.snapshot.incremental;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.source.snapshot.CascadingOrBoundaryConditions;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -19,14 +28,13 @@ import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Strings;
 
 /**
- * Chunk query builder that injects a hidden physical row identifier (e.g. Oracle ROWID, PostgreSQL ctid)
- * so it can be used as the surrogate key for incremental snapshots.
+ * Chunk query builder that injects a physical row identifier such as Oracle ROWID.
  * <p>
- * This builder is vendor-agnostic at the core level; connector-specific implementations provide
- * the appropriate physical column metadata for their database.
+ * Connector-specific implementations supply the physical column metadata.
  */
 public class PhysicalRowIdentifierChunkQueryBuilder<T extends DataCollectionId> extends AbstractChunkQueryBuilder<T> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhysicalRowIdentifierChunkQueryBuilder.class);
     private static final String DEFAULT_TABLE_ALIAS = "DBZ_PHYSICAL_ROW";
 
     private final String physicalColumnName;
@@ -38,6 +46,8 @@ public class PhysicalRowIdentifierChunkQueryBuilder<T extends DataCollectionId> 
     private final Integer physicalScale;
     private final boolean aliasWildcardProjection;
     private final String tableAlias;
+
+    private Object prefetchedChunkEndValue;
 
     public PhysicalRowIdentifierChunkQueryBuilder(RelationalDatabaseConnectorConfig config,
                                                   JdbcConnection jdbcConnection,
@@ -94,10 +104,8 @@ public class PhysicalRowIdentifierChunkQueryBuilder<T extends DataCollectionId> 
             return false;
         }
         return context.currentDataCollectionId().getSurrogateKey()
-                .map(key -> {
-                    String unquoted = Strings.unquoteIdentifierPart(key.trim());
-                    return Strings.isNullOrEmpty(unquoted) ? key.trim() : unquoted;
-                })
+                .map(String::trim)
+                .map(key -> Strings.defaultIfEmpty(Strings.unquoteIdentifierPart(key), key))
                 .filter(physicalColumnName::equalsIgnoreCase)
                 .isPresent();
     }
@@ -140,5 +148,124 @@ public class PhysicalRowIdentifierChunkQueryBuilder<T extends DataCollectionId> 
             return Optional.ofNullable(tableAlias);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Prefetches the next physical-identifier boundary before building the chunk query.
+     */
+    @Override
+    public String buildChunkQuery(IncrementalSnapshotContext<T> context, Table table, int limit, Optional<String> additionalCondition) {
+        if (limit > 0 && usesPhysicalIdentifier(context)) {
+            prefetchedChunkEndValue = executePrefetch(context, table, limit, additionalCondition);
+            LOGGER.debug("Prefetched chunk-end boundary: {}", prefetchedChunkEndValue);
+        }
+        else {
+            prefetchedChunkEndValue = null;
+        }
+        return super.buildChunkQuery(context, table, limit, additionalCondition);
+    }
+
+    /**
+     * Returns the prefetched physical-identifier boundary, falling back to the table maximum on the last chunk.
+     */
+    @Override
+    protected Optional<Object[]> getChunkUpperBound(IncrementalSnapshotContext<T> context) {
+        if (!usesPhysicalIdentifier(context)) {
+            return super.getChunkUpperBound(context);
+        }
+        if (prefetchedChunkEndValue != null) {
+            return Optional.of(new Object[]{ prefetchedChunkEndValue });
+        }
+        return context.maximumKey();
+    }
+
+    /**
+     * Orders by primary key when the physical row identifier is active.
+     */
+    @Override
+    protected List<Column> getOrderByColumns(IncrementalSnapshotContext<T> context, Table table) {
+        if (usesPhysicalIdentifier(context)) {
+            List<Column> pkColumns = getKeyMapper().getKeyKolumns(table);
+            if (!pkColumns.isEmpty()) {
+                return pkColumns;
+            }
+        }
+        return super.getOrderByColumns(context, table);
+    }
+
+    /**
+     * Returns the prefetched boundary as the next chunk start, falling back to the table maximum when no prefetch value is available.
+     */
+    @Override
+    public Object[] resolveChunkEndPosition(IncrementalSnapshotContext<T> context, Table table, Object[] lastRowKey) {
+        if (prefetchedChunkEndValue != null) {
+            return new Object[]{ prefetchedChunkEndValue };
+        }
+        if (usesPhysicalIdentifier(context) && context.maximumKey().isPresent()) {
+            return context.maximumKey().get();
+        }
+        return lastRowKey;
+    }
+
+    /**
+     * Queries for the physical-identifier value at the {@code limit}-th row from the current chunk start.
+     *
+     * @return the boundary value, or {@code null} when fewer rows remain
+     */
+    private Object executePrefetch(IncrementalSnapshotContext<T> context, Table table, int limit, Optional<String> additionalCondition) {
+        final String sql = buildPrefetchQuery(context, table, limit, additionalCondition);
+
+        LOGGER.debug("Prefetch chunk-end query: {}", sql);
+
+        try (PreparedStatement stmt = jdbcConnection.connection().prepareStatement(sql)) {
+            if (context.isNonInitialChunk()) {
+                CascadingOrBoundaryConditions.bindTriangularParamsSkipNulls(stmt, getQueryColumns(context, table), context.chunkEndPosititon(), 1, jdbcConnection);
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getObject(1);
+                }
+                return null;
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.error("Failed to prefetch chunk-end boundary for table {}", table.id(), e);
+            throw new DebeziumException("Failed to determine chunk end position via prefetch query for table " + table.id(), e);
+        }
+    }
+
+    protected String buildPrefetchQuery(IncrementalSnapshotContext<T> context, Table table, int limit, Optional<String> additionalCondition) {
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(physicalIdentifierExpression);
+        sql.append(" FROM ");
+        sql.append(buildTableReference(table));
+
+        boolean hasWhere = false;
+        if (context.isNonInitialChunk()) {
+            sql.append(" WHERE ");
+            addLowerBound(context, table, context.chunkEndPosititon(), sql);
+            hasWhere = true;
+        }
+        if (additionalCondition.isPresent()) {
+            sql.append(hasWhere ? " AND " : " WHERE ");
+            sql.append(additionalCondition.get());
+        }
+
+        sql.append(" ORDER BY ").append(getPrefetchOrderByExpression());
+        sql.append(" OFFSET ").append(limit - 1);
+        sql.append(" ROWS FETCH NEXT 1 ROWS ONLY");
+
+        return sql.toString();
+    }
+
+    protected String getPrefetchOrderByExpression() {
+        return physicalIdentifierExpression;
+    }
+
+    /**
+     * Builds a quoted table reference for {@code FROM} clauses.
+     */
+    protected String buildTableReference(Table table) {
+        return jdbcConnection.quotedTableIdString(table.id());
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/PhysicalRowIdentifierChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/PhysicalRowIdentifierChunkQueryBuilderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+public class PhysicalRowIdentifierChunkQueryBuilderTest extends DefaultChunkQueryBuilderTest {
+
+    @Test
+    public void testPhysicalIdentifierChunkingUsesPrimaryKeyOrdering() {
+        final InspectablePhysicalRowIdentifierChunkQueryBuilder chunkQueryBuilder = new InspectablePhysicalRowIdentifierChunkQueryBuilder(
+                config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Table table = createTwoPrimaryKeysTable();
+
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "ROWID");
+        final Table preparedTable = chunkQueryBuilder.prepareTable(context, table);
+
+        assertThat(chunkQueryBuilder.getQueryColumns(context, preparedTable)).extracting(Column::name)
+                .containsExactly("ROWID");
+        assertThat(chunkQueryBuilder.orderByColumns(context, preparedTable)).extracting(Column::name)
+                .containsExactly("pk1", "pk2");
+    }
+
+    @Test
+    public void testPrefetchQueryOrdersByPhysicalIdentifierExpression() {
+        final InspectablePhysicalRowIdentifierChunkQueryBuilder chunkQueryBuilder = new InspectablePhysicalRowIdentifierChunkQueryBuilder(
+                config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Table table = createTwoPrimaryKeysTable();
+
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "ROWID");
+        final Table preparedTable = chunkQueryBuilder.prepareTable(context, table);
+        context.nextChunkPosition(new Object[]{ "AAABBB" });
+
+        assertThat(chunkQueryBuilder.prefetchQuery(context, preparedTable, 128, Optional.of("\"val1\"=foo")))
+                .isEqualTo("SELECT ROWID FROM \"s1\".\"table1\" WHERE (\"ROWID\" > ?) "
+                        + "AND \"val1\"=foo ORDER BY ROWID OFFSET 127 ROWS FETCH NEXT 1 ROWS ONLY");
+    }
+
+    @Test
+    public void testResolveChunkEndPositionFallsBackToMaximumKey() {
+        final InspectablePhysicalRowIdentifierChunkQueryBuilder chunkQueryBuilder = new InspectablePhysicalRowIdentifierChunkQueryBuilder(
+                config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Table table = createTwoPrimaryKeysTable();
+
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "ROWID");
+        final Table preparedTable = chunkQueryBuilder.prepareTable(context, table);
+        context.maximumKey(new Object[]{ "AAACCC" });
+
+        assertThat(chunkQueryBuilder.resolveChunkEndPosition(context, preparedTable, new Object[]{ "AAABBB" }))
+                .containsExactly("AAACCC");
+    }
+
+    private Table createTwoPrimaryKeysTable() {
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column pk2 = Column.editor().name("pk2").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        return Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(pk2)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1", "pk2")
+                .create();
+    }
+
+    private static final class InspectablePhysicalRowIdentifierChunkQueryBuilder extends PhysicalRowIdentifierChunkQueryBuilder<TableId> {
+
+        private InspectablePhysicalRowIdentifierChunkQueryBuilder(RelationalDatabaseConnectorConfig config,
+                                                                  JdbcConnection jdbcConnection) {
+            super(config, jdbcConnection, "ROWID", "ROWID", Types.ROWID, Types.ROWID, "ROWID", null, null, false, null);
+        }
+
+        private List<Column> orderByColumns(IncrementalSnapshotContext<TableId> context, Table table) {
+            return getOrderByColumns(context, table);
+        }
+
+        private String prefetchQuery(IncrementalSnapshotContext<TableId> context, Table table, int limit,
+                                     Optional<String> additionalCondition) {
+            return super.buildPrefetchQuery(context, table, limit, additionalCondition);
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePhysicalRowIdentifierChunkQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePhysicalRowIdentifierChunkQueryBuilder.java
@@ -10,6 +10,8 @@ import java.sql.Types;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.source.snapshot.incremental.PhysicalRowIdentifierChunkQueryBuilder;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
 import io.debezium.spi.schema.DataCollectionId;
 
 import oracle.jdbc.OracleTypes;
@@ -36,5 +38,12 @@ public class OraclePhysicalRowIdentifierChunkQueryBuilder<T extends DataCollecti
                 null,
                 true,
                 ROWID_TABLE_ALIAS);
+    }
+
+    @Override
+    protected String buildTableReference(Table table) {
+        // Oracle does not use the catalog portion of the table identifier
+        final TableId stripped = new TableId(null, table.id().schema(), table.id().table());
+        return jdbcConnection.quotedTableIdString(stripped);
     }
 }


### PR DESCRIPTION

Fixes debezium/dbz#1726

## Description
The goal here is to allow decoupling so that when ROWID is used in the projection we can still use the PK for the order by as ordering by the ROWID creates significant overhead

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
