### PR TITLE
debezium/dbz#1729 Add "AI Agents OSS Helper" support for Debezium

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -1,0 +1,26 @@
+# Project Guidelines
+
+This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
+
+Debezium does not provide any way to create a quick fix branch and quick-fix commits.
+There are exceptions for docs, CI fixes and releases. 
+
+- **Fix-issue branch:** `debezium/dbz#<ISSUE_NUMBER>-<short-slug>`
+- **Quick-fix branch:** NOT ALLOWED!
+- **SonarCloud branch:** _(not configured)_
+- **Commit format (fix-issue):** `debezium/dbz#<ISSUE_NUMBER> <brief description>`
+- **Commit format (quick-fix):** NOT ALLOWED!
+- **Commit format (docs):** `[docs] <brief description>`
+- **Commit format (release):** `[release] <brief description>`
+- **CI-fix branch:** `ci/debezium/dbz#<ISSUE_NUMBER>-<short-slug>`
+- **Commit format (ci-fix):** `[ci] <brief description>`
+- **PR creation:** always
+- **Find-task source:** GitHub labels
+- **Find-task beginner label:** `good first issue`
+- **Find-task experienced label:** _(none)_
+- **Find-task intermediate:** _(none)_
+- **Find-task repo:** `debezium/dbz` (issues are tracked in a separate repo)
+- **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+1.0.0

--- a/.oss-ai-helper-rules/project-info.md
+++ b/.oss-ai-helper-rules/project-info.md
@@ -1,0 +1,43 @@
+# Project Information
+
+This rule file contains project-specific metadata used by OSS Helper commands. Commands detect the current project by matching `git remote get-url origin` against the remote pattern below.
+
+- **Remote pattern:** `debezium/debezium`
+- **GitHub repo:** `debezium/debezium`
+- **Issue tracker:** GitHub
+- **Issue tracker URL:** `https://github.com/debezium/dbz/issues`
+- **Issue ID format:** numeric
+- **SonarCloud component key:** _(none)_
+- **Documentation URL:** `https://debezium.io/documentation/`
+- **Related repositories:**
+  - `debezium/container-images` - Docker images for Debezium
+  - `debezium/debezium-charts` - Helm charts for Debezium
+  - `debezium/debezium-connector-cassandra` - CDC connector for Apache Cassandra
+  - `debezium/debezium-connector-cockroachdb` - CDC connector for CockroachDB
+  - `debezium/debezium-connector-db2` - CDC connector for Db2 LUW and z/OS
+  - `debezium/debezium-connector-ibmi` - CDC connector for IBM i (AS/400)
+  - `debezium/debezium-connector-informix` - CDC connector for IBM Informix
+  - `debezium/debezium-connector-ingres` - CDC connector for Ingres
+  - `debezium/debezium-connector-spanner` - CDC connector for Google Spanner
+  - `debezium/debezium-connector-vitess` - CDC connector for Vitess
+  - `debezium/debezium-descriptors-registry` - JSON configuration schemas registry for connectors, SMTs, and sinks
+  - `debezium/debezium-design-documents` - Design documents
+  - `debezium/debezium-examples` - Examples (configuration, Docker Compose files, etc.)
+  - `debezium/debezium.github.io` - Debezium Website
+  - `debezium/debezium-operator` - Kubernetes/OpenShift operator for Debezium Server
+  - `debezium/debezium-operator-manifests` - Operator bundle manifests for released versions
+  - `debezium/debezium-platform` - Opinionated data-centric view of Debezium components
+  - `debezium/debezium-quarkus` - Quarkus extensions for Debezium
+  - `debezium/debezium-server` - Standalone runtime for Debezium connectors
+  - `debezium/debezium-smt-go-pdk` - Go PDK for writing SMT transformations
+  - `debezium/jbang-catalog` - JBang scripts catalog
+  - `debezium/microservices-lab` - Lab for deploying streaming applications on Strimzi
+  - `debezium/mysql-binlog-connector-java` - Java library to process MySQL Binary Logs
+  - `debezium/onetimeserver` - MySQL instances for test environments
+  - `debezium/oracle-vagrant-box` - Vagrant box for Oracle DB Docker image (testing)
+  - `debezium/performance` - Performance testing
+  - `debezium/postgres-decoderbufs` - PostgreSQL logical decoder output plugin (Protocol Buffers)
+- **Create-issue supported:** yes
+
+## Version
+1.0.0

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -1,0 +1,24 @@
+# Project Standards
+
+This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
+
+- **Build tool:** Maven
+- **Build command:** `./mvnw clean install`
+- **Test command:** `./mvnw clean install`
+- **Format command:** `./mvnw process-sources`
+- **Module-specific build:** yes (always run `./mvnw` in the module directory where changes occurred)
+- **Parallelized Maven:** no (resource intensive, do NOT parallelize Maven jobs)
+- **Code style restrictions:** 
+  - Do NOT change public API signatures without justification
+  - Do NOT add new dependencies without justification
+  - Do NOT use Lombok and Guava (unless already present in the file)
+  - Ensure proper license header in files are present
+  - Maintain backwards compatibility for public APIs
+  - Checkstyle formatter rules (in `support/checkstyle/src/main/resources/checkstyle.xml`) must be followed and will be applied automatically during build or manually (see next item) 
+  - Use `./mvnw process-sources` to auto-format code
+  - Code style violations will fail CI
+  - Commits MUST be signed off (`git commit -s`) and all code changes MUST be reviewed by a human user, understood by that human user and MUST explicitly be confirmed by that human user before committing
+  - Ensure inclusive language is used everywhere, eg. allowlist/blocklist, primary/replica, placeholder/example, main branch, conflict-free, concurrent/parallel
+
+## Version
+1.0.0


### PR DESCRIPTION
Add "AI Agents OSS Helper" support for Debezium

Provide the rule files for AI Agents OSS Helper in `.oss-ai-helper-rules/` directory.

closes debezium/dbz#1729
