### PR TITLE
debezium/dbz#74 Add support for pluggable EnvelopeSchemaFactory

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -41,8 +41,10 @@ import io.debezium.bean.spi.BeanRegistry;
 import io.debezium.config.Field.ValidationOutput;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.data.DefaultEnvelopeSchemaFactory;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.Operation;
+import io.debezium.data.EnvelopeSchemaFactory;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.heartbeat.HeartbeatConnectionProvider;
 import io.debezium.heartbeat.HeartbeatErrorHandler;
@@ -806,6 +808,18 @@ public abstract class CommonConnectorConfig {
             .withDescription(
                     "Class to make transaction context & transaction struct/schemas");
 
+    public static final Field ENVELOPE_SCHEMA_FACTORY = Field.create("envelope.schema.factory")
+            .withDisplayName("Factory class for the Debezium change event envelope schema")
+            .withType(Type.CLASS)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDefault(DefaultEnvelopeSchemaFactory.class.getName())
+            .withDescription("Class implementing EnvelopeSchemaFactory that is used to define the Kafka Connect Schema " +
+                    "of the change event envelope emitted by this connector. " +
+                    "Sinks that do not require the standard CDC format can supply a custom implementation " +
+                    "to avoid the overhead of reshaping records via SMTs after the fact. " +
+                    "Defaults to " + DefaultEnvelopeSchemaFactory.class.getName() + ".");
+
     public static final Field EVENT_PROCESSING_FAILURE_HANDLING_MODE = Field.create("event.processing.failure.handling.mode")
             .withDisplayName("Event deserialization failure handling")
             .withGroup(Field.createGroupEntry(Field.Group.ADVANCED))
@@ -1510,7 +1524,8 @@ public abstract class CommonConnectorConfig {
                     EVENT_CONVERTING_FAILURE_HANDLING_MODE)
             .group(Field.Group.CONNECTOR_ADVANCED, PROVIDE_TRANSACTION_METADATA, CUSTOM_CONVERTERS, CUSTOM_POST_PROCESSORS,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE, INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES,
-                    SIGNAL_DATA_COLLECTION, SIGNAL_ENABLED_CHANNELS, NOTIFICATION_ENABLED_CHANNELS, TRANSACTION_METADATA_FACTORY)
+                    SIGNAL_DATA_COLLECTION, SIGNAL_ENABLED_CHANNELS, NOTIFICATION_ENABLED_CHANNELS, TRANSACTION_METADATA_FACTORY,
+                    ENVELOPE_SCHEMA_FACTORY)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, SNAPSHOT_MODE_TABLES,
                     SNAPSHOT_MODE_CUSTOM_NAME, SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA,
                     SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM, SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_ON_SCHEMA_ERROR,
