### PR TITLE
debezium/dbz#1533 Improve Incremental Snapshot error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ You are working on Debezium, a Change Data Capture platform. Use the Maven versi
 - Format code: `./mvnw process-sources`
 - Validate formatting: `./mvn clean install -Dformat.formatter.goal=validate -Dformat.imports.goal=check`
 - run single unit test: `./mvn test install -Dtest=<class or method reference of a unit test>`
-- run single unit integration test: `./mvn test install --Dit.test=<class or method reference of an integration test>`
+- run single unit integration test: `./mvn verify install --Dit.test=<class or method reference of an integration test>`
 
 **Core modules:**
 - debezium-bom, debezium-connector-common, debezium-util, debezium-config, debezium-api, debezium-common, debezium-connect-plugins

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -346,19 +346,17 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             LOGGER.trace("Window close emitted");
         }
         catch (SQLException e) {
-            warnAndSkip((TableId) context.currentDataCollectionId().getId(), partition, offsetContext,
+            warnAndSkip(partition, offsetContext,
                     SQL_EXCEPTION,
-                    "SQL error while executing incremental snapshot for table '{}', skipping and continuing streaming");
+                    "SQL error while executing incremental snapshot for table '%s', skipping and continuing streaming"
+                            .formatted(context.currentDataCollectionId().getId()),
+                    e);
         }
         catch (Exception e) {
-            if (e.getCause() instanceof SQLException) {
-                warnAndSkip((TableId) context.currentDataCollectionId().getId(), partition, offsetContext,
-                        SQL_EXCEPTION,
-                        "SQL error while executing incremental snapshot for table '{}', skipping and continuing streaming");
-            }
-            else {
-                throw new DebeziumException(String.format("Database error while executing incremental snapshot for table '%s'", context.currentDataCollectionId()), e);
-            }
+            warnAndSkip(partition, offsetContext,
+                    SQL_EXCEPTION,
+                    "Error while executing incremental snapshot for table '%s', skipping and continuing streaming".formatted(context.currentDataCollectionId().getId()),
+                    e);
         }
         finally {
             postReadChunk(context);
@@ -378,26 +376,33 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                 retrieveAndRefreshSchema(currentTableId, partition, offsetContext);
                 currentTable = databaseSchema.tableFor(currentTableId);
                 if (currentTable == null) {
-                    warnAndSkip(currentTableId, partition, offsetContext, UNKNOWN_SCHEMA, "Schema retrieval failed to populate the schema as expected for {}");
+                    warnAndSkip(partition, offsetContext, UNKNOWN_SCHEMA,
+                            "Schema retrieval failed to populate the schema as expected for %s".formatted(currentTableId), null);
                     return true;
                 }
             }
             catch (Exception e) {
-                LOGGER.warn("Failed to retrieve schema for {}", currentTableId, e);
-                warnAndSkip(currentTableId, partition, offsetContext, UNKNOWN_SCHEMA, "Schema retrieval failed due to an exception for {}");
+                warnAndSkip(partition, offsetContext, UNKNOWN_SCHEMA,
+                        "Schema retrieval failed due to an exception for %s".formatted(currentTableId), e);
                 return true;
             }
         }
         currentTable = chunkQueryBuilder.prepareTable(context, currentTable);
         if (chunkQueryBuilder.getQueryColumns(context, currentTable).isEmpty()) {
-            warnAndSkip(currentTableId, partition, offsetContext, NO_PRIMARY_KEY, "Incremental snapshot for table '{}' skipped because the table has no primary keys");
+            warnAndSkip(partition, offsetContext, NO_PRIMARY_KEY,
+                    "Incremental snapshot for table '%s' skipped because the table has no primary keys".formatted(currentTableId), null);
             return true;
         }
         return false;
     }
 
-    private void warnAndSkip(TableId currentTableId, P partition, OffsetContext offsetContext, TableScanCompletionStatus status, String reason) {
-        LOGGER.warn(reason, currentTableId);
+    private void warnAndSkip(P partition, OffsetContext offsetContext, TableScanCompletionStatus status, String formattedReason, Throwable t) {
+        if (t != null) {
+            LOGGER.warn(formattedReason, t);
+        }
+        else {
+            LOGGER.warn(formattedReason);
+        }
         notificationService.incrementalSnapshotNotificationService()
                 .notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned, status);
         nextDataCollection(partition, offsetContext);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -341,7 +341,10 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             emitWindowClose(partition, offsetContext);
         }
         catch (Exception e) {
-            throw new DebeziumException(String.format("Database error while executing incremental snapshot for table '%s'", context.currentDataCollectionId()), e);
+            warnAndSkip(partition, offsetContext,
+                    "Error while executing incremental snapshot for collection '%s', skipping and continuing streaming"
+                            .formatted(context.currentDataCollectionId().getId()),
+                    e);
         }
         finally {
             postReadChunk(context);
@@ -349,6 +352,18 @@ public class MongoDbIncrementalSnapshotChangeEventSource
                 postIncrementalSnapshotCompleted();
             }
         }
+    }
+
+    private void warnAndSkip(MongoDbPartition partition, OffsetContext offsetContext, String formattedReason, Throwable t) {
+        if (t != null) {
+            LOGGER.warn(formattedReason, t);
+        }
+        else {
+            LOGGER.warn(formattedReason);
+        }
+        notificationService.incrementalSnapshotNotificationService()
+                .notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned, UNKNOWN_SCHEMA);
+        nextDataCollection(partition, offsetContext);
     }
 
     private void nextDataCollection(MongoDbPartition partition, OffsetContext offsetContext) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
