### PR TITLE
debezium/dbz#1950 Fix incorrect pg_stat_replication.reply_time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.apicurio>2.6.13.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.7.7</version.postgresql.driver>
+        <version.postgresql.driver>42.7.9</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.40.7</version.mysql.binlog>
         <version.mongo.driver>5.6.2</version.mongo.driver>


### PR DESCRIPTION

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1950.

As noted in the issue, this problem appears to be caused by a bug in the PostgreSQL JDBC driver, which I have already fixed on the driver side in [pgjdbc/pgjdbc@0272f7c.](https://github.com/pgjdbc/pgjdbc/commit/0272f7c1a464c1bc622f21eb3f0efed3d8222dc5)

This fix was included in PostgreSQL JDBC driver version [42.7.9](https://jdbc.postgresql.org/changelogs/2026-01-15-42/), so the dependency has been updated to use this version.

What do you think?

## Description
<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
