### PR TITLE
debezium/dbz#1819 ChangeEventSourceCoordinator correctly initialize streaming state

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -523,6 +523,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
             streamingMetrics.connected(status);
             LOGGER.info("Connected metrics set to '{}'", status);
         }
+        this.streaming = status;
     }
 
     protected class CatchUpStreamingResult {

--- a/debezium-connector-common/src/test/java/io/debezium/junit/logging/LogInterceptor.java
+++ b/debezium-connector-common/src/test/java/io/debezium/junit/logging/LogInterceptor.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.AppenderBase;
@@ -44,14 +45,13 @@ public class LogInterceptor extends AppenderBase<ILoggingEvent> {
 
     /**
      * Provides a log interceptor based on the logger that emits the message.
+     * Prefer using either {@link #forPackage(String)} or {@link #forName(String)}
      *
      * @param loggerName logger that emits the log message
      */
     public LogInterceptor(String loggerName) {
         try {
-            final Logger logger = (Logger) LoggerFactory.getLogger(loggerName);
-            this.start();
-            logger.addAppender(this);
+            appendInterceptorAsAppender(loggerName);
         }
         catch (Exception e) {
             throw new RuntimeException("Failed to obtain logback logger for log interceptor.", e);
@@ -60,6 +60,7 @@ public class LogInterceptor extends AppenderBase<ILoggingEvent> {
 
     /**
      * Provides a log interceptor based on the logger that emits the message.
+     * Prefer using {@link #forClass(Class)}
      *
      * @param clazz class that emits the log message
      */
@@ -173,5 +174,67 @@ public class LogInterceptor extends AppenderBase<ILoggingEvent> {
             }
         }
         return false;
+    }
+
+    /**
+     * Creates a log interceptor for a package to include all classes within that package and any child
+     * packages that exist in the class hierarchy.
+     *
+     * @param packageName the package name
+     * @return a new interceptor instance
+     */
+    public static LogInterceptor forPackage(String packageName) {
+        return new LogInterceptor("%s.*".formatted(packageName));
+    }
+
+    /**
+     * Creates a log interceptor for a specific class.
+     *
+     * @param clazz the class type
+     * @return a new interceptor instance
+     */
+    public static LogInterceptor forClass(Class<?> clazz) {
+        return new LogInterceptor(clazz);
+    }
+
+    /**
+     * Creates a log interceptor for a specific logger name.
+     * <p>
+     * Loggers are hierarchical, but do not propagate logged events from child to parent loggers. So when
+     * using this specific method, an interceptor will only capture logged events that are explicitly
+     * caught by the specified name. If a logback configuration defines a logger that is for a class or
+     * package that is a child of the given name, those events will not be propagated and caught by the
+     * interceptor. For this use case, use {@link #forPackage}.
+     *
+     * @param explicitLoggerName the explicit logger name
+     * @return a new interceptor instance
+     */
+    public static LogInterceptor forName(String explicitLoggerName) {
+        return new LogInterceptor(explicitLoggerName);
+    }
+
+    private void appendInterceptorAsAppender(String name) {
+        if (name == null) {
+            return;
+        }
+
+        this.start();
+
+        String loggerName = name.trim();
+        if (loggerName.endsWith(".*")) {
+            loggerName = loggerName.substring(0, loggerName.length() - 2);
+            // Apply package and child logger appending
+            LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+            for (Logger logger : context.getLoggerList()) {
+                if (logger.getName().equals(loggerName) || logger.getName().startsWith(loggerName + ".")) {
+                    logger.addAppender(this);
+                }
+            }
+        }
+        else {
+            // Apply to explicit logger only.
+            final Logger logger = (Logger) LoggerFactory.getLogger(loggerName);
+            logger.addAppender(this);
+        }
     }
 }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -121,7 +121,7 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
         SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT * 2, 10);
         assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT * 2, consumedRecordsByTopic);
 
-        LogInterceptor interceptor = new LogInterceptor("io.debezium");
+        LogInterceptor interceptor = LogInterceptor.forPackage("io.debezium");
 
         // Send 3 blocking snapshot signals back-to-back
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
@@ -129,7 +129,7 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
         Awaitility.await()
                 .alias("Streaming did not resume after all blocking snapshots")
-                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
                 .atMost(waitTimeForRecords() * 60L, TimeUnit.SECONDS)
                 .until(() -> interceptor.countOccurrences("Streaming resumed") >= 3);
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1819

## Description
The first commit in this PR addresses a runtime regression introduced by debezium/dbz#1778 where the initial streaming state was not being initialized in the `ChangeEventSourceCoordinator`, leading to unintended mishandling of the trade off from streaming to the blocking snapshot for some connectors.

The second commit in this PR addresses a test regression introduced by the same change: a new test case uses the `LogInterceptor` to capture events for a specific package. Unfortunately, Loggers are not hierarchical, so if a specific connector module creates a dedicated logger for a class that emits the message the test is interested in, the package logger never sees it, and the test stalls. This commit introduces a specialization of `LogInterceptor` to listen for logged messages from a package, and registers the interceptor for the package, its classes, and any loggers defined in subpackages or subpackage classes, recursively.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
