### PR TITLE
DBZ-9865 Adds mariadb-vector-types anchor ID (3.4)

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -286,6 +286,7 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=spatial-data-types]
 
+[id="mariadb-vector-types"]
 === Vector types
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=vector-data-types]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9865](https://redhat.atlassian.net/browse/DBZ-9865)

## Description
Add an anchor ID to the MariaDB connector file to permit direct linking to the Vector data types topic.
Inadvertently dropped this change from an earlier commit.  
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.4`

Fixed in `3.4`  as part of fix to blocking build issue; forward port to `main` and `3.5` (#7336)
