### PR TITLE
debezium/dbz#1395 Schema Inconsistency Fixing

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -779,6 +779,7 @@ M. Gökhan Akgül
 Maithem
 Mark Allanson
 Mark Banierink
+Mohnish Kodukulla
 Rahul Khanna
 Razvan Laurus
 Ronak Jain

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -546,6 +546,7 @@ Mohamed El Shaer
 Mohamed Pudukulathan
 Mohammad Akhil
 Mohammad Yousuf Minhaj Zia
+Mohnish Kodukulla
 Moira Tagle
 Mostafa Ghadimi
 Moustapha Mahfoud

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -549,7 +549,10 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "(i.e. internal representation is not consistent with database) should be handled, including: "
                     + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
                     + "'warn' the problematic event and its binlog position will be logged and the event will be skipped; "
-                    + "'skip' the problematic event will be skipped.");
+                    + "'skip' the problematic event will be skipped. "
+                    + "For row/schema column-count mismatches, non-fail modes skip the row instead "
+                    + "of attempting any column remapping to avoid potential data misalignment "
+                    + "when synthetic/generated columns are interleaved in event payloads.");
 
     public static final Field ENABLE_TIME_ADJUSTER = Field.create("enable.time.adjuster")
             .withDisplayName("Enable Time Adjuster")

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -564,7 +564,10 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "(i.e. internal representation is not consistent with database) should be handled, including: "
                     + "'fail' (the default) an exception indicating the problematic event and its binlog position is raised, causing the connector to be stopped; "
                     + "'warn' the problematic event and its binlog position will be logged and the event will be skipped; "
-                    + "'skip' the problematic event will be skipped.");
+                    + "'skip' the problematic event will be skipped. "
+                    + "For row/schema column-count mismatches, non-fail modes skip the row instead "
+                    + "of attempting any column remapping to avoid potential data misalignment "
+                    + "when synthetic/generated columns are interleaved in event payloads.");
 
     public static final Field ENABLE_TIME_ADJUSTER = Field.create("enable.time.adjuster")
             .withDisplayName("Enable Time Adjuster")

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -8,6 +8,7 @@ package io.debezium.connector.binlog;
 import static io.debezium.util.Strings.isNullOrEmpty;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -1225,24 +1226,42 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         informAboutUnknownTableIfRequired(partition, offsetContext, event, tableId, null);
     }
 
-    private void validateChangeEventWithTable(Table table, Object[] before, Object[] after) {
+    private boolean validateChangeEventWithTable(Table table, Serializable[] before, Serializable[] after) {
         if (table != null) {
             int columnSize = table.columns().size();
-            String message = "Error processing {} of row in {} because it's different column size with internal schema size {}, but {} size {}, " +
-                    "restart connector with schema recovery mode.";
+
+            String message = "Error processing {} of row in {} because it's different column size with " +
+                    "internal schema size {}, but {} size {}, restart connector with schema recovery mode.";
             if (before != null && columnSize != before.length) {
-                LOGGER.error(message, "before", table.id().table(), columnSize, "before", before.length);
-                throw new DebeziumException(
-                        "Error processing row in " + table.id().table() + ", internal schema size " + columnSize + ", but row size " + before.length + " , " +
-                                "restart connector with schema recovery mode.");
+                if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                    LOGGER.error(message, "before", table.id().table(), columnSize, "before", before.length);
+                    throw new DebeziumException(
+                            "Error processing row in " + table.id().table() + ", internal schema size " + columnSize
+                                    + ", but row size " + before.length
+                                    + ", restart connector with schema recovery mode.");
+                }
+
+                LOGGER.warn(message, "before", table.id().table(), columnSize, "before", before.length);
+                LOGGER.warn("Skipping before row for table {} due to schema/row length mismatch "
+                        + "to avoid potential column misalignment.", table.id().table());
+                return false;
             }
             if (after != null && columnSize != after.length) {
-                LOGGER.error(message, "after", table.id().table(), columnSize, "after", after.length);
-                throw new DebeziumException(
-                        "Error processing row in " + table.id().table() + ", internal schema size " + columnSize + ", but row size " + after.length + " , " +
-                                "restart connector with schema recovery mode.");
+                if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                    LOGGER.error(message, "after", table.id().table(), columnSize, "after", after.length);
+                    throw new DebeziumException(
+                            "Error processing row in " + table.id().table() + ", internal schema size " + columnSize
+                                    + ", but row size " + after.length
+                                    + ", restart connector with schema recovery mode.");
+                }
+
+                LOGGER.warn(message, "after", table.id().table(), columnSize, "after", after.length);
+                LOGGER.warn("Skipping after row for table {} due to schema/row length mismatch "
+                        + "to avoid potential column misalignment.", table.id().table());
+                return false;
             }
         }