@@ -1551,6 +1566,7 @@ public abstract class CommonConnectorConfig {
     private final Integer queryFetchSize;
     private final SourceInfoStructMaker<? extends AbstractSourceInfo> sourceInfoStructMaker;
     private final TransactionMetadataFactory transactionMetadataFactory;
+    private final EnvelopeSchemaFactory envelopeSchemaFactory;
     private final boolean shouldProvideTransactionMetadata;
     private final EventProcessingFailureHandlingMode eventProcessingFailureHandlingMode;
     private final BinaryHandlingMode binaryHandlingMode;
@@ -1607,6 +1623,7 @@ public abstract class CommonConnectorConfig {
         this.eventConvertingFailureHandlingMode = EventConvertingFailureHandlingMode.parse(config.getString(EVENT_CONVERTING_FAILURE_HANDLING_MODE));
         this.sourceInfoStructMaker = getSourceInfoStructMaker(Version.V2);
         this.transactionMetadataFactory = getTransactionMetadataFactory();
+        this.envelopeSchemaFactory = getEnvelopeSchemaFactory(ENVELOPE_SCHEMA_FACTORY);
         this.shouldProvideTransactionMetadata = config.getBoolean(PROVIDE_TRANSACTION_METADATA);
         this.eventProcessingFailureHandlingMode = EventProcessingFailureHandlingMode.parse(config.getString(EVENT_PROCESSING_FAILURE_HANDLING_MODE));
         this.binaryHandlingMode = BinaryHandlingMode.parse(config.getString(BINARY_HANDLING_MODE));
@@ -1934,6 +1951,34 @@ public abstract class CommonConnectorConfig {
 
     public TransactionMetadataFactory getTransactionMetadataFactory() {
         return getTransactionMetadataFactory(TRANSACTION_METADATA_FACTORY);
+    }
+
+    /**
+     * Returns the {@link EnvelopeSchemaFactory} configured for this connector.
+     *
+     * <p>By default this returns a {@link DefaultEnvelopeSchemaFactory} that produces the
+     * standard Debezium CDC envelope. A different implementation may be provided via the
+     * {@code envelope.schema.factory} connector configuration property.
+     *
+     * @return the envelope schema factory; never {@code null}
+     */
+    public EnvelopeSchemaFactory getEnvelopeSchemaFactory() {
+        return envelopeSchemaFactory;
+    }
+
+    /**
+     * Loads and returns the {@link EnvelopeSchemaFactory} specified by the given config field.
+     *
+     * @param envelopeSchemaFactoryField the field containing the fully-qualified class name
+     * @return the instantiated factory; never {@code null}
+     */
+    public EnvelopeSchemaFactory getEnvelopeSchemaFactory(Field envelopeSchemaFactoryField) {
+        final EnvelopeSchemaFactory factory = config.getInstance(envelopeSchemaFactoryField, EnvelopeSchemaFactory.class);
+        if (factory == null) {
+            throw new DebeziumException("Unable to instantiate envelope schema factory class " + config.getString(envelopeSchemaFactoryField));
+        }
+        LOGGER.info("Using envelope schema factory: {}", factory.getClass().getName());
+        return factory;
     }
 
     public EnumSet<Envelope.Operation> getSkippedOperations() {

--- a/debezium-connector-common/src/main/java/io/debezium/data/DefaultEnvelopeSchemaFactory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/DefaultEnvelopeSchemaFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import io.debezium.schema.SchemaFactory;
+
+/**
+ * Default implementation of {@link EnvelopeSchemaFactory}.
+ *
+ * <p>This class delegates to {@link SchemaFactory#datatypeEnvelopeSchema()}.
+ *
+ * @author Debezium Authors
+ * @see EnvelopeSchemaFactory
+ */
+public class DefaultEnvelopeSchemaFactory implements EnvelopeSchemaFactory {
+
+    /**
+     * Returns an {@link Envelope.Builder} backed by the standard Debezium
+     * {@link SchemaFactory#datatypeEnvelopeSchema()} builder.
+     *
+     * @return a new standard Debezium envelope builder; never {@code null}
+     */
+    @Override
+    public Envelope.Builder createEnvelopeSchema() {
+        return SchemaFactory.get().datatypeEnvelopeSchema();
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/data/Envelope.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/Envelope.java
@@ -227,6 +227,34 @@ public final class Envelope {
         return SchemaFactory.get().datatypeEnvelopeSchema();
     }
 
+    /**
+     * Creates a new {@link Builder} using the supplied {@link EnvelopeSchemaFactory}.
+     *
+     * <p>This overload is the extension point for DBZ-8967: callers that need a non-standard
+     * envelope layout (e.g., sinks that do not require the full CDC format) can supply a custom
+     * factory instead of using the hardcoded default. The factory is responsible for returning
+     * an {@link Envelope.Builder}; the caller chains further configuration ({@code withName},
+     * {@code withRecord}, {@code withSource}, {@code build()}) on top of what the factory returns.
+     *
+     * <p>Example with a custom factory:
+     * <pre>{@code
+     * EnvelopeSchemaFactory myFactory = () -> Envelope.defineSchema().withDoc("Iceberg envelope");
+     * Envelope env = Envelope.defineSchema(myFactory)
+     *     .withName("my.Envelope")
+     *     .withRecord(tableSchema)
+     *     .withSource(sourceSchema)
+     *     .build();
+     * }</pre>
+     *
+     * @param factory the factory that provides the envelope builder; may not be {@code null}
+     * @return a new {@link Builder} as created by the factory; never {@code null}
+     * @see EnvelopeSchemaFactory
+     * @see DefaultEnvelopeSchemaFactory
+     */
+    public static Builder defineSchema(EnvelopeSchemaFactory factory) {
+        return factory.createEnvelopeSchema();
+    }
+
     public static Envelope fromSchema(Schema schema) {
         return new Envelope(schema);
     }

--- a/debezium-connector-common/src/main/java/io/debezium/data/EnvelopeSchemaFactory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/EnvelopeSchemaFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+/**
+ * A factory interface that provides the {@link Envelope.Builder} used to construct the Kafka Connect
+ * schema for a Debezium change event envelope.
+ *
+ * <p>By default, Debezium uses {@link DefaultEnvelopeSchemaFactory} which produces the standard
+ * CDC envelope ({@code before}, {@code after}, {@code source}, {@code op}, {@code ts_ms}, etc.).
+ *
+ * <p>Custom implementations may be provided via the {@code envelope.schema.factory} connector
+ * configuration property. This allows sinks that do not require the full CDC format (e.g., Apache
+ * Iceberg sinks) to define the envelope layout upfront, avoiding the overhead of post-processing
+ * SMTs (Single Message Transforms) that reconstruct the schema after the fact.
+ *
+ * <p>Usage example — creating a custom factory inline:
+ * <pre>{@code
+ * EnvelopeSchemaFactory myFactory = () -> Envelope.defineSchema().withDoc("Iceberg-optimized envelope");
+ *
+ * Envelope envelope = Envelope.defineSchema(myFactory)
+ *     .withName("my.topic.Envelope")
+ *     .withRecord(tableSchema)
+ *     .withSource(sourceSchema)
+ *     .build();
+ * }</pre>
+ *
+ * @author Debezium Authors
+ */
+@FunctionalInterface
+public interface EnvelopeSchemaFactory {
+
+    /**
+     * Creates and returns an {@link Envelope.Builder} that will be used to construct the envelope schema.
+     *
+     * <p>Implementations may return a modified builder (e.g., one that skips certain fields or
+     * adds custom fields). The caller is responsible for chaining the remaining builder calls
+     * ({@code withName}, {@code withRecord}, {@code withSource}, {@code build()}) after this method returns.
+     *
+     * @return a new {@link Envelope.Builder}; never {@code null}
+     */
+    Envelope.Builder createEnvelopeSchema();
+}

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -26,7 +26,9 @@ import io.debezium.DebeziumException;
 import io.debezium.annotation.Immutable;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMode;
+import io.debezium.data.DefaultEnvelopeSchemaFactory;
 import io.debezium.data.Envelope;
+import io.debezium.data.EnvelopeSchemaFactory;
 import io.debezium.data.SchemaUtil;
 import io.debezium.relational.Key.KeyMapper;
 import io.debezium.relational.Tables.ColumnNameFilter;
@@ -66,6 +68,7 @@ public class TableSchemaBuilder {
     private final CustomConverterRegistry customConverterRegistry;
     private final boolean multiPartitionMode;
     private final EventConvertingFailureHandlingMode eventConvertingFailureHandlingMode;
+    private final EnvelopeSchemaFactory envelopeSchemaFactory;
 
     /**
      * Create a new instance of the builder.
@@ -84,7 +87,7 @@ public class TableSchemaBuilder {
                               EventConvertingFailureHandlingMode eventConvertingFailureHandlingMode) {
         this(valueConverterProvider, null, schemaNameAdjuster,
                 customConverterRegistry, sourceInfoSchema, transactionSchema, fieldNamer,
-                multiPartitionMode, eventConvertingFailureHandlingMode);
+                multiPartitionMode, eventConvertingFailureHandlingMode, new DefaultEnvelopeSchemaFactory());
     }
 
     /**
@@ -104,7 +107,7 @@ public class TableSchemaBuilder {
                               EventConvertingFailureHandlingMode eventConvertingFailureHandlingMode) {
         this(valueConverterProvider, defaultValueConverter, schemaNameAdjuster,
                 customConverterRegistry, sourceInfoSchema, SchemaFactory.get().transactionBlockSchema(),
-                fieldNamer, multiPartitionMode, eventConvertingFailureHandlingMode);
+                fieldNamer, multiPartitionMode, eventConvertingFailureHandlingMode, new DefaultEnvelopeSchemaFactory());
     }
 
     /**
@@ -125,6 +128,24 @@ public class TableSchemaBuilder {
                               FieldNamer<Column> fieldNamer,
                               boolean multiPartitionMode,
                               EventConvertingFailureHandlingMode eventConvertingFailureHandlingMode) {
+        this(valueConverterProvider, defaultValueConverter, schemaNameAdjuster,
+                customConverterRegistry, sourceInfoSchema, transactionSchema, fieldNamer,
+                multiPartitionMode, eventConvertingFailureHandlingMode, new DefaultEnvelopeSchemaFactory());
+    }
+
+    /**
+     * Create a new instance of the builder with a custom {@link EnvelopeSchemaFactory}.
+     */
+    public TableSchemaBuilder(ValueConverterProvider valueConverterProvider,
+                              DefaultValueConverter defaultValueConverter,
+                              SchemaNameAdjuster schemaNameAdjuster,
+                              CustomConverterRegistry customConverterRegistry,
+                              Schema sourceInfoSchema,
+                              Schema transactionSchema,
+                              FieldNamer<Column> fieldNamer,
+                              boolean multiPartitionMode,
+                              EventConvertingFailureHandlingMode eventConvertingFailureHandlingMode,
+                              EnvelopeSchemaFactory envelopeSchemaFactory) {
         this.schemaNameAdjuster = schemaNameAdjuster;
         this.valueConverterProvider = valueConverterProvider;
         this.defaultValueConverter = Optional.ofNullable(defaultValueConverter)
@@ -135,6 +156,7 @@ public class TableSchemaBuilder {
         this.customConverterRegistry = customConverterRegistry;
         this.multiPartitionMode = multiPartitionMode;
         this.eventConvertingFailureHandlingMode = eventConvertingFailureHandlingMode;
+        this.envelopeSchemaFactory = envelopeSchemaFactory;
     }
 
     /**
@@ -188,7 +210,7 @@ public class TableSchemaBuilder {
             LOGGER.debug("Mapped columns for table '{}' to schema: {}", tableId, SchemaUtil.asDetailedString(valSchema));
         }
 
-        Envelope envelope = Envelope.defineSchema()
+        Envelope envelope = Envelope.defineSchema(envelopeSchemaFactory)
                 .withName(schemaNameAdjuster.adjust(envelopSchemaName))
                 .withRecord(valSchema)
                 .withSource(sourceInfoSchema)

--- a/debezium-connector-common/src/test/java/io/debezium/data/EnvelopeTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/EnvelopeTest.java
@@ -58,6 +58,55 @@ public class EnvelopeTest {
     }
 
     @Test
+    public void shouldUseDefaultEnvelopeSchemaFactory() {
+        // Verify that the new Envelope.defineSchema(factory) overload with the DefaultEnvelopeSchemaFactory
+        // produces a schema identical to the existing no-args Envelope.defineSchema() path.
+        EnvelopeSchemaFactory defaultFactory = new DefaultEnvelopeSchemaFactory();
+
+        Envelope envViaFactory = Envelope.defineSchema(defaultFactory)
+                .withName("factoryTest")
+                .withRecord(Schema.OPTIONAL_STRING_SCHEMA)
+                .withSource(Schema.OPTIONAL_INT64_SCHEMA)
+                .build();
+
+        Envelope envDefault = Envelope.defineSchema()
+                .withName("factoryTest")
+                .withRecord(Schema.OPTIONAL_STRING_SCHEMA)
+                .withSource(Schema.OPTIONAL_INT64_SCHEMA)
+                .build();
+
+        // Both envelopes must have exactly the same schema structure.
+        assertThat(envViaFactory.schema().fields().size()).isEqualTo(envDefault.schema().fields().size());
+        assertThat(envViaFactory.schema().version()).isEqualTo(Envelope.SCHEMA_VERSION);
+        assertOptionalField(envViaFactory, Envelope.FieldName.BEFORE, Schema.OPTIONAL_STRING_SCHEMA);
+        assertOptionalField(envViaFactory, Envelope.FieldName.AFTER, Schema.OPTIONAL_STRING_SCHEMA);
+        assertOptionalField(envViaFactory, Envelope.FieldName.SOURCE, Schema.OPTIONAL_INT64_SCHEMA);
+        assertRequiredField(envViaFactory, Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA);
+    }
+
+    @Test
+    public void shouldUseCustomEnvelopeSchemaFactory() {
+        // Verify that a custom EnvelopeSchemaFactory is actually called, and its builder is used.
+        // The custom factory injects a doc string into the envelope schema.
+        final String customDoc = "Custom envelope for Iceberg sink";
+
+        EnvelopeSchemaFactory customFactory = () -> Envelope.defineSchema().withDoc(customDoc);
+
+        Envelope env = Envelope.defineSchema(customFactory)
+                .withName("customFactoryTest")
+                .withRecord(Schema.OPTIONAL_STRING_SCHEMA)
+                .withSource(Schema.OPTIONAL_INT64_SCHEMA)
+                .build();
+
+        // The custom doc should be present on the built schema.
+        assertThat(env.schema().doc()).isEqualTo(customDoc);
+        assertThat(env.schema().name()).isEqualTo("customFactoryTest");
+        assertThat(env.schema().version()).isEqualTo(Envelope.SCHEMA_VERSION);
+        assertOptionalField(env, Envelope.FieldName.BEFORE, Schema.OPTIONAL_STRING_SCHEMA);
+        assertRequiredField(env, Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA);
+    }
+
+    @Test
     public void envelopeOperationLookupByCode() {
         assertThat(Envelope.Operation.forCode(null)).isNull();
         assertThat(Envelope.Operation.forCode("")).isNull();


### PR DESCRIPTION
Fixes debezium/dbz#74

## What
Added support for plugging in a custom `EnvelopeSchemaFactory` to define the Kafka Connect schema of the Debezium change event envelope.

## Why

Sinks like the Debezium Server Iceberg sink use the ExtractNewRecordState SMT to reshape records into a compatible structure. SMTs add per‑message overhead because the schema is reconstructed on every record. Allowing the sink to define the envelope schema upfront eliminates that cost.

## How

- **EnvelopeSchemaFactory** — a `@FunctionalInterface` returning an `Envelope.Builder`. Custom implementations control the envelope structure; the caller chains `.withName()`, `.withRecord()`, `.withSource()`, `.build()` on top.  
- **DefaultEnvelopeSchemaFactory** — delegates to `SchemaFactory.get().datatypeEnvelopeSchema()`, preserving the existing behaviour when no custom factory is set.  
- **Envelope.defineSchema(EnvelopeSchemaFactory)** — new static overload. The original `defineSchema()` is untouched.  
- **CommonConnectorConfig** — new `envelope.schema.factory` config property following the same pattern as `transaction.metadata.factory`, including `CONFIG_DEFINITION` registration and fail‑fast startup validation.  
- **TableSchemaBuilder** — the new primary constructor accepts an `EnvelopeSchemaFactory`; the `create()` method calls `Envelope.defineSchema(envelopeSchemaFactory)` instead of the hardcoded no‑args version. All three existing constructor overloads default to `DefaultEnvelopeSchemaFactory` so no existing call sites change.  
- Individual connector adoption (passing `connectorConfig.getEnvelopeSchemaFactory()` from each connector's `DatabaseSchema` class) is tracked separately. This PR scopes the core infrastructure and wiring.

## Testing

Added two test cases to `EnvelopeTest`:

- **shouldUseDefaultEnvelopeSchemaFactory** — verifies `Envelope.defineSchema(DefaultEnvelopeSchemaFactory)` is structurally identical to `Envelope.defineSchema()`.  
- **shouldUseCustomEnvelopeSchemaFactory** — verifies a lambda factory is invoked via `Envelope.defineSchema(factory)` and its modifications are preserved.  

All existing `EnvelopeTest` (3) cases continue to pass.
