### PR TITLE
DBZ-9872 Removes malformed callouts from 3.4 SQL Server connector doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2011,16 +2011,17 @@ GO
 
 EXEC sys.sp_cdc_enable_table
 @source_schema = N'dbo',
-@source_name   = N'MyTable', //<.>
-@role_name     = N'MyRole',  //<.>
-@filegroup_name = N'MyDB_CT',//<.>
+@source_name   = N'MyTable',
+@role_name     = N'MyRole',
+@filegroup_name = N'MyDB_CT',
 @supports_net_changes = 0
 GO
 ----
-<.> Specifies the name of the table that you want to capture.
-<.> Specifies a role `MyRole` to which you can add users to whom you want to grant `SELECT` permission on the captured columns of the source table.
+
+`@source_name`:: Specifies the name of the table that you want to capture.
+`@role_name`:: Specifies a role `MyRole` to which you can add users to whom you want to grant `SELECT` permission on the captured columns of the source table.
 Users in the `sysadmin` or `db_owner` role also have access to the specified change tables. If the the value of `@role_name` is explicitly set to `NULL`, no role is used to restrict access to captured information.
-<.> Specifies the `filegroup` where SQL Server places the change table for the captured table.
+`@filegroup_name`:: Specifies the `filegroup` where SQL Server places the change table for the captured table.
 The named `filegroup` must already exist.
 It is best not to locate change tables in the same `filegroup` that you use for source tables.
 


### PR DESCRIPTION
Fixes [DBZ-9872](https://redhat.atlassian.net/browse/DBZ-9872)

## Description
Removes poorly formatted callouts that rendered incorrectly in the Enabling CDC on a SQL Server table topic in the product edition of the connector doc.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.4`

