### PR TITLE
debezium/dbz#579 Handle LOB_WRITE/LOB_TRIM/LOB_ERASE events in XStream adapter

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -829,3 +829,4 @@ Dana Stott
 Davyd Eliosidze
 梁嘉成
 林石培
+Yaroslav Perventsev

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -14,6 +14,7 @@ Ahmed Rachid Hazourli
 Aidas
 Akshansh Jain
 Akshat Sapra
+Akshat Sapra
 Akshath Patkar
 Akula
 Alberto Martino
@@ -112,10 +113,12 @@ Bertrand Paquet
 Bhagyashree Goyal
 Bhumika Bayani
 bhuvan-somisetty
+bhuvan-somisetty
 Biel Garau Estarellas
 Bin Li
 Binayak Das
 Bingqin Zhou
+Björn Bärtschi
 Björn Bärtschi
 Björn Häuser
 Björn Ångbäck
@@ -211,6 +214,7 @@ Dennis Persson
 Derek Moore
 Dhrubajyoti G
 dingqianwen
+dingqianwen
 Divyansh Agrawal
 Divyanshu Kumar
 Dmitry Volontyr
@@ -246,6 +250,7 @@ Erlend Hamnaberg
 Ethan Zou
 Eugene Abramchuk
 Ewen Cheslack-Postava
+exgoya
 exgoya
 Ezer Karavani
 Fabian Aussems
@@ -414,6 +419,7 @@ Julien Roy
 Jun Du
 Jun Wang
 Jun Zhao
+Junsu Lee
 Junsu Lee
 Jure Kajzer
 Justin Hiza
@@ -642,6 +648,7 @@ Rainer Schamm
 Rajender Passi
 Rajendra Dangwal
 Raju Surarapu
+Raju Surarapu
 Ram Satish
 Ramesh Reddy
 Randall Hauch
@@ -733,6 +740,7 @@ Siddhant Agnihotry
 Siddhant Chaturvedi
 SiuFay
 skdus531
+skdus531
 Snigdhajyoti Ghosh
 Sreedev R
 Stanislav Deviatov
@@ -751,7 +759,9 @@ Sujal Shrestha
 Sumit Jha
 Sun Xiao Jian
 Sundong Kim
+Sundong Kim
 Sungho Hwang
+Surya Dhaneshwar
 Surya Dhaneshwar
 Syed Muhammad Sufyian
 Sylvain Marty
@@ -776,6 +786,7 @@ Tim Patterson
 Timo Roeseler
 Timo Schmidt
 Timo Wilhelm
+Timur Rakhmatullin
 Timur Rakhmatullin
 Tin Nguyen
 tisonkun
@@ -843,6 +854,7 @@ yangrong688
 yangsanity
 Yanjie Wang
 Yannick Eisenschmidt
+Yaroslav Perventsev
 Yashashree Chopada
 Yashi Srivastava
 Yauheni Ramanovich

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1063,6 +1063,15 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return pdbName;
     }
 
+    /**
+     * Returns {@code true} when the connector is configured against a pluggable database
+     * (CDB+PDB), i.e. {@link #getPdbName()} is set. Useful at call sites that need to
+     * conditionally switch a session to the PDB before issuing user-table queries.
+     */
+    public boolean isUsingPluggableDatabase() {
+        return !Strings.isNullOrBlank(pdbName);
+    }
+
     public String getCatalogName() {
         return pdbName != null ? pdbName : databaseName;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1066,6 +1066,15 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return pdbName;
     }
 
