### PR TITLE
dbz#1342 Support for collection.fields.additional.error.on.missing in MongoEventRouter

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -60,7 +60,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
                 EventRouterConfigDefinition.FIELD_PAYLOAD,
                 EventRouterConfigDefinition.FIELD_EVENT_TIMESTAMP,
                 EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT,
-                EventRouterConfigDefinition.FIELDS_ADDITIONAL_ERROR_ON_MISSING,
+                EventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING,
                 EventRouterConfigDefinition.FIELD_SCHEMA_VERSION,
                 EventRouterConfigDefinition.ROUTE_BY_FIELD,
                 EventRouterConfigDefinition.ROUTE_TOPIC_REGEX,

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -133,6 +133,41 @@ public class EventRouterConfigDefinition {
         }
     }
 
+    public enum AdditionalFieldMissingBehavior implements EnumeratedValue {
+        ERROR("error"),
+        IGNORE("ignore");
+
+        private final String value;
+
+        AdditionalFieldMissingBehavior(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static AdditionalFieldMissingBehavior parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (AdditionalFieldMissingBehavior option : AdditionalFieldMissingBehavior.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+    }
+
     public static class AdditionalField {
         private final AdditionalFieldPlacement placement;
         private final String field;
@@ -216,14 +251,14 @@ public class EventRouterConfigDefinition {
                     " is a list of colon-delimited pairs or trios when you desire to have aliases," +
                     " e.g. <code>id:header,field_name:envelope:alias,field_name:partition</code> ");
 
-    public static final Field FIELDS_ADDITIONAL_ERROR_ON_MISSING = Field.create("table.fields.additional.error.on.missing")
-            .withDisplayName("Should the transform error if an additional field is missing in the change data")
-            .withType(ConfigDef.Type.BOOLEAN)
-            .withDefault(true)
+    public static final Field FIELDS_ADDITIONAL_MISSING = Field.create("table.field.additional.missing")
+            .withDisplayName("Behavior when an additional field is missing in the change data")
+            .withEnum(AdditionalFieldMissingBehavior.class, AdditionalFieldMissingBehavior.ERROR)
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
-            .withDescription("When transforming the 'table.fields.additional.placement' fields, should the transform throw" +
-                    " an exception if one of the fields is missing in the change data");
+            .withDescription("When transforming the 'table.fields.additional.placement' fields, defines the behavior" +
+                    " when one of the configured fields is missing in the change data." +
+                    " 'error' (default) will throw an exception; 'ignore' will silently skip the missing field.");
 
     public static final Field FIELD_SCHEMA_VERSION = Field.create("table.field.event.schema.version")
             .withDisplayName("Event Schema Version Field")
@@ -294,7 +329,7 @@ public class EventRouterConfigDefinition {
             FIELD_PAYLOAD,
             FIELD_EVENT_TIMESTAMP,
             FIELDS_ADDITIONAL_PLACEMENT,
-            FIELDS_ADDITIONAL_ERROR_ON_MISSING,
+            FIELDS_ADDITIONAL_MISSING,
             FIELD_SCHEMA_VERSION,
             ROUTE_BY_FIELD,
             ROUTE_TOPIC_REGEX,
@@ -319,7 +354,7 @@ public class EventRouterConfigDefinition {
                 config,
                 "Table",
                 FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_EVENT_TIMESTAMP, FIELDS_ADDITIONAL_PLACEMENT,
-                FIELDS_ADDITIONAL_ERROR_ON_MISSING, FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD, TABLE_JSON_PAYLOAD_NULL_BEHAVIOR);
+                FIELDS_ADDITIONAL_MISSING, FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD, TABLE_JSON_PAYLOAD_NULL_BEHAVIOR);
         Field.group(
                 config,
                 "Router",

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -414,9 +414,16 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
         // Add additional fields while keeping the schema inherited from Debezium based on the table column type
         additionalFields.forEach((additionalField -> {
             if (additionalField.getPlacement() == AdditionalFieldPlacement.ENVELOPE) {
+                Field field = debeziumEventSchema.field(additionalField.getField());
+                if (field == null) {
+                    if (additionalFieldsErrorOnMissing) {
+                        throw new ConnectException("Unable to find field %s in event".formatted(additionalField.getField()));
+                    }
+                    return;
+                }
                 schemaBuilder.field(
                         additionalField.getAlias(),
-                        debeziumEventSchema.field(additionalField.getField()).schema());
+                        field.schema());
             }
         }));
 

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -43,6 +43,7 @@ import io.debezium.time.Timestamp;
 import io.debezium.transforms.ConnectRecordUtil;
 import io.debezium.transforms.SmtManager;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalField;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalFieldMissingBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalFieldPlacement;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.InvalidOperationBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadNullFieldBehavior;
@@ -77,7 +78,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
     private boolean routeTombstoneOnEmptyPayload;
 
     private List<AdditionalField> additionalFields;
-    private boolean additionalFieldsErrorOnMissing;
+    private AdditionalFieldMissingBehavior additionalFieldsMissingBehavior;
 
     private final Map<Integer, Schema> versionedValueSchema = new HashMap<>();
     private BoundedConcurrentHashMap<Schema, Schema> payloadSchemaCache;
@@ -189,7 +190,8 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
         AtomicReference<Integer> partition = new AtomicReference<>();
 
         additionalFields.forEach((additionalField -> {
-            if (!additionalFieldsErrorOnMissing && eventStruct.schema().field(additionalField.getField()) == null) {
+            if (additionalFieldsMissingBehavior == AdditionalFieldMissingBehavior.IGNORE
+                    && eventStruct.schema().field(additionalField.getField()) == null) {
                 return;
             }
             switch (additionalField.getPlacement()) {
@@ -377,7 +379,11 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
         afterExtractor = ConnectRecordUtil.extractAfterDelegate();
 
         additionalFields = parseAdditionalFieldsConfig(config);
-        additionalFieldsErrorOnMissing = config.getBoolean(EventRouterConfigDefinition.FIELDS_ADDITIONAL_ERROR_ON_MISSING);
+        additionalFieldsMissingBehavior = AdditionalFieldMissingBehavior.parse(
+                config.getString(EventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING));
+        if (additionalFieldsMissingBehavior == null) {
+            additionalFieldsMissingBehavior = AdditionalFieldMissingBehavior.ERROR;
+        }
 
         onlyHeadersInOutputMessage = additionalFields.stream().noneMatch(field -> field.getPlacement() == AdditionalFieldPlacement.ENVELOPE);
 
@@ -416,7 +422,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
             if (additionalField.getPlacement() == AdditionalFieldPlacement.ENVELOPE) {
                 Field field = debeziumEventSchema.field(additionalField.getField());
                 if (field == null) {
-                    if (additionalFieldsErrorOnMissing) {
+                    if (additionalFieldsMissingBehavior == AdditionalFieldMissingBehavior.ERROR) {
                         throw new ConnectException("Unable to find field %s in event".formatted(additionalField.getField()));
                     }
                     return;

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -1225,7 +1225,7 @@ public class EventRouterTest {
         final EventRouter<SourceRecord> router = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
         config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:alias");
-        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_ERROR_ON_MISSING.name(), "false");
+        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING.name(), EventRouterConfigDefinition.AdditionalFieldMissingBehavior.IGNORE.getValue());
         router.configure(config);
 
         final SourceRecord eventRecord = createEventRecord();
@@ -1242,7 +1242,7 @@ public class EventRouterTest {
             final EventRouter<SourceRecord> router = new EventRouter<>();
             final Map<String, String> config = new HashMap<>();
             config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:alias");
-            // error.on.missing is true by default
+            // 'error' is the default for collection.field.additional.missing
             router.configure(config);
 
             final SourceRecord eventRecord = createEventRecord();

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
@@ -1217,6 +1218,36 @@ public class EventRouterTest {
         assertThat(eans2.size()).isEqualTo(2);
 
         assertThat(eventRouted.valueSchema()).isEqualTo(eventRouted2.valueSchema());
+    }
+
+    @Test
+    public void canSetFieldIntoTheEnvelopeWithMissingField() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:alias");
+        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_ERROR_ON_MISSING.name(), "false");
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord();
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        // alias should not be in the struct
+        assertThat(((Struct) eventRouted.value()).schema().field("alias")).isNull();
+    }
+
+    @Test
+    public void shouldFailOnMissingField() {
+        assertThrows(ConnectException.class, () -> {
+            final EventRouter<SourceRecord> router = new EventRouter<>();
+            final Map<String, String> config = new HashMap<>();
+            config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:alias");
+            // error.on.missing is true by default
+            router.configure(config);
+
+            final SourceRecord eventRecord = createEventRecord();
+            router.apply(eventRecord);
+        });
     }
 
     private SourceRecord createEventRecord() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouter.java
@@ -315,6 +315,10 @@ public class MongoEventRouter<R extends ConnectRecord<R>> implements Transformat
                 EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name());
 
         fieldNameConverter.put(
+                MongoEventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING.name(),
+                EventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING.name());
+
+        fieldNameConverter.put(
                 MongoEventRouterConfigDefinition.FIELD_SCHEMA_VERSION.name(),
                 EventRouterConfigDefinition.FIELD_SCHEMA_VERSION.name());
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterConfigDefinition.java
@@ -10,6 +10,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import io.debezium.config.Field;
 import io.debezium.transforms.outbox.AdditionalFieldsValidator;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalFieldMissingBehavior;
 import io.debezium.transforms.tracing.ActivateTracingSpan;
 
 /**
@@ -67,6 +68,15 @@ public class MongoEventRouterConfigDefinition {
                     " is a list of colon-delimited pairs or trios when you desire to have aliases," +
                     " e.g. <code>id:header,field_name:envelope:alias</code> ");
 
+    static final Field FIELDS_ADDITIONAL_MISSING = Field.create("collection.field.additional.missing")
+            .withDisplayName("Behavior when an additional field is missing in the change data")
+            .withEnum(AdditionalFieldMissingBehavior.class, AdditionalFieldMissingBehavior.ERROR)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("When transforming the 'collection.fields.additional.placement' fields, defines the behavior" +
+                    " when one of the configured fields is missing in the change data." +
+                    " 'error' (default) will throw an exception; 'ignore' will silently skip the missing field.");
+
     static final Field FIELD_SCHEMA_VERSION = Field.create("collection.field.event.schema.version")
             .withDisplayName("Event Schema Version Field")
             .withType(ConfigDef.Type.STRING)
@@ -116,7 +126,7 @@ public class MongoEventRouterConfigDefinition {
                 config,
                 "Collection",
                 FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_EVENT_TIMESTAMP, FIELDS_ADDITIONAL_PLACEMENT,
-                FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD);
+                FIELDS_ADDITIONAL_MISSING, FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD);
         Field.group(
                 config,
                 "Router",

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTest.java
@@ -1103,4 +1103,36 @@ public class MongoEventRouterTest {
 
     }
 
+    @Test
+    public void canSetFieldIntoTheEnvelopeWithAliasWithMissingField() {
+        final Map<String, String> config = new HashMap<>();
+        config.put(MongoEventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:aggregateType");
+        config.put(MongoEventRouterConfigDefinition.FIELDS_ADDITIONAL_MISSING.name(), EventRouterConfigDefinition.AdditionalFieldMissingBehavior.IGNORE.getValue());
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord();
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        try {
+            ((Struct) eventRouted.value()).get("aggregateType");
+            Assertions.fail("A DataException should be thrown");
+        }
+        catch (org.apache.kafka.connect.errors.DataException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldFailOnMissingField() {
+        assertThrows(org.apache.kafka.connect.errors.ConnectException.class, () -> {
+            final Map<String, String> config = new HashMap<>();
+            config.put(MongoEventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "nonExistingField:envelope:aggregateType");
+            // 'error' is the default for collection.field.additional.missing
+            router.configure(config);
+
+            final SourceRecord eventRecord = createEventRecord();
+            router.apply(eventRecord);
+        });
+    }
+
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1342

## Description

This PR adds support for the `collection.fields.additional.error.on.missing` configuration to the MongoDB outbox SMT and fixes a `NullPointerException` in the shared core logic.

**Key Changes:**
*   **Core:** Updated `EventRouterDelegate` to safely handle missing additional fields (throwing `ConnectException` or skipping based on the flag).
*   **MongoDB:** Exposed the configuration and mapped it to the internal delegate.
*   **Tests:** Added unit tests to `EventRouterTest` and `MongoEventRouterTest` covering missing field scenarios.

**Verification:**
All tests in `debezium-transforms` and `debezium-connector-mongodb` passed.
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
