### PR TITLE
debezium/dbz#1933 Inherit connector MDC context

### DIFF
--- a/debezium-connector-common/pom.xml
+++ b/debezium-connector-common/pom.xml
@@ -114,6 +114,11 @@
             <artifactId>groovy-json</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.opentelemetry.javaagent</groupId>
             <artifactId>opentelemetry-testing-common</artifactId>

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -239,7 +239,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
         stateLock.lock();
 
-        try {
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
             setTaskState(DebeziumTaskState.INITIAL);
             config = Configuration.from(props);
 
@@ -347,7 +347,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     @Override
     public final List<SourceRecord> poll() throws InterruptedException {
 
-        try {
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
             // in we fail to start, return empty list and try to start next poll() method call
             if (!startIfNeededAndPossible()) {
                 return Collections.emptyList();
@@ -490,7 +490,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
     @Override
     public final void stop() {
-        try {
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
             performCommit();
         }
         catch (Exception e) {
@@ -567,7 +567,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         boolean locked = stateLock.tryLock();
 
         if (locked) {
-            try {
+            try (var rootLoggingContext = LoggingContext.initRootContext()) {
                 if (coordinator != null) {
                     Iterator<Map<String, ?>> iterator = lastOffsets.keySet().iterator();
                     while (iterator.hasNext()) {

--- a/debezium-connector-common/src/main/java/io/debezium/util/LoggingContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/util/LoggingContext.java
@@ -5,12 +5,19 @@
  */
 package io.debezium.util;
 
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.MDC;
 
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.pipeline.spi.Partition;
 
 /**
@@ -20,7 +27,7 @@ import io.debezium.pipeline.spi.Partition;
  * @author Randall Hauch
  * @since 0.2
  */
-public class LoggingContext {
+public final class LoggingContext {
 
     /**
      * The key for the connector type MDC property.
@@ -50,18 +57,43 @@ public class LoggingContext {
      * A snapshot of an MDC context that can be {@link #restore()}.
      */
     public static final class PreviousContext {
-        private static final Map<String, String> EMPTY_CONTEXT = Collections.emptyMap();
+        private static final PreviousContext EMPTY_CONTEXT = new PreviousContext(Collections.emptyMap(), Collections.emptySet());
         private final Map<String, String> context;
+        private final Set<String> rootContextKeys;
 
-        protected PreviousContext() {
-            Map<String, String> context = MDC.getCopyOfContextMap();
-            this.context = context != null ? context : EMPTY_CONTEXT;
+        private PreviousContext(final Map<String, String> context, final Set<String> rootContextKeys) {
+            this.context = context;
+            this.rootContextKeys = rootContextKeys;
+        }
+
+        /**
+         * Loads snapshot of previous MDC context including copy of root context keys that needs to be removed on {@link PreviousContext#restore()}.
+         *
+         * @return {@link PreviousContext}
+         */
+        protected static PreviousContext load() {
+            final var rootContext = RootLoggingContext.value();
+            final var currentContext = MDC.getCopyOfContextMap();
+            if (isNullOrEmpty(rootContext) && isNullOrEmpty(currentContext)) {
+                return EMPTY_CONTEXT;
+            }
+            if (isNullOrEmpty(rootContext)) {
+                return new PreviousContext(unmodifiableMap(currentContext), Collections.emptySet());
+            }
+            if (isNullOrEmpty(currentContext)) {
+                return new PreviousContext(Collections.emptyMap(), rootContext.keySet());
+            }
+            final var rootContextKeys = rootContext.keySet().stream()
+                    .filter(key -> !currentContext.containsKey(key))
+                    .collect(toUnmodifiableSet());
+            return new PreviousContext(unmodifiableMap(currentContext), rootContextKeys);
         }
 
         /**
          * Restore this logging context.
          */
         public void restore() {
+            rootContextKeys.forEach(MDC::remove);
             MDC.setContextMap(context);
         }
     }
@@ -95,7 +127,8 @@ public class LoggingContext {
         Objects.requireNonNull(connectorName, "The MDC value for the connector name may not be null");
         Objects.requireNonNull(contextName, "The MDC value for the connector context may not be null");
 
-        PreviousContext previous = new PreviousContext();
+        PreviousContext previous = PreviousContext.load();
+        Optional.ofNullable(RootLoggingContext.value()).ifPresent(MDC::setContextMap);
         if (taskId != null) {
             MDC.put(TASK_ID, taskId);
         }
@@ -128,7 +161,7 @@ public class LoggingContext {
         Objects.requireNonNull(contextName, "The MDC value for the connector context may not be null");
         Objects.requireNonNull(operation, "The operation may not be null");
 
-        PreviousContext previous = new PreviousContext();
+        PreviousContext previous = PreviousContext.load();
         try {
             forConnector(connectorType, connectorName, contextName);
             operation.run();
@@ -138,4 +171,79 @@ public class LoggingContext {
         }
     }
 
+    /**
+     * Initialise root MDC context with current MDC tags.
+     */
+    public static RootLoggingContext initRootContext() {
+        return RootLoggingContext.init();
+    }
+
+    private static <K, V> boolean isNullOrEmpty(final Map<K, V> map) {
+        return map == null || map.isEmpty();
+    }
+
+    public static final class RootLoggingContext implements AutoCloseable {
+        /**
+         * Holder of root logging context.
+         */
+        private static final InheritableThreadLocal<Map<String, String>> CONTEXT_HOLDER = new InheritableThreadLocal<>();
+
+        private static final RootLoggingContext EMPTY = new RootLoggingContext(Collections.emptySet());
+
+        /**
+         * Set of keys added to root context in this instance.
+         */
+        private final Set<String> contextKeys;
+
+        private RootLoggingContext(final Set<String> contextKeys) {
+            this.contextKeys = contextKeys;
+        }
+
+        /**
+         * Initialise root logging context.
+         *
+         * @return {@link RootLoggingContext}
+         */
+        private static RootLoggingContext init() {
+            final var context = MDC.getCopyOfContextMap();
+            if (isNullOrEmpty(context)) {
+                return EMPTY;
+            }
+            final var currentRootContext = value();
+            if (currentRootContext == null) {
+                CONTEXT_HOLDER.set(context);
+                return new RootLoggingContext(context.keySet());
+            }
+            final var patchedRootContext = new HashMap<>(currentRootContext);
+            patchedRootContext.putAll(context);
+            CONTEXT_HOLDER.set(patchedRootContext);
+            return new RootLoggingContext(context.keySet().stream().filter(it -> !currentRootContext.containsKey(it)).collect(toUnmodifiableSet()));
+        }
+
+        private static Map<String, String> value() {
+            return CONTEXT_HOLDER.get();
+        }
+
+        @VisibleForTesting
+        public static Map<String, String> valueCopy() {
+            return Optional.ofNullable(value()).map(Map::copyOf).orElse(Collections.emptyMap());
+        }
+
+        @Override
+        public void close() {
+            if (contextKeys.isEmpty()) {
+                return;
+            }
+            final var currentRootContext = value();
+            if (currentRootContext != null) {
+                final var newContext = new HashMap<>(currentRootContext);
+                contextKeys.forEach(newContext::remove);
+                if (newContext.isEmpty()) {
+                    CONTEXT_HOLDER.remove();
+                    return;
+                }
+                CONTEXT_HOLDER.set(newContext);
+            }
+        }
+    }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,6 +27,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,18 +39,20 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.LoggingContext.RootLoggingContext;
 
-public class BaseSourceTaskTest {
+class BaseSourceTaskTest {
 
     private final MyBaseSourceTask baseSourceTask = new MyBaseSourceTask();
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         baseSourceTask.initialize(mock(SourceTaskContext.class));
     }
 
     @Test
-    public void verifyTaskStartsAndStops() throws InterruptedException {
+    void verifyTaskStartsAndStops() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
         assertEquals(DebeziumTaskState.RUNNING, baseSourceTask.getTaskState());
@@ -63,7 +67,7 @@ public class BaseSourceTaskTest {
     }
 
     @Test
-    public void verifyStartAndStopWithoutPolling() {
+    void verifyStartAndStopWithoutPolling() {
         baseSourceTask.initialize(mock(SourceTaskContext.class));
         baseSourceTask.start(new HashMap<>());
         assertEquals(DebeziumTaskState.RUNNING, baseSourceTask.getTaskState());
@@ -75,7 +79,7 @@ public class BaseSourceTaskTest {
     }
 
     @Test
-    public void verifyContainsChangeDataMessages() {
+    void verifyContainsChangeDataMessages() {
         assertFalse(baseSourceTask.containsChangeDataMessages(null));
         assertFalse(baseSourceTask.containsChangeDataMessages(List.of()));
 
@@ -90,7 +94,7 @@ public class BaseSourceTaskTest {
     }
 
     @Test
-    public void verifyTaskCanBeStartedAfterStopped() throws InterruptedException {
+    void verifyTaskCanBeStartedAfterStopped() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
         assertEquals(DebeziumTaskState.RUNNING, baseSourceTask.getTaskState());
@@ -107,7 +111,7 @@ public class BaseSourceTaskTest {
     }
 
     @Test
-    public void verifyTaskRestartsSuccessfully() throws InterruptedException {
+    void verifyTaskRestartsSuccessfully() throws InterruptedException {
         MyBaseSourceTask baseSourceTask = new MyBaseSourceTask() {
             @Override
             protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
@@ -144,7 +148,7 @@ public class BaseSourceTaskTest {
     }
 
     @Test
-    public void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
+    void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
         baseSourceTask.start(new HashMap<>());
         assertEquals(DebeziumTaskState.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
@@ -154,6 +158,28 @@ public class BaseSourceTaskTest {
 
         assertEquals(1, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());
+    }
+
+    @Test
+    void verifyRootLoggingMdcContext() throws InterruptedException {
+        org.apache.kafka.connect.util.LoggingContext.clear();
+        final var connectorTaskId = new ConnectorTaskId("foo-connector", 0);
+        final var taskConfig = Map.of(CommonConnectorConfig.TOPIC_PREFIX.name(), "foo");
+        final var expectedStartRootLogging = Map.of(
+                org.apache.kafka.connect.util.LoggingContext.CONNECTOR_CONTEXT, "[foo-connector|task-0] ");
+        final var expectedRootLogging = Map.of(
+                org.apache.kafka.connect.util.LoggingContext.CONNECTOR_CONTEXT, "[foo-connector|task-0] ",
+                LoggingContext.CONNECTOR_NAME, "foo",
+                LoggingContext.CONNECTOR_CONTEXT, "lifecycle",
+                LoggingContext.CONNECTOR_TYPE, "");
+        try (var kafkaLoggingContext = org.apache.kafka.connect.util.LoggingContext.forTask(connectorTaskId)) {
+            baseSourceTask.start(taskConfig);
+            baseSourceTask.poll();
+            baseSourceTask.stop();
+
+            assertThat(baseSourceTask.startRootLoggingContext).isEqualTo(expectedStartRootLogging);
+            assertThat(baseSourceTask.pollRootLoggingContext).isEqualTo(expectedRootLogging);
+        }
     }
 
     private static void pollAndIgnoreRetryException(BaseSourceTask<Partition, OffsetContext> baseSourceTask) throws InterruptedException {
@@ -175,10 +201,12 @@ public class BaseSourceTaskTest {
         }
     }
 
-    public static class MyBaseSourceTask extends BaseSourceTask<Partition, OffsetContext> {
+    static class MyBaseSourceTask extends BaseSourceTask<Partition, OffsetContext> {
         final List<SourceRecord> records = new ArrayList<>();
         final AtomicInteger startCount = new AtomicInteger();
         final AtomicInteger stopCount = new AtomicInteger();
+        final Map<String, String> startRootLoggingContext = new HashMap<>();
+        final Map<String, String> pollRootLoggingContext = new HashMap<>();
 
         @SuppressWarnings("unchecked")
         final ChangeEventSourceCoordinator<Partition, OffsetContext> coordinator = mock(ChangeEventSourceCoordinator.class);
@@ -191,6 +219,7 @@ public class BaseSourceTaskTest {
         @Override
         protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
             startCount.incrementAndGet();
+            startRootLoggingContext.putAll(RootLoggingContext.valueCopy());
             return coordinator;
         }
 
@@ -201,6 +230,7 @@ public class BaseSourceTaskTest {
 
         @Override
         protected List<SourceRecord> doPoll() {
+            pollRootLoggingContext.putAll(RootLoggingContext.valueCopy());
             return records;
         }
 

--- a/debezium-connector-common/src/test/java/io/debezium/util/LoggingContextTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/LoggingContextTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.util.LoggingContext.RootLoggingContext;
+
+class LoggingContextTest {
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+        MDC.clear();
+    }
+
+    @Test
+    void shouldCreateLoggingContextForConnector() {
+        // given
+        final var connectorType = "type";
+        final var connectorName = "connector";
+        final var contextName = "test";
+
+        // when
+        final var previousContext = LoggingContext.forConnector(connectorType, connectorName, contextName);
+        final var context = MDC.getCopyOfContextMap();
+        previousContext.restore();
+
+        // then
+        assertThat(context).isEqualTo(Map.of(
+                LoggingContext.CONNECTOR_TYPE, connectorType,
+                LoggingContext.CONNECTOR_NAME, connectorName,
+                LoggingContext.CONNECTOR_CONTEXT, contextName));
+        assertThat(MDC.getCopyOfContextMap()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateLoggingContextForConnectorIncludingRootContext() {
+        // given
+        final var rootContextTag = "connector.context";
+        final var rootContextValue = "[foo-connector|0]";
+        MDC.put(rootContextTag, rootContextValue);
+
+        final var connectorType = "sink";
+        final var connectorName = "foo";
+        final var taskId = "5";
+        final var contextName = "root";
+        final var partition = mock(Partition.class);
+        doReturn(Map.of("foo", "bar", "bazz", "wazz")).when(partition).getLoggingContext();
+
+        // when
+        final var previousContext = LoggingContext.forConnector(connectorType, connectorName, taskId, contextName, partition);
+        final var context = MDC.getCopyOfContextMap();
+        previousContext.restore();
+
+        // then
+        assertThat(context).isEqualTo(Map.of(
+                rootContextTag, rootContextValue,
+                LoggingContext.CONNECTOR_TYPE, connectorType,
+                LoggingContext.CONNECTOR_NAME, connectorName,
+                LoggingContext.TASK_ID, taskId,
+                LoggingContext.CONNECTOR_CONTEXT, contextName,
+                "foo", "bar",
+                "bazz", "wazz"));
+        assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of(rootContextTag, rootContextValue));
+    }
+
+    @Test
+    void shouldCreateLoggingContextForOperation() {
+        // given
+        final var rootContextTag = "root";
+        final var rootContextValue = "rootValue";
+        MDC.put(rootContextTag, rootContextValue);
+
+        final var connectorType = "source";
+        final var connectorName = "temp-connector";
+        final var contextName = "temporary";
+        final var assertions = new SoftAssertions();
+
+        // when
+        LoggingContext.temporarilyForConnector(connectorType, connectorName, contextName, () -> {
+            // then
+            assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of(
+                    rootContextTag, rootContextValue,
+                    LoggingContext.CONNECTOR_TYPE, connectorType,
+                    LoggingContext.CONNECTOR_NAME, connectorName,
+                    LoggingContext.CONNECTOR_CONTEXT, contextName));
+        });
+        assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of(rootContextTag, rootContextValue));
+        assertions.assertAll();
+    }
+
+    @Test
+    void shouldInheritRootMdcContextInNewThread() {
+        // given
+        final var rootContextTag = "connector.context";
+        final var rootContextValue = "[foo-connector|0]";
+        MDC.put(rootContextTag, rootContextValue);
+        final var assertions = new SoftAssertions();
+
+        // when
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
+            final var future = CompletableFuture.runAsync(() -> {
+                final var previousContext = LoggingContext.forConnector("foo", "bar", "bazz");
+                final var context = MDC.getCopyOfContextMap();
+                previousContext.restore();
+
+                // then
+                assertions.assertThat(context).isEqualTo(Map.of(
+                        rootContextTag, rootContextValue,
+                        LoggingContext.CONNECTOR_TYPE, "foo",
+                        LoggingContext.CONNECTOR_NAME, "bar",
+                        LoggingContext.CONNECTOR_CONTEXT, "bazz"));
+                assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Collections.emptyMap());
+            }, executorService);
+            assertThat(future).succeedsWithin(1L, SECONDS);
+            assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of(rootContextTag, rootContextValue));
+            assertions.assertAll();
+        }
+    }
+
+    @Test
+    void shouldRestorePreviousMdcContextExcludingRoot() {
+        // given
+        final var rootContextTag = "connector.context";
+        final var rootContextValue = "[foo-connector|0]";
+        MDC.put(rootContextTag, rootContextValue);
+        final var assertions = new SoftAssertions();
+
+        // when
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
+            final var future = CompletableFuture.runAsync(() -> {
+                MDC.put("old", "bag");
+                final var previousContext = LoggingContext.forConnector("foo", "bar", "bazz");
+                final var context = MDC.getCopyOfContextMap();
+                previousContext.restore();
+
+                // then
+                assertions.assertThat(context).isEqualTo(Map.of(
+                        rootContextTag, rootContextValue,
+                        LoggingContext.CONNECTOR_TYPE, "foo",
+                        LoggingContext.CONNECTOR_NAME, "bar",
+                        LoggingContext.CONNECTOR_CONTEXT, "bazz"));
+                assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of("old", "bag"));
+            }, executorService);
+            assertThat(future).succeedsWithin(1L, SECONDS);
+            assertions.assertThat(MDC.getCopyOfContextMap()).isEqualTo(Map.of(rootContextTag, rootContextValue));
+            assertions.assertAll();
+        }
+    }
+
+    @Test
+    void shouldInitRootContext() {
+        // given
+        MDC.setContextMap(Map.of("foo", "bar", "bazz", "wazz"));
+
+        // when
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
+
+            // then
+            assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("foo", "bar", "bazz", "wazz"));
+        }
+        assertThat(RootLoggingContext.valueCopy()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateNestedRootContext() {
+        // given
+        MDC.put("A", "1");
+        try (var ctx1 = LoggingContext.initRootContext()) {
+            MDC.put("B", "2");
+            assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("A", "1"));
+            try (var ctx2 = LoggingContext.initRootContext()) {
+                MDC.put("C", "3");
+                assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("A", "1", "B", "2"));
+                try (var ctx3 = LoggingContext.initRootContext()) {
+                    assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("A", "1", "B", "2", "C", "3"));
+                }
+                assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("A", "1", "B", "2"));
+            }
+            assertThat(RootLoggingContext.valueCopy()).isEqualTo(Map.of("A", "1"));
+        }
+        assertThat(RootLoggingContext.valueCopy()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateLoggingContextForConnectorWithEmptyRootAndPreviousContext() {
+        // given
+        final var connectorType = "type";
+        final var connectorName = "connector";
+        final var contextName = "test";
+        MDC.setContextMap(Collections.emptyMap());
+
+        // when
+        try (var rootLoggingContext = LoggingContext.initRootContext()) {
+            MDC.clear();
+            final var previousContext = LoggingContext.forConnector(connectorType, connectorName, contextName);
+            final var context = MDC.getCopyOfContextMap();
+            previousContext.restore();
+
+            // then
+            assertThat(context).isEqualTo(Map.of(
+                    LoggingContext.CONNECTOR_TYPE, connectorType,
+                    LoggingContext.CONNECTOR_NAME, connectorName,
+                    LoggingContext.CONNECTOR_CONTEXT, contextName));
+        }
+        assertThat(MDC.getCopyOfContextMap()).isEmpty();
+    }
+
+    @AfterEach
+    void cleanup() {
+        executorService.shutdown();
+        MDC.clear();
+    }
+}

--- a/debezium-connector-postgres/src/test/resources/logback-test.xml
+++ b/debezium-connector-postgres/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
     <appender name="CONSOLE"
         class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.taskId}|%X{dbz.connectorContext}|%X{dbz.databaseName}  %m   [%c]%n</pattern>
+            <pattern>%d{ISO8601} %-5p  %X{connector.context}|%X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.taskId}|%X{dbz.connectorContext}|%X{dbz.databaseName}  %m   [%c]%n</pattern>
         </encoder>
     </appender>
 

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -55,6 +55,8 @@ import org.apache.kafka.connect.storage.OffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.LoggingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,15 +417,18 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(this.classLoader);
         try {
+            int taskId = 0;
             for (Map<String, String> taskConfig : taskConfigs) {
                 final SourceTask task = (SourceTask) taskClass.getDeclaredConstructor().newInstance();
+                final ConnectorTaskId connectorTaskId = new ConnectorTaskId(config.getString(ConnectorConfig.NAME_CONFIG), ++taskId);
                 final EngineSourceTaskContext taskContext = new EngineSourceTaskContext(
                         taskConfig,
                         connector.context().offsetStorageReader(),
                         connector.context().offsetStorageWriter(),
                         offsetCommitPolicy,
                         clock,
-                        transformations);
+                        transformations,
+                        connectorTaskId);
                 task.initialize(taskContext); // Initialize Kafka Connect source task
                 tasks.add(new EngineSourceTask(task, taskContext)); // Create new DebeziumSourceTask
             }
@@ -447,7 +452,8 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         for (EngineSourceTask task : tasks) {
             taskCompletionService.submit(() -> {
-                try {
+                LoggingContext.clear();
+                try (LoggingContext loggingContext = LoggingContext.forTask(task.context().connectorTaskId())) {
                     Thread.currentThread().setContextClassLoader(this.classLoader);
                     task.connectTask().start(task.context().config());
                 }
@@ -1249,7 +1255,11 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         public Void doCall() throws Exception {
             while (engineState.get() == State.POLLING_TASKS) {
                 LOGGER.trace("Thread {} running task {} starts polling for records.", Thread.currentThread().getName(), task.connectTask());
-                final List<SourceRecord> changeRecords = task.connectTask().poll(); // blocks until there are values ...
+                LoggingContext.clear();
+                final List<SourceRecord> changeRecords;
+                try (LoggingContext loggingContext = LoggingContext.forTask(task.context().connectorTaskId())) {
+                    changeRecords = task.connectTask().poll(); // blocks until there are values ...
+                }
                 LOGGER.trace("Thread {} polled {} records.", Thread.currentThread().getName(), changeRecords == null ? "no" : changeRecords.size());
                 if (changeRecords != null && !changeRecords.isEmpty()) {
                     try {

--- a/debezium-embedded/src/main/java/io/debezium/engine/source/DebeziumSourceTaskContext.java
+++ b/debezium-embedded/src/main/java/io/debezium/engine/source/DebeziumSourceTaskContext.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 
 import io.debezium.common.annotation.Incubating;
 import io.debezium.embedded.Transformations;
@@ -51,4 +52,9 @@ public interface DebeziumSourceTaskContext {
      * Gets the transformations which the task should apply to source events before passing them to the consumer.
      */
     Transformations transformations();
+
+    /**
+     * Gets the {@link ConnectorTaskId} of this SourceTask.
+     */
+    ConnectorTaskId connectorTaskId();
 }

--- a/debezium-embedded/src/main/java/io/debezium/engine/source/EngineSourceTaskContext.java
+++ b/debezium-embedded/src/main/java/io/debezium/engine/source/EngineSourceTaskContext.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 
 import io.debezium.embedded.Transformations;
 import io.debezium.engine.spi.OffsetCommitPolicy;
@@ -30,6 +31,7 @@ public class EngineSourceTaskContext implements DebeziumSourceTaskContext, Sourc
     private final OffsetCommitPolicy offsetCommitPolicy;
     private final io.debezium.util.Clock clock;
     private final Transformations transformations;
+    private final ConnectorTaskId connectorTaskId;
 
     public EngineSourceTaskContext(
                                    final Map<String, String> config,
@@ -37,13 +39,15 @@ public class EngineSourceTaskContext implements DebeziumSourceTaskContext, Sourc
                                    final OffsetStorageWriter offsetWriter,
                                    final OffsetCommitPolicy offsetCommitPolicy,
                                    final io.debezium.util.Clock clock,
-                                   final Transformations transformations) {
+                                   final Transformations transformations,
+                                   final ConnectorTaskId connectorTaskId) {
         this.config = config;
         this.offsetReader = offsetReader;
         this.offsetWriter = offsetWriter;
         this.offsetCommitPolicy = offsetCommitPolicy;
         this.clock = clock;
         this.transformations = transformations;
+        this.connectorTaskId = connectorTaskId;
     }
 
     @Override
@@ -86,5 +90,10 @@ public class EngineSourceTaskContext implements DebeziumSourceTaskContext, Sourc
     public PluginMetrics pluginMetrics() {
         // we don't support metrics yet
         return null;
+    }
+
+    @Override
+    public ConnectorTaskId connectorTaskId() {
+        return connectorTaskId;
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#1933

## Description

Store root MDC context initialized by Kafka `SourceWorker` in `BaseSourceTask` in order to inherit it in new threads started by Debezium.

## PR Checklist
- [x ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ x] One feature/change per PR unless tightly coupled
- [ x] Do a rebase on upstream `main`