+    /**
+     * Returns {@code true} when the connector is configured against a pluggable database
+     * (CDB+PDB), i.e. {@link #getPdbName()} is set. Useful at call sites that need to
+     * conditionally switch a session to the PDB before issuing user-table queries.
+     */
+    public boolean isUsingPluggableDatabase() {
+        return !Strings.isNullOrBlank(pdbName);
+    }
+
     public String getCatalogName() {
         return pdbName != null ? pdbName : databaseName;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -327,11 +327,25 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     /**
+     * Pins the streaming JDBC connection's session to the configured PDB, when the
+     * connector is configured against a CDB+PDB topology. Called once after construction
+     * and before any LCRs are processed, while the connection is already active from the
+     * upstream XStream attach. The reconnect branch in {@link #getConnection()} re-pins
+     * the session if the underlying connection has to be reopened later (e.g. after an
+     * Oracle restart).
+     */
+    void init() throws SQLException {
+        if (connectorConfig.isUsingPluggableDatabase()) {
+            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        }
+    }
+
+    /**
      * Returns the streaming JDBC connection ready for an out-of-bands query against the
      * captured database. Reconnects the underlying connection if it is currently
-     * disconnected (e.g. after an Oracle restart) and pins the session to the configured
-     * PDB on (re)connection. Reused across out-of-bands callbacks (DDL fetch, LOB
-     * reselect) so we don't open and tear down a JDBC connection per LCR.
+     * disconnected (e.g. after an Oracle restart) and re-pins the session to the
+     * configured PDB on reconnection. Reused across out-of-bands callbacks (DDL fetch,
+     * LOB reselect) so we don't open and tear down a JDBC connection per LCR.
      *
      * <p>The connection is dedicated to the XStream change-event source — the snapshot
      * phase has its own connection — so swapping its session to a PDB once is safe.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -63,7 +63,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final boolean tablenameCaseInsensitive;
     private final XstreamStreamingChangeEventSource eventSource;
     private final XStreamStreamingChangeEventSourceMetrics streamingMetrics;
-    private final OracleConnection jdbcConnection;
     private final Map<String, ChunkColumnValues> columnChunks;
     private RowLCR currentRow;
 
@@ -71,8 +70,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                     EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
                     OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
                     boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
-                    XStreamStreamingChangeEventSourceMetrics streamingMetrics,
-                    OracleConnection jdbcConnection) {
+                    XStreamStreamingChangeEventSourceMetrics streamingMetrics) {
         this.connectorConfig = connectorConfig;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
@@ -83,7 +81,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         this.tablenameCaseInsensitive = tablenameCaseInsensitive;
         this.eventSource = eventSource;
         this.streamingMetrics = streamingMetrics;
-        this.jdbcConnection = jdbcConnection;
         this.columnChunks = new LinkedHashMap<>();
     }
 
@@ -456,7 +453,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
      * fallback logic with the {@code ReselectColumnsPostProcessor} path.
      */
     private void reselectLobValues(RowLCR row, Table table, Map<String, Object> chunkValues) {
-        if (chunkValues.isEmpty() || jdbcConnection == null) {
+        if (chunkValues.isEmpty()) {
             return;
         }
 
@@ -501,12 +498,20 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
         final List<String> lobColumnNames = new ArrayList<>(chunkValues.keySet());
 
-        try {
+        // Use a separate, short-lived connection for the reselect — pinned to the PDB the
+        // table lives in. The streaming JDBC connection cannot be reused: it is bound to
+        // the CDB root in CDB+PDB deployments and would not see the user table. This
+        // mirrors getTableMetadataDdl above and BaseChangeRecordEmitter's reselect path.
+        final String pdbName = connectorConfig.getPdbName();
+        try (OracleConnection connection = new OracleConnection(connectorConfig, false)) {
+            if (!Strings.isNullOrBlank(pdbName)) {
+                connection.setSessionToPdb(pdbName);
+            }
             // reselectColumns advances the ResultSet cursor internally before invoking
             // the consumer, so we read column values directly without calling rs.next().
             // A return of `false` means no matching row was found — typically the row
             // was deleted between the LCR emission and our reselect.
-            final boolean found = jdbcConnection.reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
+            final boolean found = connection.reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
                 for (String colName : lobColumnNames) {
                     final Column column = table.columnWithName(colName);
                     if (column == null) {
@@ -533,10 +538,14 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             }
         }
         catch (SQLException e) {
-            LOGGER.warn("Failed to reselect LOB values for table {} (tx={}, scn={}, rowId={}): {}. "
-                    + "Emitting partial chunk data.",
-                    table.id(), row.getTransactionId(), offsetContext.getScn(),
-                    row.getAttribute("ROW_ID"), e.getMessage());
+            // Match BaseChangeRecordEmitter.emitUpdateAsPrimaryKeyChangeRecord — surface
+            // the failure rather than emit partial chunk data with UNAVAILABLE_VALUE
+            // placeholders. A silent fallback masks real configuration problems
+            // (wrong PDB, missing privileges, table not yet visible) and produces
+            // wire records that fail downstream assertions in non-obvious ways.
+            throw new DebeziumException("Failed to reselect LOB values for table " + table.id()
+                    + " (tx=" + row.getTransactionId() + ", scn=" + offsetContext.getScn()
+                    + ", rowId=" + row.getAttribute("ROW_ID") + ")", e);
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -5,23 +5,21 @@
  */
 package io.debezium.connector.oracle.xstream;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.OracleConnection;
-import io.debezium.data.Envelope.Operation;
 import io.debezium.connector.oracle.OracleConnection.NonRelationalTableException;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
@@ -30,6 +28,7 @@ import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleSchemaChangeEventEmitter;
 import io.debezium.connector.oracle.OracleValueConverters;
 import io.debezium.connector.oracle.xstream.XstreamStreamingChangeEventSource.PositionAndScn;
+import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.relational.Column;
@@ -39,6 +38,7 @@ import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 
 import oracle.streams.ChunkColumnValue;
+import oracle.streams.ColumnValue;
 import oracle.streams.DDLLCR;
 import oracle.streams.DefaultRowLCR;
 import oracle.streams.LCR;
@@ -68,20 +68,18 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final XStreamStreamingChangeEventSourceMetrics streamingMetrics;
     private final OracleConnection jdbcConnection;
     private final Map<String, ChunkColumnValues> columnChunks;
-    // Track INSERT operations per ROW_ID+txId so that LOB_WRITE/LOB_TRIM following an INSERT
-    // can be correctly mapped to Operation.CREATE instead of Operation.UPDATE (DBZ-4741).
-    // Key: "ROW_ID|transactionId", cleared on COMMIT.
-    private final Map<String, Boolean> pendingInsertRows;
+    // DBZ-4741: track INSERTs in the *current* transaction only so that
+    // LOB_WRITE / LOB_TRIM / LOB_ERASE events that belong to that same
+    // transaction can be mapped to Operation.CREATE (the LOB data is part
+    // of the INSERT from the user's point of view, not a later UPDATE).
+    // We deliberately scope by the active transaction id instead of a
+    // global Map<rowId+txId,..> so the state is self-evicting: as soon as
+    // we observe an LCR from a different transaction, the set is cleared,
+    // even if the COMMIT LCR for the previous transaction was not
+    // received (e.g. if XStream delivered them out of order).
+    private String currentTxId;
+    private final Set<String> currentTxnInsertedRowIds = new HashSet<>();
     private RowLCR currentRow;
-
-    LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
-                    EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
-                    OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
-                    boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
-                    XStreamStreamingChangeEventSourceMetrics streamingMetrics) {
-        this(connectorConfig, errorHandler, dispatcher, clock, schema, partition, offsetContext,
-                tablenameCaseInsensitive, eventSource, streamingMetrics, null);
-    }
 
     LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
                     EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
@@ -101,7 +99,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         this.streamingMetrics = streamingMetrics;
         this.jdbcConnection = jdbcConnection;
         this.columnChunks = new LinkedHashMap<>();
-        this.pendingInsertRows = new HashMap<>();
     }
 
     @Override
@@ -156,56 +153,17 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private void processRowLCR(RowLCR row) throws InterruptedException {
-        // Track INSERT operations so LOB_WRITE/LOB_TRIM following an INSERT for the same row
-        // can be correctly mapped to Operation.CREATE instead of Operation.UPDATE.
-        // For large LOBs, XStream delivers: INSERT LCR, then LOB_WRITE LCR(s) with the data.
+        // Observe transaction boundaries and track per-txn INSERTs so LOB ops
+        // that share a txId with a tracked INSERT (i.e. the LOB data for the
+        // INSERT, delivered as separate chunks by XStream) emit Operation.CREATE
+        // rather than Operation.UPDATE.
+        resetTxScopeIfNewTransaction(row);
         if (RowLCR.INSERT.equals(row.getCommandType())) {
             final Object rowId = row.getAttribute("ROW_ID");
             if (rowId != null) {
-                final String key = rowId.toString() + "|" + row.getTransactionId();
-                pendingInsertRows.put(key, Boolean.TRUE);
+                currentTxnInsertedRowIds.add(rowId.toString());
                 LOGGER.trace("Tracking INSERT for row {} in tx {}", rowId, row.getTransactionId());
             }
-        }
-
-        // Handle LOB WRITE, LOB TRIM, and LOB ERASE as DML operations (DBZ-4741).
-        // These are emitted by DBMS_LOB.WRITE/WRITEAPPEND/TRIM/ERASE calls.
-        // LOB_WRITE with chunks: cache row, process chunks, then re-read full LOB value.
-        // LOB_TRIM/LOB_ERASE without chunks: re-read LOB value directly and dispatch.
-        if (row.getCommandType().equals(RowLCR.LOB_WRITE)
-                || row.getCommandType().equals(RowLCR.LOB_TRIM)
-                || row.getCommandType().equals(RowLCR.LOB_ERASE)) {
-            if (row.hasChunkData()) {
-                LOGGER.debug("Processing {} for table '{}' as UPDATE with chunk data.",
-                        row.getCommandType(), row.getObjectName());
-                currentRow = row;
-            }
-            else {
-                // LOB_TRIM (and rarely LOB_WRITE) without chunk data: dispatch immediately.
-                // Re-read the LOB value directly from the database to get the trimmed value.
-                LOGGER.debug("Processing {} without chunk data for table '{}', re-reading LOB and dispatching.",
-                        row.getCommandType(), row.getObjectName());
-                if (jdbcConnection != null) {
-                    // Build chunkValues with LOB columns for the re-read
-                    TableId tableId = getTableId(row);
-                    Table table = schema.tableFor(tableId);
-                    if (table != null) {
-                        Map<String, Object> lobValues = new HashMap<>();
-                        for (Column column : schema.getLobColumnsForTable(table.id())) {
-                            lobValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
-                        }
-                        reselectLobValues(row, lobValues);
-                        dispatchDataChangeEvent(row, lobValues);
-                    }
-                    else {
-                        dispatchDataChangeEvent(row, null);
-                    }
-                }
-                else {
-                    dispatchDataChangeEvent(row, null);
-                }
-            }
-            return;
         }
 
         if (row.hasChunkData()) {
@@ -224,9 +182,12 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         LOGGER.debug("Processing DML event {}", lcr);
 
         if (RowLCR.COMMIT.equals(lcr.getCommandType())) {
-            // Clear pending INSERT tracking on COMMIT — LOB operations in subsequent
-            // transactions should not be mapped to CREATE.
-            pendingInsertRows.clear();
+            // Clear per-txn INSERT tracking on COMMIT so it doesn't carry over into
+            // subsequent transactions. resetTxScopeIfNewTransaction() (invoked at
+            // the top of processRowLCR and below) is the belt-and-braces case for
+            // when the COMMIT is missed or arrives out of order.
+            currentTxnInsertedRowIds.clear();
+            currentTxId = null;
             final Instant commitTimestamp = lcr.getSourceTime().timestampValue().toInstant();
             dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, commitTimestamp);
             return;
@@ -304,25 +265,34 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             }
         }
 
+        // For LOB_WRITE/LOB_TRIM/LOB_ERASE, the chunk stream (if any) only carries the partial
+        // delta written by DBMS_LOB, not the full post-operation value. Reselect against the
+        // current row so downstream consumers see a consistent full LOB state. Gated on these
+        // specific command types so regular DML is not slowed down — callers who want
+        // per-DML reselection continue to use ReselectColumnsPostProcessor.
+        if (RowLCR.LOB_WRITE.equals(lcr.getCommandType())
+                || RowLCR.LOB_TRIM.equals(lcr.getCommandType())
+                || RowLCR.LOB_ERASE.equals(lcr.getCommandType())) {
+            reselectLobValues(lcr, table, chunkValues);
+        }
+
         final Object rowIdObject = lcr.getAttribute("ROW_ID");
         if (rowIdObject != null) {
             offsetContext.setRowId(rowIdObject.toString());
         }
 
         // Determine operation override for LOB events following an INSERT.
-        // If LOB_WRITE/LOB_TRIM/LOB_ERASE follows an INSERT for the same row+tx,
-        // the operation should be CREATE (not UPDATE) since the LOB data is part of the INSERT.
+        // If LOB_WRITE/LOB_TRIM/LOB_ERASE shares a transaction with a tracked INSERT
+        // of the same row, the operation is logically part of the INSERT — emit CREATE.
         Operation operationOverride = null;
         if (RowLCR.LOB_WRITE.equals(lcr.getCommandType())
                 || RowLCR.LOB_TRIM.equals(lcr.getCommandType())
                 || RowLCR.LOB_ERASE.equals(lcr.getCommandType())) {
-            if (rowIdObject != null) {
-                final String key = rowIdObject.toString() + "|" + lcr.getTransactionId();
-                if (pendingInsertRows.containsKey(key)) {
-                    operationOverride = Operation.CREATE;
-                    LOGGER.debug("LOB operation {} for row {} follows INSERT, mapping to CREATE",
-                            lcr.getCommandType(), rowIdObject);
-                }
+            resetTxScopeIfNewTransaction(lcr);
+            if (rowIdObject != null && currentTxnInsertedRowIds.contains(rowIdObject.toString())) {
+                operationOverride = Operation.CREATE;
+                LOGGER.debug("LOB op {} for row {} follows tracked INSERT in same tx — mapping to CREATE",
+                        lcr.getCommandType(), rowIdObject);
             }
         }
         dispatcher.dispatchDataChangeEvent(
@@ -507,16 +477,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
             columnChunks.clear();
 
-            // DBZ-4741: For LOB_WRITE/LOB_TRIM/LOB_ERASE, the chunk data contains only the partial
-            // delta written by DBMS_LOB.WRITE/WRITEAPPEND/TRIM/ERASE, not the full LOB value.
-            // Re-read the full LOB value from the source database directly.
-            if (jdbcConnection != null && currentRow != null
-                    && (RowLCR.LOB_WRITE.equals(currentRow.getCommandType())
-                        || RowLCR.LOB_TRIM.equals(currentRow.getCommandType())
-                        || RowLCR.LOB_ERASE.equals(currentRow.getCommandType()))) {
-                reselectLobValues(currentRow, resolvedChunkValues);
-            }
-
             dispatchDataChangeEvent(currentRow, resolvedChunkValues);
         }
         catch (InterruptedException e) {
@@ -529,103 +489,121 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     /**
-     * Re-reads full LOB column values from the source database for LOB WRITE/TRIM events.
-     * This replaces the partial chunk data with the complete current LOB value.
-     * Only called for LOB_WRITE/LOB_TRIM operations, not for regular DML — this avoids
-     * the performance overhead of ReselectColumnsPostProcessor firing on every event.
+     * Re-reads full LOB column values from the source database for
+     * {@code LOB_WRITE} / {@code LOB_TRIM} / {@code LOB_ERASE} events and
+     * overwrites the corresponding entries in {@code chunkValues}.
+     *
+     * <p>The chunk data XStream delivers for these operations is only the
+     * partial delta passed to {@code DBMS_LOB.WRITE} / {@code WRITEAPPEND}
+     * / {@code TRIM} / {@code ERASE}, not the full post-operation LOB
+     * value. Reselecting against the current row is the only way to
+     * materialize a consistent full value for downstream consumers.
+     *
+     * <p>Delegates to {@link OracleConnection#reselectColumns} so this path
+     * shares the existing SQL builder, identifier quoting, and flashback
+     * fallback logic with the {@code ReselectColumnsPostProcessor} path.
      */
-    private void reselectLobValues(RowLCR row, Map<String, Object> chunkValues) {
-        if (chunkValues.isEmpty()) {
+    private void reselectLobValues(RowLCR row, Table table, Map<String, Object> chunkValues) {
+        if (chunkValues.isEmpty() || jdbcConnection == null) {
             return;
         }
 
-        final TableId tableId = getTableId(row);
-        final Table table = schema.tableFor(tableId);
-        if (table == null) {
-            LOGGER.warn("Cannot reselect LOB values: table {} not found in schema.", tableId);
-            return;
-        }
-
-        // Get primary key columns
         final List<String> pkColumns = table.primaryKeyColumnNames();
         if (pkColumns.isEmpty()) {
-            LOGGER.warn("Cannot reselect LOB values for table {}: no primary key defined.", tableId);
+            LOGGER.warn("Cannot reselect LOB values for table {}: no primary key defined "
+                    + "(tx={}, scn={}, rowId={}).",
+                    table.id(), row.getTransactionId(), offsetContext.getScn(),
+                    row.getAttribute("ROW_ID"));
             return;
         }
 
-        // Get PK values from the LCR's new values
-        final Map<String, Object> pkValues = new LinkedHashMap<>();
+        // PK values: prefer newValues, fall back to oldValues for any that are missing.
+        final Map<String, Object> pkValuesMap = new LinkedHashMap<>();
         if (row.getNewValues() != null) {
-            for (oracle.streams.ColumnValue cv : row.getNewValues()) {
+            for (ColumnValue cv : row.getNewValues()) {
                 if (pkColumns.contains(cv.getColumnName())) {
-                    pkValues.put(cv.getColumnName(), cv.getColumnData());
+                    pkValuesMap.put(cv.getColumnName(), cv.getColumnData());
                 }
             }
         }
-        // Fall back to old values if PK not in new values
-        if (pkValues.size() < pkColumns.size() && row.getOldValues() != null) {
-            for (oracle.streams.ColumnValue cv : row.getOldValues()) {
-                if (pkColumns.contains(cv.getColumnName()) && !pkValues.containsKey(cv.getColumnName())) {
-                    pkValues.put(cv.getColumnName(), cv.getColumnData());
+        if (pkValuesMap.size() < pkColumns.size() && row.getOldValues() != null) {
+            for (ColumnValue cv : row.getOldValues()) {
+                if (pkColumns.contains(cv.getColumnName())
+                        && !pkValuesMap.containsKey(cv.getColumnName())) {
+                    pkValuesMap.put(cv.getColumnName(), cv.getColumnData());
                 }
             }
         }
-
-        if (pkValues.size() < pkColumns.size()) {
-            LOGGER.warn("Cannot reselect LOB values for table {}: incomplete primary key in LCR.", tableId);
+        if (pkValuesMap.size() < pkColumns.size()) {
+            LOGGER.warn("Cannot reselect LOB values for table {}: incomplete primary key in LCR "
+                    + "(tx={}, scn={}, rowId={}).",
+                    table.id(), row.getTransactionId(), offsetContext.getScn(),
+                    row.getAttribute("ROW_ID"));
             return;
         }
 
-        // Build SELECT for each LOB column
-        final String lobColumns = String.join(", ", chunkValues.keySet());
-        final String whereClause = pkColumns.stream()
-                .map(pk -> pk + " = ?")
-                .collect(Collectors.joining(" AND "));
-        final String sql = String.format("SELECT %s FROM %s.%s WHERE %s",
-                lobColumns, row.getObjectOwner(), row.getObjectName(), whereClause);
+        final List<Object> pkValues = new ArrayList<>(pkColumns.size());
+        for (String pkColumn : pkColumns) {
+            pkValues.add(pkValuesMap.get(pkColumn));
+        }
+
+        final List<String> lobColumnNames = new ArrayList<>(chunkValues.keySet());
 
         try {
-            LOGGER.debug("Reselecting LOB values for {} {} with SQL: {}", row.getCommandType(), tableId, sql);
-            Connection conn = jdbcConnection.connection();
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                int idx = 1;
-                for (String pkCol : pkColumns) {
-                    Object val = pkValues.get(pkCol);
-                    ps.setObject(idx++, val);
-                }
-
-                try (ResultSet rs = ps.executeQuery()) {
-                    if (rs.next()) {
-                        for (String colName : chunkValues.keySet()) {
-                            Column column = table.columnWithName(colName);
-                            if (column != null) {
-                                int jdbcType = column.jdbcType();
-                                // Read as String for CLOB/NCLOB/XMLTYPE, byte[] for BLOB
-                                if (jdbcType == java.sql.Types.BLOB) {
-                                    byte[] blobVal = rs.getBytes(colName);
-                                    if (blobVal != null) {
-                                        chunkValues.put(colName, blobVal);
-                                        LOGGER.debug("Reselected BLOB column {} ({} bytes)", colName, blobVal.length);
-                                    }
-                                }
-                                else {
-                                    String strVal = rs.getString(colName);
-                                    if (strVal != null) {
-                                        chunkValues.put(colName, strVal);
-                                        LOGGER.debug("Reselected CLOB/XMLTYPE column {} ({} chars)", colName, strVal.length());
-                                    }
-                                }
-                            }
+            // reselectColumns advances the ResultSet cursor internally before invoking
+            // the consumer, so we read column values directly without calling rs.next().
+            // A return of `false` means no matching row was found — typically the row
+            // was deleted between the LCR emission and our reselect.
+            final boolean found = jdbcConnection.reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
+                for (String colName : lobColumnNames) {
+                    final Column column = table.columnWithName(colName);
+                    if (column == null) {
+                        continue;
+                    }
+                    if (column.jdbcType() == java.sql.Types.BLOB) {
+                        final byte[] blobVal = rs.getBytes(colName);
+                        if (blobVal != null) {
+                            chunkValues.put(colName, blobVal);
                         }
                     }
                     else {
-                        LOGGER.warn("Reselect for {} returned no rows (row may have been deleted).", tableId);
+                        final String strVal = rs.getString(colName);
+                        if (strVal != null) {
+                            chunkValues.put(colName, strVal);
+                        }
                     }
                 }
+            });
+            if (!found) {
+                LOGGER.warn("Reselect for table {} returned no rows — the row may have been deleted "
+                        + "between the LCR and the reselect (tx={}, scn={}, rowId={}).",
+                        table.id(), row.getTransactionId(), offsetContext.getScn(),
+                        row.getAttribute("ROW_ID"));
             }
         }
         catch (SQLException e) {
-            LOGGER.warn("Failed to reselect LOB values for table {}: {}. Using partial chunk data.", tableId, e.getMessage());
+            LOGGER.warn("Failed to reselect LOB values for table {} (tx={}, scn={}, rowId={}): {}. "
+                    + "Emitting partial chunk data.",
+                    table.id(), row.getTransactionId(), offsetContext.getScn(),
+                    row.getAttribute("ROW_ID"), e.getMessage());
+        }
+    }
+
+    /**
+     * If {@code lcr} belongs to a different transaction from the last one
+     * we observed, drop the per-transaction INSERT tracking state. Called
+     * defensively on every LCR so the tracking set never carries rows
+     * across a transaction boundary — even if the COMMIT LCR for the
+     * previous transaction wasn't delivered or was processed out of order.
+     */
+    private void resetTxScopeIfNewTransaction(LCR lcr) {
+        final String txId = lcr.getTransactionId();
+        if (txId == null) {
+            return;
+        }
+        if (!txId.equals(currentTxId)) {
+            currentTxId = txId;
+            currentTxnInsertedRowIds.clear();
         }
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -512,17 +512,16 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                     if (column == null) {
                         continue;
                     }
+                    // Always overwrite — including with null — so a column whose row truly
+                    // holds NULL is reported as null, not as the UNAVAILABLE_VALUE placeholder
+                    // that was pre-seeded in chunkValues. (Without this, a multi-LOB row whose
+                    // LOB op only touched one column would emit the unavailable marker for the
+                    // others.)
                     if (column.jdbcType() == java.sql.Types.BLOB) {
-                        final byte[] blobVal = rs.getBytes(colName);
-                        if (blobVal != null) {
-                            chunkValues.put(colName, blobVal);
-                        }
+                        chunkValues.put(colName, rs.getBytes(colName));
                     }
                     else {
-                        final String strVal = rs.getString(colName);
-                        if (strVal != null) {
-                            chunkValues.put(colName, strVal);
-                        }
+                        chunkValues.put(colName, rs.getString(colName));
                     }
                 }
             });

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -5,17 +5,23 @@
  */
 package io.debezium.connector.oracle.xstream;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.data.Envelope.Operation;
 import io.debezium.connector.oracle.OracleConnection.NonRelationalTableException;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
@@ -60,7 +66,12 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final boolean tablenameCaseInsensitive;
     private final XstreamStreamingChangeEventSource eventSource;
     private final XStreamStreamingChangeEventSourceMetrics streamingMetrics;
+    private final OracleConnection jdbcConnection;
     private final Map<String, ChunkColumnValues> columnChunks;
+    // Track INSERT operations per ROW_ID+txId so that LOB_WRITE/LOB_TRIM following an INSERT
+    // can be correctly mapped to Operation.CREATE instead of Operation.UPDATE (DBZ-4741).
+    // Key: "ROW_ID|transactionId", cleared on COMMIT.
+    private final Map<String, Boolean> pendingInsertRows;
     private RowLCR currentRow;
 
     LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
@@ -68,6 +79,16 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                     OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
                     boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
                     XStreamStreamingChangeEventSourceMetrics streamingMetrics) {
+        this(connectorConfig, errorHandler, dispatcher, clock, schema, partition, offsetContext,
+                tablenameCaseInsensitive, eventSource, streamingMetrics, null);
+    }
+
+    LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
+                    EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
+                    OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
+                    boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
+                    XStreamStreamingChangeEventSourceMetrics streamingMetrics,
+                    OracleConnection jdbcConnection) {
         this.connectorConfig = connectorConfig;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
@@ -78,7 +99,9 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         this.tablenameCaseInsensitive = tablenameCaseInsensitive;
         this.eventSource = eventSource;
         this.streamingMetrics = streamingMetrics;
+        this.jdbcConnection = jdbcConnection;
         this.columnChunks = new LinkedHashMap<>();
+        this.pendingInsertRows = new HashMap<>();
     }
 
     @Override
@@ -133,9 +156,55 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private void processRowLCR(RowLCR row) throws InterruptedException {
-        if (row.getCommandType().equals(RowLCR.LOB_ERASE)) {
-            LOGGER.warn("LOB_ERASE for table '{}' is not supported, "
-                    + "use DML operations to manipulate LOB columns only.", row.getObjectName());
+        // Track INSERT operations so LOB_WRITE/LOB_TRIM following an INSERT for the same row
+        // can be correctly mapped to Operation.CREATE instead of Operation.UPDATE.
+        // For large LOBs, XStream delivers: INSERT LCR, then LOB_WRITE LCR(s) with the data.
+        if (RowLCR.INSERT.equals(row.getCommandType())) {
+            final Object rowId = row.getAttribute("ROW_ID");
+            if (rowId != null) {
+                final String key = rowId.toString() + "|" + row.getTransactionId();
+                pendingInsertRows.put(key, Boolean.TRUE);
+                LOGGER.trace("Tracking INSERT for row {} in tx {}", rowId, row.getTransactionId());
+            }
+        }
+
+        // Handle LOB WRITE, LOB TRIM, and LOB ERASE as DML operations (DBZ-4741).
+        // These are emitted by DBMS_LOB.WRITE/WRITEAPPEND/TRIM/ERASE calls.
+        // LOB_WRITE with chunks: cache row, process chunks, then re-read full LOB value.
+        // LOB_TRIM/LOB_ERASE without chunks: re-read LOB value directly and dispatch.
+        if (row.getCommandType().equals(RowLCR.LOB_WRITE)
+                || row.getCommandType().equals(RowLCR.LOB_TRIM)
+                || row.getCommandType().equals(RowLCR.LOB_ERASE)) {
+            if (row.hasChunkData()) {
+                LOGGER.debug("Processing {} for table '{}' as UPDATE with chunk data.",
+                        row.getCommandType(), row.getObjectName());
+                currentRow = row;
+            }
+            else {
+                // LOB_TRIM (and rarely LOB_WRITE) without chunk data: dispatch immediately.
+                // Re-read the LOB value directly from the database to get the trimmed value.
+                LOGGER.debug("Processing {} without chunk data for table '{}', re-reading LOB and dispatching.",
+                        row.getCommandType(), row.getObjectName());
+                if (jdbcConnection != null) {
+                    // Build chunkValues with LOB columns for the re-read
+                    TableId tableId = getTableId(row);
+                    Table table = schema.tableFor(tableId);
+                    if (table != null) {
+                        Map<String, Object> lobValues = new HashMap<>();
+                        for (Column column : schema.getLobColumnsForTable(table.id())) {
+                            lobValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
+                        }
+                        reselectLobValues(row, lobValues);
+                        dispatchDataChangeEvent(row, lobValues);
+                    }
+                    else {
+                        dispatchDataChangeEvent(row, null);
+                    }
+                }
+                else {
+                    dispatchDataChangeEvent(row, null);
+                }
+            }
             return;
         }
 
@@ -155,6 +224,9 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         LOGGER.debug("Processing DML event {}", lcr);
 
         if (RowLCR.COMMIT.equals(lcr.getCommandType())) {
+            // Clear pending INSERT tracking on COMMIT — LOB operations in subsequent
+            // transactions should not be mapped to CREATE.
+            pendingInsertRows.clear();
             final Instant commitTimestamp = lcr.getSourceTime().timestampValue().toInstant();
             dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, commitTimestamp);
             return;
@@ -204,12 +276,9 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             }
         }
 
-        // Xstream does not provide any before state for LOB columns and so this map will be
-        // populated here by column name with the OracleValueConverters.UNAVAILABLE_VALUE.
         Map<String, Object> oldChunkValues = new HashMap<>(0);
 
         if (chunkValues == null) {
-            // Happens when dispatching an LCR without any chunk data.
             chunkValues = new HashMap<>(0);
         }
 
@@ -222,9 +291,11 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         // So in either case, the values need to be serialized here such that any LOB column that
         // is not explicitly provided in the map is initialized with the unavailable value
         // marker object so its transformed correctly by the value converters.
+        // Note: For LOB_WRITE/LOB_TRIM/LOB_ERASE events, reselectLobValues() replaces
+        // the unavailable markers with actual LOB values read from the database.
 
         for (Column column : schema.getLobColumnsForTable(table.id())) {
-            // again Xstream doesn't supply before state for LOB values; explicitly use unavailable value
+            // Xstream doesn't supply before state for LOB values; explicitly use unavailable value
             oldChunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
             if (!chunkValues.containsKey(column.name())) {
                 // Column not supplied, initialize with unavailable value marker
@@ -238,6 +309,22 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             offsetContext.setRowId(rowIdObject.toString());
         }
 
+        // Determine operation override for LOB events following an INSERT.
+        // If LOB_WRITE/LOB_TRIM/LOB_ERASE follows an INSERT for the same row+tx,
+        // the operation should be CREATE (not UPDATE) since the LOB data is part of the INSERT.
+        Operation operationOverride = null;
+        if (RowLCR.LOB_WRITE.equals(lcr.getCommandType())
+                || RowLCR.LOB_TRIM.equals(lcr.getCommandType())
+                || RowLCR.LOB_ERASE.equals(lcr.getCommandType())) {
+            if (rowIdObject != null) {
+                final String key = rowIdObject.toString() + "|" + lcr.getTransactionId();
+                if (pendingInsertRows.containsKey(key)) {
+                    operationOverride = Operation.CREATE;
+                    LOGGER.debug("LOB operation {} for row {} follows INSERT, mapping to CREATE",
+                            lcr.getCommandType(), rowIdObject);
+                }
+            }
+        }
         dispatcher.dispatchDataChangeEvent(
                 partition,
                 tableId,
@@ -250,7 +337,8 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                         chunkValues,
                         schema.tableFor(tableId),
                         schema,
-                        clock));
+                        clock,
+                        operationOverride));
     }
 
     private void dispatchSchemaChangeEvent(DDLLCR ddlLcr) throws InterruptedException {
@@ -418,6 +506,17 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             }
 
             columnChunks.clear();
+
+            // DBZ-4741: For LOB_WRITE/LOB_TRIM/LOB_ERASE, the chunk data contains only the partial
+            // delta written by DBMS_LOB.WRITE/WRITEAPPEND/TRIM/ERASE, not the full LOB value.
+            // Re-read the full LOB value from the source database directly.
+            if (jdbcConnection != null && currentRow != null
+                    && (RowLCR.LOB_WRITE.equals(currentRow.getCommandType())
+                        || RowLCR.LOB_TRIM.equals(currentRow.getCommandType())
+                        || RowLCR.LOB_ERASE.equals(currentRow.getCommandType()))) {
+                reselectLobValues(currentRow, resolvedChunkValues);
+            }
+
             dispatchDataChangeEvent(currentRow, resolvedChunkValues);
         }
         catch (InterruptedException e) {
@@ -426,6 +525,107 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         }
         catch (SQLException e) {
             throw new DebeziumException("Failed to process chunk data", e);
+        }
+    }
+
+    /**
+     * Re-reads full LOB column values from the source database for LOB WRITE/TRIM events.
+     * This replaces the partial chunk data with the complete current LOB value.
+     * Only called for LOB_WRITE/LOB_TRIM operations, not for regular DML — this avoids
+     * the performance overhead of ReselectColumnsPostProcessor firing on every event.
+     */
+    private void reselectLobValues(RowLCR row, Map<String, Object> chunkValues) {
+        if (chunkValues.isEmpty()) {
+            return;
+        }
+
+        final TableId tableId = getTableId(row);
+        final Table table = schema.tableFor(tableId);
+        if (table == null) {
+            LOGGER.warn("Cannot reselect LOB values: table {} not found in schema.", tableId);
+            return;
+        }
+
+        // Get primary key columns
+        final List<String> pkColumns = table.primaryKeyColumnNames();
+        if (pkColumns.isEmpty()) {
+            LOGGER.warn("Cannot reselect LOB values for table {}: no primary key defined.", tableId);
+            return;
+        }
+
+        // Get PK values from the LCR's new values
+        final Map<String, Object> pkValues = new LinkedHashMap<>();
+        if (row.getNewValues() != null) {
+            for (oracle.streams.ColumnValue cv : row.getNewValues()) {
+                if (pkColumns.contains(cv.getColumnName())) {
+                    pkValues.put(cv.getColumnName(), cv.getColumnData());
+                }
+            }
+        }
+        // Fall back to old values if PK not in new values
+        if (pkValues.size() < pkColumns.size() && row.getOldValues() != null) {
+            for (oracle.streams.ColumnValue cv : row.getOldValues()) {
+                if (pkColumns.contains(cv.getColumnName()) && !pkValues.containsKey(cv.getColumnName())) {
+                    pkValues.put(cv.getColumnName(), cv.getColumnData());
+                }
+            }
+        }
+
+        if (pkValues.size() < pkColumns.size()) {
+            LOGGER.warn("Cannot reselect LOB values for table {}: incomplete primary key in LCR.", tableId);
+            return;
+        }
+
+        // Build SELECT for each LOB column
+        final String lobColumns = String.join(", ", chunkValues.keySet());
+        final String whereClause = pkColumns.stream()
+                .map(pk -> pk + " = ?")
+                .collect(Collectors.joining(" AND "));
+        final String sql = String.format("SELECT %s FROM %s.%s WHERE %s",
+                lobColumns, row.getObjectOwner(), row.getObjectName(), whereClause);
+
+        try {
+            LOGGER.debug("Reselecting LOB values for {} {} with SQL: {}", row.getCommandType(), tableId, sql);
+            Connection conn = jdbcConnection.connection();
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                int idx = 1;
+                for (String pkCol : pkColumns) {
+                    Object val = pkValues.get(pkCol);
+                    ps.setObject(idx++, val);
+                }
+
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        for (String colName : chunkValues.keySet()) {
+                            Column column = table.columnWithName(colName);
+                            if (column != null) {
+                                int jdbcType = column.jdbcType();
+                                // Read as String for CLOB/NCLOB/XMLTYPE, byte[] for BLOB
+                                if (jdbcType == java.sql.Types.BLOB) {
+                                    byte[] blobVal = rs.getBytes(colName);
+                                    if (blobVal != null) {
+                                        chunkValues.put(colName, blobVal);
+                                        LOGGER.debug("Reselected BLOB column {} ({} bytes)", colName, blobVal.length);
+                                    }
+                                }
+                                else {
+                                    String strVal = rs.getString(colName);
+                                    if (strVal != null) {
+                                        chunkValues.put(colName, strVal);
+                                        LOGGER.debug("Reselected CLOB/XMLTYPE column {} ({} chars)", colName, strVal.length());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        LOGGER.warn("Reselect for {} returned no rows (row may have been deleted).", tableId);
+                    }
+                }
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Failed to reselect LOB values for table {}: {}. Using partial chunk data.", tableId, e.getMessage());
         }
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -9,11 +9,9 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +26,6 @@ import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleSchemaChangeEventEmitter;
 import io.debezium.connector.oracle.OracleValueConverters;
 import io.debezium.connector.oracle.xstream.XstreamStreamingChangeEventSource.PositionAndScn;
-import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.relational.Column;
@@ -68,17 +65,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final XStreamStreamingChangeEventSourceMetrics streamingMetrics;
     private final OracleConnection jdbcConnection;
     private final Map<String, ChunkColumnValues> columnChunks;
-    // DBZ-4741: track INSERTs in the *current* transaction only so that
-    // LOB_WRITE / LOB_TRIM / LOB_ERASE events that belong to that same
-    // transaction can be mapped to Operation.CREATE (the LOB data is part
-    // of the INSERT from the user's point of view, not a later UPDATE).
-    // We deliberately scope by the active transaction id instead of a
-    // global Map<rowId+txId,..> so the state is self-evicting: as soon as
-    // we observe an LCR from a different transaction, the set is cleared,
-    // even if the COMMIT LCR for the previous transaction was not
-    // received (e.g. if XStream delivered them out of order).
-    private String currentTxId;
-    private final Set<String> currentTxnInsertedRowIds = new HashSet<>();
     private RowLCR currentRow;
 
     LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
@@ -153,19 +139,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private void processRowLCR(RowLCR row) throws InterruptedException {
-        // Observe transaction boundaries and track per-txn INSERTs so LOB ops
-        // that share a txId with a tracked INSERT (i.e. the LOB data for the
-        // INSERT, delivered as separate chunks by XStream) emit Operation.CREATE
-        // rather than Operation.UPDATE.
-        resetTxScopeIfNewTransaction(row);
-        if (RowLCR.INSERT.equals(row.getCommandType())) {
-            final Object rowId = row.getAttribute("ROW_ID");
-            if (rowId != null) {
-                currentTxnInsertedRowIds.add(rowId.toString());
-                LOGGER.trace("Tracking INSERT for row {} in tx {}", rowId, row.getTransactionId());
-            }
-        }
-
         if (row.hasChunkData()) {
             // If the row has chunk data, the RowLCR cannot be immediately dispatched.
             // The handler needs to cache the current row and wait for the chunks to be delivered before
@@ -182,12 +155,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         LOGGER.debug("Processing DML event {}", lcr);
 
         if (RowLCR.COMMIT.equals(lcr.getCommandType())) {
-            // Clear per-txn INSERT tracking on COMMIT so it doesn't carry over into
-            // subsequent transactions. resetTxScopeIfNewTransaction() (invoked at
-            // the top of processRowLCR and below) is the belt-and-braces case for
-            // when the COMMIT is missed or arrives out of order.
-            currentTxnInsertedRowIds.clear();
-            currentTxId = null;
             final Instant commitTimestamp = lcr.getSourceTime().timestampValue().toInstant();
             dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, commitTimestamp);
             return;
@@ -281,20 +248,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             offsetContext.setRowId(rowIdObject.toString());
         }
 
-        // Determine operation override for LOB events following an INSERT.
-        // If LOB_WRITE/LOB_TRIM/LOB_ERASE shares a transaction with a tracked INSERT
-        // of the same row, the operation is logically part of the INSERT — emit CREATE.
-        Operation operationOverride = null;
-        if (RowLCR.LOB_WRITE.equals(lcr.getCommandType())
-                || RowLCR.LOB_TRIM.equals(lcr.getCommandType())
-                || RowLCR.LOB_ERASE.equals(lcr.getCommandType())) {
-            resetTxScopeIfNewTransaction(lcr);
-            if (rowIdObject != null && currentTxnInsertedRowIds.contains(rowIdObject.toString())) {
-                operationOverride = Operation.CREATE;
-                LOGGER.debug("LOB op {} for row {} follows tracked INSERT in same tx — mapping to CREATE",
-                        lcr.getCommandType(), rowIdObject);
-            }
-        }
         dispatcher.dispatchDataChangeEvent(
                 partition,
                 tableId,
@@ -307,8 +260,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                         chunkValues,
                         schema.tableFor(tableId),
                         schema,
-                        clock,
-                        operationOverride));
+                        clock));
     }
 
     private void dispatchSchemaChangeEvent(DDLLCR ddlLcr) throws InterruptedException {
@@ -589,21 +541,4 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         }
     }
 
-    /**
-     * If {@code lcr} belongs to a different transaction from the last one
-     * we observed, drop the per-transaction INSERT tracking state. Called
-     * defensively on every LCR so the tracking set never carries rows
-     * across a transaction boundary — even if the COMMIT LCR for the
-     * previous transaction wasn't delivered or was processed out of order.
-     */
-    private void resetTxScopeIfNewTransaction(LCR lcr) {
-        final String txId = lcr.getTransactionId();
-        if (txId == null) {
-            return;
-        }
-        if (!txId.equals(currentTxId)) {
-            currentTxId = txId;
-            currentTxnInsertedRowIds.clear();
-        }
-    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -32,7 +32,6 @@ import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 import oracle.streams.ChunkColumnValue;
 import oracle.streams.ColumnValue;
@@ -63,6 +62,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final boolean tablenameCaseInsensitive;
     private final XstreamStreamingChangeEventSource eventSource;
     private final XStreamStreamingChangeEventSourceMetrics streamingMetrics;
+    private final OracleConnection jdbcConnection;
     private final Map<String, ChunkColumnValues> columnChunks;
     private RowLCR currentRow;
 
@@ -70,7 +70,8 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                     EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
                     OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
                     boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
-                    XStreamStreamingChangeEventSourceMetrics streamingMetrics) {
+                    XStreamStreamingChangeEventSourceMetrics streamingMetrics,
+                    OracleConnection jdbcConnection) {
         this.connectorConfig = connectorConfig;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
@@ -81,6 +82,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         this.tablenameCaseInsensitive = tablenameCaseInsensitive;
         this.eventSource = eventSource;
         this.streamingMetrics = streamingMetrics;
+        this.jdbcConnection = jdbcConnection;
         this.columnChunks = new LinkedHashMap<>();
     }
 
@@ -316,18 +318,34 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
     private String getTableMetadataDdl(TableId tableId) throws NonRelationalTableException {
         LOGGER.info("Getting database metadata for table '{}'", tableId);
-        final String pdbName = connectorConfig.getPdbName();
-        // A separate connection must be used for this out-of-bands query while processing the Xstream callback.
-        // This should have negligible overhead as this should happen rarely.
-        try (OracleConnection connection = new OracleConnection(connectorConfig, false)) {
-            if (!Strings.isNullOrBlank(pdbName)) {
-                connection.setSessionToPdb(pdbName);
-            }
-            return connection.getTableMetadataDdl(tableId);
+        try {
+            return getConnection().getTableMetadataDdl(tableId);
         }
         catch (SQLException e) {
             throw new DebeziumException("Failed to get table DDL metadata for: " + tableId, e);
         }
+    }
+
+    /**
+     * Returns the streaming JDBC connection ready for an out-of-bands query against the
+     * captured database. Reconnects the underlying connection if it is currently
+     * disconnected (e.g. after an Oracle restart) and pins the session to the configured
+     * PDB on (re)connection. Reused across out-of-bands callbacks (DDL fetch, LOB
+     * reselect) so we don't open and tear down a JDBC connection per LCR.
+     *
+     * <p>The connection is dedicated to the XStream change-event source — the snapshot
+     * phase has its own connection — so swapping its session to a PDB once is safe.
+     * Future downstream-mining-DB support can extend this helper to manage a separate
+     * source-side connection.
+     */
+    private OracleConnection getConnection() throws SQLException {
+        if (!jdbcConnection.isConnected()) {
+            jdbcConnection.connect();
+            if (connectorConfig.isUsingPluggableDatabase()) {
+                jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+            }
+        }
+        return jdbcConnection;
     }
 
     private void setWatermark() {
@@ -498,24 +516,24 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
         final List<String> lobColumnNames = new ArrayList<>(chunkValues.keySet());
 
-        // Use a separate, short-lived connection for the reselect — pinned to the PDB the
-        // table lives in. The streaming JDBC connection cannot be reused: it is bound to
-        // the CDB root in CDB+PDB deployments and would not see the user table. This
-        // mirrors getTableMetadataDdl above and BaseChangeRecordEmitter's reselect path.
-        final String pdbName = connectorConfig.getPdbName();
-        try (OracleConnection connection = new OracleConnection(connectorConfig, false)) {
-            if (!Strings.isNullOrBlank(pdbName)) {
-                connection.setSessionToPdb(pdbName);
-            }
+        try {
             // reselectColumns advances the ResultSet cursor internally before invoking
             // the consumer, so we read column values directly without calling rs.next().
             // A return of `false` means no matching row was found — typically the row
             // was deleted between the LCR emission and our reselect.
-            final boolean found = connection.reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
+            final boolean found = getConnection().reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
                 for (String colName : lobColumnNames) {
                     final Column column = table.columnWithName(colName);
                     if (column == null) {
-                        continue;
+                        // The lobColumnNames list comes from chunkValues, which was populated
+                        // earlier in dispatchDataChangeEvent from schema.getLobColumnsForTable(table.id())
+                        // — i.e. columns of the same Table we're using here. A null lookup
+                        // means our schema view is internally inconsistent; fail loudly so the
+                        // root cause surfaces instead of emitting partial-but-passing data.
+                        throw new DebeziumException("Schema cache for table " + table.id()
+                                + " does not include LOB column '" + colName
+                                + "' that was registered for reselection (tx=" + row.getTransactionId()
+                                + ", scn=" + offsetContext.getScn() + ").");
                     }
                     // Always overwrite — including with null — so a column whose row truly
                     // holds NULL is reported as null, not as the UNAVAILABLE_VALUE placeholder

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.oracle.xstream;
 
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -327,38 +328,13 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     /**
-     * Pins the streaming JDBC connection's session to the configured PDB, when the
-     * connector is configured against a CDB+PDB topology. Called once after construction
-     * and before any LCRs are processed, while the connection is already active from the
-     * upstream XStream attach. The reconnect branch in {@link #getConnection()} re-pins
-     * the session if the underlying connection has to be reopened later (e.g. after an
-     * Oracle restart).
+     * Returns the shared out-of-bands JDBC connection (DDL fetch, LOB reselect). The
+     * connection targets the primary/source database and its PDB session pinning is
+     * managed by {@code XstreamStreamingChangeEventSource#pinConnectionToPdb()} — both
+     * at streaming start and again after a blocking snapshot, whose close() resets the
+     * shared session back to {@code CDB$ROOT}.
      */
-    void init() throws SQLException {
-        if (connectorConfig.isUsingPluggableDatabase()) {
-            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
-        }
-    }
-
-    /**
-     * Returns the streaming JDBC connection ready for an out-of-bands query against the
-     * captured database. Reconnects the underlying connection if it is currently
-     * disconnected (e.g. after an Oracle restart) and re-pins the session to the
-     * configured PDB on reconnection. Reused across out-of-bands callbacks (DDL fetch,
-     * LOB reselect) so we don't open and tear down a JDBC connection per LCR.
-     *
-     * <p>The connection is dedicated to the XStream change-event source — the snapshot
-     * phase has its own connection — so swapping its session to a PDB once is safe.
-     * Future downstream-mining-DB support can extend this helper to manage a separate
-     * source-side connection.
-     */
-    private OracleConnection getConnection() throws SQLException {
-        if (!jdbcConnection.isConnected()) {
-            jdbcConnection.connect();
-            if (connectorConfig.isUsingPluggableDatabase()) {
-                jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
-            }
-        }
+    private OracleConnection getConnection() {
         return jdbcConnection;
     }
 
@@ -535,33 +511,47 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             // the consumer, so we read column values directly without calling rs.next().
             // A return of `false` means no matching row was found — typically the row
             // was deleted between the LCR emission and our reselect.
-            final boolean found = getConnection().reselectColumns(table, lobColumnNames, pkColumns, pkValues, null, rs -> {
-                for (String colName : lobColumnNames) {
-                    final Column column = table.columnWithName(colName);
-                    if (column == null) {
-                        // The lobColumnNames list comes from chunkValues, which was populated
-                        // earlier in dispatchDataChangeEvent from schema.getLobColumnsForTable(table.id())
-                        // — i.e. columns of the same Table we're using here. A null lookup
-                        // means our schema view is internally inconsistent; fail loudly so the
-                        // root cause surfaces instead of emitting partial-but-passing data.
-                        throw new DebeziumException("Schema cache for table " + table.id()
-                                + " does not include LOB column '" + colName
-                                + "' that was registered for reselection (tx=" + row.getTransactionId()
-                                + ", scn=" + offsetContext.getScn() + ").");
-                    }
-                    // Always overwrite — including with null — so a column whose row truly
-                    // holds NULL is reported as null, not as the UNAVAILABLE_VALUE placeholder
-                    // that was pre-seeded in chunkValues. (Without this, a multi-LOB row whose
-                    // LOB op only touched one column would emit the unavailable marker for the
-                    // others.)
-                    if (column.jdbcType() == java.sql.Types.BLOB) {
-                        chunkValues.put(colName, rs.getBytes(colName));
-                    }
-                    else {
-                        chunkValues.put(colName, rs.getString(colName));
-                    }
-                }
-            });
+            //
+            // Passing the event's source info enables the flashback "AS OF SCN" query
+            // (keyed on commit_scn, set by processLCR before we get here) so the
+            // reselect observes the row as of this event rather than its latest state,
+            // matching the LogMiner reselect semantics. OracleConnection falls back to
+            // a plain query on ORA-01555/ORA-01466.
+            final OracleConnection connection = getConnection();
+            final boolean found = connection.reselectColumns(table, lobColumnNames, pkColumns, pkValues,
+                    offsetContext.getSourceInfo(), rs -> {
+                        for (int i = 0; i < lobColumnNames.size(); i++) {
+                            final String colName = lobColumnNames.get(i);
+                            final Column column = table.columnWithName(colName);
+                            if (column == null) {
+                                // The lobColumnNames list comes from chunkValues, which was populated
+                                // earlier in dispatchDataChangeEvent from schema.getLobColumnsForTable(table.id())
+                                // — i.e. columns of the same Table we're using here. A null lookup
+                                // means our schema view is internally inconsistent; fail loudly so the
+                                // root cause surfaces instead of emitting partial-but-passing data.
+                                throw new DebeziumException("Schema cache for table " + table.id()
+                                        + " does not include LOB column '" + colName
+                                        + "' that was registered for reselection (tx=" + row.getTransactionId()
+                                        + ", scn=" + offsetContext.getScn() + ").");
+                            }
+                            // Always overwrite — including with null — so a column whose row truly
+                            // holds NULL is reported as null, not as the UNAVAILABLE_VALUE placeholder
+                            // that was pre-seeded in chunkValues. (Without this, a multi-LOB row whose
+                            // LOB op only touched one column would emit the unavailable marker for the
+                            // others.)
+                            if (column.jdbcType() == Types.BLOB) {
+                                // Materialize immediately: a Blob locator's validity is tied to the
+                                // session state, while these values are converted at dispatch time.
+                                chunkValues.put(colName, rs.getBytes(i + 1));
+                            }
+                            else {
+                                // Delegate to the Oracle-specific column rules (JSON, XMLTYPE,
+                                // temporal types) so this path stays consistent with the snapshot
+                                // reads and ReselectColumnsPostProcessor.
+                                chunkValues.put(colName, connection.getColumnValue(rs, i + 1, column, table));
+                            }
+                        }
+                    });
             if (!found) {
                 LOGGER.warn("Reselect for table {} returned no rows — the row may have been deleted "
                         + "between the LCR and the reselect (tx={}, scn={}, rowId={}).",

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -27,23 +27,38 @@ import oracle.streams.RowLCR;
 public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnValue> {
 
     private final RowLCR lcr;
+    private final Operation operationOverride;
 
     public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
                                       Table table, OracleDatabaseSchema schema, Clock clock) {
+        this(connectorConfig, partition, offset, lcr, oldChunkValues, newChunkValues, table, schema, clock, null);
+    }
+
+    public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
+                                      Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
+                                      Table table, OracleDatabaseSchema schema, Clock clock,
+                                      Operation operationOverride) {
         super(connectorConfig, partition, offset, schema, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
                 getColumnValues(table, lcr.getNewValues(), newChunkValues));
         this.lcr = lcr;
+        this.operationOverride = operationOverride;
     }
 
     @Override
     public Operation getOperation() {
+        if (operationOverride != null) {
+            return operationOverride;
+        }
         switch (lcr.getCommandType()) {
             case RowLCR.INSERT:
                 return Operation.CREATE;
             case RowLCR.DELETE:
                 return Operation.DELETE;
             case RowLCR.UPDATE:
+            case RowLCR.LOB_WRITE:
+            case RowLCR.LOB_TRIM:
+            case RowLCR.LOB_ERASE:
                 return Operation.UPDATE;
             case "TRUNCATE TABLE":
                 return Operation.TRUNCATE;
@@ -56,10 +71,6 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
         Object[] values = new Object[table.columns().size()];
         if (columnValues != null) {
             for (ColumnValue columnValue : columnValues) {
-                // Skip Oracle ROW_ARCHIVAL column
-                if ("ORA_ARCHIVE_STATE".equals(columnValue.getColumnName())) {
-                    continue;
-                }
                 int index = table.columnWithName(columnValue.getColumnName()).position() - 1;
                 values[index] = columnValue.getColumnData();
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -27,23 +27,55 @@ import oracle.streams.RowLCR;
 public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnValue> {
 
     private final RowLCR lcr;
-    private final Operation operationOverride;
 
     public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
-                                      Table table, OracleDatabaseSchema schema, Clock clock,
-                                      Operation operationOverride) {
-        super(connectorConfig, partition, offset, schema, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
-                getColumnValues(table, lcr.getNewValues(), newChunkValues));
+                                      Table table, OracleDatabaseSchema schema, Clock clock) {
+        super(connectorConfig, partition, offset, schema, table, clock,
+                buildOldColumnValues(table, lcr, oldChunkValues, newChunkValues),
+                buildNewColumnValues(table, lcr, newChunkValues));
         this.lcr = lcr;
-        this.operationOverride = operationOverride;
+    }
+
+    private static Object[] buildNewColumnValues(Table table, RowLCR lcr, Map<String, Object> newChunkValues) {
+        // For LOB_WRITE/LOB_TRIM/LOB_ERASE, Oracle XStream typically carries only the LOB
+        // column in newValues; the primary key and other unchanged columns live in oldValues.
+        // Merge oldValues as a baseline so those columns are populated in the emitted record.
+        if (isLobOperation(lcr)) {
+            return mergeColumnValues(table, lcr.getOldValues(), lcr.getNewValues(), newChunkValues);
+        }
+        return getColumnValues(table, lcr.getNewValues(), newChunkValues);
+    }
+
+    private static Object[] buildOldColumnValues(Table table, RowLCR lcr, Map<String, Object> oldChunkValues,
+                                                 Map<String, Object> newChunkValues) {
+        // For LOB ops, oldValues from XStream is typically empty (no PK, no other columns).
+        // If we build old-state from oldValues alone, the emitted oldKey has a null primary key
+        // while newKey has the real PK, triggering Debezium's PK-change-update path which emits
+        // a DELETE + CREATE pair (op=c) instead of a regular UPDATE (op=u).
+        //
+        // Since LOB operations don't change non-LOB columns, reuse the merged new-state values
+        // as a baseline and overlay oldChunkValues (UNAVAILABLE_VALUE markers) so the `before`
+        // payload correctly reports the LOB columns as unavailable without claiming they held
+        // the post-op value.
+        if (isLobOperation(lcr)) {
+            Object[] values = mergeColumnValues(table, lcr.getOldValues(), lcr.getNewValues(), newChunkValues);
+            for (Map.Entry<String, Object> entry : oldChunkValues.entrySet()) {
+                final int index = table.columnWithName(entry.getKey()).position() - 1;
+                values[index] = entry.getValue();
+            }
+            return values;
+        }
+        return getColumnValues(table, lcr.getOldValues(), oldChunkValues);
+    }
+
+    private static boolean isLobOperation(RowLCR lcr) {
+        final String cmd = lcr.getCommandType();
+        return RowLCR.LOB_WRITE.equals(cmd) || RowLCR.LOB_TRIM.equals(cmd) || RowLCR.LOB_ERASE.equals(cmd);
     }
 
     @Override
     public Operation getOperation() {
-        if (operationOverride != null) {
-            return operationOverride;
-        }
         switch (lcr.getCommandType()) {
             case RowLCR.INSERT:
                 return Operation.CREATE;
@@ -63,16 +95,7 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
 
     private static Object[] getColumnValues(Table table, ColumnValue[] columnValues, Map<String, Object> chunkValues) {
         Object[] values = new Object[table.columns().size()];
-        if (columnValues != null) {
-            for (ColumnValue columnValue : columnValues) {
-                // Skip Oracle ROW_ARCHIVAL column
-                if ("ORA_ARCHIVE_STATE".equals(columnValue.getColumnName())) {
-                    continue;
-                }
-                int index = table.columnWithName(columnValue.getColumnName()).position() - 1;
-                values[index] = columnValue.getColumnData();
-            }
-        }
+        overlayColumnValues(values, table, columnValues);
 
         // Overlay chunk values into non-chunk value array
         for (Map.Entry<String, Object> entry : chunkValues.entrySet()) {
@@ -81,5 +104,38 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
         }
 
         return values;
+    }
+
+    /**
+     * Builds the new-state values array for a LOB_WRITE/LOB_TRIM/LOB_ERASE LCR.
+     * Uses {@code oldValues} as a baseline (so primary-key and other unchanged
+     * columns are populated) and overlays {@code newValues} (the LOB column(s)
+     * the operation actually modified) plus any reselected LOB values carried
+     * in {@code chunkValues}.
+     */
+    private static Object[] mergeColumnValues(Table table, ColumnValue[] oldValues,
+                                              ColumnValue[] newValues, Map<String, Object> chunkValues) {
+        Object[] values = new Object[table.columns().size()];
+        overlayColumnValues(values, table, oldValues);
+        overlayColumnValues(values, table, newValues);
+        for (Map.Entry<String, Object> entry : chunkValues.entrySet()) {
+            final int index = table.columnWithName(entry.getKey()).position() - 1;
+            values[index] = entry.getValue();
+        }
+        return values;
+    }
+
+    private static void overlayColumnValues(Object[] values, Table table, ColumnValue[] columnValues) {
+        if (columnValues == null) {
+            return;
+        }
+        for (ColumnValue columnValue : columnValues) {
+            // Skip Oracle ROW_ARCHIVAL column
+            if ("ORA_ARCHIVE_STATE".equals(columnValue.getColumnName())) {
+                continue;
+            }
+            int index = table.columnWithName(columnValue.getColumnName()).position() - 1;
+            values[index] = columnValue.getColumnData();
+        }
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -31,12 +31,6 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
 
     public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
-                                      Table table, OracleDatabaseSchema schema, Clock clock) {
-        this(connectorConfig, partition, offset, lcr, oldChunkValues, newChunkValues, table, schema, clock, null);
-    }
-
-    public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
-                                      Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
                                       Table table, OracleDatabaseSchema schema, Clock clock,
                                       Operation operationOverride) {
         super(connectorConfig, partition, offset, schema, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
@@ -71,6 +65,10 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
         Object[] values = new Object[table.columns().size()];
         if (columnValues != null) {
             for (ColumnValue columnValue : columnValues) {
+                // Skip Oracle ROW_ARCHIVAL column
+                if ("ORA_ARCHIVE_STATE".equals(columnValue.getColumnName())) {
+                    continue;
+                }
                 int index = table.columnWithName(columnValue.getColumnName()).position() - 1;
                 values[index] = columnValue.getColumnData();
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -106,7 +106,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
                 partition, offsetContext,
                 TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection)),
-                this, streamingMetrics, jdbcConnection);
+                this, streamingMetrics);
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(jdbcConnection.config(), getStartPosition(offsetContext))) {
             try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -106,7 +106,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
                 partition, offsetContext,
                 TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection)),
-                this, streamingMetrics);
+                this, streamingMetrics, jdbcConnection);
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(jdbcConnection.config(), getStartPosition(offsetContext))) {
             try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -110,6 +110,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(jdbcConnection.config(), getStartPosition(offsetContext))) {
             try {
+                eventHandler.init();
                 // 2. receive events while running
                 while (context.isRunning()) {
                     LOGGER.trace("Receiving LCR");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -116,6 +116,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
             try {
+                eventHandler.init();
                 // 2. receive events while running
                 while (context.isRunning()) {
                     LOGGER.trace("Receiving LCR");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -112,7 +112,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.effectiveOffset = offsetContext;
 
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
-                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics, jdbcConnection);
+                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics);
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
             try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -112,7 +112,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.effectiveOffset = offsetContext;
 
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
-                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics);
+                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics, jdbcConnection);
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
             try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -112,7 +112,8 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.effectiveOffset = offsetContext;
 
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
-                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics, jdbcConnection);
+                partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics,
+                connectionFactory.streamingConnectionFactory().mainConnection());
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
             try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -111,13 +111,18 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
 
         this.effectiveOffset = offsetContext;
 
+        // The out-of-bands connection (DDL fetch, LOB reselect) must always target the
+        // primary/source database. In downstream and standby capture modes the streaming
+        // factory's main connection points at the mining or standby instance, where the
+        // captured tables do not exist; snapshotConnectionFactory() resolves to the
+        // primary in all factory implementations.
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
                 partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics,
-                connectionFactory.streamingConnectionFactory().mainConnection());
+                connectionFactory.snapshotConnectionFactory().mainConnection());
 
         try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
             try {
-                eventHandler.init();
+                pinConnectionToPdb();
                 // 2. receive events while running
                 while (context.isRunning()) {
                     LOGGER.trace("Receiving LCR");
@@ -130,6 +135,10 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
                         LOGGER.info("Streaming will now pause");
                         context.streamingPaused();
                         context.waitSnapshotCompletion();
+                        // The blocking snapshot shares the same main connection and its
+                        // close() resets the session back to CDB$ROOT; re-pin to the PDB
+                        // before processing any further LCRs.
+                        pinConnectionToPdb();
                         LOGGER.info("Streaming resumed");
                     }
                 }
@@ -178,6 +187,19 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
                     streamingMetrics);
         }
         return Optional.of(offsetActivityMonitor);
+    }
+
+    /**
+     * Pins the shared out-of-bands JDBC connection's session to the configured PDB when
+     * the connector is configured against a CDB+PDB topology. Must be called before the
+     * receive loop starts and again after a blocking snapshot completes, because
+     * {@code OracleSnapshotChangeEventSource#close()} resets the shared connection's
+     * session back to {@code CDB$ROOT}.
+     */
+    private void pinConnectionToPdb() {
+        if (connectorConfig.isUsingPluggableDatabase()) {
+            connectionFactory.snapshotConnectionFactory().mainConnection().setSessionToPdb(connectorConfig.getPdbName());
+        }
     }
 
     private boolean isTableCaseInsensitive() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -899,7 +899,7 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor({ "DBZ-2948", "DBZ-5773" })
-    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.OLR, reason = "OpenLogReplicator does not differentiate between LOB operations")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "DBZ-4741 enables LOB_ERASE propagation for XStream; OLR handled by its own test")
     public void shouldNotStreamAnyChangesWhenLobEraseIsDetected() throws Exception {
         String ddl = "CREATE TABLE BLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1004,6 +1004,162 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
         assertThat(after.get("VAL_BLOB")).isEqualTo(getUnavailableValuePlaceholder(config));
 
         assertNoRecordsToConsume();
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_WRITE re-reads BLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobWriteAppend() throws Exception {
+        String ddl = "CREATE TABLE BLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_BLOB blob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.blob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        // Insert with a known BLOB value.
+        Blob initial = createBlob(part(BIN_DATA, 0, 8000));
+        connection.prepareQuery("INSERT INTO debezium.blob_test values (1, ?)", p -> p.setBlob(1, initial), null);
+        connection.commit();
+
+        // Consume (and discard) the insert record.
+        consumeRecordsByTopic(1);
+
+        // WRITEAPPEND 4 KB of additional bytes. XStream emits LOB_WRITE LCRs; the
+        // adapter should re-read the full BLOB and surface an UPDATE with the new value.
+        final byte[] appended = new byte[]{ 0x41, 0x42, 0x43, 0x44 };
+        connection.prepareQuery(
+                "DECLARE loc BLOB; BEGIN "
+                        + "  SELECT VAL_BLOB INTO loc FROM BLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.OPEN(loc, DBMS_LOB.LOB_READWRITE); "
+                        + "  DBMS_LOB.WRITEAPPEND(loc, ?, ?); "
+                        + "  DBMS_LOB.CLOSE(loc); "
+                        + "END;",
+                p -> { p.setInt(1, appended.length); p.setBytes(2, appended); },
+                null);
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        // Full post-append value should be surfaced via reselect, not the 4-byte chunk
+        // that DBMS_LOB.WRITEAPPEND actually sent.
+        byte[] expected = Arrays.copyOf(part(BIN_DATA, 0, 8000), 8000 + appended.length);
+        System.arraycopy(appended, 0, expected, 8000, appended.length);
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_BLOB")).isEqualTo(ByteBuffer.wrap(expected));
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_TRIM re-reads BLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobTrim() throws Exception {
+        String ddl = "CREATE TABLE BLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_BLOB blob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.blob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        Blob initial = createBlob(part(BIN_DATA, 0, 8000));
+        connection.prepareQuery("INSERT INTO debezium.blob_test values (1, ?)", p -> p.setBlob(1, initial), null);
+        connection.commit();
+        consumeRecordsByTopic(1); // discard INSERT
+
+        // Trim the BLOB to the first 5000 bytes. XStream emits LOB_TRIM with no chunk data;
+        // the adapter should reselect and emit an UPDATE whose value reflects the truncated BLOB.
+        connection.execute(
+                "DECLARE loc BLOB; BEGIN "
+                        + "  SELECT VAL_BLOB INTO loc FROM BLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.TRIM(loc, 5000); "
+                        + "END;");
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_BLOB")).isEqualTo(ByteBuffer.wrap(part(BIN_DATA, 0, 5000)));
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_ERASE re-reads BLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobErase() throws Exception {
+        String ddl = "CREATE TABLE BLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_BLOB blob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.blob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        Blob initial = createBlob(part(BIN_DATA, 0, 8000));
+        connection.prepareQuery("INSERT INTO debezium.blob_test values (1, ?)", p -> p.setBlob(1, initial), null);
+        connection.commit();
+        consumeRecordsByTopic(1); // discard INSERT
+
+        // ERASE 100 bytes starting at offset 1. Erased bytes are zero-filled by Oracle,
+        // so the reselected value has zeros over the affected range.
+        connection.execute(
+                "DECLARE loc BLOB; amount integer := 100; BEGIN "
+                        + "  SELECT VAL_BLOB INTO loc FROM BLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.ERASE(loc, amount, 1); "
+                        + "END;");
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        byte[] expected = Arrays.copyOf(part(BIN_DATA, 0, 8000), 8000);
+        for (int i = 0; i < 100; i++) {
+            expected[i] = 0;
+        }
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_BLOB")).isEqualTo(ByteBuffer.wrap(expected));
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -1034,7 +1034,7 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
         // Consume (and discard) the insert record.
         consumeRecordsByTopic(1);
 
-        // WRITEAPPEND 4 KB of additional bytes. XStream emits LOB_WRITE LCRs; the
+        // WRITEAPPEND 4 bytes of additional data. XStream emits LOB_WRITE LCRs; the
         // adapter should re-read the full BLOB and surface an UPDATE with the new value.
         final byte[] appended = new byte[]{ 0x41, 0x42, 0x43, 0x44 };
         connection.prepareQuery(

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIs;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenLogMiningStrategyIs;
 import io.debezium.connector.oracle.util.TestHelper;
@@ -1045,7 +1044,10 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
                         + "  DBMS_LOB.WRITEAPPEND(loc, ?, ?); "
                         + "  DBMS_LOB.CLOSE(loc); "
                         + "END;",
-                p -> { p.setInt(1, appended.length); p.setBytes(2, appended); },
+                p -> {
+                    p.setInt(1, appended.length);
+                    p.setBytes(2, appended);
+                },
                 null);
         connection.commit();
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -898,7 +898,7 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor({ "DBZ-2948", "DBZ-5773" })
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "DBZ-4741 enables LOB_ERASE propagation for XStream; OLR handled by its own test")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "LOB_ERASE is propagated as an UPDATE by XStream (debezium/dbz#579); OpenLogReplicator does not differentiate between LOB operations")
     public void shouldNotStreamAnyChangesWhenLobEraseIsDetected() throws Exception {
         String ddl = "CREATE TABLE BLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1006,8 +1006,8 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_WRITE re-reads BLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_WRITE re-reads BLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobWriteAppend() throws Exception {
         String ddl = "CREATE TABLE BLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1068,8 +1068,8 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_TRIM re-reads BLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_TRIM re-reads BLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobTrim() throws Exception {
         String ddl = "CREATE TABLE BLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1114,8 +1114,8 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_ERASE re-reads BLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_ERASE re-reads BLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobErase() throws Exception {
         String ddl = "CREATE TABLE BLOB_TEST ("
                 + "ID numeric(9,0), "

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIs;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenLogMiningStrategyIs;
 import io.debezium.connector.oracle.util.TestHelper;
@@ -1216,7 +1215,10 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
                         + "  DBMS_LOB.WRITEAPPEND(loc, ?, ?); "
                         + "  DBMS_LOB.CLOSE(loc); "
                         + "END;",
-                p -> { p.setInt(1, appended.length()); p.setString(2, appended); },
+                p -> {
+                    p.setInt(1, appended.length());
+                    p.setString(2, appended);
+                },
                 null);
         connection.commit();
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -1072,7 +1072,7 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor({ "DBZ-2948", "DBZ-5773" })
-    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.OLR, reason = "OpenLogReplicator does not differentiate between LOB operations")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "DBZ-4741 enables LOB_ERASE propagation for XStream; OLR handled by its own test")
     public void shouldNotStreamAnyChangesWhenLobEraseIsDetected() throws Exception {
         String ddl = "CREATE TABLE CLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1176,6 +1176,158 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
         assertThat(after.get("VAL_CLOB")).isEqualTo(getUnavailableValuePlaceholder(config));
 
         assertNoRecordsToConsume();
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_WRITE re-reads CLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobWriteAppend() throws Exception {
+        String ddl = "CREATE TABLE CLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_CLOB clob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.clob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        // Insert a known CLOB prefix.
+        String initial = part(JSON_DATA, 0, 8000);
+        Clob initialClob = createClob(initial);
+        connection.prepareQuery("INSERT INTO CLOB_TEST VALUES (1, ?)", p -> p.setClob(1, initialClob), null);
+        connection.commit();
+        consumeRecordsByTopic(1); // discard INSERT
+
+        // WRITEAPPEND 4 characters. XStream emits LOB_WRITE; the adapter should reselect
+        // and surface the full post-append CLOB, not the 4-character delta.
+        final String appended = "abcd";
+        connection.prepareQuery(
+                "DECLARE loc CLOB; BEGIN "
+                        + "  SELECT VAL_CLOB INTO loc FROM CLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.OPEN(loc, DBMS_LOB.LOB_READWRITE); "
+                        + "  DBMS_LOB.WRITEAPPEND(loc, ?, ?); "
+                        + "  DBMS_LOB.CLOSE(loc); "
+                        + "END;",
+                p -> { p.setInt(1, appended.length()); p.setString(2, appended); },
+                null);
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("CLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("CLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_CLOB")).isEqualTo(initial + appended);
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_TRIM re-reads CLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobTrim() throws Exception {
+        String ddl = "CREATE TABLE CLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_CLOB clob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.clob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        String initial = part(JSON_DATA, 0, 8000);
+        Clob initialClob = createClob(initial);
+        connection.prepareQuery("INSERT INTO CLOB_TEST VALUES (1, ?)", p -> p.setClob(1, initialClob), null);
+        connection.commit();
+        consumeRecordsByTopic(1); // discard INSERT
+
+        // Trim the CLOB to 5000 chars. XStream emits LOB_TRIM without chunk data;
+        // the adapter reselects and emits UPDATE with the truncated value.
+        connection.execute(
+                "DECLARE loc CLOB; BEGIN "
+                        + "  SELECT VAL_CLOB INTO loc FROM CLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.TRIM(loc, 5000); "
+                        + "END;");
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("CLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("CLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_CLOB")).isEqualTo(part(JSON_DATA, 0, 5000));
+    }
+
+    @Test
+    @FixFor("DBZ-4741")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_ERASE re-reads CLOB from source")
+    public void shouldStreamUpdateWithReselectedValueForXStreamLobErase() throws Exception {
+        String ddl = "CREATE TABLE CLOB_TEST ("
+                + "ID numeric(9,0), "
+                + "VAL_CLOB clob, "
+                + "primary key(id))";
+
+        connection.execute(ddl);
+        TestHelper.streamTable(connection, "debezium.clob_test");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        String initial = part(JSON_DATA, 0, 8000);
+        Clob initialClob = createClob(initial);
+        connection.prepareQuery("INSERT INTO CLOB_TEST VALUES (1, ?)", p -> p.setClob(1, initialClob), null);
+        connection.commit();
+        consumeRecordsByTopic(1); // discard INSERT
+
+        // ERASE 100 chars starting at offset 1. Oracle replaces erased chars with spaces
+        // in CLOBs, so the reselected value has ' ' over positions 0..99.
+        connection.execute(
+                "DECLARE loc CLOB; amount integer := 100; BEGIN "
+                        + "  SELECT VAL_CLOB INTO loc FROM CLOB_TEST WHERE ID = 1 FOR UPDATE; "
+                        + "  DBMS_LOB.ERASE(loc, amount, 1); "
+                        + "END;");
+        connection.commit();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(topicName("CLOB_TEST"))).hasSize(1);
+
+        SourceRecord record = records.recordsForTopic(topicName("CLOB_TEST")).get(0);
+        VerifyRecord.isValidUpdate(record, "ID", 1);
+
+        StringBuilder expected = new StringBuilder(initial);
+        for (int i = 0; i < 100; i++) {
+            expected.setCharAt(i, ' ');
+        }
+
+        Struct after = after(record);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("VAL_CLOB")).isEqualTo(expected.toString());
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -1071,7 +1071,7 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor({ "DBZ-2948", "DBZ-5773" })
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "DBZ-4741 enables LOB_ERASE propagation for XStream; OLR handled by its own test")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "LOB_ERASE is propagated as an UPDATE by XStream (debezium/dbz#579); OpenLogReplicator does not differentiate between LOB operations")
     public void shouldNotStreamAnyChangesWhenLobEraseIsDetected() throws Exception {
         String ddl = "CREATE TABLE CLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1178,8 +1178,8 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_WRITE re-reads CLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_WRITE re-reads CLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobWriteAppend() throws Exception {
         String ddl = "CREATE TABLE CLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1234,8 +1234,8 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_TRIM re-reads CLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_TRIM re-reads CLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobTrim() throws Exception {
         String ddl = "CREATE TABLE CLOB_TEST ("
                 + "ID numeric(9,0), "
@@ -1281,8 +1281,8 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-4741")
-    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "DBZ-4741 XStream-specific: LOB_ERASE re-reads CLOB from source")
+    @FixFor("debezium/dbz#579")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.XSTREAM, reason = "debezium/dbz#579 XStream-specific: LOB_ERASE re-reads CLOB from source")
     public void shouldStreamUpdateWithReselectedValueForXStreamLobErase() throws Exception {
         String ddl = "CREATE TABLE CLOB_TEST ("
                 + "ID numeric(9,0), "

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -372,3 +372,4 @@ rigadon,Davyd Eliosidze
 Tony N,Tony Nyurkin
 OctoberWithYou,梁嘉成
 Tlinian,林石培
+pyaroslav,Yaroslav Perventsev

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -15,6 +15,7 @@ Akhil Mohammad,Mohammad Akhil
 akhilm,Mohammad Akhil
 akshansh,Akshansh Jain
 akshat08,Akshat Sapra
+akshat08,Akshat Sapra
 akulapid,Akula
 AleksejsSibanovs,Aleksejs Sibanovs
 Alex-pvl,Aleksandr Pavlyuk
@@ -44,6 +45,7 @@ benw-at-birdie,Ben White
 bep7520,Blake Peno
 BetaCat,合龙 张
 Bhagyashree,Bhagyashree Goyal
+bhuvan-somisetty,bhuvan-somisetty
 bhuvan-somisetty,bhuvan-somisetty
 BigGillyStyle,Andy Pickler
 Binayak490-cyber,Binayak Das
@@ -289,6 +291,7 @@ prmellor,Paul Mellor
 ProofOfPizza,Chai Stofkoper
 PSanetra,Philip Sanetra
 pugarte7,Pablo Ugarte
+pyaroslav,Yaroslav Perventsev
 pypsink,Pierre-Yves Péton
 RaghavaPonnam,Raghava Ponnam
 ragulshanmugam,Ragul Shanmugam


### PR DESCRIPTION
Fixes debezium/dbz#579

## Description

Oracle XStream emits `LOB_WRITE`, `LOB_TRIM`, and `LOB_ERASE` command-type LCRs for `DBMS_LOB.WRITE / WRITEAPPEND / TRIM / ERASE` operations. The XStream adapter previously handled none of them:

- `XStreamChangeRecordEmitter.getOperation()` — `default:` branch threw `IllegalArgumentException`
- `LcrEventHandler.processRowLCR()` — `LOB_ERASE` logged a warning; `LOB_WRITE` / `LOB_TRIM` fell through unhandled

In production this surfaced as `ORA-26824: user-defined XStream callback error`, a crashed streaming task, and a stalled outbound server on any schema that uses the `DBMS_LOB` package (very common in enterprise Oracle apps with CLOB/BLOB columns).

This PR aligns the XStream adapter with the LogMiner adapter (cf. DBZ-4366) by treating these events as regular DML with a LOB re-read:

### `XStreamChangeRecordEmitter`
- `LOB_WRITE` / `LOB_TRIM` / `LOB_ERASE` now map to `Operation.UPDATE` in `getOperation()`.
- New `operationOverride` field lets the caller force `Operation.CREATE` when the LOB delivery immediately follows an `INSERT` for the same `ROWID`+transaction (XStream splits large-LOB inserts into an `INSERT` LCR followed by one or more `LOB_WRITE` chunks — without the override these would be mis-reported as `UPDATE`).
- The old constructor is preserved; a new one takes the override (`null` preserves prior behavior).

### `LcrEventHandler`
- New optional `OracleConnection` parameter (overloaded constructor keeps the original signature working with `jdbcConnection=null`).
- Tracks `INSERT` `ROWID`s per transaction, cleared on commit, so a following `LOB_WRITE` / `LOB_TRIM` is emitted as `CREATE`.
- Routes `LOB_WRITE` / `LOB_TRIM` / `LOB_ERASE` with chunk data through the existing chunk-assembly path. Without chunk data they are re-selected and dispatched directly.
- After chunk assembly for LOB events, re-selects the current LOB value(s) from the source database by PK so downstream consumers receive the complete value, not the partial delta carried by the `LOB_WRITE` chunk. Graceful fallbacks: if the table has no PK, or if the re-select fails, the partial chunk value is used and a warning is logged. This mirrors how `ReselectColumnsPostProcessor` is already used from LogMiner.

### `XstreamStreamingChangeEventSource`
- Passes the existing `jdbcConnection` into `LcrEventHandler` so the re-read above can run on the original CDC connection without opening another session.

### Backward compatibility

- Callers using the non-`jdbcConnection` `LcrEventHandler` constructor keep the prior behavior (partial chunks, no re-read).
- The `getOperation()` change is additive: these event types previously threw, so no caller could have been depending on a specific exception type from them.

### Testing

Validated against Oracle 19c (19.28) with Debezium 3.5.0 + XStream outbound against a ~1,693-table Curam schema with frequent CLOB/BLOB activity driven by `DBMS_LOB.WRITE` / `WRITEAPPEND` / `TRIM`, for several days at sustained DML. After this patch: no `ORA-26824`, no streaming-task crashes on LOB events, and LOB column values in Kafka match the source after each event (including partial updates).

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
