### PR TITLE
[docs] 3.4 Fixes formatting of list entries in KC YAML example descriptions

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -80,12 +80,12 @@ Valid types are `zip`, `tgz`, or `jar`.
 JDBC driver files are in `.jar` format.
 The `type` value of the artifact must match the extension of the file that is referenced in the `url` field.
 
-`plugins.artifacts.url:::
+`plugins.artifacts.url`:::
 Specifies the addresses of the repository that store artifacts for the required build components.
 The OpenShift cluster must have access to the specified server.
 The examples provides URLs for the following components:
 
-`debezium-connector`-{connector-file}:::
+`debezium-connector-{connector-file}`:::
 Specifies the source for the {prodname} Kafka connector artifact.
 
 `apicurio-registry-distro-connect-converter`:::

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-informix-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-informix-kafka-connect-yaml.adoc
@@ -80,12 +80,12 @@ Valid types are `zip`, `tgz`, or `jar`.
 JDBC driver files are in `.jar` format.
 The `type` value of the artifact must match the extension of the file that is referenced in the `url` field.
 
-`plugins.artifacts.url``:::
+`plugins.artifacts.url`:::
 Specifies the addresses of the repository that store artifacts for the required build components.
 The OpenShift cluster must have access to the specified server.
 The examples provides URLs for the following components:
 
-`debezium-connector`-{connector-file}:::
+`debezium-connector-{connector-file}`:::
 Specifies the source for the {prodname} Kafka connector artifact.
 
 `apicurio-registry-distro-connect-converter`:::


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
[docs]  Fixes formatting in KC example descriptions
## Description
Corrects monospace formatting of entries in the lists of description terms that follow the Kafka Connect examples in the Streams deployment exampls for the Db2 and Informix connectors.

This change affects the downstream documentation only.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.4`
