### PR TITLE
debezium/dbz#1914: idempotent logminer partial rollbacks (ec,ispn)

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -947,7 +947,8 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
      * @return true if an event was found and undone, false otherwise
      */
     private boolean rollbackTransactionEventWithRowId(Transaction transaction, LogMinerEventRow row) {
-        if (getTransactionCache().rollbackTransactionEventWithRowId(transaction, row.getRowId())) {
+        final int rollbackId = transaction.getNextEventId();
+        if (getTransactionCache().rollbackTransactionEventWithRowId(transaction, rollbackId, row.getRowId())) {
             // This metric won't necessarily be accurate when LOB is enabled, it will scale based on the
             // number of times a given transaction is re-mined.
             getMetrics().increasePartialRollbackCount();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
@@ -151,10 +151,11 @@ public interface LogMinerTransactionCache<T extends Transaction> {
      * Marks as rolled back a specific transaction event by unique row identifier.
      *
      * @param transaction the transaction, should not be {@code null}
+     * @param rollbackId the rollback event's identifier
      * @param rowId the event's unique row identifier
      * @return {@code true} if the event was found and removed, {@code false} if it was not found
      */
-    boolean rollbackTransactionEventWithRowId(T transaction, String rowId);
+    boolean rollbackTransactionEventWithRowId(T transaction, int rollbackId, String rowId);
 
     /**
      * Checks whether a specific transaction's event with the event key is cached.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
@@ -175,7 +175,7 @@ public class EhcacheCacheProvider extends AbstractCacheProvider<EhcacheTransacti
         return new EhcacheLogMinerTransactionCache(
                 getCache(TRANSACTIONS_CACHE_NAME, String.class, EhcacheTransaction.class, evictionListener),
                 getCache(EVENTS_CACHE_NAME, String.class, LogMinerEvent.class, evictionListener),
-                getCache(ROLLBACKS_CACHE_NAME, String.class, Boolean.class, evictionListener),
+                getCache(ROLLBACKS_CACHE_NAME, String.class, Integer.class, evictionListener),
                 evictionListener);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -32,7 +32,7 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
 
     private final Cache<String, EhcacheTransaction> transactionCache;
     private final Cache<String, LogMinerEvent> eventCache;
-    private final Cache<String, Boolean> rollbackCache;
+    private final Cache<String, Integer> rollbackCache;
     private final EhcacheEvictionListener evictionListener;
 
     // Heap-backed caches for quick access to specific metadata to speed up processing
@@ -40,7 +40,7 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
 
     public EhcacheLogMinerTransactionCache(Cache<String, EhcacheTransaction> transactionCache,
                                            Cache<String, LogMinerEvent> eventCache,
-                                           Cache<String, Boolean> rollbackCache,
+                                           Cache<String, Integer> rollbackCache,
                                            EhcacheEvictionListener evictionListener) {
         this.transactionCache = transactionCache;
         this.eventCache = eventCache;
@@ -160,9 +160,15 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
             final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
-                rollbackCache.put(eventKey, Boolean.TRUE);
-                return true;
+            if (event != null && event.getRowId() == encodedRowId) {
+                final Integer cachedRollbackId = rollbackCache.get(eventKey);
+                if (cachedRollbackId == null) {
+                    rollbackCache.put(eventKey, rollbackId);
+                    return true;
+                }
+                if (cachedRollbackId == rollbackId) {
+                    return true;
+                }
             }
         }
         return false;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -154,7 +154,7 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
     }
 
     @Override
-    public boolean rollbackTransactionEventWithRowId(EhcacheTransaction transaction, String rowId) {
+    public boolean rollbackTransactionEventWithRowId(EhcacheTransaction transaction, int rollbackId, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
@@ -29,14 +29,14 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
 
     private final BasicCache<String, InfinispanTransaction> transactionCache;
     private final BasicCache<String, LogMinerEvent> eventCache;
-    private final BasicCache<String, Boolean> rollbackCache;
+    private final BasicCache<String, Integer> rollbackCache;
 
     // Heap-backed caches for quick access to specific metadata to speed up processing
     private final Map<String, TreeSet<Integer>> eventIdsByTransactionId = new HashMap<>();
 
     public InfinispanLogMinerTransactionCache(BasicCache<String, InfinispanTransaction> transactionCache,
                                               BasicCache<String, LogMinerEvent> eventCache,
-                                              BasicCache<String, Boolean> rollbackCache) {
+                                              BasicCache<String, Integer> rollbackCache) {
         this.transactionCache = transactionCache;
         this.eventCache = eventCache;
         this.rollbackCache = rollbackCache;
@@ -148,9 +148,15 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
             final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
-                rollbackCache.put(eventKey, Boolean.TRUE);
-                return true;
+            if (event != null && event.getRowId() == encodedRowId) {
+                final Integer cachedRollbackId = rollbackCache.get(eventKey);
+                if (cachedRollbackId == null) {
+                    rollbackCache.put(eventKey, rollbackId);
+                    return true;
+                }
+                if (cachedRollbackId == rollbackId) {
+                    return true;
+                }
             }
         }
         return false;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
@@ -142,7 +142,7 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
     }
 
     @Override
-    public boolean rollbackTransactionEventWithRowId(InfinispanTransaction transaction, String rowId) {
+    public boolean rollbackTransactionEventWithRowId(InfinispanTransaction transaction, int rollbackId, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
@@ -7,11 +7,9 @@ package io.debezium.connector.oracle.logminer.buffered.memory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -32,7 +30,7 @@ public class MemoryLogMinerTransactionCache extends AbstractLogMinerTransactionC
     private final Map<String, MemoryTransaction> transactionsByTransactionId = new HashMap<>();
     private final Map<String, List<LogMinerEventEntry>> eventsByTransactionId = new HashMap<>();
     private final Map<String, HashMap<Integer, LogMinerEvent>> eventsByEventIdByTransactionId = new HashMap<>();
-    private final Map<String, Set<Integer>> rollbacksByTransactionId = new HashMap<>();
+    private final Map<String, Map<Integer, Integer>> rollbacksByTransactionId = new HashMap<>();
 
     @Override
     public MemoryTransaction getTransaction(String transactionId) {
@@ -87,12 +85,12 @@ public class MemoryLogMinerTransactionCache extends AbstractLogMinerTransactionC
     public void forEachEvent(MemoryTransaction transaction, LogMinerEventPredicate predicate) throws InterruptedException {
         final var events = eventsByTransactionId.get(transaction.getTransactionId());
         if (events != null) {
-            final Set<Integer> rollbacks = rollbacksByTransactionId.getOrDefault(transaction.getTransactionId(), Set.of());
+            final Map<Integer, Integer> rollbacks = rollbacksByTransactionId.getOrDefault(transaction.getTransactionId(), Map.of());
             try (var stream = events.stream()) {
                 final Iterator<LogMinerEventEntry> iterator = stream.iterator();
                 while (iterator.hasNext()) {
                     final LogMinerEventEntry entry = iterator.next();
-                    if (!predicate.test(entry.event, rollbacks.contains(entry.eventId))) {
+                    if (!predicate.test(entry.event, rollbacks.containsKey(entry.eventId))) {
                         break;
                     }
                 }
@@ -130,16 +128,22 @@ public class MemoryLogMinerTransactionCache extends AbstractLogMinerTransactionC
     }
 
     @Override
-    public boolean rollbackTransactionEventWithRowId(MemoryTransaction transaction, String rowId) {
+    public boolean rollbackTransactionEventWithRowId(MemoryTransaction transaction, int rollbackId, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final var events = eventsByTransactionId.get(transaction.getTransactionId());
         if (events != null) {
-            final Set<Integer> rollbacks = rollbacksByTransactionId.computeIfAbsent(transaction.getTransactionId(), k -> new HashSet<>());
+            final Map<Integer, Integer> rollbacks = rollbacksByTransactionId.computeIfAbsent(transaction.getTransactionId(), k -> new HashMap<>());
             for (int i = events.size() - 1; i >= 0; i--) {
                 final LogMinerEventEntry entry = events.get(i);
-                if (entry.event.getRowId() == encodedRowId && !rollbacks.contains(entry.eventId)) {
-                    rollbacks.add(entry.eventId);
-                    return true;
+                if (entry.event.getRowId() == encodedRowId) {
+                    final Integer cachedRollbackId = rollbacks.get(entry.eventId);
+                    if (cachedRollbackId == null) {
+                        rollbacks.put(entry.eventId, rollbackId);
+                        return true;
+                    }
+                    if (cachedRollbackId == rollbackId) {
+                        return true;
+                    }
                 }
             }
         }

--- a/debezium-connector-oracle/src/main/resources/ehcache/configuration-template.xml
+++ b/debezium-connector-oracle/src/main/resources/ehcache/configuration-template.xml
@@ -56,7 +56,7 @@
     <cache alias="rollbacks">
         <!-- Debezium specifically sets the key/value types -->
         <key-type>java.lang.String</key-type>
-        <value-type>java.lang.Boolean</value-type>
+        <value-type>java.lang.Integer</value-type>
         ${log.mining.buffer.ehcache.rollbacks.config}
     </cache>
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceIT.java
@@ -22,6 +22,8 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.util.OracleMetricsHelper;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
@@ -285,6 +287,45 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceIT exten
         }
         finally {
             TestHelper.dropTable(connection, "dbz1553");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1914")
+    public void shouldRollbackToSavepointIdempotently() throws Exception {
+        TestHelper.dropTable(connection, "dbz1914");
+        try {
+            connection.execute("CREATE TABLE dbz1914 (id numeric(9,0) primary key, data varchar2(50))");
+            TestHelper.streamTable(connection, "dbz1914");
+
+            Configuration config = getBufferImplementationConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1914")
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .build();
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+            OracleMetricsHelper.waitForOffsetScnAfter(Scn.NULL);
+
+            Scn offsetScn = Scn.valueOf(OracleMetricsHelper.getOffsetScn().toString());
+            connection.executeWithoutCommitting(
+                    "INSERT INTO dbz1914(id,data) VALUES (1,'insert 1')",
+                    "SAVEPOINT s1",
+                    "UPDATE dbz1914 SET data = 'update 1' WHERE id = 1",
+                    "ROLLBACK TO SAVEPOINT s1");
+            OracleMetricsHelper.waitForOffsetScnAfter(offsetScn);
+            connection.executeWithoutCommitting("INSERT INTO dbz1914 (id,data) VALUES (2,'insert 2')");
+            connection.commit();
+
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic("server1.DEBEZIUM.DBZ1914");
+            assertThat(tableRecords).hasSize(1);
+
+            Struct after = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo("insert 1");
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1914");
         }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
@@ -11,6 +11,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.math.BigInteger;
@@ -52,6 +53,7 @@ import io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerStreamingC
 import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope.Operation;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.pipeline.DataChangeEvent;
@@ -626,6 +628,27 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
         }
     }
 
+    @Test
+    @FixFor("DBZ-1914")
+    public void testSavepointRollbackIdempotence() throws Exception {
+        final Configuration config = getConfig().build();
+
+        try (var source = getChangeEventSource(config)) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'insert'"));
+            source.processEvent(getUpdateLogMinerEventRow(3, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'update'"));
+            source.processEvent(getRollbackToSavepointLogMinerEventRow(4, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'insert'"));
+            // Simulate a new mining session
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'insert'"));
+            source.processEvent(getUpdateLogMinerEventRow(3, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'update'"));
+            source.processEvent(getRollbackToSavepointLogMinerEventRow(4, TRANSACTION_ID_1, Instant.now(), "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'insert'"));
+            source.processEvent(getCommitLogMinerEventRow(5, TRANSACTION_ID_1));
+            Mockito.verify(dispatcher, Mockito.times(1))
+                    .dispatchDataChangeEvent(any(), any(), argThat(emitter -> emitter.getOperation() == Operation.CREATE));
+        }
+    }
+
     private OracleDatabaseSchema createOracleDatabaseSchema() throws Exception {
         Configuration configuration = getConfig().build();
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(configuration);
@@ -790,6 +813,26 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
         Mockito.when(row.getTableId()).thenReturn(TableId.parse("ORCLPDB1.DEBEZIUM." + tableName));
         Mockito.when(row.getRedoSql()).thenReturn(
                 "delete from \"DEBEZIUM\".\"%s\" where ROWID = '%s';".formatted(tableName, rowId));
+        Mockito.when(row.getRsId()).thenReturn("A.B.C");
+        Mockito.when(row.getTablespaceName()).thenReturn("DEBEZIUM");
+        Mockito.when(row.getUserName()).thenReturn(TestHelper.SCHEMA_USER);
+        return row;
+    }
+
+    private LogMinerEventRow getRollbackToSavepointLogMinerEventRow(long scn, String transactionId, Instant changeTime, String tableName, String rowId,
+                                                                    String dataValue) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.UPDATE);
+        Mockito.when(row.isRollbackFlag()).thenReturn(true);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(changeTime);
+        Mockito.when(row.getRowId()).thenReturn(rowId);
+        Mockito.when(row.getOperation()).thenReturn("UPDATE");
+        Mockito.when(row.getTableName()).thenReturn(tableName);
+        Mockito.when(row.getTableId()).thenReturn(TableId.parse("ORCLPDB1.DEBEZIUM." + tableName));
+        Mockito.when(row.getRedoSql()).thenReturn(
+                "update \"DEBEZIUM\".\"%s\" set \"DATA\" = %s;".formatted(tableName, dataValue));
         Mockito.when(row.getRsId()).thenReturn("A.B.C");
         Mockito.when(row.getTablespaceName()).thenReturn("DEBEZIUM");
         Mockito.when(row.getUserName()).thenReturn(TestHelper.SCHEMA_USER);


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1914

## Description
This PR makes partial rollbacks idempotent when using ehcache or infinispan transaction cache. It depends on #7423.

**Breaking change**: This PR changes the value type of the rollback cache to Integer. Consequently, the cache must be cleared before upgrading.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
