### PR TITLE
debezium/dbz#1813 Reduce memory usage using Interner

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/AttributeEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/AttributeEditorImpl.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.Interner;
 
 /**
  * Implementation of the {@link AttributeEditor} contract.
@@ -116,7 +117,9 @@ final class AttributeEditorImpl implements AttributeEditor {
 
     @Override
     public Attribute create() {
-        return new AttributeImpl(name, value);
+        return Interner.intern(new AttributeImpl(
+                Interner.intern(name),
+                Interner.intern(value)));
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -6,8 +6,11 @@
 package io.debezium.relational;
 
 import java.sql.Types;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import io.debezium.util.Interner;
 
 final class ColumnEditorImpl implements ColumnEditor {
 
@@ -242,8 +245,15 @@ final class ColumnEditorImpl implements ColumnEditor {
 
     @Override
     public Column create() {
-        return new ColumnImpl(name, position, jdbcType, nativeType, typeName, typeExpression, charsetName, tableCharsetName,
-                length, scale, enumValues, optional, autoIncremented, generated, defaultValueExpression, hasDefaultValue, comment);
+        Column column = new ColumnImpl(
+                Interner.intern(name), position, jdbcType, nativeType,
+                Interner.intern(typeName), Interner.intern(typeExpression),
+                Interner.intern(charsetName), Interner.intern(tableCharsetName),
+                length, scale, enumValues == null ? Collections.emptyList() : Interner.intern(Collections.unmodifiableList(enumValues)),
+                optional, autoIncremented, generated,
+                Interner.intern(defaultValueExpression), hasDefaultValue,
+                Interner.intern(comment));
+        return Interner.intern(column);
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -23,6 +23,7 @@ import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryMetrics;
+import io.debezium.util.Interner;
 
 /**
  * Configuration options shared across the relational CDC connectors which use a persistent database schema history.
@@ -64,12 +65,15 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
 
     public static final Field STORE_ONLY_CAPTURED_DATABASES_DDL = SchemaHistory.STORE_ONLY_CAPTURED_DATABASES_DDL;
 
+    public static final Field MEMORY_OPTIMIZATION = SchemaHistory.MEMORY_OPTIMIZATION;
+
     protected static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .history(
                     SCHEMA_HISTORY,
                     SKIP_UNPARSEABLE_DDL_STATEMENTS,
                     STORE_ONLY_CAPTURED_TABLES_DDL,
-                    STORE_ONLY_CAPTURED_DATABASES_DDL)
+                    STORE_ONLY_CAPTURED_DATABASES_DDL,
+                    MEMORY_OPTIMIZATION)
             .create();
 
     protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass,
@@ -110,6 +114,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
         this.skipUnparseableDDL = config.getBoolean(SKIP_UNPARSEABLE_DDL_STATEMENTS);
         this.storeOnlyCapturedTablesDdl = config.getBoolean(STORE_ONLY_CAPTURED_TABLES_DDL);
         this.storeOnlyCapturedDatabasesDdl = config.getBoolean(STORE_ONLY_CAPTURED_DATABASES_DDL);
+        Interner.setEnabled(config.getBoolean(MEMORY_OPTIMIZATION));
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
@@ -11,6 +11,7 @@ import io.debezium.annotation.Immutable;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
+import io.debezium.util.Interner;
 
 /**
  * Unique identifier for a database table.
@@ -133,9 +134,9 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
      * @param tableIdMapper the customization of fully quailified table name
      */
     public TableId(String catalogName, String schemaName, String tableName, TableIdToStringMapper tableIdMapper) {
-        this.catalogName = catalogName;
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+        this.catalogName = Interner.intern(catalogName);
+        this.schemaName = Interner.intern(schemaName);
+        this.tableName = Interner.intern(tableName);
         assert this.tableName != null;
         this.id = tableIdMapper == null ? tableId(this.catalogName, this.schemaName, this.tableName) : tableIdMapper.toString(this);
     }

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.debezium.annotation.PackagePrivate;
+import io.debezium.util.Interner;
 import io.debezium.util.Strings;
 
 final class TableImpl implements Table {
@@ -32,16 +33,17 @@ final class TableImpl implements Table {
     @PackagePrivate
     TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName, String comment, List<Attribute> attributes) {
         this.id = id;
-        this.columnDefs = Collections.unmodifiableList(sortedColumns);
-        this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Collections.unmodifiableList(pkColumnNames);
+        this.columnDefs = Interner.intern(Collections.unmodifiableList(sortedColumns));
+        this.pkColumnNames = Interner.intern(Collections.unmodifiableList(pkColumnNames));
         Map<String, Column> defsByLowercaseName = new LinkedHashMap<>();
         for (Column def : this.columnDefs) {
-            defsByLowercaseName.put(def.name().toLowerCase(), def);
+            defsByLowercaseName.put(Interner.intern(def.name().toLowerCase()), def);
         }
-        this.columnsByLowercaseName = Collections.unmodifiableMap(defsByLowercaseName);
-        this.defaultCharsetName = defaultCharsetName;
-        this.comment = comment;
-        this.attributes = attributes;
+        this.columnsByLowercaseName = Interner.intern(Collections.unmodifiableMap(defsByLowercaseName));
+        this.defaultCharsetName = Interner.intern(defaultCharsetName);
+        this.comment = Interner.intern(comment);
+        this.attributes = Interner.intern(
+                attributes == null ? Collections.emptyList() : Collections.unmodifiableList(attributes));
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -131,6 +131,16 @@ public interface SchemaHistory {
             .withDescription("The unique identifier of the Debezium connector")
             .withNoValidation();
 
+    Field MEMORY_OPTIMIZATION = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "memory.optimization")
+            .withDisplayName("Enable memory optimization for schema history")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Controls whether Debezium deduplicates identical schema objects (tables, columns, attributes) "
+                    + "in memory using an interner. When enabled, this can significantly reduce heap usage for connectors "
+                    + "that track many tables with similar structures. When disabled (the default), no deduplication is performed.")
+            .withDefault(false);
+
     // Temporary preference for DDL over logical schema due to DBZ-32
     Field INTERNAL_PREFER_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "prefer.ddl")
             .withDisplayName("Prefer DDL for schema recovery")

