### PR TITLE
debezium/dbz#1713 Use log count/size in place of batch/sleep

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -928,4 +928,10 @@ public class OracleConnection extends JdbcConnection {
     public <T extends DataCollectionId> ChunkQueryBuilder<T> chunkQueryBuilder(RelationalDatabaseConnectorConfig connectorConfig) {
         return new OraclePhysicalRowIdentifierChunkQueryBuilder<>(connectorConfig, this);
     }
+
+    public long getMaximumRedoLogFileSize() throws SQLException {
+        return queryAndMap(
+                "SELECT MAX(BYTES) FROM V$LOG",
+                singleResultMapper(rs -> rs.getLong(1), "Failed to get maximum redo log file size"));
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -57,22 +57,9 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     protected static final int DEFAULT_PORT = 1528;
     protected static final int DEFAULT_LOG_FILE_QUERY_MAX_RETRIES = 5;
 
-    protected final static int DEFAULT_BATCH_SIZE = 20_000;
-    protected final static int DEFAULT_BATCH_INCREMENT_SIZE = 20_000;
-    protected final static int MIN_BATCH_SIZE = 1_000;
-    protected final static int MAX_BATCH_SIZE = 100_000;
-
-    protected final static int DEFAULT_SCN_GAP_SIZE = 1_000_000;
-    protected final static int DEFAULT_SCN_GAP_TIME_INTERVAL = 20_000;
-
     protected final static int DEFAULT_TRANSACTION_EVENTS_THRESHOLD = 0;
 
     protected final static int DEFAULT_QUERY_FETCH_SIZE = 10_000;
-
-    protected final static Duration MAX_SLEEP_TIME = Duration.ofMillis(3_000);
-    protected final static Duration DEFAULT_SLEEP_TIME = Duration.ofMillis(1_000);
-    protected final static Duration MIN_SLEEP_TIME = Duration.ZERO;
-    protected final static Duration SLEEP_TIME_INCREMENT = Duration.ofMillis(200);
 
     protected final static Duration ARCHIVE_LOG_ONLY_POLL_TIME = Duration.ofMillis(10_000);
 
@@ -214,83 +201,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 10))
             .withDescription("Complete JDBC URL as an alternative to specifying hostname, port and database provided "
                     + "as a way to support alternative connection scenarios.");
