### PR TITLE
debezium/dbz#1944 Avoid NPE in ApproximateStructSizeCalculator for null source partition or offset

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/util/ApproximateStructSizeCalculator.java
+++ b/debezium-connector-common/src/main/java/io/debezium/util/ApproximateStructSizeCalculator.java
@@ -29,6 +29,9 @@ public class ApproximateStructSizeCalculator {
         // assuming 100 bytes per entry of partition / offset / header
         final Map<String, ?> sourcePartition = changeEvent.sourcePartition();
         final Map<String, ?> sourceOffset = changeEvent.sourceOffset();
+        // The Spanner connector's RemoveFinishedPartitionOperation emits finished-partition
+        // heartbeat records with a null source offset, violating Kafka's SourceRecord
+        // contract (non-null maps, possibly empty). Guard against NPE here.
         long value = (sourcePartition == null ? 0 : sourcePartition.size()) * 100L
                 + (sourceOffset == null ? 0 : sourceOffset.size()) * 100L
                 + changeEvent.headers().size() * 100L;

--- a/debezium-connector-common/src/main/java/io/debezium/util/ApproximateStructSizeCalculator.java
+++ b/debezium-connector-common/src/main/java/io/debezium/util/ApproximateStructSizeCalculator.java
@@ -27,7 +27,11 @@ public class ApproximateStructSizeCalculator {
 
     public static long getApproximateRecordSize(SourceRecord changeEvent) {
         // assuming 100 bytes per entry of partition / offset / header
-        long value = changeEvent.sourcePartition().size() * 100L + changeEvent.sourceOffset().size() * 100L + changeEvent.headers().size() * 100L;
+        final Map<String, ?> sourcePartition = changeEvent.sourcePartition();
+        final Map<String, ?> sourceOffset = changeEvent.sourceOffset();
+        long value = (sourcePartition == null ? 0 : sourcePartition.size()) * 100L
+                + (sourceOffset == null ? 0 : sourceOffset.size()) * 100L
+                + changeEvent.headers().size() * 100L;
         value += 8; // timestamp
 
         // key and value, ignoring schemas, assuming they are constant, shared on the heap

--- a/debezium-connector-common/src/test/java/io/debezium/util/ApproximateStructSizeCalculatorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/ApproximateStructSizeCalculatorTest.java
@@ -39,4 +39,32 @@ public class ApproximateStructSizeCalculatorTest {
         actual = ApproximateStructSizeCalculator.getApproximateRecordSize(sourceRecord);
         assertEquals(actual, 115);
     }
+
+    @Test
+    public void testGetApproximateRecordSizeWithNullSourcePartitionAndOffset() {
+        Schema valueSchema = SchemaBuilder.struct().build();
+
+        // baseline with empty source partition and offset
+        SourceRecord baseline = new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), "dummy",
+                valueSchema, new Struct(valueSchema));
+        long expected = ApproximateStructSizeCalculator.getApproximateRecordSize(baseline);
+
+        // test null source partition
+        SourceRecord withNullPartition = new SourceRecord(null, Collections.emptyMap(), "dummy",
+                valueSchema, new Struct(valueSchema));
+        long actual = ApproximateStructSizeCalculator.getApproximateRecordSize(withNullPartition);
+        assertEquals(actual, expected);
+
+        // test null source offset
+        SourceRecord withNullOffset = new SourceRecord(Collections.emptyMap(), null, "dummy",
+                valueSchema, new Struct(valueSchema));
+        actual = ApproximateStructSizeCalculator.getApproximateRecordSize(withNullOffset);
+        assertEquals(actual, expected);
+
+        // test both null
+        SourceRecord withNulls = new SourceRecord(null, null, "dummy",
+                valueSchema, new Struct(valueSchema));
+        actual = ApproximateStructSizeCalculator.getApproximateRecordSize(withNulls);
+        assertEquals(actual, expected);
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1944

## Description
<!-- Briefly describe your changes here. -->

`SourceRecord#sourcePartition()` and `SourceRecord#sourceOffset()` may legitimately return `null`. For example, the Spanner connector's `RemoveFinishedPartitionOperation` enqueues finished-partition heartbeat records with a `null` source offset.

When `max.queue.size.in.bytes > 0`, `ChangeEventQueue` calls `ApproximateStructSizeCalculator.getApproximateRecordSize(record)`, which previously dereferenced both `sourcePartition()` and `sourceOffset()` unconditionally and threw `NullPointerException`. The exception propagated out of the producer thread, causing the connector task to restart repeatedly. Reproduced on 2.6.1 and 3.5.0.Final.

This change treats a `null` source partition or offset as size `0` to match the semantics of an empty map. Only the two affected map lookups are guarded; all other behavior is unchanged.

Added `testGetApproximateRecordSizeWithNullSourcePartitionAndOffset` in `ApproximateStructSizeCalculatorTest`, covering null partition, null offset, and both null. Each case asserts the computed size matches the empty-map baseline.

### AI tool usage disclosure
I diagnosed the NPE and authored the fix and tests myself. I used Claude Code assistively to navigate the codebase and review the patch. All changes were reviewed, built, and tested locally before submission. I take full responsibility for the contents of this PR.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`