@@ -948,6 +948,37 @@ public class IncrementalSnapshotIT extends AbstractMongoConnectorIT {
         return stopMessageFound.get();
     }
 
+    @Test
+    @FixFor("dbz#1533")
+    public void shouldNotGetStuckOnInvalidAdditionalCondition() throws Exception {
+        // Testing.Print.enable();
+
+        populateDataCollection();
+        startConnector();
+
+        // Send a snapshot signal with a malformed additional condition.
+        // MongoDB's Document.parse() will throw a JsonParseException inside readChunk()
+        // when it tries to use the condition for the max-key query.
+        // The connector should NOT get stuck and should remain responsive.
+        insertDocuments("dbA", "signals",
+                Document.parse("{\"type\": \"execute-snapshot\", \"payload\": {"
+                        + "\"type\": \"INCREMENTAL\","
+                        + "\"data-collections\": [\"" + fullDataCollectionName() + "\"],"
+                        + "\"additional-conditions\": [{\"data-collection\": \"" + fullDataCollectionName() + "\", \"filter\": \"(THIS IS NOT VALID BSON)\"}]}}"));
+
+        // Wait to ensure the signal is processed
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Send a VALID snapshot signal to prove the connector is still functional
+        sendAdHocSnapshotSignal();
+
+        final int expectedRecordCount = ROW_COUNT;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            assertThat(dbChanges).contains(entry(i + 1, i));
+        }
+    }
+
     @Override
     protected int getMaximumEnqueuedRecordCount() {
         return ROW_COUNT * 3;

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -1244,6 +1244,42 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         });
     }
 
+    @Test
+    @FixFor("dbz#1533")
+    public void shouldNotGetStuckOnInvalidSurrogateKey() throws Exception {
+        // Testing.Print.enable();
+
+        populateTable();
+        startConnector();
+
+        // Send a snapshot signal with an INVALID surrogate key that doesn't exist in the table.
+        // This should be handled gracefully - the table should be skipped with a warning
+        // and the connector should NOT get stuck in a restart loop.
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "\"totally_invalid_column_name\"", tableDataCollectionId());
+
+        // Wait to ensure the signal is processed
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Send a VALID snapshot signal to prove the connector is still functional
+        sendAdHocSnapshotSignal();
+
+        // Insert a streaming change to verify connector is still processing events
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
+                    tableName(),
+                    connection.quoteIdentifier(pkFieldName()),
+                    ROW_COUNT + 1,
+                    ROW_COUNT));
+        }
+
+        // The valid signal should complete and the streaming insert should also be captured
+        final int expectedRecordCount = ROW_COUNT + 1;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            assertThat(dbChanges).contains(entry(i + 1, i));
+        }
+    }
+
     private void assertOpenCloseEventCount(JdbcConnection.ResultSetConsumer consumer) throws SQLException {
         try (JdbcConnection connection = databaseConnection()) {
             connection.query("SELECT count(id) from " + signalTableName() + " where type='snapshot-window-close'", consumer);


### PR DESCRIPTION
Fixes debezium/dbz#1533

## Description
This pull request improves the error handling and robustness of incremental snapshot processing in both the core and MongoDB connectors. It ensures that malformed or invalid snapshot signals and schema issues do not cause the connector to get stuck or crash, and adds tests to verify this behavior. Additionally, logging and notification mechanisms have been refactored for consistency and clarity.

**Error handling and robustness improvements:**

* Refactored the `warnAndSkip` method in `AbstractIncrementalSnapshotChangeEventSource` to consistently handle errors by logging formatted messages and notifying the snapshot completion service, reducing the risk of the connector getting stuck on exceptions. The method signature and usage were updated throughout the class. [[1]](diffhunk://#diff-7dbdc0391912be71af699f3bdd2e3c324b7b9960f73f8f4df712cfe17862269aL349-R359) [[2]](diffhunk://#diff-7dbdc0391912be71af699f3bdd2e3c324b7b9960f73f8f4df712cfe17862269aL381-R405)
* Updated error handling in the MongoDB incremental snapshot source to use a new `warnAndSkip` method, ensuring that exceptions (such as parsing errors from malformed signals) are logged and the connector remains responsive. [[1]](diffhunk://#diff-6099936034d32691ba4f9786c14927dfb656ff63a63878e7c16594c8fe62b4d4L344-R347) [[2]](diffhunk://#diff-6099936034d32691ba4f9786c14927dfb656ff63a63878e7c16594c8fe62b4d4R357-R368)

**Testing for resilience to invalid snapshot signals:**

* Added a test to the MongoDB connector (`IncrementalSnapshotIT`) to verify that the connector does not get stuck when receiving a snapshot signal with an invalid additional condition, and remains functional for subsequent valid signals.
* Added a test to the embedded pipeline (`AbstractIncrementalSnapshotTest`) to verify that the connector handles invalid surrogate keys gracefully, skipping the table with a warning and continuing to process valid signals and streaming changes.

**Documentation and build improvements:**

* Updated the `AGENTS.md` documentation to correct the Maven command for running a single unit integration test, ensuring developers use the correct build lifecycle phase.

## PR Checklist

- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
