### PR TITLE
DBZ-1912 Allow customizing the zero-date fallback value (per type) for MySQL/MariaDB

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -99,9 +99,6 @@ public class ZeroDateFallbackConverter
 
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final String NULL_TOKEN = "NULL";
-    private static final String SCHEMA_DATE = "io.debezium.time.Date";
-    private static final String SCHEMA_TIMESTAMP = "io.debezium.time.Timestamp";
-    private static final String SCHEMA_ZONED_TIMESTAMP = "io.debezium.time.ZonedTimestamp";
     private static final int SCHEMA_VERSION = 1;
 
     private boolean applyToDate;
@@ -188,7 +185,7 @@ public class ZeroDateFallbackConverter
         final Integer fallback = effective == null ? null : (int) effective.toEpochDay();
         final boolean hasDefault = field.hasDefaultValue();
 
-        SchemaBuilder schema = SchemaBuilder.int32().name(SCHEMA_DATE).version(SCHEMA_VERSION);
+        SchemaBuilder schema = SchemaBuilder.int32().name(io.debezium.time.Date.SCHEMA_NAME).version(SCHEMA_VERSION);
         if (fallback == null) {
             schema = schema.optional();
         }
@@ -223,7 +220,7 @@ public class ZeroDateFallbackConverter
         final Long fallback = effective == null ? null : effective.toInstant(ZoneOffset.UTC).toEpochMilli();
         final boolean hasDefault = field.hasDefaultValue();
 
-        SchemaBuilder schema = SchemaBuilder.int64().name(SCHEMA_TIMESTAMP).version(SCHEMA_VERSION);
+        SchemaBuilder schema = SchemaBuilder.int64().name(io.debezium.time.Timestamp.SCHEMA_NAME).version(SCHEMA_VERSION);
         if (fallback == null) {
             schema = schema.optional();
         }
@@ -258,7 +255,7 @@ public class ZeroDateFallbackConverter
         final String fallback = effective == null ? null : effective.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         final boolean hasDefault = field.hasDefaultValue();
 
-        SchemaBuilder schema = SchemaBuilder.string().name(SCHEMA_ZONED_TIMESTAMP).version(SCHEMA_VERSION);
+        SchemaBuilder schema = SchemaBuilder.string().name(io.debezium.time.ZonedTimestamp.SCHEMA_NAME).version(SCHEMA_VERSION);
         if (fallback == null) {
             schema = schema.optional();
         }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.converters;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Field;
