### PR TITLE
[docs] Fix incorrect guidance about wal_writer_delay and synchronous_commit

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2404,7 +2404,7 @@ without missing any events.
 This requires the state of the slot to be synchronized from primary to replica server;
 refer to the Postgres documentation for the details.
 
-If you are working with a `synchronous_commit` setting other than `on`,
+If you are working with `synchronous_commit` set to `off`,
 the recommendation is to set `wal_writer_delay` to a value such as 10 milliseconds to achieve a low latency of change events.
 Otherwise, its default value is applied, which adds a latency of about 200 milliseconds.
 


### PR DESCRIPTION
## Description
<!-- Briefly describe your changes here. -->

The current documentation states:

> If you are working with a synchronous_commit setting other than on, the recommendation is to set wal_writer_delay to a value such as 10 milliseconds to achieve a low latency of change events.

However, this statement does not seem accurate according to PostgreSQL behavior.

As described in [the PostgreSQL documentation](https://www.postgresql.org/docs/18/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT), `remote_apply`, `remote_write`, and `local` provide the same local synchronization semantics as `on`. In all of these modes, the server waits for the WAL record to be flushed to disk before reporting commit success to the client. Therefore, `wal_writer_delay` does not affect commit visibility latency in these modes.
The only mode where `wal_writer_delay` influences the delay between commit acknowledgement and WAL flush is `synchronous_commit` = `off`.

Because of this, the current wording:

> other than on

seems to incorrectly imply that `remote_apply`, `remote_write`, and `local` are also affected by `wal_writer_delay`.

What do you think?

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
