### PR TITLE
DBZ-9755: Detect and fail on stale MySQL binlog connections

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -108,6 +108,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
     private static final String KEEPALIVE_THREAD_NAME = "blc-keepalive";
     private static final String SET_STATEMENT_REGEX = "SET STATEMENT .* FOR";
     private static final Pattern TRUNCATE_STATEMENT_PATTERN = Pattern.compile("(SET STATEMENT .*)?TRUNCATE TABLE .*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final int STALE_CONNECTION_CHECK_MULTIPLIER = 3;
 
     private final BinaryLogClient client;
     private final BinlogStreamingChangeEventSourceMetrics<?, P> metrics;
@@ -341,6 +342,45 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
             while (context.isRunning()) {
                 Thread.sleep(100);
                 waitWhenStreamingPaused(context);
+
+                // DBZ-9755: Detect stale/dead connections that don't cause the task to fail.
+                if (client.isKeepAlive()) {
+                    long keepAliveInterval = connectorConfig.getConfig().getLong(BinlogConnectorConfig.KEEP_ALIVE_INTERVAL_MS);
+                    long staleThreshold = keepAliveInterval * STALE_CONNECTION_CHECK_MULTIPLIER;
+
+                    // Case 1: Client reports disconnected but task is still running.
+                    // This happens when the keepalive thread detects a dead connection but
+                    // fails to reconnect, leaving the task in a zombie RUNNING state.
+                    if (!client.isConnected()) {
+                        long millisSinceLastEvent = metrics.getMilliSecondsSinceLastEvent();
+                        if (millisSinceLastEvent > staleThreshold && millisSinceLastEvent > 0) {
+                            LOGGER.warn("BinaryLogClient is disconnected and no events received for {} ms. "
+                                    + "Triggering task failure to force reconnection (DBZ-9755).",
+                                    millisSinceLastEvent);
+                            errorHandler.setProducerThrowable(new DebeziumException(
+                                    String.format("Binlog client disconnected: no events for %d ms. "
+                                            + "See https://github.com/debezium/dbz/issues/1474",
+                                            millisSinceLastEvent)));
+                            break;
+                        }
+                    }
+                    // Case 2: Client reports connected but connection is actually stale.
+                    // TCP remains ESTABLISHED but MySQL session is dead (half-open connection).
+                    else {
+                        long millisSinceLastEvent = metrics.getMilliSecondsSinceLastEvent();
+                        if (millisSinceLastEvent > staleThreshold && millisSinceLastEvent > 0) {
+                            LOGGER.warn("No binlog events received for {} ms (threshold: {} ms). "
+                                    + "Connection may be stale (DBZ-9755). Triggering task failure to force reconnection.",
+                                    millisSinceLastEvent, staleThreshold);
+                            errorHandler.setProducerThrowable(new DebeziumException(
+                                    String.format("Stale binlog connection detected: no events received for %d ms "
+                                            + "(keepAliveInterval=%d ms, threshold=%d ms). "
+                                            + "See https://github.com/debezium/dbz/issues/1474",
+                                            millisSinceLastEvent, keepAliveInterval, staleThreshold)));
+                            break;
+                        }
+                    }
+                }
             }
         }
         finally {


### PR DESCRIPTION
## Problem

When a TCP connection remains ESTABLISHED but the MySQL session is dead (e.g., due to AWS NAT Gateway idle timeout of 350 seconds silently dropping the connection mapping), the binlog client's read thread blocks indefinitely on `socket.read()`. The task remains in RUNNING state with no error logs, but no data flows — a "silent disconnect."

This was observed in production with 17/19 connectors to the same RDS instance simultaneously entering this state. The only indicator was `Connected=0` in JMX metrics, while task status remained RUNNING.

## Root Cause

The main streaming loop in `BinlogStreamingChangeEventSource` only checks `context.isRunning()` without any connection health validation. When the TCP connection enters a half-dead state (ESTABLISHED but no data flowing), neither the keepalive thread nor the IO thread raises an exception, so the loop continues indefinitely.

## Fix

Added stale connection detection to the main streaming loop. When `keepAlive` is enabled and no binlog events (including MySQL heartbeats) have been received for `3 × keepAliveInterval`, the task is failed with a descriptive error. This allows Kafka Connect's restart policy to re-establish a fresh connection.

The detection uses the existing `MilliSecondsSinceLastEvent` metric from `BinaryLogClientStatistics`.

## Prerequisites

- `connect.keep.alive=true` (default)
- `heartbeat.interval.ms` configured (recommended)

Without heartbeat, idle databases with no writes could trigger false positives.

## Testing

Reproduced by pausing a MySQL Docker container on a remote server. Without the fix, the connector stays RUNNING indefinitely. With the fix, the task fails after `3 × keepAliveInterval` and Kafka Connect restarts it.

Fixes: https://github.com/debezium/dbz/issues/1474
