### PR TITLE
debezium/dbz#1800 Avoid TypeRegistry initialization for BeanRegistry

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -113,13 +113,15 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             throw new RetriableException("Couldn't obtain encoding for database", e);
         }
 
+        final TypeRegistry sharedTypeRegistry = PostgresConnection.createTypeRegistry(connectorConfig.getJdbcConfig());
+
         final PostgresValueConverterBuilder valueConverterBuilder = (typeRegistry) -> PostgresValueConverter.of(
                 connectorConfig,
                 databaseCharset,
                 typeRegistry);
 
         MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
-                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL));
+                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), sharedTypeRegistry, valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL));
         // Global JDBC connection used both for snapshotting and streaming.
         // Must be able to resolve datatypes.
         jdbcConnection = connectionFactory.mainConnection();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -461,6 +461,7 @@ public class TypeRegistry {
      * Prime the {@link TypeRegistry} with all existing database types
      */
     private void prime() throws SQLException {
+        LOGGER.trace("Priming type registry with database types");
         try (Statement statement = connection.connection().createStatement();
                 ResultSet rs = statement.executeQuery(SQL_TYPES)) {
             final List<TypeBuilderWithSchema> delayResolvedBuilders = new ArrayList<>();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -100,26 +100,35 @@ public class PostgresConnection extends JdbcConnection {
 
     /**
      * Creates a Postgres connection using the supplied configuration.
-     * If necessary this connection is able to resolve data type mappings.
-     * Such a connection requires a {@link PostgresValueConverter}, and will provide its own {@link TypeRegistry}.
-     * Usually only one such connection per connector is needed.
+     * If the connection needs to resolve data types, it needs to create both {@link TypeRegistry} and {@link PostgresValueConverter}
+     * in advance, and pass them to this constructor.
      *
      * @param config {@link Configuration} instance, may not be null.
+     * @param typeRegistry an already-primed {@link TypeRegistry} instance
      * @param valueConverterBuilder supplies a configured {@link PostgresValueConverter} for a given {@link TypeRegistry}
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
+    public PostgresConnection(JdbcConfiguration config, TypeRegistry typeRegistry, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
         super(addDefaultSettings(config, connectionUsage), FACTORY, PostgresConnection::validateServerVersion, "\"", "\"");
 
-        if (Objects.isNull(valueConverterBuilder)) {
+        if (Objects.isNull(typeRegistry) || Objects.isNull(valueConverterBuilder)) {
             this.typeRegistry = null;
             this.defaultValueConverter = null;
         }
         else {
-            this.typeRegistry = new TypeRegistry(this);
+            this.typeRegistry = typeRegistry;
 
             final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
+        }
+    }
+
+    public static TypeRegistry createTypeRegistry(JdbcConfiguration config) {
+        try (PostgresConnection connection = new PostgresConnection(config, PostgresConnection.CONNECTION_GENERAL)) {
+            return new TypeRegistry(connection);
+        }
+        catch (DebeziumException e) {
+            throw new DebeziumException("Failed to create TypeRegistry", e);
         }
     }
 
@@ -154,7 +163,7 @@ public class PostgresConnection extends JdbcConnection {
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
     public PostgresConnection(JdbcConfiguration config, String connectionUsage) {
-        this(config, null, connectionUsage);
+        this(config, null, null, connectionUsage);
     }
 
     static JdbcConfiguration addDefaultSettings(JdbcConfiguration configuration, String connectionUsage) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -102,6 +102,8 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Strings;
 
+import ch.qos.logback.classic.Level;
+
 /**
  * Integration test for {@link PostgresConnector} using an {@link io.debezium.engine.DebeziumEngine}
  *
@@ -4351,5 +4353,27 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         stopConnector();
         TestHelper.execute("DROP SCHEMA IF EXISTS dbz1258 CASCADE;");
+    }
+
+    @Test
+    @FixFor("DBZ-1800")
+    void shouldInitializeTypeRegistryOnlyOnceOnConnectorStart() throws Exception {
+        LogInterceptor interceptor = new LogInterceptor(TypeRegistry.class);
+        interceptor.setLoggerLevel(TypeRegistry.class, Level.TRACE);
+
+        // Verify that TypeRegistry is created only once even if multiple
+        // snapshot connections are established.
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MAX_THREADS, 2)
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForSnapshotToBeCompleted();
+        assertConnectorIsRunning();
+
+        List<String> matched = interceptor.getLogEntriesThatContainsMessage("Priming type registry with database types");
+        assertThat(matched.size()).isEqualTo(1);
+
+        stopConnector();
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -925,14 +925,18 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertConnectorIsRunning();
         waitForStreamingRunning();
 
-        SourceRecords actualRecords = consumeRecordsByTopic(6);
+        // JdbcConnection#connection() is called multiple times during connector start-up,
+        // so the given statements will be executed multiple times, resulting in multiple
+        // records. Note that the required number of records can vary if the number of
+        // connection() invocations changes due to future implementation updates.
+        SourceRecords actualRecords = consumeRecordsByTopic(7);
         assertKey(actualRecords.allRecordsInOrder().get(0), "pk", 1);
         assertKey(actualRecords.allRecordsInOrder().get(1), "pk", 2);
 
-        // JdbcConnection#connection() is called multiple times during connector start-up,
-        // so the given statements will be executed multiple times, resulting in multiple
-        // records; here we're interested just in the first insert for s2.a
-        assertValueField(actualRecords.allRecordsInOrder().get(5), "after/bb", "hello; world");
+        // Here we're interested just in the first insert for s2.a.
+        // Note that the index passed to get() may also need to be updated if the number
+        // of generated records changes in the future.
+        assertValueField(actualRecords.allRecordsInOrder().get(6), "after/bb", "hello; world");
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -162,9 +162,11 @@ public final class TestHelper {
      */
     public static PostgresConnection createWithTypeRegistry() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
+        final TypeRegistry typeregistry = PostgresConnection.createTypeRegistry(config.getJdbcConfig());
 
         return new PostgresConnection(
                 config.getJdbcConfig(),
+                typeregistry,
                 getPostgresValueConverterBuilder(config),
                 CONNECTION_TEST);
     }
@@ -274,21 +276,20 @@ public final class TestHelper {
 
     public static TypeRegistry getTypeRegistry() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
-            return connection.getTypeRegistry();
-        }
+        return PostgresConnection.createTypeRegistry(config.getJdbcConfig());
     }
 
     public static PostgresDefaultValueConverter getDefaultValueConverter() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
+        final TypeRegistry typeRegistry = PostgresConnection.createTypeRegistry(config.getJdbcConfig());
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), typeRegistry, getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
             return connection.getDefaultValueConverter();
         }
     }
 
     public static Charset getDatabaseCharset() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), CONNECTION_TEST)) {
             return connection.getDatabaseCharset();
         }
     }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1800

## Description
Currently, TypeRegistry was initialized for the `BeanRegistry` connection, but as far as I see, BeanRegistry is only used by Reselect columns and does not require type metadata.
This change skips unnecessary `TypeRegistry` construction for that connection.

**Alternative considered: making TypeRegistry a singleton**
I also considered making `TypeRegistry` a singleton to prevent multiple initializations.

However, `TypeRegistry` currently takes a `PostgresConnection` in its constructor, and in the current design it is created from different connections. Making it a singleton as-is would effectively ignore the connection passed after the first initialization, which feels semantically incorrect.

A cleaner design might require changing the constructor to accept a config object and let `TypeRegistry` manage its own connection internally.
However, that broadens the scope of this PR, so this approach was not pursued here.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
