### PR TITLE
debezium/dbz#1561 Detect network errors in MySqlConnection to prevent misleading SHOW MASTER STATUS fallback

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
@@ -46,11 +46,23 @@ public class MySqlConnection extends BinlogConnectorConnection {
                 String version = queryAndMap("SELECT VERSION()", rs -> {
                     return rs.next() ? rs.getString(1) : "unknown";
                 });
-                LOGGER.info("MySQL version {} detected, falling back to '{}'",
-                        version, MASTER_STATUS_STATEMENT);
+
+                String[] parts = version.split("\\.");
+                int major = Integer.parseInt(parts[0]); // 8
+                int minor = Integer.parseInt(parts[1]); // 4
+
+                if (major > 8 || (major == 8 && minor >= 4)) {
+                    throw new DebeziumException("MySQL version " + version +
+                            " should support SHOW BINARY LOG STATUS but it failed. Check database permissions or connectivity.", e);
+                }
+
+                LOGGER.info("MySQL version {} detected, falling back to '{}'", version, MASTER_STATUS_STATEMENT);
             }
             catch (SQLException ve) {
                 LOGGER.warn("Could not determine MySQL version during fallback detection: {}", ve.getMessage());
+            }
+            catch (NumberFormatException nfe) {
+                LOGGER.warn("Could not parse MySQL version string during fallback detection: {}", nfe.getMessage());
             }
 
             binaryLogStatusStatement = MASTER_STATUS_STATEMENT;
@@ -60,9 +72,17 @@ public class MySqlConnection extends BinlogConnectorConnection {
         binaryLogStatusStatement = BINARY_LOG_STATUS_STATEMENT;
     }
 
-    public boolean isNetworkError(SQLException e) {
+    public static boolean isNetworkError(SQLException e) {
         String sqlState = e.getSQLState();
-        return sqlState != null && sqlState.startsWith("08");
+        if (sqlState == null) {
+            return false;
+        }
+
+        // Network-related connection failures (not config/auth errors)
+        return sqlState.equals("08001") // Cannot connect to server
+                || sqlState.equals("08003") // Connection does not exist
+                || sqlState.equals("08006") // Connection failure
+                || sqlState.equals("08S01"); // Communication link failure
     }
 
     public String binaryLogStatusStatement() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
@@ -38,12 +38,31 @@ public class MySqlConnection extends BinlogConnectorConnection {
             });
         }
         catch (SQLException e) {
-            LOGGER.info("Using '{}' to get binary log status", MASTER_STATUS_STATEMENT);
+            if (isNetworkError(e)) {
+                throw new DebeziumException("Failed to establish connection with the database: ", e);
+            }
+
+            try {
+                String version = queryAndMap("SELECT VERSION()", rs -> {
+                    return rs.next() ? rs.getString(1) : "unknown";
+                });
+                LOGGER.info("MySQL version {} detected, falling back to '{}'",
+                        version, MASTER_STATUS_STATEMENT);
+            }
+            catch (SQLException ve) {
+                LOGGER.warn("Could not determine MySQL version during fallback detection: {}", ve.getMessage());
+            }
+
             binaryLogStatusStatement = MASTER_STATUS_STATEMENT;
             return;
         }
         LOGGER.info("Using '{}' to get binary log status", BINARY_LOG_STATUS_STATEMENT);
         binaryLogStatusStatement = BINARY_LOG_STATUS_STATEMENT;
+    }
+
+    public boolean isNetworkError(SQLException e) {
+        String sqlState = e.getSQLState();
+        return sqlState != null && sqlState.startsWith("08");
     }
 
     public String binaryLogStatusStatement() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