+        return true;
     }
 
     private <T extends EventData, U> void handleChange(P partition,
@@ -1275,7 +1294,10 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
             if (startingRowNumber < numRows) {
                 for (int rowIndex = startingRowNumber; rowIndex != numRows; ++rowIndex) {
                     U row = rows.get(rowIndex);
-                    changeEventValidator.validate(tableId, row);
+                    // Skip this row if validation fails (e.g., schema/row column count mismatch)
+                    if (!changeEventValidator.validate(tableId, row)) {
+                        continue;
+                    }
                     offsetContext.setRowNumber(rowIndex, numRows);
                     offsetContext.event(tableId, eventTimestamp);
                     changeEmitter.emit(tableId, row);
@@ -1536,7 +1558,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
 
     @FunctionalInterface
     private interface ChangeEventValidator<U> {
-        void validate(TableId tableId, U row);
+        boolean validate(TableId tableId, U row);
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -1329,24 +1329,42 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         return aligned;
     }
 
-    private void validateChangeEventWithTable(Table table, Object[] before, Object[] after) {
+    private boolean validateChangeEventWithTable(Table table, Serializable[] before, Serializable[] after) {
         if (table != null) {
             int columnSize = table.columns().size();
-            String message = "Error processing {} of row in {} because it's different column size with internal schema size {}, but {} size {}, " +
-                    "restart connector with schema recovery mode.";
+
+            String message = "Error processing {} of row in {} because it's different column size with " +
+                    "internal schema size {}, but {} size {}, restart connector with schema recovery mode.";
             if (before != null && columnSize != before.length) {
-                LOGGER.error(message, "before", table.id().table(), columnSize, "before", before.length);
-                throw new DebeziumException(
-                        "Error processing row in " + table.id().table() + ", internal schema size " + columnSize + ", but row size " + before.length + " , " +
-                                "restart connector with schema recovery mode.");
+                if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                    LOGGER.error(message, "before", table.id().table(), columnSize, "before", before.length);
+                    throw new DebeziumException(
+                            "Error processing row in " + table.id().table() + ", internal schema size " + columnSize
+                                    + ", but row size " + before.length
+                                    + ", restart connector with schema recovery mode.");
+                }
+
+                LOGGER.warn(message, "before", table.id().table(), columnSize, "before", before.length);
+                LOGGER.warn("Skipping before row for table {} due to schema/row length mismatch "
+                        + "to avoid potential column misalignment.", table.id().table());
+                return false;
             }
             if (after != null && columnSize != after.length) {
-                LOGGER.error(message, "after", table.id().table(), columnSize, "after", after.length);
-                throw new DebeziumException(
-                        "Error processing row in " + table.id().table() + ", internal schema size " + columnSize + ", but row size " + after.length + " , " +
-                                "restart connector with schema recovery mode.");
+                if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                    LOGGER.error(message, "after", table.id().table(), columnSize, "after", after.length);
+                    throw new DebeziumException(
+                            "Error processing row in " + table.id().table() + ", internal schema size " + columnSize
+                                    + ", but row size " + after.length
+                                    + ", restart connector with schema recovery mode.");
+                }
+
+                LOGGER.warn(message, "after", table.id().table(), columnSize, "after", after.length);
+                LOGGER.warn("Skipping after row for table {} due to schema/row length mismatch "
+                        + "to avoid potential column misalignment.", table.id().table());
+                return false;
             }
         }
+        return true;
     }
 
     private <T extends EventData, U> void handleChange(P partition,
@@ -1379,7 +1397,10 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
             if (startingRowNumber < numRows) {
                 for (int rowIndex = startingRowNumber; rowIndex != numRows; ++rowIndex) {
                     U row = rows.get(rowIndex);
-                    changeEventValidator.validate(tableId, row);
+                    // Skip this row if validation fails (e.g., schema/row column count mismatch)
+                    if (!changeEventValidator.validate(tableId, row)) {
+                        continue;
+                    }
                     offsetContext.setRowNumber(rowIndex, numRows);
                     offsetContext.event(tableId, eventTimestamp);
                     changeEmitter.emit(tableId, row);
@@ -1650,7 +1671,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
 
     @FunctionalInterface
     private interface ChangeEventValidator<U> {
-        void validate(TableId tableId, U row);
+        boolean validate(TableId tableId, U row);
     }
 
     /**

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
@@ -11,15 +11,18 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
@@ -28,6 +31,7 @@ import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.SkipWhenDatabaseVersion;
+import io.debezium.junit.logging.LogInterceptor;
 
 /**
  * @author Inki Hwang
@@ -386,6 +390,90 @@ public abstract class BinlogSchemaValidateIT<C extends SourceConnector> extends 
 
         SourceRecord tombstoneEvent = recordsForTopic.get(3);
         assertTombstone(tombstoneEvent);
+    }
+
+    @Test
+    @FixFor("dbz#1395")
+    public void shouldFailOnInconsistentRowLengthWhenSchemaHandlingModeIsFail() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(BinlogStreamingChangeEventSource.class);
+
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(BinlogConnectorConfig.INCONSISTENT_SCHEMA_HANDLING_MODE,
+                        CommonConnectorConfig.EventProcessingFailureHandlingMode.FAIL)
+                .build();
+
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        start(getConnectorClass(), config, (success, message, error) -> exception.set(error));
+        waitForSnapshotToBeCompleted(getConnectorName(), DATABASE.getServerName());
+
+        String primaryPort = System.getProperty("database.port", "3306");
+        String replicaPort = System.getProperty("database.replica.port", "3306");
+        boolean replicaIsPrimary = primaryPort.equals(replicaPort);
+        if (!replicaIsPrimary) {
+            Thread.sleep(5000L);
+        }
+
+        alterTableWithSqlBinLogOff("ALTER TABLE dbz7093 ADD newcol VARCHAR(20);", replicaIsPrimary);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                connection.execute("INSERT INTO dbz7093(id, age, name, newcol) VALUES (201, 1,'name1','newcol1');");
+            }
+        }
+
+        Awaitility.await().atMost(Duration.ofSeconds(waitTimeForRecords()))
+                .until(() -> logInterceptor.containsMessage("internal schema size")
+                        || logInterceptor.containsMessage("different column size"));
+
+        waitForEngineShutdown();
+        assertConnectorNotRunning();
+
+        assertThat(logInterceptor.containsMessage("internal schema size")
+                || logInterceptor.containsMessage("different column size")).isTrue();
+
+        assertThat(exception.get()).isNotNull();
+    }
+
+    @Test
+    @FixFor("dbz#1395")
+    public void shouldSkipInconsistentRowLengthWhenSchemaHandlingModeIsSkip() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(BinlogStreamingChangeEventSource.class);
+
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(BinlogConnectorConfig.INCONSISTENT_SCHEMA_HANDLING_MODE,
+                        CommonConnectorConfig.EventProcessingFailureHandlingMode.SKIP)
+                .build();
+
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        start(getConnectorClass(), config, (success, message, error) -> exception.set(error));
+        waitForSnapshotToBeCompleted(getConnectorName(), DATABASE.getServerName());
+
+        String primaryPort = System.getProperty("database.port", "3306");
+        String replicaPort = System.getProperty("database.replica.port", "3306");
+        boolean replicaIsPrimary = primaryPort.equals(replicaPort);
+        if (!replicaIsPrimary) {
+            Thread.sleep(5000L);
+        }
+
+        alterTableWithSqlBinLogOff("ALTER TABLE dbz7093 ADD newcol VARCHAR(20);", replicaIsPrimary);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                connection.execute("INSERT INTO dbz7093(id, age, name, newcol) VALUES (201, 1,'name1','newcol1');");
+            }
+        }
+
+        Awaitility.await().atMost(Duration.ofSeconds(waitTimeForRecords()))
+                .until(() -> logInterceptor.containsMessage("due to schema/row length mismatch"));
+
+        assertConnectorIsRunning();
+        stopConnector();
+
+        assertThat(exception.get()).isNull();
     }
 
     private void alterTableWithSqlBinLogOff(String ddl, boolean replicaIsPrimary) throws SQLException {

--- a/debezium-connector-common/src/main/java/io/debezium/relational/Column.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/Column.java
@@ -129,6 +129,13 @@ public interface Column extends Comparable<Column> {
     boolean isGenerated();
 
     /**
+     * Determine whether this column is a synthetic column.
+     *
+     * @return {@code true} if it is a synthetic column, or {@code false} otherwise
+     */
+    boolean isSynthetic();
+
+    /**
      * Get the database-specific complete expression defining the column's default value.
      *
      * @return the complete type expression

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditor.java
@@ -115,6 +115,13 @@ public interface ColumnEditor {
     boolean isGenerated();
 
     /**
+     * Determine whether this column is a synthetic column.
+     *
+     * @return {@code true} if it is a synthetic column, or {@code false} otherwise
+     */
+    boolean isSynthetic();
+
+    /**
      * Get the database-specific complete expression defining the column's default value.
      *
      * @return the complete type expression
@@ -239,6 +246,14 @@ public interface ColumnEditor {
      * @return this editor so callers can chain methods together
      */
     ColumnEditor generated(boolean generated);
+
+    /**
+     * Set whether the column is a synthetic column.
+     *
+     * @param synthetic {@code true} if the column is a synthetic column, or {@code false} otherwise
+     * @return this editor so callers can chain methods together
+     */
+    ColumnEditor synthetic(boolean synthetic);
 
     /**
      * Set the position of the column within the table definition.

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -24,6 +24,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     private boolean optional = true;
     private boolean autoIncremented = false;
     private boolean generated = false;
+    private boolean synthetic = false;
     private String defaultValueExpression = null;
     private boolean hasDefaultValue = false;
     private List<String> enumValues;
@@ -95,6 +96,11 @@ final class ColumnEditorImpl implements ColumnEditor {
     @Override
     public boolean isGenerated() {
         return generated;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return synthetic;
     }
 
     @Override
@@ -197,6 +203,12 @@ final class ColumnEditorImpl implements ColumnEditor {
     }
 
     @Override
+    public ColumnEditorImpl synthetic(boolean synthetic) {
+        this.synthetic = synthetic;
+        return this;
+    }
+
+    @Override
     public ColumnEditorImpl position(int position) {
         this.position = position;
         return this;
@@ -243,7 +255,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     @Override
     public Column create() {
         return new ColumnImpl(name, position, jdbcType, nativeType, typeName, typeExpression, charsetName, tableCharsetName,
-                length, scale, enumValues, optional, autoIncremented, generated, defaultValueExpression, hasDefaultValue, comment);
+                length, scale, enumValues, optional, autoIncremented, generated, synthetic, defaultValueExpression, hasDefaultValue, comment);
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -27,6 +27,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     private boolean optional = true;
     private boolean autoIncremented = false;
     private boolean generated = false;
+    private boolean synthetic = false;
     private String defaultValueExpression = null;
     private boolean hasDefaultValue = false;
     private List<String> enumValues;
@@ -98,6 +99,11 @@ final class ColumnEditorImpl implements ColumnEditor {
     @Override
     public boolean isGenerated() {
         return generated;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return synthetic;
     }
 
     @Override
@@ -200,6 +206,12 @@ final class ColumnEditorImpl implements ColumnEditor {
     }
 
     @Override
+    public ColumnEditorImpl synthetic(boolean synthetic) {
+        this.synthetic = synthetic;
+        return this;
+    }
+
+    @Override
     public ColumnEditorImpl position(int position) {
         this.position = position;
         return this;
@@ -250,7 +262,7 @@ final class ColumnEditorImpl implements ColumnEditor {
                 Interner.intern(typeName), Interner.intern(typeExpression),
                 Interner.intern(charsetName), Interner.intern(tableCharsetName),
                 length, scale, enumValues == null ? null : Interner.intern(Collections.unmodifiableList(enumValues)),
-                optional, autoIncremented, generated,
+                optional, autoIncremented, generated, synthetic,
                 Interner.intern(defaultValueExpression), hasDefaultValue,
                 Interner.intern(comment));
         return Interner.intern(column);

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -25,6 +25,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
     private final boolean optional;
     private final boolean autoIncremented;
     private final boolean generated;
+    private final boolean synthetic;
     private final String defaultValueExpression;
     private final boolean hasDefaultValue;
     private final List<String> enumValues;
@@ -34,19 +35,41 @@ final class ColumnImpl implements Column, Comparable<Column> {
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          boolean optional, boolean autoIncremented, boolean generated) {
         this(columnName, position, jdbcType, componentType, typeName, typeExpression, charsetName,
-                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, null, false, null);
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, false, null, false, null);
+    }
+
+    protected ColumnImpl(String columnName, int position, int jdbcType, int componentType, String typeName, String typeExpression,
+                         String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
+                         boolean optional, boolean autoIncremented, boolean generated, boolean synthetic) {
+        this(columnName, position, jdbcType, componentType, typeName, typeExpression, charsetName,
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, synthetic, null, false, null);
     }
 
     protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          boolean optional, boolean autoIncremented, boolean generated, String defaultValueExpression, boolean hasDefaultValue) {
         this(columnName, position, jdbcType, nativeType, typeName, typeExpression, charsetName,
-                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, defaultValueExpression, hasDefaultValue, null);
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, false, defaultValueExpression, hasDefaultValue, null);
+    }
+
+    protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
+                         String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
+                         boolean optional, boolean autoIncremented, boolean generated, boolean synthetic, String defaultValueExpression, boolean hasDefaultValue) {
+        this(columnName, position, jdbcType, nativeType, typeName, typeExpression, charsetName,
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, synthetic, defaultValueExpression, hasDefaultValue, null);
     }
 
     protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          List<String> enumValues, boolean optional, boolean autoIncremented, boolean generated,
+                         String defaultValueExpression, boolean hasDefaultValue, String comment) {
+        this(columnName, position, jdbcType, nativeType, typeName, typeExpression, charsetName, defaultCharsetName, columnLength, columnScale, enumValues,
+                optional, autoIncremented, generated, false, defaultValueExpression, hasDefaultValue, comment);
+    }
+
+    protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
+                         String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
+                         List<String> enumValues, boolean optional, boolean autoIncremented, boolean generated, boolean synthetic,
                          String defaultValueExpression, boolean hasDefaultValue, String comment) {
         this.name = columnName;
         this.position = position;
@@ -65,6 +88,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
         this.optional = optional;
         this.autoIncremented = autoIncremented;
         this.generated = generated;
+        this.synthetic = synthetic;
         this.defaultValueExpression = defaultValueExpression;
         this.hasDefaultValue = hasDefaultValue;
         this.enumValues = enumValues == null ? new ArrayList<>() : enumValues;
@@ -133,6 +157,11 @@ final class ColumnImpl implements Column, Comparable<Column> {
     }
 
     @Override
+    public boolean isSynthetic() {
+        return synthetic;
+    }
+
+    @Override
     public Optional<String> defaultValueExpression() {
         return Optional.ofNullable(defaultValueExpression);
     }
@@ -175,6 +204,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                     this.isOptional() == that.isOptional() &&
                     this.isAutoIncremented() == that.isAutoIncremented() &&
                     this.isGenerated() == that.isGenerated() &&
+                    this.isSynthetic() == that.isSynthetic() &&
                     Objects.equals(this.defaultValueExpression(), that.defaultValueExpression()) &&
                     this.hasDefaultValue() == that.hasDefaultValue() &&
                     this.enumValues().equals(that.enumValues());
@@ -205,6 +235,9 @@ final class ColumnImpl implements Column, Comparable<Column> {
         if (generated) {
             sb.append(" GENERATED");
         }
+        if (synthetic) {
+            sb.append(" SYNTHETIC");
+        }
         if (hasDefaultValue() && defaultValueExpression == null) {
             sb.append(" DEFAULT VALUE NULL");
         }
@@ -231,6 +264,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                 .optional(isOptional())
                 .autoIncremented(isAutoIncremented())
                 .generated(isGenerated())
+                .synthetic(isSynthetic())
                 .enumValues(enumValues)
                 .comment(comment);
         if (hasDefaultValue()) {

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -164,7 +164,10 @@ public class TableSchemaBuilder {
         AtomicBoolean hasPrimaryKey = new AtomicBoolean(false);
 
         Key tableKey = new Key.Builder(table).customKeyMapper(keysMapper).build();
-        tableKey.keyColumns().forEach(column -> {
+        List<Column> keyColumns = tableKey.keyColumns().stream()
+                .filter(column -> !column.isSynthetic())
+                .collect(Collectors.toList());
+        keyColumns.forEach(column -> {
             addField(keySchemaBuilder, table, column, null);
             hasPrimaryKey.set(true);
         });
@@ -174,6 +177,7 @@ public class TableSchemaBuilder {
 
         table.columns()
                 .stream()
+                .filter(column -> !column.isSynthetic())
                 .filter(column -> filter == null || filter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .forEach(column -> {
                     ColumnMapper mapper = mappers == null ? null : mappers.mapperFor(tableId, column);
@@ -196,7 +200,7 @@ public class TableSchemaBuilder {
                 .build();
 
         // Create the generators ...
-        StructGenerator keyGenerator = createKeyGenerator(keySchema, tableId, tableKey.keyColumns(), topicNamingStrategy);
+        StructGenerator keyGenerator = createKeyGenerator(keySchema, tableId, keyColumns, topicNamingStrategy);
         StructGenerator valueGenerator = createValueGenerator(valSchema, tableId, table.columns(), filter, mappers);
 
         // And the table schema ...
@@ -287,6 +291,7 @@ public class TableSchemaBuilder {
                                                    ColumnNameFilter filter, ColumnMappers mappers) {
         if (schema != null) {
             List<Column> columnsThatShouldBeAdded = columns.stream()
+                    .filter(column -> !column.isSynthetic())
                     .filter(column -> filter == null || filter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                     .collect(Collectors.toList());
             int[] recordIndexes = indexesForColumns(columnsThatShouldBeAdded);

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/jdbc/MariaDbConnection.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/jdbc/MariaDbConnection.java
@@ -5,7 +5,12 @@
  */
 package io.debezium.connector.mariadb.jdbc;
 
+import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
@@ -18,6 +23,11 @@ import io.debezium.connector.binlog.jdbc.BinlogFieldReader;
 import io.debezium.connector.binlog.jdbc.ConnectionConfiguration;
 import io.debezium.connector.mariadb.gtid.MariaDbGtidSet;
 import io.debezium.connector.mariadb.gtid.MariaDbGtidSet.MariaDbGtid;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables.ColumnNameFilter;
+import io.debezium.relational.Tables.TableFilter;
 
 /**
  * A concrete implementation of {@link BinlogConnectorConnection} for MariaDB.
@@ -103,4 +113,85 @@ public class MariaDbConnection extends BinlogConnectorConnection {
         LOGGER.info("Final merged GTID set to use when connecting to MariaDB: {}", mergedGtidSet);
         return mergedGtidSet;
     }
+
+    @Override
+    protected Map<TableId, List<Column>> getColumnsDetails(String catalogName, String schemaName,
+                                                           String tableName, TableFilter tableFilter,
+                                                           ColumnNameFilter columnFilter, DatabaseMetaData metadata,
+                                                           final Set<TableId> viewIds,
+                                                           boolean throwOnCaseInsensitiveColumnMismatch)
+            throws SQLException {
+        Map<TableId, List<Column>> columnsByTable = super.getColumnsDetails(catalogName, schemaName, tableName,
+                tableFilter, columnFilter, metadata, viewIds, throwOnCaseInsensitiveColumnMismatch);
+
+        // Fetch explicitly synthetic columns that the JDBC driver omitted
+        // (e.g., MariaDB DB_ROW_HASH for unique generated columns)
+        for (Map.Entry<TableId, List<Column>> entry : columnsByTable.entrySet()) {
+            TableId tableId = entry.getKey();
+            List<Column> columns = entry.getValue();
+
+            try {
+                String sql = "SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, "
+                        + "NUMERIC_SCALE, IS_NULLABLE, ORDINAL_POSITION "
+                        + "FROM INFORMATION_SCHEMA.COLUMNS "
+                        + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? "
+                        + "AND (EXTRA LIKE '%GENERATED%' OR EXTRA LIKE '%INVISIBLE%')";
+
+                prepareQueryAndMap(sql, ps -> {
+                    ps.setString(1, tableId.catalog());
+                    ps.setString(2, tableId.table());
+                }, rs -> {
+                    while (rs.next()) {
+                        String columnName = rs.getString(1);
+                        // Only process it if the JDBC driver missed it completely
+                        if (!columns.stream().anyMatch(c -> c.name().equals(columnName))) {
+                            boolean isSynthetic = false;
+                            if (columnName.startsWith("DB_ROW_HASH")) {
+                                LOGGER.debug("Including DB_ROW_HASH as synthetic column for {}: {}",
+                                        tableId, columnName);
+                                isSynthetic = true;
+                            }
+
+                            LOGGER.debug("Injecting synthetic/generated column for {}: {}",
+                                    tableId, columnName);
+
+                            // Check explicit exclusions to respect explicitly excluded flags Native to Debezium
+                            if (columnFilter != null && !columnFilter.matches(tableId.catalog(), tableId.schema(),
+                                    tableId.table(), columnName)) {
+                                LOGGER.debug("Explicitly excluded synthetic column for {}: {}", tableId, columnName);
+                                continue;
+                            }
+
+                            ColumnEditor editor = Column.editor()
+                                    .name(columnName)
+                                    .type(rs.getString(2))
+                                    .length(rs.getInt(3) == 0 ? -1 : rs.getInt(3))
+                                    .scale(rs.getInt(5) == 0 ? null : rs.getInt(5))
+                                    .optional("YES".equalsIgnoreCase(rs.getString(6)))
+                                    .position(rs.getInt(7))
+                                    .synthetic(isSynthetic)
+                                    .generated(!isSynthetic);
+
+                            columns.add(editor.create());
+                        }
+                    }
+                    return null;
+                });
+
+                // Ensure columns are sorted by physical ORDINAL_POSITION naturally
+                Collections.sort(columns);
+                for (int i = 0; i < columns.size(); i++) {
+                    Column col = columns.get(i);
+                    columns.set(i, col.edit().position(i + 1).create());
+                }
+
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Failed to natively augment synthetic columns metadata for {}: {}",
+                        tableId, e.getMessage());
+            }
+        }
+        return columnsByTable;
+    }
+
 }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbSyntheticColumnsIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbSyntheticColumnsIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.AbstractBinlogConnectorIT;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.doc.FixFor;
+import io.debezium.util.Testing;
+
+/**
+ * Integration test for dbz#1395: MariaDB Connector Fails with Schema Inconsistency on Tables
+ * Using Generated Columns in Unique Constraints.
+ *
+ * <p>When a MariaDB table has a virtual generated column used in a unique index, MariaDB internally
+ * creates a synthetic {@code DB_ROW_HASH_*} column to support the constraint. This synthetic column
+ * appears in the binlog row events but is not visible via standard JDBC metadata. This test verifies
+ * that Debezium correctly handles such tables by:
+ * <ol>
+ *   <li>Not failing with a schema/row column-count mismatch.</li>
+ *   <li>Excluding the synthetic {@code DB_ROW_HASH_*} column from the emitted Kafka record payload.</li>
+ * </ol>
+ *
+ * @author Debezium Authors
+ */
+public class MariaDbSyntheticColumnsIT extends AbstractBinlogConnectorIT<MariaDbConnector>
+        implements MariaDbCommon {
+
+    private static final Path SCHEMA_HISTORY_PATH = Testing.Files
+            .createTestingPath("file-schema-history-synthetic-cols.txt")
+            .toAbsolutePath();
+
+    private final UniqueDatabase DATABASE = TestHelper
+            .getUniqueDatabase("syntheticcols", "mariadb_synthetic_column_test")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    @BeforeEach
+    public void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    /**
+     * Tests that when streaming changes from a table that has a virtual generated column
+     * participating in a unique constraint, Debezium correctly:
+     * <ul>
+     *   <li>Processes INSERT events without throwing a schema/row length mismatch error.</li>
+     *   <li>Emits Kafka records that contain the real application columns (id, text_val, v_col).</li>
+     *   <li>Does <em>not</em> include the synthetic internal {@code DB_ROW_HASH_*} column in the payload.</li>
+     * </ul>
+     */
+    @Test
+    @FixFor("dbz#1395")
+    public void shouldExcludeSyntheticDbRowHashColumnAndNotFail() throws Exception {
+        Configuration config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("dbz1395"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .build();
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(getConnectorName(), DATABASE.getServerName());
+
+        // Stream a change to verify binlog handling does not fail due to DB_ROW_HASH.
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO dbz1395 (id, text_val) VALUES (1, 'hello')");
+
+        // Consume exactly 1 record (the snapshot had no rows; the DDL only created the table).
+        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic(DATABASE.topicForTable("dbz1395"));
+        assertThat(records)
+                .describedAs("Expected exactly 1 CDC record for the insert into dbz1395")
+                .hasSize(1);
+
+        SourceRecord record = records.get(0);
+        Struct value = (Struct) record.value();
+        Struct after = value.getStruct("after");
+
+        // Verify the real application columns are present and correct.
+        assertThat(after.schema().field("id")).isNotNull();
+        assertThat(after.schema().field("text_val")).isNotNull();
+        assertThat(after.schema().field("v_col")).isNotNull();
+        assertThat(after.getInt32("id")).isEqualTo(1);
+        assertThat(after.getString("text_val")).isEqualTo("hello");
+        assertThat(after.getString("v_col")).isEqualTo("HELLO");
+
+        // The synthetic DB_ROW_HASH_* column must NOT appear in the Kafka payload.
+        boolean hasSyntheticColumn = after.schema().fields().stream()
+                .anyMatch(f -> f.name().startsWith("DB_ROW_HASH"));
+        assertThat(hasSyntheticColumn)
+                .describedAs("synthetic DB_ROW_HASH column should be excluded from the Kafka payload")
+                .isFalse();
+    }
+}

--- a/debezium-connector-mariadb/src/test/resources/ddl/mariadb_synthetic_column_test.sql
+++ b/debezium-connector-mariadb/src/test/resources/ddl/mariadb_synthetic_column_test.sql
@@ -1,0 +1,9 @@
+-- Table with a virtual generated column in a unique key.
+-- MariaDB 10.2.1+ automatically creates a synthetic DB_ROW_HASH column to support
+-- the unique index on a virtual column. This table is used to verify dbz#1395.
+CREATE TABLE dbz1395 (
+    id INT NOT NULL PRIMARY KEY,
+    text_val VARCHAR(255),
+    v_col VARCHAR(255) GENERATED ALWAYS AS (UPPER(text_val)) VIRTUAL,
+    UNIQUE KEY (v_col)
+);


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1395<the Debezium Issue Number>

## Description
<!-- Briefly describe your changes here. -->
This PR addresses DBZ-1395 where the MariaDB connector fails due to a schema mismatch when generated columns are used in unique constraints.

MariaDB introduces hidden columns (e.g. DB_ROW_HASH_*) that appear in binlog events but are not exposed via JDBC metadata, leading to a mismatch between the internal schema and row data.

To handle this safely, the connector now queries INFORMATION_SCHEMA to detect such hidden/generated columns. These are tracked internally but excluded from the emitted schema, and validation accounts for them without shifting any visible columns.

In non-fail modes, rows are skipped rather than attempting unsafe alignment, avoiding any risk of silent data misplacement.

Added integration test (MariaDbHiddenColumnsIT) to cover this scenario.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