+import io.debezium.function.Predicates;
+import io.debezium.metadata.ConfigDescriptor;
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+import io.debezium.util.Strings;
+
+/**
+ * Replaces MySQL/MariaDB zero-date sentinels ({@code 0000-00-00} / {@code 0000-00-00 00:00:00})
+ * with either {@code null} or a user-chosen literal, per JDBC type and optionally per column.
+ *
+ * <h2>Supported types</h2>
+ * <ul>
+ *   <li>{@code DATE} &rarr; {@code io.debezium.time.Date} (INT32 epoch days)</li>
+ *   <li>{@code DATETIME} &rarr; {@code io.debezium.time.Timestamp} (INT64 epoch millis)</li>
+ *   <li>{@code TIMESTAMP} &rarr; {@code io.debezium.time.ZonedTimestamp} (STRING ISO-8601)</li>
+ * </ul>
+ *
+ * <h2>Two policies, selectable per type</h2>
+ * <ul>
+ *   <li><b>NULL policy</b> &mdash; the row and the column schema's {@code defaultValue} slot both
+ *       become {@code null}. The schema is promoted to nullable. Active when the fallback option
+ *       is {@code NULL} (case-insensitive) or unset (default).</li>
+ *   <li><b>User-value policy</b> &mdash; the row and the column schema's {@code defaultValue} are
+ *       set to the configured literal. Schema stays NOT NULL. Any DDL {@code DEFAULT} on the
+ *       column is overridden by this value.</li>
+ * </ul>
+ *
+ * <h2>Resolution order</h2>
+ * Column-level override &gt; type-level fallback &gt; NULL.
+ *
+ * <h2>Configuration</h2>
+ * <ul>
+ *   <li>{@code <prefix>.target.types} &mdash; comma-separated subset of
+ *       {@code DATE,DATETIME,TIMESTAMP}. Default applies to all three.</li>
+ *   <li>{@code <prefix>.fallback.date} / {@code .fallback.datetime} / {@code .fallback.timestamp}
+ *       &mdash; per-type replacement. {@code NULL} (default) or a type-appropriate literal.</li>
+ *   <li>{@code <prefix>.column.<db>.<table>.<column>.fallback} &mdash; column-specific override of
+ *       the type-level value. Look-up key is built from
+ *       {@code field.dataCollection() + "." + field.name()}.</li>
+ *   <li>{@code <prefix>.selector} &mdash; comma-separated regex applied to
+ *       {@code <db>.<table>.<column>}. Default {@code .*} (every matching-type column).</li>
+ * </ul>
+ *
+ * <h2>How it interacts with DDL defaults</h2>
+ * The implementation relies on {@code TableSchemaBuilder} invoking the registered conversion
+ * lambda exactly once at schema-build time (for resolving the column's {@code defaultValue}
+ * slot). A per-column {@link AtomicBoolean} guards that first call:
+ * <ul>
+ *   <li>Under the NULL policy, the lambda returns {@code null} on the first call, which leaves
+ *       the schema's {@code defaultValue} slot empty so AvroConverter does not back-fill null rows
+ *       with the DDL default.</li>
+ *   <li>Under the user-value policy, the lambda returns the configured literal on the first call,
+ *       so the schema's {@code defaultValue} adopts the user's sentinel regardless of the DDL
+ *       default.</li>
+ * </ul>
+ * Row-level emission is unaffected: for every row event the lambda inspects {@code input == null}
+ * to distinguish zero-date rows (collapsed to {@code null} by the binlog deserializer / JDBC
+ * driver) from genuine values, so a real {@code 1970-01-01 00:00:00 UTC} row still emits {@code 0}
+ * even when the converter is enabled. This means false positives are not possible at the row
+ * level.
+ * <p>
+ * The first-call behavior depends on Debezium internals rather than a published SPI contract and
+ * may need adjustment if {@code TableSchemaBuilder} ever invokes the lambda a different number of
+ * times during schema build.
+ *
+ * @author minleejae
+ */
+public class ZeroDateFallbackConverter
+        implements CustomConverter<SchemaBuilder, RelationalColumn>, ConfigDescriptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZeroDateFallbackConverter.class);
+
+    private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final String NULL_TOKEN = "NULL";
+    private static final String SCHEMA_DATE = "io.debezium.time.Date";
+    private static final String SCHEMA_TIMESTAMP = "io.debezium.time.Timestamp";
+    private static final String SCHEMA_ZONED_TIMESTAMP = "io.debezium.time.ZonedTimestamp";
+    private static final int SCHEMA_VERSION = 1;
+
+    private boolean applyToDate;
+    private boolean applyToDatetime;
+    private boolean applyToTimestamp;
+
+    private LocalDate fallbackDate;
+    private LocalDateTime fallbackDatetime;
+    private OffsetDateTime fallbackTimestamp;
+
+    private Predicate<RelationalColumn> selector = x -> true;
+    private Properties rawProps;
+
+    @Override
+    public void configure(Properties props) {
+        this.rawProps = props;
+
+        final String targets = props.getProperty(
+                ZeroDateFallbackConverterConfig.TARGET_TYPES.name(),
+                ZeroDateFallbackConverterConfig.DEFAULT_TARGET_TYPES).toUpperCase();
+        final Set<String> tokens = parseCsv(targets);
+        this.applyToDate = tokens.contains("DATE");
+        this.applyToDatetime = tokens.contains("DATETIME");
+        this.applyToTimestamp = tokens.contains("TIMESTAMP");
+
+        this.fallbackDate = parseDateFallback(props.getProperty(
+                ZeroDateFallbackConverterConfig.FALLBACK_DATE.name()));
+        this.fallbackDatetime = parseDatetimeFallback(props.getProperty(
+                ZeroDateFallbackConverterConfig.FALLBACK_DATETIME.name()));
+        this.fallbackTimestamp = parseTimestampFallback(props.getProperty(
+                ZeroDateFallbackConverterConfig.FALLBACK_TIMESTAMP.name()));
+
+        final String selectorConfig = props.getProperty(
+                ZeroDateFallbackConverterConfig.SELECTOR.name(),
+                ZeroDateFallbackConverterConfig.DEFAULT_SELECTOR);
+        if (!Strings.isNullOrBlank(selectorConfig) && !ZeroDateFallbackConverterConfig.DEFAULT_SELECTOR.equals(selectorConfig.trim())) {
+            this.selector = Predicates.includes(selectorConfig.trim(), x -> x.dataCollection() + "." + x.name());
+        }
+
+        LOGGER.info("ZeroDateFallbackConverter configured: targets=[DATE={}, DATETIME={}, TIMESTAMP={}], "
+                + "fallback=[date={}, datetime={}, timestamp={}], selector='{}'",
+                applyToDate, applyToDatetime, applyToTimestamp,
+                describe(fallbackDate), describe(fallbackDatetime), describe(fallbackTimestamp),
+                selectorConfig);
+    }
+
+    @Override
+    public void converterFor(RelationalColumn field, ConverterRegistration<SchemaBuilder> registration) {
+        if (!selector.test(field)) {
+            return;
+        }
+
+        final int jdbcType = field.jdbcType();
+        final String typeName = field.typeName() != null ? field.typeName().toUpperCase() : "";
+
+        if (jdbcType == Types.DATE && applyToDate) {
+            registerDate(field, registration);
+        }
+        else if (jdbcType == Types.TIMESTAMP && applyToDatetime && "DATETIME".equals(typeName)) {
+            registerDatetime(field, registration);
+        }
+        else if ((jdbcType == Types.TIMESTAMP_WITH_TIMEZONE || "TIMESTAMP".equals(typeName)) && applyToTimestamp) {
+            registerTimestamp(field, registration);
+        }
+        else {
+            LOGGER.debug("Skipping field '{}.{}' jdbcType={} typeName='{}'",
+                    field.dataCollection(), field.name(), jdbcType, typeName);
+        }
+    }
+
+    @Override
+    public Field.Set getConfigFields() {
+        return Field.setOf(
+                ZeroDateFallbackConverterConfig.TARGET_TYPES,
+                ZeroDateFallbackConverterConfig.FALLBACK_DATE,
+                ZeroDateFallbackConverterConfig.FALLBACK_DATETIME,
+                ZeroDateFallbackConverterConfig.FALLBACK_TIMESTAMP,
+                ZeroDateFallbackConverterConfig.SELECTOR);
+    }
+
+    private void registerDate(RelationalColumn field, ConverterRegistration<SchemaBuilder> registration) {
+        final String columnRaw = lookupColumnFallback(field);
+        final LocalDate effective = (columnRaw != null) ? parseDateFallback(columnRaw) : fallbackDate;
+        final Integer fallback = effective == null ? null : (int) effective.toEpochDay();
+        final boolean hasDefault = field.hasDefaultValue();
+
+        SchemaBuilder schema = SchemaBuilder.int32().name(SCHEMA_DATE).version(SCHEMA_VERSION);
+        if (fallback == null) {
+            schema = schema.optional();
+        }
+        logRegistration("DATE", field, columnRaw, hasDefault, fallback);
+
+        final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
+        registration.register(schema, input -> {
+            if (!firstCallSeen.getAndSet(true) && hasDefault) {
+                return fallback;
+            }
+            if (input == null) {
+                return fallback;
+            }
+            if (input instanceof Date date) {
+                return (int) date.toLocalDate().toEpochDay();
+            }
+            if (input instanceof LocalDate ld) {
+                return (int) ld.toEpochDay();
+            }
+            if (input instanceof Integer i) {
+                return i;
+            }
+            LOGGER.warn("Unexpected input type {} on DATE field '{}.{}', returning fallback",
+                    input.getClass().getName(), field.dataCollection(), field.name());
+            return fallback;
+        });
+    }
+
+    private void registerDatetime(RelationalColumn field, ConverterRegistration<SchemaBuilder> registration) {
+        final String columnRaw = lookupColumnFallback(field);
+        final LocalDateTime effective = (columnRaw != null) ? parseDatetimeFallback(columnRaw) : fallbackDatetime;
+        final Long fallback = effective == null ? null : effective.toInstant(ZoneOffset.UTC).toEpochMilli();
+        final boolean hasDefault = field.hasDefaultValue();
+
+        SchemaBuilder schema = SchemaBuilder.int64().name(SCHEMA_TIMESTAMP).version(SCHEMA_VERSION);
+        if (fallback == null) {
+            schema = schema.optional();
+        }
+        logRegistration("DATETIME", field, columnRaw, hasDefault, fallback);
+
+        final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
+        registration.register(schema, input -> {
+            if (!firstCallSeen.getAndSet(true) && hasDefault) {
+                return fallback;
+            }
+            if (input == null) {
+                return fallback;
+            }
+            if (input instanceof Timestamp ts) {
+                return ts.getTime();
+            }
+            if (input instanceof LocalDateTime ldt) {
+                return ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+            }
+            if (input instanceof Long l) {
+                return l;
+            }
+            LOGGER.warn("Unexpected input type {} on DATETIME field '{}.{}', returning fallback",
+                    input.getClass().getName(), field.dataCollection(), field.name());
+            return fallback;
+        });
+    }
+
+    private void registerTimestamp(RelationalColumn field, ConverterRegistration<SchemaBuilder> registration) {
+        final String columnRaw = lookupColumnFallback(field);
+        final OffsetDateTime effective = (columnRaw != null) ? parseTimestampFallback(columnRaw) : fallbackTimestamp;
+        final String fallback = effective == null ? null : effective.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        final boolean hasDefault = field.hasDefaultValue();
+
+        SchemaBuilder schema = SchemaBuilder.string().name(SCHEMA_ZONED_TIMESTAMP).version(SCHEMA_VERSION);
+        if (fallback == null) {
+            schema = schema.optional();
+        }
+        logRegistration("TIMESTAMP", field, columnRaw, hasDefault, fallback);
+
+        final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
+        registration.register(schema, input -> {
+            if (!firstCallSeen.getAndSet(true) && hasDefault) {
+                return fallback;
+            }
+            if (input == null) {
+                return fallback;
+            }
+            if (input instanceof Timestamp ts) {
+                return ts.toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            }
+            if (input instanceof OffsetDateTime odt) {
+                return odt.withOffsetSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            }
+            if (input instanceof ZonedDateTime zdt) {
+                return zdt.withZoneSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            }
+            if (input instanceof String s) {
+                return s;
+            }
+            LOGGER.warn("Unexpected input type {} on TIMESTAMP field '{}.{}', returning fallback",
+                    input.getClass().getName(), field.dataCollection(), field.name());
+            return fallback;
+        });
+    }
+
+    private String lookupColumnFallback(RelationalColumn field) {
+        if (rawProps == null) {
+            return null;
+        }
+        final String key = ZeroDateFallbackConverterConfig.COLUMN_FALLBACK_PREFIX
+                + field.dataCollection() + "." + field.name()
+                + ZeroDateFallbackConverterConfig.COLUMN_FALLBACK_SUFFIX;
+        return rawProps.getProperty(key);
+    }
+
+    private static void logRegistration(String typeLabel, RelationalColumn field, String columnRaw,
+                                        boolean hasDefault, Object fallback) {
+        if (!LOGGER.isDebugEnabled()) {
+            return;
+        }
+        LOGGER.debug("Registered {} converter on '{}.{}' source={} hasDefault={} fallback={}",
+                typeLabel, field.dataCollection(), field.name(),
+                columnRaw != null ? "column-level" : "type-level",
+                hasDefault,
+                fallback == null ? "NULL" : fallback);
+    }
+
+    private static Set<String> parseCsv(String raw) {
+        final Set<String> out = new HashSet<>();
+        for (String token : raw.split(",")) {
+            final String trimmed = token.trim();
+            if (!trimmed.isEmpty()) {
+                out.add(trimmed);
+            }
+        }
+        return out;
+    }
+
+    static LocalDate parseDateFallback(String raw) {
+        if (isNullToken(raw)) {
+            return null;
+        }
+        return LocalDate.parse(raw.trim());
+    }
+
+    static LocalDateTime parseDatetimeFallback(String raw) {
+        if (isNullToken(raw)) {
+            return null;
+        }
+        return LocalDateTime.parse(raw.trim(), DATETIME_FMT);
+    }
+
+    static OffsetDateTime parseTimestampFallback(String raw) {
+        if (isNullToken(raw)) {
+            return null;
+        }
+        return OffsetDateTime.parse(raw.trim()).withOffsetSameInstant(ZoneOffset.UTC);
+    }
+
+    private static boolean isNullToken(String raw) {
+        return raw == null || raw.trim().isEmpty() || NULL_TOKEN.equalsIgnoreCase(raw.trim());
+    }
+
+    private static String describe(Object value) {
+        return value == null ? NULL_TOKEN : value.toString();
+    }
+}

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -99,6 +99,9 @@ public class ZeroDateFallbackConverter
 
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final String NULL_TOKEN = "NULL";
+    private static final String TYPE_DATE = "DATE";
+    private static final String TYPE_DATETIME = "DATETIME";
+    private static final String TYPE_TIMESTAMP = "TIMESTAMP";
     private static final int SCHEMA_VERSION = 1;
 
     private boolean applyToDate;
@@ -120,9 +123,9 @@ public class ZeroDateFallbackConverter
                 ZeroDateFallbackConverterConfig.TARGET_TYPES.name(),
                 ZeroDateFallbackConverterConfig.DEFAULT_TARGET_TYPES).toUpperCase();
         final Set<String> tokens = parseCsv(targets);
-        this.applyToDate = tokens.contains("DATE");
-        this.applyToDatetime = tokens.contains("DATETIME");
-        this.applyToTimestamp = tokens.contains("TIMESTAMP");
+        this.applyToDate = tokens.contains(TYPE_DATE);
+        this.applyToDatetime = tokens.contains(TYPE_DATETIME);
+        this.applyToTimestamp = tokens.contains(TYPE_TIMESTAMP);
 
         this.fallbackDate = parseDateFallback(props.getProperty(
                 ZeroDateFallbackConverterConfig.FALLBACK_DATE.name()));
@@ -157,10 +160,10 @@ public class ZeroDateFallbackConverter
         if (jdbcType == Types.DATE && applyToDate) {
             registerDate(field, registration);
         }
