### PR TITLE
[docs] Add closing delimiter to read-only logical standby TP admonition

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2996,6 +2996,7 @@ Red{nbsp}Hat does not recommend using them in production.
 These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
 endif::product[]
 
 ifdef::community[]


### PR DESCRIPTION
(cherry picked from commit 2012376a0e0c52387b5995eaf6397c1a23d84af8)

## Description
Inserts closing delimiter that was omitted from the Tech preview admonition for the read-only logical standby feature in the product edition of the Oracle connector. The missing delimiter prevented the downstream docs from building.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.4`
