### PR TITLE
debezium/dbz#1830 Add internal property to toggle SQLServer CDC column filters

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -103,6 +103,14 @@ public class SqlServerConnection extends JdbcConnection {
             " ORDER BY object_id, column_id";
 
     /**
+     * Queries the list of all column names and their change table identifiers in the given database.
+     */
+    private static final String GET_ALL_COLUMNS = "SELECT tables.object_id, columns.name" +
+            " FROM #db.sys.columns columns" +
+            " INNER JOIN #db.cdc.change_tables tables ON tables.source_object_id = columns.object_id" +
+            " ORDER BY tables.object_id, columns.column_id";
+
+    /**
      * Queries the list of capture instances in the given database.
      *
      * If two or more capture instances with the same start LSN are available for a given source table,
@@ -509,8 +517,10 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     public List<SqlServerChangeTable> getChangeTables(String databaseName, Lsn toLsn) throws SQLException {
+        String sqlTemplate = !config.isOverrideCdcColumnFilter() ? GET_CAPTURED_COLUMNS : GET_ALL_COLUMNS;
+
         Map<Integer, List<String>> columns = queryAndMap(
-                replaceDatabaseNamePlaceholder(GET_CAPTURED_COLUMNS, databaseName),
+                replaceDatabaseNamePlaceholder(sqlTemplate, databaseName),
                 rs -> {
                     Map<Integer, List<String>> result = new HashMap<>();
                     while (rs.next()) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -47,6 +47,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorConfig.class);
 
     public static final String MAX_TRANSACTIONS_PER_ITERATION_CONFIG_NAME = "max.iteration.transactions";
+    public static final String CDC_COLUMN_FILTER_OVERRIDE_CONFIG_NAME = "change.column.filter.override";
+
     protected static final int DEFAULT_PORT = 1433;
     protected static final int DEFAULT_MAX_TRANSACTIONS_PER_ITERATION = 500;
     private static final String READ_ONLY_INTENT = "ReadOnly";
@@ -401,6 +403,16 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withValidation(Field::isNonNegativeInteger)
             .withDescription("This property can be used to reduce the connector memory usage footprint when changes are streamed from multiple tables per database.");
 
+    public static final Field CDC_COLUMN_FILTER_OVERRIDE = Field.create(CDC_COLUMN_FILTER_OVERRIDE_CONFIG_NAME)
+            .withDisplayName("CDC column filter override")
+            .withDefault(false)
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 2))
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isBoolean)
+            .withDescription(
+                    "This property can be used to override the default behavior of only including columns that are marked for CDC. Recommended for snapshot-only migrations since SQL Server requires CDC enablement at the table or column-level.");
+
     public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
             .withDisplayName("Snapshot mode")
             .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
@@ -525,6 +537,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final SnapshotLockingMode snapshotLockingMode;
     private final boolean readOnlyDatabaseConnection;
     private final int maxTransactionsPerIteration;
+    private final boolean overrideCdcColumnFilter;
     private final boolean optionRecompile;
     private final int queryFetchSize;
     private final DataQueryMode dataQueryMode;
@@ -568,6 +581,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         this.maxTransactionsPerIteration = config.getInteger(MAX_TRANSACTIONS_PER_ITERATION);
+        this.overrideCdcColumnFilter = config.getBoolean(CDC_COLUMN_FILTER_OVERRIDE);
 
         if (!config.getBoolean(MAX_LSN_OPTIMIZATION)) {
             LOGGER.warn("The option '{}' is no longer taken into account. The optimization is always enabled.", MAX_LSN_OPTIMIZATION.name());
@@ -627,6 +641,10 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public int getMaxTransactionsPerIteration() {
         return maxTransactionsPerIteration;
+    }
+
+    public boolean isOverrideCdcColumnFilter() {
+        return overrideCdcColumnFilter;
     }
 
     public boolean getOptionRecompile() {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -403,16 +403,6 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withValidation(Field::isNonNegativeInteger)
             .withDescription("This property can be used to reduce the connector memory usage footprint when changes are streamed from multiple tables per database.");
 
-    public static final Field CDC_COLUMN_FILTER_OVERRIDE = Field.create(CDC_COLUMN_FILTER_OVERRIDE_CONFIG_NAME)
-            .withDisplayName("CDC column filter override")
-            .withDefault(false)
-            .withType(Type.BOOLEAN)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 2))
-            .withImportance(Importance.LOW)
-            .withValidation(Field::isBoolean)
-            .withDescription(
-                    "This property can be used to override the default behavior of only including columns that are marked for CDC. Recommended for snapshot-only migrations since SQL Server requires CDC enablement at the table or column-level.");
-
     public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
             .withDisplayName("Snapshot mode")
             .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
@@ -456,6 +446,16 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                             + "each table, and this is done using a flashback query that requires no locks. However, in some cases it may be desirable to avoid "
                             + "locks entirely which can be done by specifying 'none'. This mode is only safe to use if no schema changes are happening while the "
                             + "snapshot is taken.");
+
+    public static final Field CDC_COLUMN_FILTER_OVERRIDE = Field.createInternal(CDC_COLUMN_FILTER_OVERRIDE_CONFIG_NAME)
+            .withDisplayName("CDC column filter override")
+            .withDefault(false)
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 3))
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isBoolean)
+            .withDescription(
+                    "This property can be used to override the default behavior of only including columns that have been enabled for CDC. Must only be used for snapshot migrations, otherwise columns not enabled for CDC will be missing from change events and would result in inconsistent schemas and possible failures.");
 
     public static final Field INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE = Field.create("incremental.snapshot.option.recompile")
             .withDisplayName("Recompile SELECT statements")

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -1486,6 +1486,47 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-1830")
+    public void whenCaptureInstanceExcludesColumnsAndColumnOverrideExpectSnapshotToIncludeAllColumns() throws Exception {
+        connection.execute(
+                "CREATE TABLE excluded_column_table_a (id int, name varchar(30), amount int, primary key(id))");
+        connection.execute("INSERT INTO excluded_column_table_a VALUES(10, 'a name', 100)");
+
+        TestHelper.enableTableCdc(connection, "excluded_column_table_a", "dbo_excluded_column_table_a",
+                Arrays.asList("id", "name"));
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.CDC_COLUMN_FILTER_OVERRIDE, true)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        // Note that any change events will fail since 'amount' is not enabled for cdc
+        TestHelper.waitForSnapshotToBeCompleted();
+
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.excluded_column_table_a");
+
+        Schema expectedSchema = SchemaBuilder.struct()
+                .optional()
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("amount", Schema.OPTIONAL_INT32_SCHEMA)
+                .build();
+        Struct expectedValueSnapshot = new Struct(expectedSchema)
+                .put("id", 10)
+                .put("name", "a name")
+                .put("amount", 100);
+
+        assertThat(tableA).hasSize(1);
+        SourceRecordAssert.assertThat(tableA.get(0))
+                .valueAfterFieldSchemaIsEqualTo(expectedSchema)
+                .valueAfterFieldIsEqualTo(expectedValueSnapshot);
+        stopConnector();
+    }
+
+    @Test
     @FixFor("DBZ-2522")
     public void whenMultipleCaptureInstancesExcludesColumnsExpectLatestCDCTableUtilized() throws Exception {
         connection.execute(


### PR DESCRIPTION
Fixes debezium/dbz#1830

## Description
Adds a property to use all columns in a cdc-enabled table, even if not all columns are cdc-enabled. The property is false by default.
- Please let me know if this is actually 'internal'. Is there a way to make this property more private?

See related chat: [#community-sqlserver > Snapshot omits columns not enabled for CDC @ 💬](https://debezium.zulipchat.com/#narrow/channel/348252-community-sqlserver/topic/Snapshot.20omits.20columns.20not.20enabled.20for.20CDC/near/585829902)

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
