### PR TITLE
debezium/dbz#1164 Add unavailable value placeholder for SQL Server

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -43,6 +43,7 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
     private static final int COL_COMMIT_LSN = 1;
     private static final int COL_ROW_LSN = 2;
     private static final int COL_OPERATION = 3;
+    private static final int COL_UPDATE_MASK = 4;
     private static final int COL_DATA = 5;
 
     private ResultSetMapper<Object[]> resultSetMapper;
@@ -120,6 +121,12 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
      * aforementioned order of values in array, raw database results have to be adjusted
      * accordingly.
      *
+     * <p>For UPDATE operations, max-type columns ({@code varchar(max)}, {@code nvarchar(max)},
+     * {@code varbinary(max)}) that were not modified are stored as NULL in the CDC capture table.
+     * This method uses the {@code __$update_mask} bitmask to detect such columns and replaces
+     * their NULL values with {@link SqlServerValueConverters#UNAVAILABLE_VALUE} so that they
+     * are emitted using the configured {@code unavailable.value.placeholder}.
+     *
      * @param table original table
      * @return a mapper which adjusts order of values in case the capture instance contains only
      * a subset of columns
@@ -129,14 +136,34 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
         final ResultSetMetaData rsmd = getResultSet().getMetaData();
         final int columnCount = rsmd.getColumnCount() - columnDataOffset;
         final List<String> resultColumns = new ArrayList<>(columnCount);
+        final boolean[] maxColumns = new boolean[columnCount];
+        boolean hasAnyMaxColumn = false;
         for (int i = 0; i < columnCount; ++i) {
             resultColumns.add(rsmd.getColumnName(columnDataOffset + i));
+            final int jdbcType = rsmd.getColumnType(columnDataOffset + i);
+            maxColumns[i] = SqlServerDatabaseSchema.isMaxColumnJdbcType(jdbcType);
+            if (maxColumns[i]) {
+                hasAnyMaxColumn = true;
+            }
         }
         final int resultColumnCount = resultColumns.size();
+        final boolean checkUpdateMask = hasAnyMaxColumn;
 
         final IndicesMapping indicesMapping = new IndicesMapping(columnMap.getSourceTableColumns(), resultColumns);
         return resultSet -> {
             final Object[] data = new Object[columnMap.getGreatestColumnPosition()];
+
+            final byte[] updateMask;
+            final int operation;
+            if (checkUpdateMask) {
+                operation = resultSet.getInt(COL_OPERATION);
+                updateMask = resultSet.getBytes(COL_UPDATE_MASK);
+            }
+            else {
+                operation = 0;
+                updateMask = null;
+            }
+
             for (int i = 0; i < resultColumnCount; i++) {
                 int index = indicesMapping.getSourceTableColumnIndex(i);
                 if (index == INVALID_COLUMN_INDEX) {
@@ -144,9 +171,50 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
                     continue;
                 }
                 data[index] = getColumnData(resultSet, columnDataOffset + i);
+
+                if (maxColumns[i] && data[index] == null
+                        && isUpdateOperation(operation)
+                        && !isColumnChanged(updateMask, i)) {
+                    LOGGER.trace("Column at index {} for table '{}' was not changed in UPDATE, replacing with unavailable value placeholder",
+                            i, table.id());
+                    data[index] = SqlServerValueConverters.UNAVAILABLE_VALUE;
+                }
             }
             return data;
         };
+    }
+
+    /**
+     * Check whether the given operation is an UPDATE (before or after image).
+     *
+     * @param operation the CDC operation code
+     * @return {@code true} if the operation is an UPDATE
+     */
+    private static boolean isUpdateOperation(int operation) {
+        return operation == SqlServerChangeRecordEmitter.OP_UPDATE_BEFORE
+                || operation == SqlServerChangeRecordEmitter.OP_UPDATE_AFTER;
+    }
+
+    /**
+     * Check whether a column was changed based on the CDC {@code __$update_mask} bitmask.
+     *
+     * <p>The update mask is a {@code varbinary} value where each bit corresponds to a
+     * captured column in ordinal order. A bit value of 1 indicates the column was modified.
+     *
+     * @param updateMask the raw update mask bytes from the CDC result set
+     * @param columnIndex the 0-based index of the column in the captured column list
+     * @return {@code true} if the column was changed, or if the mask is unavailable
+     */
+    private static boolean isColumnChanged(byte[] updateMask, int columnIndex) {
+        if (updateMask == null) {
+            return true;
+        }
+        final int byteIndex = columnIndex / 8;
+        final int bitIndex = columnIndex % 8;
+        if (byteIndex >= updateMask.length) {
+            return true;
+        }
+        return (updateMask[byteIndex] & (1 << bitIndex)) != 0;
     }
 
     private class IndicesMapping {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -94,7 +94,8 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         final TopicNamingStrategy<TableId> topicNamingStrategy = connectorConfig.getTopicNamingStrategy(CommonConnectorConfig.TOPIC_NAMING_STRATEGY, true);
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
         final SqlServerValueConverters valueConverters = new SqlServerValueConverters(connectorConfig.getDecimalMode(),
-                connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode());
+                connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode(),
+                connectorConfig.getUnavailableValuePlaceholder());
 
         MainConnectionProvidingConnectionFactory<SqlServerConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
                 () -> new SqlServerConnection(connectorConfig,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -5,11 +5,14 @@
  */
 package io.debezium.connector.sqlserver;
 
+import java.sql.Types;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.relational.Column;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.HistorizedRelationalDatabaseSchema;
 import io.debezium.relational.Table;
@@ -74,6 +77,32 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
     @Override
     protected DdlParser getDdlParser() {
         return null;
+    }
+
+    /**
+     * Returns whether the provided column is a max-type column ({@code varchar(max)},
+     * {@code nvarchar(max)}, or {@code varbinary(max)}) whose NULL value in the CDC
+     * capture table should be replaced by the {@code unavailable.value.placeholder}
+     * when the column was not changed during an UPDATE.
+     *
+     * @param column the relational column model
+     * @return {@code true} if the column is a max-type column
+     */
+    public static boolean isMaxColumn(Column column) {
+        return isMaxColumnJdbcType(column.jdbcType());
+    }
+
+    /**
+     * Returns whether the provided JDBC type represents a max-type column
+     * ({@code varchar(max)}, {@code nvarchar(max)}, or {@code varbinary(max)}).
+     *
+     * @param jdbcType the JDBC type code
+     * @return {@code true} if the JDBC type is a max-type
+     */
+    public static boolean isMaxColumnJdbcType(int jdbcType) {
+        return jdbcType == Types.LONGVARCHAR
+                || jdbcType == Types.LONGNVARCHAR
+                || jdbcType == Types.LONGVARBINARY;
     }
 
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
@@ -31,8 +32,13 @@ import microsoft.sql.DateTimeOffset;
  */
 public class SqlServerValueConverters extends JdbcValueConverters {
 
-    public SqlServerValueConverters() {
-    }
+    /**
+     * Marker value indicating an unavailable column value.
+     */
+    public static final Object UNAVAILABLE_VALUE = new Object();
+
+    private final byte[] unavailableValuePlaceholderBinary;
+    private final String unavailableValuePlaceholderString;
 
     /**
      * Create a new instance that always uses UTC for the default time zone when
@@ -50,7 +56,46 @@ public class SqlServerValueConverters extends JdbcValueConverters {
      */
     public SqlServerValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
                                     CommonConnectorConfig.BinaryHandlingMode binaryMode) {
+        this(decimalMode, temporalPrecisionMode, binaryMode, null);
+    }
+
+    /**
+     * Create a new instance that always uses UTC for the default time zone when
+     * converting values without timezone information to values that require
+     * timezones.
+     *
+     * @param decimalMode
+     *            how {@code DECIMAL} and {@code NUMERIC} values should be
+     *            treated; may be null if
+     *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE}
+     *            is to be used
+     * @param temporalPrecisionMode
+     *            date/time value will be represented either as Connect datatypes or Debezium specific datatypes
+     * @param binaryMode
+     *            how binary columns should be represented
+     * @param unavailableValuePlaceholder
+     *            the placeholder value for unavailable column values; may be null
+     */
+    public SqlServerValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                                    CommonConnectorConfig.BinaryHandlingMode binaryMode,
+                                    byte[] unavailableValuePlaceholder) {
         super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, null, null, binaryMode);
