### PR TITLE
debezium/dbz#1877 Recover stale SqlServer connections at streaming iteration start

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -319,6 +319,14 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     @Override
+    public synchronized void reconnect() throws SQLException {
+        // JdbcConnection#reconnect() bypasses connection(boolean) and would skip setAutoCommit(false).
+        LOGGER.info("Reopening SQL Server JDBC connection");
+        close();
+        connection();
+    }
+
+    @Override
     public Set<TableId> getAllTableIds(String catalogName) throws SQLException {
         return super.getAllTableIds(catalogName);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -181,9 +181,19 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             TxLogPosition lastProcessedPosition = streamingExecutionContext.getLastProcessedPosition();
 
             if (context.isRunning()) {
-                commitTransaction();
-                endTransaction(partition, offsetContext.getSourceTime());
-                final Lsn toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                Lsn toLsn;
+                // Recover before iteration state mutates: a connection idle-killed during long schema
+                // recovery surfaces here on the first DB call. Refresh only the broken side and retry
+                // once so streaming resumes instead of failing the task.
+                try {
+                    commitTransaction();
+                    endTransaction(partition, offsetContext.getSourceTime());
+                    toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                }
+                catch (SQLException e) {
+                    recoverStaleConnections(e, databaseName);
+                    toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                }
 
                 // Shouldn't happen if the agent is running, but it is better to guard against such situation
                 if (!toLsn.isAvailable()) {
@@ -402,6 +412,32 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             dataConnection.commit();
             metadataConnection.commit();
         }
+    }
+
+    private void recoverStaleConnections(SQLException e, String databaseName) throws SQLException {
+        boolean dataValid;
+        boolean metadataValid;
+        try {
+            dataValid = dataConnection.isValid();
+            metadataValid = metadataConnection.isValid();
+        }
+        catch (SQLException probeEx) {
+            e.addSuppressed(probeEx);
+            throw e;
+        }
+        if (dataValid && metadataValid) {
+            throw e;
+        }
+        LOGGER.warn("Stale connection detected at start of streaming iteration for database '{}' (data valid={}, metadata valid={}); refreshing",
+                databaseName, dataValid, metadataValid, e);
+        if (!dataValid) {
+            dataConnection.reconnect();
+        }
+        if (!metadataValid) {
+            metadataConnection.reconnect();
+        }
+        LOGGER.info("Refreshed connections (data refreshed={}, metadata refreshed={}) for database '{}'",
+                !dataValid, !metadataValid, databaseName);
     }
 
     private void migrateTable(SqlServerPartition partition, final Queue<SqlServerChangeTable> schemaChangeCheckpoints, SqlServerOffsetContext offsetContext)

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -618,6 +619,75 @@ public class SqlServerConnectionIT {
                     .isInstanceOf(SQLException.class)
                     .hasMessage("The query has timed out.");
         }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void reconnectShouldRebuildConnectionWithAutoCommitDisabled() throws SQLException {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection connection = TestHelper.testConnection()) {
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+
+            connection.reconnect();
+
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void reconnectShouldRecoverAfterServerKillsSession() throws Exception {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection connection = TestHelper.testConnection()) {
+            connection.connect();
+
+            Connection before = connection.connection();
+            int spid = currentSpid(connection);
+            try (SqlServerConnection admin = TestHelper.adminConnection()) {
+                admin.connect();
+                admin.execute("KILL " + spid);
+            }
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !connection.isValid());
+
+            connection.reconnect();
+
+            assertThat(connection.isValid()).isTrue();
+            assertThat(connection.connection()).isNotSameAs(before);
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void isValidShouldDistinguishKilledFromHealthyConnections() throws Exception {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection data = TestHelper.testConnection();
+                SqlServerConnection metadata = TestHelper.testConnection()) {
+            data.connect();
+            metadata.connect();
+
+            int dataSpid = currentSpid(data);
+            try (SqlServerConnection admin = TestHelper.adminConnection()) {
+                admin.connect();
+                admin.execute("KILL " + dataSpid);
+            }
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !data.isValid());
+            assertThat(metadata.isValid()).isTrue();
+
+            data.reconnect();
+
+            assertThat(data.isValid()).isTrue();
+            assertThat(metadata.isValid()).isTrue();
+        }
+    }
+
+    private static int currentSpid(SqlServerConnection connection) throws SQLException {
+        return connection.queryAndMap("SELECT @@SPID", rs -> {
+            rs.next();
+            return rs.getInt(1);
+        });
     }
 
     private long toMillis(OffsetDateTime datetime) {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [debezium/dbz#1877](https://github.com/debezium/dbz/issues/1877)

## Description
<!-- Briefly describe your changes here. -->

**Problem**
- When schema history recovery on a connector with a large history topic exceeds an intermediate LB / firewall idle timeout, the JDBC connections are silently closed during the replay.
- The first SQL call after recovery throws `SQLServerException: The connection is broken and recovery is not possible`.
- The error is retriable, so connector enters a retry loop - but every retry re-runs schema history recovery on fresh-but-equally-doomed connections and never makes forward progress.

**Fix**
- Wrap `commitTransaction()` / `endTransaction()` / `getToLsn()` at the top of `executeIteration()` in a try/catch.
- On `SQLException`, probe both `dataConnection` and `metadataConnection` with `isValid()`, refresh only the invalid side(s) via `reconnect()`, retry `getToLsn()` once.
- If both connections are valid, rethrow - the `SQLException` is a real SQL error, not a connection issue.
- Recovery is placed at the top of the iteration because `streamingExecutionContexts` (per-partition state, `lastProcessedPosition` etc.) is only mutated later; mid-iteration recovery would need explicit retry plumbing to keep state consistent with committed offsets.
- Override `SqlServerConnection.reconnect()` to do `close() + connection()` so the rebuilt connection routes through the existing `connection(boolean)` override and `setAutoCommit(false)` is restored.

## Test Plan

**New integration tests in `SqlServerConnectionIT`**
- `reconnectShouldRebuildConnectionWithAutoCommitDisabled` - `autoCommit=false` preserved across `reconnect()`.
- `reconnectShouldRecoverAfterServerKillsSession` -`KILL <spid>` from a separate admin connection, wait for `isValid()=false`, `reconnect()`, assert new `Connection` instance + `autoCommit=false`.
- `isValidShouldDistinguishKilledFromHealthyConnections` - kill one of two open connections, assert `isValid()` distinguishes killed from healthy peer.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
