### PR TITLE
DBZ-9865 Adds missing MariaDB anchor ID; shares MySQL vector types doc w/ MariaDB

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -384,7 +384,6 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 == Data type mappings
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=data-type-mappings]
-include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=data-type-mappings-list-mysql-only]
 
 [id="mysql-basic-types"]
 === Basic types

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1780,13 +1780,8 @@ Details are in the following sections:
 * xref:{context}-decimal-types[]
 * xref:{context}-boolean-values[]
 * xref:{context}-spatial-types[]
+* xref:{context}-vector-types[]
 endif::product[]
-end::data-type-mappings[]
-tag::data-type-mappings-list-mysql-only[]
-ifdef::product[]
-* xref:mysql-vector-types[]
-endif::product[]
-end::data-type-mappings-list-mysql-only[]
 
 
 


### PR DESCRIPTION
Add-on fix to [DBZ-9865](https://redhat.atlassian.net/browse/DBZ-9865)

## Description
Remove conditionals in shared file that filtered out vector types doc for MariaDB. 
Adds missing ID to enable direct linking to Vector types from main data mapping topic 
## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

Backported to 3.4 (#7332 ) and 3.5 (#7333 )