-        else if (jdbcType == Types.TIMESTAMP && applyToDatetime && "DATETIME".equals(typeName)) {
+        else if (jdbcType == Types.TIMESTAMP && applyToDatetime && TYPE_DATETIME.equals(typeName)) {
             registerDatetime(field, registration);
         }
-        else if ((jdbcType == Types.TIMESTAMP_WITH_TIMEZONE || "TIMESTAMP".equals(typeName)) && applyToTimestamp) {
+        else if ((jdbcType == Types.TIMESTAMP_WITH_TIMEZONE || TYPE_TIMESTAMP.equals(typeName)) && applyToTimestamp) {
             registerTimestamp(field, registration);
         }
         else {
@@ -189,7 +192,7 @@ public class ZeroDateFallbackConverter
         if (fallback == null) {
             schema = schema.optional();
         }
-        logRegistration("DATE", field, columnRaw, hasDefault, fallback);
+        logRegistration(TYPE_DATE, field, columnRaw, hasDefault, fallback);
 
         final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
         registration.register(schema, input -> {
@@ -224,7 +227,7 @@ public class ZeroDateFallbackConverter
         if (fallback == null) {
             schema = schema.optional();
         }
-        logRegistration("DATETIME", field, columnRaw, hasDefault, fallback);
+        logRegistration(TYPE_DATETIME, field, columnRaw, hasDefault, fallback);
 
         final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
         registration.register(schema, input -> {
@@ -259,7 +262,7 @@ public class ZeroDateFallbackConverter
         if (fallback == null) {
             schema = schema.optional();
         }
-        logRegistration("TIMESTAMP", field, columnRaw, hasDefault, fallback);
+        logRegistration(TYPE_TIMESTAMP, field, columnRaw, hasDefault, fallback);
 
         final AtomicBoolean firstCallSeen = new AtomicBoolean(false);
         registration.register(schema, input -> {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -309,7 +309,7 @@ public class ZeroDateFallbackConverter
                 typeLabel, field.dataCollection(), field.name(),
                 columnRaw != null ? "column-level" : "type-level",
                 hasDefault,
-                fallback == null ? "NULL" : fallback);
+                fallback == null ? NULL_TOKEN : fallback);
     }
 
     private static Set<String> parseCsv(String raw) {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -345,7 +345,7 @@ public class ZeroDateFallbackConverter
     }
 
     private static boolean isNullToken(String raw) {
-        return raw == null || raw.trim().isEmpty() || NULL_TOKEN.equalsIgnoreCase(raw.trim());
+        return Strings.isNullOrBlank(raw) || NULL_TOKEN.equalsIgnoreCase(raw.trim());
     }
 
     private static String describe(Object value) {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -14,7 +14,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -313,14 +312,7 @@ public class ZeroDateFallbackConverter
     }
 
     private static Set<String> parseCsv(String raw) {
-        final Set<String> out = new HashSet<>();
-        for (String token : raw.split(",")) {
-            final String trimmed = token.trim();
-            if (!trimmed.isEmpty()) {
-                out.add(trimmed);
-            }
-        }
-        return out;
+        return Strings.setOfTrimmed(raw, ',', s -> s.isEmpty() ? null : s);
     }
 
     static LocalDate parseDateFallback(String raw) {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterConfig.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.converters;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import io.debezium.config.Field;
+
+/**
+ * Configuration fields for {@link ZeroDateFallbackConverter}.
+ * <p>
+ * Type-level fallbacks and the target-types filter are exposed as proper {@link Field}s.
+ * Column-level overrides use a dynamic property key
+ * ({@code column.<dataCollection>.<column>.fallback}) and are looked up directly from the
+ * raw {@link java.util.Properties} passed to {@link ZeroDateFallbackConverter#configure}, so
+ * they do not need a static {@link Field} definition.
+ */
+public class ZeroDateFallbackConverterConfig {
+
+    public static final String DEFAULT_TARGET_TYPES = "DATE,DATETIME,TIMESTAMP";
+    public static final String DEFAULT_SELECTOR = ".*";
+
+    public static final Field TARGET_TYPES = Field.create("target.types")
+            .withDisplayName("Target JDBC types")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(DEFAULT_TARGET_TYPES)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Comma-separated list of JDBC temporal types this converter applies to. " +
+                    "Allowed tokens: DATE, DATETIME, TIMESTAMP. Default is to apply to all three.");
+
+    public static final Field FALLBACK_DATE = Field.create("fallback.date")
+            .withDisplayName("DATE zero-date fallback")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Replacement value emitted for MySQL/MariaDB DATE zero-date rows " +
+                    "(0000-00-00). Use 'NULL' (or leave unset) to emit null and promote the column " +
+                    "schema to optional. Otherwise specify an ISO-8601 date literal (yyyy-MM-dd).");
+
+    public static final Field FALLBACK_DATETIME = Field.create("fallback.datetime")
+            .withDisplayName("DATETIME zero-date fallback")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Replacement value emitted for MySQL/MariaDB DATETIME zero-date rows " +
+                    "(0000-00-00 00:00:00). Use 'NULL' (or leave unset) to emit null and promote the " +
+                    "column schema to optional. Otherwise specify a UTC datetime literal " +
+                    "(yyyy-MM-dd HH:mm:ss).");
+
+    public static final Field FALLBACK_TIMESTAMP = Field.create("fallback.timestamp")
+            .withDisplayName("TIMESTAMP zero-date fallback")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Replacement value emitted for MySQL/MariaDB TIMESTAMP zero-date rows. " +
+                    "Use 'NULL' (or leave unset) to emit null and promote the column schema to " +
+                    "optional. Otherwise specify an ISO-8601 offset datetime literal " +
+                    "(e.g. 1970-01-01T00:00:00Z).");
+
+    public static final Field SELECTOR = Field.create("selector")
+            .withDisplayName("Column selector")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(DEFAULT_SELECTOR)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Comma-separated list of regex patterns matched against " +
+                    "<database>.<table>.<column>. Only matching columns have this converter applied. " +
+                    "Default '.*' matches every column whose JDBC type is in target.types.");
+
+    /** Property key prefix for column-level fallback overrides. */
+    public static final String COLUMN_FALLBACK_PREFIX = "column.";
+    /** Property key suffix for column-level fallback overrides. */
+    public static final String COLUMN_FALLBACK_SUFFIX = ".fallback";
+
+    private ZeroDateFallbackConverterConfig() {
+    }
+}

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/event/RowDeserializers.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/event/RowDeserializers.java
@@ -473,6 +473,9 @@ public class RowDeserializers {
      */
     protected static Serializable deserializeTimestamp(ByteArrayInputStream inputStream) throws IOException {
         long epochSecond = inputStream.readLong(4);
+        if (epochSecond == 0) {
+            return null; // 0000-00-00 00:00:00 — MySQL TIMESTAMP min is 1970-01-01 00:00:01 UTC
+        }
         int nanoSeconds = 0; // no fractional seconds
         return ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond, nanoSeconds), ZoneOffset.UTC);
     }
@@ -490,6 +493,9 @@ public class RowDeserializers {
     protected static Serializable deserializeTimestampV2(int meta, ByteArrayInputStream inputStream) throws IOException {
         long epochSecond = bigEndianLong(inputStream.read(4), 0, 4);
         int nanoSeconds = deserializeFractionalSecondsInNanos(meta, inputStream);
+        if (epochSecond == 0 && nanoSeconds == 0) {
+            return null; // 0000-00-00 00:00:00.000000 — outside legal MySQL TIMESTAMP range
+        }
         return ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond, nanoSeconds), ZoneOffset.UTC);
     }
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRegressionIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRegressionIT.java
@@ -245,22 +245,11 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
                 assertThat(after.getInt64("c3")).isNull(); // epoch millis
 
                 // '0000-00-00 00:00:00.00'