-
-    public static final Field LOG_MINING_BATCH_SIZE_MIN = Field.create("log.mining.batch.size.min")
-            .withDisplayName("Minimum batch size for reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 13))
-            .withDefault(MIN_BATCH_SIZE)
-            .withDescription(
-                    "The minimum SCN interval size that this connector will try to read from redo/archive logs.");
-
-    public static final Field LOG_MINING_BATCH_SIZE_INCREMENT = Field.create("log.mining.batch.size.increment")
-            .withDisplayName("Increment/Decrement batch size for reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 12))
-            .withDefault(DEFAULT_BATCH_INCREMENT_SIZE)
-            .withDescription("Active batch size will be also increased/decreased by this amount for tuning connector throughput when needed.");
-
-    public static final Field LOG_MINING_BATCH_SIZE_DEFAULT = Field.create("log.mining.batch.size.default")
-            .withDisplayName("Default batch size for reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 11))
-            .withDefault(DEFAULT_BATCH_SIZE)
-            .withDescription("The starting SCN interval size that the connector will use for reading data from redo/archive logs.");
-
-    public static final Field LOG_MINING_BATCH_SIZE_MAX = Field.create("log.mining.batch.size.max")
-            .withDisplayName("Maximum batch size for reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 14))
-            .withDefault(MAX_BATCH_SIZE)
-            .withDescription("The maximum SCN interval size that this connector will use when reading from redo/archive logs.");
-
-    public static final Field LOG_MINING_SLEEP_TIME_MIN_MS = Field.create("log.mining.sleep.time.min.ms")
-            .withDisplayName("Minimum sleep time in milliseconds when reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 16))
-            .withDefault(MIN_SLEEP_TIME.toMillis())
-            .withDescription(
-                    "The minimum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
-
-    public static final Field LOG_MINING_SLEEP_TIME_DEFAULT_MS = Field.create("log.mining.sleep.time.default.ms")
-            .withDisplayName("Default sleep time in milliseconds when reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 15))
-            .withDefault(DEFAULT_SLEEP_TIME.toMillis())
-            .withDescription(
-                    "The amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
-
-    public static final Field LOG_MINING_SLEEP_TIME_MAX_MS = Field.create("log.mining.sleep.time.max.ms")
-            .withDisplayName("Maximum sleep time in milliseconds when reading redo/archive logs.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 17))
-            .withDefault(MAX_SLEEP_TIME.toMillis())
-            .withDescription(
-                    "The maximum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
-
-    public static final Field LOG_MINING_SLEEP_TIME_INCREMENT_MS = Field.create("log.mining.sleep.time.increment.ms")
-            .withDisplayName("The increment in sleep time in milliseconds used to tune auto-sleep behavior.")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 18))
-            .withDefault(SLEEP_TIME_INCREMENT.toMillis())
-            .withDescription(
-                    "The maximum amount of time that the connector will use to tune the optimal sleep time when reading data from LogMiner. Value is in milliseconds.");
 
     public static final Field LOG_MINING_ARCHIVE_LOG_ONLY_MODE = Field.create("log.mining.archive.log.only.mode")
             .withDisplayName("Specifies whether log mining should only target archive logs or both archive and redo logs")
@@ -471,28 +381,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withImportance(Importance.LOW)
             .withDescription("When set to true the underlying buffer cache is not retained when the connector is stopped. " +
                     "When set to false (the default), the buffer cache is retained across restarts.");
-
-    public static final Field LOG_MINING_SCN_GAP_DETECTION_GAP_SIZE_MIN = Field.create("log.mining.scn.gap.detection.gap.size.min")
-            .withDisplayName("SCN gap size used to detect SCN gap")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 30))
-            .withDefault(DEFAULT_SCN_GAP_SIZE)
-            .withDescription("Used for SCN gap detection, if the difference between current SCN and previous end SCN is " +
-                    "bigger than this value, and the time difference of current SCN and previous end SCN is smaller than " +
-                    "log.mining.scn.gap.detection.time.interval.max.ms, consider it a SCN gap.");
-
-    public static final Field LOG_MINING_SCN_GAP_DETECTION_TIME_INTERVAL_MAX_MS = Field.create("log.mining.scn.gap.detection.time.interval.max.ms")
-            .withDisplayName("Timer interval used to detect SCN gap")
-            .withType(Type.LONG)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 31))
-            .withDefault(DEFAULT_SCN_GAP_TIME_INTERVAL)
-            .withDescription("Used for SCN gap detection, if the difference between current SCN and previous end SCN is " +
-                    "bigger than log.mining.scn.gap.detection.gap.size.min, and the time difference of current SCN and previous end SCN is smaller than " +
-                    " this value, consider it a SCN gap.");
 
     public static final Field LOG_MINING_LOG_QUERY_MAX_RETRIES = Field.createInternal("log.mining.log.query.max.retries")
             .withDisplayName("Maximum number of retries before failing to locate redo logs")
@@ -832,6 +720,16 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDescription("Specifies the maximum memory in bytes the LogMiner session can use for performing SQL sort operations. " +
                     "Setting this to 0 (the default) uses the database's default SORT_AREA_SIZE.");
 
+    public static final Field LOG_MINING_LOG_COUNT_MIN = Field.create("log.mining.log.count.min")
+            .withDisplayName("Minimum number of logs per redo thread to mine")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(2)
+            .withValidation(Field::isNonNegativeInteger)
+            .withDescription("Specifies the minimum number of logs to mine per redo thread. " +
+                    "Setting this to 0 disables the cap, and all available logs are mined in a single pass.");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("Oracle")
             .excluding(
@@ -860,14 +758,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     RAC_NODES,
                     INTERVAL_HANDLING_MODE,
                     ARCHIVE_LOG_HOURS,
-                    LOG_MINING_BATCH_SIZE_DEFAULT,
-                    LOG_MINING_BATCH_SIZE_MIN,
-                    LOG_MINING_BATCH_SIZE_MAX,
-                    LOG_MINING_BATCH_SIZE_INCREMENT,
-                    LOG_MINING_SLEEP_TIME_DEFAULT_MS,
-                    LOG_MINING_SLEEP_TIME_MIN_MS,
-                    LOG_MINING_SLEEP_TIME_MAX_MS,
-                    LOG_MINING_SLEEP_TIME_INCREMENT_MS,
                     LOG_MINING_TRANSACTION_RETENTION_MS,
                     LOG_MINING_ARCHIVE_LOG_ONLY_MODE,
                     LOB_ENABLED,
@@ -885,8 +775,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_BUFFER_INFINISPAN_CACHE_SCHEMA_CHANGES,
                     LOG_MINING_BUFFER_TRANSACTION_EVENTS_THRESHOLD,
                     LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS,
-                    LOG_MINING_SCN_GAP_DETECTION_GAP_SIZE_MIN,
-                    LOG_MINING_SCN_GAP_DETECTION_TIME_INTERVAL_MAX_MS,
                     UNAVAILABLE_VALUE_PLACEHOLDER,
                     BINARY_HANDLING_MODE,
                     SCHEMA_NAME_ADJUSTMENT_MODE,
@@ -926,7 +814,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_USE_CTE_QUERY,
                     LOG_MINING_REDO_THREAD_SCN_ADJUSTMENT,
                     LOG_MINING_HASH_AREA_SIZE,
-                    LOG_MINING_SORT_AREA_SIZE)
+                    LOG_MINING_SORT_AREA_SIZE,
+                    LOG_MINING_LOG_COUNT_MIN)
             .events(SOURCE_INFO_STRUCT_MAKER,
                     SIGNAL_DATA_COLLECTION)
             .create();
@@ -965,14 +854,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final LogMiningStrategy logMiningStrategy;
     private final Set<String> racNodes;
     private final Duration archiveLogRetention;
-    private final int logMiningBatchSizeMin;
-    private final int logMiningBatchSizeMax;
-    private final int logMiningBatchSizeDefault;
-    private final int logMiningBatchSizeIncrement;
-    private final Duration logMiningSleepTimeMin;
-    private final Duration logMiningSleepTimeMax;
-    private final Duration logMiningSleepTimeDefault;
-    private final Duration logMiningSleepTimeIncrement;
     private final Duration logMiningTransactionRetention;
     private final boolean archiveLogOnlyMode;
     private final Duration archiveLogOnlyScnPollTime;
@@ -982,8 +863,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final LogMiningBufferType logMiningBufferType;
     private final long logMiningBufferTransactionEventsThreshold;
     private final boolean logMiningBufferDropOnStop;
-    private final int logMiningScnGapDetectionGapSizeMin;
-    private final int logMiningScnGapDetectionTimeIntervalMaxMs;
     private final int logMiningLogFileQueryMaxRetries;
     private final Duration logMiningInitialDelay;
     private final Duration logMiningMaxDelay;
@@ -1009,6 +888,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final Integer logMiningRedoThreadScnAdjustment;
     private final Long logMiningHashAreaSize;
     private final Long logMiningSortAreaSize;
+    private final Integer logMiningMinimumLogCount;
     private final ArchiveDestinationNameResolver destinationNameResolver;
     private final boolean logMiningBufferTrackRsId;
 
@@ -1052,14 +932,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningStrategy = LogMiningStrategy.parse(config.getString(LOG_MINING_STRATEGY));
         this.racNodes = resolveRacNodes(config);
         this.archiveLogRetention = config.getDuration(ARCHIVE_LOG_HOURS, ChronoUnit.HOURS);
-        this.logMiningBatchSizeMin = config.getInteger(LOG_MINING_BATCH_SIZE_MIN);
-        this.logMiningBatchSizeMax = config.getInteger(LOG_MINING_BATCH_SIZE_MAX);
-        this.logMiningBatchSizeDefault = config.getInteger(LOG_MINING_BATCH_SIZE_DEFAULT);
-        this.logMiningBatchSizeIncrement = config.getInteger(LOG_MINING_BATCH_SIZE_INCREMENT);
-        this.logMiningSleepTimeMin = Duration.ofMillis(config.getInteger(LOG_MINING_SLEEP_TIME_MIN_MS));
-        this.logMiningSleepTimeMax = Duration.ofMillis(config.getInteger(LOG_MINING_SLEEP_TIME_MAX_MS));
-        this.logMiningSleepTimeDefault = Duration.ofMillis(config.getInteger(LOG_MINING_SLEEP_TIME_DEFAULT_MS));
-        this.logMiningSleepTimeIncrement = Duration.ofMillis(config.getInteger(LOG_MINING_SLEEP_TIME_INCREMENT_MS));
         this.logMiningTransactionRetention = config.getDuration(LOG_MINING_TRANSACTION_RETENTION_MS, ChronoUnit.MILLIS);
         this.archiveLogOnlyMode = config.getBoolean(LOG_MINING_ARCHIVE_LOG_ONLY_MODE);
         this.logMiningUsernameIncludes = Strings.setOfTrimmed(config.getString(LOG_MINING_USERNAME_INCLUDE_LIST), String::new);
@@ -1068,8 +940,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningBufferTransactionEventsThreshold = config.getLong(LOG_MINING_BUFFER_TRANSACTION_EVENTS_THRESHOLD);
         this.logMiningBufferDropOnStop = config.getBoolean(LOG_MINING_BUFFER_DROP_ON_STOP);
         this.archiveLogOnlyScnPollTime = Duration.ofMillis(config.getInteger(LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS));
-        this.logMiningScnGapDetectionGapSizeMin = config.getInteger(LOG_MINING_SCN_GAP_DETECTION_GAP_SIZE_MIN);
-        this.logMiningScnGapDetectionTimeIntervalMaxMs = config.getInteger(LOG_MINING_SCN_GAP_DETECTION_TIME_INTERVAL_MAX_MS);
         this.logMiningLogFileQueryMaxRetries = config.getInteger(LOG_MINING_LOG_QUERY_MAX_RETRIES);
         this.logMiningInitialDelay = Duration.ofMillis(config.getLong(LOG_MINING_LOG_BACKOFF_INITIAL_DELAY_MS));
         this.logMiningMaxDelay = Duration.ofMillis(config.getLong(LOG_MINING_LOG_BACKOFF_MAX_DELAY_MS));
@@ -1105,6 +975,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningRedoThreadScnAdjustment = config.getInteger(LOG_MINING_REDO_THREAD_SCN_ADJUSTMENT);
         this.logMiningHashAreaSize = config.getLong(LOG_MINING_HASH_AREA_SIZE);
         this.logMiningSortAreaSize = config.getLong(LOG_MINING_SORT_AREA_SIZE);
+        this.logMiningMinimumLogCount = config.getInteger(LOG_MINING_LOG_COUNT_MIN);
         this.logMiningBufferTrackRsId = config.getBoolean(LOG_MINING_BUFFER_TRACK_RS_ID);
 
         this.logMiningEhCacheConfiguration = config.subset("log.mining.buffer.ehcache", false);
@@ -1877,77 +1748,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     }
 
     /**
-     *
-     * @return int The minimum SCN interval used when mining redo/archive logs
-     */
-    public int getLogMiningBatchSizeMin() {
-        return logMiningBatchSizeMin;
-    }
-
-    /**
-     *
-     * @return int The maximum SCN interval used when mining redo/archive logs
-     */
-    public int getLogMiningBatchSizeMax() {
-        return logMiningBatchSizeMax;
-    }
-
-    /**
-     * @return the size to increment/decrement log mining batches
-     */
-    public int getLogMiningBatchSizeIncrement() {
-        return logMiningBatchSizeIncrement;
-    }
-
-    /**
-     *
-     * @return int Scn gap size for SCN gap detection
-     */
-    public int getLogMiningScnGapDetectionGapSizeMin() {
-        return logMiningScnGapDetectionGapSizeMin;
-    }
-
-    /**
-     *
-     * @return int Time interval for SCN gap detection
-     */
-    public int getLogMiningScnGapDetectionTimeIntervalMaxMs() {
-        return logMiningScnGapDetectionTimeIntervalMaxMs;
-    }
-
-    /**
-     *
-     * @return int The minimum sleep time used when mining redo/archive logs
-     */
-    public Duration getLogMiningSleepTimeMin() {
-        return logMiningSleepTimeMin;
-    }
-
-    /**
-     *
-     * @return int The maximum sleep time used when mining redo/archive logs
-     */
-    public Duration getLogMiningSleepTimeMax() {
-        return logMiningSleepTimeMax;
-    }
-
-    /**
-     *
-     * @return int The default sleep time used when mining redo/archive logs
-     */
-    public Duration getLogMiningSleepTimeDefault() {
-        return logMiningSleepTimeDefault;
-    }
-
-    /**
-     *
-     * @return int The increment in sleep time when doing auto-tuning while mining redo/archive logs
-     */
-    public Duration getLogMiningSleepTimeIncrement() {
-        return logMiningSleepTimeIncrement;
-    }
-
-    /**
      * @return the duration for which long running transactions are permitted in the transaction buffer between log switches
      */
     public Duration getLogMiningTransactionRetention() {
@@ -2022,14 +1822,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public boolean isLogMiningBufferDropOnStop() {
         return logMiningBufferDropOnStop;
-    }
-
-    /**
-     *
-     * @return int The default SCN interval used when mining redo/archive logs
-     */
-    public int getLogMiningBatchSizeDefault() {
-        return logMiningBatchSizeDefault;
     }
 
     /**
@@ -2291,6 +2083,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public Long getLogMiningSortAreaSize() {
         return logMiningSortAreaSize;
+    }
+
+    /**
+     * The LogMiner mining session minimum number of logs to mine per pass per redo thread.
+     */
+    public Integer getLogMiningMinimumLogCount() {
+        return logMiningMinimumLogCount;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
@@ -232,7 +232,7 @@ public abstract class AbstractLogMinerStreamingAdapter
 
     protected List<LogFile> getOrderedLogsFromScn(OracleConnectorConfig config, Scn sinceScn, OracleConnection connection) throws SQLException {
         final LogFileCollector collector = new LogFileCollector(config, connection);
-        return collector.getLogs(sinceScn)
+        return collector.getLogs(sinceScn).logFiles()
                 .stream()
                 .sorted(Comparator.comparing(LogFile::getSequence))
                 .collect(Collectors.toList());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -37,6 +36,8 @@ import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleSchemaChangeEventEmitter;
 import io.debezium.connector.oracle.RedoThreadState;
 import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
+import io.debezium.connector.oracle.logminer.LogFileSessionSelector.SessionLogSelection;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSourceMetrics.BatchMetrics;
 import io.debezium.connector.oracle.logminer.events.DmlEvent;
 import io.debezium.connector.oracle.logminer.events.EventType;
@@ -123,11 +124,12 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     private boolean sequenceUnavailable = false;
     private List<LogFile> currentLogFiles;
     private List<LogFile> sessionLogFiles;
+    private LogFileSessionSelector logFileSessionSelector;
+    private boolean sessionLogFilesChanged = false;
     private List<BigInteger> currentRedoLogSequences;
     private OracleOffsetContext effectiveOffset;
     private OraclePartition partition;
     private ChangeEventSourceContext context;
-    private int currentBatchSize;
     private long currentSleepTime;
     private OffsetActivityMonitor offsetActivityMonitor;
 
@@ -158,9 +160,6 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         this.xmlBeginParser = new XmlBeginParser();
         this.tableFilter = connectorConfig.getTableFilters().dataCollectionFilter();
         this.archiveDestinationNames = connectorConfig.getArchiveDestinationNameResolver().getDestinationNames(jdbcConnection);
-
-        metrics.setBatchSize(connectorConfig.getLogMiningBatchSizeDefault());
-        metrics.setSleepTime(connectorConfig.getLogMiningSleepTimeDefault().toMillis());
     }
 
     @Override
@@ -182,6 +181,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             this.partition = partition;
             this.context = context;
             this.offsetActivityMonitor = new OffsetActivityMonitor(MAX_ITERATIONS_BEFORE_OFFSET_STALE, getOffsetContext(), getMetrics());
+            this.logFileSessionSelector = resolveLogFileSessionSelector(connectorConfig, jdbcConnection);
 
             // perform various pre-streaming initialization steps
             prepareJdbcConnection(false);
@@ -315,6 +315,10 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         return currentLogFiles;
     }
 
+    protected boolean hasSessionLogFilesChanged() {
+        return sessionLogFilesChanged;
+    }
+
     protected List<LogFile> getSessionLogFiles() {
         return sessionLogFiles;
     }
@@ -419,11 +423,10 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             }
 
             LOGGER.debug("{}.", getBatchMetrics());
-            LOGGER.debug("Processed in {} ms. Lag {}. Active Transactions: {}. Sleep: {}. Offsets: {}",
+            LOGGER.debug("Processed in {} ms. Lag {}. Active Transactions: {}. Offsets: {}",
                     Duration.between(startProcessTime, Instant.now()),
                     getMetrics().getLagFromSourceInMilliseconds(),
                     getMetrics().getNumberOfActiveTransactions(),
-                    getMetrics().getSleepTimeInMilliseconds(),
                     getOffsetContext());
         }
     }
@@ -870,97 +873,17 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     }
 
     /**
-     * Calculates the mining session's upper boundary based on batch size limits.
+     * Calculates the mining session's upper boundary.
      *
      * @param lowerBoundsScn the current lower boundary
-     * @param previousUpperBounds the previous upper boundary
      * @param currentScn the database current write position system change number
      * @return the next iterations maximum upper boundary
      * @throws SQLException if a database exception is thrown
      */
