### PR TITLE
debezium/dbz#1948 Increase Oracle TMT provision to >= 64GB

### DIFF
--- a/debezium-testing/tmt/plans/oracle.fmf
+++ b/debezium-testing/tmt/plans/oracle.fmf
@@ -10,7 +10,7 @@ discover:
 # Required HW
 provision:
   hardware:
-    memory: ">= 32 GiB"
+    memory: ">= 64 GiB"
     cpu:
       processors: ">= 16"
 
@@ -36,7 +36,7 @@ execute:
   summary: Run oracle connector functional tests
   provision:
     hardware:
-      memory: ">= 32 GiB"
+      memory: ">= 64 GiB"
       cpu:
         processors: ">= 16"
   discover+:

--- a/debezium-testing/tmt/plans/oracle.fmf
+++ b/debezium-testing/tmt/plans/oracle.fmf
@@ -13,6 +13,8 @@ provision:
     memory: ">= 64 GiB"
     cpu:
       processors: ">= 16"
+    disk:
+      - size: ">= 250 GiB"
 
 # Install required packages and scripts for running debezium suite
 prepare:
@@ -39,6 +41,8 @@ execute:
       memory: ">= 64 GiB"
       cpu:
         processors: ">= 16"
+      disk:
+        - size: ">= 250 GiB"
   discover+:
     test:
       - oracle


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1948

## Description
Increase the hardware provision on TMT for Oracle from `>= 32GB` to `>= 64GB`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