+        if (unavailableValuePlaceholder != null) {
+            this.unavailableValuePlaceholderBinary = unavailableValuePlaceholder;
+            this.unavailableValuePlaceholderString = new String(unavailableValuePlaceholder);
+        }
+        else {
+            this.unavailableValuePlaceholderBinary = null;
+            this.unavailableValuePlaceholderString = null;
+        }
+    }
+
+    public byte[] getUnavailableValuePlaceholderBinary() {
+        return unavailableValuePlaceholderBinary;
+    }
+
+    public String getUnavailableValuePlaceholderString() {
+        return unavailableValuePlaceholderString;
     }
 
     @Override
@@ -99,6 +144,22 @@ public class SqlServerValueConverters extends JdbcValueConverters {
     @Override
     protected int getTimePrecision(Column column) {
         return column.scale().get();
+    }
+
+    @Override
+    protected Object convertString(Column column, Field fieldDefn, Object data) {
+        if (data == UNAVAILABLE_VALUE) {
+            return unavailableValuePlaceholderString;
+        }
+        return super.convertString(column, fieldDefn, data);
+    }
+
+    @Override
+    protected Object convertBinary(Column column, Field fieldDefn, Object data, BinaryHandlingMode mode) {
+        if (data == UNAVAILABLE_VALUE) {
+            data = unavailableValuePlaceholderBinary;
+        }
+        return super.convertBinary(column, fieldDefn, data, mode);
     }
 
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMaxColumnTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMaxColumnTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.Column;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+/**
+ * Tests for max-type column handling (varchar(max), nvarchar(max), varbinary(max))
+ * and the unavailable value placeholder mechanism.
+ */
+public class SqlServerMaxColumnTest {
+
+    private static final byte[] PLACEHOLDER = RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER
+            .getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldIdentifyMaxColumnJdbcTypes() {
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.LONGVARCHAR)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.LONGNVARCHAR)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.LONGVARBINARY)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.VARCHAR)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.NVARCHAR)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.VARBINARY)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumnJdbcType(Types.INTEGER)).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldIdentifyMaxColumnFromColumnModel() {
+        final var varcharMax = Column.editor()
+                .name("col_varchar_max")
+                .jdbcType(Types.LONGVARCHAR)
+                .create();
+        final var nvarcharMax = Column.editor()
+                .name("col_nvarchar_max")
+                .jdbcType(Types.LONGNVARCHAR)
+                .create();
+        final var varbinaryMax = Column.editor()
+                .name("col_varbinary_max")
+                .jdbcType(Types.LONGVARBINARY)
+                .create();
+        final var varchar100 = Column.editor()
+                .name("col_varchar")
+                .jdbcType(Types.VARCHAR)
+                .create();
+        final var intCol = Column.editor()
+                .name("col_int")
+                .jdbcType(Types.INTEGER)
+                .create();
+
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varcharMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(nvarcharMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varbinaryMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varchar100)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(intCol)).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldConvertUnavailableValueToPlaceholderString() {
+        final var converters = new SqlServerValueConverters(
+                JdbcValueConverters.DecimalMode.PRECISE,
+                TemporalPrecisionMode.ADAPTIVE,
+                CommonConnectorConfig.BinaryHandlingMode.BYTES,
+                PLACEHOLDER);
+
+        final var column = Column.editor()
+                .name("col_varchar_max")
+                .jdbcType(Types.LONGVARCHAR)
+                .optional(true)
+                .create();
+
+        final var fieldDefn = new org.apache.kafka.connect.data.Field(
+                "col_varchar_max", 0, SchemaBuilder.string().optional().build());
+
+        final var converter = converters.converter(column, fieldDefn);
+
+        // UNAVAILABLE_VALUE should be converted to placeholder string
+        final var result = converter.convert(SqlServerValueConverters.UNAVAILABLE_VALUE);
+        assertThat(result).isEqualTo(RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER);
+
+        // null should remain null for optional columns
+        final var nullResult = converter.convert(null);
+        assertThat(nullResult).isNull();
+
+        // Regular string values should pass through
+        final var regularResult = converter.convert("hello");
+        assertThat(regularResult).isEqualTo("hello");
+    }
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldConvertUnavailableValueToPlaceholderBinary() {
+        final var converters = new SqlServerValueConverters(
+                JdbcValueConverters.DecimalMode.PRECISE,
+                TemporalPrecisionMode.ADAPTIVE,
+                CommonConnectorConfig.BinaryHandlingMode.BYTES,
+                PLACEHOLDER);
+
+        final var column = Column.editor()
+                .name("col_varbinary_max")
+                .jdbcType(Types.LONGVARBINARY)
+                .optional(true)
+                .create();
+
+        final var fieldDefn = new org.apache.kafka.connect.data.Field(
+                "col_varbinary_max", 0, Schema.OPTIONAL_BYTES_SCHEMA);
+
+        final var converter = converters.converter(column, fieldDefn);
+
+        // UNAVAILABLE_VALUE should be converted to placeholder bytes
+        final var result = converter.convert(SqlServerValueConverters.UNAVAILABLE_VALUE);
+        assertThat(result).isNotNull();
+
+        // null should remain null for optional columns
+        final var nullResult = converter.convert(null);
+        assertThat(nullResult).isNull();
+    }
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldReturnPlaceholderValues() {
+        final var converters = new SqlServerValueConverters(
+                JdbcValueConverters.DecimalMode.PRECISE,
+                TemporalPrecisionMode.ADAPTIVE,
+                CommonConnectorConfig.BinaryHandlingMode.BYTES,
+                PLACEHOLDER);
+
+        assertThat(converters.getUnavailableValuePlaceholderString())
+                .isEqualTo(RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER);
+        assertThat(converters.getUnavailableValuePlaceholderBinary())
+                .isEqualTo(PLACEHOLDER);
+    }
+
+    @Test
+    @FixFor("dbz#1164")
+    void shouldReturnNullPlaceholderWhenNotConfigured() {
+        final var converters = new SqlServerValueConverters(
+                JdbcValueConverters.DecimalMode.PRECISE,
+                TemporalPrecisionMode.ADAPTIVE,
+                CommonConnectorConfig.BinaryHandlingMode.BYTES);
+
+        assertThat(converters.getUnavailableValuePlaceholderString()).isNull();
+        assertThat(converters.getUnavailableValuePlaceholderBinary()).isNull();
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1164

## Description
Adds `unavailable.value.placeholder` support for SQL Server's `varchar(max)`, `nvarchar(max)`, and `varbinary(max)` columns that are treated as unchanged during UPDATE operations, matching the existing behavior used by PostgreSQL TOAST and Oracle LOB column types.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
