### PR TITLE
debezium/dbz#1848 Preserve nulls in ByLogicalTableRouter

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/ByLogicalTableRouter.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/ByLogicalTableRouter.java
@@ -342,7 +342,7 @@ public class ByLogicalTableRouter<R extends ConnectRecord<R>> implements Transfo
     private Struct updateKey(Schema newKeySchema, Struct oldKey, String oldTopic) {
         final Struct newKey = new Struct(newKeySchema);
         for (org.apache.kafka.connect.data.Field field : oldKey.schema().fields()) {
-            newKey.put(field.name(), oldKey.get(field));
+            newKey.put(field.name(), oldKey.getWithoutDefault(field.name()));
         }
 
         String physicalTableIdentifier = oldTopic;
@@ -413,7 +413,7 @@ public class ByLogicalTableRouter<R extends ConnectRecord<R>> implements Transfo
     private Struct updateValue(Schema newValueSchema, Struct oldValue) {
         final Struct newValue = new Struct(newValueSchema);
         for (org.apache.kafka.connect.data.Field field : oldValue.schema().fields()) {
-            newValue.put(field.name(), oldValue.get(field));
+            newValue.put(field.name(), oldValue.getWithoutDefault(field.name()));
         }
         return newValue;
     }

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
@@ -8,6 +8,7 @@ package io.debezium.transforms;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
 import io.debezium.relational.history.HistoryRecord.Fields;
 
@@ -321,6 +323,62 @@ public class ByLogicalTableRouterTest {
         SourceRecord transformed = router.apply(record);
         assertThat(transformed.topic()).isEqualTo("schema_changes_rerouted");
         assertThat(transformed.value()).isSameAs(record.value());
+    }
+
+    @Test
+    @FixFor("dbz#1848")
+    public void shouldPreserveNullForNullableFieldWithNonNullDefault() {
+        final ByLogicalTableRouter<SourceRecord> router = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+        props.put("topic.regex", "(.+)\\.(.+)\\.(.+)");
+        props.put("topic.replacement", "$1.$3");
+        props.put("key.enforce.uniqueness", "false");
+        router.configure(props);
+
+        Schema flagSchema = SchemaBuilder.int16().optional().defaultValue((short) 0).build();
+
+        Schema keySchema = SchemaBuilder.struct()
+                .name("shard_1.inventory.customers.Key")
+                .field("id", Schema.INT64_SCHEMA)
+                .field("flag", flagSchema)
+                .build();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("shard_1.inventory.customers.Value")
+                .field("id", Schema.INT64_SCHEMA)
+                .field("flag", flagSchema)
+                .build();
+
+        Schema sourceSchema = SchemaBuilder.struct()
+                .name("source")
+                .field("table", Schema.STRING_SCHEMA)
+                .build();
+
+        Envelope envelope = Envelope.defineSchema()
+                .withName("shard_1.inventory.customers.Envelope")
+                .withRecord(valueSchema)
+                .withSource(sourceSchema)
+                .build();
+
+        Struct key = new Struct(keySchema).put("id", 1L).put("flag", null);
+        Struct before = new Struct(valueSchema).put("id", 1L).put("flag", null);
+        Struct after = new Struct(valueSchema).put("id", 1L).put("flag", null);
+        Struct source = new Struct(sourceSchema).put("table", "customers");
+        Struct envelopeValue = envelope.update(before, after, source, Instant.now());
+
+        SourceRecord record = new SourceRecord(null, null, "shard_1.inventory.customers", null,
+                keySchema, key, envelope.schema(), envelopeValue);
+
+        SourceRecord transformed = router.apply(record);
+
+        Struct transformedKey = (Struct) transformed.key();
+        Struct transformedValue = (Struct) transformed.value();
+        Struct transformedBefore = transformedValue.getStruct(Envelope.FieldName.BEFORE);
+        Struct transformedAfter = transformedValue.getStruct(Envelope.FieldName.AFTER);
+
+        assertThat(transformedKey.getWithoutDefault("flag")).isNull();
+        assertThat(transformedBefore.getWithoutDefault("flag")).isNull();
+        assertThat(transformedAfter.getWithoutDefault("flag")).isNull();
     }
 
     // FIXME: This SMT can use more tests for more detailed coverage.


### PR DESCRIPTION
Closes debezium/dbz#1848.

## Summary

`ByLogicalTableRouter` rebuilds the key and value `Struct` for every record so it can apply a new logical schema name. Inside that rebuild, both `updateKey` and `updateValue` read source field values via `oldStruct.get(field)`, which substitutes the schema default whenever the slot is null. For any nullable column that carries a non-null default (e.g. MySQL `TINYINT(1) NULL DEFAULT 0`, `INT NULL DEFAULT 0`), real `NULL` values are silently replaced by the default before the record reaches the value converter. Downstream consumers see the default in place of the original null.

This also makes Confluent's `value.converter.ignore.default.for.nullables=true` AvroConverter fix (CP 7.3, schema-registry [#2326](https://github.com/confluentinc/schema-registry/pull/2326)) effectively a no-op for any pipeline that includes `ByLogicalTableRouter`, because by the time the converter runs the `Struct` no longer holds a `null` for it to preserve.

## Change

Switch both `updateKey` and `updateValue` to read field values via `Struct.getWithoutDefault(String)`, which returns the raw stored slot exactly as it was set. Real `NULL` values in columns with non-null defaults now survive the SMT.

## How was it tested?

* New regression test `ByLogicalTableRouterTest#shouldPreserveNullForNullableFieldWithNonNullDefault` constructs a record with a nullable `INT16` field carrying a non-null default (`(short) 0`) and a real `null` value in both the key `Struct` and the envelope's `before`/`after` `Struct`s. It applies the SMT and asserts that all three field positions still report `null` via `Struct.getWithoutDefault` after the rebuild. The test fails on `main` and passes with the fix.
* `./mvnw -pl debezium-connect-plugins -am test` is green for the full module test suite (11 tests, including the new one).
* The full build (`./mvnw clean install -DskipITs`) also runs `Debezium Kafka Connect Plugins` cleanly. An unrelated container-startup failure in `debezium-connector-mysql`'s `KafkaSchemaHistoryTest` was observed locally; it does not touch any code path changed in this PR.
* I observed the bug end-to-end in a real Debezium 3.0.7.Final + MySQL pipeline (a record produced by an `UPDATE ... SET col = NULL` against a nullable-with-default column) and verified that backporting this same fix into a local fork of `ByLogicalTableRouter` resolves the issue and lets the resulting Avro records carry the `null` branch of the field's union.

## AI assistance disclosure

Per `AI_USAGE_POLICY.md`, I used Claude (Anthropic) assistively while investigating this bug, reading the relevant Debezium and Kafka Connect source, drafting the fix, and drafting the regression test. I reviewed every line, ran the test suite locally to verify the change, observed the bug in our own pipeline beforehand, and verified that the same fix resolves it after deploying a local fork of the SMT to our dev environment. I am responsible for the contents of this PR.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
