### PR TITLE
debezium/dbz#1917: prevent merging distinct operations on the same row

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -134,7 +134,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
             acceptDmlEvent(dmlEvent, rolledBack, transactionId, transactionSequence);
         }
         else {
-            acceptManipulationEvent(event);
+            acceptManipulationEvent(event, rolledBack);
         }
     }
 
@@ -171,6 +171,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
 
         if (tryMerge(accumulatorEvent, event)) {
+            rowState.event.setRowId(event.getRowId());
             rowState.rolledBack = rolledBack;
             rowState.transactionSequence = transactionSequence;
         }
@@ -203,24 +204,26 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptManipulationEvent(LogMinerEvent event) {
+    private void acceptManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (event instanceof LobWriteEvent || event instanceof LobEraseEvent) {
-            acceptLobManipulationEvent(event);
+            acceptLobManipulationEvent(event, rolledBack);
         }
         else if (event instanceof ExtendedStringWriteEvent) {
-            acceptExtendedStringManipulationEvent(event);
+            acceptExtendedStringManipulationEvent(event, rolledBack);
         }
         else if (event instanceof XmlWriteEvent || event instanceof XmlEndEvent) {
-            acceptXmlManipulationEvent(event);
+            acceptXmlManipulationEvent(event, rolledBack);
         }
     }
 