-                String c4 = after.getString("c4"); // timestamp
-                OffsetDateTime c4DateTime = OffsetDateTime.parse(c4, ZonedTimestamp.FORMATTER);
-
-                // Timestamp is stored as UTC
-                assertThat(c4DateTime.getOffset()).isEqualTo(ZoneOffset.UTC);
-
-                // In case the timestamp string not in our timezone, convert to UTC so we can compare ...
-                c4DateTime = c4DateTime.withOffsetSameInstant(ZoneOffset.of("Z"));
-                assertThat(c4DateTime.getYear()).isEqualTo(1970);
-                assertThat(c4DateTime.getMonth()).isEqualTo(Month.JANUARY);
-                assertThat(c4DateTime.getDayOfMonth()).isEqualTo(1);
-                // Difference depends upon whether the zone we're in is also using DST as it is on the date in question ...
-                assertThat(c4DateTime.getHour()).isIn(0, 1);
-                assertThat(c4DateTime.getMinute()).isEqualTo(0);
-                assertThat(c4DateTime.getSecond()).isEqualTo(0);
-                assertThat(c4DateTime.getNano()).isEqualTo(0);
+                // DBZ-1912: nullable zero-date TIMESTAMP collapses to null in the streaming
+                // deserialization path (consistent with the snapshot CONVERT_TO_NULL behavior and
+                // with how DATE/DATETIME zero-dates were already handled). Pre-DBZ-1912 the binlog
+                // wire epochSecond=0 surfaced here as the string "1970-01-01T00:00:00Z".
+                assertThat(after.getString("c4")).isNull(); // timestamp
             }
             else if (record.topic().endsWith("dbz_123_bitvaluetest")) {
                 // All row events should have the same values ...
@@ -422,14 +411,17 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
         assertThat(rec1.get("c1")).isNull();
         assertThat(rec1.get("c2")).isEqualTo(0L);
         assertThat(rec1.get("c3")).isNull();
-        assertThat(rec1.get("c4")).isEqualTo("1970-01-01T00:00:00.00Z");
+        // DBZ-1912: zero-date TIMESTAMP collapses to null in the streaming deserialization
+        // path (previously emitted "1970-01-01T00:00:00.00Z").
+        assertThat(rec1.get("c4")).isNull();
         assertThat(rec1.get("nnc1")).isEqualTo(0);
         assertThat(rec1.get("nnc2")).isEqualTo(0L);
         assertThat(rec1.get("nnc3")).isEqualTo(0L);
         assertThat(rec2.get("c1")).isNull();
         assertThat(rec2.get("c2")).isEqualTo(60_000_000L); // 1 minute
         assertThat(rec2.get("c3")).isNull();
-        assertThat(rec2.get("c4")).isEqualTo("1970-01-01T00:00:00.00Z");
+        // DBZ-1912: zero-date TIMESTAMP collapses to null (see above).
+        assertThat(rec2.get("c4")).isNull();
         assertThat(rec2.get("nnc1")).isEqualTo(0);
         assertThat(rec2.get("nnc2")).isEqualTo(60_000_000L); // 1 minute
         assertThat(rec2.get("nnc3")).isEqualTo(0L);
@@ -591,22 +583,10 @@ public abstract class BinlogRegressionIT<C extends SourceConnector> extends Abst
                 assertThat(c3).isNull();
 
                 // '0000-00-00 00:00:00.00'
-                String c4 = after.getString("c4"); // MySQL timestamp, so always ZonedTimestamp
-                OffsetDateTime c4DateTime = OffsetDateTime.parse(c4, ZonedTimestamp.FORMATTER);
-
-                // Timestamp is stored as UTC
-                assertThat(c4DateTime.getOffset()).isEqualTo(ZoneOffset.UTC);
-
-                // In case the timestamp string not in our timezone, convert to UTC so we can compare ...
-                c4DateTime = c4DateTime.withOffsetSameInstant(ZoneOffset.of("Z"));
-                assertThat(c4DateTime.getYear()).isEqualTo(1970);
-                assertThat(c4DateTime.getMonth()).isEqualTo(Month.JANUARY);
-                assertThat(c4DateTime.getDayOfMonth()).isEqualTo(1);
-                // Difference depends upon whether the zone we're in is also using DST as it is on the date in question ...
-                assertThat(c4DateTime.getHour()).isIn(0, 1);
-                assertThat(c4DateTime.getMinute()).isEqualTo(0);
-                assertThat(c4DateTime.getSecond()).isEqualTo(0);
-                assertThat(c4DateTime.getNano()).isEqualTo(0);
+                // DBZ-1912: nullable zero-date TIMESTAMP collapses to null in the streaming
+                // deserialization path (see the matching assertion in
+                // shouldConsumeAllEventsFromDatabaseUsingStreaming above).
+                assertThat(after.getString("c4")).isNull(); // MySQL timestamp, so always ZonedTimestamp
             }
             else if (record.topic().endsWith("dbz_123_bitvaluetest")) {
                 // All row events should have the same values ...

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogZeroDateFallbackConverterIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogZeroDateFallbackConverterIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.converters.ZeroDateFallbackConverter;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.data.Envelope;
+
+/**
+ * Integration tests for {@link ZeroDateFallbackConverter}.
+ *
+ * <p>Verifies the converter's behavior across four scenarios over a fixture table {@code dt_full}
+ * with 9 DATE/DATETIME/TIMESTAMP columns (no default / epoch default / non-epoch default) and 3
+ * rows (real-1970 / zero-date / normal). Snapshot-only; streaming-path coverage is provided by
+ * {@code RowDeserializersTest} and the lambda input-type unit tests.
+ *
+ * @author minleejae
+ */
+public abstract class BinlogZeroDateFallbackConverterIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
+
+    private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-zero-date-converter.txt").toAbsolutePath();
+
+    // Pre-computed wire-format constants used across all scenarios.
+    private static final int EPOCH_DAYS_REAL_1970 = 0;
+    private static final int EPOCH_DAYS_NORMAL = (int) LocalDate.parse("2024-06-15").toEpochDay();
+    private static final long EPOCH_MS_REAL_1970 = 0L;
+    private static final long EPOCH_MS_NORMAL = LocalDateTime.parse("2024-06-15T12:34:56").toInstant(ZoneOffset.UTC).toEpochMilli();
+    private static final String ISO_REAL_1970 = "1970-01-02T00:00:00Z";
+    private static final String ISO_NORMAL = "2024-06-15T12:34:56Z";
+
+    private final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase("zdfb", "zero_date_fallback_converter")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    @BeforeEach
+    void beforeEach() {
+        stopConnector();
+        // sql_mode='' allows zero-date INSERTs to land; time_zone='+00:00' forces the fixture
+        // session to UTC so TIMESTAMP literals are stored without per-CI timezone drift.
+        DATABASE.createAndInitialize(Collections.singletonMap(
+                "sessionVariables", "sql_mode='',time_zone='+00:00'"));
+        initializeConnectorTestFramework();
+        Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    /**
+     * Scenario 1 — all type-level fallbacks are NULL. Zero-date rows emit null on every temporal
+     * column; real-1970 / normal rows still flow through normal conversion.
+     */
+    @Test
+    void scenarioDefault_allNullFallback_zeroDateEmitsNull() throws InterruptedException {
+        config = baseConfig().build();
+        start(getConnectorClass(), config);
+
+        final List<SourceRecord> recs = readDtFullRecords();
+        assertScenarioDefault(recs);
+    }
+
+    /**
+     * Scenario 2 — all type-level fallbacks set to user values. Zero-date rows emit the user
+     * sentinel; real-1970 / normal rows are unaffected.
+     */
+    @Test
+    void scenarioTypedValues_userSentinels_zeroDateEmitsUserValues() throws InterruptedException {
+        config = baseConfig()
+                .with("zero-date.fallback.date", "2000-01-01")
+                .with("zero-date.fallback.datetime", "2000-01-01 00:00:00")
+                .with("zero-date.fallback.timestamp", "2000-01-01T00:00:00Z")
+                .build();
+        start(getConnectorClass(), config);
+
+        final int sentinelDays = (int) LocalDate.parse("2000-01-01").toEpochDay();
+        final long sentinelMs = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+        final String sentinelIso = "2000-01-01T00:00:00Z";
+
+        final List<SourceRecord> recs = readDtFullRecords();
+        // Zero-date row: every column emits the configured sentinel.
+        assertRow(recs, 2, "d_no_default", sentinelDays);
+        assertRow(recs, 2, "d_epoch_default", sentinelDays);
+        assertRow(recs, 2, "d_other_default", sentinelDays);
+        assertRow(recs, 2, "dt_no_default", sentinelMs);
+        assertRow(recs, 2, "dt_epoch_default", sentinelMs);
+        assertRow(recs, 2, "dt_other_default", sentinelMs);
+        assertRow(recs, 2, "ts_no_default", sentinelIso);
+        assertRow(recs, 2, "ts_epoch_default", sentinelIso);
+        assertRow(recs, 2, "ts_other_default", sentinelIso);
+
+        // Real-1970 row: unchanged.
+        assertRow(recs, 1, "d_no_default", EPOCH_DAYS_REAL_1970);
+        assertRow(recs, 1, "dt_no_default", EPOCH_MS_REAL_1970);
+        assertRow(recs, 1, "ts_no_default", ISO_REAL_1970);
+        // Normal row: unchanged.
+        assertRow(recs, 3, "d_no_default", EPOCH_DAYS_NORMAL);
+        assertRow(recs, 3, "dt_no_default", EPOCH_MS_NORMAL);
+        assertRow(recs, 3, "ts_no_default", ISO_NORMAL);
+    }
+
+    /**
+     * Scenario 3 — mixed policy. DATE / TIMESTAMP are NULL, DATETIME is a user sentinel.
+     */
+    @Test
+    void scenarioMixed_dateAndTimestampNull_datetimeUserValue() throws InterruptedException {
+        config = baseConfig()
+                .with("zero-date.fallback.datetime", "2000-01-01 00:00:00")
+                .build();
+        start(getConnectorClass(), config);
+
+        final long datetimeSentinel = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        final List<SourceRecord> recs = readDtFullRecords();
+        // DATE columns: NULL policy
+        assertSchemaOptional(recs, "d_no_default", true);
+        assertSchemaOptional(recs, "d_epoch_default", true);
+        // TIMESTAMP columns: NULL policy
+        assertSchemaOptional(recs, "ts_no_default", true);
+        assertSchemaOptional(recs, "ts_epoch_default", true);
+        // DATETIME columns: user-value policy → NOT NULL retained
+        assertSchemaOptional(recs, "dt_no_default", false);
+
+        // Zero-date row
+        assertRow(recs, 2, "d_no_default", null);
+        assertRow(recs, 2, "ts_no_default", null);
+        assertRow(recs, 2, "dt_no_default", datetimeSentinel);
+        assertRow(recs, 2, "dt_other_default", datetimeSentinel);
+    }
+
+    /**
+     * Scenario 4 — column-level FQN override. Three DATETIME columns get three different
+     * effective policies (NULL / type-level value / column-level value).
+     */
+    @Test
+    void scenarioColumnOverride_perColumnEffectivePolicy() throws InterruptedException {
+        final String db = DATABASE.getDatabaseName();
+        config = baseConfig()
+                .with("zero-date.fallback.datetime", "2000-01-01 00:00:00")
+                .with("zero-date.column." + db + ".dt_full.dt_no_default.fallback", "NULL")
+                .with("zero-date.column." + db + ".dt_full.dt_other_default.fallback", "2099-12-31 23:59:59")
+                .build();
+        start(getConnectorClass(), config);
+
+        final long typeLevelSentinel = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+        final long columnLevelSentinel = LocalDateTime.parse("2099-12-31T23:59:59").toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        final List<SourceRecord> recs = readDtFullRecords();
+        // dt_no_default: column-level NULL → schema optional
+        assertSchemaOptional(recs, "dt_no_default", true);
+        // dt_epoch_default: no column key → falls back to type-level
+        assertSchemaOptional(recs, "dt_epoch_default", false);
+        // dt_other_default: column-level value
+        assertSchemaOptional(recs, "dt_other_default", false);
+
+        // Zero-date row receives each column's distinct policy
+        assertRow(recs, 2, "dt_no_default", null);
+        assertRow(recs, 2, "dt_epoch_default", typeLevelSentinel);
+        assertRow(recs, 2, "dt_other_default", columnLevelSentinel);
+    }
+
+    // -- helpers --------------------------------------------------------------------------------
+
+    private Configuration.Builder baseConfig() {
+        return DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("dt_full"))
+                .with(BinlogConnectorConfig.CUSTOM_CONVERTERS, "zero-date")
+                // Override the IT framework default (US/Samoa) so TIMESTAMP emit is deterministic
+                // UTC regardless of CI MySQL/MariaDB version. mysql-connector-j 8.0 only applies
+                // connectionTimeZone to the JVM side, so also force the MySQL server session to
+                // UTC via sessionVariables (mariadb-java-client syncs both sides automatically).
+                .with("database.connectionTimeZone", "UTC")
+                .with("database.sessionVariables", "time_zone='+00:00'")
+                .with("zero-date.type", ZeroDateFallbackConverter.class.getName());
+    }
+
+    private List<SourceRecord> readDtFullRecords() throws InterruptedException {
+        // Snapshot emits schema-change events ahead of the 3 data rows, so consume a comfortably
+        // larger window. recordsForTopic() filters down to just the dt_full table records.
+        final SourceRecords records = consumeRecordsByTopic(15);
+        return records.recordsForTopic(DATABASE.topicForTable("dt_full"));
+    }
+
+    private void assertScenarioDefault(List<SourceRecord> recs) {
+        // All temporal columns are optional under the default NULL policy.
+        for (String name : new String[]{
+                "d_no_default", "d_epoch_default", "d_other_default",
+                "dt_no_default", "dt_epoch_default", "dt_other_default",
+                "ts_no_default", "ts_epoch_default", "ts_other_default" }) {
+            assertSchemaOptional(recs, name, true);
+        }
+
+        // Real-1970 row (id=1): genuine values flow through, NOT replaced with NULL.
+        assertRow(recs, 1, "d_no_default", EPOCH_DAYS_REAL_1970);
+        assertRow(recs, 1, "dt_no_default", EPOCH_MS_REAL_1970);
+        assertRow(recs, 1, "ts_no_default", ISO_REAL_1970);
+
+        // Zero-date row (id=2): every temporal column emits null.
+        assertRow(recs, 2, "d_no_default", null);
+        assertRow(recs, 2, "d_epoch_default", null);
+        assertRow(recs, 2, "d_other_default", null);
+        assertRow(recs, 2, "dt_no_default", null);
+        assertRow(recs, 2, "dt_epoch_default", null);
+        assertRow(recs, 2, "dt_other_default", null);
+        assertRow(recs, 2, "ts_no_default", null);
+        assertRow(recs, 2, "ts_epoch_default", null);
+        assertRow(recs, 2, "ts_other_default", null);
+
+        // Normal row (id=3): genuine values unaffected.
+        assertRow(recs, 3, "d_no_default", EPOCH_DAYS_NORMAL);
+        assertRow(recs, 3, "dt_no_default", EPOCH_MS_NORMAL);
+        assertRow(recs, 3, "ts_no_default", ISO_NORMAL);
+    }
+
+    private static void assertSchemaOptional(List<SourceRecord> recs, String fieldName, boolean expectedOptional) {
+        final Schema afterSchema = recs.get(0).valueSchema().field(Envelope.FieldName.AFTER).schema();
+        assertThat(afterSchema.field(fieldName).schema().isOptional())
+                .as("schema.optional for field %s", fieldName)
+                .isEqualTo(expectedOptional);
+    }
+
+    private static void assertRow(List<SourceRecord> recs, int id, String fieldName, Object expected) {
+        final SourceRecord rec = recs.stream()
+                .filter(r -> ((Struct) r.value()).getStruct(Envelope.FieldName.AFTER).getInt32("id") == id)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No record with id=" + id));
+        final Struct after = ((Struct) rec.value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get(fieldName))
+                .as("after.%s for id=%d", fieldName, id)
+                .isEqualTo(expected);
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+
+/**
+ * Unit tests for {@link ZeroDateFallbackConverter}, covering type-level configuration,
+ * column-level FQN overrides, the NULL vs user-value policies (including the first-call
+ * schema-default trick), input-type dispatch, and target-types / selector filters.
+ *
+ * @author minleejae
+ */
+class ZeroDateFallbackConverterTest {
+
+    private static final String DATA_COLLECTION = "appdb.users";
+
+    // -- configure() ---------------------------------------------------------------------------
+
+    @Test
+    void shouldDefaultAllFallbacksToNull() {
+        final ZeroDateFallbackConverter converter = newConfigured(new Properties());
+
+        final Registration reg = registerOn(converter, dateColumn("d", false));
+        assertThat(reg.schema.isOptional()).isTrue();
+        assertThat(reg.converter.convert(null)).isNull();
+    }
+
+    @Test
+    void shouldParseDateFallbackLiteral() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.date", "2000-01-01");
+
+        final ZeroDateFallbackConverter converter = newConfigured(props);
+        final Registration reg = registerOn(converter, dateColumn("d", false));
+
+        assertThat(reg.schema.isOptional()).isFalse();
+        assertThat(reg.converter.convert(null)).isEqualTo((int) LocalDate.parse("2000-01-01").toEpochDay());
+    }
+
+    @Test
+    void shouldTreatNullTokenAsNullPolicy() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.date", "NULL");
+        props.setProperty("fallback.datetime", "null");
+        props.setProperty("fallback.timestamp", "  Null  ");
+
+        final ZeroDateFallbackConverter converter = newConfigured(props);
+
+        assertThat(registerOn(converter, dateColumn("d", false)).schema.isOptional()).isTrue();
+        assertThat(registerOn(converter, datetimeColumn("dt", false)).schema.isOptional()).isTrue();
+        assertThat(registerOn(converter, timestampColumn("ts", false)).schema.isOptional()).isTrue();
+    }
+
+    @Test
+    void shouldRejectInvalidDateLiteral() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.date", "not-a-date");
+
+        assertThatThrownBy(() -> newConfigured(props))
+                .isInstanceOf(java.time.format.DateTimeParseException.class);
+    }
+
+    @Test
+    void shouldRejectInvalidDatetimeLiteral() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.datetime", "2000-01-01"); // missing time portion
+
+        assertThatThrownBy(() -> newConfigured(props))
+                .isInstanceOf(java.time.format.DateTimeParseException.class);
+    }
+
+    @Test
+    void shouldRejectInvalidTimestampLiteral() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.timestamp", "2000-01-01 00:00:00"); // missing offset
+
+        assertThatThrownBy(() -> newConfigured(props))
+                .isInstanceOf(java.time.format.DateTimeParseException.class);
+    }
+
+    // -- target.types --------------------------------------------------------------------------
+
+    @Test
+    void shouldSkipTypesNotInTargetSet() {
+        final Properties props = new Properties();
+        props.setProperty("target.types", "DATETIME");
+
+        final ZeroDateFallbackConverter converter = newConfigured(props);
+
+        assertThat(tryRegister(converter, dateColumn("d", false))).isNull();
+        assertThat(tryRegister(converter, datetimeColumn("dt", false))).isNotNull();
+        assertThat(tryRegister(converter, timestampColumn("ts", false))).isNull();
+    }
+
+    @Test
+    void shouldDefaultTargetTypesToAllThree() {
+        final ZeroDateFallbackConverter converter = newConfigured(new Properties());
+
+        assertThat(tryRegister(converter, dateColumn("d", false))).isNotNull();
+        assertThat(tryRegister(converter, datetimeColumn("dt", false))).isNotNull();
+        assertThat(tryRegister(converter, timestampColumn("ts", false))).isNotNull();
+    }
+
+    // -- DATE branch ---------------------------------------------------------------------------
+
+    @Test
+    void dateLambda_inputNull_returnsFallback() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.date", "2000-01-01")),
+                dateColumn("d", false));
+        assertThat(reg.converter.convert(null)).isEqualTo((int) LocalDate.parse("2000-01-01").toEpochDay());
+    }
+
+    @Test
+    void dateLambda_javaSqlDate_returnsEpochDays() {
+        final Registration reg = registerOn(newConfigured(new Properties()), dateColumn("d", false));
+        assertThat(reg.converter.convert(Date.valueOf("2024-06-15")))
+                .isEqualTo((int) LocalDate.parse("2024-06-15").toEpochDay());
+    }
+
+    @Test
+    void dateLambda_localDate_returnsEpochDays() {
+        final Registration reg = registerOn(newConfigured(new Properties()), dateColumn("d", false));
+        assertThat(reg.converter.convert(LocalDate.parse("2024-06-15")))
+                .isEqualTo((int) LocalDate.parse("2024-06-15").toEpochDay());
+    }
+
+    @Test
+    void dateLambda_integerInput_passesThrough() {
+        final Registration reg = registerOn(newConfigured(new Properties()), dateColumn("d", false));
+        assertThat(reg.converter.convert(19889)).isEqualTo(19889);
+    }
+
+    @Test
+    void dateLambda_unexpectedInput_returnsFallback() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.date", "2000-01-01")),
+                dateColumn("d", false));
+        assertThat(reg.converter.convert("garbage"))
+                .isEqualTo((int) LocalDate.parse("2000-01-01").toEpochDay());
+    }
+
+    // -- DATETIME branch -----------------------------------------------------------------------
+
+    @Test
+    void datetimeLambda_inputNull_returnsFallback() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.datetime", "2000-01-01 00:00:00")),
+                datetimeColumn("dt", false));
+        final long expected = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+        assertThat(reg.converter.convert(null)).isEqualTo(expected);
+    }
+
+    @Test
+    void datetimeLambda_javaSqlTimestamp_returnsEpochMillis() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false));
+        final Timestamp ts = Timestamp.valueOf("2024-06-15 12:34:56");
+        assertThat(reg.converter.convert(ts)).isEqualTo(ts.getTime());
+    }
+
+    @Test
+    void datetimeLambda_localDateTime_returnsEpochMillisInUtc() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false));
+        final LocalDateTime ldt = LocalDateTime.parse("2024-06-15T12:34:56");
+        assertThat(reg.converter.convert(ldt))
+                .isEqualTo(ldt.toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    void datetimeLambda_longInput_passesThrough() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false));
+        assertThat(reg.converter.convert(1_718_454_896_000L)).isEqualTo(1_718_454_896_000L);
+    }
+
+    @Test
+    void datetimeLambda_unexpectedInput_returnsFallback() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.datetime", "2000-01-01 00:00:00")),
+                datetimeColumn("dt", false));
+        final long expected = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+        assertThat(reg.converter.convert("garbage")).isEqualTo(expected);
+    }
+
+    // -- TIMESTAMP branch ----------------------------------------------------------------------
+
+    @Test
+    void timestampLambda_inputNull_returnsFallback() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.timestamp", "1970-01-01T00:00:00Z")),
+                timestampColumn("ts", false));
+        assertThat(reg.converter.convert(null)).isEqualTo("1970-01-01T00:00:00Z");
+    }
+
+    @Test
+    void timestampLambda_javaSqlTimestamp_returnsIso8601Utc() {
+        final Registration reg = registerOn(newConfigured(new Properties()), timestampColumn("ts", false));
+        final Timestamp ts = Timestamp.from(OffsetDateTime.parse("2024-06-15T12:34:56Z").toInstant());
+        assertThat(reg.converter.convert(ts)).isEqualTo("2024-06-15T12:34:56Z");
+    }
+
+    @Test
+    void timestampLambda_offsetDateTime_normalizedToUtc() {
+        final Registration reg = registerOn(newConfigured(new Properties()), timestampColumn("ts", false));
+        final OffsetDateTime odt = OffsetDateTime.parse("2024-06-15T21:34:56+09:00");
+        assertThat(reg.converter.convert(odt)).isEqualTo("2024-06-15T12:34:56Z");
+    }
+
+    @Test
+    void timestampLambda_zonedDateTime_normalizedToUtc() {
+        final Registration reg = registerOn(newConfigured(new Properties()), timestampColumn("ts", false));
+        final ZonedDateTime zdt = ZonedDateTime.parse("2024-06-15T12:34:56Z");
+        assertThat(reg.converter.convert(zdt)).isEqualTo("2024-06-15T12:34:56Z");
+    }
+
+    @Test
+    void timestampLambda_stringInput_passesThrough() {
+        final Registration reg = registerOn(newConfigured(new Properties()), timestampColumn("ts", false));
+        assertThat(reg.converter.convert("2024-06-15T12:34:56Z")).isEqualTo("2024-06-15T12:34:56Z");
+    }
+
+    // -- First-call schema-default trick -------------------------------------------------------
+
+    @Test
+    void firstCall_columnWithDdlDefault_returnsFallback_underNullPolicy() {
+        final Registration reg = registerOn(newConfigured(new Properties()), dateColumn("d", true));
+
+        // Schema must be optional under NULL policy
+        assertThat(reg.schema.isOptional()).isTrue();
+        // First call (schema-default conversion) ignores input and returns null
+        assertThat(reg.converter.convert(LocalDate.parse("2024-06-15"))).isNull();
+        // Subsequent row-level calls dispatch normally
+        assertThat(reg.converter.convert(LocalDate.parse("2024-06-15")))
+                .isEqualTo((int) LocalDate.parse("2024-06-15").toEpochDay());
+    }
+
+    @Test
+    void firstCall_columnWithDdlDefault_returnsFallback_underUserValuePolicy() {
+        final Registration reg = registerOn(newConfigured(propsWith("fallback.datetime", "2000-01-01 00:00:00")),
+                datetimeColumn("dt", true));
+        final long expected = LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        // Schema retains NOT NULL semantics (no .optional())
+        assertThat(reg.schema.isOptional()).isFalse();
+        // First call returns the user-configured fallback regardless of the DDL default's resolved value
+        assertThat(reg.converter.convert(LocalDate.parse("1970-01-01"))).isEqualTo(expected);
+        // Row-level: real-1970 still emits 0L because it's a genuine LocalDateTime (non-null)
+        assertThat(reg.converter.convert(LocalDateTime.parse("1970-01-01T00:00:00"))).isEqualTo(0L);
+    }
+
+    @Test
+    void firstCall_columnWithoutDdlDefault_dispatchesNormally() {
+        final Registration reg = registerOn(newConfigured(new Properties()), dateColumn("d", false));
+        // No first-call guard fires because hasDefaultValue=false; row-level dispatch from the very first call
+        assertThat(reg.converter.convert(LocalDate.parse("2024-06-15")))
+                .isEqualTo((int) LocalDate.parse("2024-06-15").toEpochDay());
+    }
+
+    // -- Column-level override ----------------------------------------------------------------
+
+    @Test
+    void columnLevelOverride_takesPrecedenceOverTypeLevel() {
+        final Properties props = new Properties();
+        props.setProperty("fallback.datetime", "2000-01-01 00:00:00");
+        props.setProperty("column.appdb.users.deleted_at.fallback", "NULL");
+        props.setProperty("column.appdb.users.shipped_at.fallback", "2099-12-31 23:59:59");
+
+        final ZeroDateFallbackConverter converter = newConfigured(props);
+
+        final Registration nullCol = registerOn(converter, datetimeColumn("deleted_at", false));
+        final Registration otherCol = registerOn(converter, datetimeColumn("shipped_at", false));
+        final Registration typeCol = registerOn(converter, datetimeColumn("created_at", false));
+
+        // Column-level NULL overrides type-level value
+        assertThat(nullCol.schema.isOptional()).isTrue();
+        assertThat(nullCol.converter.convert(null)).isNull();
+        // Column-level value overrides type-level value
+        assertThat(otherCol.schema.isOptional()).isFalse();
+        assertThat(otherCol.converter.convert(null))
+                .isEqualTo(LocalDateTime.parse("2099-12-31T23:59:59").toInstant(ZoneOffset.UTC).toEpochMilli());
+        // No column-level key → falls back to type-level
+        assertThat(typeCol.schema.isOptional()).isFalse();
+        assertThat(typeCol.converter.convert(null))
+                .isEqualTo(LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    // -- selector ------------------------------------------------------------------------------
+
+    @Test
+    void selector_filtersOutNonMatchingColumns() {
+        final Properties props = new Properties();
+        props.setProperty("selector", "appdb\\.users\\.deleted_at");
+
+        final ZeroDateFallbackConverter converter = newConfigured(props);
+
+        assertThat(tryRegister(converter, datetimeColumn("deleted_at", false))).isNotNull();
+        assertThat(tryRegister(converter, datetimeColumn("created_at", false))).isNull();
+    }
+
+    @Test
+    void selector_defaultWildcardMatchesAll() {
+        final ZeroDateFallbackConverter converter = newConfigured(new Properties());
+        assertThat(tryRegister(converter, datetimeColumn("deleted_at", false))).isNotNull();
+        assertThat(tryRegister(converter, datetimeColumn("any_other_column", false))).isNotNull();
+    }
+
+    // -- TIMESTAMP_WITH_TIMEZONE variant ------------------------------------------------------
+
+    @Test
+    void shouldAcceptTimestampWithTimezoneJdbcType() {
+        final RelationalColumn col = Mockito.mock(RelationalColumn.class);
+        Mockito.when(col.name()).thenReturn("ts");
+        Mockito.when(col.dataCollection()).thenReturn(DATA_COLLECTION);
+        Mockito.when(col.jdbcType()).thenReturn(Types.TIMESTAMP_WITH_TIMEZONE);
+        Mockito.when(col.typeName()).thenReturn("TIMESTAMP_WITH_TIMEZONE");
+        Mockito.when(col.hasDefaultValue()).thenReturn(false);
+
+        final ZeroDateFallbackConverter converter = newConfigured(new Properties());
+        assertThat(tryRegister(converter, col)).isNotNull();
+    }
+
+    // -- Config descriptor --------------------------------------------------------------------
+
+    @Test
+    void configDescriptorExposesAllFields() {
+        final ZeroDateFallbackConverter converter = new ZeroDateFallbackConverter();
+        assertThat(converter.getConfigFields().asArray())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "target.types", "fallback.date", "fallback.datetime", "fallback.timestamp", "selector");
+    }
+
+    // -- helpers ------------------------------------------------------------------------------
+
+    private static ZeroDateFallbackConverter newConfigured(Properties props) {
+        final ZeroDateFallbackConverter converter = new ZeroDateFallbackConverter();
+        converter.configure(props);
+        return converter;
+    }
+
+    private static Properties propsWith(String key, String value) {
+        final Properties p = new Properties();
+        p.setProperty(key, value);
+        return p;
+    }
+
+    private static RelationalColumn dateColumn(String name, boolean hasDefault) {
+        return mockColumn(name, Types.DATE, "DATE", hasDefault);
+    }
+
+    private static RelationalColumn datetimeColumn(String name, boolean hasDefault) {
+        return mockColumn(name, Types.TIMESTAMP, "DATETIME", hasDefault);
+    }
+
+    private static RelationalColumn timestampColumn(String name, boolean hasDefault) {
+        return mockColumn(name, Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP", hasDefault);
+    }
+
+    private static RelationalColumn mockColumn(String name, int jdbcType, String typeName, boolean hasDefault) {
+        final RelationalColumn col = Mockito.mock(RelationalColumn.class);
+        Mockito.when(col.name()).thenReturn(name);
+        Mockito.when(col.dataCollection()).thenReturn(DATA_COLLECTION);
+        Mockito.when(col.jdbcType()).thenReturn(jdbcType);
+        Mockito.when(col.typeName()).thenReturn(typeName);
+        Mockito.when(col.hasDefaultValue()).thenReturn(hasDefault);
+        return col;
+    }
+
+    private static Registration registerOn(ZeroDateFallbackConverter converter, RelationalColumn column) {
+        final Registration reg = tryRegister(converter, column);
+        assertThat(reg).as("converter did not register a schema for column %s", column.name()).isNotNull();
+        return reg;
+    }
+
+    private static Registration tryRegister(ZeroDateFallbackConverter converter, RelationalColumn column) {
+        final AtomicReference<SchemaBuilder> schemaRef = new AtomicReference<>();
+        final AtomicReference<CustomConverter.Converter> convRef = new AtomicReference<>();
+        converter.converterFor(column, (schema, conv) -> {
+            schemaRef.set(schema);
+            convRef.set(conv);
+        });
+        if (schemaRef.get() == null) {
+            return null;
+        }
+        return new Registration(schemaRef.get().build(), convRef.get());
+    }
+
+    private record Registration(Schema schema, CustomConverter.Converter converter) {
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/event/RowDeserializersTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/event/RowDeserializersTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
+/**
+ * Unit tests for {@link RowDeserializers}, in particular the zero-date detection in the
+ * {@code TIMESTAMP} deserializers. {@code DATE} / {@code DATETIME} already detected zero-date
+ * via the {@code year/month/day == 0} branches; the {@code TIMESTAMP} branch was missing the
+ * equivalent check (epoch-zero), causing streaming TIMESTAMP zero-dates to bypass the
+ * configured zero-date fallback. See {@code zero.date.fallback.value*} on
+ * {@link io.debezium.connector.binlog.BinlogConnectorConfig}.
+ */
+class RowDeserializersTest {
+
+    /**
+     * MySQL stores {@code TIMESTAMP '0000-00-00 00:00:00'} as 4 zero bytes on the wire. Because the
+     * legal {@code TIMESTAMP} range starts at {@code 1970-01-01 00:00:01} UTC, a wire value of
+     * epoch-zero unambiguously signals the zero-date sentinel and must be returned as {@code null}
+     * so the downstream fallback can apply the configured per-type sentinel.
+     */
+    @Test
+    void deserializeTimestampReturnsNullForZeroEpoch() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ 0, 0, 0, 0 });
+        assertThat(RowDeserializers.deserializeTimestamp(input)).isNull();
+    }
+
+    /** Sanity check: a non-zero epoch second is converted to the corresponding UTC ZonedDateTime.
+     *  V1 reads {@code epochSecond} as a little-endian 32-bit value (per shyiko binlog client). */
+    @Test
+    void deserializeTimestampReturnsZonedDateTimeForNonZeroEpoch() throws IOException {
+        // 1234567890 (2009-02-13 23:31:30 UTC) = 0x499602D2 → little-endian bytes
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ (byte) 0xD2, 0x02, (byte) 0x96, 0x49 });
+
+        Object result = RowDeserializers.deserializeTimestamp(input);
+
+        assertThat(result).isInstanceOf(ZonedDateTime.class);
+        ZonedDateTime zdt = (ZonedDateTime) result;
+        assertThat(zdt.toEpochSecond()).isEqualTo(1234567890L);
+        assertThat(zdt.getZone()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    /** V2 (with fractional precision) at {@code meta=0} reads only 4 bytes; zero bytes signal zero-date. */
+    @Test
+    void deserializeTimestampV2ReturnsNullForZeroBytesNoFraction() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ 0, 0, 0, 0 });
+        assertThat(RowDeserializers.deserializeTimestampV2(0, input)).isNull();
+    }
+
+    /** V2 at {@code meta=0} with a non-zero epoch decodes normally. */
+    @Test
+    void deserializeTimestampV2ReturnsZonedDateTimeForNonZeroSeconds() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ 0x49, (byte) 0x96, 0x02, (byte) 0xD2 });
+
+        Object result = RowDeserializers.deserializeTimestampV2(0, input);
+
+        assertThat(result).isInstanceOf(ZonedDateTime.class);
+        ZonedDateTime zdt = (ZonedDateTime) result;
+        assertThat(zdt.toEpochSecond()).isEqualTo(1234567890L);
+        assertThat(zdt.getZone()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    /**
+     * V2 at {@code meta=4} (microsecond precision, 2 fractional bytes) reads 4 + 2 = 6 bytes.
+     * All-zero input → both {@code epochSecond == 0} and {@code nanoSeconds == 0} → null.
+     */
+    @Test
+    void deserializeTimestampV2ReturnsNullForZeroBytesWithFraction() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ 0, 0, 0, 0, 0, 0 });
+        assertThat(RowDeserializers.deserializeTimestampV2(4, input)).isNull();
+    }
+
+    /**
+     * Edge case: epoch-zero bytes with non-zero fractional bytes. MySQL semantics never produce this
+     * (legal {@code TIMESTAMP(N)} starts at {@code 1970-01-01 00:00:01}), but the V2 zero-date guard
+     * conservatively requires both seconds AND nanos to be zero. So this case decodes to a
+     * non-null {@link ZonedDateTime} rather than being reclassified as a zero-date.
+     */
+    @Test
+    void deserializeTimestampV2DoesNotReturnNullWhenOnlyFractionIsZero() throws IOException {
+        // meta=4 (microsecond precision): bytes = {0,0,0,0} (epoch=0) + {0x10, 0x00} (fraction=4096)
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[]{ 0, 0, 0, 0, 0x10, 0x00 });
+
+        Object result = RowDeserializers.deserializeTimestampV2(4, input);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(ZonedDateTime.class);
+    }
+}

