### PR TITLE
debezium/dbz#1786 Update to Infinispan 16.1.3 & Protostream 6.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,8 @@
         <version.com.google.protobuf.protoc>3.25.5</version.com.google.protobuf.protoc>
 
         <!-- Infinispan version for Oracle and Debezium Server sink -->
-        <version.infinispan>15.2.1.Final</version.infinispan>
-        <version.infinispan.protostream>5.0.13.Final</version.infinispan.protostream>
+        <version.infinispan>16.1.3</version.infinispan>
+        <version.infinispan.protostream>6.0.6</version.infinispan.protostream>
 
         <!-- EhCache Specific Versions -->
         <version.ehcache>3.11.1</version.ehcache>


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1786

## Description
Updates the Oracle connector and Debezium Server to Infinispan 16.1.3 & its dependency Protostream to 6.0.6.

_NOTE: While users can use the Infinispan 16.1 Hotrod Client with older Infinispan Server versions, the Infinispan Server 16.1 now requires Java 25. If you intend to keep both client/server synchronized, be aware of this Java requirement for the Infinispan Server side._


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
