### PR TITLE
debezium/dbz#1805 Fix KafkaConnectDiscoveryService platform compatibility

### DIFF
--- a/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/source/kafkaconnect/KafkaConnectDiscoveryService.java
+++ b/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/source/kafkaconnect/KafkaConnectDiscoveryService.java
@@ -8,6 +8,7 @@ package io.debezium.schemagenerator.source.kafkaconnect;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -61,7 +62,8 @@ public class KafkaConnectDiscoveryService {
             ComponentType.HEADER_CONVERTER, "org.apache.kafka.connect.storage.HeaderConverter",
             ComponentType.PREDICATE, "org.apache.kafka.connect.transforms.predicates.Predicate");
     public static final String META_INF_SERVICES_FORLDER = "META-INF/services/";
-    public static final String JAR_FILE = "jar:file:";
+    public static final String JAR = "jar:";
+    public static final String JAR_FILE = JAR + "file:";
     public static final String ORG_APACHE_KAFKA = "org.apache.kafka.";
     public static final String CLASS_EXTENSION = ".class";
 
@@ -253,8 +255,7 @@ public class KafkaConnectDiscoveryService {
      * @return file system path to the JAR
      */
     private String extractJarPath(String urlString) {
-        return urlString.substring(
-                JAR_FILE.length(),
-                urlString.indexOf("!"));
+        final String fileUrl = urlString.substring(JAR.length(), urlString.indexOf("!"));
+        return Paths.get(URI.create(fileUrl)).toString();
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1805

## Description
Fix platform compatibility of `KafkaConnectDiscoveryService` on Windows

On Windows, the old code would yield
```
an IllegalPathException: Illegal char <:> at index 2: /C://Users/...
```

I can confirm the PR change compiles on both Fedora/Linux and Windows 11.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
