### PR TITLE
debezium/dbz#1807 Restore additional condition on MongoDB incremental snapshot offset reload

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
@@ -211,7 +211,10 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
         try {
             List<LinkedHashMap<String, String>> dataCollections = mapper.readValue(dataCollectionsStr, mapperTypeRef);
             List<DataCollection<T>> dataCollectionsList = dataCollections.stream()
-                    .map(x -> new DataCollection<T>((T) CollectionId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID))))
+                    .map(x -> new DataCollection<T>(
+                            (T) CollectionId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID)),
+                            stripWrappingParentheses(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)),
+                            ""))
                     .filter(x -> x.getId() != null)
                     .collect(Collectors.toList());
             return dataCollectionsList;
@@ -219,6 +222,23 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
         catch (JsonProcessingException e) {
             throw new DebeziumException("Cannot de-serialize dataCollectionsToSnapshot information: " + dataCollectionsStr);
         }
+    }
+
+    /**
+     * Strips the outer parentheses added by {@link DataCollection#getAdditionalCondition()} during
+     * serialization, so the deserialized {@link DataCollection} field holds the same bare condition
+     * value as it did before serialization. Without this, the field would re-wrap on subsequent
+     * serialization cycles, accumulating parentheses and ultimately breaking
+     * {@code Document.parse} when the condition is applied to MongoDB queries.
+     */
+    private static String stripWrappingParentheses(String wrapped) {
+        if (wrapped == null) {
+            return "";
+        }
+        if (wrapped.length() < 2 || !wrapped.startsWith("(") || !wrapped.endsWith(")")) {
+            return wrapped;
+        }
+        return wrapped.substring(1, wrapped.length() - 1);
     }
 
     public boolean snapshotRunning() {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContextTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContextTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.mongodb.CollectionId;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.signal.actions.snapshotting.AdditionalCondition;
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+
+public class MongoDbIncrementalSnapshotContextTest {
+
+    /**
+     * The MongoDB incremental snapshot context must preserve additional conditions across
+     * serialization round-trips (i.e., across connector restarts). Previously
+     * {@code stringToDataCollections} only restored the collection ID, silently dropping the
+     * {@code additional_condition} field, which caused the snapshot to resume with no filter
+     * on every chunk after a restart.
+     */
+    @Test
+    @FixFor("debezium/dbz#1807")
+    public void shouldPreserveAdditionalConditionAcrossOffsetRoundTrip() {
+        final String collectionId = "dbA.c1";
+        final String filter = "{aa: {$lt: 250}}";
+
+        final MongoDbIncrementalSnapshotContext<CollectionId> original = new MongoDbIncrementalSnapshotContext<>(false);
+
+        final AdditionalCondition condition = AdditionalCondition.AdditionalConditionBuilder.builder()
+                .dataCollection(Pattern.compile(collectionId, Pattern.CASE_INSENSITIVE))
+                .filter(filter)
+                .build();
+
+        original.addDataCollectionNamesToSnapshot("test-correlation", List.of(collectionId), List.of(condition), "");
+        // Set state required for store() to actually serialize the data collections
+        original.sendEvent(new Object[]{ "k" });
+        original.maximumKey(new Object[]{ "max" });
+
+        final Map<String, Object> offsets = new HashMap<>();
+        original.store(offsets);
+
+        final MongoDbIncrementalSnapshotContext<CollectionId> restored = MongoDbIncrementalSnapshotContext.load(offsets, false);
+
+        final DataCollection<CollectionId> restoredCollection = restored.currentDataCollectionId();
+        assertThat(restoredCollection).isNotNull();
+        assertThat(restoredCollection.getId().identifier()).isEqualTo(collectionId);
+        assertThat(restoredCollection.getAdditionalCondition()).hasValue("(" + filter + ")");
+    }
+
+    /**
+     * Verifies that repeated serialization round-trips do not accumulate parentheses on the
+     * additional condition. Without the parenthesis-stripping logic in
+     * {@code stringToDataCollections}, the field would re-wrap on each cycle, eventually
+     * breaking {@code Document.parse} when the condition is applied to a MongoDB query.
+     */
+    @Test
+    @FixFor("debezium/dbz#1807")
+    public void shouldNotAccumulateParenthesesAcrossMultipleRoundTrips() {
+        final String collectionId = "dbA.c1";
+        final String filter = "{aa: {$lt: 250}}";
+
+        MongoDbIncrementalSnapshotContext<CollectionId> context = new MongoDbIncrementalSnapshotContext<>(false);
+
+        final AdditionalCondition condition = AdditionalCondition.AdditionalConditionBuilder.builder()
+                .dataCollection(Pattern.compile(collectionId, Pattern.CASE_INSENSITIVE))
+                .filter(filter)
+                .build();
+
+        context.addDataCollectionNamesToSnapshot("test-correlation", List.of(collectionId), List.of(condition), "");
+        context.sendEvent(new Object[]{ "k" });
+        context.maximumKey(new Object[]{ "max" });
+
+        for (int i = 0; i < 3; i++) {
+            final Map<String, Object> offsets = new HashMap<>();
+            context.store(offsets);
+            context = MongoDbIncrementalSnapshotContext.load(offsets, false);
+            context.sendEvent(new Object[]{ "k" });
+            context.maximumKey(new Object[]{ "max" });
+        }
+
+        final DataCollection<CollectionId> restoredCollection = context.currentDataCollectionId();
+        assertThat(restoredCollection.getAdditionalCondition()).hasValue("(" + filter + ")");
+    }
+
+    /**
+     * Verifies that a collection with no additional condition round-trips cleanly.
+     */
+    @Test
+    @FixFor("debezium/dbz#1807")
+    public void shouldHandleEmptyAdditionalConditionAcrossOffsetRoundTrip() {
+        final String collectionId = "dbA.c1";
+
+        final MongoDbIncrementalSnapshotContext<CollectionId> original = new MongoDbIncrementalSnapshotContext<>(false);
+
+        original.addDataCollectionNamesToSnapshot("test-correlation", List.of(collectionId), List.of(), "");
+        original.sendEvent(new Object[]{ "k" });
+        original.maximumKey(new Object[]{ "max" });
+
+        final Map<String, Object> offsets = new HashMap<>();
+        original.store(offsets);
+
+        final MongoDbIncrementalSnapshotContext<CollectionId> restored = MongoDbIncrementalSnapshotContext.load(offsets, false);
+
+        final DataCollection<CollectionId> restoredCollection = restored.currentDataCollectionId();
+        assertThat(restoredCollection).isNotNull();
+        assertThat(restoredCollection.getId().identifier()).isEqualTo(collectionId);
+        assertThat(restoredCollection.getAdditionalCondition()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/debezium/dbz/issues/1807

`MongoDbIncrementalSnapshotContext.stringToDataCollections()` previously read only the collection ID from the serialized offset, silently discarding the `additional_condition` value that `dataCollectionsToSnapshotAsString()` had written. After any connector restart during an incremental snapshot with additional conditions, the filter was permanently lost and the snapshot resumed completely unfiltered.

### Changes

- **Deserialization fix**: Updated `stringToDataCollections()` to restore the `additional_condition` field from the serialized offset alongside the collection ID.
- **Parenthesis stripping**: Added `stripWrappingParentheses()` helper to unwrap the parentheses that `DataCollection.getAdditionalCondition()` adds during serialization, preventing accumulation across save/load cycles that would break `Document.parse`.
- **Unit tests**: Added `MongoDbIncrementalSnapshotContextTest` with three tests covering round-trip preservation, parenthesis accumulation prevention, and empty condition handling.

### How to reproduce

1. Start a MongoDB connector with an incremental snapshot using `additional-conditions`
2. Restart the connector while the snapshot is in progress
3. Observe that the `incremental_snapshot_collections_additional_condition` field in the offset becomes `null` after restart
4. Subsequent chunk queries no longer apply the filtering conditions