### PR TITLE
debezium/dbz#1638: Fix incremental snapshot for PostgreSQL tables without prior DML events 

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -560,6 +560,7 @@ Raf Liwoch
 Rafael Câmara
 Rafael Rain
 Raghava Ponnam
+Raghuvansh Rastogi
 Rajendra Dangwal
 Ram Satish
 Ramesh Reddy

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -437,6 +437,7 @@ Mark Bereznitsky
 Mark Drilling
 Mark Ducommun
 Mark Lambert
+Mark McDonald
 Markus Kull
 Maros Orsak
 Micro Huang

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -168,6 +168,13 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
         return schema.tableFor(table.id());
     }
 
+    @Override
+    protected Table readSchemaForTable(TableId tableId) throws SQLException {
+        LOGGER.debug("Reading schema for table '{}' during incremental snapshot.", tableId);
+        schema.refreshFromIncrementalSnapshot(jdbcConnection, tableId);
+        return schema.tableFor(tableId);
+    }
+
     private void readUntilNewTransactionChange(P partition, OffsetContext offsetContext) throws InterruptedException {
 
         Long eventTxId = offsetContext.getSourceInfo().getInt64(SourceInfo.TXID_KEY);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -57,4 +57,11 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
         schema.refreshFromIncrementalSnapshot(jdbcConnection, table.id());
         return schema.tableFor(table.id());
     }
+
+    @Override
+    protected Table readSchemaForTable(TableId tableId) throws SQLException {
+        LOGGER.debug("Reading schema for table '{}' during incremental snapshot.", tableId);
+        schema.refreshFromIncrementalSnapshot(jdbcConnection, tableId);
+        return schema.tableFor(tableId);
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -543,6 +543,26 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
         assertThat(dbChanges).contains(entry(1, 1));
     }
 
+    @Test
+    @FixFor("DBZ-1638")
+    public void shouldSnapshotTableWithoutPriorDmlEvents() throws Exception {
+        // start connector (no initial snapshot)
+        startConnector();
+
+        // create a new table AFTER connector is running
+        //   (so Debezium has never seen any events for it)
+        TestHelper.execute(
+                "CREATE TABLE s1.new_table (pk SERIAL, val integer, PRIMARY KEY(pk));" +
+                        "INSERT INTO s1.new_table (val) VALUES (1), (2), (3);");
+
+        // trigger incremental snapshot on the new table
+        sendAdHocSnapshotSignal("s1.new_table");
+
+        // verify we get the 3 records (3 data + 3 signal records)
+        final var records = consumeRecordsByTopic(3 + 3);
+        assertThat(records.recordsForTopic("test_server.s1.new_table")).hasSize(3);
+    }
+
     protected void populate4PkTable() throws SQLException {
         try (JdbcConnection connection = databaseConnection()) {
             populate4PkTable(connection, "s1.a4");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -550,7 +550,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
         startConnector();
 
         // create a new table AFTER connector is running
-        //   (so Debezium has never seen any events for it)
+        // (so Debezium has never seen any events for it)
         TestHelper.execute(
                 "CREATE TABLE s1.new_table (pk SERIAL, val integer, PRIMARY KEY(pk));" +
                         "INSERT INTO s1.new_table (val) VALUES (1), (2), (3);");

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -178,6 +178,7 @@ Skezzowski,Balázs Sipos
 subodh,Subodh Kant Chaturvedi
 sahapasci,Sahap Asci
 mfvitale,Mario Fiore Vitale
+mhmcdonald,Mark McDonald
 Raul Estrada,Raúl Estrada
 xiaowu,Wu Zhenhua
 yoheimuta,Yohei Yoshimuta

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -83,6 +83,7 @@ siufay325,SiuFay
 JeremyVigny,Jeremy Vigny
 JLDLaughlin,Jessica Laughlin
 RaghavaPonnam,Raghava Ponnam
+Ra9huvansh,Raghuvansh Rastogi
 kyleyj,Kyley Jex
 raphaelauv,Raphael Auv
 chriscollingwood,Chris Collingwood


### PR DESCRIPTION
Fixes debezium/dbz#1638

## Description

When `snapshot.mode=no_data` is used, no initial snapshot is taken and table schemas are not loaded into memory. If an ad-hoc incremental snapshot is subsequently triggered for a table that has never had any prior DML events, the base class attempts to recover the schema via `readSchemaForTable()`. The default implementation uses a generic JDBC `readSchema` path which does not handle PostgreSQL-specific requirements, causing the snapshot to fail with "Schema retrieval failed due to an exception for `<table>`".

The fix overrides `readSchemaForTable()` in both `PostgresSignalBasedIncrementalSnapshotChangeEventSource` and `PostgresReadOnlyIncrementalSnapshotChangeEventSource` to use the PostgreSQL-native `schema.refreshFromIncrementalSnapshot()` path, consistent with how `refreshTableSchema()` is already overridden in both classes.

A regression test `shouldSnapshotTableWithoutPriorDmlEvents` has been added to `IncrementalSnapshotIT` to verify the fix.

Credit: this fix was originally proposed by @mhmcdonald in #7135, which was closed without being merged.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`