--- a/debezium-connector-binlog/src/test/resources/ddl/zero_date_fallback_converter.sql
+++ b/debezium-connector-binlog/src/test/resources/ddl/zero_date_fallback_converter.sql
@@ -1,0 +1,34 @@
+CREATE TABLE dt_full (
+  id              INT PRIMARY KEY,
+  label           VARCHAR(64),
+  d_no_default    DATE     NOT NULL,
+  d_epoch_default DATE     NOT NULL DEFAULT '1970-01-01',
+  d_other_default DATE     NOT NULL DEFAULT '2030-12-31',
+  dt_no_default   DATETIME NOT NULL,
+  dt_epoch_default DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00',
+  dt_other_default DATETIME NOT NULL DEFAULT '2030-12-31 23:59:59',
+  ts_no_default   TIMESTAMP NOT NULL,
+  ts_epoch_default TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
+  ts_other_default TIMESTAMP NOT NULL DEFAULT '2030-12-31 23:59:59'
+);
+
+INSERT INTO dt_full VALUES (
+  1, 'real-1970',
+  '1970-01-01', '1970-01-01', '1970-01-01',
+  '1970-01-01 00:00:00', '1970-01-01 00:00:00', '1970-01-01 00:00:00',
+  '1970-01-02 00:00:00', '1970-01-02 00:00:00', '1970-01-02 00:00:00'
+);
+
+INSERT INTO dt_full VALUES (
+  2, 'zero-date',
+  '0000-00-00', '0000-00-00', '0000-00-00',
+  '0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00',
+  '0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00'
+);
+
+INSERT INTO dt_full VALUES (
+  3, 'normal',
+  '2024-06-15', '2024-06-15', '2024-06-15',
+  '2024-06-15 12:34:56', '2024-06-15 12:34:56', '2024-06-15 12:34:56',
+  '2024-06-15 12:34:56', '2024-06-15 12:34:56', '2024-06-15 12:34:56'
+);

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/metadata/MariaDbMetadataProvider.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/metadata/MariaDbMetadataProvider.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import io.debezium.connector.binlog.converters.JdbcSinkDataTypesConverter;
 import io.debezium.connector.binlog.converters.TinyIntOneToBooleanConverter;
