### PR TITLE
debezium/dbz#1735: fix partial rollbacks for out-of-line lobs

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -593,6 +593,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDefault(false)
             .withValidation(OracleConnectorConfig::validateLogMiningIncludeRedoSql);
 
+    public static final Field LOG_MINING_INCLUDE_INTERNAL_EVENTS = Field.create("log.mining.include.internal.events")
+            .withDisplayName("Specifies whether the connector supports mining INTERNAL events")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(false)
+            .withDescription("When set to 'false', the default, INTERNAL events will not be captured. " +
+                    "When 'lob.enabled' is 'true' and all LOB columns of an operation are stored out-of-line, " +
+                    "INTERNAL events provide the ROW_IDs necessary for accurate ROLLBACK TO SAVEPOINT handling. " +
+                    "NOTE: Enabling this may significantly increase the volume of events returned by LogMiner.");
+
     public static final Field SNAPSHOT_DATABASE_ERRORS_MAX_RETRIES = Field.create("snapshot.database.errors.max.retries")
             .withDisplayName("The maximum number of retries before snapshot database errors are not retried")
             .withType(Type.INT)
@@ -930,6 +941,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final String logMiningInifispanGlobalConfiguration;
     private final Set<String> logMiningSchemaChangesUsernameExcludes;
     private final Boolean logMiningIncludeRedoSql;
+    private final boolean logMiningIncludeInternalEvents;
     private final boolean logMiningContinuousMining;
     private final Configuration logMiningEhCacheConfiguration;
     private final boolean logMiningUseSqlRelaxedQuoteDetection;
@@ -1010,6 +1022,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningInifispanGlobalConfiguration = config.getString(LOG_MINING_BUFFER_INFINISPAN_CACHE_GLOBAL);
         this.logMiningSchemaChangesUsernameExcludes = Strings.setOf(config.getString(LOG_MINING_SCHEMA_CHANGES_USERNAME_EXCLUDE_LIST), String::new);
         this.logMiningIncludeRedoSql = config.getBoolean(LOG_MINING_INCLUDE_REDO_SQL);
+        this.logMiningIncludeInternalEvents = config.getBoolean(LOG_MINING_INCLUDE_INTERNAL_EVENTS);
         this.logMiningContinuousMining = config.getBoolean(LOG_MINING_CONTINUOUS_MINE);
         this.logMiningUseSqlRelaxedQuoteDetection = config.getBoolean(LOG_MINING_SQL_RELAXED_QUOTE_DETECTION);
         this.logMiningClientIdIncludes = Strings.setOfTrimmed(config.getString(LOG_MINING_CLIENTID_INCLUDE_LIST), String::new);
