### PR TITLE
debezium/dbz#305 Sanitize MongoDB SMT schema names for Avro compatibility

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -9,10 +9,12 @@ import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.CONFI
 import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DELETED_FIELD;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -146,6 +148,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
     private boolean flattenStruct;
     private String delimiter;
     private boolean rewriteTombstoneDeletesWithId;
+    private SchemaNameAdjuster schemaNameAdjuster;
     private final Field.Set configFields = CONFIG_FIELDS.with(ARRAY_ENCODING, FLATTEN_STRUCT, DELIMITER);
 
     @Override
@@ -155,6 +158,22 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
         FieldNameAdjustmentMode fieldNameAdjustmentMode = FieldNameAdjustmentMode.parse(
                 config.getString(CommonConnectorConfig.FIELD_NAME_ADJUSTMENT_MODE));
         SchemaNameAdjuster fieldNameAdjuster = fieldNameAdjustmentMode.createAdjuster();
+
+        // We intentionally use SchemaNameAdjuster.AVRO here instead of the field-level
+        // AVRO_FIELD_NAMER adjuster. The field-level adjuster treats dots as invalid characters
+        // and would replace them with underscores, destroying the dotted schema namespace.
+        // The schema-level adjuster correctly preserves dots while sanitizing other characters.
+        switch (fieldNameAdjustmentMode) {
+            case AVRO:
+                schemaNameAdjuster = SchemaNameAdjuster.AVRO;
+                break;
+            case AVRO_UNICODE:
+                schemaNameAdjuster = SchemaNameAdjuster.AVRO_UNICODE;
+                break;
+            default:
+                schemaNameAdjuster = SchemaNameAdjuster.NO_OP;
+        }
+
         converter = new MongoDataConverter(
                 ArrayEncoding.parse(config.getString(ARRAY_ENCODING)),
                 FieldNameSelector.defaultNonRelationalSelector(fieldNameAdjuster),
@@ -274,6 +293,16 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
             newValueSchemaName = record.valueSchema().name();
             if (Envelope.isEnvelopeSchema(newValueSchemaName)) {
                 newValueSchemaName = newValueSchemaName.substring(0, newValueSchemaName.length() - 9);
+            }
+
+            // Avro validates each dot-separated segment of a schema name independently,
+            // so we must adjust each segment on its own. Applying the adjuster to the full
+            // dotted name would only check the very first character of the entire string,
+            // letting invalid segments like "10019_AutoState" slip through.
+            if (schemaNameAdjuster != SchemaNameAdjuster.NO_OP) {
+                newValueSchemaName = Arrays.stream(newValueSchemaName.split("\\."))
+                        .map(schemaNameAdjuster::adjust)
+                        .collect(Collectors.joining("."));
             }
 
             Map<String, Map<Object, BsonType>> valueMap = converter.parseBsonDocument(valueDocument);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -236,4 +236,58 @@ public class ExtractNewDocumentStateTest {
         // when
         assertThrows(IllegalArgumentException.class, () -> transformation.apply(eventRecord));
     }
+
+    /**
+     * Verifies that when {@code field.name.adjustment.mode} is set to {@code avro},
+     * schema names containing dot-separated segments that start with a digit
+     * (e.g. collection names like "10019_AutoState") are properly sanitized.
+     *
+     * Without this fix, the Avro converter would reject the schema name because
+     * it validates each segment independently and digits are not valid first characters.
+     */
+    @Test
+    @FixFor("DBZ-305")
+    public void shouldAdjustSchemaNameWhenConfiguredForAvro() {
+        ExtractNewDocumentState<SourceRecord> avroTransformation = new ExtractNewDocumentState<>();
+        avroTransformation.configure(Collect.hashMapOf(
+                "array.encoding", "array",
+                "field.name.adjustment.mode", "avro"));
+
+        Schema keySchema = SchemaBuilder.struct()
+                .name("mongo.DASMongoDB.10019_AutoState.Key")
+                .field("id", Schema.STRING_SCHEMA)
+                .build();
+        Struct keyStruct = new Struct(keySchema).put("id", "{\"_id\": 1}");
+
+        Schema updateDescriptionSchema = SchemaBuilder.struct()
+                .name("mongo.DASMongoDB.10019_AutoState.updateDescription")
+                .field("updatedFields", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("removedFields", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .field("truncatedArrays", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .optional()
+                .build();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("mongo.DASMongoDB.10019_AutoState.Envelope")
+                .field("after", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("updateDescription", updateDescriptionSchema)
+                .field("op", Schema.STRING_SCHEMA)
+                .build();
+        Struct valueStruct = new Struct(valueSchema)
+                .put("after", "{\"_id\": 1, \"foo\": \"bar\"}")
+                .put("op", "c");
+
+        final SourceRecord eventRecord = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "mongo.DASMongoDB.10019_AutoState",
+                keySchema,
+                keyStruct,
+                valueSchema,
+                valueStruct);
+
+        SourceRecord transformed = avroTransformation.apply(eventRecord);
+
+        assertThat(transformed.valueSchema().name()).isEqualTo("mongo.DASMongoDB._10019_AutoState");
+    }
 }

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -562,6 +562,16 @@ For a struct specification, the SMT also inserts an underscore between the struc
  +
 If you specify a field that is not present in the original change event message, the SMT still adds the specified field to the `value` element of the modified message.
 
+|[[mongodb-extract-new-record-state-field-name-adjustment-mode]]xref:mongodb-extract-new-record-state-field-name-adjustment-mode[`field.name.adjustment.mode`]
+|`none`
+|Specifies how the SMT adjusts field and schema names for compatibility with different message converters.
+Set one of the following options:
+
+`none` (default):: No adjustment is performed.
+
+`avro`:: The SMT replaces any character that is invalid for Avro field names with an underscore character (`_`). It also adjusts the dot-separated segments of the output schema name individually, replacing invalid initial characters with an underscore to prevent Avro `SchemaParseException` errors when collection names begin with a digit.
+
+`avro_unicode`:: Similar to `avro`, but replaces invalid characters with their Unicode equivalent (e.g., `_u0031` for a leading `1`).
 |===
 
 [id="debezium-event-flattening-smt-for-mongodb-known-limitations"]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#305

## Description
This PR fixes an `org.apache.avro.SchemaParseException` in the `ExtractNewDocumentState` SMT when MongoDB collection names start with a digit.

The issue occurs because the SMT removes the `.Envelope` suffix and produces a dotted schema name (e.g. `mongo.DASMongoDB.10019_AutoState`). Avro validates each segment independently, and `10019_AutoState` is invalid since it starts with a digit. Applying `SchemaNameAdjuster.adjust()` to the full name does not fix this, as it only validates the first character of the entire string.

* The SMT now derives a schema-level `SchemaNameAdjuster` from `field.name.adjustment.mode`.
* Uses `SchemaNameAdjuster.AVRO` (or `AVRO_UNICODE`) instead of the field-level adjuster to preserve dotted names.
* Splits the schema name by `.`, adjusts each segment, and joins them back (e.g. `10019_AutoState`  -> `_10019_AutoState`).
* Added a regression test `shouldAdjustSchemaNameWhenConfiguredForAvro` to verify the fix.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`