### PR TITLE
Fix IllegalArgumentException when CDC capture pollinginterval is 0

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -92,6 +92,7 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String CDC_JOB_INFO_JOB_TYPE_COLUMN_NAME = "job_type";
     private static final String CDC_JOB_INFO_JOB_TYPE_CAPTURE_VALUE = "capture";
     private static final String CDC_JOB_INFO_POLLING_INTERVAL_COLUMN_NAME = "pollinginterval";
+    private static final long DEFAULT_CDC_POLLING_INTERVAL_SECONDS = 5;
     private static final String GET_START_LSN_FOR_LAST_BATCH_SCANNED = "SELECT TOP 1 start_lsn from sys.dm_cdc_log_scan_sessions ORDER BY session_id DESC";
     private static final String START_LSN_INDICATING_EMPTY_BATCH = "00000000:00000000:0000\u0000";
 
@@ -838,7 +839,7 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     public Duration getCdcCapturePollingInterval() {
-        AtomicLong cdcCapturePollingInterval = new AtomicLong(5); // default
+        AtomicLong cdcCapturePollingInterval = new AtomicLong(DEFAULT_CDC_POLLING_INTERVAL_SECONDS);
         try {
             call(GET_CDC_JOB_INFO, null, rs -> {
                 while (rs.next()) {
@@ -851,7 +852,13 @@ public class SqlServerConnection extends JdbcConnection {
         catch (SQLException e) {
             LOGGER.warn("Exception caught while calling sys.sp_cdc_help_jobs", e);
         }
-        return Duration.ofSeconds(cdcCapturePollingInterval.get());
+        long interval = cdcCapturePollingInterval.get();
+        if (interval <= 0) {
+            LOGGER.info("CDC capture polling interval is {} (e.g. Azure SQL Database); using default of {} seconds",
+                    interval, DEFAULT_CDC_POLLING_INTERVAL_SECONDS);
+            interval = DEFAULT_CDC_POLLING_INTERVAL_SECONDS;
+        }
+        return Duration.ofSeconds(interval);
     }
 
     public boolean didTransactionEnd() {


### PR DESCRIPTION
Fixes debezium/dbz#1923

On Azure SQL Database (and other managed SQL Server environments), sys.sp_cdc_help_jobs reports pollinginterval=0 for the capture job because CDC capture is handled by an internal Azure scheduler, not SQL Server Agent. The value 0 is a valid metadata placeholder.

getCdcCapturePollingInterval() returned Duration.ofSeconds(0), which caused ElapsedTimeStrategy.constant() to throw
IllegalArgumentException('Initial delay must be positive') in resetEndTransactionTimer(), crashing the connector task on the first CDC change event.

Guard against non-positive pollinginterval values by falling back to the default of 5 seconds, matching the on-prem SQL Server default.

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#<the Debezium Issue Number>

## Description
<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ ] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
