### PR TITLE
debezium/dbz-1378 Added Debezium level reproducer test

### DIFF
--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
@@ -7,14 +7,30 @@ package io.debezium.connector.mariadb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.apache.kafka.common.config.Config;
+import org.junit.jupiter.api.Test;
 
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
 import io.debezium.connector.binlog.BinlogConnectorIT;
+import io.debezium.connector.binlog.util.BinlogTestConnection;
+import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.connector.mariadb.MariaDbConnectorConfig.SnapshotLockingMode;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
 
 /**
  * @author Chris Cranford
@@ -75,5 +91,92 @@ public class MariaDbConnectorIT extends BinlogConnectorIT<MariaDbConnector, Mari
     protected String getExpectedQuery(String statement) {
 
         return "SET STATEMENT max_statement_time=600 FOR " + statement;
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1378")
+    public void shouldStartWithEmptyGtidSet() throws Exception {
+        final UniqueDatabase database = getDatabase();
+
+        final Configuration initialConfig = database.defaultConfig()
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, database.qualifiedTableName("products"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .build();
+
+        start(getConnectorClass(), initialConfig);
+        waitForStreamingRunning(getConnectorName(), database.getServerName());
+
+        // Generate at least one GTID and persist it into the offset.
+        try (BinlogTestConnection db = getTestDatabaseConnection(database.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("INSERT INTO products VALUES (default,'dbz-1378-prime','Prime',10.50)");
+        }
+
+        final SourceRecords firstRunRecords = consumeRecordsByTopic(1);
+        assertThat(firstRunRecords.recordsForTopic(database.topicForTable("products")).size()).isEqualTo(1);
+
+        stopConnector();
+
+        // Verify restart offset actually contains GTID state before applying excludes.
+        final String serverName = initialConfig.getString(CommonConnectorConfig.TOPIC_PREFIX);
+        final Map<String, String> partition = createPartition(serverName, database.getDatabaseName()).getSourcePartition();
+        final Map<String, ?> lastCommittedOffset = readLastCommittedOffset(initialConfig, partition);
+        final MariaDbOffsetContext offsetContext = loadOffsets(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, serverName)
+                .build(), lastCommittedOffset);
+        assertThat(offsetContext.gtidSet()).isNotBlank();
+
+        final Configuration restartConfig = database.defaultConfig()
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, database.qualifiedTableName("products"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.GTID_SOURCE_EXCLUDES, ".*")
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .build();
+
+        final Logger binlogClientLogger = Logger.getLogger(BinaryLogClient.class.getName());
+        final List<String> secondStartMessages = new ArrayList<>();
+        final Handler captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record != null && record.getLevel().intValue() >= Level.INFO.intValue()) {
+                    secondStartMessages.add(record.getMessage());
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        binlogClientLogger.addHandler(captureHandler);
+        try {
+            // Re-start with GTID excludes so filtered GTID becomes empty and exercises the problematic path.
+            start(getConnectorClass(), restartConfig);
+            waitForStreamingRunning(getConnectorName(), database.getServerName());
+
+            try (BinlogTestConnection db = getTestDatabaseConnection(database.getDatabaseName());
+                    JdbcConnection connection = db.connect()) {
+                connection.execute("INSERT INTO products VALUES (default,'dbz-1378-restart','Restart',11.50)");
+            }
+
+            final SourceRecords secondRunRecords = consumeRecordsByTopic(1);
+            assertThat(secondRunRecords.recordsForTopic(database.topicForTable("products")).size()).isEqualTo(1);
+            assertConnectorIsRunning();
+        }
+        finally {
+            binlogClientLogger.removeHandler(captureHandler);
+        }
+
+        // With the upstream fix (0.40.7+), empty GTID state must not use MariaDB GTID connect-state path.
+        // Older behavior (0.40.6) logs this line and follows the buggy path.
+        assertThat(secondStartMessages)
+                .noneMatch(message -> message != null && message.startsWith("Requesting streaming from GTID set:"));
+
+        stopConnector();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.7.7</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
-        <version.mysql.binlog>0.40.6</version.mysql.binlog>
+        <version.mysql.binlog>0.40.7</version.mysql.binlog>
         <version.mongo.driver>5.6.2</version.mongo.driver>
         <version.sqlserver.driver>12.4.2.jre8</version.sqlserver.driver>
         <version.db2.driver>11.5.0.0</version.db2.driver>


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1378


#### **Description**
This PR adds a new integration test `shouldStartWithEmptyGtidSet` to `BinlogConnectorIT` to verify the fix for the `NullPointerException`  occurring in the MariaDB connector.

The issue was triggered when the connector attempted to start a binlog stream with an empty or null GTID set, causing a crash in the upstream `mysql-binlog-connector-java` library. This test specifically configures the connector with `gtid.source.excludes = .*` and `snapshot.mode = never` to simulate a start-up state where the GTID set is not yet available, ensuring the connector now handles this path gracefully.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
