### PR TITLE
ORA-26913 RAC instance pinning issue for XStream adapter

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -6242,3 +6242,23 @@ yum install -y libaio
 ----
 apt-get install -y libaio1
 ----
+
+*What causes `ORA-26913` when using XStream with Oracle RAC?*::
+This error only occurs in Oracle Real Application Clusters (RAC) environments and does not affect standalone Oracle installations.
++
+In a RAC environment, the XStream outbound server is pinned to a specific RAC instance.
+When the JDBC connection is load-balanced by the Oracle listener to a different instance, XStream cannot attach and fails with:
+
+----
+oracle.streams.StreamsException: ORA-26913: must connect to instance X where XStream Outbound server is running
+----
+
+When `database.hostname` and `database.port` are used, the connector has no control over which RAC instance the connection lands on, as the Oracle listener can route the connection to any available instance.
+
+To fix this, use the `database.url` property with a full TNS descriptor that specifies the `SERVICE_NAME` of an instance-pinned service.
+Including `ENABLE=broken` in the descriptor also enables TCP keepalive, which prevents network load balancers or firewalls from silently dropping idle XStream connections:
+
+`database.url=jdbc:oracle:oci:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=<host>)(PORT=<port>)))(CONNECT_DATA=(SERVICE_NAME=<instance-pinned-service>)))`
+
+Note that a PDB service name must not be used.
+The XStream outbound server is defined at the CDB level (`CDB$ROOT`), and connecting via a PDB service name results in `ORA-26701: Streams process does not exist`.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -6204,6 +6204,7 @@ By setting this to `true`, the connector will no longer treat all zero scale num
 *What causes `ORA-17023: Unsupported feature: getOCIHandles` and how to fix it?*::
 This error occurs when the {prodname} Oracle connector is configured to use XStream but connects to Oracle using the Thin JDBC driver instead of the OCI driver.
 +
+--
 When the connector starts, XStream internally calls `connection.getOCIHandles()` to attach to the outbound server.
 The Oracle JDBC driver provides two connection types:
 
@@ -6242,23 +6243,32 @@ yum install -y libaio
 ----
 apt-get install -y libaio1
 ----
+--
 
-*What causes `ORA-26913` when using XStream with Oracle RAC?*::
-This error only occurs in Oracle Real Application Clusters (RAC) environments and does not affect standalone Oracle installations.
+*What causes `ORA-26913` when using XStream?*::
+This error is only applicable when connecting the {prodname} Oracle connector to an Oracle Real Application Clusters (RAC) environment.
 +
-In a RAC environment, the XStream outbound server is pinned to a specific RAC instance.
-When the JDBC connection is load-balanced by the Oracle listener to a different instance, XStream cannot attach and fails with:
+--
+In Oracle RAC environments, the XStream outbound server runs only on a specific RAC instance on the cluster.
+When using the `database.hostname` and `database.port`, the connector has no control over which RAC instance the connector will use because the JDBC connection is load-balanced by the Oracle TNS listener.
+This will cause attaching to the XStream outbound server to fail with:
 
 ----
 oracle.streams.StreamsException: ORA-26913: must connect to instance X where XStream Outbound server is running
 ----
 
-When `database.hostname` and `database.port` are used, the connector has no control over which RAC instance the connection lands on, as the Oracle listener can route the connection to any available instance.
+Instead of using `database.hostname` and `database.port`, using the `database.url` with a full TNS descriptor specifying the `SERVICE_NAME` for the instance-pinned service, the {prodname} Oracle connector will successfully attach to the XStream outbound server on the correct RAC instance.
+Enabling `ENABLE=broken` in the TNS descriptor also enables TCP keepalives, preventing network load balancers or firewalls from silently dropping idle XStream connections.
 
-To fix this, use the `database.url` property with a full TNS descriptor that specifies the `SERVICE_NAME` of an instance-pinned service.
-Including `ENABLE=broken` in the descriptor also enables TCP keepalive, which prevents network load balancers or firewalls from silently dropping idle XStream connections:
+.Example TNS descriptor
+[source,json]
+----
+"database.url": "jdbc:oracle:oci:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=<host>)(PORT=<port>)))(CONNECT_DATA=(SERVICE_NAME=<instance-pinned-service>)))"
+----
 
-`database.url=jdbc:oracle:oci:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=<host>)(PORT=<port>)))(CONNECT_DATA=(SERVICE_NAME=<instance-pinned-service>)))`
-
-Note that a PDB service name must not be used.
-The XStream outbound server is defined at the CDB level (`CDB$ROOT`), and connecting via a PDB service name results in `ORA-26701: Streams process does not exist`.
+[IMPORTANT]
+====
+A pluggable database (PDB) name must not be used.
+The XStream outbound server is a container root database (`CDB$ROOT`) service, and connecting with a pluggable database name will result in an `ORA-26701: Streams process does not exist` exception.
+====
+--


### PR DESCRIPTION
Fixes debezium/dbz#1880

Add a FAQ entry to the Oracle Xstream connector documentation explaining ORA-26913 
which occurs in Oracle RAC environments when the XStream outbound server is 
pinned to a specific RAC instance but the JDBC connection is load-balanced 
to a different instance.

Documents the fix: use database.url with a full TNS descriptor specifying 
an instance-pinned SERVICE_NAME and ENABLE=broken for TCP keepalive.

Also documents that a PDB service name must not be used as the XStream 
outbound server is defined at CDB level.
