### PR TITLE
debezium/dbz#1863 Avoid calling pg_replication_slot_advance() when slot LSN is ahead of offset LSN

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -689,7 +689,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         final int maxRetries = connectorConfig.maxRetries();
         final Duration delay = connectorConfig.retryDelay();
         int tryCount = 0;
-        boolean isReplicationSlotBehindOffsetStore = offset.compareTo(defaultStartingPos) > 0;
+        final boolean isReplicationSlotBehindOffsetStore = offset.compareTo(defaultStartingPos) > 0;
         while (true) {
             try {
                 if (connectorConfig.slotSeekToKnownOffsetOnStart() && isReplicationSlotBehindOffsetStore) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -693,7 +693,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         while (true) {
             try {
                 if (connectorConfig.slotSeekToKnownOffsetOnStart() && isReplicationSlotBehindOffsetStore) {
-                    validateSlotIsInExpectedState(walPosition);
+                    advanceReplicationSlot(walPosition);
                 }
                 return createReplicationStream(lsn, walPosition);
             }
@@ -719,7 +719,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 (offset.compareTo(defaultStartingPos) < 0 && connectorConfig.offsetSeekToSlotOnStart());
     }
 
-    protected void validateSlotIsInExpectedState(WalPositionLocator walPosition) throws SQLException {
+    protected void advanceReplicationSlot(WalPositionLocator walPosition) throws SQLException {
         Lsn lsn = walPosition.getLastCommitStoredLsn() != null ? walPosition.getLastCommitStoredLsn() : walPosition.getLastEventStoredLsn();
         if (lsn == null || !connectorConfig.isFlushLsnOnSource()) {
             return;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -689,9 +689,10 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         final int maxRetries = connectorConfig.maxRetries();
         final Duration delay = connectorConfig.retryDelay();
         int tryCount = 0;
+        boolean isReplicationSlotBehindOffsetStore = offset.compareTo(defaultStartingPos) > 0;
         while (true) {
             try {
-                if (connectorConfig.slotSeekToKnownOffsetOnStart()) {
+                if (connectorConfig.slotSeekToKnownOffsetOnStart() && isReplicationSlotBehindOffsetStore) {
                     validateSlotIsInExpectedState(walPosition);
                 }
                 return createReplicationStream(lsn, walPosition);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4399,7 +4399,7 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-1863")
+    @FixFor("debezium/dbz#1863")
     public void testTrustGreaterLsnWithNonCapturedTableUpdates() throws Exception {
         // This test verifies that when offset.mismatch.strategy is set to trust_greater_lsn,
         // updates to non-captured tables (i.e., tables not included in the publication) do

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2163,11 +2163,18 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     private String getConfirmedFlushLsn(PostgresConnection connection) throws SQLException {
+        return getConfirmedFlushLsn(
+                connection,
+                TestHelper.decoderPlugin(),
+                ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+    }
+
+    private String getConfirmedFlushLsn(PostgresConnection connection, LogicalDecoder decoder, String slotName) throws SQLException {
         final String lsn = connection.prepareQueryAndMap(
-                "select * from pg_replication_slots where slot_name = ? and database = ? and plugin = ?", statement -> {
-                    statement.setString(1, ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+                "select confirmed_flush_lsn from pg_replication_slots where slot_name = ? and database = ? and plugin = ?", statement -> {
+                    statement.setString(1, slotName);
                     statement.setString(2, "postgres");
-                    statement.setString(3, TestHelper.decoderPlugin().getPostgresPluginName());
+                    statement.setString(3, decoder.getPostgresPluginName());
                 },
                 rs -> {
                     if (rs.next()) {
@@ -4389,5 +4396,70 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertThat(matched.size()).isEqualTo(1);
 
         stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-1863")
+    public void testTrustGreaterLsnWithNonCapturedTableUpdates() throws Exception {
+        // This test verifies that when offset.mismatch.strategy is set to trust_greater_lsn,
+        // updates to non-captured tables (i.e., tables not included in the publication) do
+        // not cause connector restart failures.
+        // In this test, s1.a is treated as the captured table, and s2.a as the non-captured table.
+
+        final String PUBLICATION = "dbz_s1_a";
+        final String SLOT = "dbz_s1_a_slot";
+
+        try {
+            TestHelper.execute(SETUP_TABLES_STMT);
+            TestHelper.execute("CREATE PUBLICATION " + PUBLICATION + " FOR TABLE s1.a;");
+
+            Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                    .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false")
+                    .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, "true")
+                    .with(PostgresConnectorConfig.PUBLICATION_NAME, PUBLICATION)
+                    .with(PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.PGOUTPUT)
+                    .with(PostgresConnectorConfig.LSN_FLUSH_MODE, "connector_and_driver")
+                    .with(PostgresConnectorConfig.SLOT_NAME, SLOT)
+                    .with(PostgresConnectorConfig.OFFSET_SLOT_MISMATCH_STRATEGY, "trust_greater_lsn");
+
+            start(PostgresConnector.class, configBuilder.build());
+            assertConnectorIsRunning();
+
+            try (PostgresConnection connection = TestHelper.create()) {
+                Lsn lsnBeforeCapturedTableInsert = Lsn.valueOf(getConfirmedFlushLsn(connection, LogicalDecoder.PGOUTPUT, SLOT));
+                TestHelper.execute("INSERT INTO s2.a (aa, bb) VALUES (2, 'hello');");
+
+                Awaitility.await()
+                        .alias("confirmed_flush_lsn did not advance after non-captured table update")
+                        .pollInterval(1000, TimeUnit.MILLISECONDS)
+                        .atMost(waitTimeForRecords() * 30, TimeUnit.SECONDS)
+                        .until(() -> {
+                            Lsn lsnAfterNonCapturedTableInsert = Lsn.valueOf(getConfirmedFlushLsn(connection, LogicalDecoder.PGOUTPUT, SLOT));
+                            return lsnAfterNonCapturedTableInsert.compareTo(lsnBeforeCapturedTableInsert) > 0;
+                        });
+            }
+            stopConnector();
+            assertConnectorNotRunning();
+
+            LogInterceptor interceptor = new LogInterceptor(PostgresReplicationConnection.class);
+
+            start(PostgresConnector.class, configBuilder.build());
+
+            // Note we do not call assertConnectorIsRunning() immediately after start().
+            // When the issue occurs, the connector fails during the startup process.
+            // Calling assertConnectorIsRunning() too early can incorrectly succeed
+            // because the connector is still in the process of starting.
+            Awaitility.await().atMost(waitTimeForRecords() * 5, TimeUnit.SECONDS)
+                    .until(() -> interceptor
+                            .containsMessage("Starting replication stream from LSN"));
+            assertConnectorIsRunning();
+
+            stopConnector();
+            assertConnectorNotRunning();
+        }
+        finally {
+            TestHelper.execute("DROP PUBLICATION IF EXISTS " + PUBLICATION + ";");
+            TestHelper.execute("SELECT pg_drop_replication_slot('" + SLOT + "');");
+        }
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1863

## Description
Added a test to reproduce the issue.

Introduced a guard to avoid calling pg_replication_slot_advance() when the replication slot LSN is already ahead of the offset LSN.

Renamed the function validateSlotIsInExpectedState() because its name suggests it only performs validation, while it actually calls pg_replication_slot_advance().

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
  - If you think the 3rd change is not minimal, please feel free to discard that commit.
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
  - After rebasing, local regression tests failed with the error: `org.apache.kafka.common.config.ConfigException: Missing required configuration "bootstrap.servers" which has no default value`. 
 
```
$ ./mvnw clean install -pl debezium-connector-postgres
..
[ERROR] io.debezium.connector.postgresql.PostgresChunkedSnapshotIT.shouldStreamInsertedRowDuringSnapshotOfSameTable -- Time elapsed: 0.928 s <<< ERROR!                                                          org.apache.kafka.common.config.ConfigException: Missing required configuration "bootstrap.servers" which has no default value.                                                                                           at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:537)
        at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:527)                                                                                                                                            at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:118)                                                                                                                                 at org.apache.kafka.connect.runtime.WorkerConfig.<init>(WorkerConfig.java:449)
        at io.debezium.embedded.EmbeddedWorkerConfig.<init>(EmbeddedWorkerConfig.java:34)                                                                                                                                at io.debezium.embedded.async.AsyncEmbeddedEngine.<init>(AsyncEmbeddedEngine.java:171)                                                                                                                           at io.debezium.embedded.async.AsyncEmbeddedEngine$AsyncEngineBuilder.build(AsyncEmbeddedEngine.java:1011)
        at io.debezium.embedded.async.AbstractAsyncEngineConnectorTest.createEngine(AbstractAsyncEngineConnectorTest.java:28)                                                                                            at io.debezium.embedded.AbstractConnectorTest.start(AbstractConnectorTest.java:470)                                                                                                                              at io.debezium.embedded.AbstractConnectorTest.start(AbstractConnectorTest.java:395)
        at io.debezium.embedded.AbstractConnectorTest.start(AbstractConnectorTest.java:345)                                                                                                                              at io.debezium.embedded.AbstractConnectorTest.start(AbstractConnectorTest.java:264)
        at io.debezium.pipeline.AbstractChunkedSnapshotTest.shouldStreamInsertedRowDuringSnapshotOfSameTable(AbstractChunkedSnapshotTest.java:425)                                                                       at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)                                                                                                                                                    at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)

[ERROR] io.debezium.connector.postgresql.PostgresChunkedSnapshotIT.shouldSnapshotUsingPerTableMultiplierOverrides -- Time elapsed: 0.177 s <<< ERROR!
org.apache.kafka.common.config.ConfigException: Missing required configuration "bootstrap.servers" which has no default value.                                                                                           at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:537)
        at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:527)
...
```
`git bisect` indicated that commit ea4cafd2a60 caused this error. Reverting that commit resolves the problem, so I believe this error is unrelated to this PR.