-    protected Scn calculateUpperBounds(Scn lowerBoundsScn, Scn previousUpperBounds, Scn currentScn) throws SQLException {
+    protected Scn calculateUpperBounds(Scn lowerBoundsScn, Scn currentScn) throws SQLException {
         final Scn maximumScn = getConfig().isArchiveLogOnlyMode() ? getMaximumArchiveLogsScn(lowerBoundsScn) : currentScn;
 
-        final Scn maximumBatchScn = lowerBoundsScn.add(Scn.valueOf(metrics.getBatchSize()));
-        final Scn defaultBatchSizeScn = Scn.valueOf(connectorConfig.getLogMiningBatchSizeDefault());
-        final Scn maxBatchSizeScn = Scn.valueOf(connectorConfig.getLogMiningBatchSizeMax());
-
-        // Initially set the upper bounds based on batch size
-        // The following logic will alter this value as needed based on specific rules
-        Scn result = maximumBatchScn;
-
-        // Check if the batch upper bounds is greater than the current upper bounds
-        // If it isn't, there is no need to update the batch size
-        boolean batchUpperBoundsScnAfterCurrentScn = false;
-        if (maximumBatchScn.subtract(maximumScn).compareTo(defaultBatchSizeScn) > 0) {
-            // Don't update the batch size, batch upper bounds currently large enough
-            decrementBatchSize();
-            batchUpperBoundsScnAfterCurrentScn = true;
-        }
-
-        if (maximumScn.subtract(maximumBatchScn).compareTo(defaultBatchSizeScn) > 0) {
-            // Update batch size because the database upper position is greater than the batch size
-            incrementBatchSize();
-        }
-
-        if (maximumScn.compareTo(maximumBatchScn) < 0) {
-            if (!batchUpperBoundsScnAfterCurrentScn) {
-                incrementSleepTime();
-            }
-            // Batch upperbounds greater than database max possible read position.
-            // Cap it at the max possible database read position
-            LOGGER.debug("Batch upper bounds {} exceeds maximum read position, capping to {}.", maximumBatchScn, maximumScn);
-            result = maximumScn;
-        }
-        else {
-            if (!previousUpperBounds.isNull() && maximumBatchScn.compareTo(previousUpperBounds) <= 0) {
-                // Batch size is too small, make a large leap
-                // This will always add the max batch size window rather than smaller increments
-                // This fits more closely to the same semantics as maximumScn, but for very large bursts, it
-                // keeps the window relatively capped.
-                Scn extendedUpperBounds = previousUpperBounds.add(maxBatchSizeScn);
-                if (extendedUpperBounds.compareTo(maximumScn) > 0) {
-                    extendedUpperBounds = maximumScn;
-                }
-                LOGGER.debug("Batch size upper bounds {} too small, using maximum read position {} instead.", maximumBatchScn, extendedUpperBounds);
-                result = extendedUpperBounds;
-            }
-            else {
-                decrementSleepTime();
-                if (maximumBatchScn.compareTo(lowerBoundsScn) < 0) {
-                    // Batch SCN calculation resulted in a value before start SCN, fallback to max read position
-                    LOGGER.debug("Batch upper bounds {} is before start SCN {}, fallback to maximum read position {}.", maximumBatchScn, lowerBoundsScn, maximumScn);
-                    result = maximumScn;
-                }
-                else if (!previousUpperBounds.isNull()) {
-                    final Scn deltaScn = maximumScn.subtract(previousUpperBounds);
-                    if (deltaScn.compareTo(Scn.valueOf(connectorConfig.getLogMiningScnGapDetectionGapSizeMin())) > 0) {
-                        Optional<Instant> prevEndScnTimestamp = jdbcConnection.getScnToTimestamp(previousUpperBounds);
-                        if (prevEndScnTimestamp.isPresent()) {
-                            Optional<Instant> upperBoundsScnTimestamp = jdbcConnection.getScnToTimestamp(maximumScn);
-                            if (upperBoundsScnTimestamp.isPresent()) {
-                                long deltaTime = ChronoUnit.MILLIS.between(prevEndScnTimestamp.get(), upperBoundsScnTimestamp.get());
-                                if (deltaTime < connectorConfig.getLogMiningScnGapDetectionTimeIntervalMaxMs()) {
-                                    LOGGER.debug(
-                                            "SCN delta {} is less than {} within a time window of {} milliseconds. " +
-                                                    "This could indicate a high volume of changes or an unusual increase in the SCN over the time window. " +
-                                                    "Using upperbounds SCN {} at timestamp {} (start SCN {}, previous end SCN {} at timestamp {}).",
-                                            deltaScn,
-                                            connectorConfig.getLogMiningScnGapDetectionGapSizeMin(),
-                                            connectorConfig.getLogMiningScnGapDetectionTimeIntervalMaxMs(),
-                                            maximumScn,
-                                            upperBoundsScnTimestamp.get(),
-                                            lowerBoundsScn,
-                                            previousUpperBounds,
-                                            prevEndScnTimestamp.get());
-                                    result = maximumScn;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        Scn result = maximumScn;
 
         // If the connector is configured with maximum SCN deviation, apply the deviation time.
         // This rolls the current maximum read SCN position back based on the deviation duration.
@@ -1035,7 +958,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      * @throws InterruptedException if the thread is interrupted
      */
     protected void pauseBetweenMiningSessions() throws InterruptedException {
-        Duration period = Duration.ofMillis(metrics.getSleepTimeInMilliseconds());
+        Duration period = Duration.ofSeconds(1);
         Metronome.sleeper(period, clock).pause();
     }
 
@@ -1092,7 +1015,8 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      */
     protected Scn getMaximumArchiveLogsScn(Scn startScn) throws SQLException {
         // It is safe to query these in real-time
-        final List<LogFile> archiveLogs = logCollector.getLogs(startScn).stream().filter(LogFile::isArchive).toList();
+        final List<LogFile> archiveLogs = logCollector.getLogs(startScn).logFiles()
+                .stream().filter(LogFile::isArchive).toList();
         if (archiveLogs.isEmpty()) {
             throw new DebeziumException("Cannot get maximum archive log SCN as no archive logs are present.");
         }
@@ -1158,37 +1082,29 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     }
 
     /**
-     * Collects all the log state for the given SCN window.
+     * Collects all the log state for the given SCN window and computes the final upper boundary.
      *
      * @param lowerBoundsScn the lower SCN window boundary, should never be {@code null}
      * @param upperBoundsScn the upper SCN window boundary, should never be {@code null}
-     * @return {@code true} if a new session must be forced because session logs changed, {@code false} otherwise
+     * @return the updated mining session upper boundary, never {@code null}
      * @throws SQLException if a database exception occurs
      */
-    protected boolean collectLogs(Scn lowerBoundsScn, Scn upperBoundsScn) throws SQLException {
-        currentLogFiles = logCollector.getLogs(lowerBoundsScn);
+    protected Scn collectLogsAndFinalUpperBoundary(Scn lowerBoundsScn, Scn upperBoundsScn) throws SQLException {
+        final LogFilesResult logFilesResult = logCollector.getLogs(lowerBoundsScn);
+        currentLogFiles = logFilesResult.logFiles();
 
-        boolean forceSession = false;
+        Scn upperBoundaryScn = upperBoundsScn;
         if (!useContinuousMining) {
-            List<LogFile> sessionLogFilesToAdd = new ArrayList<>();
-            for (LogFile logFile : currentLogFiles) {
-                // All logs must be enqueued for redo_log_catalog mode
-                // This is because the later logs, on log switch, will have the data dictionary.
-                // For other mining strategies, it's safe to only enqueue the necessary logs for the range.
-                if (isUsingCatalogInRedoStrategy()) {
-                    sessionLogFilesToAdd.add(logFile);
-                }
-                else if (logFile.getFirstScn().compareTo(upperBoundsScn) <= 0) {
-                    sessionLogFilesToAdd.add(logFile);
-                }
+            SessionLogSelection sessionLogSelection = logFileSessionSelector.selectLogsForSession(logFilesResult, upperBoundsScn);
+
+            sessionLogFilesChanged = !sessionLogSelection.logFiles().equals(sessionLogFiles);
+            sessionLogFiles = sessionLogSelection.logFiles();
+
+            if (sessionLogFilesChanged) {
+                LOGGER.trace("LogMiner session log files list changed, forcing a new mining session.");
             }
 
-            if (!isUsingCatalogInRedoStrategy() && !sessionLogFilesToAdd.equals(sessionLogFiles)) {
-                LOGGER.trace("LogMiner session log file list changed, forcing a new mining session.");
-                forceSession = true;
-            }
-
-            sessionLogFiles = sessionLogFilesToAdd;
+            upperBoundaryScn = sessionLogSelection.effectiveUpperBounds();
         }
 
         metrics.setRedoLogStatuses(jdbcConnection.queryAndMap(
@@ -1201,7 +1117,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
                     return results;
                 }));
 
-        return forceSession;
+        return upperBoundaryScn;
     }
 
     /**
@@ -2154,86 +2070,6 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         }
     }
 
-    /**
-     * Increments the mining batch size.
-     */
-    private void incrementBatchSize() {
-        int batchSizeMax = connectorConfig.getLogMiningBatchSizeMax();
-        int batchSizeIncrement = connectorConfig.getLogMiningBatchSizeIncrement();
-        if (currentBatchSize < batchSizeMax) {
-            final int previousBatchSize = currentBatchSize;
-            currentBatchSize = Math.min(currentBatchSize + batchSizeIncrement, batchSizeMax);
-            metrics.setBatchSize(currentBatchSize);
-            if (previousBatchSize != currentBatchSize && currentBatchSize == batchSizeMax) {
-                LOGGER.debug("The connector is now using the maximum batch size {}.", currentBatchSize);
-            }
-            else if (previousBatchSize != currentBatchSize) {
-                LOGGER.debug("Updated batch size window, using batch size {}", currentBatchSize);
-            }
-        }
-    }
-
-    /**
-     * Increments the sleep time to wait in between mining iterations.
-     */
-    private void incrementSleepTime() {
-        long sleepTimeMax = connectorConfig.getLogMiningSleepTimeMax().toMillis();
-        long sleepTimeIncrement = connectorConfig.getLogMiningSleepTimeIncrement().toMillis();
-        if (currentSleepTime < sleepTimeMax) {
-            final long previousSleepTime = currentSleepTime;
-            currentSleepTime = Math.min(currentSleepTime + sleepTimeIncrement, sleepTimeMax);
-            metrics.setSleepTime(currentSleepTime);
-            if (previousSleepTime != currentSleepTime) {
-                if (currentSleepTime == sleepTimeMax) {
-                    LOGGER.debug("The connector is now using the maximum sleep time {}.", currentSleepTime);
-                }
-                else {
-                    LOGGER.debug("Update sleep time, using {}", currentBatchSize);
-                }
-            }
-        }
-    }
-
-    /**
-     * Decrements the mining batch size.
-     */
-    private void decrementBatchSize() {
-        int batchSizeMin = connectorConfig.getLogMiningBatchSizeMin();
-        int batchSizeIncrement = connectorConfig.getLogMiningBatchSizeIncrement();
-        if (currentBatchSize > batchSizeMin) {
-            final int previousBatchSize = currentBatchSize;
-            currentBatchSize = Math.max(currentBatchSize - batchSizeIncrement, batchSizeMin);
-            metrics.setBatchSize(currentBatchSize);
-            if (previousBatchSize != currentBatchSize && currentBatchSize == batchSizeMin) {
-                LOGGER.debug("The connector is now using the minimum batch size {}.", currentBatchSize);
-            }
-            else if (previousBatchSize != currentBatchSize) {
-                LOGGER.debug("Updated batch size window, using batch size {}", currentBatchSize);
-            }
-        }
-    }
-
-    /**
-     * Decrements the sleep time to wait in between mining iterations.
-     */
-    private void decrementSleepTime() {
-        long sleepTimeMin = connectorConfig.getLogMiningSleepTimeMin().toMillis();
-        long sleepTimeIncrement = connectorConfig.getLogMiningSleepTimeIncrement().toMillis();
-        if (currentSleepTime > sleepTimeMin) {
-            final long previousSleepTime = currentSleepTime;
-            currentSleepTime = Math.max(currentSleepTime - sleepTimeIncrement, sleepTimeMin);
-            metrics.setSleepTime(currentSleepTime);
-            if (previousSleepTime != currentSleepTime) {
-                if (currentSleepTime == sleepTimeMin) {
-                    LOGGER.debug("The connector is now using the minimum sleep time {}.", currentSleepTime);
-                }
-                else {
-                    LOGGER.debug("Update sleep time, using {}", currentBatchSize);
-                }
-            }
-        }
-    }
-
     private boolean isNoSqlRedoForTemporaryTable(LogMinerEventRow event) {
         return NO_REDO_SQL_FOR_TEMPORARY_TABLES.equals(event.getRedoSql());
     }
@@ -2256,5 +2092,18 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
                 .flatMap(Optional::stream)
                 .min(Scn::compareTo)
                 .orElseThrow(() -> new DebeziumException("Failed to resolve archive logs upper bounds"));
+    }
+
+    private LogFileSessionSelector resolveLogFileSessionSelector(OracleConnectorConfig connectorConfig, OracleConnection connection) throws SQLException {
+        final int minimumLogCountPerThread = connectorConfig.getLogMiningMinimumLogCount();
+        if (minimumLogCountPerThread > 0) {
+            switch (connectorConfig.getLogMiningStrategy()) {
+                case HYBRID, ONLINE_CATALOG: {
+                    final long maximumRedoLogFileSize = connection.getMaximumRedoLogFileSize();
+                    return new CappedLogFileSessionSelector(minimumLogCountPerThread, maximumRedoLogFileSize);
+                }
+            }
+        }
+        return new UnboundedLogFileSessionSelector();
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.RedoThreadState.RedoThread;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
+
+/**
+ * A LogMiner log file selector that caps the returned logs based on user configuration, while capping the
+ * mining session window upper boundary to the minimum upper system change number across all threads.
+ *
+ * @author Chris Cranford
+ */
+public class CappedLogFileSessionSelector implements LogFileSessionSelector {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(CappedLogFileSessionSelector.class);
+
+    private final int minimumLogsPerRedoThread;
+    private final long redoLogSizeInBytes;
+
+    private int logsPerRedoThread;
+    private Map<Integer, List<LogFile>> previousCappedLogsByThread;
+
+    public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes) {
+        this.minimumLogsPerRedoThread = minimumLogsPerRedoThread;
+        this.redoLogSizeInBytes = redoLogSizeInBytes;
+        this.logsPerRedoThread = minimumLogsPerRedoThread;
+    }
+
+    @Override
+    public SessionLogSelection selectLogsForSession(LogFilesResult logFilesResult, Scn upperBoundary) {
+        Scn effectiveUpperBoundary = upperBoundary;
+
+        // Groups all collected logs by redo thread, sorted in ascending order by sequence.
+        // The ordering is important for this algorithm when inspecting what is the first/last logs per thread.
+        final Map<Integer, List<LogFile>> logsByThread = logFilesResult.logFiles().stream()
+                .sorted(Comparator.comparing(LogFile::getSequence))
+                .collect(Collectors.groupingBy(LogFile::getThread));
+
+        Map<Integer, List<LogFile>> cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
+
+        if (previousCappedLogsByThread != null) {
+            if (cappedLogsByThread.equals(previousCappedLogsByThread)) {
+                // Same log set as last iteration: the lower watermark did not advance, so a long-running
+                // transaction may extend beyond the current cap. Grow by one log to find the end.
+                logsPerRedoThread++;
+                LOGGER.debug("Capped log set unchanged, growing log count per redo thread to {}.", logsPerRedoThread);
+                cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
+            }
+            else if (logsPerRedoThread > minimumLogsPerRedoThread) {
+                // Log set changed: the watermark advanced, so reset the count back to the configured minimum.
+                logsPerRedoThread = minimumLogsPerRedoThread;
+                LOGGER.debug("Capped log set changed, resetting log count per redo thread to {}.", logsPerRedoThread);
+                cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
+            }
+        }
+
+        previousCappedLogsByThread = cappedLogsByThread;
+
+        boolean allThreadsMineOnline = true;
+        for (RedoThread redoThread : logFilesResult.redoThreadState().getThreads()) {
+            if (redoThread.isOpen()) {
+                final List<LogFile> threadLogs = cappedLogsByThread.get(redoThread.getThreadId());
+                if (threadLogs == null) {
+                    // Should never happen, just sanity check
+                    throw new DebeziumException("Redo thread %d is open, expected logs".formatted(redoThread.getThreadId()));
+                }
+
+                // Checks if the last log in the thread's capped list is an online redo log.
+                // When all redo threads are capped to the online redo, we handle this differently.
+                final LogFile lastThreadLog = threadLogs.get(threadLogs.size() - 1);
+                if (!lastThreadLog.isCurrent()) {
+                    allThreadsMineOnline = false;
+
+                    // When last log is an archive, cap the upper boundary to the logs next scn, but
+                    // only if its next scn value is less than the current effective upper boundary.
+                    // This guarantees we get the smallest upper position across all threads.
+                    final Scn lastLogNextScn = lastThreadLog.getNextScn();
+                    if (lastLogNextScn.compareTo(effectiveUpperBoundary) < 0) {
+                        effectiveUpperBoundary = lastLogNextScn;
+                    }
+                }
+            }
+        }
+
+        if (allThreadsMineOnline) {
+            LOGGER.debug("All threads are reading online redo, using all logs and reading up to {}.", upperBoundary);
+            // When all threads mine online redo logs, no upper boundary cap is necessary
+            // Resort the log files in thread+sequence order for application.
+            return new SessionLogSelection(
+                    logFilesResult.logFiles().stream()
+                            .sorted(Comparator.comparingInt(LogFile::getThread)
+                                    .thenComparing(LogFile::getSequence))
+                            .toList(),
+                    upperBoundary);
+        }
+
+        LOGGER.debug("Using capped logs, reading up to {}.", effectiveUpperBoundary);
+        // Use the calculated effective upper boundary
+        // Resort the capped log files in thread+sequence order for application
+        return new SessionLogSelection(
+                cappedLogsByThread.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .flatMap(entry -> entry.getValue().stream())
+                        .toList(),
+                effectiveUpperBoundary);
+    }
+
+    private Map<Integer, List<LogFile>> getThreadLogsCappedBySize(Map<Integer, List<LogFile>> logsByThread, long thresholdBytes) {
+        final Map<Integer, List<LogFile>> logsByThreadCapped = new HashMap<>();
+        for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
+            final List<LogFile> cappedLogs = new ArrayList<>();
+
+            long accumulatedSize = 0;
+            for (LogFile logFile : entry.getValue()) {
+                accumulatedSize += logFile.getBytes();
+                cappedLogs.add(logFile);
+
+                if (accumulatedSize >= thresholdBytes) {
+                    break;
+                }
+            }
+
+            logsByThreadCapped.put(entry.getKey(), cappedLogs);
+        }
+        return logsByThreadCapped;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
@@ -70,11 +70,11 @@ public class LogFileCollector {
      * Get a list of all log files that should be mined given the specified system change number.
      *
      * @param offsetScn minimum system change number to start reading changes from, should not be {@code null}
-     * @return list of log file instances that should be added to the mining session, never {@code null}
+     * @return a {@link LogFilesResult} that provides the logs and redo thread state used, never {@code null}
      * @throws SQLException if there is a database failure during the collection
      * @throws LogFileNotFoundException if we were unable to collect logs due to a non-SQL related failure
      */
-    public List<LogFile> getLogs(Scn offsetScn) throws SQLException, LogFileNotFoundException {
+    public LogFilesResult getLogs(Scn offsetScn) throws SQLException, LogFileNotFoundException {
         LOGGER.debug("Collecting logs based on the read SCN position {}.", offsetScn);
         final DelayStrategy retryStrategy = DelayStrategy.exponential(initialDelay, maxRetryDelay);
         for (int attempt = 0; attempt <= maxAttempts; ++attempt) {
@@ -92,7 +92,7 @@ public class LogFileCollector {
                 continue;
             }
 
-            return files;
+            return new LogFilesResult(files, currentRedoThreadState);
         }
         throw new LogFileNotFoundException(offsetScn);
     }
@@ -107,7 +107,7 @@ public class LogFileCollector {
      */
     public boolean isScnInArchiveLogs(Scn scn) throws SQLException {
         try {
-            final List<LogFile> allLogs = getLogs(scn);
+            final List<LogFile> allLogs = getLogs(scn).logFiles();
             final Map<Integer, List<LogFile>> threadLogs = allLogs.stream()
                     .collect(Collectors.groupingBy(LogFile::getThread));
 
@@ -686,4 +686,12 @@ public class LogFileCollector {
         }
     }
 
+    /**
+     * A result object when collecting Oracle logs.
+     *
+     * @param logFiles the logs that were fetched, never {@code null}
+     * @param redoThreadState the redo thread state used when fetching logs, never {@code null}
+     */
+    public record LogFilesResult(List<LogFile> logFiles, RedoThreadState redoThreadState) {
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileSessionSelector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.util.List;
+
+import io.debezium.connector.oracle.Scn;
+
+/**
+ * Defines the contract for the selector that computes what logs should be added to the LogMiner session.
+ *
+ * @author Chris Cranford
+ */
+public interface LogFileSessionSelector {
+    /**
+     * The selected logs based on the selector strategy.
+     *
+     * @param logFiles the log files selected, never {@code null}
+     * @param effectiveUpperBounds the effective upper boundary for the mining session, never {@code null}
+     */
+    record SessionLogSelection(List<LogFile> logFiles, Scn effectiveUpperBounds) {
+    }
+
+    /**
+     * Selects logs for the LogMiner mining session.
+     *
+     * @param logFilesResult the collected log files result object, should not be {@code null}
+     * @param upperBoundary the pre-computed upper boundary of the system, should not be {@code null}
+     * @return the selected logs and boundary based on the selector implementation
+     */
+    SessionLogSelection selectLogsForSession(LogFileCollector.LogFilesResult logFilesResult, Scn upperBoundary);
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetrics.java
@@ -69,8 +69,7 @@ public class LogMinerStreamingChangeEventSourceMetrics
     private final AtomicInteger logMinerQueryCount = new AtomicInteger();
     private final AtomicInteger jdbcRows = new AtomicInteger();
 
-    private final AtomicLong minimumLogsMined = new AtomicLong();
-    private final AtomicLong maximumLogsMined = new AtomicLong();
+    private final LongHistogramMetric minedLogsCount = new LongHistogramMetric();
     private final AtomicLong maxBatchProcessingThroughput = new AtomicLong();
     private final AtomicLong timeDifference = new AtomicLong();
     private final AtomicLong processedRowsCount = new AtomicLong();
@@ -91,8 +90,8 @@ public class LogMinerStreamingChangeEventSourceMetrics
     private final DurationHistogramMetric parseTimeDuration = new DurationHistogramMetric();
     private final DurationHistogramMetric resultSetNextDuration = new DurationHistogramMetric();
 
-    private final MaxLongValueMetric userGlobalAreaMemory = new MaxLongValueMetric();
-    private final MaxLongValueMetric processGlobalAreaMemory = new MaxLongValueMetric();
+    private final LongHistogramMetric userGlobalAreaMemory = new LongHistogramMetric();
+    private final LongHistogramMetric processGlobalAreaMemory = new LongHistogramMetric();
 
     private final LRUSet<String> abandonedTransactionIds = new LRUSet<>(TRANSACTION_ID_SET_SIZE);
     private final LRUSet<String> rolledBackTransactionIds = new LRUSet<>(TRANSACTION_ID_SET_SIZE);
@@ -146,6 +145,7 @@ public class LogMinerStreamingChangeEventSourceMetrics
 
         abandonedTransactionIds.reset();
         rolledBackTransactionIds.reset();
+        minedLogsCount.reset();
 
         oldestScnTime.set(null);
     }
@@ -195,12 +195,17 @@ public class LogMinerStreamingChangeEventSourceMetrics
 
     @Override
     public long getMinimumMinedLogCount() {
-        return minimumLogsMined.get();
+        return minedLogsCount.getMin();
     }
 
     @Override
     public long getMaximumMinedLogCount() {
-        return maximumLogsMined.get();
+        return minedLogsCount.getMax();
+    }
+
+    @Override
+    public long getCurrentMinedLogCount() {
+        return minedLogsCount.getValue();
     }
 
     @Override
@@ -489,15 +494,7 @@ public class LogMinerStreamingChangeEventSourceMetrics
      */
     public void setMinedLogFileNames(Set<String> minedLogFileNames) {
         this.minedLogFileNames.set(minedLogFileNames.toArray(String[]::new));
-        if (minedLogFileNames.size() < minimumLogsMined.get()) {
-            minimumLogsMined.set(minedLogFileNames.size());
-        }
-        else if (minimumLogsMined.get() == 0) {
-            minimumLogsMined.set(minedLogFileNames.size());
-        }
-        if (minedLogFileNames.size() > maximumLogsMined.get()) {
-            maximumLogsMined.set(minedLogFileNames.size());
-        }
+        this.minedLogsCount.setValueAndCalculate(minedLogFileNames.size());
     }
 
     /**
@@ -785,8 +782,7 @@ public class LogMinerStreamingChangeEventSourceMetrics
                 ", databaseZoneOffset=" + databaseZoneOffset +
                 ", logSwitchCount=" + logSwitchCount +
                 ", logMinerQueryCount=" + logMinerQueryCount +
-                ", minimumLogsMined=" + minimumLogsMined +
-                ", maximumLogsMined=" + maximumLogsMined +
+                ", minedLogsCount=" + minedLogsCount +
                 ", maxBatchProcessingThroughput=" + maxBatchProcessingThroughput +
                 ", timeDifference=" + timeDifference +
                 ", processedRowsCount=" + processedRowsCount +
@@ -883,28 +879,37 @@ public class LogMinerStreamingChangeEventSourceMetrics
     }
 
     /**
-     * Utility class for tracking the current and maximum long value.
+     * Utility class for tracking the current, minimum, and maximum long value.
      */
     @ThreadSafe
-    static class MaxLongValueMetric {
+    static class LongHistogramMetric {
 
-        private final AtomicLong value = new AtomicLong();
-        private final AtomicLong max = new AtomicLong();
+        private final AtomicLong value = new AtomicLong(0L);
+        private final AtomicLong max = new AtomicLong(-1L);
+        private final AtomicLong min = new AtomicLong(-1L);
 
         public void reset() {
             value.set(0L);
-            max.set(0L);
+            max.set(-1L);
+            min.set(-1L);
         }
 
-        public void setValueAndCalculateMax(long value) {
+        public void setValueAndCalculate(long value) {
             this.value.set(value);
-            if (max.get() < value) {
-                max.set(value);
-            }
+
+            setMin(value);
+            setMax(value);
         }
 
         public void setValue(long value) {
             this.value.set(value);
+        }
+
+        public void setMin(long min) {
+            final long minimumValue = this.min.get();
+            if (minimumValue == -1 || minimumValue > min) {
+                this.min.set(min);
+            }
         }
 
         public void setMax(long max) {
@@ -918,12 +923,18 @@ public class LogMinerStreamingChangeEventSourceMetrics
         }
 
         public long getMax() {
-            return max.get();
+            final long maximumValue = max.get();
+            return maximumValue == -1 ? 0 : maximumValue;
+        }
+
+        public long getMin() {
+            final long minimumValue = min.get();
+            return minimumValue == -1 ? 0 : minimumValue;
         }
 
         @Override
         public String toString() {
-            return String.format("{value=%d,max=%d}", value.get(), max.get());
+            return "{value=%d,min=%d,max=%d}".formatted(value.get(), min.get(), max.get());
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetrics.java
@@ -46,7 +46,6 @@ public class LogMinerStreamingChangeEventSourceMetrics
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogMinerStreamingChangeEventSourceMetrics.class);
 
-    private static final long MILLIS_PER_SECOND = 1000L;
     private static final int TRANSACTION_ID_SET_SIZE = 10;
 
     private final OracleConnectorConfig connectorConfig;
@@ -66,12 +65,10 @@ public class LogMinerStreamingChangeEventSourceMetrics
     private final AtomicReference<String[]> redoLogStatuses = new AtomicReference<>(new String[0]);
     private final AtomicReference<ZoneOffset> databaseZoneOffset = new AtomicReference<>(ZoneOffset.UTC);
 
-    private final AtomicInteger batchSize = new AtomicInteger();
     private final AtomicInteger logSwitchCount = new AtomicInteger();
     private final AtomicInteger logMinerQueryCount = new AtomicInteger();
     private final AtomicInteger jdbcRows = new AtomicInteger();
 
-    private final AtomicLong sleepTime = new AtomicLong();
     private final AtomicLong minimumLogsMined = new AtomicLong();
     private final AtomicLong maximumLogsMined = new AtomicLong();
     private final AtomicLong maxBatchProcessingThroughput = new AtomicLong();
@@ -116,8 +113,6 @@ public class LogMinerStreamingChangeEventSourceMetrics
                                                      CapturedTablesSupplier capturedTablesSupplier) {
         super(taskContext, changeEventQueueMetrics, metadataProvider, capturedTablesSupplier);
         this.connectorConfig = connectorConfig;
-        this.batchSize.set(connectorConfig.getLogMiningBatchSizeDefault());
-        this.sleepTime.set(connectorConfig.getLogMiningSleepTimeDefault().toMillis());
         this.clock = clock;
         this.startTime = clock.instant();
         this.batchMetrics = new BatchMetrics(this);
@@ -161,11 +156,6 @@ public class LogMinerStreamingChangeEventSourceMetrics
     }
 
     @Override
-    public long getSleepTimeInMilliseconds() {
-        return sleepTime.get();
-    }
-
-    @Override
     public BigInteger getCurrentScn() {
         return currentScn.get().asBigInteger();
     }
@@ -201,11 +191,6 @@ public class LogMinerStreamingChangeEventSourceMetrics
     @Override
     public String[] getMinedLogFileNames() {
         return minedLogFileNames.get();
-    }
-
-    @Override
-    public int getBatchSize() {
-        return batchSize.get();
     }
 
     @Override
@@ -447,24 +432,6 @@ public class LogMinerStreamingChangeEventSourceMetrics
      */
     public ZoneOffset getDatabaseOffset() {
         return databaseZoneOffset.get();
-    }
-
-    /**
-     * Set the currently used batch size for querying LogMiner.
-     *
-     * @param batchSize batch size used for querying LogMiner
-     */
-    public void setBatchSize(int batchSize) {
-        this.batchSize.set(batchSize);
-    }
-
-    /**
-     * Set the connector's currently used sleep/pause time between LogMiner queries.
-     *
-     * @param sleepTime sleep time between LogMiner queries
-     */
-    public void setSleepTime(long sleepTime) {
-        this.sleepTime.set(sleepTime);
     }
 
     /**
@@ -816,10 +783,8 @@ public class LogMinerStreamingChangeEventSourceMetrics
                 ", currentLogFileNames=" + Arrays.asList(currentLogFileNames.get()) +
                 ", redoLogStatuses=" + Arrays.asList(redoLogStatuses.get()) +
                 ", databaseZoneOffset=" + databaseZoneOffset +
-                ", batchSize=" + batchSize +
                 ", logSwitchCount=" + logSwitchCount +
                 ", logMinerQueryCount=" + logMinerQueryCount +
-                ", sleepTime=" + sleepTime +
                 ", minimumLogsMined=" + minimumLogsMined +
                 ", maximumLogsMined=" + maximumLogsMined +
                 ", maxBatchProcessingThroughput=" + maxBatchProcessingThroughput +

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetricsMXBean.java
@@ -28,11 +28,6 @@ public interface LogMinerStreamingChangeEventSourceMetricsMXBean
     long getMillisecondsToKeepTransactionsInBuffer();
 
     /**
-     * @return number of milliseconds that the connector sleeps between LogMiner queries
-     */
-    long getSleepTimeInMilliseconds();
-
-    /**
      * @return the current system change number of the database
      */
     BigInteger getCurrentScn();
@@ -75,14 +70,6 @@ public interface LogMinerStreamingChangeEventSourceMetricsMXBean
      * @return array of all archive and redo logs that are read by the mining session
      */
     String[] getMinedLogFileNames();
-
-    /**
-     * Specifies the maximum gap between the start and end system change number range used for
-     * querying changes from LogMiner.
-     *
-     * @return the LogMiner query batch size
-     */
-    int getBatchSize();
 
     /**
      * @return the minimum number of logs used by a mining session

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSourceMetricsMXBean.java
@@ -82,6 +82,11 @@ public interface LogMinerStreamingChangeEventSourceMetricsMXBean
     long getMaximumMinedLogCount();
 
     /**
+     * @return the current number of logs used by a mining session
+     */
+    long getCurrentMinedLogCount();
+
+    /**
      * @return the minimum SCN used for reading the current mined logs.
      */
     BigInteger getMiningSessionLowerBounds();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelector.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.oracle.Scn;
+
+/**
+ * The legacy behavior that applies no log caps and uses all logs collected, and preserves the pre-computed
+ * upper boundary as the maximum session boundary.
+ *
+ * @author Chris Cranford
+ */
+public class UnboundedLogFileSessionSelector implements LogFileSessionSelector {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(UnboundedLogFileSessionSelector.class);
+
+    @Override
+    public SessionLogSelection selectLogsForSession(LogFileCollector.LogFilesResult logFilesResult, Scn upperBoundary) {
+        LOGGER.debug("Using all logs and reading up to {}.", upperBoundary);
+        return new SessionLogSelection(logFilesResult.logFiles(), upperBoundary);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -148,7 +148,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                 Scn currentScn = getCurrentScn();
                 getMetrics().setCurrentScn(currentScn);
 
-                sessionEndScn = calculateUpperBounds(readScn, sessionEndScn, currentScn);
+                sessionEndScn = calculateUpperBounds(readScn, currentScn);
                 if (sessionEndScn.isNull()) {
                     LOGGER.debug("Requested delay of mining by one iteration");
                     pauseBetweenMiningSessions();
@@ -157,8 +157,8 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
                 flushStrategy.flush(getCurrentScn());
 
-                final boolean forceNewSession = collectLogs(sessionStartScn, sessionEndScn);
-                if (!needsNewSession && forceNewSession) {
+                sessionEndScn = collectLogsAndFinalUpperBoundary(sessionStartScn, sessionEndScn);
+                if (!needsNewSession && hasSessionLogFilesChanged()) {
                     endMiningSession();
                     needsNewSession = true;
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -141,21 +141,21 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
             Scn currentScn = getCurrentScn();
             getMetrics().setCurrentScn(currentScn);
 
-            final boolean forceNewSession = collectLogs(minLogScn, getCurrentScn());
-            if (!isUsingCatalogInRedoStrategy() && !needsNewSession && forceNewSession) {
+            upperBoundsScn = calculateUpperBounds(minLogScn, currentScn);
+            if (upperBoundsScn.isNull()) {
+                LOGGER.debug("Delaying mining transaction logs by one iteration");
+                pauseBetweenMiningSessions();
+                continue;
+            }
+
+            upperBoundsScn = collectLogsAndFinalUpperBoundary(minLogScn, upperBoundsScn);
+            if (!needsNewSession && hasSessionLogFilesChanged()) {
                 endMiningSession();
                 needsNewSession = true;
             }
 
             minLogScn = computeResumeScnAndUpdateOffsets(minLogScn, minCommitScn);
             getMetrics().setOffsetScn(minLogScn);
-
-            upperBoundsScn = calculateUpperBounds(minLogScn, upperBoundsScn, currentScn);
-            if (upperBoundsScn.isNull()) {
-                LOGGER.debug("Delaying mining transaction logs by one iteration");
-                pauseBetweenMiningSessions();
-                continue;
-            }
 
             if (needsNewSession) {
                 if (needsConnectionRestart) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -134,33 +134,6 @@ public class OracleConnectorConfigTest {
     }
 
     @Test
-    void validBatchDefaults() throws Exception {
-
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
-                Configuration.create()
-                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
-                        .build());
-
-        assertEquals(connectorConfig.getLogMiningBatchSizeDefault(), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
-        assertEquals(connectorConfig.getLogMiningBatchSizeMax(), OracleConnectorConfig.MAX_BATCH_SIZE);
-        assertEquals(connectorConfig.getLogMiningBatchSizeMin(), OracleConnectorConfig.MIN_BATCH_SIZE);
-    }
-
-    @Test
-    void validSleepDefaults() throws Exception {
-
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
-                Configuration.create()
-                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
-                        .build());
-
-        assertEquals(connectorConfig.getLogMiningSleepTimeDefault(), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeMax(), OracleConnectorConfig.MAX_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeMin(), OracleConnectorConfig.MIN_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeIncrement(), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
-    }
-
-    @Test
     @FixFor("DBZ-5146")
     public void validQueryFetchSizeDefaults() throws Exception {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -5484,9 +5484,6 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6660")
                     .with(OracleConnectorConfig.LOG_MINING_MAX_SCN_DEVIATION_MS, deviationMs.toString())
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MAX, "100")
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_DEFAULT, "100")
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MIN, "100")
                     .build();
 
             final LogInterceptor sourceLogging = new LogInterceptor(AbstractLogMinerStreamingChangeEventSource.class);
@@ -5557,9 +5554,6 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ6660")
                     .with(OracleConnectorConfig.LOG_MINING_MAX_SCN_DEVIATION_MS, deviationMs.toString())
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MAX, "100")
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_DEFAULT, "100")
-                    .with(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MIN, "100")
                     .build();
 
             final LogInterceptor sourceLogging = new LogInterceptor(BufferedLogMinerStreamingChangeEventSource.class);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.RedoThreadState;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
+import io.debezium.connector.oracle.logminer.LogFileSessionSelector.SessionLogSelection;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for {@link CappedLogFileSessionSelector}.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
+public class CappedLogFileSessionSelectorTest {
+
+    private static final long ONE_GB = 1024L * 1024L * 1024L;
+    private static final Scn UPPER_BOUNDS = Scn.valueOf(1000);
+
+    // threshold: 2 logs * 1 GB = 2 GB per thread
+    private final CappedLogFileSessionSelector selector = new CappedLogFileSessionSelector(2, ONE_GB);
+
+    @Test
+    @FixFor("dbz#1713")
+    void testSingleThreadAllLogsWithinThresholdAllLogsReturned() {
+        // arc1(500MB) + arc2(500MB) + redo(500MB): total 1.5 GB < 2 GB, all fit
+        // last log is online redo => allThreadsMineOnline=true => all original logs, bounds unchanged
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 300, 3, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testSingleThreadExceedsThresholdLastCappedIsArchiveCappedAndTightenedBounds() {
+        // arc1(1GB) hits 1 GB, arc2(1GB) hits 2 GB => threshold met, loop breaks after arc2
+        // arc3 and redo excluded; last capped = arc2(archive, nextScn=300)
+        // allThreadsMineOnline=false, effectiveUpperBounds tightened to 300
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testSingleThreadThresholdReachedWithOnlineRedoAsLastAllLogsReturnedOriginalBounds() {
+        // arc1(1GB) + redo(1GB): threshold reached with redo as the last log
+        // last is online redo => allThreadsMineOnline=true => all original logs, bounds unchanged
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createRedoLog("redo1.log", 200, 2, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testSingleThreadArchiveBoundsNotTightenedWhenAlreadyBelowOriginal() {
+        // arc1(1GB) + arc2(1GB): capped at arc2(nextScn=300)
+        // original upper bounds is already 250 (< arc2.nextScn=300), so bounds stays at 250
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("redo1.log", 300, 3, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), Scn.valueOf(250));
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(250));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testTwoThreadsThread1HasArchiveLastBoundsTightenedToThread1() {
+        // Thread 1: arc1(1GB) + arc2(1GB, nextScn=300) => capped, last=arc2(archive)
+        // Thread 2: arc1(1GB) + redo(1GB) => capped at redo, last=redo(online)
+        // Thread 1 sets allThreadsMineOnline=false and effectiveUpperBounds=300
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("t1_arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("t1_arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 400, 4, 1),
+                createArchiveLog("t2_arc1.log", 100, 250, 1, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 250, 2, 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactlyInAnyOrder("t1_arc1.log", "t1_arc2.log", "t2_arc1.log", "t2_redo.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testTwoThreadsBothOnlineLastAllLogsReturnedOriginalBounds() {
+        // Thread 1: arc1(1GB) + redo => last=redo(online)
+        // Thread 2: arc1(1GB) + redo => last=redo(online)
+        // allThreadsMineOnline=true => all original logs, bounds unchanged
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 200, 1, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 200, 2, 1),
+                createArchiveLog("t2_arc1.log", 100, 200, 1, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 200, 2, 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testTwoThreadsBothArchiveLastBoundsTightenedToFirstThreadProcessed() {
+        // Thread 1: arc1(1GB) + arc2(1GB, nextScn=300) => capped, last=arc2(archive)
+        // Thread 2: arc1(1GB) + arc2(1GB, nextScn=350) => capped, last=arc2(archive)
+        // Thread 1 sets allThreadsMineOnline=false, effectiveUpperBounds=300
+        // Thread 2 is skipped (allThreadsMineOnline already false)
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("t1_arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 300, 3, 1),
+                createArchiveLog("t2_arc1.log", 100, 250, 1, 2, ONE_GB),
+                createArchiveLog("t2_arc2.log", 250, 350, 2, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 350, 3, 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactlyInAnyOrder("t1_arc1.log", "t1_arc2.log", "t2_arc1.log", "t2_arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testOpenThreadWithNoLogsInResultThrowsException() {
+        // Thread 1 is open but no logs exist for it in the result set
+        List<LogFile> logs = List.of(
+                createArchiveLog("t2_arc1.log", 100, 200, 1, 2, ONE_GB));
+
+        assertThatThrownBy(() -> selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("1");
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testSingleThreadArchiveOnlyWithinThresholdBoundsTightenedToLastArchive() {
+        // No online redo present (archive-log-only mode scenario); all archives fit within threshold
+        // last log is archive => allThreadsMineOnline=false, bounds tightened to last archive nextScn
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB / 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testClosedThreadWithNoLogsDoesNotThrow() {
+        // Thread 2 is CLOSED and has no logs; the null guard is inside isOpen(), so no exception
+        // Thread 1 is OPEN and mines online redo => allThreadsMineOnline=true, all logs returned
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createRedoLog("t1_redo.log", 200, 2, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, openAndClosedThread()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testRepeatedIdenticalCapResultGrowsByOneEachIteration() {
+        // Two identical calls with the same log set: second call should produce an expanded cap (3 logs)
+        // arc1(1GB) + arc2(1GB) + arc3(1GB) + redo; threshold=2GB, capped at arc1+arc2 on first call
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // First call: arc1+arc2 (threshold 2GB met), no previous to compare against
+        SessionLogSelection first = selector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(first.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+
+        // Second call: same log set => logsPerRedoThread grows to 3 => arc1+arc2+arc3
+        SessionLogSelection second = selector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testChangedCapResultResetsToMinimum() {
+        // First call with 3 archives; watermark then advances bringing new logs; count must reset
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+
+        // First call: capped at arc1+arc2
+        selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
+        // Second call (same): grows to 3 => arc1+arc2+arc3
+        selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
+
+        // Third call: new log set (arc4 added, arc1 gone => capped set differs from previous)
+        // logsPerRedoThread resets to minimumLogsPerRedoThread=2 => arc2+arc3
+        List<LogFile> advancedLogs = List.of(
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 500, 5, 1));
+
+        SessionLogSelection third = selector.selectLogsForSession(
+                new LogFilesResult(advancedLogs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testRepeatedIdenticalCapResultGrowsMultipleSteps() {
+        // Three identical calls: counter grows 2->3->4 across three iterations
+        // arc1(1GB)+arc2(1GB)+arc3(1GB)+arc4(1GB)+redo; threshold starts at 2GB
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 500, 5, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // Call 1: no previous, threshold=2GB => arc1+arc2
+        selector.selectLogsForSession(result, UPPER_BOUNDS);
+
+        // Call 2: same cap => grow to 3 => arc1+arc2+arc3
+        selector.selectLogsForSession(result, UPPER_BOUNDS);
+
+        // Call 3: still same as call-2 result => grow to 4 => arc1+arc2+arc3+arc4
+        SessionLogSelection third = selector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testChangedCapResultAtMinimumNoRecompute() {
+        // Log set changes on second call but logsPerRedoThread was never incremented (still at minimum).
+        // The else-if branch (logsPerRedoThread > minimum) is not entered, so no recompute happens.
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+
+        // Call 1: capped at arc1+arc2 (threshold 2GB)
+        selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
+
+        // Call 2: new log set (arc1 gone, arc4 added); cap differs from previous but counter was never grown
+        List<LogFile> advancedLogs = List.of(
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 500, 5, 1));
+
+        SessionLogSelection second = selector.selectLogsForSession(
+                new LogFilesResult(advancedLogs, singleThreadOpen()), UPPER_BOUNDS);
+        // logsPerRedoThread stays at minimum (2); initial compute at 2GB threshold is used as-is
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testReGrowthAfterReset() {
+        // Grow -> reset -> then re-grow from minimum on subsequent identical iterations
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+        LogFilesResult initialResult = new LogFilesResult(initialLogs, singleThreadOpen());
+
+        // Call 1: capped at arc1+arc2
+        selector.selectLogsForSession(initialResult, UPPER_BOUNDS);
+        // Call 2: same => grow to 3 => arc1+arc2+arc3
+        selector.selectLogsForSession(initialResult, UPPER_BOUNDS);
+
+        // Call 3: new logs => cap differs, logsPerRedoThread > minimum => reset to 2
+        List<LogFile> advancedLogs = List.of(
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 500, 5, 1));
+        LogFilesResult advancedResult = new LogFilesResult(advancedLogs, singleThreadOpen());
+        selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
+
+        // Call 4: same advanced logs => cap unchanged from call 3 => re-grow to 3 from reset minimum
+        SessionLogSelection fourth = selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
+        assertThat(fourth.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log", "arc4.log");
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testTwoThreadsBothArchiveLastBoundsTightenedToSmallestNextScn() {
+        // Thread 1: arc1(1GB)+arc2(1GB, nextScn=300) => capped, last=arc2(archive)
+        // Thread 2: arc1(1GB)+arc2(1GB, nextScn=200) => capped, last=arc2(archive)
+        // Both threads end on archive; effectiveUpperBounds must be the minimum across both (200, not 300)
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("t1_arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 300, 3, 1),
+                createArchiveLog("t2_arc1.log", 50, 150, 1, 2, ONE_GB),
+                createArchiveLog("t2_arc2.log", 150, 200, 2, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 200, 3, 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactlyInAnyOrder("t1_arc1.log", "t1_arc2.log", "t2_arc1.log", "t2_arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
+    }
+
+    private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {
+        return LogFile.forArchive(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), thread, bytes, false, false);
+    }
+
+    private static LogFile createRedoLog(String name, long startScn, int seq, int thread) {
+        return LogFile.forRedo(name, Scn.valueOf(startScn), Scn.valueOf(Long.MAX_VALUE), BigInteger.valueOf(seq), true, thread, ONE_GB);
+    }
+
+    private static RedoThreadState singleThreadOpen() {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(1)
+                .status("OPEN")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(100))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoScn(Scn.valueOf(1000))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
+    }
+
+    private static RedoThreadState twoThreadsOpen() {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(1)
+                .status("OPEN")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(100))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoScn(Scn.valueOf(1000))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .thread()
+                .threadId(2)
+                .status("OPEN")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(100))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoScn(Scn.valueOf(1000))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
+    }
+
+    private static RedoThreadState openAndClosedThread() {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(1)
+                .status("OPEN")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(100))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoScn(Scn.valueOf(1000))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .thread()
+                .threadId(2)
+                .status("CLOSED")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(100))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(200))
+                .disabledTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .lastRedoScn(Scn.valueOf(200))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .conId(0L)
+                .build()
+                .build();
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorIT.java
@@ -74,23 +74,23 @@ public class LogFileCollectorIT extends AbstractAsyncEngineConnectorTest {
 
         // case 1 : oldest scn = current scn
         Scn currentScn = connection.getCurrentScn();
-        List<LogFile> redoFiles = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(currentScn);
+        List<LogFile> redoFiles = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(currentScn).logFiles();
         assertThat(redoFiles).hasSize(instances); // just the current redo log
 
         // case 2 : oldest scn = oldest in not cleared archive
         List<Scn> oneDayArchivedNextScn = getOneDayArchivedLogNextScn(connection);
         Scn oldestArchivedScn = getOldestArchivedScn(oneDayArchivedNextScn);
-        List<LogFile> files = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(oldestArchivedScn);
+        List<LogFile> files = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(oldestArchivedScn).logFiles();
         assertLogFilesHaveNoGaps(instances, files, oneDayArchivedNextScn);
 
-        files = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(oldestArchivedScn.subtract(Scn.ONE));
+        files = getLogFileCollector(Duration.ofHours(0L), false, null).getLogs(oldestArchivedScn.subtract(Scn.ONE)).logFiles();
         assertLogFilesHaveNoGaps(instances, files, oneDayArchivedNextScn);
     }
 
     @Test
     @FixFor("DBZ-3561")
     public void shouldOnlyReturnArchiveLogs() throws Exception {
-        List<LogFile> files = getLogFileCollector(Duration.ofHours(0L), true, null).getLogs(Scn.valueOf(0));
+        List<LogFile> files = getLogFileCollector(Duration.ofHours(0L), true, null).getLogs(Scn.valueOf(0)).logFiles();
         files.forEach(file -> assertThat(file.getType()).isEqualTo(LogFile.Type.ARCHIVE));
     }
 
@@ -105,7 +105,7 @@ public class LogFileCollectorIT extends AbstractAsyncEngineConnectorTest {
         }
 
         // Test environment always has 1 destination at LOG_ARCHIVE_DEST_1
-        List<LogFile> files = getLogFileCollector(Duration.ofHours(1L), true, "LOG_ARCHIVE_DEST_1").getLogs(Scn.valueOf(0));
+        List<LogFile> files = getLogFileCollector(Duration.ofHours(1L), true, "LOG_ARCHIVE_DEST_1").getLogs(Scn.valueOf(0)).logFiles();
         assertThat(files.isEmpty()).isFalse();
         files.forEach(file -> assertThat(file.getType()).isEqualTo(LogFile.Type.ARCHIVE));
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
@@ -1469,7 +1469,7 @@ public class LogFileCollectorTest {
         final OracleConnection connection = getOracleConnectionMock(redoThreadState, files);
         final LogFileCollector collector = getLogFileCollector(config, connection);
 
-        final List<LogFile> result = collector.getLogs(Scn.valueOf(103401));
+        final List<LogFile> result = collector.getLogs(Scn.valueOf(103401)).logFiles();
         assertThat(result).hasSize(2);
         assertThat(getLogFileWithName(result, "logfile1").getNextScn()).isEqualTo(Scn.valueOf(103700));
         assertThat(getLogFileWithName(result, "logfile2").getNextScn()).isEqualTo(Scn.valueOf(104000));
@@ -1489,7 +1489,7 @@ public class LogFileCollectorTest {
         final OracleConnection connection = getOracleConnectionMock(redoThreadState, files);
         final LogFileCollector collector = getLogFileCollector(config, connection);
 
-        final List<LogFile> result = collector.getLogs(Scn.valueOf(103401));
+        final List<LogFile> result = collector.getLogs(Scn.valueOf(103401)).logFiles();
         assertThat(result).hasSize(2);
         assertThat(getLogFileWithName(result, "logfile1")).isNull();
     }
@@ -1508,7 +1508,7 @@ public class LogFileCollectorTest {
         final OracleConnection connection = getOracleConnectionMock(redoThreadState, files);
         final LogFileCollector collector = getLogFileCollector(config, connection);
 
-        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301));
+        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301)).logFiles();
         assertThat(result).hasSize(3);
         assertThat(getLogFileWithName(result, "logfile2").getNextScn()).isEqualTo(TestHelper.SCN_MAX);
     }
@@ -1527,7 +1527,7 @@ public class LogFileCollectorTest {
         final OracleConnection connection = getOracleConnectionMock(redoThreadState, files);
         final LogFileCollector collector = getLogFileCollector(config, connection);
 
-        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301));
+        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301)).logFiles();
         assertThat(result).hasSize(3);
         assertThat(getLogFileWithName(result, "logfile2").getNextScn()).isEqualTo(TestHelper.SCN_MAX);
     }
@@ -1548,7 +1548,7 @@ public class LogFileCollectorTest {
         final OracleConnection connection = getOracleConnectionMock(redoThreadState, files);
         final LogFileCollector collector = getLogFileCollector(config, connection);
 
-        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301));
+        final List<LogFile> result = collector.getLogs(Scn.valueOf(103301)).logFiles();
         assertThat(result).hasSize(3);
         assertThat(getLogFileWithName(result, "logfile2").getNextScn()).isEqualTo(Scn.valueOf(largeScnValue));
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
@@ -1570,7 +1570,7 @@ public class LogFileCollectorTest {
         LogFileCollector collector = setCollectorLogFiles(getLogFileCollector(config, connection), files);
 
         // Since no thread state changes and mining from SCN 1, we should get the same log files
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
 
         // Bump redo thread state
         // No redo thread state changes, no checkpoints or log switches
@@ -1579,7 +1579,7 @@ public class LogFileCollectorTest {
         setConnectionRedoThreadState(connection, redoThreadState);
 
         // Should get the same logs even after state advancement
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
     }
 
     @Test
@@ -1600,7 +1600,7 @@ public class LogFileCollectorTest {
         LogFileCollector collector = setCollectorLogFiles(getLogFileCollector(config, connection), files);
 
         // Since no thread state changes yet, we should get the same logs
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
 
         // Transition redo thread 1 to CLOSED (offline)
         redoThreadState = transitionRedoThreadToOffline(redoThreadState, 1, 1);
@@ -1615,7 +1615,7 @@ public class LogFileCollectorTest {
         files.add(createRedoLog("redo02.log", 50, 2, 2));
         collector = setCollectorLogFiles(collector, files);
 
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
     }
 
     @Test
@@ -1637,7 +1637,7 @@ public class LogFileCollectorTest {
         LogFileCollector collector = setCollectorLogFiles(getLogFileCollector(config, connection), files);
 
         // Since no thread state changes yet, we should get the same logs.
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
 
         // Transition node 1 to OPEN (online)
         redoThreadState = transitionRedoThreadToOnline(redoThreadState, 1);
@@ -1652,7 +1652,7 @@ public class LogFileCollectorTest {
         files.add(createRedoLog("redo02.log", 50, 2, 2));
         collector = setCollectorLogFiles(collector, files);
 
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
     }
 
     @Test
@@ -1673,7 +1673,7 @@ public class LogFileCollectorTest {
         LogFileCollector collector = setCollectorLogFiles(getLogFileCollector(config, connection), files);
 
         // Since no thread state changes yet, we should get the same logs.
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
 
         // Add new redo thread 3 in CLOSED state
         RedoThreadState.Builder builder = duplicateState(redoThreadState);
@@ -1712,7 +1712,7 @@ public class LogFileCollectorTest {
         files.add(createRedoLog("redo03.log", 1000, 4, 3));
         collector = setCollectorLogFiles(collector, files);
 
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
     }
 
     @Test
@@ -1733,7 +1733,7 @@ public class LogFileCollectorTest {
         LogFileCollector collector = setCollectorLogFiles(getLogFileCollector(config, connection), files);
 
         // Since no thread state changes yet, we should get the same logs.
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
 
         // Add new redo thread 3 in CLOSED state
         RedoThreadState.Builder builder = duplicateState(redoThreadState);
@@ -1772,7 +1772,7 @@ public class LogFileCollectorTest {
         files.add(createRedoLog("redo03.log", 1100, 4, 3));
         collector = setCollectorLogFiles(collector, files);
 
-        assertThat(collector.getLogs(Scn.ONE)).isEqualTo(files);
+        assertThat(collector.getLogs(Scn.ONE).logFiles()).isEqualTo(files);
     }
 
     @Test
@@ -2378,7 +2378,8 @@ public class LogFileCollectorTest {
     }
 
     private static Configuration.Builder getDefaultConfig() {
-        return TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_LOG_QUERY_MAX_RETRIES, 0);
+        return TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_LOG_QUERY_MAX_RETRIES, 0);
     }
 
     private OracleConnection getOracleConnectionMock(RedoThreadState state) throws SQLException {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelectorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.oracle.RedoThreadState;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
+import io.debezium.connector.oracle.logminer.LogFileSessionSelector.SessionLogSelection;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for {@link UnboundedLogFileSessionSelector}.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
+public class UnboundedLogFileSessionSelectorTest {
+
+    private final UnboundedLogFileSessionSelector selector = new UnboundedLogFileSessionSelector();
+
+    @Test
+    @FixFor("dbz#1713")
+    void testAllLogsReturnedWithOriginalUpperBounds() {
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1),
+                createArchiveLog("arc2.log", 200, 300, 2, 1),
+                createRedoLog("redo1.log", 300, 3, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, emptyState()), Scn.valueOf(500));
+
+        assertThat(result.logFiles()).isEqualTo(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testEmptyLogListReturnedUnchanged() {
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(List.of(), emptyState()), Scn.valueOf(500));
+
+        assertThat(result.logFiles()).isEmpty();
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+    }
+
+    @Test
+    @FixFor("dbz#1713")
+    void testUpperBoundsPreservedRegardlessOfLogContent() {
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 900, 1, 1));
+
+        // upper bounds of 400 is less than arc1.nextScn=900; selector must not alter it
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, emptyState()), Scn.valueOf(400));
+
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
+    private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread) {
+        return LogFile.forArchive(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), thread,
+                1024L * 1024L * 1024L, false, false);
+    }
+
+    private static LogFile createRedoLog(String name, long startScn, int seq, int thread) {
+        return LogFile.forRedo(name, Scn.valueOf(startScn), Scn.valueOf(Long.MAX_VALUE), BigInteger.valueOf(seq), true,
+                thread, 1024L * 1024L * 1024L);
+    }
+
+    private static RedoThreadState emptyState() {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(1)
+                .status("OPEN")
+                .enabled("PUBLIC")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointScn(Scn.valueOf(50))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(Scn.valueOf(50))
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoScn(Scn.valueOf(1000))
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -167,20 +167,7 @@ public class TestHelper {
             builder.withDefault(OracleConnectorConfig.OLR_HOST, OPENLOGREPLICATOR_HOST);
             builder.withDefault(OracleConnectorConfig.OLR_PORT, OPENLOGREPLICATOR_PORT);
         }
-        else if (isUnbufferedLogMiner()) {
-            // Speeds up tests
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN_MS, 0);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT_MS, 500);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT_MS, 500);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX_MS, 1000);
-        }
-        else {
-            // Speeds up tests
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN_MS, 0);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT_MS, 500);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT_MS, 500);
-            builder.with(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX_MS, 1000);
-
+        else if (isBufferedLogMiner()) {
             final Boolean readOnly = Boolean.parseBoolean(System.getProperty(OracleConnectorConfig.LOG_MINING_READ_ONLY.name()));
             if (readOnly) {
                 builder.with(OracleConnectorConfig.LOG_MINING_READ_ONLY, readOnly);

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4953,6 +4953,10 @@ If the buffer is empty, the value will be `0`.
 |`long`
 |The maximum number of logs specified for any LogMiner session.
 
+|[[oracle-streaming-metrics-current-mined-log-count]]<<oracle-streaming-metrics-current-mined-log-count, `+CurrentMinedLogCount+`>>
+|`long`
+|The current number of logs specified for the LogMiner session.
+
 |[[oracle-streaming-metrics-redologstatuses]]<<oracle-streaming-metrics-redologstatuses, `+RedoLogStatuses+`>>
 |`string[]`
 |Array of the current state for each online redo log in the database with the format `_filename_\|_status_`.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1284,38 +1284,6 @@ The following example shows an Ehcache configuration that includes both a global
 endif::community[]
 
 // Type: concept
-// ModuleID: debezium-oracle-connector-scn-gap-detection
-// Title: How the {prodname} Oracle connector detects gaps in SCN values
-[[scn-jumps]]
-=== SCN gap detection
-
-When the {prodname} Oracle connector is configured to use LogMiner, it collects change events from Oracle by using a start and end range that is based on system change numbers (SCNs).
-The connector manages this range automatically, increasing or decreasing the range depending on whether the connector is able to stream changes in near real-time, or must process a backlog of changes due to the volume of large or bulk transactions in the database.
-
-Under certain circumstances, the Oracle database advances the SCN by an unusually high amount, rather than increasing the SCN value at a constant rate.
-Such a jump in the SCN value can occur because of the way that a particular integration interacts with the database, or as a result of events such as hot backups.
-
-The {prodname} Oracle connector relies on the following configuration properties to detect the SCN gap and adjust the mining range.
-
-`log.mining.scn.gap.detection.gap.size.min`:: Specifies the minimum gap size.
-`log.mining.scn.gap.detection.time.interval.max.ms`:: Specifies the maximum time interval.
-
-The connector first compares the difference in the number of changes between the current SCN and the highest SCN in the current mining range.
-If the difference between the current SCN value and the highest SCN value is greater than the minimum gap size, then the connector has potentially detected a SCN gap.
-To confirm whether a gap exists, the connector next compares the timestamps of the current SCN and the SCN at the end of the previous mining range.
-If the difference between the timestamps is less than the maximum time interval, then the existence of an SCN gap is confirmed.
-
-When an SCN gap occurs, the {prodname} connector automatically uses the current SCN as the end point for the range of the current mining session.
-This allows the connector to quickly catch up to the real-time events without mining smaller ranges in between that return no changes because the SCN value was increased by an unexpectedly large number.
-When the connector performs the preceding steps in response to an SCN gap, it ignores the value that is specified by the xref:oracle-property-log-mining-batch-size-max[log.mining.batch.size.max] property.
-After the connector finishes the mining session and catches back up to real-time events, it resumes enforcement of the maximum log mining batch size.
-
-[WARNING]
-====
-SCN gap detection is available only if the large SCN increment occurs while the connector is running and processing near real-time events.
-====
-
-// Type: concept
 // ModuleID: how-debezium-manages-offsets-in-databases-that-change-infrequently
 // Title: How {prodname} manages offsets in databases that change infrequently
 [[low-change-frequency-offset-management]]
@@ -4370,6 +4338,12 @@ The schema, table, and username configuration include/exclude lists should not s
 `regex`:: The query is generated using Oracle's `REGEXP_LIKE` operator to filter schema and table names on the database side, along with usernames using a SQL in-clause.
 The schema and table configuration include/exclude lists can safely specify regular expressions.
 
+|[[oracle-property-log-mining-log-count-min]]<<oracle-property-log-count-min, `+log.mining.log.count.min+`>>
+|`2`
+|The minimum number of transaction logs to read per redo thread in each mining step. +
+ +
+This configuration property has no effect when using xref:#oracle-property-log-mining-strategy[`log.mining.strategy`] is set to `redo_log_catalog`.
+
 |[[oracle-property-log-mining-buffer-type]]<<oracle-property-log-mining-buffer-type, `+log.mining.buffer.type+`>>
 |`memory`
 |The buffer type controls how the connector manages buffering transaction data. +
@@ -4483,39 +4457,6 @@ By setting this value to something greater than `0`, this specifies the maximum 
 By default, the JDBC connection is not closed across log switches or maximum session lifetimes. +
 This should be enabled if you experience excessive Oracle SGA growth with LogMiner.
 
-|[[oracle-property-log-mining-batch-size-min]]<<oracle-property-log-mining-batch-size-min, `+log.mining.batch.size.min+`>>
-|`1000`
-|The minimum SCN interval size that this connector attempts to read from redo/archive logs.
-
-|[[oracle-property-log-mining-batch-size-max]]<<oracle-property-log-mining-batch-size-max, `+log.mining.batch.size.max+`>>
-|`100000`
-|The maximum SCN interval size that this connector uses when reading from redo/archive logs.
-
-|[[oracle-property-log-mining-batch-size-increment]]<<oracle-property-log-mining-batch-size-increment, `+log.mining.batch.size.increment+`>>
-|`20000`
-|The amount to increase/decrease the interval that the connector uses to read from redo/archive logs.
-
-|[[oracle-property-log-mining-batch-size-default]]<<oracle-property-log-mining-batch-size-default, `+log.mining.batch.size.default+`>>
-|`20000`
-|The starting SCN interval size that the connector uses for reading data from redo/archive logs.
-This also servers as a measure for adjusting batch size - when the difference between current SCN and beginning/end SCN of the batch is bigger than this value, batch size is increased/decreased.
-
-|[[oracle-property-log-mining-sleep-time-min-ms]]<<oracle-property-log-mining-sleep-time-min-ms, `+log.mining.sleep.time.min.ms+`>>
-|`0`
-|The minimum amount of time that the connector sleeps after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
-
-|[[oracle-property-log-mining-sleep-time-max-ms]]<<oracle-property-log-mining-sleep-time-max-ms, `+log.mining.sleep.time.max.ms+`>>
-|`3000`
-|The maximum amount of time that the connector ill sleeps after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
-
-|[[oracle-property-log-mining-sleep-time-default-ms]]<<oracle-property-log-mining-sleep-time-default-ms, `+log.mining.sleep.time.default.ms+`>>
-|`1000`
-|The starting amount of time that the connector sleeps after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
-
-|[[oracle-property-log-mining-sleep-time-increment-ms]]<<oracle-property-log-mining-sleep-time-increment-ms, `+log.mining.sleep.time.increment.ms+`>>
-|`200`
-|The maximum amount of time up or down that the connector uses to tune the optimal sleep time when reading data from logminer. Value is in milliseconds.
-
 |[[oracle-property-archive-log-hours]]<<oracle-property-archive-log-hours, `+archive.log.hours+`>>
 |`0`
 |The number of hours in the past from SYSDATE to mine archive logs.
@@ -4595,16 +4536,6 @@ It can be useful to set this property if you want the capturing process to inclu
 |No default
 |List of JDBC connection client ids to exclude from the LogMiner query.
 It can be useful to set this property if you want the capturing process to always exclude the changes specific JDBC connection clients.
-
-|[[oracle-property-log-mining-scn-gap-detection-gap-size-min]]<<oracle-property-log-mining-scn-gap-detection-gap-size-min, `+log.mining.scn.gap.detection.gap.size.min+`>>
-|`1000000`
-|Specifies a value that the connector compares to the difference between the current and previous SCN values to determine whether an SCN gap exists.
-If the difference between the SCN values is greater than the specified value, and the time difference is smaller than xref:oracle-property-log-mining-scn-gap-detection-time-interval-max-ms[`log.mining.scn.gap.detection.time.interval.max.ms`] then an SCN gap is detected, and the connector uses a mining window larger than the configured maximum batch.
-
-|[[oracle-property-log-mining-scn-gap-detection-time-interval-max-ms]]<<oracle-property-log-mining-scn-gap-detection-time-interval-max-ms, `+log.mining.scn.gap.detection.time.interval.max.ms+`>>
-|`20000`
-|Specifies a value,  in milliseconds, that the connector compares to the difference between the current and previous SCN timestamps  to determine whether an SCN gap exists.
-If the difference between the timestamps is less than the specified value, and the SCN delta is greater than xref:oracle-property-log-mining-scn-gap-detection-gap-size-min[`log.mining.scn.gap.detection.gap.size.min`], then an SCN gap is detected and the connector uses a mining window larger than the configured maximum batch.
 
 |[[oracle-property-log-mining-flush-table-name]]<<oracle-property-log-mining-flush-table-name, `+log.mining.flush.table.name+`>>
 |`LOG_MINING_FLUSH`


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1713

## Description
One of the most common pieces of feedback about the Oracle connector is that it's very difficult to determine which settings to use for `log.mining.batch.size.*`. Given that an SCN is not unique, and batch jobs or high activity throughput can cause multiple changes to be assigned the same SCN, values you might use during normal activity time are not sufficient for high-volume periods. 

So what is needed is a consistent way to read a consistent block of data, regardless of how many unique SCN changes are within that block. The most logical representation of that is a log's size in bytes.

At the forefront of this PR, all logic related to the following properties is gone:
* `log.mining.batch.size.*`
* `log.mining.sleep.time.*`
* `log.mining.scn.gap.detection.*`

These options attempted to help the old algorithm provide a sliding scale based on whether the connector was close to real time or falling behind. This is what made it difficult to tune.

For `redo_log_catalog`, this means each mining step pauses for exactly 1s between polls, and the connector will use the `UnboundedLogFileSessionSelector`, reading all available log files from the current read position to present. This is the same behavior as existed before, as this is needed due to the flushing of the data dictionary.

_This new feature may be patched in for redo_log_catalog users, but that's currently out of scope_.

For other mining strategies (`hybrid` and `online_catalog`), a new `CappedLogFileSessionSelector` implementation is used, based on the new configuration property `log.mining.log.count.min`. This setting specifies the minimum number of logs per redo thread that should be mined in a given mining step, defaulting to `2`. If the user overrides this option and sets the count to `0`, the connector will fall back to `UnboundedLogFileSessionSelector` behavior.

With `hybrid` or `online_catalog` and given a redo log file size of 1GB on an Oracle RAC cluster with 2 nodes, the connector will attempt to read at least 4GB of data per mining step (2 * 1GB * number of nodes). This makes it much easier to identify the IO cost per mining step with consistent values.

In addition, this `CappedLogFileSessionSelector` has built-in long-running transaction support. When a subsequent mining step resolves exactly to the same log files as the previous mining step, the minimum number of logs will be incremented by 1, effectively adding 1 more log per thread to the mine log list. This helps keep the IO load contained during long-running transactions while also preventing the connector from stalling due to capped logs.

In addition to the removal of metrics for batch/sleep, a new metric, `CurrentMinedLogCount`, was added to track the current number of logs in the active or prior mining session. This complements the existing min/max tracking, providing a solid histogram-like representation of the upper/lower bounds and the current value for trend analysis.

<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
