### PR TITLE
Add start retry guard, task lifecycle JMX metrics, and Postgres WAL-level/slot log metrics

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -197,6 +197,9 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private final Map<Map<String, ?>, Map<String, ?>> lastOffsets = new HashMap<>();
 
     private Duration retriableRestartWait;
+    private int startRetryCount = 0;
+    private int startMaxRetries = ErrorHandler.RETRIES_UNLIMITED;
+    private TaskLifecycleMetrics taskLifecycleMetrics;
 
     private final ElapsedTimeStrategy pollOutputDelay;
 
@@ -264,6 +267,13 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
             retriableRestartWait = config.getDuration(CommonConnectorConfig.RETRIABLE_RESTART_WAIT, ChronoUnit.MILLIS);
             // need to reset the delay or you only get one delayed restart
+            startMaxRetries = config.getInteger(CommonConnectorConfig.MAX_RETRIES_ON_ERROR);
+
+            // Register task lifecycle metrics MBean (available before coordinator starts)
+            taskLifecycleMetrics = new TaskLifecycleMetrics();
+            taskLifecycleMetrics.setStartMaxRetries(startMaxRetries);
+            taskLifecycleMetrics.setTaskState("INITIAL");
+
             restartDelay = null;
             if (!config.validateAndRecord(getAllConfigurationFields(), LOGGER::error)) {
                 throw new ConnectException("Error configuring an instance of " + getClass().getSimpleName() + "; check the logs for details");
@@ -435,6 +445,20 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         return false;
     }
 
+    private void updateRetryMetrics() {
+        if (taskLifecycleMetrics != null) {
+            taskLifecycleMetrics.setStartRetryCount(startRetryCount);
+            taskLifecycleMetrics.setTaskState(getTaskState().name());
+            if (coordinator != null && coordinator.getErrorHandler() != null) {
+                taskLifecycleMetrics.setPollRetryCount(coordinator.getErrorHandler().getRetries());
+            }
+        }
+    }
+
+    protected TaskLifecycleMetrics getTaskLifecycleMetrics() {
+        return taskLifecycleMetrics;
+    }
+
     /**
      * Returns the next batch of source records, if any are available.
      */
@@ -468,11 +492,20 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
                 // we're in restart mode... check if it's time to restart
                 if (restartDelay.hasElapsed()) {
+                    if (startMaxRetries != ErrorHandler.RETRIES_UNLIMITED && startRetryCount >= startMaxRetries) {
+                        LOGGER.error("Maximum start retries ({}) exhausted. Task will not recover.", startMaxRetries);
+                        throw new ConnectException("Task failed to start after " + startRetryCount + " retries");
+                    }
+                    startRetryCount++;
+                    updateRetryMetrics();
+                    LOGGER.warn("Start retry attempt {} of {}", startRetryCount,
+                            startMaxRetries == ErrorHandler.RETRIES_UNLIMITED ? "unlimited" : startMaxRetries);
                     LOGGER.info("Attempting to restart task.");
-                    preStart(config);
                     this.coordinator = start(config);
                     LOGGER.info("Successfully restarted task");
                     restartDelay = null;
+                    startRetryCount = 0;
+                    updateRetryMetrics();
                     setTaskState(DebeziumTaskState.RUNNING);
                     result = true;
                 }
