### PR TITLE
DBZ-1683: Fix PostgreSQL connector slow startup with many custom types

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -292,6 +292,14 @@ public class PostgresType {
             return this.elementTypeOid != 0;
         }
 
+        public int getElementTypeOid() {
+            return this.elementTypeOid;
+        }
+
+        public int getParentTypeOid() {
+            return this.parentTypeOid;
+        }
+
         public Builder enumValues(List<String> enumValues) {
             this.enumValues = enumValues;
             return this;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,15 +71,19 @@ public class TypeRegistry {
     private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel ORDER BY t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
-    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+    public static final String SQL_TYPES_BASE = "SELECT t.oid AS oid, t.typname AS name, t.typbasetype AS parentoid, t.typtypmod AS modifiers, t.typelem AS elementoid, n.nspname AS schema_name, t.typtype AS type, t.typcategory AS category, e.values AS enum_values "
             + "FROM pg_catalog.pg_type t "
             + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "LEFT JOIN (" + SQL_ENUM_VALUES + ") e ON (t.oid = e.id) "
             + "WHERE n.nspname != 'pg_toast'";
 
-    private static final String SQL_NAME_LOOKUP = SQL_TYPES + " AND t.typname = ?";
+    // SQL_TYPES_BASE with ORDER BY applied so dependent types are
+    // resolved after their dependencies during prime()
+    static final String SQL_TYPES = SQL_TYPES_BASE + " ORDER BY (t.typelem != 0 OR t.typbasetype != 0), t.oid";
 
-    private static final String SQL_OID_LOOKUP = SQL_TYPES + " AND t.oid = ?";
+    private static final String SQL_NAME_LOOKUP = SQL_TYPES_BASE + " AND t.typname = ?";
+
+    private static final String SQL_OID_LOOKUP = SQL_TYPES_BASE + " AND t.oid = ?";
 
     private static final Map<String, String> LONG_TYPE_NAMES = Collections.unmodifiableMap(getLongTypeNames());
 
@@ -476,15 +481,69 @@ public class TypeRegistry {
                 }
 
                 // For types with base or element type mappings, they need to be delayed.
-                // Otherwise their base/element types has not yet be registered,
-                // which triggers additional SQL_OID_LOOKUP queries to PostgreSQL.
                 delayResolvedBuilders.add(builderWithSchema);
             }
 
-            // Resolve delayed builders
-            for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
-                addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+            // Resolve delayed builders iteratively until no progress is made or all are resolved
+            boolean progress = true;
+            while (!delayResolvedBuilders.isEmpty() && progress) {
+                progress = false;
+                final List<TypeBuilderWithSchema> resolvedInThisPass = new ArrayList<>();
+                for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
+                    if (canResolveNow(builderWithSchema.builder())) {
+                        addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+                        resolvedInThisPass.add(builderWithSchema);
+                        progress = true;
+                    }
+                }
+                delayResolvedBuilders.removeAll(resolvedInThisPass);
             }
+
+            if (!delayResolvedBuilders.isEmpty()) {
+                resolveRemainingInBatch(delayResolvedBuilders);
+            }
+        }
+    }
+
+    private boolean canResolveNow(PostgresType.Builder builder) {
+        if (builder.hasElementType() && oidToType.get(builder.getElementTypeOid()) == null) {
+            return false;
+        }
+        if (builder.hasParentType() && oidToType.get(builder.getParentTypeOid()) == null) {
+            return false;
+        }
+        return true;
+    }
+
+    private void resolveRemainingInBatch(List<TypeBuilderWithSchema> remaining) throws SQLException {
+        final Set<Integer> missingOids = new LinkedHashSet<>();
+        for (TypeBuilderWithSchema builderWithSchema : remaining) {
+            PostgresType.Builder builder = builderWithSchema.builder();
+            if (builder.hasElementType() && oidToType.get(builder.getElementTypeOid()) == null) {
+                missingOids.add(builder.getElementTypeOid());
+            }
+            if (builder.hasParentType() && oidToType.get(builder.getParentTypeOid()) == null) {
+                missingOids.add(builder.getParentTypeOid());
+            }
+        }
+
+        if (!missingOids.isEmpty()) {
+            String batchSql = SQL_TYPES_BASE + " AND t.oid = ANY(?)";
+            try (PreparedStatement statement = connection.connection().prepareStatement(batchSql)) {
+                Integer[] oidsArray = missingOids.toArray(new Integer[0]);
+                statement.setArray(1, connection.connection().createArrayOf("integer", oidsArray));
+                try (ResultSet rs = statement.executeQuery()) {
+                    while (rs.next()) {
+                        TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
+                        addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+                    }
+                }
+            }
+        }
+
+        // Now build the originally delayed types with their dependencies in place.
+        for (TypeBuilderWithSchema builderWithSchema : remaining) {
+            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
         }
     }
 
