### PR TITLE
debezium/dbz#1813 Reduce memory usage using Interner

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/AttributeEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/AttributeEditorImpl.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.Interner;
 
 /**
  * Implementation of the {@link AttributeEditor} contract.
@@ -116,7 +117,9 @@ final class AttributeEditorImpl implements AttributeEditor {
 
     @Override
     public Attribute create() {
-        return new AttributeImpl(name, value);
+        return Interner.intern(new AttributeImpl(
+                Interner.intern(name),
+                Interner.intern(value)));
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -6,8 +6,11 @@
 package io.debezium.relational;
 
 import java.sql.Types;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import io.debezium.util.Interner;
 
 final class ColumnEditorImpl implements ColumnEditor {
 
@@ -242,8 +245,15 @@ final class ColumnEditorImpl implements ColumnEditor {
 
     @Override
     public Column create() {
-        return new ColumnImpl(name, position, jdbcType, nativeType, typeName, typeExpression, charsetName, tableCharsetName,
-                length, scale, enumValues, optional, autoIncremented, generated, defaultValueExpression, hasDefaultValue, comment);
+        Column column = new ColumnImpl(
+                Interner.intern(name), position, jdbcType, nativeType,
+                Interner.intern(typeName), Interner.intern(typeExpression),
+                Interner.intern(charsetName), Interner.intern(tableCharsetName),
+                length, scale, enumValues == null ? null : Interner.intern(Collections.unmodifiableList(enumValues)),
+                optional, autoIncremented, generated,
+                Interner.intern(defaultValueExpression), hasDefaultValue,
+                Interner.intern(comment));
+        return Interner.intern(column);
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -23,6 +23,7 @@ import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryMetrics;
+import io.debezium.util.Interner;
 
 /**
  * Configuration options shared across the relational CDC connectors which use a persistent database schema history.
@@ -64,12 +65,15 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
 
     public static final Field STORE_ONLY_CAPTURED_DATABASES_DDL = SchemaHistory.STORE_ONLY_CAPTURED_DATABASES_DDL;
 
+    public static final Field MEMORY_OPTIMIZATION = SchemaHistory.MEMORY_OPTIMIZATION;
+
     protected static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .history(
                     SCHEMA_HISTORY,
                     SKIP_UNPARSEABLE_DDL_STATEMENTS,
                     STORE_ONLY_CAPTURED_TABLES_DDL,
-                    STORE_ONLY_CAPTURED_DATABASES_DDL)
+                    STORE_ONLY_CAPTURED_DATABASES_DDL,
+                    MEMORY_OPTIMIZATION)
             .create();
 
     protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass,
@@ -110,6 +114,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
         this.skipUnparseableDDL = config.getBoolean(SKIP_UNPARSEABLE_DDL_STATEMENTS);
         this.storeOnlyCapturedTablesDdl = config.getBoolean(STORE_ONLY_CAPTURED_TABLES_DDL);
         this.storeOnlyCapturedDatabasesDdl = config.getBoolean(STORE_ONLY_CAPTURED_DATABASES_DDL);
+        Interner.setEnabled(config.getBoolean(MEMORY_OPTIMIZATION));
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -21,8 +21,12 @@ import io.debezium.function.Predicates;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.InternerMetrics;
+import io.debezium.relational.history.MemoryOptimizationMode;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryMetrics;
+import io.debezium.util.Interner;
+import io.debezium.util.InternerStats;
 
 /**
  * Configuration options shared across the relational CDC connectors which use a persistent database schema history.
@@ -39,6 +43,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
     private final Class<? extends SourceConnector> connectorClass;
     private final boolean multiPartitionMode;
     private final Predicate<String> ddlFilter;
+    private final InternerStats internerStats;
     protected boolean skipUnparseableDDL;
     protected boolean storeOnlyCapturedTablesDdl;
     protected boolean storeOnlyCapturedDatabasesDdl;
@@ -64,12 +69,15 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
 
     public static final Field STORE_ONLY_CAPTURED_DATABASES_DDL = SchemaHistory.STORE_ONLY_CAPTURED_DATABASES_DDL;
 
+    public static final Field MEMORY_OPTIMIZATION = SchemaHistory.MEMORY_OPTIMIZATION;
+
     protected static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .history(
                     SCHEMA_HISTORY,
                     SKIP_UNPARSEABLE_DDL_STATEMENTS,
                     STORE_ONLY_CAPTURED_TABLES_DDL,
-                    STORE_ONLY_CAPTURED_DATABASES_DDL)
+                    STORE_ONLY_CAPTURED_DATABASES_DDL,
+                    MEMORY_OPTIMIZATION)
             .create();
 
     protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass,
@@ -110,6 +118,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
         this.skipUnparseableDDL = config.getBoolean(SKIP_UNPARSEABLE_DDL_STATEMENTS);
         this.storeOnlyCapturedTablesDdl = config.getBoolean(STORE_ONLY_CAPTURED_TABLES_DDL);
         this.storeOnlyCapturedDatabasesDdl = config.getBoolean(STORE_ONLY_CAPTURED_DATABASES_DDL);
+        this.internerStats = Interner.activate(MemoryOptimizationMode.parse(config.getString(MEMORY_OPTIMIZATION)).toInternerMode());
     }
 
     /**
@@ -133,9 +142,12 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                 .withDefault(SchemaHistory.INTERNAL_CONNECTOR_ID, logicalName)
                 .build();
 
+        InternerMetrics internerMetrics = internerStats != null
+                ? new InternerMetrics(this, multiPartitionMode(), internerStats)
+                : null;
         HistoryRecordComparator historyComparator = getHistoryRecordComparator();
         schemaHistory.configure(schemaHistoryConfig, historyComparator,
-                new SchemaHistoryMetrics(this, multiPartitionMode()), useCatalogBeforeSchema()); // validates
+                new SchemaHistoryMetrics(this, multiPartitionMode(), internerMetrics), useCatalogBeforeSchema()); // validates
 
         return schemaHistory;
     }

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import io.debezium.util.Interner;
+
 class TableEditorImpl implements TableEditor {
 
     private TableId id;
@@ -306,6 +308,6 @@ class TableEditorImpl implements TableEditor {
         });
         updatePrimaryKeys();
         List<Attribute> attributes = new ArrayList<>(this.attributes.values());
-        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment, attributes);
+        return Interner.intern(new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment, attributes));
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
@@ -11,6 +11,7 @@ import io.debezium.annotation.Immutable;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
+import io.debezium.util.Interner;
 
 /**
  * Unique identifier for a database table.
@@ -133,9 +134,9 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
      * @param tableIdMapper the customization of fully quailified table name
      */
     public TableId(String catalogName, String schemaName, String tableName, TableIdToStringMapper tableIdMapper) {
-        this.catalogName = catalogName;
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+        this.catalogName = Interner.intern(catalogName);
+        this.schemaName = Interner.intern(schemaName);
+        this.tableName = Interner.intern(tableName);
         assert this.tableName != null;
         this.id = tableIdMapper == null ? tableId(this.catalogName, this.schemaName, this.tableName) : tableIdMapper.toString(this);
     }

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableId.java
@@ -11,6 +11,7 @@ import io.debezium.annotation.Immutable;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
+import io.debezium.util.Interner;
 
 /**
  * Unique identifier for a database table.
@@ -133,11 +134,11 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
      * @param tableIdMapper the customization of fully quailified table name
      */
     public TableId(String catalogName, String schemaName, String tableName, TableIdToStringMapper tableIdMapper) {
-        this.catalogName = catalogName;
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+        this.catalogName = Interner.intern(catalogName);
+        this.schemaName = Interner.intern(schemaName);
+        this.tableName = Interner.intern(tableName);
         assert this.tableName != null;
-        this.id = tableIdMapper == null ? tableId(this.catalogName, this.schemaName, this.tableName) : tableIdMapper.toString(this);
+        this.id = Interner.intern(tableIdMapper == null ? tableId(this.catalogName, this.schemaName, this.tableName) : tableIdMapper.toString(this));
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.debezium.annotation.PackagePrivate;
+import io.debezium.util.Interner;
 import io.debezium.util.Strings;
 
 final class TableImpl implements Table {
@@ -32,16 +33,16 @@ final class TableImpl implements Table {
     @PackagePrivate
     TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName, String comment, List<Attribute> attributes) {
         this.id = id;
-        this.columnDefs = Collections.unmodifiableList(sortedColumns);
-        this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Collections.unmodifiableList(pkColumnNames);
+        this.columnDefs = Interner.intern(Collections.unmodifiableList(sortedColumns));
+        this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Interner.intern(Collections.unmodifiableList(pkColumnNames));
         Map<String, Column> defsByLowercaseName = new LinkedHashMap<>();
         for (Column def : this.columnDefs) {
-            defsByLowercaseName.put(def.name().toLowerCase(), def);
+            defsByLowercaseName.put(Interner.intern(def.name().toLowerCase()), def);
         }
-        this.columnsByLowercaseName = Collections.unmodifiableMap(defsByLowercaseName);
-        this.defaultCharsetName = defaultCharsetName;
-        this.comment = comment;
-        this.attributes = attributes;
+        this.columnsByLowercaseName = Interner.intern(Collections.unmodifiableMap(defsByLowercaseName));
+        this.defaultCharsetName = Interner.intern(defaultCharsetName);
+        this.comment = Interner.intern(comment);
+        this.attributes = attributes == null ? null : Interner.intern(Collections.unmodifiableList(attributes));
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.debezium.annotation.PackagePrivate;
+import io.debezium.util.Interner;
 import io.debezium.util.Strings;
 
 final class TableImpl implements Table {
@@ -31,17 +32,17 @@ final class TableImpl implements Table {
 
     @PackagePrivate
     TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName, String comment, List<Attribute> attributes) {
-        this.id = id;
-        this.columnDefs = Collections.unmodifiableList(sortedColumns);
-        this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Collections.unmodifiableList(pkColumnNames);
+        this.id = Interner.intern(id);
+        this.columnDefs = Interner.intern(Collections.unmodifiableList(sortedColumns));
+        this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Interner.intern(Collections.unmodifiableList(pkColumnNames));
         Map<String, Column> defsByLowercaseName = new LinkedHashMap<>();
         for (Column def : this.columnDefs) {
-            defsByLowercaseName.put(def.name().toLowerCase(), def);
+            defsByLowercaseName.put(Interner.intern(def.name().toLowerCase()), def);
         }
-        this.columnsByLowercaseName = Collections.unmodifiableMap(defsByLowercaseName);
-        this.defaultCharsetName = defaultCharsetName;
-        this.comment = comment;
-        this.attributes = attributes;
+        this.columnsByLowercaseName = Interner.intern(Collections.unmodifiableMap(defsByLowercaseName));
+        this.defaultCharsetName = Interner.intern(defaultCharsetName);
+        this.comment = Interner.intern(comment);
+        this.attributes = attributes == null ? null : Interner.intern(Collections.unmodifiableList(attributes));
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/Tables.java
@@ -23,6 +23,7 @@ import io.debezium.schema.DataCollectionFilters.DataCollectionFilter;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Collect;
 import io.debezium.util.FunctionalReadWriteLock;
+import io.debezium.util.Interner;
 
 /**
  * Structural definitions for a set of tables in a JDBC database.
@@ -262,7 +263,7 @@ public final class Tables {
      */
     public Table overwriteTable(Table table) {
         return lock.write(() -> {
-            TableImpl updated = new TableImpl(table);
+            TableImpl updated = Interner.intern(new TableImpl(table));
             try {
                 return tablesByTableId.put(updated.id(), updated);
             }
@@ -308,8 +309,8 @@ public final class Tables {
                 return null;
             }
             tablesByTableId.remove(existing.id());
-            TableImpl updated = new TableImpl(newTableId, existing.columns(),
-                    existing.primaryKeyColumnNames(), existing.defaultCharsetName(), existing.comment(), existing.attributes());
+            TableImpl updated = Interner.intern(new TableImpl(newTableId, existing.columns(),
+                    existing.primaryKeyColumnNames(), existing.defaultCharsetName(), existing.comment(), existing.attributes()));
             try {
                 return tablesByTableId.put(updated.id(), updated);
             }
@@ -333,8 +334,8 @@ public final class Tables {
             Table existing = tablesByTableId.get(tableId);
             Table updated = changer.apply(existing);
             if (updated != existing) {
-                tablesByTableId.put(tableId, new TableImpl(tableId, updated.columns(),
-                        updated.primaryKeyColumnNames(), updated.defaultCharsetName(), updated.comment(), updated.attributes()));
+                tablesByTableId.put(tableId, Interner.intern(new TableImpl(tableId, updated.columns(),
+                        updated.primaryKeyColumnNames(), updated.defaultCharsetName(), updated.comment(), updated.attributes())));
             }
             changes.add(tableId);
             return existing;

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/InternerMXBean.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/InternerMXBean.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational.history;
+
+/**
+ * JMX metrics for the schema object interner.
+ * Exposed under {@code debezium.<connector>:type=connector-metrics,context=interner,server=<logical-name>}.
+ *
+ * <p>Hit and miss counts cover non-string objects only (columns, attributes, lists).
+ * String values are delegated to the JVM string pool and are not counted here.</p>
+ */
+public interface InternerMXBean {
+
+    /** Number of times {@code intern()} returned an already-cached canonical instance. */
+    long getHitCount();
+
+    /** Number of times {@code intern()} stored a new instance in the pool. */
+    long getMissCount();
+
+    /**
+     * Current number of entries held in the pool.
+     * Includes entries whose referents may have been garbage-collected but not yet expunged.
+     */
+    int getPoolSize();
+
+    /**
+     * Hit ratio as a percentage ({@code hitCount / (hitCount + missCount) * 100}),
+     * or {@code 0} if no calls have been recorded yet.
+     */
+    double getHitRatioPercent();
+}

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/InternerMetrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/InternerMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational.history;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.metrics.Metrics;
+import io.debezium.util.InternerStats;
+
+/**
+ * JMX metrics for the schema object interner, registered under
+ * {@code debezium.<connector>:type=connector-metrics,context=interner,server=<logical-name>}.
+ *
+ * <p>Lifecycle is tied to the surrounding {@link SchemaHistoryMetrics}: this bean is registered
+ * when schema history starts and unregistered when it stops.</p>
+ */
+@ThreadSafe
+public class InternerMetrics extends Metrics implements InternerMXBean {
+
+    private static final String CONTEXT_NAME = "interner";
+
+    private final InternerStats stats;
+
+    public InternerMetrics(CommonConnectorConfig connectorConfig, boolean multiPartitionMode, InternerStats stats) {
+        super(connectorConfig, CONTEXT_NAME, multiPartitionMode);
+        this.stats = stats;
+    }
+
+    @Override
+    public long getHitCount() {
+        return stats.hitCount();
+    }
+
+    @Override
+    public long getMissCount() {
+        return stats.missCount();
+    }
+
+    @Override
+    public int getPoolSize() {
+        return stats.poolSize();
+    }
+
+    @Override
+    public double getHitRatioPercent() {
+        long hits = stats.hitCount();
+        long total = hits + stats.missCount();
+        return total == 0 ? 0.0 : hits * 100.0 / total;
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/MemoryOptimizationMode.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/MemoryOptimizationMode.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational.history;
+
+import io.debezium.config.EnumeratedValue;
+import io.debezium.util.Interner;
+
+/**
+ * Controls how Debezium deduplicates identical schema objects in memory using an interner.
+ *
+ * @see SchemaHistory#MEMORY_OPTIMIZATION
+ */
+public enum MemoryOptimizationMode implements EnumeratedValue {
+
+    /** No deduplication is performed. */
+    OFF("off"),
+
+    /** Each connector uses its own isolated intern pool. */
+    ON("on"),
+
+    /** All connectors share a single JVM-wide pool, maximising deduplication across similar schemas. */
+    SHARED("shared");
+
+    private final String value;
+
+    MemoryOptimizationMode(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    public Interner.Mode toInternerMode() {
+        return switch (this) {
+            case OFF -> Interner.Mode.OFF;
+            case ON -> Interner.Mode.ON;
+            case SHARED -> Interner.Mode.SHARED;
+        };
+    }
+
+    public static MemoryOptimizationMode parse(String value) {
+        if (value == null || value.isBlank()) {
+            return OFF;
+        }
+        MemoryOptimizationMode result = EnumeratedValue.parse(MemoryOptimizationMode.class, value);
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    "Invalid memory optimization mode: '" + value + "'. Valid values are: off, on, shared");
+        }
+        return result;
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -131,6 +131,16 @@ public interface SchemaHistory {
             .withDescription("The unique identifier of the Debezium connector")
             .withNoValidation();
 
+    Field MEMORY_OPTIMIZATION = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "memory.optimization")
+            .withDisplayName("Enable memory optimization for schema history")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Controls whether Debezium deduplicates identical schema objects (tables, columns, attributes) "
+                    + "in memory using an interner. When enabled, this can significantly reduce heap usage for connectors "
+                    + "that track many tables with similar structures. When disabled (the default), no deduplication is performed.")
+            .withDefault(false);
+
     // Temporary preference for DDL over logical schema due to DBZ-32
     Field INTERNAL_PREFER_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "prefer.ddl")
             .withDisplayName("Prefer DDL for schema recovery")

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -131,6 +131,14 @@ public interface SchemaHistory {
             .withDescription("The unique identifier of the Debezium connector")
             .withNoValidation();
 
+    Field MEMORY_OPTIMIZATION = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "memory.optimization")
+            .withDisplayName("Memory optimization mode for schema history")
+            .withEnum(MemoryOptimizationMode.class, MemoryOptimizationMode.OFF)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Controls how Debezium deduplicates identical schema objects (tables, columns, attributes) "
+                    + "in memory using an interner.");
+
     // Temporary preference for DDL over logical schema due to DBZ-32
     Field INTERNAL_PREFER_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "prefer.ddl")
             .withDisplayName("Prefer DDL for schema recovery")

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -50,8 +50,15 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     private final ElapsedTimeStrategy lastChangeAppliedLogDelay = ElapsedTimeStrategy.constant(clock, PAUSE_BETWEEN_LOG_MESSAGES);
     private final ElapsedTimeStrategy lastChangeRecoveredLogDelay = ElapsedTimeStrategy.constant(clock, PAUSE_BETWEEN_LOG_MESSAGES);
 
+    private final InternerMetrics internerMetrics;
+
     public SchemaHistoryMetrics(CommonConnectorConfig connectorConfig, boolean multiPartitionMode) {
+        this(connectorConfig, multiPartitionMode, null);
+    }
+
+    public SchemaHistoryMetrics(CommonConnectorConfig connectorConfig, boolean multiPartitionMode, InternerMetrics internerMetrics) {
         super(connectorConfig, CONTEXT_NAME, multiPartitionMode);
+        this.internerMetrics = internerMetrics;
         lastChangeAppliedLogDelay.hasElapsed();
         lastChangeRecoveredLogDelay.hasElapsed();
     }
@@ -100,12 +107,18 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     public void started() {
         status = SchemaHistoryStatus.RUNNING;
         register();
+        if (internerMetrics != null) {
+            internerMetrics.register();
+        }
     }
 
     @Override
     public void stopped() {
         status = SchemaHistoryStatus.STOPPED;
         unregister();
+        if (internerMetrics != null) {
+            internerMetrics.unregister();
+        }
     }
 
     @Override

--- a/debezium-connector-common/src/test/java/io/debezium/relational/SchemaObjectInterningReflectionTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/SchemaObjectInterningReflectionTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.util.Interner;
+import io.debezium.util.Interner.Mode;
+
+/**
+ * Verifies via reflection that all internable fields and instances of the schema object
+ * classes are properly routed through {@link Interner}.
+ *
+ * <p>Three layers of coverage:</p>
+ * <ol>
+ *   <li><b>String fields</b>: single instance created with {@code new String(...)}.
+ *       {@code value == value.intern()} is true if the field was routed through
+ *       {@link Interner#intern} (which delegates to {@link String#intern}).</li>
+ *   <li><b>Class instances</b>: two independently created equal instances must be the
+ *       same object reference, proving the whole object is interned.</li>
+ *   <li><b>Reference fields across unequal instances</b>: two unequal instances that
+ *       share some field values; those equal-valued fields must be the same reference.
+ *       Checked with reflection so any newly added field that bypasses {@link Interner}
+ *       is caught automatically.</li>
+ * </ol>
+ */
+public class SchemaObjectInterningReflectionTest {
+
+    private static final Set<Class<?>> BOXED_PRIMITIVES = Set.of(
+            Boolean.class, Byte.class, Short.class, Integer.class, Long.class,
+            Float.class, Double.class, Character.class);
+
+    @BeforeEach
+    void enableInterner() {
+        Interner.activate(Mode.SHARED);
+    }
+
+    @AfterEach
+    void resetInterner() {
+        Interner.clear();
+        Interner.activate(Mode.OFF);
+    }
+
+    // ---- Layer 1: String fields are JVM-interned ----
+
+    @Test
+    void columnStringFieldsShouldBeJvmInterned() {
+        Column col = Column.editor()
+                .name(new String("col_id"))
+                .type(new String("BIGINT"), new String("BIGINT UNSIGNED"))
+                .jdbcType(Types.BIGINT).length(19).optional(false)
+                .charsetName(new String("utf8"))
+                .defaultValueExpression(new String("0"))
+                .comment(new String("primary key"))
+                .create();
+
+        assertAllStringFieldsInterned(col);
+    }
+
+    @Test
+    void attributeStringFieldsShouldBeJvmInterned() {
+        Attribute attr = Attribute.editor()
+                .name(new String("engine"))
+                .value(new String("InnoDB"))
+                .create();
+
+        assertAllStringFieldsInterned(attr);
+    }
+
+    @Test
+    void tableIdStringFieldsShouldBeJvmInterned() {
+        TableId id = new TableId(new String("mydb"), new String("myschema"), new String("orders"));
+
+        assertAllStringFieldsInterned(id);
+    }
+
+    @Test
+    void tableStringFieldsShouldBeJvmInterned() {
+        Table table = Table.editor()
+                .tableId(new TableId("cat", "sch", "t"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT)
+                        .length(19).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .setComment(new String("the main table"))
+                .create();
+
+        assertAllStringFieldsInterned(table);
+    }
+
+    // ---- Layer 2: Class instances are pool-interned ----
+
+    @Test
+    void twoEqualColumnInstancesShouldBeSameObject() {
+        Column col1 = Column.editor()
+                .name(new String("status"))
+                .type(new String("VARCHAR"), new String("VARCHAR(64)"))
+                .jdbcType(Types.VARCHAR).length(64).optional(true).create();
+        Column col2 = Column.editor()
+                .name(new String("status"))
+                .type(new String("VARCHAR"), new String("VARCHAR(64)"))
+                .jdbcType(Types.VARCHAR).length(64).optional(true).create();
+
+        assertThat(col1).isSameAs(col2);
+    }
+
+    @Test
+    void twoEqualAttributeInstancesShouldBeSameObject() {
+        Attribute attr1 = Attribute.editor().name(new String("engine")).value(new String("InnoDB")).create();
+        Attribute attr2 = Attribute.editor().name(new String("engine")).value(new String("InnoDB")).create();
+
+        assertThat(attr1).isSameAs(attr2);
+    }
+
+    @Test
+    void twoEqualTableInstancesShouldBeSameObject() {
+        Table table1 = buildTable("db1", "s1", "orders");
+        Table table2 = buildTable("db1", "s1", "orders");
+
+        assertThat(table1).isSameAs(table2);
+    }
+
+    @Test
+    void twoEqualTableIdInstancesShouldBeSameObjectWhenStoredInTable() {
+        // TableId objects are interned as fields of TableImpl: two tables sharing the same
+        // logical identifier (same catalog/schema/table) must reuse the same TableId instance.
+        Table table1 = buildTable("cat", "sch", "users");
+        Table table2 = buildTable("cat", "sch", "users");
+
+        // Same Table instance because the whole Table is interned
+        assertThat(table1).isSameAs(table2);
+        assertThat(table1.id()).isSameAs(table2.id());
+    }
+
+    // ---- Layer 3: Reference fields shared across unequal instances ----
+
+    @Test
+    void unequalColumnsWithSameTypeShouldShareTypeStringFields() {
+        // Two columns with different names: different Column instances, but common type
+        // fields must resolve to the same references.
+        Column col1 = Column.editor()
+                .name(new String("col_a"))
+                .type(new String("VARCHAR"), new String("VARCHAR(255)"))
+                .jdbcType(Types.VARCHAR).length(255).optional(true)
+                .comment(new String("a note"))
+                .create();
+        Column col2 = Column.editor()
+                .name(new String("col_b"))
+                .type(new String("VARCHAR"), new String("VARCHAR(255)"))
+                .jdbcType(Types.VARCHAR).length(255).optional(true)
+                .comment(new String("a note"))
+                .create();
+
+        assertThat(col1).isNotSameAs(col2);
+        assertEqualFieldsShareReference(col1, col2);
+    }
+
+    @Test
+    void unequalColumnsWithSameEnumValuesShouldShareEnumList() {
+        // Different Column instances; enumValues list must be shared.
+        Column col1 = Column.editor()
+                .name(new String("status_a"))
+                .type(new String("ENUM"), new String("ENUM('A','B')"))
+                .jdbcType(Types.VARCHAR)
+                .enumValues(Arrays.asList(new String("A"), new String("B")))
+                .create();
+        Column col2 = Column.editor()
+                .name(new String("status_b"))
+                .type(new String("ENUM"), new String("ENUM('A','B')"))
+                .jdbcType(Types.VARCHAR)
+                .enumValues(Arrays.asList(new String("A"), new String("B")))
+                .create();
+
+        assertThat(col1).isNotSameAs(col2);
+        assertEqualFieldsShareReference(col1, col2);
+    }
+
+    @Test
+    void unequalTablesWithSameColumnsShouldShareCollectionFields() {
+        // Two tables with different IDs but identical structure; column lists and maps must
+        // resolve to the same references.
+        Table table1 = buildTable("db1", "s1", "orders");
+        Table table2 = buildTable("db2", "s2", "orders");
+
+        assertThat(table1).isNotSameAs(table2);
+        assertEqualFieldsShareReference(table1, table2);
+    }
+
+    @Test
+    void tablesWithSameIdButDifferentStructureShouldShareTableIdInstance() {
+        // Simulates a schema change: same table identifier, different column set.
+        // Even though the two Table instances are different, they must share the same
+        // interned TableId object.
+        Table before = Table.editor()
+                .tableId(new TableId(new String("cat"), new String("sch"), new String("users")))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT)
+                        .length(19).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+        Table after = Table.editor()
+                .tableId(new TableId(new String("cat"), new String("sch"), new String("users")))
+                .addColumns(
+                        Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT)
+                                .length(19).optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR)
+                                .length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        assertThat(before).isNotSameAs(after);
+        assertThat(before.id()).isSameAs(after.id());
+        // Reflection confirms all equal-valued fields (including the TableId field) share references
+        assertEqualFieldsShareReference(before, after);
+    }
+
+    // ---- Reflection helpers ----
+
+    /**
+     * Asserts that every non-null String field in the class hierarchy of {@code obj}
+     * satisfies {@code value == value.intern()}.
+     *
+     * <p>Constructing strings with {@code new String(...)} ensures non-literal references,
+     * so any field that bypasses {@link Interner#intern} (which delegates to
+     * {@link String#intern}) will hold a non-canonical instance and fail.</p>
+     */
+    private void assertAllStringFieldsInterned(Object obj) {
+        List<String> failures = new ArrayList<>();
+        walkDeclaredFields(obj.getClass(), field -> {
+            if (!String.class.equals(field.getType())) {
+                return;
+            }
+            String value = readField(field, obj);
+            if (value != null && value != value.intern()) {
+                failures.add(obj.getClass().getSimpleName() + "#" + field.getName() + ": String not interned");
+            }
+        });
+        assertThat(failures).as("String fields not interned").isEmpty();
+    }
+
+    /**
+     * For every non-primitive, non-boxed reference field declared on the class hierarchy,
+     * if both {@code obj1} and {@code obj2} hold an equal (non-null, non-empty) value for
+     * that field, asserts the two values are the same object reference.
+     *
+     * <p>This catches any field (String, Collection, Map, or a custom type like
+     * {@link TableId}) that was added to a class without being wired through
+     * {@link Interner#intern}: two equal instances would hold distinct references instead
+     * of sharing the canonical pool entry.</p>
+     *
+     * <p>Empty collections are excluded: we do not require them to be interned
+     * (no memory benefit).</p>
+     */
+    private void assertEqualFieldsShareReference(Object obj1, Object obj2) {
+        assertThat(obj1.getClass()).isEqualTo(obj2.getClass());
+        List<String> failures = new ArrayList<>();
+        walkDeclaredFields(obj1.getClass(), field -> {
+            Class<?> type = field.getType();
+            if (type.isPrimitive() || BOXED_PRIMITIVES.contains(type)) {
+                return;
+            }
+            Object v1 = readField(field, obj1);
+            Object v2 = readField(field, obj2);
+            if (v1 == null || v2 == null) {
+                return;
+            }
+            if (v1 instanceof Collection && ((Collection<?>) v1).isEmpty()) {
+                return;
+            }
+            if (v1 instanceof Map && ((Map<?, ?>) v1).isEmpty()) {
+                return;
+            }
+            if (!v1.equals(v2)) {
+                return; // genuinely different values: not expected to share a reference
+            }
+            if (v1 != v2) {
+                failures.add(obj1.getClass().getSimpleName() + "#" + field.getName()
+                        + " (" + type.getSimpleName() + "): equal values are different references");
+            }
+        });
+        assertThat(failures).as("Fields with equal values that should share references").isEmpty();
+    }
+
+    private void walkDeclaredFields(Class<?> clazz, Consumer<Field> consumer) {
+        for (Class<?> c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field field : c.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                field.setAccessible(true);
+                consumer.accept(field);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T readField(Field field, Object obj) {
+        try {
+            return (T) field.get(obj);
+        }
+        catch (IllegalAccessException e) {
+            throw new RuntimeException("Cannot read field " + field, e);
+        }
+    }
+
+    private Table buildTable(String catalog, String schema, String table) {
+        return Table.editor()
+                .tableId(new TableId(catalog, schema, new String(table)))
+                .addColumns(
+                        Column.editor().name(new String("id")).type(new String("BIGINT"))
+                                .jdbcType(Types.BIGINT).length(19).optional(false).create(),
+                        Column.editor().name(new String("amount")).type(new String("DECIMAL"))
+                                .jdbcType(Types.DECIMAL).length(10).create())
+                .setPrimaryKeyNames(new String("id"))
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .addAttribute(Attribute.editor().name(new String("engine")).value(new String("InnoDB")).create())
+                .create();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.util.Interner;
+
+/**
+ * Tests that Column and Attribute objects are interned at creation time, and that
+ * structurally identical tables across tenants share object references, reducing memory usage.
+ */
+public class TableImplInterningTest {
+
+    @BeforeEach
+    public void enableInterner() {
+        Interner.setEnabled(true);
+    }
+
+    @AfterEach
+    public void resetInterner() {
+        Interner.clear();
+        Interner.setEnabled(false);
+    }
+
+    @Test
+    public void shouldShareColumnObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.id()).isNotEqualTo(table2.id());
+        // Columns are interned at creation — same structure yields same references
+        for (int i = 0; i < table1.columns().size(); i++) {
+            assertThat(table1.columns().get(i)).isSameAs(table2.columns().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualColumnObjectsAcrossTablesWithDifferentStructure() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        // Lists differ, but the shared "id" column is the same interned instance
+        assertThat(table1.columns().get(0)).isSameAs(table2.columns().get(0));
+        assertThat(table1.columns().get(1)).isNotSameAs(table2.columns().get(1));
+    }
+
+    @Test
+    public void shouldShareAttributeObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        for (int i = 0; i < table1.attributes().size(); i++) {
+            assertThat(table1.attributes().get(i)).isSameAs(table2.attributes().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualAttributeObjectsAcrossTablesWithDifferentAttributes() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("partition").value("hash").create())
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("row_format").value("DYNAMIC").create())
+                .create();
+
+        // The "engine" attribute is identical and should be the same interned instance
+        assertThat(table1.attributeWithName("engine")).isSameAs(table2.attributeWithName("engine"));
+    }
+
+    @Test
+    public void shouldPreservePkColumnNameOrder() {
+        Table table = Table.editor()
+                .tableId(new TableId("cat", "sch", "t"))
+                .addColumns(
+                        Column.editor().name("b").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("a").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("b", "a")
+                .create();
+
+        assertThat(table.primaryKeyColumnNames()).containsExactly("b", "a");
+    }
+
+    @Test
+    public void shouldShareDefaultCharsetNameString() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        assertThat(table1.defaultCharsetName()).isSameAs(table2.defaultCharsetName());
+    }
+
+    @Test
+    public void shouldShareColumnStringFields() {
+        Column col1 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+        Column col2 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+
+        // Same interned Column instance
+        assertThat(col1).isSameAs(col2);
+        // String fields are interned
+        assertThat(col1.name()).isSameAs(col2.name());
+        assertThat(col1.typeName()).isSameAs(col2.typeName());
+    }
+
+    @Test
+    public void shouldShareColumnListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        // The entire column list instance is shared, not just individual columns
+        assertThat(table1.columns()).isSameAs(table2.columns());
+    }
+
+    @Test
+    public void shouldSharePkColumnNamesListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.primaryKeyColumnNames()).isSameAs(table2.primaryKeyColumnNames());
+    }
+
+    @Test
+    public void shouldShareAttributeListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.attributes()).isSameAs(table2.attributes());
+    }
+
+    @Test
+    public void shouldShareTableNameStringAcrossTableIds() {
+        TableId id1 = new TableId(new String("tenant1"), new String("schema1"), new String("users"));
+        TableId id2 = new TableId(new String("tenant2"), new String("schema2"), new String("users"));
+
+        // Table names are interned — "users" is the same reference
+        assertThat(id1.table()).isSameAs(id2.table());
+    }
+
+    @Test
+    public void shouldWorkCorrectlyWithTablesOverwriteTable() {
+        Tables tables = new Tables();
+
+        tables.overwriteTable(createTable("tenant1", "schema1", "users"));
+        tables.overwriteTable(createTable("tenant2", "schema2", "users"));
+
+        Table stored1 = tables.forTable(new TableId("tenant1", "schema1", "users"));
+        Table stored2 = tables.forTable(new TableId("tenant2", "schema2", "users"));
+
+        // Individual columns are shared
+        for (int i = 0; i < stored1.columns().size(); i++) {
+            assertThat(stored1.columns().get(i)).isSameAs(stored2.columns().get(i));
+        }
+        // Entire column list is shared
+        assertThat(stored1.columns()).isSameAs(stored2.columns());
+    }
+
+    private static Table createTable(String catalog, String schema, String tableName) {
+        return Table.editor()
+                .tableId(new TableId(catalog, schema, tableName))
+                .addColumns(
+                        Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                                .optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .create();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/TableImplInterningTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.util.Interner;
+import io.debezium.util.Interner.Mode;
+
+/**
+ * Tests that Column and Attribute objects are interned at creation time, and that
+ * structurally identical tables across tenants share object references, reducing memory usage.
+ */
+public class TableImplInterningTest {
+
+    @BeforeEach
+    public void enableInterner() {
+        Interner.activate(Mode.SHARED);
+    }
+
+    @AfterEach
+    public void resetInterner() {
+        Interner.clear();
+        Interner.activate(Mode.OFF);
+    }
+
+    @Test
+    public void shouldShareColumnObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.id()).isNotEqualTo(table2.id());
+        // Columns are interned at creation — same structure yields same references
+        for (int i = 0; i < table1.columns().size(); i++) {
+            assertThat(table1.columns().get(i)).isSameAs(table2.columns().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualColumnObjectsAcrossTablesWithDifferentStructure() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(
+                        Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255).optional(true).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        // Lists differ, but the shared "id" column is the same interned instance
+        assertThat(table1.columns().get(0)).isSameAs(table2.columns().get(0));
+        assertThat(table1.columns().get(1)).isNotSameAs(table2.columns().get(1));
+    }
+
+    @Test
+    public void shouldShareAttributeObjectsAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        for (int i = 0; i < table1.attributes().size(); i++) {
+            assertThat(table1.attributes().get(i)).isSameAs(table2.attributes().get(i));
+        }
+    }
+
+    @Test
+    public void shouldShareIndividualAttributeObjectsAcrossTablesWithDifferentAttributes() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("partition").value("hash").create())
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "t"))
+                .addColumns(Column.editor().name("id").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .addAttribute(Attribute.editor().name("row_format").value("DYNAMIC").create())
+                .create();
+
+        // The "engine" attribute is identical and should be the same interned instance
+        assertThat(table1.attributeWithName("engine")).isSameAs(table2.attributeWithName("engine"));
+    }
+
+    @Test
+    public void shouldPreservePkColumnNameOrder() {
+        Table table = Table.editor()
+                .tableId(new TableId("cat", "sch", "t"))
+                .addColumns(
+                        Column.editor().name("b").type("INT").jdbcType(Types.INTEGER).optional(false).create(),
+                        Column.editor().name("a").type("INT").jdbcType(Types.INTEGER).optional(false).create())
+                .setPrimaryKeyNames("b", "a")
+                .create();
+
+        assertThat(table.primaryKeyColumnNames()).containsExactly("b", "a");
+    }
+
+    @Test
+    public void shouldShareDefaultCharsetNameString() {
+        Table table1 = Table.editor()
+                .tableId(new TableId("tenant1", "schema1", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        Table table2 = Table.editor()
+                .tableId(new TableId("tenant2", "schema2", "users"))
+                .addColumns(Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                        .optional(false).create())
+                .setPrimaryKeyNames("id")
+                .setDefaultCharsetName(new String("utf8mb4"))
+                .create();
+
+        assertThat(table1.defaultCharsetName()).isSameAs(table2.defaultCharsetName());
+    }
+
+    @Test
+    public void shouldShareColumnStringFields() {
+        Column col1 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+        Column col2 = Column.editor().name(new String("id")).type(new String("BIGINT"))
+                .jdbcType(Types.BIGINT).length(19).optional(false).create();
+
+        // Same interned Column instance
+        assertThat(col1).isSameAs(col2);
+        // String fields are interned
+        assertThat(col1.name()).isSameAs(col2.name());
+        assertThat(col1.typeName()).isSameAs(col2.typeName());
+    }
+
+    @Test
+    public void shouldShareColumnListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        // The entire column list instance is shared, not just individual columns
+        assertThat(table1.columns()).isSameAs(table2.columns());
+    }
+
+    @Test
+    public void shouldSharePkColumnNamesListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.primaryKeyColumnNames()).isSameAs(table2.primaryKeyColumnNames());
+    }
+
+    @Test
+    public void shouldShareAttributeListAcrossTablesWithSameStructure() {
+        Table table1 = createTable("tenant1", "schema1", "users");
+        Table table2 = createTable("tenant2", "schema2", "users");
+
+        assertThat(table1.attributes()).isSameAs(table2.attributes());
+    }
+
+    @Test
+    public void shouldShareTableNameStringAcrossTableIds() {
+        TableId id1 = new TableId(new String("tenant1"), new String("schema1"), new String("users"));
+        TableId id2 = new TableId(new String("tenant2"), new String("schema2"), new String("users"));
+
+        // Table names are interned — "users" is the same reference
+        assertThat(id1.table()).isSameAs(id2.table());
+    }
+
+    @Test
+    public void shouldWorkCorrectlyWithTablesOverwriteTable() {
+        Tables tables = new Tables();
+
+        tables.overwriteTable(createTable("tenant1", "schema1", "users"));
+        tables.overwriteTable(createTable("tenant2", "schema2", "users"));
+
+        Table stored1 = tables.forTable(new TableId("tenant1", "schema1", "users"));
+        Table stored2 = tables.forTable(new TableId("tenant2", "schema2", "users"));
+
+        // Individual columns are shared
+        for (int i = 0; i < stored1.columns().size(); i++) {
+            assertThat(stored1.columns().get(i)).isSameAs(stored2.columns().get(i));
+        }
+        // Entire column list is shared
+        assertThat(stored1.columns()).isSameAs(stored2.columns());
+    }
+
+    private static Table createTable(String catalog, String schema, String tableName) {
+        return Table.editor()
+                .tableId(new TableId(catalog, schema, tableName))
+                .addColumns(
+                        Column.editor().name("id").type("BIGINT").jdbcType(Types.BIGINT).length(19)
+                                .optional(false).create(),
+                        Column.editor().name("name").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create(),
+                        Column.editor().name("email").type("VARCHAR").jdbcType(Types.VARCHAR).length(255)
+                                .optional(true).create())
+                .setPrimaryKeyNames("id")
+                .addAttribute(Attribute.editor().name("engine").value("InnoDB").create())
+                .create();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class InternerTest {
+
+    @BeforeEach
+    public void enableInterner() {
+        Interner.setEnabled(true);
+    }
+
+    @AfterEach
+    public void resetInterner() {
+        Interner.clear();
+        Interner.setEnabled(false);
+    }
+
+    @Test
+    public void shouldReturnSameReferenceForEqualStrings() {
+        String a = new String("hello");
+        String b = new String("hello");
+        assertThat(a).isNotSameAs(b);
+
+        String internedA = Interner.intern(a);
+        String internedB = Interner.intern(b);
+        assertThat(internedA).isSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnDifferentReferencesForDifferentStrings() {
+        String internedA = Interner.intern(new String("hello"));
+        String internedB = Interner.intern(new String("world"));
+        assertThat(internedA).isNotSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnNullForNullInput() {
+        assertThat(Interner.intern((String) null)).isNull();
+    }
+
+    @Test
+    public void shouldWorkWithLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "c");
+        assertThat(list1).isNotSameAs(list2);
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    @Test
+    public void shouldNotInternDifferentLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "d");
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isNotSameAs(interned2);
+    }
+
+    @Test
+    public void shouldClearPool() {
+        Interner.intern(Arrays.asList("a", "b"));
+        assertThat(Interner.size()).isGreaterThan(0);
+
+        Interner.clear();
+        assertThat(Interner.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReinternAfterClear() {
+        List<String> a = Arrays.asList("hello", "world");
+        List<String> internedA = Interner.intern(a);
+        assertThat(internedA).isSameAs(a);
+
+        Interner.clear();
+
+        List<String> b = Arrays.asList("hello", "world");
+        List<String> internedB = Interner.intern(b);
+        assertThat(internedB).isSameAs(b);
+        assertThat(internedB).isNotSameAs(a);
+    }
+
+    @Test
+    public void shouldReleaseEntriesWhenNoLongerStronglyReferenced() {
+        // Intern a list and keep a strong reference
+        List<String> kept = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(kept).isNotNull();
+
+        // Intern a list without keeping a strong reference
+        Interner.intern(new ArrayList<>(Arrays.asList("lose", "me")));
+
+        // Force GC — the unreferenced list should be collected
+        System.gc();
+        System.gc();
+
+        // The kept entry must still be internable to the same reference
+        List<String> reInterned = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(reInterned).isSameAs(kept);
+    }
+
+    @Test
+    public void shouldInternListsWithMixedTypes() {
+        List<Object> list1 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+        List<Object> list2 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+
+        List<Object> interned1 = Interner.intern(list1);
+        List<Object> interned2 = Interner.intern(list2);
+
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    // --- Tests for disabled interner ---
+
+    @Test
+    public void shouldReturnInputWhenDisabled() {
+        Interner.setEnabled(false);
+
+        List<String> list1 = Arrays.asList("a", "b");
+        List<String> list2 = Arrays.asList("a", "b");
+
+        assertThat(Interner.intern(list1)).isSameAs(list1);
+        assertThat(Interner.intern(list2)).isSameAs(list2);
+        assertThat(list1).isNotSameAs(list2);
+    }
+
+    @Test
+    public void shouldReturnNullWhenDisabled() {
+        Interner.setEnabled(false);
+        assertThat(Interner.intern((Integer) null)).isNull();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/InternerTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.history.MemoryOptimizationMode;
+import io.debezium.util.Interner.Mode;
+
+public class InternerTest {
+
+    @BeforeEach
+    public void enableInterner() {
+        Interner.activate(Mode.SHARED);
+    }
+
+    @AfterEach
+    public void resetInterner() {
+        Interner.clear();
+        Interner.activate(Mode.OFF);
+    }
+
+    @Test
+    public void shouldReturnSameReferenceForEqualStrings() {
+        String a = new String("hello");
+        String b = new String("hello");
+        assertThat(a).isNotSameAs(b);
+
+        String internedA = Interner.intern(a);
+        String internedB = Interner.intern(b);
+        assertThat(internedA).isSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnDifferentReferencesForDifferentStrings() {
+        String internedA = Interner.intern(new String("hello"));
+        String internedB = Interner.intern(new String("world"));
+        assertThat(internedA).isNotSameAs(internedB);
+    }
+
+    @Test
+    public void shouldReturnNullForNullInput() {
+        assertThat(Interner.intern((String) null)).isNull();
+    }
+
+    @Test
+    public void shouldWorkWithLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "c");
+        assertThat(list1).isNotSameAs(list2);
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    @Test
+    public void shouldNotInternDifferentLists() {
+        List<String> list1 = Arrays.asList("a", "b", "c");
+        List<String> list2 = Arrays.asList("a", "b", "d");
+
+        List<String> interned1 = Interner.intern(list1);
+        List<String> interned2 = Interner.intern(list2);
+        assertThat(interned1).isNotSameAs(interned2);
+    }
+
+    @Test
+    public void shouldClearPool() {
+        Interner.intern(Arrays.asList("a", "b"));
+        assertThat(Interner.size()).isGreaterThan(0);
+
+        Interner.clear();
+        assertThat(Interner.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReinternAfterClear() {
+        List<String> a = Arrays.asList("hello", "world");
+        List<String> internedA = Interner.intern(a);
+        assertThat(internedA).isSameAs(a);
+
+        Interner.clear();
+
+        List<String> b = Arrays.asList("hello", "world");
+        List<String> internedB = Interner.intern(b);
+        assertThat(internedB).isSameAs(b);
+        assertThat(internedB).isNotSameAs(a);
+    }
+
+    @Test
+    public void shouldReleaseEntriesWhenNoLongerStronglyReferenced() {
+        // Intern a list and keep a strong reference
+        List<String> kept = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(kept).isNotNull();
+
+        // Intern a list without keeping a strong reference
+        Interner.intern(new ArrayList<>(Arrays.asList("lose", "me")));
+
+        // Force GC — the unreferenced list should be collected
+        System.gc();
+        System.gc();
+
+        // The kept entry must still be internable to the same reference
+        List<String> reInterned = Interner.intern(new ArrayList<>(Arrays.asList("keep", "me")));
+        assertThat(reInterned).isSameAs(kept);
+    }
+
+    @Test
+    public void shouldInternListsWithMixedTypes() {
+        List<Object> list1 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+        List<Object> list2 = Arrays.asList(new String("hello"), Integer.valueOf(42), Arrays.asList("nested"));
+
+        List<Object> interned1 = Interner.intern(list1);
+        List<Object> interned2 = Interner.intern(list2);
+
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    // --- Tests for disabled interner ---
+
+    @Test
+    public void shouldReturnInputWhenDisabled() {
+        Interner.activate(Mode.OFF);
+
+        List<String> list1 = Arrays.asList("a", "b");
+        List<String> list2 = Arrays.asList("a", "b");
+
+        assertThat(Interner.intern(list1)).isSameAs(list1);
+        assertThat(Interner.intern(list2)).isSameAs(list2);
+        assertThat(list1).isNotSameAs(list2);
+    }
+
+    @Test
+    public void shouldReturnNullWhenDisabled() {
+        Interner.activate(Mode.OFF);
+        assertThat(Interner.intern((Integer) null)).isNull();
+    }
+
+    // --- Stats tests ---
+
+    @Test
+    public void activateShouldReturnNullForOffMode() {
+        assertThat(Interner.activate(Mode.OFF)).isNull();
+    }
+
+    @Test
+    public void activateShouldReturnStatsForOnMode() {
+        InternerStats stats = Interner.activate(Mode.ON);
+        assertThat(stats).isNotNull();
+        assertThat(stats.hitCount()).isEqualTo(0);
+        assertThat(stats.missCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void statsShouldTrackMissOnFirstIntern() {
+        InternerStats stats = Interner.activate(Mode.ON);
+        Interner.intern(Arrays.asList("a", "b"));
+        assertThat(stats.missCount()).isEqualTo(1);
+        assertThat(stats.hitCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void statsShouldTrackHitOnDuplicateIntern() {
+        InternerStats stats = Interner.activate(Mode.ON);
+        Interner.intern(Arrays.asList("a", "b"));
+        Interner.intern(Arrays.asList("a", "b"));
+        assertThat(stats.missCount()).isEqualTo(1);
+        assertThat(stats.hitCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void sharedModeStatsShouldBeReturnedByActivate() {
+        InternerStats stats1 = Interner.activate(Mode.SHARED);
+        InternerStats stats2 = Interner.activate(Mode.SHARED);
+        assertThat(stats1).isSameAs(stats2);
+    }
+
+    // --- Tests for ON mode isolation ---
+
+    @Test
+    public void onModeShouldUseIsolatedPool() {
+        // Two separate "connectors" represented by two ON-mode activations
+        Interner.activate(Mode.ON);
+        List<String> list = Arrays.asList("a", "b", "c");
+        List<String> internedFirst = Interner.intern(list);
+
+        // Activate a new ON pool (simulates a second connector on this thread)
+        Interner.activate(Mode.ON);
+        List<String> internedSecond = Interner.intern(Arrays.asList("a", "b", "c"));
+
+        // Different pools → different canonical instances
+        assertThat(internedFirst).isNotSameAs(internedSecond);
+    }
+
+    @Test
+    public void onModeShouldDeduplicateWithinItsOwnPool() {
+        Interner.activate(Mode.ON);
+        List<String> a = Interner.intern(Arrays.asList("x", "y"));
+        List<String> b = Interner.intern(Arrays.asList("x", "y"));
+        assertThat(a).isSameAs(b);
+    }
+
+    @Test
+    public void sharedModeShouldShareAcrossActivations() {
+        Interner.activate(Mode.SHARED);
+        List<String> a = Interner.intern(Arrays.asList("p", "q"));
+
+        // Re-activating SHARED still uses the same global pool
+        Interner.activate(Mode.SHARED);
+        List<String> b = Interner.intern(Arrays.asList("p", "q"));
+
+        assertThat(a).isSameAs(b);
+    }
+
+    // --- MemoryOptimizationMode.parse tests ---
+
+    @Test
+    public void shouldParseOffMode() {
+        assertThat(MemoryOptimizationMode.parse("off")).isEqualTo(MemoryOptimizationMode.OFF);
+        assertThat(MemoryOptimizationMode.parse("OFF")).isEqualTo(MemoryOptimizationMode.OFF);
+        assertThat(MemoryOptimizationMode.parse(null)).isEqualTo(MemoryOptimizationMode.OFF);
+        assertThat(MemoryOptimizationMode.parse("")).isEqualTo(MemoryOptimizationMode.OFF);
+    }
+
+    @Test
+    public void shouldParseOnMode() {
+        assertThat(MemoryOptimizationMode.parse("on")).isEqualTo(MemoryOptimizationMode.ON);
+        assertThat(MemoryOptimizationMode.parse("ON")).isEqualTo(MemoryOptimizationMode.ON);
+    }
+
+    @Test
+    public void shouldParseSharedMode() {
+        assertThat(MemoryOptimizationMode.parse("shared")).isEqualTo(MemoryOptimizationMode.SHARED);
+        assertThat(MemoryOptimizationMode.parse("SHARED")).isEqualTo(MemoryOptimizationMode.SHARED);
+    }
+
+    @Test
+    public void shouldThrowForUnknownMode() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> MemoryOptimizationMode.parse("invalid"));
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/Interner.java
+++ b/debezium-util/src/main/java/io/debezium/util/Interner.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A thread-safe, static interner that deduplicates objects by their {@link Object#equals(Object) equals}
+ * semantics, similar to {@link String#intern()} but for arbitrary immutable types.
+ *
+ * <p>This implementation uses weak references
+ * so that interned instances become eligible for garbage collection once no strong references
+ * to them remain. This prevents the memory leaks inherent in a strong-reference pool.</p>
+ *
+ * <p>This is useful when many equal copies of immutable objects exist in memory, for example
+ * when thousands of database schemas share identical table structures.</p>
+ *
+ * <p>Warning: do not use with mutable objects. The interning contract assumes that
+ * objects do not change after being interned.</p>
+ */
+public final class Interner {
+
+    private static final ConcurrentMap<WeakEntry, WeakEntry> MAP = new ConcurrentHashMap<>();
+    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+    private static boolean enabled = false;
+
+    private Interner() {
+    }
+
+    /**
+     * Enables or disables the interner.
+     * When disabled, {@link #intern(Object)} returns the input value without deduplication.
+     *
+     * @param enabled {@code true} to enable interning, {@code false} to bypass it
+     */
+    public static void setEnabled(boolean enabled) {
+        Interner.enabled = enabled;
+    }
+
+    /**
+     * Returns a canonical instance equal to the given value. If an equal value has already been
+     * interned and is still strongly reachable, the previously interned instance is returned.
+     * Otherwise, the given value is stored and returned.
+     *
+     * <p>When the interner is {@link #setEnabled(boolean) disabled}, the sample is returned as-is.</p>
+     *
+     * <p>Note that a previously interned instance may be garbage-collected if no strong references
+     * to it remain, in which case a subsequent call with an equal value will intern the new instance.</p>
+     *
+     * @param sample the value to intern; may be {@code null}
+     * @param <T> the type of the value
+     * @return the canonical instance, or {@code null} if the input was {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T intern(T sample) {
+        if (!enabled || sample == null) {
+            return sample;
+        }
+        if (sample instanceof String) {
+            return (T) ((String) sample).intern();
+        }
+        removeStaleEntries();
+        WeakEntry newEntry = new WeakEntry(sample, QUEUE);
+        while (true) {
+            WeakEntry existing = MAP.putIfAbsent(newEntry, newEntry);
+            if (existing == null) {
+                return sample;
+            }
+            T canonical = (T) existing.get();
+            if (canonical != null) {
+                return canonical;
+            }
+            MAP.remove(existing, existing);
+        }
+    }
+
+    /**
+     * Returns the number of entries currently held in the pool. This includes entries whose
+     * referents may have been garbage-collected but not yet expunged.
+     *
+     * @return the pool size
+     */
+    static int size() {
+        return MAP.size();
+    }
+
+    /**
+     * Removes all entries from the pool.
+     */
+    public static void clear() {
+        MAP.clear();
+        removeStaleEntries();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void removeStaleEntries() {
+        Reference<?> ref;
+        while ((ref = QUEUE.poll()) != null) {
+            MAP.remove((WeakEntry) ref, (WeakEntry) ref);
+        }
+    }
+
+    /**
+     * A weak-reference wrapper used as both key and value in the intern pool.
+     *
+     * <p>The {@link #hashCode()} is cached at construction time from the referent, so it remains
+     * stable even after the referent is garbage-collected. The {@link #equals(Object)} method
+     * uses identity comparison as a fast path (needed for stale entry removal), then falls back
+     * to content-based comparison using the referents' {@code equals()} method.</p>
+     */
+    private static final class WeakEntry extends WeakReference<Object> {
+        private final int hashCode;
+
+        WeakEntry(Object referent, ReferenceQueue<Object> QUEUE) {
+            super(referent, QUEUE);
+            this.hashCode = referent.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof WeakEntry)) {
+                return false;
+            }
+            Object thisRef = this.get();
+            Object thatRef = ((WeakEntry) obj).get();
+            return thisRef != null && thisRef.equals(thatRef);
+        }
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/Interner.java
+++ b/debezium-util/src/main/java/io/debezium/util/Interner.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A thread-safe interner that deduplicates objects by their {@link Object#equals(Object) equals}
+ * semantics, similar to {@link String#intern()} but for arbitrary immutable types.
+ *
+ * <p>Three modes are available, configured per connector via {@link #activate(Mode)}:</p>
+ * <ul>
+ *   <li>{@link Mode#OFF}: no interning, all calls return the input as-is.</li>
+ *   <li>{@link Mode#ON}: each activation creates an isolated pool for the calling thread hierarchy.
+ *       Useful to avoid cross-connector interference while still deduplicating within a single connector.</li>
+ *   <li>{@link Mode#SHARED}: all activations with this mode share a single JVM-wide pool.
+ *       Maximizes deduplication when many connectors track identical schema structures.</li>
+ * </ul>
+ *
+ * <p>Each pool uses weak references so interned instances become eligible for garbage collection
+ * once no strong references to them remain.</p>
+ *
+ * <p>Warning: do not use with mutable objects. The interning contract assumes that
+ * objects do not change after being interned.</p>
+ */
+public final class Interner {
+
+    /**
+     * Controls how the interner pools schema objects.
+     */
+    public enum Mode {
+        /** No interning is performed. */
+        OFF,
+        /** Each connector uses its own isolated intern pool. */
+        ON,
+        /** All connectors configured with this mode share a single global pool. */
+        SHARED;
+    }
+
+    private static final Pool SHARED_POOL = new Pool();
+
+    /**
+     * InheritableThreadLocal so that connector-spawned threads (e.g. snapshot workers)
+     * inherit the pool activated on the connector task thread.
+     */
+    private static final InheritableThreadLocal<Pool> ACTIVE = new InheritableThreadLocal<>();
+
+    private Interner() {
+    }
+
+    /**
+     * Activates the given mode on the current thread (and any threads it subsequently spawns).
+     * <ul>
+     *   <li>{@link Mode#OFF}: disables interning on this thread; returns {@code null}.</li>
+     *   <li>{@link Mode#ON}: creates a new isolated pool for this thread; returns its {@link InternerStats}.</li>
+     *   <li>{@link Mode#SHARED}: routes interning through the shared global pool; returns its {@link InternerStats}.</li>
+     * </ul>
+     *
+     * @return the active pool's statistics handle, or {@code null} when mode is {@link Mode#OFF}
+     */
+    public static InternerStats activate(Mode mode) {
+        return switch (mode) {
+            case OFF -> {
+                ACTIVE.remove();
+                yield null;
+            }
+            case ON -> {
+                Pool pool = new Pool();
+                ACTIVE.set(pool);
+                yield pool;
+            }
+            case SHARED -> {
+                ACTIVE.set(SHARED_POOL);
+                yield SHARED_POOL;
+            }
+        };
+    }
+
+    /**
+     * Returns a canonical instance equal to the given value. If an equal value has already been
+     * interned in the active pool and is still strongly reachable, the previously interned instance
+     * is returned. Otherwise the given value is stored and returned.
+     *
+     * <p>When no pool is active (mode is {@link Mode#OFF} or {@link #activate} was never called),
+     * the sample is returned as-is.</p>
+     *
+     * @param sample the value to intern; may be {@code null}
+     * @param <T> the type of the value
+     * @return the canonical instance, or {@code null} if the input was {@code null}
+     */
+    public static <T> T intern(T sample) {
+        if (sample == null) {
+            return null;
+        }
+        Pool pool = ACTIVE.get();
+        if (pool == null) {
+            return sample;
+        }
+        return pool.intern(sample);
+    }
+
+    /**
+     * Clears all pools (both the active pool and the shared pool).
+     * Primarily intended for testing.
+     */
+    public static void clear() {
+        Pool active = ACTIVE.get();
+        if (active != null && active != SHARED_POOL) {
+            active.clear();
+        }
+        SHARED_POOL.clear();
+    }
+
+    /**
+     * Returns the number of entries in the active pool, or in the shared pool if no pool is active.
+     */
+    static int size() {
+        Pool pool = ACTIVE.get();
+        return pool != null ? pool.size() : SHARED_POOL.size();
+    }
+
+    /**
+     * An isolated intern pool backed by a weak-reference map.
+     * Hit and miss counts are tracked via {@link LongAdder} for minimal write overhead on the hot path.
+     * String values are delegated to {@link String#intern()} and are not counted.
+     */
+    static final class Pool implements InternerStats {
+        private final ConcurrentMap<WeakEntry, WeakEntry> map = new ConcurrentHashMap<>();
+        private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+        private final LongAdder hitCount = new LongAdder();
+        private final LongAdder missCount = new LongAdder();
+
+        @SuppressWarnings("unchecked")
+        <T> T intern(T sample) {
+            if (sample instanceof String) {
+                return (T) ((String) sample).intern();
+            }
+            removeStaleEntries();
+            WeakEntry newEntry = new WeakEntry(sample, queue);
+            while (true) {
+                WeakEntry existing = map.putIfAbsent(newEntry, newEntry);
+                if (existing == null) {
+                    missCount.increment();
+                    return sample;
+                }
+                T canonical = (T) existing.get();
+                if (canonical != null) {
+                    hitCount.increment();
+                    return canonical;
+                }
+                map.remove(existing, existing);
+            }
+        }
+
+        void clear() {
+            map.clear();
+            removeStaleEntries();
+        }
+
+        int size() {
+            return map.size();
+        }
+
+        @Override
+        public long hitCount() {
+            return hitCount.sum();
+        }
+
+        @Override
+        public long missCount() {
+            return missCount.sum();
+        }
+
+        @Override
+        public int poolSize() {
+            return map.size();
+        }
+
+        @SuppressWarnings("unchecked")
+        private void removeStaleEntries() {
+            Reference<?> ref;
+            while ((ref = queue.poll()) != null) {
+                map.remove((WeakEntry) ref, (WeakEntry) ref);
+            }
+        }
+    }
+
+    /**
+     * A weak-reference wrapper used as both key and value in the intern pool.
+     *
+     * <p>The {@link #hashCode()} is cached at construction time from the referent, so it remains
+     * stable even after the referent is garbage-collected. The {@link #equals(Object)} method
+     * uses identity comparison as a fast path (needed for stale entry removal), then falls back
+     * to content-based comparison using the referents' {@code equals()} method.</p>
+     */
+    private static final class WeakEntry extends WeakReference<Object> {
+        private final int hashCode;
+
+        WeakEntry(Object referent, ReferenceQueue<Object> queue) {
+            super(referent, queue);
+            this.hashCode = referent.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof WeakEntry)) {
+                return false;
+            }
+            Object thisRef = this.get();
+            Object thatRef = ((WeakEntry) obj).get();
+            return thisRef != null && thisRef.equals(thatRef);
+        }
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/InternerStats.java
+++ b/debezium-util/src/main/java/io/debezium/util/InternerStats.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+/**
+ * Read-only view of an {@link Interner} pool's runtime statistics.
+ * Returned by {@link Interner#activate(Interner.Mode)} when interning is enabled,
+ * and exposed via JMX to monitor deduplication effectiveness.
+ */
+public interface InternerStats {
+
+    /** Number of times {@code intern()} returned an already-cached canonical instance. */
+    long hitCount();
+
+    /** Number of times {@code intern()} stored a new instance in the pool. */
+    long missCount();
+
+    /** Current number of entries held in the pool (including entries pending GC expiry). */
+    int poolSize();
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -31,6 +31,10 @@ tag::common-schema-history[]
 The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_`.
 end::common-schema-history[]
 
+tag::common-interner[]
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=interner,server=_<topic.prefix>_`.
+end::common-interner[]
+
 tag::sqlserver-schema-history[]
 The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<topic.prefix>_,task=_<task.id>_`.
 end::sqlserver-schema-history[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -58,4 +58,10 @@ Specify one of the following values:
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
 `false`:: The connector records schema structures for all logical databases.
 
+|[[{context}-property-database-history-memory-optimization]]<<{context}-property-database-history-memory-optimization, `+schema.history.internal.memory.optimization+`>>
+|`false`
+|A Boolean value that controls whether {prodname} deduplicates identical schema objects (tables, columns, attributes) in memory.
+When enabled, the connector uses an interner to share canonical instances of equal schema objects, which can significantly reduce heap usage for connectors that track many tables with similar structures.
+When disabled (the default), no deduplication is performed.
+
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -58,4 +58,13 @@ Specify one of the following values:
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
 `false`:: The connector records schema structures for all logical databases.
 
+|[[{context}-property-database-history-memory-optimization]]<<{context}-property-database-history-memory-optimization, `+schema.history.internal.memory.optimization+`>>
+|`off`
+|Controls how {prodname} deduplicates identical schema objects (tables, columns, attributes) in memory using an interner. +
+Specify one of the following values:
+
+`off`:: No deduplication is performed (the default).
+`on`:: Each connector uses its own isolated intern pool. Reduces heap usage within a single connector without interfering with other connectors.
+`shared`:: All connectors configured with `shared` share a single global intern pool. Maximises deduplication when many connectors track tables with similar structures.
+
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -38,3 +38,32 @@ The following table lists the schema history metrics that are available.
 |The string representation of the last applied change.
 
 |===
+
+=== Interner metrics
+
+The connector interns schema objects (columns, table identifiers, type names) to reduce heap usage.
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=interner,server=_<topic.prefix>_`.
+
+The following table lists the interner metrics that are available.
+
+[cols="45%a,25%a,30%a",options="header"]
+|===
+|Attributes |Type |Description
+
+|[[connectors-interner-metric-hitcount_{context}]]<<connectors-interner-metric-hitcount_{context}, `HitCount`>>
+|`long`
+|Number of times `intern()` returned an already-cached canonical instance.
+
+|[[connectors-interner-metric-misscount_{context}]]<<connectors-interner-metric-misscount_{context}, `MissCount`>>
+|`long`
+|Number of times `intern()` stored a new instance in the pool.
+
+|[[connectors-interner-metric-poolsize_{context}]]<<connectors-interner-metric-poolsize_{context}, `PoolSize`>>
+|`int`
+|Current number of entries held in the pool. Includes entries whose referents may have been garbage-collected but not yet expunged.
+
+|[[connectors-interner-metric-hitratiopercent_{context}]]<<connectors-interner-metric-hitratiopercent_{context}, `HitRatioPercent`>>
+|`double`
+|Hit ratio as a percentage (`hitCount / (hitCount + missCount) * 100`), or `0.0` if no calls have been recorded yet.
+
+|===


### PR DESCRIPTION
## Summary
- Introduce a generic `Interner` utility to deduplicate frequently repeated strings and objects in memory
- Apply interning to `TableId`, `TableImpl`, `ColumnImpl`, and `AttributeImpl` to reduce heap usage
- Add a configurable `schema.history.internal.memory.optimization` option to enable the `Interner` (default is `off`), either for the connector only (`on`) or shared with other connectors (`shared`).

Closes https://github.com/debezium/dbz/issues/1813

## Test plan
- [x] `InternerTest` — verifies interning behavior (identity, concurrency, null handling)
- [x] `TableImplInterningTest` — verifies interning applied correctly to relational model objects