+import io.debezium.connector.binlog.converters.ZeroDateFallbackConverter;
 import io.debezium.connector.mariadb.MariaDbConnector;
 import io.debezium.connector.mariadb.Module;
 import io.debezium.metadata.ComponentMetadata;
@@ -27,6 +28,7 @@ public class MariaDbMetadataProvider implements ComponentMetadataProvider {
         return List.of(
                 componentMetadataFactory.createComponentMetadata(new MariaDbConnector(), Module.version()),
                 componentMetadataFactory.createComponentMetadata(new TinyIntOneToBooleanConverter(), Module.version()),
-                componentMetadataFactory.createComponentMetadata(new JdbcSinkDataTypesConverter(), Module.version()));
+                componentMetadataFactory.createComponentMetadata(new JdbcSinkDataTypesConverter(), Module.version()),
+                componentMetadataFactory.createComponentMetadata(new ZeroDateFallbackConverter(), Module.version()));
     }
 }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ZeroDateFallbackConverterIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ZeroDateFallbackConverterIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import io.debezium.connector.binlog.BinlogZeroDateFallbackConverterIT;
+
+/**
+ * MariaDB-specific tests for the {@link io.debezium.connector.binlog.converters.ZeroDateFallbackConverter}.
+ *
+ * @author minleejae
+ */
+public class ZeroDateFallbackConverterIT extends BinlogZeroDateFallbackConverterIT<MariaDbConnector> implements MariaDbCommon {
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/metadata/MySqlMetadataProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/metadata/MySqlMetadataProvider.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import io.debezium.connector.binlog.converters.JdbcSinkDataTypesConverter;
 import io.debezium.connector.binlog.converters.TinyIntOneToBooleanConverter;
+import io.debezium.connector.binlog.converters.ZeroDateFallbackConverter;
 import io.debezium.connector.mysql.Module;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.transforms.ReadToInsertEvent;
@@ -29,6 +30,7 @@ public class MySqlMetadataProvider implements ComponentMetadataProvider {
                 componentMetadataFactory.createComponentMetadata(new MySqlConnector(), Module.version()),
                 componentMetadataFactory.createComponentMetadata(new ReadToInsertEvent<>(), Module.version()),
                 componentMetadataFactory.createComponentMetadata(new TinyIntOneToBooleanConverter(), Module.version()),
-                componentMetadataFactory.createComponentMetadata(new JdbcSinkDataTypesConverter(), Module.version()));
+                componentMetadataFactory.createComponentMetadata(new JdbcSinkDataTypesConverter(), Module.version()),
+                componentMetadataFactory.createComponentMetadata(new ZeroDateFallbackConverter(), Module.version()));
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlZeroDateFallbackConverterIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlZeroDateFallbackConverterIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.binlog.BinlogZeroDateFallbackConverterIT;
+
+/**
+ * MySQL-specific tests for the {@link io.debezium.connector.binlog.converters.ZeroDateFallbackConverter}.
+ *
+ * @author minleejae
+ */
+public class MySqlZeroDateFallbackConverterIT extends BinlogZeroDateFallbackConverterIT<MySqlConnector> implements MySqlCommon {
+
+}

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -307,6 +307,10 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=jdbc-sink-data-types]
 
