### PR TITLE
debezium/dbz#1837 Update to latest Oracle 23.26.x driver

### DIFF
--- a/debezium-connector-oracle/README.md
+++ b/debezium-connector-oracle/README.md
@@ -30,7 +30,7 @@ In order to build this connector, the following pre-requisites must be met:
 mvn install:install-file \
   -DgroupId=com.oracle.instantclient \
   -DartifactId=xstreams \
-  -Dversion=21.15.0.0 \
+  -Dversion=23.26.1.0.0 \
   -Dpackaging=jar \
   -Dfile=xstreams.jar
 ```

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -915,33 +915,11 @@
             </properties>
         </profile>
         <profile>
-            <id>oracle-23</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
-            </properties>
-        </profile>
-        <profile>
-            <id>oracle-26</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
-            </properties>
-        </profile>
-        <profile>
             <id>oracle-free</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
                 <oracle.image.name>container-registry.oracle.com/database/free</oracle.image.name>
                 <oracle.image.version>23.26.0.0</oracle.image.version>
             </properties>

--- a/debezium-testing/tmt/tests/debezium/test.sh
+++ b/debezium-testing/tmt/tests/debezium/test.sh
@@ -29,7 +29,7 @@ then
   export LD_LIBRARY_PATH=$ORACLE_ARTIFACT_DIR
   if [ "$ORACLE_REGISTRY" != "quay.io/rh_integration/dbz-oracle" ]
   then
-    export ORACLE_HOME=/usr/lib/oracle/21/client64
+    export ORACLE_HOME=/usr/lib/oracle/23/client64
     export PATH=$ORACLE_HOME/bin:$PATH
     export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$LD_LIBRARY_PATH
     export ORACLE_CONNECTION="-Ddatabase.dbname=FREEPDB1 -Ddatabase.pdb.name=FREEPDB1"

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -19,7 +19,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '3.2.5'
     db2-version: '11.5.0.0'
-    ojdbc-version: '21.15.0.0'
+    ojdbc-version: '23.26.1.0.0'
     informix-jdbc-version: '15.0.1.1'
     ifx-changestream-version: '1.1.3'
     min-java-connectors-version: '17'

--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
         <version.jt400>11.1</version.jt400> <!-- IBM Toolbox for Java (JT400) for Debezium JDBC connector Db2i dialect -->
         <!-- These two should be aligned by major versions but minor could vary -->
         <!-- Oracle publishes the driver versions more frequently than the instant client -->
-        <version.oracle.driver>21.15.0.0</version.oracle.driver>
-        <version.oracle.instantclient>21.15.0.0</version.oracle.instantclient>
+        <version.oracle.driver>23.26.1.0.0</version.oracle.driver>
+        <version.oracle.instantclient>23.26.1.0.0</version.oracle.instantclient>
 
         <!-- Databases, should align with database drivers -->
         <version.mysql.server>8.2</version.mysql.server>


### PR DESCRIPTION
Fixes debezium/dbz#1837

## Description


Updates the Oracle JDBC driver from version 21.15.0.0 to 23.26.2.0.0 and the Oracle Instant Client from 21.15.0.0 to 23.26.1.0.0, unifying the driver version across all Oracle database version profiles (19, 21, 23, 26).

- **pom.xml** (root): Changed `version.oracle.driver` property from `21.15.0.0` to `23.26.2.0.0` and `version.oracle.instantclient` from `21.15.0.0` to `23.26.1.0.0`. This affects all managed dependencies in the BOM (`ojdbc11`, `orai18n`, `xdb`, `xmlparserv2`, `xstreams`).

- **debezium-connector-oracle/pom.xml**: Removed the `oracle-23` and `oracle-26` Maven profiles, which only contained driver/instantclient version overrides (`23.3.0.23.09` / `23.3.0.0`) that are now redundant. Removed the driver/instantclient overrides from the `oracle-free` profile while keeping its container image properties (`oracle.image.name`, `oracle.image.version`) and build configuration intact.

- **documentation/antora.yml**: Updated the `ojdbc-version` attribute from `21.15.0.0` to `23.26.2.0.0`. This attribute is used in documentation download links for the Oracle JDBC driver.

- **debezium-connector-oracle/README.md**: Updated the `xstreams.jar` manual install example to use version `23.26.1.0.0` (matching the new instant client version).

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

## Follow-up tasks
- [x] Update Jenkins
- [x]  Update Testing Farm (In Progress)
