### PR TITLE
dbz#1648 Update Informix driver to build kafka connect

### DIFF
--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaConnectBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/builders/FabricKafkaConnectBuilder.java
@@ -95,7 +95,7 @@ public class FabricKafkaConnectBuilder extends
                 artifactServer.createDebeziumPlugin("postgres"),
                 artifactServer.createDebeziumPlugin("mongodb"),
                 artifactServer.createDebeziumPlugin("sqlserver"),
-                artifactServer.createDebeziumPlugin("informix", List.of("ifx/ifx-changestream-client", "ifx/jdbc")),
+                artifactServer.createDebeziumPlugin("informix", List.of("ifx/jdbc")),
                 artifactServer.createDebeziumPlugin("db2", List.of("jdbc/jcc")),
                 // jdbc sink connector, not to be confused with the libraries stored in jdbc directory used in db2 and oracle connectors
                 artifactServer.createDebeziumPlugin("jdbc")));

--- a/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/tests/informix/InformixTests.java
+++ b/debezium-testing/debezium-testing-system/src/test/java/io/debezium/testing/system/tests/informix/InformixTests.java
@@ -150,9 +150,6 @@ public abstract class InformixTests extends ConnectorTest {
     public void shouldExtractNewRecordState(SqlDatabaseController dbController) throws Exception {
         connectController.undeployConnector(connectorConfig.getConnectorName());
 
-        // FIXME: Remove when https://github.com/debezium/dbz/issues/1704 is resolved
-        Thread.sleep(Duration.ofMinutes(3));
-
         connectorConfig = connectorConfig.addJdbcUnwrapSMT();
         connectController.deployConnector(connectorConfig);
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1648

## Description
Aftwe the update of the informix driver, we need to update the informix plugins used to build kafka connect. 

Additionally, removed the sleep on the informix system test as the bug has been properly fixed. 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