-    private void acceptLobManipulationEvent(LogMinerEvent event) {
+    private void acceptLobManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentLobDetails.isInitialized()) {
             // should only happen when we start streaming in the middle of a LOB transaction (DBZ-4367)
             LOGGER.debug("Got LOB manipulation event without preceding LOB selector; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentLobDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.LOB_WRITE != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentLobDetails.columnName);
@@ -238,11 +241,13 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptExtendedStringManipulationEvent(LogMinerEvent event) {
+    private void acceptExtendedStringManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentExtendedStringDetails.isInitialized()) {
             LOGGER.debug("Got ExtendedString manipulation event without preceding ExtendedString begin; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentExtendedStringDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.EXTENDED_STRING_WRITE != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentExtendedStringDetails.columnName);
@@ -260,12 +265,14 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
     }
 
-    private void acceptXmlManipulationEvent(LogMinerEvent event) {
+    private void acceptXmlManipulationEvent(LogMinerEvent event, boolean rolledBack) {
         if (!currentXmlDetails.isInitialized()) {
             // should only happen when we start streaming in the middle of an XML transaction (DBZ-4367)
             LOGGER.trace("Got XML manipulation event without preceding XML begin; ignoring {} {}.", event.getEventType(), event);
             return;
         }
+
+        updateRowState(currentXmlDetails.rowId, event.getRowId(), rolledBack);
 
         if (EventType.XML_WRITE != event.getEventType() && EventType.XML_END != event.getEventType()) {
             LOGGER.warn("\t{} for table '{}' column '{}' is not supported.", event.getEventType(), event.getTableId(), currentXmlDetails.columnName);
@@ -287,6 +294,14 @@ public class TransactionCommitConsumer implements AutoCloseable {
         }
         catch (DebeziumException exception) {
             LOGGER.warn("\tInvalid XML manipulation event: {} ; ignoring {} {}", exception, event.getEventType(), event);
+        }
+    }
+
+    private void updateRowState(String rowStateId, long rowId, boolean rolledBack) {
+        final RowState rowState = rows.get(rowStateId);
+        if (rowState != null) {
+            rowState.event.setRowId(rowId);
+            rowState.rolledBack = rolledBack;
         }
     }
 
@@ -337,6 +352,9 @@ public class TransactionCommitConsumer implements AutoCloseable {
 
     private boolean tryMerge(DmlEvent prev, DmlEvent next) {
         if (prev == null) { // first event for this row.
+            return false;
+        }
+        if (prev.getRowId() != RowIdCodec.EMPTY_ROW_ID) {
             return false;
         }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -170,7 +170,10 @@ public class TransactionCommitConsumer implements AutoCloseable {
             return;
         }
 
-        if (tryMerge(accumulatorEvent, event, rolledBack)) {
+        if (rowState != null
+                && !rowState.rolledBack
+                && !(accumulatorEvent.getRowId() != RowIdCodec.EMPTY_ROW_ID && rolledBack)
+                && tryMerge(accumulatorEvent, event)) {
             rowState.event.setRowId(event.getRowId());
             rowState.rolledBack = rolledBack;
             rowState.transactionSequence = transactionSequence;
@@ -350,14 +353,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
         dispatchChangeEvent(event, rowState.rolledBack, rowState.transactionId, rowState.transactionSequence);
     }
 
-    private boolean tryMerge(DmlEvent prev, DmlEvent next, boolean rolledBack) {
-        if (prev == null) { // first event for this row.
-            return false;
-        }
-        if (prev.getRowId() != RowIdCodec.EMPTY_ROW_ID && rolledBack) {
-            return false;
-        }
-
+    private boolean tryMerge(DmlEvent prev, DmlEvent next) {
         // we can only merge into INSERT, UPDATE and SEL_LOB_LOCATOR
         // we can only merge from UPDATE and SEL_LOB_LOCATOR
         // merges _from_ SEL_LOB_LOCATOR are basically noops.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -173,6 +173,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
         if (rowState != null
                 && !rowState.rolledBack
                 && !(accumulatorEvent.getRowId() != RowIdCodec.EMPTY_ROW_ID && rolledBack)
+                && !(accumulatorEvent.getRowId() != RowIdCodec.EMPTY_ROW_ID && event.getRowId() == RowIdCodec.EMPTY_ROW_ID)
                 && tryMerge(accumulatorEvent, event)) {
             rowState.event.setRowId(event.getRowId());
             rowState.rolledBack = rolledBack;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -170,7 +170,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
             return;
         }
 
-        if (tryMerge(accumulatorEvent, event)) {
+        if (tryMerge(accumulatorEvent, event, rolledBack)) {
             rowState.event.setRowId(event.getRowId());
             rowState.rolledBack = rolledBack;
             rowState.transactionSequence = transactionSequence;
@@ -350,11 +350,11 @@ public class TransactionCommitConsumer implements AutoCloseable {
         dispatchChangeEvent(event, rowState.rolledBack, rowState.transactionId, rowState.transactionSequence);
     }
 
-    private boolean tryMerge(DmlEvent prev, DmlEvent next) {
+    private boolean tryMerge(DmlEvent prev, DmlEvent next, boolean rolledBack) {
         if (prev == null) { // first event for this row.
             return false;
         }
-        if (prev.getRowId() != RowIdCodec.EMPTY_ROW_ID) {
+        if (prev.getRowId() != RowIdCodec.EMPTY_ROW_ID && rolledBack) {
             return false;
         }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
@@ -21,7 +21,7 @@ public class LogMinerEvent {
     private final EventType eventType;
     private final Scn scn;
     private final TableId tableId;
-    private final long rowId;
+    private long rowId;
     private final String rsId;
     private final long changeTime;
 
@@ -52,6 +52,10 @@ public class LogMinerEvent {
 
     public Long getRowId() {
         return rowId;
+    }
+
+    public void setRowId(long rowId) {
+        this.rowId = rowId;
     }
 
     public String getRowIdAsString() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -2229,7 +2229,7 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
     public void shouldRollbackExactlyOneOperation() throws Exception {
         TestHelper.dropTable(connection, "DBZ1917");
         try {
-            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA BLOB)");
+            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA BLOB, DATA2 BLOB)");
             TestHelper.streamTable(connection, "DBZ1917");
 
             Configuration config = TestHelper.defaultConfig()
@@ -2244,17 +2244,30 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
             connection.prepareQuery("INSERT INTO DBZ1917(id,data) VALUES (1,?)", ps -> ps.setBlob(1, insert1Blob), null);
             final Blob update1Blob = createBlob("update 1".getBytes(StandardCharsets.UTF_8));
             connection.executeWithoutCommitting("SAVEPOINT s1");
-            connection.prepareQuery("UPDATE DBZ1917 SET data = ? WHERE id = 1", ps -> ps.setBlob(1, update1Blob), null);
+            connection.prepareQuery("UPDATE DBZ1917 SET data2 = ? WHERE id = 1", ps -> ps.setBlob(1, update1Blob), null);
             connection.executeWithoutCommitting("ROLLBACK TO SAVEPOINT s1");
+
+            final Blob update2Blob = createBlob("update 2".getBytes(StandardCharsets.UTF_8));
+            connection.prepareQuery("UPDATE DBZ1917 SET data = ? WHERE id = 1", ps -> ps.setBlob(1, update2Blob), null);
+            final Blob update3Blob = createBlob("update 2".getBytes(StandardCharsets.UTF_8));
+            connection.executeWithoutCommitting("SAVEPOINT s2");
+            connection.prepareQuery("UPDATE DBZ1917 SET data = ? WHERE id = 1", ps -> ps.setBlob(1, update3Blob), null);
+            connection.executeWithoutCommitting("ROLLBACK TO SAVEPOINT s2");
+
+            final Blob update4Blob = createBlob("update 1".getBytes(StandardCharsets.UTF_8));
+            connection.executeWithoutCommitting("SAVEPOINT s3");
+            connection.prepareQuery("UPDATE DBZ1917 SET data2 = ? WHERE id = 1", ps -> ps.setBlob(1, update4Blob), null);
+            connection.executeWithoutCommitting("ROLLBACK TO SAVEPOINT s3");
             final Blob insert2Blob = createBlob("insert 2".getBytes(StandardCharsets.UTF_8));
             connection.prepareQuery("INSERT INTO DBZ1917 (id,data) VALUES (2,?)", ps -> ps.setBlob(1, insert2Blob), null);
             connection.commit();
 
-            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic(topicName("DBZ1917"));
-            assertThat(tableRecords).hasSize(1);
-            SourceRecord insert1 = tableRecords.get(0);
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(2).recordsForTopic(topicName("DBZ1917"));
+            assertThat(tableRecords).hasSize(2);
+            SourceRecord insert1 = tableRecords.get(1);
             assertThat(getAfterField(insert1, "ID")).isEqualTo(1);
-            assertThat(getAfterField(insert1, "DATA")).isEqualTo(getByteBufferFromBlob(insert1Blob));
+            assertThat(getAfterField(insert1, "DATA")).isEqualTo(getByteBufferFromBlob(update2Blob));
+            assertThat(getAfterField(insert1, "DATA2")).isEqualTo(getUnavailableValuePlaceholder(config));
 
             stopConnector();
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -2224,6 +2224,45 @@ public class OracleBlobDataTypesIT extends AbstractAsyncEngineConnectorTest {
         }
     }
 
+    @Test
+    @FixFor("DBZ-1917")
+    public void shouldRollbackExactlyOneOperation() throws Exception {
+        TestHelper.dropTable(connection, "DBZ1917");
+        try {
+            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA BLOB)");
+            TestHelper.streamTable(connection, "DBZ1917");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1917")
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .build();
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final Blob insert1Blob = createBlob("insert 1".getBytes(StandardCharsets.UTF_8));
+            connection.prepareQuery("INSERT INTO DBZ1917(id,data) VALUES (1,?)", ps -> ps.setBlob(1, insert1Blob), null);
+            final Blob update1Blob = createBlob("update 1".getBytes(StandardCharsets.UTF_8));
+            connection.executeWithoutCommitting("SAVEPOINT s1");
+            connection.prepareQuery("UPDATE DBZ1917 SET data = ? WHERE id = 1", ps -> ps.setBlob(1, update1Blob), null);
+            connection.executeWithoutCommitting("ROLLBACK TO SAVEPOINT s1");
+            final Blob insert2Blob = createBlob("insert 2".getBytes(StandardCharsets.UTF_8));
+            connection.prepareQuery("INSERT INTO DBZ1917 (id,data) VALUES (2,?)", ps -> ps.setBlob(1, insert2Blob), null);
+            connection.commit();
+
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic(topicName("DBZ1917"));
+            assertThat(tableRecords).hasSize(1);
+            SourceRecord insert1 = tableRecords.get(0);
+            assertThat(getAfterField(insert1, "ID")).isEqualTo(1);
+            assertThat(getAfterField(insert1, "DATA")).isEqualTo(getByteBufferFromBlob(insert1Blob));
+
+            stopConnector();
+        }
+        finally {
+            TestHelper.dropTable(connection, "DBZ1917");
+        }
+    }
+
     private static byte[] part(byte[] buffer, int start, int length) {
         return Arrays.copyOfRange(buffer, start, length);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -2702,6 +2702,42 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
         }
     }
 
+    @Test
+    @FixFor("DBZ-1917")
+    public void shouldRollbackExactlyOneOperation() throws Exception {
+        TestHelper.dropTable(connection, "DBZ1917");
+        try {
+            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA CLOB)");
+            TestHelper.streamTable(connection, "DBZ1917");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ1917")
+                    .with(OracleConnectorConfig.LOB_ENABLED, "true")
+                    .build();
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.execute(
+                    "INSERT INTO DBZ1917(id,data) VALUES (1,'insert 1')",
+                    "SAVEPOINT s1",
+                    "UPDATE DBZ1917 SET data = 'update 1' WHERE id = 1",
+                    "ROLLBACK TO SAVEPOINT s1",
+                    "INSERT INTO DBZ1917 (id,data) VALUES (2,'insert 2')");
+
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic(topicName("DBZ1917"));
+            assertThat(tableRecords).hasSize(1);
+            SourceRecord insert1 = tableRecords.get(0);
+            assertThat(getAfterField(insert1, "ID")).isEqualTo(1);
+            assertThat(getAfterField(insert1, "DATA")).isEqualTo("insert 1");
+
+            stopConnector();
+        }
+        finally {
+            TestHelper.dropTable(connection, "DBZ1917");
+        }
+    }
+
     private String createRandomStringWithAlphaNumeric(int length) {
         return RandomStringUtils.randomAlphabetic(length);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -2721,17 +2721,25 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
             connection.execute(
                     "INSERT INTO DBZ1917(id,data) VALUES (1,'insert 1')",
                     "SAVEPOINT s1",
-                    "UPDATE DBZ1917 SET data = 'update 1' WHERE id = 1",
+                    "UPDATE DBZ1917 SET data2 = 'update 1' WHERE id = 1",
                     "ROLLBACK TO SAVEPOINT s1",
-                    "UPDATE DBZ1917 SET data2 = 'update 2' WHERE id = 1",
+
+                    "UPDATE DBZ1917 SET data = 'update 2' WHERE id = 1",
+                    "SAVEPOINT s2",
+                    "UPDATE DBZ1917 SET data = 'update 3' WHERE id = 1",
+                    "ROLLBACK TO SAVEPOINT s2",
+
+                    "SAVEPOINT s3",
+                    "UPDATE DBZ1917 SET data2 = 'update 4' WHERE id = 1",
+                    "ROLLBACK TO SAVEPOINT s3",
                     "INSERT INTO DBZ1917 (id,data) VALUES (2,'insert 2')");
 
             List<SourceRecord> tableRecords = consumeRecordsByTopic(2).recordsForTopic(topicName("DBZ1917"));
             assertThat(tableRecords).hasSize(2);
             SourceRecord insert1 = tableRecords.get(1);
             assertThat(getAfterField(insert1, "ID")).isEqualTo(1);
-            assertThat(getAfterField(insert1, "DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
-            assertThat(getAfterField(insert1, "DATA2")).isEqualTo("update 2");
+            assertThat(getAfterField(insert1, "DATA")).isEqualTo("update 2");
+            assertThat(getAfterField(insert1, "DATA2")).isEqualTo(getUnavailableValuePlaceholder(config));
 
             stopConnector();
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -2707,7 +2707,7 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
     public void shouldRollbackExactlyOneOperation() throws Exception {
         TestHelper.dropTable(connection, "DBZ1917");
         try {
-            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA CLOB)");
+            connection.execute("CREATE TABLE DBZ1917(id numeric(9,0), DATA CLOB, DATA2 CLOB)");
             TestHelper.streamTable(connection, "DBZ1917");
 
             Configuration config = TestHelper.defaultConfig()
@@ -2723,13 +2723,15 @@ public class OracleClobDataTypeIT extends AbstractAsyncEngineConnectorTest {
                     "SAVEPOINT s1",
                     "UPDATE DBZ1917 SET data = 'update 1' WHERE id = 1",
                     "ROLLBACK TO SAVEPOINT s1",
+                    "UPDATE DBZ1917 SET data2 = 'update 2' WHERE id = 1",
                     "INSERT INTO DBZ1917 (id,data) VALUES (2,'insert 2')");
 
-            List<SourceRecord> tableRecords = consumeRecordsByTopic(1).recordsForTopic(topicName("DBZ1917"));
-            assertThat(tableRecords).hasSize(1);
-            SourceRecord insert1 = tableRecords.get(0);
+            List<SourceRecord> tableRecords = consumeRecordsByTopic(2).recordsForTopic(topicName("DBZ1917"));
+            assertThat(tableRecords).hasSize(2);
+            SourceRecord insert1 = tableRecords.get(1);
             assertThat(getAfterField(insert1, "ID")).isEqualTo(1);
-            assertThat(getAfterField(insert1, "DATA")).isEqualTo("insert 1");
+            assertThat(getAfterField(insert1, "DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
+            assertThat(getAfterField(insert1, "DATA2")).isEqualTo("update 2");
 
             stopConnector();
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
@@ -11,6 +11,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.math.BigInteger;
@@ -52,6 +53,7 @@ import io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerStreamingC
 import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope.Operation;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.pipeline.DataChangeEvent;
@@ -623,6 +625,25 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
             source.processEvent(getCommitLogMinerEventRow(5, TRANSACTION_ID_1));
             Mockito.verify(dispatcher, Mockito.never())
                     .dispatchDataChangeEvent(any(), any(), any());
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1917")
+    public void testSavepointRollbackExactlyOneOperation() throws Exception {
+        final Configuration config = getConfig()
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .build();
+
+        try (var source = getChangeEventSource(config)) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAA", "EMPTY_CLOB()"));
+            source.processEvent(getUpdateLogMinerEventRow(3, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAB", "'insert'"));
+            source.processEvent(getUpdateLogMinerEventRow(4, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAB", "'update'"));
+            source.processEvent(getRollbackToSavepointLogMinerEventRow(5, TRANSACTION_ID_1, Instant.now(), LOB_TABLE_NAME, "AAAAAAAAAAAAAAAAAB"));
+            source.processEvent(getCommitLogMinerEventRow(6, TRANSACTION_ID_1));
+            Mockito.verify(dispatcher, Mockito.times(1))
+                    .dispatchDataChangeEvent(any(), any(), argThat(emitter -> emitter.getOperation() == Operation.CREATE));
         }
     }
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1917

## Description
With `lob.enabled=true` all consecutive operations on the same row are merged into a single event. This leads to broken partial rollback behavior: a rollback intended for a single event applies to the entire merged event. The PR distinguishes between events that are parts of a complex operation and events that are independent operations on the same row: once a merged event gets a non-empty ROW_ID it is considered "finalized" and no subsequent events can be merged into it.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