+=== Zero-date fallback
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=zero-date-fallback]
+
 
 // Type: assembly
 // ModuleID: setting-up-mariadb-to-run-a-debezium-connector

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -431,6 +431,10 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=jdbc-sink-data-types]
 
+=== Zero-date fallback
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=zero-date-fallback]
+
 
 // Type: assembly
 // ModuleID: setting-up-mysql-to-run-a-debezium-connector

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2260,6 +2260,72 @@ For example, to set the scope of the Boolean converter, add the following rule t
 end::jdbc-sink-data-types[]
 
 
+=== Zero-date fallback
+
+tag::zero-date-fallback[]
+By default, MySQL/MariaDB allow inserting `0000-00-00` (DATE) and `0000-00-00 00:00:00` (DATETIME / TIMESTAMP) values, which are sentinel "zero-date" values that do not represent any real instant in time.
+{prodname} cannot represent these sentinels in its standard temporal logical types (`io.debezium.time.Date`, `io.debezium.time.Timestamp`, `io.debezium.time.ZonedTimestamp`), so by default it collapses them either to `null` (when the column is nullable) or to the epoch (`1970-01-01[T00:00:00Z]`) when the column is `NOT NULL`.
+
+The `ZeroDateFallbackConverter` custom converter lets you decide, per JDBC type or per column, what value the connector emits for zero-date rows.
+You can also opt to emit `null` for `NOT NULL` columns — the converter promotes the column's Kafka Connect schema to optional and clears its `defaultValue` slot so the `null` row is not back-filled with the column's DDL default during Avro serialization.
+
+.Example: `ZeroDateFallbackConverter` configuration
+[source]
+----
+converters=zero-date
+zero-date.type=io.debezium.connector.binlog.converters.ZeroDateFallbackConverter
+zero-date.target.types=DATE,DATETIME,TIMESTAMP
+zero-date.fallback.date=NULL
+zero-date.fallback.datetime=2000-01-01 00:00:00
+zero-date.fallback.timestamp=1970-01-01T00:00:00Z
+zero-date.column.appdb.users.deleted_at.fallback=NULL
+zero-date.column.appdb.orders.shipped_at.fallback=2099-12-31 23:59:59
+zero-date.selector=.*
+----
+
+[cols="2,1,3"]
+|===
+|Property |Default |Description
+
+|`target.types`
+|`DATE,DATETIME,TIMESTAMP`
+|Comma-separated subset of `DATE`, `DATETIME`, `TIMESTAMP` controlling which JDBC temporal types the converter applies to.
+
+|`fallback.date`
+|`NULL`
+|Value emitted for zero-date `DATE` rows. `NULL` (or unset) promotes the column schema to optional and emits `null`. Otherwise an ISO-8601 date literal (`yyyy-MM-dd`).
+
+|`fallback.datetime`
+|`NULL`
+|Value emitted for zero-date `DATETIME` rows. `NULL` (or unset) promotes the column schema to optional and emits `null`. Otherwise a UTC datetime literal (`yyyy-MM-dd HH:mm:ss`).
+
+|`fallback.timestamp`
+|`NULL`
+|Value emitted for zero-date `TIMESTAMP` rows. `NULL` (or unset) promotes the column schema to optional and emits `null`. Otherwise an ISO-8601 offset datetime literal (for example, `1970-01-01T00:00:00Z`).
+
+|`column.<db>.<table>.<column>.fallback`
+|(unset)
+|Column-specific override of the type-level fallback. Same allowed values as the type-level options (`NULL` or a type-appropriate literal). The lookup key uses the fully-qualified column name reported by `RelationalColumn#dataCollection()`.
+
+|`selector`
+|`.*`
+|Comma-separated list of regular expressions matched against `<db>.<table>.<column>`. Only matching columns are passed through the converter. The default wildcard applies the converter to every column whose JDBC type is included in `target.types`.
+|===
+
+Resolution order for the effective fallback is: column-level override > type-level fallback > `NULL`.
+
+The converter distinguishes zero-date rows from genuine `1970-01-01` rows by relying on the binlog deserializer / JDBC driver to surface zero-date values as `null` at the SPI input.
+Row-level emission therefore has no false positives: a real `1970-01-01 00:00:00 UTC` row continues to emit `0` (epoch days / millis) as it does without the converter, while zero-date rows emit the configured fallback (or `null`).
+
+[NOTE]
+====
+The converter applies the user-configured fallback to the Kafka Connect schema's `defaultValue` slot at schema-build time, regardless of the column's DDL default.
+This relies on `TableSchemaBuilder` invoking the registered converter lambda exactly once during schema build for the purpose of resolving the column's default.
+This is an internal contract rather than a published SPI guarantee.
+====
+end::zero-date-fallback[]
+
+
 
 
 