@@ -2016,6 +2029,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public boolean isLogMiningIncludeRedoSql() {
         return logMiningIncludeRedoSql;
+    }
+
+    /**
+        * @return true if INTERNAL events are to be captured.
+        */
+    public boolean isLogMiningIncludeInternalEvents() {
+        return logMiningIncludeInternalEvents;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -486,6 +486,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
                 preProcessEvent(event);
 
                 switch (event.getEventType()) {
+                    case INTERNAL -> handleInternalEvent(event);
                     case MISSING_SCN -> handleMissingScnEvent(event);
                     case START -> handleStartEvent(event);
                     case COMMIT -> handleCommitEvent(event);
@@ -517,6 +518,15 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      */
     protected void preProcessEvent(LogMinerEventRow event) {
         getBatchMetrics().rowProcessed();
+    }
+
+    /**
+     * Handles processing {@code INTERNAL} operation events.
+     *
+     * @param event the event, should not be {@code null}
+     */
+    protected void handleInternalEvent(LogMinerEventRow event) {
+        // no-op
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -134,7 +134,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
             acceptDmlEvent(dmlEvent, rolledBack, transactionId, transactionSequence);
         }
         else {
-            acceptManipulationEvent(event);
+            acceptManipulationEvent(event, rolledBack);
         }
     }
 
@@ -171,6 +171,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
 
         if (tryMerge(accumulatorEvent, event)) {
+            rowState.event.setRowId(event.getRowId());
             rowState.rolledBack = rolledBack;
             rowState.transactionSequence = transactionSequence;
         }
@@ -203,24 +204,26 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptManipulationEvent(LogMinerEvent event) {
+    private void acceptManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (event instanceof LobWriteEvent || event instanceof LobEraseEvent) {
-            acceptLobManipulationEvent(event);
+            acceptLobManipulationEvent(event, rolledBack);
         }
         else if (event instanceof ExtendedStringWriteEvent) {
-            acceptExtendedStringManipulationEvent(event);
+            acceptExtendedStringManipulationEvent(event, rolledBack);
         }
         else if (event instanceof XmlWriteEvent || event instanceof XmlEndEvent) {
-            acceptXmlManipulationEvent(event);
+            acceptXmlManipulationEvent(event, rolledBack);
         }
     }
 
-    private void acceptLobManipulationEvent(LogMinerEvent event) {
+    private void acceptLobManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentLobDetails.isInitialized()) {
             // should only happen when we start streaming in the middle of a LOB transaction (DBZ-4367)
             LOGGER.debug("Got LOB manipulation event without preceding LOB selector; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentLobDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.LOB_WRITE != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentLobDetails.columnName);
@@ -238,11 +241,13 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptExtendedStringManipulationEvent(LogMinerEvent event) {
+    private void acceptExtendedStringManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentExtendedStringDetails.isInitialized()) {
             LOGGER.debug("Got ExtendedString manipulation event without preceding ExtendedString begin; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentExtendedStringDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.EXTENDED_STRING_WRITE != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentExtendedStringDetails.columnName);
@@ -260,12 +265,14 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptXmlManipulationEvent(LogMinerEvent event) {
+    private void acceptXmlManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentXmlDetails.isInitialized()) {
             // should only happen when we start streaming in the middle of an XML transaction (DBZ-4367)
             LOGGER.trace("Got XML manipulation event without preceding XML begin; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentXmlDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.XML_WRITE != event.getEventType() && EventType.XML_END != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentXmlDetails.columnName);
@@ -287,6 +294,14 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
         catch (DebeziumException exception) {
             LOGGER.warn("\tInvalid XML manipulation event: {} ; ignoring {} {}", exception, event.getEventType(), event);
+        }
+    }
+
+    private void updateRowState(String rowStateId, long rowId, boolean rolledBack) {
+        final RowState rowState = rows.get(rowStateId);
+        if (rowState != null) {
+            rowState.event.setRowId(rowId);
+            rowState.rolledBack = rolledBack;
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
@@ -136,12 +136,21 @@ public class BufferedLogMinerQueryBuilder extends AbstractLogMinerQueryBuilder {
         operationInClause.withValues(getOperationCodesList(isCteQuery));
         predicate.append("(").append(operationInClause.build());
 
+        // Handle INTERNAL operations that can contain ROW_IDs for INSERT/UPDATE operations with empty ROW_IDs
+        if (connectorConfig.isLobEnabled() && connectorConfig.isLogMiningIncludeInternalEvents()) {
+            predicate.append(getInternalPredicate());
+        }
+
         // Handle DDL operations
         if (connectorConfig.storeOnlyCapturedTables()) {
             predicate.append(getDdlPredicate());
         }
 
         return predicate.append(")").toString();
+    }
+
+    private static String getInternalPredicate() {
+        return " OR (OPERATION_CODE = 0 AND ROLLBACK = 0 AND ROW_ID NOT LIKE '%AAAAAAAAAAAA')";
     }
 
     private static String getDdlPredicate() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -366,6 +366,16 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     }
 
     @Override
+    protected void handleInternalEvent(LogMinerEventRow event) {
+        if (!event.isRollbackFlag() && event.getRowId() != null && !event.getRowId().endsWith("AAAAAAAAAAAA")) {
+            final Transaction transaction = getTransactionCache().getTransaction(event.getTransactionId());
+            if (transaction != null) {
+                getTransactionCache().updateLastEventEmptyRowId(transaction, event.getRowId());
+            }
+        }
+    }
+
+    @Override
     protected void handleStartEvent(LogMinerEventRow event) {
         final String transactionId = event.getTransactionId();
         if (!isRecentlyProcessed(transactionId)) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/LogMinerTransactionCache.java
@@ -157,6 +157,16 @@ public interface LogMinerTransactionCache<T extends Transaction> {
     boolean rollbackTransactionEventWithRowId(T transaction, String rowId);
 
     /**
+     * Updates the ROW_ID of the last event in the given transaction if it's empty.
+     * Called when an INTERNAL event reveals the actual row address
+     * so that savepoint rollback UPDATEs or DELETEs can match the correct event.
+     *
+     * @param transaction the transaction, should not be {@code null}
+     * @param rowId the non-empty ROW_ID to assign to the last event
+     */
+    void updateLastEventEmptyRowId(T transaction, String rowId);
+
+    /**
      * Checks whether a specific transaction's event with the event key is cached.
      *
      * @param transaction the transaction, should not be {@code null}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -37,6 +37,8 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
 
     // Heap-backed caches for quick access to specific metadata to speed up processing
     private final Map<String, TreeSet<Integer>> eventIdsByTransactionId = new HashMap<>();
+    // Heap-backed caches for non-empty ROW_IDs from INTERNAL events
+    private final Map<String, Map<Integer, Long>> rowIdsByEventIdByTransactionId = new HashMap<>();
 
     public EhcacheLogMinerTransactionCache(Cache<String, EhcacheTransaction> transactionCache,
                                            Cache<String, LogMinerEvent> eventCache,
@@ -110,8 +112,10 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
             try (var stream = events.stream()) {
                 final Iterator<Integer> iterator = stream.iterator();
                 while (iterator.hasNext()) {
-                    final String eventKey = transaction.getEventId(iterator.next());
-                    if (!predicate.test(eventCache.get(eventKey), rollbackCache.containsKey(eventKey))) {
+                    final int eventId = iterator.next();
+                    final String eventKey = transaction.getEventId(eventId);
+                    final LogMinerEvent event = getTransactionEvent(transaction, eventId);
+                    if (!predicate.test(event, rollbackCache.containsKey(eventKey))) {
                         break;
                     }
                 }
@@ -121,7 +125,17 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
 
     @Override
     public LogMinerEvent getTransactionEvent(EhcacheTransaction transaction, int eventKey) {
-        return eventCache.get(transaction.getEventId(eventKey));
+        final LogMinerEvent event = eventCache.get(transaction.getEventId(eventKey));
+        if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
+            final Map<Integer, Long> rowIdsByEventId = rowIdsByEventIdByTransactionId.get(transaction.getTransactionId());
+            if (rowIdsByEventId != null) {
+                final Long rowId = rowIdsByEventId.get(eventKey);
+                if (rowId != null) {
+                    event.setRowId(rowId);
+                }
+            }
+        }
+        return event;
     }
 
     @Override
@@ -151,18 +165,16 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
             rollbackCache.removeAll(keys);
         }
         eventIdsByTransactionId.remove(transaction.getTransactionId());
+        rowIdsByEventIdByTransactionId.remove(transaction.getTransactionId());
     }
 
     @Override
     public void updateLastEventEmptyRowId(EhcacheTransaction transaction, String rowId) {
         final int numberOfEvents = transaction.getNumberOfEvents();
         if (numberOfEvents > 0) {
-            final String eventKey = transaction.getEventId(numberOfEvents - 1);
-            final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
-                event.setRowId(RowIdCodec.encode(rowId));
-                eventCache.put(eventKey, event);
-            }
+            rowIdsByEventIdByTransactionId
+                    .computeIfAbsent(transaction.getTransactionId(), id -> new HashMap<>())
+                    .computeIfAbsent(numberOfEvents - 1, id -> RowIdCodec.encode(rowId));
         }
     }
 
@@ -172,7 +184,7 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
-            final LogMinerEvent event = eventCache.get(eventKey);
+            final LogMinerEvent event = getTransactionEvent(transaction, eventId);
             if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
                 rollbackCache.put(eventKey, Boolean.TRUE);
                 return true;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -154,6 +154,19 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
     }
 
     @Override
+    public void updateLastEventEmptyRowId(EhcacheTransaction transaction, String rowId) {
+        final int numberOfEvents = transaction.getNumberOfEvents();
+        if (numberOfEvents > 0) {
+            final String eventKey = transaction.getEventId(numberOfEvents - 1);
+            final LogMinerEvent event = eventCache.get(eventKey);
+            if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
+                event.setRowId(RowIdCodec.encode(rowId));
+                eventCache.put(eventKey, event);
+            }
+        }
+    }
+
+    @Override
     public boolean rollbackTransactionEventWithRowId(EhcacheTransaction transaction, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
@@ -33,6 +33,8 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
 
     // Heap-backed caches for quick access to specific metadata to speed up processing
     private final Map<String, TreeSet<Integer>> eventIdsByTransactionId = new HashMap<>();
+    // Heap-backed caches for non-empty ROW_IDs from INTERNAL events
+    private final Map<String, Map<Integer, Long>> rowIdsByEventIdByTransactionId = new HashMap<>();
 
     public InfinispanLogMinerTransactionCache(BasicCache<String, InfinispanTransaction> transactionCache,
                                               BasicCache<String, LogMinerEvent> eventCache,
@@ -103,8 +105,10 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
             try (var stream = events.stream()) {
                 final Iterator<Integer> iterator = stream.iterator();
                 while (iterator.hasNext()) {
-                    final String eventKey = transaction.getEventId(iterator.next());
-                    if (!predicate.test(eventCache.get(eventKey), rollbackCache.containsKey(eventKey))) {
+                    final int eventId = iterator.next();
+                    final String eventKey = transaction.getEventId(eventId);
+                    final LogMinerEvent event = getTransactionEvent(transaction, eventId);
+                    if (!predicate.test(event, rollbackCache.containsKey(eventKey))) {
                         break;
                     }
                 }
@@ -114,7 +118,17 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
 
     @Override
     public LogMinerEvent getTransactionEvent(InfinispanTransaction transaction, int eventKey) {
-        return eventCache.get(transaction.getEventId(eventKey));
+        final LogMinerEvent event = eventCache.get(transaction.getEventId(eventKey));
+        if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
+            final Map<Integer, Long> rowIdsByEventId = rowIdsByEventIdByTransactionId.get(transaction.getTransactionId());
+            if (rowIdsByEventId != null) {
+                final Long rowId = rowIdsByEventId.get(eventKey);
+                if (rowId != null) {
+                    event.setRowId(rowId);
+                }
+            }
+        }
+        return event;
     }
 
     @Override
@@ -139,18 +153,16 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
             });
         }
         eventIdsByTransactionId.remove(transaction.getTransactionId());
+        rowIdsByEventIdByTransactionId.remove(transaction.getTransactionId());
     }
 
     @Override
     public void updateLastEventEmptyRowId(InfinispanTransaction transaction, String rowId) {
         final int numberOfEvents = transaction.getNumberOfEvents();
         if (numberOfEvents > 0) {
-            final String eventKey = transaction.getEventId(numberOfEvents - 1);
-            final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
-                event.setRowId(RowIdCodec.encode(rowId));
-                eventCache.put(eventKey, event);
-            }
+            rowIdsByEventIdByTransactionId
+                    .computeIfAbsent(transaction.getTransactionId(), id -> new HashMap<>())
+                    .computeIfAbsent(numberOfEvents - 1, id -> RowIdCodec.encode(rowId));
         }
     }
 
@@ -160,7 +172,7 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
-            final LogMinerEvent event = eventCache.get(eventKey);
+            final LogMinerEvent event = getTransactionEvent(transaction, eventId);
             if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
                 rollbackCache.put(eventKey, Boolean.TRUE);
                 return true;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
@@ -142,6 +142,19 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
     }
 
     @Override
+    public void updateLastEventEmptyRowId(InfinispanTransaction transaction, String rowId) {
+        final int numberOfEvents = transaction.getNumberOfEvents();
+        if (numberOfEvents > 0) {
+            final String eventKey = transaction.getEventId(numberOfEvents - 1);
+            final LogMinerEvent event = eventCache.get(eventKey);
+            if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
+                event.setRowId(RowIdCodec.encode(rowId));
+                eventCache.put(eventKey, event);
+            }
+        }
+    }
+
+    @Override
     public boolean rollbackTransactionEventWithRowId(InfinispanTransaction transaction, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
@@ -130,6 +130,17 @@ public class MemoryLogMinerTransactionCache extends AbstractLogMinerTransactionC
     }
 
     @Override
+    public void updateLastEventEmptyRowId(MemoryTransaction transaction, String rowId) {
+        final var eventsByEventId = eventsByEventIdByTransactionId.get(transaction.getTransactionId());
+        if (eventsByEventId != null) {
+            final LogMinerEvent event = eventsByEventId.get(transaction.getNumberOfEvents() - 1);
+            if (event != null && event.getRowId() == RowIdCodec.EMPTY_ROW_ID) {
+                event.setRowId(RowIdCodec.encode(rowId));
+            }
+        }
+    }
+
+    @Override
     public boolean rollbackTransactionEventWithRowId(MemoryTransaction transaction, String rowId) {
         final long encodedRowId = RowIdCodec.encode(rowId);
         final var events = eventsByTransactionId.get(transaction.getTransactionId());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/EventType.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/EventType.java
@@ -11,6 +11,7 @@ package io.debezium.connector.oracle.logminer.events;
  * @author Chris Cranford
  */
 public enum EventType {
+    INTERNAL(0),
     INSERT(1),
     DELETE(2),
     UPDATE(3),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
@@ -21,7 +21,7 @@ public class LogMinerEvent {
     private final EventType eventType;
     private final Scn scn;
     private final TableId tableId;
-    private final long rowId;
+    private long rowId;
     private final String rsId;
     private final long changeTime;
 
@@ -52,6 +52,10 @@ public class LogMinerEvent {
 
     public Long getRowId() {
         return rowId;
+    }
+
+    public void setRowId(long rowId) {
+        this.rowId = rowId;
     }
 
     public String getRowIdAsString() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -89,6 +89,12 @@ public class LogMinerQueryBuilderTest {
     }
 
     @Test
+    @FixFor("DBZ-1735")
+    public void testLogMinerQueryWithLobAndInternalEventsEnabled() {
+        assertQuery(TestHelper.defaultConfig().with(LOB_ENABLED, true).with(OracleConnectorConfig.LOG_MINING_INCLUDE_INTERNAL_EVENTS, true).build());
+    }
+
+    @Test
     @FixFor("DBZ-7847")
     public void testTableIncludeListWithMoreThan1000Elements() {
         String tables = IntStream.range(0, 1001).mapToObj(i -> "DEBEZIUM\\.T" + i).collect(Collectors.joining(","));
@@ -259,6 +265,7 @@ public class LogMinerQueryBuilderTest {
 
     private String getBufferedQuery(OracleConnectorConfig config) {
         final String operationDdlPredicate = " OR (OPERATION_CODE = 5 AND INFO NOT LIKE 'INTERNAL DDL%')";
+        final String internalEventsPredicate = " OR (OPERATION_CODE = 0 AND ROLLBACK = 0 AND ROW_ID NOT LIKE '%AAAAAAAAAAAA')";
 
         String query = "SELECT " + buildSelectColumns(config) + "FROM V$LOGMNR_CONTENTS WHERE ";
 
@@ -278,6 +285,7 @@ public class LogMinerQueryBuilderTest {
 
         query += "(";
         query += "OPERATION_CODE IN (" + codes + ")";
+        query += config.isLobEnabled() && config.isLogMiningIncludeInternalEvents() ? internalEventsPredicate : "";
         query += config.storeOnlyCapturedTables() ? operationDdlPredicate : "";
         query += ")";
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceIT.java
@@ -287,4 +287,101 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceIT exten
             TestHelper.dropTable(connection, "dbz1553");
         }
     }
+
+    @Test
+    @FixFor("DBZ-1735")
+    public void shouldRollbackEventWithEmptyOrOutOfLineLobs() throws Exception {
+        TestHelper.dropTable(connection, "dbz1735");
+        try {
+            connection.execute("CREATE TABLE dbz1735 (id numeric(9,0) primary key, data varchar2(50), clob0 clob, clob1 clob)");
+            TestHelper.streamTable(connection, "dbz1735");
+
+            Configuration config = getBufferImplementationConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1735")
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .with(OracleConnectorConfig.LOG_MINING_INCLUDE_INTERNAL_EVENTS, "true")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // data + empty:
+            // - AAAAAAAAAAAAAAAAAA INSERT
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA DELETE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "INSERT INTO dbz1735 (id, data, clob0, clob1) VALUES (1, '1', EMPTY_CLOB(), EMPTY_CLOB())",
+                    "ROLLBACK TO SAVEPOINT s1");
+            // data + out-of-line:
+            // - AAAAAAAAAAAAAAAAAA INSERT
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA DELETE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "INSERT INTO dbz1735 (id, data, clob0, clob1) VALUES (2, '2', '%s', '%s')".formatted("3".repeat(1985), "3".repeat(1986)),
+                    "ROLLBACK TO SAVEPOINT s1");
+            connection.execute("INSERT INTO dbz1735 (id, data, clob0, clob1) VALUES (3, '3', '3', '3')");
+            // out-of-line:
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA UPDATE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "UPDATE dbz1735 SET clob0 = '%s' WHERE id = 3".formatted("3".repeat(1985)),
+                    "ROLLBACK TO SAVEPOINT s1");
+            // data + out-of-line:
+            // - AAAAAAAAAAAAAAAAAA UPDATE
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA UPDATE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "UPDATE dbz1735 SET data = '33', clob0 = '%s' WHERE id = 3".formatted("3".repeat(1985)),
+                    "ROLLBACK TO SAVEPOINT s1");
+            // out-of-line + out-of-line:
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA UPDATE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "UPDATE dbz1735 SET clob0 = '%s', clob1 = '%s' WHERE id = 3".formatted("3".repeat(1985), "3".repeat(1986)),
+                    "ROLLBACK TO SAVEPOINT s1");
+            // data + out-of-line + out-of-line:
+            // - AAAAAAAAAAAAAAAAAA UPDATE
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAAAAAAAAAAAAAAAAA SELECT_LOB_LOCATOR
+            // - AAAAAAAAAAAAAAAAAA LOB_WRITEs
+            // - AAASncAAMAAAACDAAA INTERNAL
+            // - AAASncAAMAAAACDAAA UPDATE ROLLBACK
+            connection.execute(
+                    "SAVEPOINT s1",
+                    "UPDATE dbz1735 SET data = '3', clob0 = '%s', clob1 = '%s' WHERE id = 3".formatted("3".repeat(1985), "3".repeat(1986)),
+                    "ROLLBACK TO SAVEPOINT s1");
+
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic("server1.DEBEZIUM.DBZ1735");
+            assertThat(tableRecords).hasSize(1);
+
+            Struct after = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(3);
+            assertThat(after.get("DATA")).isEqualTo("3");
+            assertThat(after.get("CLOB0")).isEqualTo("3");
+            assertThat(after.get("CLOB1")).isEqualTo("3");
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz1735");
+        }
+    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
@@ -626,6 +626,24 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
         }
     }
 
+    @Test
+    @FixFor("DBZ-1735")
+    public void testSavepointRollbackInsertWithOutOfLineLob() throws Exception {
+        final Configuration config = getConfig()
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        try (var source = getChangeEventSource(config)) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAA", "EMPTY_CLOB()"));
+            source.processEvent(getInternalLogMinerEventRow(3, TRANSACTION_ID_1, Instant.now(), "AAAAAAAAAAAAAAAAAB"));
+            source.processEvent(getRollbackToSavepointLogMinerEventRow(4, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAB"));
+            source.processEvent(getCommitLogMinerEventRow(5, TRANSACTION_ID_1));
+            Mockito.verify(dispatcher, Mockito.never())
+                    .dispatchDataChangeEvent(any(), any(), any());
+        }
+    }
+
     private OracleDatabaseSchema createOracleDatabaseSchema() throws Exception {
         Configuration configuration = getConfig().build();
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(configuration);
@@ -701,6 +719,16 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
                 .build();
 
         return new LogMinerStreamingChangeEventSourceMetrics(taskContext, queue, null, connectorConfig, java.util.Collections::emptyList);
+    }
+
+    private LogMinerEventRow getInternalLogMinerEventRow(long scn, String transactionId, Instant changeTime, String rowId) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.INTERNAL);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(changeTime);
+        Mockito.when(row.getRowId()).thenReturn(rowId);
+        return row;
     }
 
     private LogMinerEventRow getStartLogMinerEventRow(long scn, String transactionId) {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1735

## Description
This PR is based on the assumption that all cached events with an empty ROW_ID, followed by an event with a non-empty ROW_ID, must be merged. In other words, a transaction can have only one active complex operation at any given moment.

The approach is simple: when an incoming INTERNAL event has a non-empty ROW_ID, update the ROW_ID of the last transaction event if it is empty.

This PR adds INTERNAL events with non-empty ROW_IDs to the oracle logminer buffered query builder, but they aren't stored in the transaction cache.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