--- a/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that Column and Attribute objects are interned at creation time, and that
+ * structurally identical tables across tenants share object references, reducing memory usage.
+ */
+public class TableImplInterningTest {
+
+    @Test
+    public void shouldShareColumnObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.id()).isNotEqualTo(table2.id());
+        // Columns are interned at creation — same structure yields same references
+        for (int i = 0; i < table1.columns().size(); i++) {
+            assertThat(table1.columns().get(i)).isSameAs(table2.columns().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualColumnObjectsAcrossTablesWithDifferentStructure() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        // Lists differ, but the shared "id" column is the same interned instance
+        assertThat(table1.columns().get(0)).isSameAs(table2.columns().get(0));
+        assertThat(table1.columns().get(1)).isNotSameAs(table2.columns().get(1));
+    }
+
+    @Test
+    public void shouldShareAttributeObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        for (int i = 0; i < table1.attributes().size(); i++) {
+            assertThat(table1.attributes().get(i)).isSameAs(table2.attributes().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualAttributeObjectsAcrossTablesWithDifferentAttributes() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("partition").value("hash").create())
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("row_format").value("DYNAMIC").create())
+                .create();
+
+        // The "engine" attribute is identical and should be the same interned instance
+        assertThat(table1.attributeWithName("engine")).isSameAs(table2.attributeWithName("engine"));
+    }
+
+    @Test
+    public void shouldPreservePkColumnNameOrder() {
+        Table table = Table.editor()
+                .tableId(new TableId("cat", "sch", "t"))
+                .addColumns(
+                        Column.editor().name("b").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("a").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("b", "a")
+                .create();
+
+        assertThat(table.primaryKeyColumnNames()).containsExactly("b", "a");
+    }
+
+    @Test
+    public void shouldShareDefaultCharsetNameString() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        assertThat(table1.defaultCharsetName()).isSameAs(table2.defaultCharsetName());
+    }
+
+    @Test
+    public void shouldShareColumnStringFields() {
+        Column col1 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+        Column col2 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+
+        // Same interned Column instance
+        assertThat(col1).isSameAs(col2);
+        // String fields are interned
+        assertThat(col1.name()).isSameAs(col2.name());
+        assertThat(col1.typeName()).isSameAs(col2.typeName());
+    }
+
+    @Test
+    public void shouldShareColumnListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        // The entire column list instance is shared, not just individual columns
+        assertThat(table1.columns()).isSameAs(table2.columns());
+    }
+
+    @Test
+    public void shouldSharePkColumnNamesListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.primaryKeyColumnNames()).isSameAs(table2.primaryKeyColumnNames());
+    }
+
+    @Test
+    public void shouldShareAttributeListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.attributes()).isSameAs(table2.attributes());
+    }
+
+    @Test
+    public void shouldShareTableNameStringAcrossTableIds() {
+        TableId id1 = new TableId(new String("tenant1"), new String("schema1"), new String("users"));
+        TableId id2 = new TableId(new String("tenant2"), new String("schema2"), new String("users"));
+
+        // Table names are interned — "users" is the same reference
+        assertThat(id1.table()).isSameAs(id2.table());
+    }
+
+    @Test
+    public void shouldWorkCorrectlyWithTablesOverwriteTable() {
+        Tables tables = new Tables();
+
+        tables.overwriteTable(createTable("tenant1", "schema1", "users"));
+        tables.overwriteTable(createTable("tenant2", "schema2", "users"));
+
+        Table stored1 = tables.forTable(new TableId("tenant1", "schema1", "users"));
+        Table stored2 = tables.forTable(new TableId("tenant2", "schema2", "users"));
+
+        // Individual columns are shared
+        for (int i = 0; i < stored1.columns().size(); i++) {
+            assertThat(stored1.columns().get(i)).isSameAs(stored2.columns().get(i));
+        }
+        // Entire column list is shared
+        assertThat(stored1.columns()).isSameAs(stored2.columns());
+    }
+
+    private static Table createTable(String catalog, String schema, String tableName) {
+        return Table.editor()
+                .tableId(new TableId(catalog, schema, tableName))
+                .addColumns(
+                        Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                                .optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .create();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class InternerTest {
+
+    @BeforeEach
+    public void enableInterner() {
+        Interner.setEnabled(true);
+    }
+
+    @AfterEach
+    public void resetInterner() {
+        Interner.clear();
+        Interner.setEnabled(false);
+    }
+
+    @Test
+    public void shouldReturnSameReferenceForEqualStrings() {
+        String a = new String("hello");
+        String b = new String("hello");
+        assertThat(a).isNotSameAs(b);
+
+        String internedA = Interner.intern(a);
+        String internedB = Interner.intern(b);
+        assertThat(internedA).isSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnDifferentReferencesForDifferentStrings() {
+        String internedA = Interner.intern(new String("hello"));
+        String internedB = Interner.intern(new String("world"));
+        assertThat(internedA).isNotSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnNullForNullInput() {
+        assertThat(Interner.intern((String) null)).isNull();
+    }
+
+    @Test
+    public void shouldWorkWithLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "c");
+        assertThat(list1).isNotSameAs(list2);
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    @Test
+    public void shouldNotInternDifferentLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "d");
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isNotSameAs(interned2);
+    }
+
+    @Test
+    public void shouldClearPool() {
+        Interner.intern("hello");
+        assertThat(Interner.size()).isGreaterThan(0);
+
+        Interner.clear();
+        assertThat(Interner.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReinternAfterClear() {
+        String a = new String("hello");
+        String internedA = Interner.intern(a);
+        assertThat(internedA).isSameAs(a);
+
+        Interner.clear();
+
+        String b = new String("hello");
+        String internedB = Interner.intern(b);
+        assertThat(internedB).isSameAs(b);
+        assertThat(internedB).isNotSameAs(a);
+    }
+
+    @Test
+    public void shouldReleaseEntriesWhenNoLongerStronglyReferenced() {
+        // Intern a list and keep a strong reference
+        List<String> kept = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(kept).isNotNull();
+
+        // Intern a list without keeping a strong reference
+        Interner.intern(new ArrayList<>(Arrays.asList("lose", "me")));
+
+        // Force GC — the unreferenced list should be collected
+        System.gc();
+        System.gc();
+
+        // The kept entry must still be internable to the same reference
+        List<String> reInterned = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(reInterned).isSameAs(kept);
+    }
+
+    @Test
+    public void shouldInternListsWithMixedTypes() {
+        List<Object> list1 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+        List<Object> list2 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+
+        List<Object> interned1 = Interner.intern(list1);
+        List<Object> interned2 = Interner.intern(list2);
+
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    // --- Tests for disabled interner ---
+
+    @Test
+    public void shouldReturnInputWhenDisabled() {
+        Interner.setEnabled(false);
+
+        List<String> list1 = Arrays.asList("a", "b");
+        List<String> list2 = Arrays.asList("a", "b");
+
+        assertThat(Interner.intern(list1)).isSameAs(list1);
+        assertThat(Interner.intern(list2)).isSameAs(list2);
+        assertThat(list1).isNotSameAs(list2);
+    }
+
+    @Test
+    public void shouldReturnNullWhenDisabled() {
+        Interner.setEnabled(false);
+        assertThat(Interner.intern((Integer) null)).isNull();
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/Interner.java
+++ b/debezium-util/src/main/java/io/debezium/util/Interner.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A thread-safe, static interner that deduplicates objects by their {@link Object#equals(Object) equals}
+ * semantics, similar to {@link String#intern()} but for arbitrary immutable types.
+ *
+ * <p>This implementation uses weak references
+ * so that interned instances become eligible for garbage collection once no strong references
+ * to them remain. This prevents the memory leaks inherent in a strong-reference pool.</p>
+ *
+ * <p>This is useful when many equal copies of immutable objects exist in memory, for example
+ * when thousands of database schemas share identical table structures.</p>
+ *
+ * <p>Warning: do not use with mutable objects. The interning contract assumes that
+ * objects do not change after being interned.</p>
+ */
+public final class Interner {
+
+    private static final ConcurrentMap<WeakEntry, WeakEntry> MAP = new ConcurrentHashMap<>();
+    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+    private static boolean enabled = false;
+
+    private Interner() {
+    }
+
+    /**
+     * Enables or disables the interner.
+     * When disabled, {@link #intern(Object)} returns the input value without deduplication.
+     *
+     * @param enabled {@code true} to enable interning, {@code false} to bypass it
+     */
+    public static void setEnabled(boolean enabled) {
+        Interner.enabled = enabled;
+    }
+
+    /**
+     * Returns a canonical instance equal to the given value. If an equal value has already been
+     * interned and is still strongly reachable, the previously interned instance is returned.
+     * Otherwise, the given value is stored and returned.
+     *
+     * <p>When the interner is {@link #setEnabled(boolean) disabled}, the sample is returned as-is.</p>
+     *
+     * <p>Note that a previously interned instance may be garbage-collected if no strong references
+     * to it remain, in which case a subsequent call with an equal value will intern the new instance.</p>
+     *
+     * @param sample the value to intern; may be {@code null}
+     * @param <T> the type of the value
+     * @return the canonical instance, or {@code null} if the input was {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T intern(T sample) {
+        if (!enabled || sample == null) {
+            return sample;
+        }
+        if (sample instanceof String) {
+            return (T) ((String) sample).intern();
+        }
+        removeStaleEntries();
+        WeakEntry newEntry = new WeakEntry(sample, QUEUE);
+        while (true) {
+            WeakEntry existing = MAP.putIfAbsent(newEntry, newEntry);
+            if (existing == null) {
+                return sample;
+            }
+            T canonical = (T) existing.get();
+            if (canonical != null) {
+                return canonical;
+            }
+            MAP.remove(existing, existing);
+        }
+    }
+
+    /**
+     * Returns the number of entries currently held in the pool. This includes entries whose
+     * referents may have been garbage-collected but not yet expunged.
+     *
+     * @return the pool size
+     */
+    static int size() {
+        return MAP.size();
+    }
+
+    /**
+     * Removes all entries from the pool.
+     */
+    static void clear() {
+        MAP.clear();
+        removeStaleEntries();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void removeStaleEntries() {
+        Reference<?> ref;
+        while ((ref = QUEUE.poll()) != null) {
+            MAP.remove((WeakEntry) ref, (WeakEntry) ref);
+        }
+    }
+
+    /**
+     * A weak-reference wrapper used as both key and value in the intern pool.
+     *
+     * <p>The {@link #hashCode()} is cached at construction time from the referent, so it remains
+     * stable even after the referent is garbage-collected. The {@link #equals(Object)} method
+     * uses identity comparison as a fast path (needed for stale entry removal), then falls back
+     * to content-based comparison using the referents' {@code equals()} method.</p>
+     */
+    private static final class WeakEntry extends WeakReference<Object> {
+        private final int hashCode;
+
+        WeakEntry(Object referent, ReferenceQueue<Object> QUEUE) {
+            super(referent, QUEUE);
+            this.hashCode = referent.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof WeakEntry)) {
+                return false;
+            }
+            Object thisRef = this.get();
+            Object thatRef = ((WeakEntry) obj).get();
+            return thisRef != null && thisRef.equals(thatRef);
+        }
+    }
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -58,4 +58,10 @@ Specify one of the following values:
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
 `false`:: The connector records schema structures for all logical databases.
 
+|[[{context}-property-database-history-memory-optimization]]<<{context}-property-database-history-memory-optimization, `+schema.history.internal.memory.optimization+`>>
+|`false`
+|A Boolean value that controls whether {prodname} deduplicates identical schema objects (tables, columns, attributes) in memory.
+When enabled, the connector uses an interner to share canonical instances of equal schema objects, which can significantly reduce heap usage for connectors that track many tables with similar structures.
+When disabled (the default), no deduplication is performed.
+
 |===


### PR DESCRIPTION
## Summary
- Introduce a generic `Interner` utility to deduplicate frequently repeated strings and objects in memory
- Apply interning to `TableId`, `TableImpl`, `ColumnEditorImpl`, and `AttributeEditorImpl` to reduce heap usage
- Add a configurable `schema.history.internal.store.only.captured.databases.ddl` option to limit stored DDL history

Closes https://github.com/debezium/dbz/issues/1813

## Test plan
- [x] `InternerTest` — verifies interning behavior (identity, concurrency, null handling)
- [x] `TableImplInterningTest` — verifies interning applied correctly to relational model objects