### PR DESCRIPTION
Closes [debezium/dbz#1912](https://github.com/debezium/dbz/issues/1912).

## Summary

Adds four optional connector properties to the MySQL and MariaDB connectors that let users replace the hardcoded `1970-01-01` zero-date fallback with a sentinel of their choice, with per-type overrides:

| Property | Default | Purpose |
|---|---|---|
| `zero.date.fallback.value` | `1970-01-01` | General default |
| `zero.date.fallback.value.date` | (unset → inherit) | DATE override |
| `zero.date.fallback.value.datetime` | (unset → inherit) | DATETIME override |
| `zero.date.fallback.value.timestamp` | (unset → inherit) | TIMESTAMP override |

Cascading lookup: type-specific override → general default → `LocalDate.EPOCH`. Validator: ISO-8601 `yyyy-MM-dd`, range `0001-01-01..9999-12-31`. Both DDL parsing (schema default) and row-event conversion (payload value) read from the same cascading source.

The three sentinels are bundled into an immutable `io.debezium.jdbc.ZeroDateFallback` parameter object; the existing `JdbcValueConverters` constructor used by `postgres`/`oracle`/`sqlserver` delegates with `ZeroDateFallback.defaultEpoch()`, so other connectors are unaffected.

## Commits

1. `DBZ-1912 Allow customizing the zero-date fallback value (per type) for MySQL/MariaDB` — config + cascading getter + 12 fallback site swaps + `ZeroDateFallback` parameter object + tests + docs.
2. `DBZ-1912 Detect zero-date in streaming TIMESTAMP deserialization` — adds the `epochSecond == 0` guard in `RowDeserializers.deserializeTimestamp(V2)` so streaming `TIMESTAMP` zero-dates flow through the same fallback infrastructure as `DATE`/`DATETIME`. Without this guard the per-type `*.timestamp` override is silently inert during streaming. MySQL `TIMESTAMP`'s legal range starts at `1970-01-01 00:00:01` UTC, so `epochSecond == 0` unambiguously signals the zero-date sentinel.

## Backward compatibility

All four properties are optional. With no configuration the emitted output is byte-for-byte identical to today's hardcoded `1970-01-01` fallback. No schema changes (sentinel only affects values, not Avro/Protobuf logical types). Other Debezium connectors are unaffected.

## Test plan

- [x] Unit tests for `BinlogConnectorConfig` cascading lookup and validators (`MySqlConnectorConfigTest` +9 cases)
- [x] Unit tests for `MySqlDefaultValueConverter` zero-date sentinel (`MySqlZeroDateFallbackTest`, 7 cases covering DDL parsing path)
- [x] Unit tests for `ZeroDateFallback` parameter object (`ZeroDateFallbackTest`, 7 cases)
- [x] Unit tests for `RowDeserializers.deserializeTimestamp(V2)` zero-detection (`RowDeserializersTest`, 6 cases incl. V2 nanos guard)
- [x] Integration test extension in `BinlogDefaultValueAllZeroTimeIT` for the streaming row payload (covers both MySQL and MariaDB via the abstract base)
- [x] End-to-end Docker validation: MySQL source → Kafka Avro + Schema Registry → JDBC sink to MySQL, across three scenarios (default / uniform `9999-12-31` / per-type `.datetime=1001-01-01`), both snapshot and streaming paths

All units green: `debezium-connector-common` 386, `debezium-connector-binlog` 30, `debezium-connector-mysql` 325, `debezium-connector-mariadb` 289, `debezium-connector-postgres / oracle / sqlserver` compile (no behavior change).

## Out of scope

A `zero.date.handling.mode=null` mode that promotes the schema to `optional` and emits Kafka `null` instead of a sentinel — a schema-breaking change that warrants a separate proposal. The cascading getter introduced here is shaped to support it.