### PR TITLE
DBZ-9870 Relocates anchor Ids from shared file to MariaDB/MySQL files

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -323,77 +323,24 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=creating-a-db-user]
 
+[id="permissions-explained-mariadb-connector"]
+==== Descriptions of user permissions
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=permissions-explained]
+
 // Type: procedure
 // ModuleID: enabling-the-mariadb-binlog-for-debezium
 // Title: Enabling the MariaDB binlog for {prodname}
 [[enable-mariadb-binlog]]
 === Enabling the binlog
 
-You must enable binary logging for {connector-name} replication.
-The binary logs record transaction updates in a way that enables replicas to propagate those changes.
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-binlog]
 
-.Prerequisites
+[id="binlog-configuration-properties-mariadb-connector"]
+==== Descriptions of MariaDB binlog configuration properties
 
-* A {connector-name} server.
-* Appropriate {connector-name} user privileges.
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=binlog-config-props]
 
-.Procedure
-
-. Check whether the `log-bin` option is enabled:
-+
-include::{partialsdir}/modules/snippets/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=setting-up-the-db-enabling-binlog]
-
-. If the binlog is `OFF`, add the properties in the following table to the configuration file for the {connector-name} server:
-+
-[source,properties,subs="+attributes"]
-----
-server-id         = 223344 # Querying variable is called server_id, e.g. SELECT variable_value FROM information_schema.global_variables WHERE variable_name='server_id';
-log_bin                     = {context}-bin
-binlog_format               = ROW
-binlog_row_image            = FULL
-binlog_expire_logs_seconds  = 864000
-log_bin_compress            = 0
-----
-
-. Confirm your changes by checking the binlog status once more:
-+
-include::{partialsdir}/modules/snippets/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=setting-up-the-db-enabling-binlog]
-
-. If you run {connector-name} on Amazon RDS, you must enable automated backups for your database instance for binary logging to occur.
-If the database instance is not configured to perform automated backups, the binlog is disabled, even if you apply the settings described in the previous steps.
-
-+
-[id="binlog-configuration-properties-{context}-connector"]
-.Descriptions of {connector-name} binlog configuration properties
-[cols="1,4",options="header",subs="+attributes"]
-|===
-|Property |Description
-
-|`server-id`
-|The value for the `server-id` must be unique for each server and replication client in the {connector-name} cluster.
-
-|`log_bin`
-|The value of `log_bin` is the base name of the sequence of binlog files.
-
-|`binlog_format`
-|The `binlog-format` must be set to `ROW` or `row`.
-
-|`binlog_row_image`
-|The `binlog_row_image` must be set to `FULL` or `full`.
-
-|`binlog_expire_logs_seconds`
-|The `binlog_expire_logs_seconds` corresponds to deprecated system variable `expire_logs_days`.
-This is the number of seconds for automatic binlog file removal.
-The default value is `2592000`, which equals 30 days.
-Set the value to match the needs of your environment.
-For more information, see xref:{context}-purges-binlog-files-used-by-debezium[{connector-name} purges binlog files].
-
-|`log_bin_compress`
-|Whether or not the binary log can be compressed. The {prodname}
-{connector-name} connector does not support compressed binary log entries, so
-`log_bin_compress` must be set to `0` (the default), which means no compression.
-
-|===
 
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -447,6 +447,11 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=creating-a-db-user]
 
+[id="permissions-explained-mysql-connector"]
+==== Descriptions of user permissions
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=permissions-explained]
+
 // Type: procedure
 // ModuleID: enabling-the-mysql-binlog-for-debezium
 // Title: Enabling the MySQL binlog for {prodname}
@@ -455,6 +460,10 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-binlog]
 
+[id="binlog-configuration-properties-mysql-connector"]
+==== Descriptions of MySQL binlog configuration properties
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=binlog-config-props]
 
 // Type: procedure
 // ModuleID: enabling-mysql-gtids-for-debezium

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1783,7 +1783,7 @@ Details are in the following sections:
 * xref:{context}-vector-types[]
 endif::product[]
 
-
+end::data-type-mappings[]
 
 === Basic types
 
@@ -2329,8 +2329,11 @@ IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that doe
 {context}> FLUSH PRIVILEGES;
 ----
 
-+
-[id="permissions-explained-{context}-connector"]
+end::creating-a-db-user[]
+
+
+
+tag::permissions-explained[]
 .Descriptions of user permissions
 [cols="3,7",options="header",subs="+attributes"]
 |===
@@ -2367,10 +2370,7 @@ The connector always requires this.
 |Specifies the user's {connector-name} password.
 
 |===
-
-end::creating-a-db-user[]
-
-
+end::permissions-explained[]
 
 
 
@@ -2409,8 +2409,10 @@ include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=se
 . If you run {connector-name} on Amazon RDS, you must enable automated backups for your database instance for binary logging to occur.
 If the database instance is not configured to perform automated backups, the binlog is disabled, even if you apply the settings described in the previous steps.
 
-+
-[id="binlog-configuration-properties-{context}-connector"]
+end::enabling-binlog[]
+
+
+tag::binlog-config-props[]
 .Descriptions of {connector-name} binlog configuration properties
 [cols="1,4",options="header",subs="+attributes"]
 |===
@@ -2434,10 +2436,14 @@ This is the number of seconds for automatic binlog file removal.
 The default value is `2592000`, which equals 30 days.
 Set the value to match the needs of your environment.
 For more information, see xref:{context}-purges-binlog-files-used-by-debezium[{connector-name} purges binlog files].
-
+ifdef::MARIADB[]
+|`log_bin_compress`
+|Whether or not the binary log can be compressed. The {prodname}
+{connector-name} connector does not support compressed binary log entries, so
+`log_bin_compress` must be set to `0` (the default), which means no compression.
+endif::MARIADB[]
 |===
-
-end::enabling-binlog[]
+end::binlog-config-props[]
 
 
 
@@ -2468,7 +2474,6 @@ You can prevent this behavior by configuring `interactive_timeout` and `wait_tim
 ----
 {context}> wait_timeout=<duration-in-seconds>
 ----
-
 +
 .Descriptions of {connector-name} session timeout options
 [cols="3,7",options="header",subs="+attributes"]


### PR DESCRIPTION
(cherry picked from commit 99271edcc13a256c18b9aa7e4556ab48d6275d13)

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9870](https://redhat.atlassian.net/browse/DBZ-9870)

## Description
Fixes downstream ID collision error that prevented the documentation by building. The problem results when IDs are added to a shared file. The solution is to retain content in the shared file, but place the IDs and corresponding headings in the parent file.  

Tested in local Antora and downstream builds

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.5`
