### PR TITLE
debezium/dbz#1836 Add XStream tests for Oracle 23.26.1

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -226,53 +226,6 @@ jobs:
   - job: tests
     trigger: pull_request
     # Suffix for job name
-    identifier: "oracle-21"
-    targets:
-      centos-stream-8-x86_64:
-        distros: ["debezium-tf-2130"]
-    skip_build: true
-    manual_trigger: true
-    labels:
-      - oracle
-      - oracle-logminer
-    tf_extra_params:
-      test:
-        tmt:
-          name: oracle
-      environments:
-        - variables:
-            ORACLE_VERSION: 21.3.0
-            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            TEST_PROFILE: oracle
-
-  ###############################################################################################
-  - job: tests
-    trigger: pull_request
-    # Suffix for job name
-    identifier: "oracle-21-xs"
-    targets:
-      centos-stream-8-x86_64:
-        distros: [ "debezium-tf-2130-xs" ]
-    skip_build: true
-    manual_trigger: true
-    labels:
-      - oracle
-      - oracle-xstream
-    tf_extra_params:
-      test:
-        tmt:
-          name: oracle
-      environments:
-        - variables:
-            ORACLE_VERSION: 21.3.0-xs
-            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            TEST_PROFILE: oracle
-            ORACLE_ARG: "-Poracle-xstream"
-
-  ###############################################################################################
-  - job: tests
-    trigger: pull_request
-    # Suffix for job name
     identifier: "oracle-19"
     targets:
       centos-stream-8-x86_64:
@@ -281,6 +234,7 @@ jobs:
     manual_trigger: true
     labels:
       - oracle
+      - oracle-19
       - oracle-logminer
     tf_extra_params:
       test:
@@ -304,6 +258,7 @@ jobs:
     manual_trigger: true
     labels:
       - oracle
+      - oracle-19
       - oracle-logminer
       - oracle-logminer-unbuffered
     tf_extra_params:
@@ -329,6 +284,7 @@ jobs:
     manual_trigger: true
     labels:
       - oracle
+      - oracle-19
       - oracle-xstream
     tf_extra_params:
       test:
@@ -340,6 +296,131 @@ jobs:
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
             TEST_PROFILE: oracle
             ORACLE_ARG: "-Poracle-xstream"
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-ispn"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-19
+      - oracle-logminer
+      - oracle-infinispan
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-infinispan-buffer -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-ehcache"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-19
+      - oracle-logminer
+      - oracle-ehcache
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0
+            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-ehcache -pl debezium-connector-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-se"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930-se" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-19
+      - oracle-logminer
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0-se
+            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            TEST_PROFILE: oracle
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-19-se-xs"
+    targets:
+      centos-stream-8-x86_64:
+        distros: [ "debezium-tf-1930-se-xs" ]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-19
+      - oracle-xstream
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 19.3.0-se-xs
+            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            TEST_PROFILE: oracle
+            ORACLE_ARG: "-Poracle-xstream"
+
+  ###############################################################################################
+  - job: tests
+    trigger: pull_request
+    # Suffix for job name
+    identifier: "oracle-21"
+    targets:
+      centos-stream-8-x86_64:
+        distros: ["debezium-tf-2130"]
+    skip_build: true
+    manual_trigger: true
+    labels:
+      - oracle
+      - oracle-21
+      - oracle-logminer
+    tf_extra_params:
+      test:
+        tmt:
+          name: oracle
+      environments:
+        - variables:
+            ORACLE_VERSION: 21.3.0
+            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            TEST_PROFILE: oracle
 
   ###############################################################################################
   - job: tests
@@ -370,64 +451,15 @@ jobs:
   - job: tests
     trigger: pull_request
     # Suffix for job name
-    identifier: "oracle-19-ispn"
+    identifier: "oracle-26"
     targets:
       centos-stream-8-x86_64:
-        distros: [ "debezium-tf-1930" ]
+        distros: [ "debezium-tf-2326" ]
     skip_build: true
     manual_trigger: true
     labels:
       - oracle
-      - oracle-logminer
-      - oracle-infinispan
-    tf_extra_params:
-      test:
-        tmt:
-          name: oracle
-      environments:
-        - variables:
-            ORACLE_VERSION: 19.3.0
-            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-infinispan-buffer -pl debezium-connector-oracle"
-            TEST_PROFILE: oracle
-
-  ###############################################################################################
-  - job: tests
-    trigger: pull_request
-    # Suffix for job name
-    identifier: "oracle-19-ehcache"
-    targets:
-      centos-stream-8-x86_64:
-        distros: [ "debezium-tf-1930" ]
-    skip_build: true
-    manual_trigger: true
-    labels:
-      - oracle
-      - oracle-logminer
-      - oracle-ehcache
-    tf_extra_params:
-      test:
-        tmt:
-          name: oracle
-      environments:
-        - variables:
-            ORACLE_VERSION: 19.3.0
-            ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-ehcache -pl debezium-connector-oracle"
-            TEST_PROFILE: oracle
-
-  ###############################################################################################
-  - job: tests
-    trigger: pull_request
-    # Suffix for job name
-    identifier: "oracle-19-se"
-    targets:
-      centos-stream-8-x86_64:
-        distros: [ "debezium-tf-1930-se" ]
-    skip_build: true
-    manual_trigger: true
-    labels:
-      - oracle
+      - oracle-26
       - oracle-logminer
     tf_extra_params:
       test:
@@ -435,22 +467,24 @@ jobs:
           name: oracle
       environments:
         - variables:
-            ORACLE_VERSION: 19.3.0-se
+            ORACLE_VERSION: 23.26.1
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-26 -pl debezium-connector-oracle"
             TEST_PROFILE: oracle
 
   ###############################################################################################
   - job: tests
     trigger: pull_request
     # Suffix for job name
-    identifier: "oracle-19-se-xs"
+    identifier: "oracle-26-xs"
     targets:
       centos-stream-8-x86_64:
-        distros: [ "debezium-tf-1930-se-xs" ]
+        distros: [ "debezium-tf-2326-xs" ]
     skip_build: true
     manual_trigger: true
     labels:
       - oracle
+      - oracle-26
       - oracle-xstream
     tf_extra_params:
       test:
@@ -458,7 +492,7 @@ jobs:
           name: oracle
       environments:
         - variables:
-            ORACLE_VERSION: 19.3.0-se-xs
+            ORACLE_VERSION: 23.26.1-xs
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-26,oracle-xstream -pl debezium-connector-oracle"
             TEST_PROFILE: oracle
-            ORACLE_ARG: "-Poracle-xstream"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -469,7 +469,7 @@ jobs:
         - variables:
             ORACLE_VERSION: 23.26.1
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-26 -pl debezium-connector-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-26"
             TEST_PROFILE: oracle
 
   ###############################################################################################
@@ -494,5 +494,6 @@ jobs:
         - variables:
             ORACLE_VERSION: 23.26.1-xs
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-26,oracle-xstream -pl debezium-connector-oracle"
+            ORACLE_PROFILE_ARGS: "-Poracle-26,oracle-xstream"
+            ORACLE_ARG: "-Poracle-xstream,oracle-26"
             TEST_PROFILE: oracle

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc11</artifactId>
+            <version>${version.oracle.driver}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -452,6 +453,7 @@
                 <dependency>
                     <groupId>com.oracle.instantclient</groupId>
                     <artifactId>xstreams</artifactId>
+                    <version>${version.oracle.instantclient}</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -925,7 +925,18 @@
             <properties>
                 <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
                 <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
-                <oracle.image>container-registry.oracle.com/database/free:23.26.0.0</oracle.image>
+            </properties>
+        </profile>
+        <profile>
+            <id>oracle-free</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
+                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
+                <oracle.image.name>container-registry.oracle.com/database/free</oracle.image.name>
+                <oracle.image.version>23.26.0.0</oracle.image.version>
             </properties>
             <build>
                 <plugins>
@@ -955,7 +966,7 @@
                             <imagePullPolicy>IfNotPresent</imagePullPolicy>
                             <images>
                                 <image>
-                                    <name>${oracle.image}</name>
+                                    <name>${oracle.image.name}:${oracle.image.version}</name>
                                     <alias>oracle</alias>
                                     <run>
                                         <ports>
@@ -966,7 +977,7 @@
                                             <ENABLE_ARCHIVELOG>true</ENABLE_ARCHIVELOG>
                                         </env>
                                         <log>
-                                            <prefix>oracle26</prefix>
+                                            <prefix>oracle</prefix>
                                             <enabled>true</enabled>
                                             <color>blue</color>
                                         </log>
@@ -976,7 +987,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/src/test/docker/23.26.0.0:/opt/oracle/scripts/startup</volume>
+                                                <volume>${project.basedir}/src/test/docker/${oracle.image.version}:/opt/oracle/scripts/startup</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -339,6 +339,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                 }
                 eventSource.getXsOut().setProcessedLowWatermark(
                         message.position.getRawPosition(),
+                        message.position.getRawPosition(),
                         XStreamOut.DEFAULT_MODE);
             }
             else if (message.scn != null) {
@@ -346,6 +347,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                     LOGGER.debug("Recording position with SCN {}", message.scn);
                 }
                 eventSource.getXsOut().setProcessedLowWatermark(
+                        message.scn,
                         message.scn,
                         XStreamOut.DEFAULT_MODE);
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -203,6 +203,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         return e.getErrorCode() == 26653
                 || e.getErrorCode() == 23656
                 || e.getErrorCode() == 26928
+                || e.getErrorCode() == 26812 // An active session currently attached to XStream server
                 || e.getMessage().contains("did not start properly and is currently in state")
                 || e.getMessage().contains("Timeout occurred while starting XStream process")
                 || e.getMessage().contains("Unable to communicate with XStream apply coordinator process");


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1836

## Description
* Removes Oracle 21c XStream test job (always ran too long)
* Introduces LogMiner and XStream 26ai (23.26.1) packit jobs
* Move `oracle-26` profile to `oracle-free` (for community users)
* Introduce a dedicated `oracle-26` profile like the other Oracle profiles
* Two new pre-baked images have been pushed to quay.io `23.26.1` and `23.26.1-xs`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
