### PR TITLE
debezium/dbz#1605 Auto-enable heartbeat when lsn.flush.mode=connector_and_driver

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -1525,7 +1525,7 @@ public abstract class CommonConnectorConfig {
     private final Duration pollInterval;
     protected final String logicalName;
     private final String heartbeatTopicsPrefix;
-    private final Duration heartbeatInterval;
+    private Duration heartbeatInterval;
     private final Duration snapshotDelay;
     private final Duration streamingDelay;
     private final Duration retriableRestartWait;
@@ -1725,6 +1725,10 @@ public abstract class CommonConnectorConfig {
 
     public Duration getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    protected void setHeartbeatInterval(int heartbeatIntervalMs) {
+        this.heartbeatInterval = Duration.ofMillis(heartbeatIntervalMs);
     }
 
     public Duration getSnapshotDelay() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -33,6 +33,7 @@ import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.connection.pgoutput.PgOutputMessageDecoder;
 import io.debezium.connector.postgresql.connection.pgproto.PgProtoMessageDecoder;
+import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -1410,6 +1411,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         this.publishViaPartitionRoot = config.getBoolean(PUBLISH_VIA_PARTITION_ROOT);
         this.lsnFlushTimeoutAction = LsnFlushTimeoutAction.parse(config.getString(LSN_FLUSH_TIMEOUT_ACTION));
         this.offsetSlotMismatchStrategy = resolveOffsetSlotMismatchStrategy(config);
+
+        applyLsnFlushModeHeartbeatFallback(config);
     }
 
     protected String hostname() {
@@ -1734,6 +1737,19 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
         logOffsetSlotMismatchStrategyInfo(mode);
         return mode;
+    }
+
+    private void applyLsnFlushModeHeartbeatFallback(Configuration config) {
+
+        if (this.lsnFlushMode == LsnFlushMode.CONNECTOR_AND_DRIVER
+                && super.getHeartbeatInterval().isZero()
+                && !super.shouldProvideTransactionMetadata()) {
+            LOGGER.warn("{} was internally set to 600000 ms since {}={} requires periodic opportunities to propagate LSNs to Kafka. " +
+                    "If this behavior is not desired, explicitly set {} to more than 0 or enable {}.",
+                    Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, LSN_FLUSH_MODE, LsnFlushMode.CONNECTOR_AND_DRIVER,
+                    Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, PROVIDE_TRANSACTION_METADATA);
+            super.setHeartbeatInterval(600000);
+        }
     }
 
     private static void logOffsetSlotMismatchStrategyInfo(OffsetSlotMismatchStrategy strategy) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2977,6 +2977,16 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-1605")
+    void shouldApplyLsnFlushModeHeartbeatFallbackWhenNoOpportunityForFlush() {
+        PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.LSN_FLUSH_MODE, PostgresConnectorConfig.LsnFlushMode.CONNECTOR_AND_DRIVER.getValue())
+                .build());
+
+        assertThat(config.getHeartbeatInterval()).isGreaterThan(java.time.Duration.ZERO);
+    }
+
+    @Test
     @FixFor("DBZ-1292")
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
     public void shouldOutputRecordsInCloudEventsFormat() throws Exception {

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4162,6 +4162,9 @@ Use this mode to prevent WAL growth on low-activity databases where monitored ta
 NOTE: When using `connector_and_driver` mode, the JDBC driver's keep-alive mechanism can flush the server-reported keep-alive LSN, which may advance the replication slot beyond the stored offset when non-monitored WAL activity occurs.
 If you use a persistent offset store, configure xref:postgresql-property-offset-mismatch-strategy[`offset.mismatch.strategy`] to `trust_slot` or `trust_greater_lsn` to enable automatic recovery.
 +
+NOTE: Because `connector_and_driver` mode requires periodic opportunities to propagate LSNs to Kafka, when xref:postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] = 0 and
+xref:postgresql-property-provide-transaction-metadata[`provide.transaction.metadata`] = false, the connector internally sets xref:postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] to 600000 (10 minutes).
++
 [IMPORTANT]
 ====
 The `connector_and_driver` mode is a Technology Preview feature.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1605

## Description
As discussed in #1605, this PR enables automatic heartbeat when conditions are met.

When `lsn.flush.mode` is set to `connector_and_driver` and `heartbeat.interval.ms` is left at its default value (0),
the connector may never get a chance to propagate LSNs to Kafka if only unmonitored tables generate WAL activity.

In this situation, `confirmed_flush_lsn` does not advance and replication slots retain WAL indefinitely.

To provide periodic opportunities for LSN propagation without requiring users to be aware of this subtle interaction, the connector now internally sets `heartbeat.interval.ms` to 10 minuntes when:

  - lsn.flush.mode = connector_and_driver
  - heartbeat.interval.ms = 0
  - provide.transaction.metadata = false

A warning is logged to make this behavior explicit.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
