### PR TITLE
debezium/dbz#1815 Fix  schema-generator on Oracle connector

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -361,6 +361,11 @@
             <plugin>
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-schema-generator</artifactId>
+                <configuration>
+                    <jvmArgs>
+                        <arg>-Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl</arg>
+                    </jvmArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/maven/SchemaGeneratorMojo.java
+++ b/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/maven/SchemaGeneratorMojo.java
@@ -63,6 +63,12 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     private String filenameSuffix = "";
 
     /**
+     * Optional JVM arguments to pass to the schema generator process.
+     */
+    @Parameter
+    private List<String> jvmArgs;
+
+    /**
      * Gives access to the Maven project information.
      */
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
@@ -84,7 +90,8 @@ public class SchemaGeneratorMojo extends AbstractMojo {
         String classPath = getClassPath();
 
         try {
-            int result = exec(SchemaGenerator.class.getName(), classPath, Collections.emptyList(),
+            List<String> effectiveJvmArgs = jvmArgs != null ? jvmArgs : Collections.emptyList();
+            int result = exec(SchemaGenerator.class.getName(), classPath, effectiveJvmArgs,
                     Arrays.<String> asList(format, outputDirectory.getAbsolutePath(), String.valueOf(groupDirectoryPerComponent),
                             quoteIfNecessary(filenamePrefix), quoteIfNecessary(filenameSuffix),
                             project.getArtifact().getFile().getAbsolutePath()));


### PR DESCRIPTION
Fixes debezium/dbz#1815

## Description
Use javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl when running schema-generator on Oracle connector

## PR Checklist
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