@@ -497,6 +530,9 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             LOGGER.warn("Error while performing commit.", e);
         }
         finally {
+            if (taskLifecycleMetrics != null) {
+                taskLifecycleMetrics = null;
+            }
             stop(false);
             DebeziumOpenLineageEmitter
                     .cleanup(DebeziumOpenLineageEmitter.connectorContext(getMaskedConfigurationMap(config.asMap()), connectorName(), cdcSourceTaskContext.getRunId()));

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -10,15 +10,7 @@ import static io.debezium.util.Loggings.maybeRedactSensitiveData;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -26,6 +18,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import io.debezium.pipeline.JmxUtils;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -65,6 +58,9 @@ import io.debezium.util.ElapsedTimeStrategy;
 import io.debezium.util.LoggingContext;
 import io.debezium.util.Metronome;
 import io.debezium.util.Strings;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 
 /**
  * Base class for Debezium's CDC {@link SourceTask} implementations. Provides functionality common to all connectors,
@@ -200,6 +196,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private int startRetryCount = 0;
     private int startMaxRetries = ErrorHandler.RETRIES_UNLIMITED;
     private TaskLifecycleMetrics taskLifecycleMetrics;
+    private ObjectName taskLifeCycleMetricsObjectName;
 
     private final ElapsedTimeStrategy pollOutputDelay;
 
@@ -273,6 +270,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             taskLifecycleMetrics = new TaskLifecycleMetrics();
             taskLifecycleMetrics.setStartMaxRetries(startMaxRetries);
             taskLifecycleMetrics.setTaskState("INITIAL");
+            taskLifeCycleMetricsObjectName = taskLifeCycleMetricsObjectName();
+            JmxUtils.registerMXBean(taskLifeCycleMetricsObjectName, taskLifecycleMetrics);
 
             restartDelay = null;
             if (!config.validateAndRecord(getAllConfigurationFields(), LOGGER::error)) {
@@ -530,7 +529,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             LOGGER.warn("Error while performing commit.", e);
         }
         finally {
-            if (taskLifecycleMetrics != null) {
+            if (null != taskLifeCycleMetricsObjectName) {
+                JmxUtils.unregisterMXBean(taskLifeCycleMetricsObjectName);
                 taskLifecycleMetrics = null;
             }
             stop(false);
@@ -694,5 +694,36 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         serviceRegistry.registerServiceProvider(new SnapshotterServiceProvider());
         serviceRegistry.registerServiceProvider(new DebeziumHeaderProducerProvider());
         serviceRegistry.registerServiceProvider(new CustomConverterServiceProvider());
+    }
+
+    public static Map<String, String> customTagMap(String customTags) {
+        if (customTags == null || customTags.trim().isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return Arrays.stream(customTags.split(","))
+                .map(String::trim)
+                .filter(pair -> !pair.isEmpty())
+                .map(pair -> pair.split("=", 2))
+                .collect(Collectors.toMap(
+                        parts -> parts[0].trim(),
+                        parts -> (parts.length > 1) ? parts[1].trim() : "",
+                        (existing, replacement) -> replacement
+                ));
+    }
+
+    private ObjectName taskLifeCycleMetricsObjectName() {
+        StringBuilder jmxObjectNameBuilder = new StringBuilder("debezium.common:type=connector-metrics,context=task-lifecycle").append(",server=")
+                .append(config.getString("topic.prefix"));
+
+        for (Map.Entry<String, String> customTags : customTagMap(config.getString("custom.metric.tags")).entrySet()) {
+            jmxObjectNameBuilder.append(",").append(customTags.getKey()).append("=").append(customTags.getValue());
+        }
+        try {
+            return new ObjectName(jmxObjectNameBuilder.toString());
+        }
+        catch (MalformedObjectNameException e) {
+            throw new RuntimeException("Unable to register the MBean '" + jmxObjectNameBuilder + "'", e);
+        }
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetrics.java
@@ -28,8 +28,8 @@ public class TaskLifecycleMetrics implements TaskLifecycleMetricsMXBean {
     private final AtomicInteger startMaxRetries = new AtomicInteger(-1);
     private final AtomicInteger pollRetryCount = new AtomicInteger();
     private final AtomicReference<String> taskState = new AtomicReference<>("INITIAL");
-    private final AtomicLong cachedReplicationSlotLagInBytes = new AtomicLong();
-    private volatile LongSupplier replicationSlotLagSupplier;
+    private final AtomicLong lagInBytes = new AtomicLong();
+    private volatile LongSupplier lagSupplier;
 
     @Override
     public int getStartRetryCount() {
@@ -71,23 +71,23 @@ public class TaskLifecycleMetrics implements TaskLifecycleMetricsMXBean {
      * Sets the supplier that computes replication slot lag on demand.
      * Called once during connector setup with a reference to the JDBC connection.
      */
-    public void setReplicationSlotLagSupplier(LongSupplier supplier) {
-        this.replicationSlotLagSupplier = supplier;
+    public void setLagSupplier(LongSupplier supplier) {
+        this.lagSupplier = supplier;
     }
 
     @Override
-    public long getReplicationSlotLagInBytes() {
-        LongSupplier supplier = replicationSlotLagSupplier;
+    public long getLagInBytes() {
+        LongSupplier supplier = lagSupplier;
         if (supplier != null) {
             try {
                 long lag = supplier.getAsLong();
-                cachedReplicationSlotLagInBytes.set(lag);
+                lagInBytes.set(lag);
                 return lag;
             }
             catch (Exception e) {
                 LOGGER.debug("Failed to compute replication slot lag, returning cached value", e);
             }
         }
-        return cachedReplicationSlotLagInBytes.get();
+        return lagInBytes.get();
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.ThreadSafe;
+
+/**
+ * Thread-safe implementation of task lifecycle metrics.
+ * Lives for the entire task lifetime, independent of coordinator/streaming metrics.
+ */
+@ThreadSafe
+public class TaskLifecycleMetrics implements TaskLifecycleMetricsMXBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskLifecycleMetrics.class);
+
+    private final AtomicInteger startRetryCount = new AtomicInteger();
+    private final AtomicInteger startMaxRetries = new AtomicInteger(-1);
+    private final AtomicInteger pollRetryCount = new AtomicInteger();
+    private final AtomicReference<String> taskState = new AtomicReference<>("INITIAL");
+    private final AtomicLong cachedReplicationSlotLagInBytes = new AtomicLong();
+    private volatile LongSupplier replicationSlotLagSupplier;
+
+    @Override
+    public int getStartRetryCount() {
+        return startRetryCount.get();
+    }
+
+    public void setStartRetryCount(int count) {
+        startRetryCount.set(count);
+    }
+
+    @Override
+    public int getStartMaxRetries() {
+        return startMaxRetries.get();
+    }
+
+    public void setStartMaxRetries(int max) {
+        startMaxRetries.set(max);
+    }
+
+    @Override
+    public int getPollRetryCount() {
+        return pollRetryCount.get();
+    }
+
+    public void setPollRetryCount(int count) {
+        pollRetryCount.set(count);
+    }
+
+    @Override
+    public String getTaskState() {
+        return taskState.get();
+    }
+
+    public void setTaskState(String state) {
+        taskState.set(state);
+    }
+
+    /**
+     * Sets the supplier that computes replication slot lag on demand.
+     * Called once during connector setup with a reference to the JDBC connection.
+     */
+    public void setReplicationSlotLagSupplier(LongSupplier supplier) {
+        this.replicationSlotLagSupplier = supplier;
+    }
+
+    @Override
+    public long getReplicationSlotLagInBytes() {
+        LongSupplier supplier = replicationSlotLagSupplier;
+        if (supplier != null) {
+            try {
+                long lag = supplier.getAsLong();
+                cachedReplicationSlotLagInBytes.set(lag);
+                return lag;
+            }
+            catch (Exception e) {
+                LOGGER.debug("Failed to compute replication slot lag, returning cached value", e);
+            }
+        }
+        return cachedReplicationSlotLagInBytes.get();
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetricsMXBean.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetricsMXBean.java
@@ -20,5 +20,5 @@ public interface TaskLifecycleMetricsMXBean {
 
     String getTaskState();
 
-    long getReplicationSlotLagInBytes();
+    long getLagInBytes();
 }

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetricsMXBean.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/TaskLifecycleMetricsMXBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+/**
+ * Exposes task lifecycle metrics via JMX.
+ * Registered independently of the streaming/snapshot metrics so that
+ * retry counts are visible even when the coordinator has not yet started.
+ */
+public interface TaskLifecycleMetricsMXBean {
+
+    int getStartRetryCount();
+
+    int getStartMaxRetries();
+
+    int getPollRetryCount();
+
+    String getTaskState();
+
+    long getReplicationSlotLagInBytes();
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import io.debezium.pipeline.*;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -43,10 +44,6 @@ import io.debezium.document.DocumentReader;
 import io.debezium.heartbeat.HeartbeatFactory;
 import io.debezium.jdbc.DefaultMainConnectionProvidingConnectionFactory;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
-import io.debezium.pipeline.ChangeEventSourceCoordinator;
-import io.debezium.pipeline.DataChangeEvent;
-import io.debezium.pipeline.ErrorHandler;
-import io.debezium.pipeline.GuardrailValidator;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
@@ -158,6 +155,21 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
         connectorConfig.getBeanRegistry().add(StandardBeanNames.VALUE_CONVERTER, valueConverter);
         connectorConfig.getBeanRegistry().add(StandardBeanNames.OFFSETS, previousOffsets);
         connectorConfig.getBeanRegistry().add(StandardBeanNames.CDC_SOURCE_TASK_CONTEXT, taskContext);
+
+        // Wire WAL lag supplier to task lifecycle metrics (lazy computation on JMX scrape)
+        if (getTaskLifecycleMetrics() != null) {
+            final String slotName = connectorConfig.slotName();
+            getTaskLifecycleMetrics().setReplicationSlotLagSupplier(() -> {
+                try {
+                    return beanRegistryJdbcConnection.getWalLagInBytes(slotName);
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            // Register the task lifecycle MBean for JMX monitoring
+            JmxUtils.registerMXBean(getTaskLifecycleMetrics(), connectorConfig, "connector-metrics", "task-lifecycle");
+        }
 
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);
         final Snapshotter snapshotter = snapshotterService.getSnapshotter();
@@ -515,7 +527,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             if (snapshotterService.getSnapshotter() != null && snapshotterService.getSnapshotter().shouldStream()) {
                 // Logical WAL_LEVEL is only necessary for CDC snapshotting
-                throw new SQLException("Postgres server wal_level property must be 'logical' but is: '" + walLevel + "'");
+                throw new RetriableException("Postgres server wal_level property must be 'logical' but is: '" + walLevel + "'");
             }
             else {
                 LOGGER.warn("WAL_LEVEL check failed but this is ignored as CDC was not requested");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -159,7 +159,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
         // Wire WAL lag supplier to task lifecycle metrics (lazy computation on JMX scrape)
         if (getTaskLifecycleMetrics() != null) {
             final String slotName = connectorConfig.slotName();
-            getTaskLifecycleMetrics().setReplicationSlotLagSupplier(() -> {
+            getTaskLifecycleMetrics().setLagSupplier(() -> {
                 try {
                     return beanRegistryJdbcConnection.getWalLagInBytes(slotName);
                 }
@@ -167,8 +167,6 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     throw new RuntimeException(e);
                 }
             });
-            // Register the task lifecycle MBean for JMX monitoring
-            JmxUtils.registerMXBean(getTaskLifecycleMetrics(), connectorConfig, "connector-metrics", "task-lifecycle");
         }
 
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -299,6 +299,22 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     /**
+     * Returns the WAL lag in bytes between the current WAL position and the replication slot's
+     * restart LSN. This indicates how much WAL data the slot is holding back from being recycled.
+     *
+     * @param slotName the name of the replication slot
+     * @return the WAL lag in bytes, or 0 if the slot is not found
+     * @throws SQLException if a database access error occurs
+     */
+    public long getWalLagInBytes(String slotName) throws SQLException {
+        return prepareQueryAndMap(
+                "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS wal_lag_bytes "
+                        + "FROM pg_replication_slots WHERE slot_name = ?",
+                statement -> statement.setString(1, slotName),
+                rs -> rs.next() ? rs.getLong("wal_lag_bytes") : 0L);
+    }
+
+    /**
      * Retrieves the catalog xmin value from the replication slot.
      *
      * @param slotName the name of the slot
@@ -365,7 +381,13 @@ public class PostgresConnection extends JdbcConnection {
         for (int attempt = 1; attempt <= MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT; attempt++) {
             final ServerInfo.ReplicationSlot slot = fetchReplicationSlotInfo(slotName, pluginName);
             if (slot != null) {
-                LOGGER.info("Obtained valid replication slot {}", slot);
+                if (slot.equals(ServerInfo.ReplicationSlot.INVALID)) {
+                    LOGGER.info("Replication slot '{}' not found for plugin '{}' and database '{}'",
+                            slotName, pluginName, database);
+                }
+                else {
+                    LOGGER.info("Obtained valid replication slot {}", slot);
+                }
                 return slot;
             }
             LOGGER.warn(


### PR DESCRIPTION
 ## Summary

  Addresses three operational concerns when running the Postgres connector behind Network Load Balancers.

  ### Start retry guard in BaseSourceTask

  When the coordinator's start() throws a RetriableException, the task enters RESTARTING state and retries indefinitely on each poll() cycle. In scenarios where the connector is permanently partitioned from
  Postgres (e.g., NLB routing to a failed primary), this causes an infinite retry loop with no way for operators to detect or bound it.

  Adds a retry counter that respects the existing errors.max.retries config. Once exhausted, the task throws a fatal ConnectException so Kafka Connect can surface the failure. The counter resets to 0 on
  successful restart.

  ### Task lifecycle JMX metrics (TaskLifecycleMetrics)

  Existing Debezium metrics (streaming, snapshot) are only registered after the coordinator starts successfully, making retry state during startup invisible to monitoring. Adds a new TaskLifecycleMetricsMXBean
  registered early in the task lifecycle, exposing:

  - startRetryCount / startMaxRetries — current and max start retries
  - pollRetryCount — retries from the ErrorHandler (once coordinator is live)
  - taskState — current DebeziumTaskState name
  - replicationSlotLagInBytes — WAL lag computed lazily on JMX scrape via pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)

  ### Postgres-specific corrections

  - checkWalLevel now throws RetriableException instead of SQLException when wal_level != logical. During primary takeover behind an NLB, the load balancer may route the request to a standby which will not have WAL_LEVEL = "logical". This leads to immediate failure and the only way to avoid is having longer delay which delays the actual failure. A
  RetriableException lets the framework retry rather than killing the task permanently while allowing to keep a smaller delay to detect actual failure faster.
  - readReplicationSlotInfo log level corrected: previously logged "Obtained valid replication slot" at INFO even for INVALID slots. Now distinguishes between a missing slot (logged with slot name, plugin, and
  database) and a genuinely valid slot.
  - New getWalLagInBytes(slotName) method on PostgresConnection for the lifecycle metrics supplier.

  ## Files changed

  - debezium-connector-common/.../BaseSourceTask.java — retry counter, metrics wiring, guard in poll()
  - debezium-connector-common/.../TaskLifecycleMetrics.java — new thread-safe metrics bean
  - debezium-connector-common/.../TaskLifecycleMetricsMXBean.java — new JMX MBean interface
  - debezium-connector-postgres/.../PostgresConnectorTask.java — WAL lag supplier, MBean registration, RetriableException for WAL level check
  - debezium-connector-postgres/.../PostgresConnection.java — getWalLagInBytes(), slot info log correction
