### PR TITLE
debezium/dbz#1874 Fix Oracle test / Kafka 4.2 compatibility

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/HybridMiningStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/HybridMiningStrategyIT.java
@@ -1216,6 +1216,7 @@ public class HybridMiningStrategyIT extends AbstractAsyncEngineConnectorTest {
         embeddedConfig.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, OFFSET_STORE_PATH.toAbsolutePath().toString());
         embeddedConfig.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, keyConverter.getClass().getName());
         embeddedConfig.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, valueConverter.getClass().getName());
+        embeddedConfig.put(WorkerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         System.out.println(embeddedConfig);
 
         final OffsetBackingStore store = KafkaConnectUtil.fileOffsetBackingStore();


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1874

## Description
Fixes regression with an incompatibility in `HybridMiningStrategyIT` after upgrading to Kafka 4.2. This is because the old `WorkerConfig` class used a default value of `bootstrap.servers` set to `localhost:9092`. However, in 4.2+, this default value has been removed, and a value must be specified explicitly.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
