### PR TITLE
debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if not first row in batch

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
@@ -27,12 +27,7 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-
-        if (POSITIVE_INFINITY.equals(value) || NEGATIVE_INFINITY.equals(value)) {
-            return "cast(? as timestamptz)";
-        }
-
-        return super.getQueryBinding(column, schema, value);
+        return "cast(? as timestamptz)";
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -309,6 +309,52 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
 
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-1658")
+    public void testInsertModeInsertBatchWithNormalAndInfinityTimestamps(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.INSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema zonedTimestampSchema = SchemaBuilder.string()
+                .name("io.debezium.time.ZonedTimestamp")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord normalTimestampRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "2024-01-15T10:30:00Z" }), config);
+
+        final JdbcKafkaSinkRecord negativeInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 2,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "-infinity" }), config);
+
+        final JdbcKafkaSinkRecord positiveInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 3,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "infinity" }), config);
+
+        consume(List.of(normalTimestampRecord, negativeInfinityRecord, positiveInfinityRecord));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(normalTimestampRecord));
+        tableAssert.exists().hasNumberOfRows(3).hasNumberOfColumns(2);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2, (byte) 3);
+    }
+
     private static Schema buildGeoTypeSchema(String type) {
 
         SchemaBuilder schemaBuilder = SchemaBuilder.struct()

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.integration.postgres;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -311,7 +312,7 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-1658")
+    @FixFor("dbz#1658")
     public void testInsertModeInsertBatchWithNormalAndInfinityTimestamps(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {
 
         final Map<String, String> properties = getDefaultSinkConfig();
@@ -353,6 +354,62 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
         tableAssert.exists().hasNumberOfRows(3).hasNumberOfColumns(2);
 
         getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2, (byte) 3);
+        tableAssert.column("timestamptz_col").isOfClass(Timestamp.class, false)
+                .hasValues(
+                        Timestamp.from(Instant.parse("2024-01-15T10:30:00Z")),
+                        new Timestamp(PGStatement.DATE_NEGATIVE_INFINITY),
+                        new Timestamp(PGStatement.DATE_POSITIVE_INFINITY));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("dbz#1658")
+    public void testInsertModeInsertBatchWithInfinityAndNormalTimestamps(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.INSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema zonedTimestampSchema = SchemaBuilder.string()
+                .name("io.debezium.time.ZonedTimestamp")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord negativeInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "-infinity" }), config);
+
+        final JdbcKafkaSinkRecord positiveInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 2,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "infinity" }), config);
+
+        final JdbcKafkaSinkRecord normalTimestampRecord = factory.createRecordWithSchemaValue(topicName, (byte) 3,
+                List.of("timestamptz_col"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "2024-01-15T10:30:00Z" }), config);
+
+        consume(List.of(negativeInfinityRecord, positiveInfinityRecord, normalTimestampRecord));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(negativeInfinityRecord));
+        tableAssert.exists().hasNumberOfRows(3).hasNumberOfColumns(2);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2, (byte) 3);
+        tableAssert.column("timestamptz_col").isOfClass(Timestamp.class, false)
+                .hasValues(
+                        new Timestamp(PGStatement.DATE_NEGATIVE_INFINITY),
+                        new Timestamp(PGStatement.DATE_POSITIVE_INFINITY),
+                        Timestamp.from(Instant.parse("2024-01-15T10:30:00Z")));
     }
 
     private static Schema buildGeoTypeSchema(String type) {


### PR DESCRIPTION
Fixes debezium/dbz#1658

## Description

Makes `ZonedTimestampType.getQueryBinding()` return `cast(? as timestamptz)` unconditionally, instead of only for infinity values, so the SQL binding is consistent across all records in a batch.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`