@@ -33,9 +33,28 @@ public class MySqlConnection extends BinlogConnectorConnection {
     public MySqlConnection(MySqlConnectionConfiguration connectionConfig, BinlogFieldReader fieldReader) {
         super(connectionConfig, fieldReader);
 
+        this.binaryLogStatusStatement = resolveBinaryLogStatusStatement();
+    }
+
+    public static boolean isNetworkError(SQLException e) {
+        String sqlState = e.getSQLState();
+        if (sqlState == null) {
+            return false;
+        }
+
+        return sqlState.equals("08001") // Cannot connect to server
+                || sqlState.equals("08003") // Connection does not exist
+                || sqlState.equals("08004") // Connection rejected by server
+                || sqlState.equals("08006") // Connection failure
+                || sqlState.equals("08S01"); // Communication link failure
+    }
+
+    private String resolveBinaryLogStatusStatement() {
         try {
             query(BINARY_LOG_STATUS_STATEMENT, rs -> {
             });
+            LOGGER.info("Using '{}' to get binary log status", BINARY_LOG_STATUS_STATEMENT);
+            return BINARY_LOG_STATUS_STATEMENT;
         }
         catch (SQLException e) {
             if (isNetworkError(e)) {
@@ -48,6 +67,11 @@ public class MySqlConnection extends BinlogConnectorConnection {
                 });
 
                 String[] parts = version.split("\\.");
+                if (parts.length < 2) {
+                    LOGGER.warn("Unexpected MySQL version format: {}. Proceeding with fallback.", version);
+                    return MASTER_STATUS_STATEMENT;
+                }
+
                 int major = Integer.parseInt(parts[0]); // 8
                 int minor = Integer.parseInt(parts[1]); // 4
 
@@ -64,25 +88,8 @@ public class MySqlConnection extends BinlogConnectorConnection {
             catch (NumberFormatException nfe) {
                 LOGGER.warn("Could not parse MySQL version string during fallback detection: {}", nfe.getMessage());
             }
-
-            binaryLogStatusStatement = MASTER_STATUS_STATEMENT;
-            return;
+            return MASTER_STATUS_STATEMENT;
         }
-        LOGGER.info("Using '{}' to get binary log status", BINARY_LOG_STATUS_STATEMENT);
-        binaryLogStatusStatement = BINARY_LOG_STATUS_STATEMENT;
-    }
-
-    public static boolean isNetworkError(SQLException e) {
-        String sqlState = e.getSQLState();
-        if (sqlState == null) {
-            return false;
-        }
-
-        // Network-related connection failures (not config/auth errors)
-        return sqlState.equals("08001") // Cannot connect to server
-                || sqlState.equals("08003") // Connection does not exist
-                || sqlState.equals("08006") // Connection failure
-                || sqlState.equals("08S01"); // Communication link failure
     }
 
     public String binaryLogStatusStatement() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectionTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.mysql.jdbc.MySqlConnection;
+
+/**
+ * Unit test for MySqlConnection network error detection.
+ *
+ * @author Arya Dharmadhikari
+ */
+
+public class MySqlConnectionTest {
+
+    @Test
+    public void shouldIdentifyConnectionErrorSQLStates() {
+        // Specific network-related connection failures
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Cannot connect", "08001"))).isTrue();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Connection does not exist", "08003"))).isTrue();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Server rejected connection", "08004"))).isTrue();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Connection failure", "08006"))).isTrue();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Communication link failure", "08S01"))).isTrue();
+    }
+
+    @Test
+    public void shouldNotIdentifyNonConnectionErrors() {
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Syntax error", "42000"))).isFalse();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Unknown command", "42S02"))).isFalse();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Access denied", "28000"))).isFalse();
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Duplicate key", "23000"))).isFalse();
+    }
+
+    @Test
+    public void shouldHandleNullSQLStateGracefully() {
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Error with no SQLState", ""))).isFalse();
+    }
+
+    @Test
+    public void shouldHandleEmptySQLStateGracefully() {
+        assertThat(MySqlConnection.isNetworkError(new SQLException("Error with empty SQLState", ""))).isFalse();
+    }
+}


### PR DESCRIPTION
## Description
- Fixes debezium/dbz#1561

## Problem
When the MySQL connector loses database connectivity during the constructor's version detection, it silently falls back to using `SHOW MASTER STATUS` on MySQL 8.4+ servers. This causes all subsequent operations like `knownGtidSet()` to fail with a misleading error about `SHOW MASTER STATUS` not being supported, rather than reporting the actual network connectivity issue.

## Solution
Added network error detection using JDBC SQLState codes:
- Network errors (SQLState 08xxx) now throw `DebeziumException` with a clear message
- Non-network errors continue to trigger version detection and legitimate fallback
- MySQL version is logged when falling back to aid debugging

## Changes
- Made `isNetworkError()` a static method that checks for connection-related SQLState codes
- Updated constructor to call `isNetworkError()` before attempting fallback
- Added unit tests for `isNetworkError()` covering all edge cases

## Testing
- [x] Unit tests verify SQLState detection logic
- [x] Full MySQL connector test suite passes
- Manual verification pending: constructor behavior with actual network failures

## Future Enhancement
A version compatibility check could be added to detect cases where `SHOW BINARY LOG STATUS` fails on MySQL 8.4+ for reasons other than network errors (e.g., permissions). I kept this out of the current PR to keep the fix minimal and focused on the reported issue, but happy to add it or track it separately if it feels worthwhile.

## Flowchart
<img width="731" height="767" alt="Screenshot 2026-04-24 at 11 36 35 PM" src="https://github.com/user-attachments/assets/b378ef69-1187-444a-824a-189e9dfe1cfb" />

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