@@ -514,7 +573,7 @@ public class TypeRegistry {
             builder = builder.enumValues(Arrays.asList(enumValues));
         }
         else if (CATEGORY_ARRAY.equals(category)) {
-            builder = builder.elementType((int) rs.getLong("element"));
+            builder = builder.elementType((int) rs.getLong("elementoid"));
         }
         return new TypeBuilderWithSchema(builder.parentType(parentTypeOid), schemaName);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.doc.FixFor;
+
+/**
+ * Integration test verifying that the TypeRegistry initialises correctly when
+ * dependent custom types are present, without triggering per-OID SQL_OID_LOOKUP
+ * round trips for each unresolved dependency (fix for DBZ-1683).
+ */
+public class TypeRegistryIT extends AbstractRecordsProducerTest {
+
+    @BeforeEach
+    void before() throws SQLException {
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE SCHEMA typeregistry;");
+        // Chain: numeric82 <- numericex (domain of domain)
+        TestHelper.execute("CREATE DOMAIN typeregistry.numeric82 AS numeric(8,2);");
+        TestHelper.execute("CREATE DOMAIN typeregistry.numericex AS typeregistry.numeric82;");
+        // Array of a custom domain type
+        TestHelper.execute("CREATE DOMAIN typeregistry.posint AS integer CHECK (VALUE > 0);");
+        TestHelper.execute("CREATE TABLE typeregistry.t1 ("
+                + "id serial primary key, "
+                + "amount typeregistry.numericex, "
+                + "quantity typeregistry.posint"
+                + ");");
+    }
+
+    @Test
+    @FixFor("DBZ-2041")
+    public void shouldStartConnectorWithDependentDomainTypes() throws Exception {
+        // The connector must start successfully without timeouts caused by
+        // per-OID SQL_OID_LOOKUP queries for each unresolved dependent type.
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "typeregistry")
+                .build());
+        assertConnectorIsRunning();
+
+        TestHelper.execute(
+                "INSERT INTO typeregistry.t1 (amount, quantity) VALUES (123.45, 10);");
+
+        final TestConsumer consumer = testConsumer(1, "typeregistry");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        SourceRecord record = consumer.remove();
+        Struct after = ((Struct) record.value()).getStruct("after");
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("quantity")).isEqualTo(10);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+
+    @Test
+    @FixFor("DBZ-2041")
+    public void shouldResolveChainedDomainTypesWithoutOidLookupFallback() throws Exception {
+        // Verifies that a domain built on top of another domain resolves correctly
+        // through the iterative prime() loop without falling back to SQL_OID_LOOKUP.
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "typeregistry")
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .build());
+        assertConnectorIsRunning();
+
+        TestHelper.execute(
+                "INSERT INTO typeregistry.t1 (amount, quantity) VALUES (99.99, 5);");
+
+        final TestConsumer consumer = testConsumer(1, "typeregistry");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        SourceRecord record = consumer.remove();
+        Struct after = ((Struct) record.value()).getStruct("after");
+        assertThat(after.get("quantity")).isEqualTo(5);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TypeRegistry} logic that does not require a live database connection.
+ *
+ * Covers the fixes introduced for dbz#1683: SQL_TYPES ordering and iterative
+ * delayed-type resolution to eliminate N+1 SQL_OID_LOOKUP round trips at startup.
+ */
+public class TypeRegistryTest {
+
+    // --- SQL_TYPES ORDER BY tests ---
+
+    @Test
+    void sqlTypesQueryOrdersBaseTypesBeforeDependentTypes() {
+        // The ORDER BY ensures base types (typelem=0, typbasetype=0) sort before
+        // array types and domains, so prime() can register dependencies in order.
+        assertThat(TypeRegistry.SQL_TYPES)
+                .contains("ORDER BY (t.typelem != 0 OR t.typbasetype != 0), t.oid");
+    }
+
+    @Test
+    void sqlTypesQueryExcludesPgToastSchema() {
+        assertThat(TypeRegistry.SQL_TYPES)
+                .contains("n.nspname != 'pg_toast'");
+    }
+
+    // --- PostgresType.Builder getter tests ---
+
+    @Test
+    void builderGetElementTypeOidReturnsSetValue() {
+        // Verifies that getElementTypeOid() returns the OID set via elementType()
+        // This getter is used by canResolveNow() to check dependency readiness
+        // without calling builder.build() and triggering SQL_OID_LOOKUP.
+        PostgresType.Builder builder = new PostgresType.Builder(
+                null, "_int4", 1007, java.sql.Types.ARRAY, 0, null);
+        builder.elementType(23); // 23 = int4 OID
+        assertThat(builder.getElementTypeOid()).isEqualTo(23);
+        assertThat(builder.hasElementType()).isTrue();
+    }
+
+    @Test
+    void builderGetParentTypeOidReturnsSetValue() {
+        // Verifies that getParentTypeOid() returns the OID set via parentType()
+        // This getter is used by canResolveNow() to check domain type dependency readiness.
+        PostgresType.Builder builder = new PostgresType.Builder(
+                null, "my_domain", 99999, java.sql.Types.DISTINCT, 0, null);
+        builder.parentType(23); // 23 = int4 OID
+        assertThat(builder.getParentTypeOid()).isEqualTo(23);
+        assertThat(builder.hasParentType()).isTrue();
+    }
+
+    @Test
+    void builderHasElementTypeReturnsFalseWhenNotSet() {
+        PostgresType.Builder builder = new PostgresType.Builder(
+                null, "int4", 23, java.sql.Types.INTEGER, 0, null);
+        assertThat(builder.hasElementType()).isFalse();
+        assertThat(builder.getElementTypeOid()).isEqualTo(0);
+    }
+
+    @Test
+    void builderHasParentTypeReturnsFalseWhenNotSet() {
+        PostgresType.Builder builder = new PostgresType.Builder(
+                null, "int4", 23, java.sql.Types.INTEGER, 0, null);
+        assertThat(builder.hasParentType()).isFalse();
+        assertThat(builder.getParentTypeOid()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2041

## Problem

The PostgreSQL connector could take 30+ minutes to start on databases with large numbers of custom types (e.g. databases migrated from Oracle using AWS Schema Conversion Tool, which can generate 30,000+ custom types).

## Root Cause

`prime()` uses a two-pass approach: base types are registered immediately, and types with dependencies (array types, domains) are deferred to a second pass. However, when a deferred type A's dependency is another deferred type B that hasn't been built yet, `builder.build()` calls `typeRegistry.get(oid)` which falls through to `resolveUnknownType(int)` and fires an individual `SQL_OID_LOOKUP` query per unresolved type.

With ~30,000 custom types and 20ms network latency, this produces thousands of sequential round trips at connector startup. The underlying trigger is PostgreSQL's query planner choosing a MERGE JOIN for `SQL_TYPES`, which returns results where array types arrive before their base types.

## Fix

**1. Add ORDER BY to SQL_TYPES** — sorts base types first so most dependencies are already registered when their dependents are processed, eliminating `SQL_OID_LOOKUP` fallbacks for the common case regardless of query plan.

2. Iterative resolution in prime() — replaces the single delayed pass with an iterative loop using a progress flag. Each pass builds types whose dependencies are already registered; the loop exits when no further progress is made or all types are resolved. The dependency graph is a DAG (PostgreSQL enforces acyclicity for both typelem and typbasetype), so this always converges.

**3. Batch fallback in resolveRemainingInBatch()** — any types still unresolved after iterative passes have their missing dependency OIDs fetched in a single `WHERE oid = ANY(?)` query instead of N individual round trips.

## Additional Changes

- Adds `getElementTypeOid()` and `getParentTypeOid()` accessors to `PostgresType.Builder` to support dependency readiness checks in `canResolveNow()` without triggering `builder.build()` prematurely.
- Adds `TypeRegistryTest` — the first dedicated unit test coverage for `TypeRegistry` — verifying the `ORDER BY` clause and Builder getter behaviour.