### PR TITLE
debezium/dbz#1884 Preliminary support for OSON (Oracle JSON)

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -56,6 +56,7 @@ import io.debezium.util.Strings;
 
 import oracle.jdbc.OracleTypes;
 import oracle.sql.CharacterSet;
+import oracle.sql.json.OracleJsonObject;
 
 public class OracleConnection extends JdbcConnection {
 
@@ -633,6 +634,14 @@ public class OracleConnection extends JdbcConnection {
         // "NULLS LAST is the default for ascending order"
         // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SELECT.html
         return Optional.of(true);
+    }
+
+    @Override
+    public Object getColumnValue(ResultSet rs, int columnIndex, Column column, Table table) throws SQLException {
+        if (column.jdbcType() == OracleTypes.JSON || "JSON".equals(column.typeName())) {
+            return rs.getObject(columnIndex, OracleJsonObject.class);
+        }
+        return super.getColumnValue(rs, columnIndex, column, table);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -205,7 +205,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
      * Returns whether the specified value is the unavailable value placeholder for an LOB column.
      */
     public boolean isColumnUnavailableValuePlaceholder(Column column, Object value) {
-        if (isClobColumn(column) || isXmlColumn(column) || isExtendedStringColumn(column)) {
+        if (isClobColumn(column) || isXmlColumn(column) || isExtendedStringColumn(column) || isJsonColumn(column)) {
             return valueConverters.getUnavailableValuePlaceholderString().equals(value);
         }
         else if (isBlobColumn(column)) {
@@ -218,14 +218,14 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
      * Return whether the column is replaced by the {@code unavailable.value.placeholder}.
      */
     public static boolean isNullReplacedByUnavailableValue(Column column) {
-        return isLobColumn(column) || isXmlColumn(column) || isExtendedStringColumn(column);
+        return isLobColumn(column) || isXmlColumn(column) || isExtendedStringColumn(column) || isJsonColumn(column);
     }
 
     /**
      * Return whether the provided relational column model is a LOB data type.
      */
     private static boolean isLobColumn(Column column) {
-        return isClobColumn(column) || isBlobColumn(column);
+        return isClobColumn(column) || isBlobColumn(column) || isJsonColumn(column);
     }
 
     /**
@@ -259,6 +259,10 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
         return column.jdbcType() == OracleTypes.NVARCHAR && column.length() > 2000;
     }
 
+    private static boolean isJsonColumn(Column column) {
+        return "JSON".equals(column.typeName());
+    }
+
     private void buildAndRegisterTableObjectIdReferences(Table table) {
         final Attribute attribute = table.attributeWithName(ATTRIBUTE_OBJECT_ID);
         if (attribute != null) {
@@ -286,6 +290,11 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         lobColumns.add(column);
                     }
                     break;
+                default: {
+                    if (isJsonColumn(column)) {
+                        lobColumns.add(column);
+                    }
+                }
             }
         }
         if (!lobColumns.isEmpty()) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.SQLException;
@@ -35,6 +36,7 @@ import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.connector.oracle.logminer.UnistrHelper;
 import io.debezium.connector.oracle.util.TimestampUtils;
+import io.debezium.data.Json;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.jdbc.JdbcValueConverters;
@@ -61,6 +63,7 @@ import oracle.sql.RAW;
 import oracle.sql.TIMESTAMP;
 import oracle.sql.TIMESTAMPLTZ;
 import oracle.sql.TIMESTAMPTZ;
+import oracle.sql.json.OracleJsonFactory;
 
 public class OracleValueConverters extends JdbcValueConverters {
 
@@ -91,6 +94,8 @@ public class OracleValueConverters extends JdbcValueConverters {
 
     private static final Pattern TO_TIMESTAMP_TZ = Pattern.compile("TO_TIMESTAMP_TZ\\('(.*)'\\)", Pattern.CASE_INSENSITIVE);
     private static final BigDecimal MICROSECONDS_PER_SECOND = new BigDecimal(1_000_000);
+
+    private final OracleJsonFactory jsonFactory = new OracleJsonFactory();
 
     private final OracleConnection connection;
     private final boolean legacyDecimalModeStrategy;
@@ -149,6 +154,10 @@ public class OracleValueConverters extends JdbcValueConverters {
             case OracleTypes.ROWID:
                 return SchemaBuilder.string();
             default: {
+                if ("JSON".equals(column.typeName())) {
+                    return Json.builder();
+                }
+
                 SchemaBuilder builder = super.schemaBuilder(column);
                 logger.debug("JdbcValueConverters returned '{}' for column '{}'", builder != null ? builder.getClass().getName() : null, column.name());
                 return builder;
@@ -233,6 +242,11 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return (data) -> convertIntervalDaySecond(column, fieldDefn, data);
             case OracleTypes.RAW:
                 return (data) -> convertBinary(column, fieldDefn, data, binaryMode);
+            default: {
+                if ("JSON".equals(column.typeName())) {
+                    return (data) -> convertJson(column, fieldDefn, data);
+                }
+            }
         }
 
         return super.converter(column, fieldDefn);
@@ -376,6 +390,38 @@ public class OracleValueConverters extends JdbcValueConverters {
         catch (SQLException e) {
             throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
         }
+    }
+
+    protected Object convertJson(Column column, Field fieldDefn, Object data) {
+        try {
+            if (data instanceof String stringData) {
+                if (stringData.startsWith("/* JSON */ ")) {
+                    stringData = stringData.substring(11);
+                }
+
+                if (EMPTY_CLOB_FUNCTION.equals(stringData) || EMPTY_BLOB_FUNCTION.equals(stringData)) {
+                    return column.isOptional() ? null : "";
+                }
+                else if (UnistrHelper.isUnistrFunction(stringData)) {
+                    return UnistrHelper.convert(stringData);
+                }
+                else if (isHexToRawFunctionCall(stringData)) {
+                    final byte[] jsonData = RAW.hexString2Bytes(getHexToRawHexString(stringData));
+                    return jsonFactory.createJsonBinaryValue(ByteBuffer.wrap(jsonData)).asJsonObject().toString();
+                }
+
+                data = stringData;
+            }
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Couldn't convert value for json column " + column.name(), e);
+        }
+
+        if (data == UNAVAILABLE_VALUE) {
+            return unavailableValuePlaceholderString;
+        }
+
+        return super.convertString(column, fieldDefn, data);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -521,6 +521,23 @@ public class LogMinerDmlParser implements DmlParser {
                 index += 1;
                 start = index;
             }
+            else if (c == '/' && lookAhead == '*' && lookAhead2 == ' ' && inColumnValue && !inSingleQuote) {
+                // Handles special use cases of hints, e.g. '/* JSON */' in values
+                if (!inSpecial) {
+                    start = index;
+                    inSpecial = true;
+                }
+                for (int i = index + 2; i < sql.length() - 1; i++) {
+                    if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
+                        index = i + 1;
+                        break;
+                    }
+                }
+                // Skip whitespace between comment and the actual value
+                while (index + 1 < sql.length() && sql.charAt(index + 1) == ' ') {
+                    index++;
+                }
+            }
             else if (inColumnValue && !inSingleQuote) {
                 if (!inSpecial) {
                     start = index;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJsonDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJsonDataTypeIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.junit.EqualityCheck;
+import io.debezium.junit.SkipWhenDatabaseVersion;
+import io.debezium.util.Testing;
+
+import oracle.jdbc.OracleType;
+
+/**
+ * Integration tests for JSON data type support.
+ *
+ * <p>For Oracle LogMiner, the {@code JSON} data type is not emitted out-of-the-box. This data type
+ * requires that the Oracle GoldenGate feature be enabled, otherwise LogMiner emits events for a table
+ * that uses {@code JSON} as unsupported.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 21, minor = 0, reason = "JSON was added in Oracle 21+")
+public class OracleJsonDataTypeIT extends AbstractAsyncEngineConnectorTest {
+
+    private OracleConnection connection;
+
+    @BeforeAll
+    static void beforeAll() throws SQLException {
+        TestHelper.dropAllTables();
+
+        if (TestHelper.isAnyLogMiner()) {
+            TestHelper.enableGoldenGateReplication();
+        }
+    }
+
+    @AfterAll
+    static void afterAll() throws SQLException {
+        if (TestHelper.isAnyLogMiner()) {
+            TestHelper.disableGoldenGateReplication();
+        }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        connection = TestHelper.testConnection();
+        TestHelper.dropTable(connection, "dbz1884");
+
+        setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        if (connection != null) {
+            TestHelper.dropTable(connection, "dbz1884");
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("dbz#1884")
+    public void shouldSnapshotJsonDataTypeValues() throws Exception {
+        connection.execute("CREATE TABLE dbz1884 (id number(9,0) primary key, extra_data json)");
+        TestHelper.streamTable(connection, "dbz1884");
+
+        final String jsonData = "{\"name\":\"Sally Field\",\"age\":77}";
+
+        connection.prepareQuery("INSERT INTO dbz1884 (id,extra_data) values (1,?)",
+                ps -> ps.setObject(1, jsonData, OracleType.JSON), null);
+        connection.commit();
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.DBZ1884")
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic(topicName("DBZ1884"));
+        assertThat(records).hasSize(1);
+
+        final SourceRecord record = records.get(0);
+        VerifyRecord.isValidRead(record, "ID", 1);
+        assertThat(after(record).get("ID")).isEqualTo(1);
+        assertThat(after(record).get("EXTRA_DATA")).isEqualTo(jsonData);
+    }
+
+    @Test
+    @FixFor("dbz#1884")
+    public void shouldStreamJsonDataTypeValuesWithoutLobEnabled() throws Exception {
+        connection.execute("CREATE TABLE dbz1884 (id number(9,0) primary key, extra_data json)");
+        TestHelper.streamTable(connection, "dbz1884");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.DBZ1884")
+                .with(OracleConnectorConfig.LOB_ENABLED, Boolean.TRUE)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        final String jsonInsertData = "{\"name\":\"Sally Field\",\"age\":77}";
+        final String jsonUpdateData = "{\"greet\":\"Hello World\"}";
+
+        connection.prepareQuery("INSERT INTO dbz1884 (id,extra_data) values (1,?)",
+                ps -> ps.setObject(1, jsonInsertData, OracleType.JSON), null);
+        connection.commit();
+
+        connection.execute("UPDATE dbz1884 SET extra_data = '%s' WHERE ID = 1".formatted(jsonUpdateData));
+        connection.execute("DELETE FROM dbz1884 WHERE id = 1");
+
+        List<SourceRecord> records = consumeRecordsByTopic(3).recordsForTopic(topicName("DBZ1884"));
+        assertThat(records).hasSize(3);
+
+        final SourceRecord insert = records.get(0);
+        VerifyRecord.isValidInsert(insert, "ID", 1);
+        assertThat(before(insert)).isNull();
+        assertThat(after(insert).get("ID")).isEqualTo(1);
+        assertThat(after(insert).get("EXTRA_DATA")).isEqualTo(jsonInsertData);
+
+        final SourceRecord update = records.get(1);
+        VerifyRecord.isValidUpdate(update, "ID", 1);
+        assertThat(before(update).get("ID")).isEqualTo(1);
+        assertThat(before(update).get("EXTRA_DATA")).isEqualTo(unavailableValuePlaceholder(config));
+        assertThat(after(update).get("ID")).isEqualTo(1);
+        assertThat(after(update).get("EXTRA_DATA")).isEqualTo(jsonUpdateData);
+
+        final SourceRecord delete = records.get(2);
+        VerifyRecord.isValidDelete(delete, "ID", 1);
+        assertThat(before(delete).get("ID")).isEqualTo(1);
+        assertThat(before(delete).get("EXTRA_DATA")).isEqualTo(unavailableValuePlaceholder(config));
+        assertThat(after(records.get(2))).isNull();
+    }
+
+    private static Struct before(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+    }
+
+    private static Struct after(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+    }
+
+    private static String topicName(String tableName) {
+        return TestHelper.SERVER_NAME + ".DEBEZIUM." + tableName;
+    }
+
+    private static String unavailableValuePlaceholder(Configuration config) {
+        return config.getString(OracleConnectorConfig.UNAVAILABLE_VALUE_PLACEHOLDER);
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
@@ -788,4 +788,42 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getNewValues()[1]).isEqualTo("'Update1'");
         assertThat(entry.getNewValues()[2]).isEqualTo("'Update2'");
     }
+
+    @Test
+    @FixFor("dbz#1884")
+    public void shouldParseJsonAsBinaryInsert() throws Exception {
+        final LogMinerDmlParser parser = new LogMinerDmlParser(new OracleConnectorConfig(Configuration.empty()));
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.DBZ1872"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("EXTRA_DATA").create())
+                .create();
+
+        String sql = "insert into \"DEBEZIUM\".\"DBZ1872\"(\"ID\",\"EXTRA_DATA\") values ('1',/* JSON */ EMPTY_BLOB());";
+        LogMinerDmlEntry entry = parser.parse(sql, table);
+        assertThat(entry.getEventType()).isEqualTo(EventType.INSERT);
+        assertThat(entry.getOldValues()).isEmpty();
+        assertThat(entry.getNewValues()[0]).isEqualTo("1");
+        assertThat(entry.getNewValues()[1]).isEqualTo("/* JSON */ EMPTY_BLOB()");
+    }
+
+    @Test
+    @FixFor("dbz#1884")
+    public void shouldParseJsonAsBinaryUpdate() throws Exception {
+        final LogMinerDmlParser parser = new LogMinerDmlParser(new OracleConnectorConfig(Configuration.empty()));
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.DBZ1872"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("EXTRA_DATA").create())
+                .create();
+
+        String sql = "update \"DEBEZIUM\".\"DBZ1872\" set \"EXTRA_DATA\" = /* JSON */ HEXTORAW('ff4a5a012106020009001700009ce600050000046e616d650361676584020201000800140b53616c6c79204669656c6421c14e') where \"ID\" = '1';";
+        LogMinerDmlEntry entry = parser.parse(sql, table);
+        assertThat(entry.getEventType()).isEqualTo(EventType.UPDATE);
+        assertThat(entry.getOldValues()[0]).isEqualTo("1");
+        assertThat(entry.getOldValues()[1]).isNull();
+        assertThat(entry.getNewValues()[0]).isEqualTo("1");
+        assertThat(entry.getNewValues()[1])
+                .isEqualTo("/* JSON */ HEXTORAW('ff4a5a012106020009001700009ce600050000046e616d650361676584020201000800140b53616c6c79204669656c6421c14e')");
+    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -895,4 +895,15 @@ public class TestHelper {
         };
     }
 
+    public static void enableGoldenGateReplication() throws SQLException {
+        try (OracleConnection admin = adminConnection(true)) {
+            admin.execute("ALTER SYSTEM SET enable_goldengate_replication=TRUE SCOPE=BOTH");
+        }
+    }
+
+    public static void disableGoldenGateReplication() throws SQLException {
+        try (OracleConnection admin = adminConnection(true)) {
+            admin.execute("ALTER SYSTEM SET enable_goldengate_replication=TRUE SCOPE=BOTH");
+        }
+    }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2521,7 +2521,8 @@ The {prodname} connector for Oracle does not support the Oracle VECTOR data type
 [id="oracle-json-types"]
 === JSON types
 
-The {prodname} Oracle connector can capture changes to tables that include `JSON` column types when using the LogMiner adapter with the `ENABLE_GOLDENGATE_REPLICATION` database feature enabled.
+A {prodname} Oracle connector that uses the LogMiner adapter can capture changes from tables that include `JSON` column types.
+To enable capture of JSON types, the database initialization parameter `ENABLE_GOLDENGATE_REPLICATION` must be  set to `TRUE` to permit GoldenGate services to capture and apply changes across the entire instance.
 
 ifdef::community[]
 [NOTE]
@@ -2543,10 +2544,9 @@ endif::product[]
 
 [IMPORTANT]
 ====
-The ability to capture changes from tables that include `JSON` columns is limited to the Oracle LogMiner adapter, and requires that the `ENABLE_GOLDENGATE_REPLICATION` database feature be enabled.
 Oracle support for `JSON` data types is a premium feature that is only available through a GoldenGate license.
 
-Because the Oracle OCI driver cannot  read metadata for tables that contain a `JSON` column type, connectors configured to use the Oracle XStream adapter the connector cannot capture `JSON` data.
+Because the Oracle OCI driver cannot read metadata for tables that contain a `JSON` column type, connectors configured to use the Oracle XStream adapter the connector cannot capture `JSON` data.
 This limitation applies to all Oracle 21.x and 23.x drivers tested through version 23.26.1.
 ====
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2518,6 +2518,51 @@ _This data type is not supported when using Oracle XStream._
 
 The {prodname} connector for Oracle does not support the Oracle VECTOR data type.
 
+[id="oracle-json-types"]
+=== JSON types
+ifdef::community[]
+[NOTE]
+====
+Support for `JSON` is currently in an incubating state.
+Depending on the feedback that we receive, the exact semantics, configuration options, and so forth might change in future revisions.
+Please let us know if you encounter any problems with using these data types.
+====
+endif::community[]
+ifdef::product[]
+[IMPORTANT]
+====
+Use of the `JSON` with the {prodname} Oracle connector is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
+====
+endif::product[]
+
+[IMPORTANT]
+====
+The ability to capture changes for a table that includes a `JSON` column type is limited to the Oracle LogMiner adapter, and requires that `ENABLE_GOLDENGATE_REPLICATION` database feature be enabled.
+Oracle's support for `JSON` data types is a premium feature that is only available through a GoldenGate license.
+
+The ability to capture `JSON` data types using the Oracle XStream adapter is currently unsupported.
+This is due to an Oracle OCI driver limitation that does not currently allow the driver to read metadata for tables that contain a `JSON` column type.
+The limitation is present in all Oracle 21.x and 23.x drivers tested through 23.26.1.
+====
+
+The following table describes how the connector maps JSON data types.
+
+.Mappings for Oracle JSON data types
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|Oracle data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`JSON`
+|`STRING`
+|`io.debezium.data.Json`
+
+|===
+
 [id="oracle-xml-types"]
 === XML types
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2522,7 +2522,7 @@ The {prodname} connector for Oracle does not support the Oracle VECTOR data type
 === JSON types
 
 A {prodname} Oracle connector that uses the LogMiner adapter can capture changes from tables that include `JSON` column types.
-To enable capture of JSON types, the database initialization parameter `ENABLE_GOLDENGATE_REPLICATION` must be  set to `TRUE` to permit GoldenGate services to capture and apply changes across the entire instance.
+To permit {prodname} to capture JSON types, set the Oracle database initialization parameter https://docs.oracle.com/en/database/oracle/oracle-database/26/refrn/ENABLE_GOLDENGATE_REPLICATION.html[`ENABLE_GOLDENGATE_REPLICATION`] to `TRUE` so that the GoldenGate services can capture changes and apply them across the entire instance.
 
 ifdef::community[]
 [NOTE]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2520,10 +2520,13 @@ The {prodname} connector for Oracle does not support the Oracle VECTOR data type
 
 [id="oracle-json-types"]
 === JSON types
+
+The {prodname} Oracle connector can capture changes to tables that include `JSON` column types when using the LogMiner adapter with the `ENABLE_GOLDENGATE_REPLICATION` database feature enabled.
+
 ifdef::community[]
 [NOTE]
 ====
-Support for `JSON` is currently in an incubating state.
+Oracle connector support for `JSON` is currently in an incubating state.
 Depending on the feedback that we receive, the exact semantics, configuration options, and so forth might change in future revisions.
 Please let us know if you encounter any problems with using these data types.
 ====
@@ -2531,7 +2534,7 @@ endif::community[]
 ifdef::product[]
 [IMPORTANT]
 ====
-Use of the `JSON` with the {prodname} Oracle connector is a Technology Preview feature only.
+The ability of the {prodname} Oracle connector to process `JSON` data is a Technology Preview feature only.
 Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
 Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
@@ -2540,12 +2543,11 @@ endif::product[]
 
 [IMPORTANT]
 ====
-The ability to capture changes for a table that includes a `JSON` column type is limited to the Oracle LogMiner adapter, and requires that `ENABLE_GOLDENGATE_REPLICATION` database feature be enabled.
-Oracle's support for `JSON` data types is a premium feature that is only available through a GoldenGate license.
+The ability to capture changes from tables that include `JSON` columns is limited to the Oracle LogMiner adapter, and requires that the `ENABLE_GOLDENGATE_REPLICATION` database feature be enabled.
+Oracle support for `JSON` data types is a premium feature that is only available through a GoldenGate license.
 
-The ability to capture `JSON` data types using the Oracle XStream adapter is currently unsupported.
-This is due to an Oracle OCI driver limitation that does not currently allow the driver to read metadata for tables that contain a `JSON` column type.
-The limitation is present in all Oracle 21.x and 23.x drivers tested through 23.26.1.
+Because the Oracle OCI driver cannot  read metadata for tables that contain a `JSON` column type, connectors configured to use the Oracle XStream adapter the connector cannot capture `JSON` data.
+This limitation applies to all Oracle 21.x and 23.x drivers tested through version 23.26.1.
 ====
 
 The following table describes how the connector maps JSON data types.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1884

## Description
This is a preliminary pass at support for Oracle OSON (Oracle JSON) data types, aka `JSON`.

## Limitations

* Oracle does not support emitting events for tables with `JSON` columns with native LogMiner.
* The `JSON` data type can only be mined when `ENABLE_GOLDENGATE_REPLICATION` is enabled.
* Oracle XStream OCI (thick client) crashes when trying to read metadata for a table with a `JSON` column.

For these reasons, this PR is in draft until we can decide whether these limitations are acceptable or need to be addressed before we are comfortable supporting `JSON` data types, even partially.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

