### PR TITLE
[docs] Add closing delimiter to read-only logical standby TP admonition

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3067,6 +3067,7 @@ Red{nbsp}Hat does not recommend using them in production.
 These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
 endif::product[]
 
 ifdef::community[]


### PR DESCRIPTION
[docs] Appends closing delimiter to admonition block

## Description
A closing delimiter was omitted from the Tech preview admonition for the read-only logical standby feature in the product edition of the Oracle connector. The missing delimiter prevented the downstream docs from building.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`


Backported to 3.4 (#7329 ) and 3.5 (#7330 ).