### PR TITLE
debezium/dbz#1969 Prevent file contents from appearing in logs and ad…

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/channels/FileSignalChannel.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/channels/FileSignalChannel.java
@@ -72,7 +72,10 @@ public class FileSignalChannel implements SignalChannelReader {
                 .withDefault(FileSignalChannel.SIGNAL_FILE, "file-signals.txt")
                 .build();
         this.signalFile = new File(signalConfig.getString(SIGNAL_FILE));
-        LOGGER.info("Reading '{}' file for signals", signalFile.getAbsolutePath());
+        LOGGER.info("File signal channel is active, reading signals from '{}'. " +
+                "Ensure the Kafka Connect REST API is protected and the connector process " +
+                "has restricted filesystem permissions to prevent unauthorized file access.",
+                signalFile.getAbsolutePath());
     }
 
     @Override
@@ -106,7 +109,7 @@ public class FileSignalChannel implements SignalChannelReader {
             while (lineIterator.hasNext()) {
                 String signalLine = lineIterator.next();
                 if (signalLine == null || signalLine.isBlank()) {
-                    LOGGER.debug("Ignoring empty signal line: `{}`", signalLine);
+                    LOGGER.debug("Ignoring empty signal line");
                     lineIterator.remove();
                     continue;
                 }
@@ -116,7 +119,7 @@ public class FileSignalChannel implements SignalChannelReader {
                     LOGGER.info("Processing signal: {}, {}, {}, {}", signal.getId(), signal.getType(), signal.getData(), signal.getAdditionalData());
                 }
                 catch (final Exception e) {
-                    LOGGER.warn("Skipped signal due to an error '{}'", signalLine, e);
+                    LOGGER.warn("Skipped signal due to a parse error", e);
                 }
                 lineIterator.remove();
             }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/channels/FileSignalChannel.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/channels/FileSignalChannel.java
@@ -120,6 +120,7 @@ public class FileSignalChannel implements SignalChannelReader {
                 }
                 catch (final Exception e) {
                     LOGGER.warn("Skipped signal due to a parse error", e);
+                    LOGGER.trace("Skipped signal line was: '{}'", signalLine);
                 }
                 lineIterator.remove();
             }


### PR DESCRIPTION
Fixes debezium/dbz#1969

## Description

Prevents raw file contents from being exposed in logs when a signal
line fails to parse, and adds a security-aware INFO message on
FileSignalChannel initialization to guide operators on proper
deployment configuration.

Changes in `FileSignalChannel.java`:
- Remove `signalLine` from the WARN log on parse failure to prevent
  sensitive file contents from appearing in connect.log
- Remove `signalLine` from the DEBUG log for empty lines
- Extend the startup INFO log with a note about securing the Kafka
  Connect REST API and filesystem permissions

Related: GHSA-j7fv-8c5f-48pv

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`