### PR TITLE
debezium/dbz#1916 Fix Julian/Gregorian calendar jump for Postgres timestamp

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -98,6 +98,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
     public static final OffsetDateTime POSITIVE_INFINITY_OFFSET_DATE_TIME = OffsetDateTime.ofInstant(Conversions.toInstantFromMillis(PGStatement.DATE_POSITIVE_INFINITY),
             ZoneOffset.UTC);
     public static final LocalDate POSITIVE_INFINITY_LOCAL_DATE = LocalDate.parse("-5877611-06-21");
+    public static final String POSITIVE_INFINITY_TIMESTAMP_PG_STRING = "infinity";
 
     public static final Date NEGATIVE_INFINITY_DATE = new Date(PGStatement.DATE_NEGATIVE_INFINITY);
     public static final Timestamp NEGATIVE_INFINITY_TIMESTAMP = new Timestamp(PGStatement.DATE_NEGATIVE_INFINITY);
@@ -106,6 +107,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
     public static final OffsetDateTime NEGATIVE_INFINITY_OFFSET_DATE_TIME = OffsetDateTime.ofInstant(Conversions.toInstantFromMillis(PGStatement.DATE_NEGATIVE_INFINITY),
             ZoneOffset.UTC);
     public static final LocalDate NEGATIVE_INFINITY_LOCAL_DATE = LocalDate.parse("-5877611-06-22");
+    public static final String NEGATIVE_INFINITY_TIMESTAMP_PG_STRING = "-infinity";
 
     /**
      * Variable scale decimal/numeric is defined by metadata
@@ -945,7 +947,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
     @Override
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
         if (data instanceof String str) {
-            if (POSITIVE_INFINITY.equalsIgnoreCase(str) || NEGATIVE_INFINITY.equalsIgnoreCase(str)) {
+            if (POSITIVE_INFINITY_TIMESTAMP_PG_STRING.equals(str) || NEGATIVE_INFINITY_TIMESTAMP_PG_STRING.equals(str)) {
                 return str;
             }
 
@@ -959,10 +961,10 @@ public class PostgresValueConverter extends JdbcValueConverters {
         }
 
         if (POSITIVE_INFINITY_OFFSET_DATE_TIME.equals(data)) {
-            return "infinity";
+            return POSITIVE_INFINITY_TIMESTAMP_PG_STRING;
         }
         else if (NEGATIVE_INFINITY_OFFSET_DATE_TIME.equals(data)) {
-            return "-infinity";
+            return NEGATIVE_INFINITY_TIMESTAMP_PG_STRING;
         }
         else if (data instanceof OffsetDateTime) {
             data = ((OffsetDateTime) data).toZonedDateTime();
@@ -1177,16 +1179,15 @@ public class PostgresValueConverter extends JdbcValueConverters {
         if (data == null) {
             return null;
         }
-        if (data instanceof String str) {
-            if (POSITIVE_INFINITY.equalsIgnoreCase(str)) {
-                return POSITIVE_INFINITY_LOCAL_DATE_TIME;
-            }
-            else if (NEGATIVE_INFINITY.equalsIgnoreCase(str)) {
-                return NEGATIVE_INFINITY_LOCAL_DATE_TIME;
-            }
-
-            final Instant instant = DateTimeFormat.get().timestampToInstant(str);
-            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        if (data instanceof String s) {
+            return switch (s) {
+                case POSITIVE_INFINITY_TIMESTAMP_PG_STRING -> POSITIVE_INFINITY_LOCAL_DATE_TIME;
+                case NEGATIVE_INFINITY_TIMESTAMP_PG_STRING -> NEGATIVE_INFINITY_LOCAL_DATE_TIME;
+                default -> {
+                    final Instant instant = DateTimeFormat.get().timestampToInstant(s);
+                    yield LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+                }
+            };
         }
         if (!(data instanceof Timestamp)) {
             return data;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -54,6 +54,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.HStoreHandlingMode;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.IntervalHandlingMode;
+import io.debezium.connector.postgresql.connection.DateTimeFormat;
 import io.debezium.connector.postgresql.data.Ltree;
 import io.debezium.connector.postgresql.proto.PgProto;
 import io.debezium.data.Bits;
@@ -943,6 +944,15 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     @Override
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
+        if (data instanceof String) {
+            final String str = (String) data;
+            if (str.endsWith("infinity")) {
+                return str;
+            }
+
+            data = DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(str).withOffsetSameInstant(ZoneOffset.UTC);
+        }
+
         if (data instanceof java.util.Date) {
             // any Date like subclasses will be given to us by the JDBC driver, which uses the local VM TZ, so we need to go
             // back to GMT
@@ -1167,6 +1177,18 @@ public class PostgresValueConverter extends JdbcValueConverters {
     protected Object convertTimestampToLocalDateTime(Column column, Field fieldDefn, Object data) {
         if (data == null) {
             return null;
+        }
+        if (data instanceof String) {
+            final String str = (String) data;
+            switch (str) {
+                case "infinity":
+                    return POSITIVE_INFINITY_LOCAL_DATE_TIME;
+                case "-infinity":
+                    return NEGATIVE_INFINITY_LOCAL_DATE_TIME;
+            }
+
+            final Instant instant = DateTimeFormat.get().timestampToInstant(str);
+            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
         }
         if (!(data instanceof Timestamp)) {
             return data;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -944,9 +944,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     @Override
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
-        if (data instanceof String) {
-            final String str = (String) data;
-            if (str.endsWith("infinity")) {
+        if (data instanceof String str) {
+            if (POSITIVE_INFINITY.equalsIgnoreCase(str) || NEGATIVE_INFINITY.equalsIgnoreCase(str)) {
                 return str;
             }
 
@@ -1178,13 +1177,12 @@ public class PostgresValueConverter extends JdbcValueConverters {
         if (data == null) {
             return null;
         }
-        if (data instanceof String) {
-            final String str = (String) data;
-            switch (str) {
-                case "infinity":
-                    return POSITIVE_INFINITY_LOCAL_DATE_TIME;
-                case "-infinity":
-                    return NEGATIVE_INFINITY_LOCAL_DATE_TIME;
+        if (data instanceof String str) {
+            if (POSITIVE_INFINITY.equalsIgnoreCase(str)) {
+                return POSITIVE_INFINITY_LOCAL_DATE_TIME;
+            }
+            else if (NEGATIVE_INFINITY.equalsIgnoreCase(str)) {
+                return NEGATIVE_INFINITY_LOCAL_DATE_TIME;
             }
 
             final Instant instant = DateTimeFormat.get().timestampToInstant(str);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -787,6 +787,10 @@ public class PostgresConnection extends JdbcConnection {
                 case PgOid.TIMETZ:
                     // In order to guarantee that we resolve TIMETZ columns with proper microsecond precision,
                     // read the column as a string instead and then re-parse inside the converter.
+                case PgOid.TIMESTAMP:
+                case PgOid.TIMESTAMPTZ:
+                    // Read as string to avoid java.sql.Timestamp's Julian-Gregorian calendar conversion
+                    // which corrupts dates before 1582-10-15 (PostgreSQL uses proleptic Gregorian).
                     return rs.getString(columnIndex);
                 default:
                     Object x = rs.getObject(columnIndex);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -670,33 +670,21 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
         String expectedTzLarge = "+21016-11-04T06:51:30.123456Z";
         String expectedTzLargeZero = "+21016-11-04T06:51:30.000000Z";
 
-        // The assertion for minimimum timestamps is problematic as it seems that Java and PostgreSQL handles conversion from large negative date
-        // to microseconds in different way
-        // written to database: 4713-12-31T23:59:59.999999 BC
-        // arrived from decoding plugin: -210831897600000001
-        // value from decoding plugin converted to Instant: -4712-12-31T23:59:59.999999Z - 1 year difference
-        // JDBC driver delivers Timestamp B.C.E. 4713-12-31T23:59:59.000+0100 that internally contains -210835184391000001 and translates to Instant -4712-11-23T22:59:59.999999Z
-        // The result is that JDBC driver and logical decoding plugin provides different values which moreover
-        // do not map to Java conversions
-        // It seems that JDBC driver always uses Gregorian calendar while Java Time API uses Julian
-        // Also it seems that further distortions could be introduced by timezone used so instead of matching
-        // against exact value the requested date should be smaller than -4712-11-01
+        // Both snapshot and streaming now parse timestamps as strings using the proleptic Gregorian calendar
+        // (via DateTimeFormat), so they produce consistent values for extreme negative dates.
+        // Written to database: 4713-12-31T23:59:59.999999 BC
+        // Proleptic Gregorian: -4712-12-31T23:59:59.999999Z (4713 BC = year -4712 in astronomical numbering)
         final SchemaAndValueField.Condition largeNegativeTimestamp = (String fieldName, Object expectedValue, Object actualValue) -> {
-            final long expectedMinTsStreaming = -210831897600000001L;
-            final long expectedMinTsSnapshot = LocalDateTime.of(-4712, 11, 1, 0, 0, 0).toInstant(java.time.ZoneOffset.UTC).getEpochSecond() * 1_000_000;
+            final long expectedMinTs = -210831897600000001L;
             final long ts = (long) actualValue;
-            assertTrue(ts >= expectedMinTsSnapshot && ts < 0, "Negative timestamp don't match for " + fieldName + ", got " + actualValue);
+            assertEquals(expectedMinTs, ts, "Negative timestamp don't match for " + fieldName);
         };
-        // The same issue is with timezoned timestamp
         // Database: 4714-12-31T23:59:59.999999Z BC
-        // JDBC: -4713-11-23T23:59:59.999999Z
-        // Streamed as: -210863520000000001
-        // Java conversion: -4713-12-31T23:59:59.999999Z
+        // Proleptic Gregorian: -4713-12-31T23:59:59.999999Z
         final SchemaAndValueField.Condition largeNegativeTzTimestamp = (String fieldName, Object expectedValue, Object actualValue) -> {
-            final String expectedMinTsStreaming = "-4713-12-31T23:59:59.999999Z";
-            final String expectedMinTsSnapshot = "-4713-11-23T23:59:59.999999Z";
-            assertTrue(expectedMinTsSnapshot.equals(actualValue) || expectedMinTsStreaming.equals(actualValue),
-                    "Negative timestamp don't match for " + fieldName + ", got " + actualValue);
+            final String expectedMinTs = "-4713-12-31T23:59:59.999999Z";
+            assertEquals(expectedMinTs, actualValue,
+                    "Negative timestamp don't match for " + fieldName);
         };
         return Arrays.asList(new SchemaAndValueField("ts", MicroTimestamp.builder().optional().build(), expectedTs),
                 new SchemaAndValueField("tsneg", MicroTimestamp.builder().optional().build(), expectedNegTs),

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
@@ -415,7 +415,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         // somehow on github pipeline it fails expected:<+292269055-12-02Z> but was:<+292269055-12-03Z>
         assertTrue(after.get("date_ninf").toString().contains("+292269055-12-"));
         assertEquals(after.get("tz_max"), "+294247-01-01T23:59:59.999999Z");
-        assertEquals(after.get("tz_min"), "-4713-11-23T23:59:59.999999Z");
+        assertEquals(after.get("tz_min"), "-4713-12-31T23:59:59.999999Z");
         assertEquals(after.get("ts_pinf"), "+294247-01-10T04:00:25.2Z");
         assertEquals(after.get("ts_ninf"), "-290308-12-21T19:59:27.6Z");
         assertEquals(after.get("tz_pinf"), "infinity");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -53,6 +53,8 @@ import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Collect;
 
 /**
@@ -1321,6 +1323,52 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         buildWithStreamProducer(TestHelper.defaultConfig());
         waitForSnapshotToBeCompleted();
         waitForStreamingToStart();
+    }
+
+    @Test
+    @FixFor("DBZ-1916")
+    public void shouldSnapshotPre1582TimestampCorrectly() throws Exception {
+        TestHelper.execute("CREATE TABLE pre1582_ts_table (pk SERIAL, "
+                + "ts TIMESTAMP NOT NULL, "
+                + "tstz TIMESTAMPTZ NOT NULL, "
+                + "PRIMARY KEY(pk));");
+        TestHelper.execute("INSERT INTO pre1582_ts_table (ts, tstz) VALUES ("
+                + "'0001-01-31T00:00:00'::TIMESTAMP, "
+                + "'0001-01-31T00:00:00+00'::TIMESTAMPTZ)");
+        TestHelper.execute("INSERT INTO pre1582_ts_table (ts, tstz) VALUES ("
+                + "'1000-06-15T12:30:45.123456'::TIMESTAMP, "
+                + "'1000-06-15T12:30:45.123456+00'::TIMESTAMPTZ)");
+
+        buildNoStreamProducer(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.pre1582_ts_table"));
+
+        final TestConsumer consumer = testConsumer(2, "public");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final long expectedTsMicros1 = java.time.LocalDateTime.of(1, 1, 31, 0, 0, 0)
+                .toInstant(java.time.ZoneOffset.UTC).getEpochSecond() * 1_000_000;
+        final String expectedTstz1 = "0001-01-31T00:00:00.000000Z";
+
+        final long expectedTsMicros2 = java.time.LocalDateTime.of(1000, 6, 15, 12, 30, 45, 123456000)
+                .toInstant(java.time.ZoneOffset.UTC).getEpochSecond() * 1_000_000 + 123456;
+        final String expectedTstz2 = "1000-06-15T12:30:45.123456Z";
+
+        final List<SchemaAndValueField> expected1 = Arrays.asList(
+                new SchemaAndValueField("ts", MicroTimestamp.builder().build(), expectedTsMicros1),
+                new SchemaAndValueField("tstz", ZonedTimestamp.builder().build(), expectedTstz1));
+
+        final List<SchemaAndValueField> expected2 = Arrays.asList(
+                new SchemaAndValueField("ts", MicroTimestamp.builder().build(), expectedTsMicros2),
+                new SchemaAndValueField("tstz", ZonedTimestamp.builder().build(), expectedTstz2));
+
+        final var records = new ArrayList<SourceRecord>();
+        consumer.process(records::add);
+
+        assertThat(records).hasSize(2);
+        VerifyRecord.isValidRead(records.get(0), PK_FIELD, 1);
+        assertRecordSchemaAndValues(expected1, records.get(0), Envelope.FieldName.AFTER);
+        VerifyRecord.isValidRead(records.get(1), PK_FIELD, 2);
+        assertRecordSchemaAndValues(expected2, records.get(1), Envelope.FieldName.AFTER);
     }
 
     private void buildNoStreamProducer(Configuration.Builder config) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -1326,7 +1326,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
-    @FixFor("DBZ-1916")
+    @FixFor("debezium/dbz#1916")
     public void shouldSnapshotPre1582TimestampCorrectly() throws Exception {
         TestHelper.execute("CREATE TABLE pre1582_ts_table (pk SERIAL, "
                 + "ts TIMESTAMP NOT NULL, "


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1916 Fix Julian/Gregorian calendar jump for Postgres timestamp

## Description
### Brief summary of the issue
This PR is an attempt to fix the issue found in Postgres where timestamps much lesser than Unix time 0 (1970-01-01) get converted incorrectly.

### Cause
After some digging, it was due to how `java.sql.Timestamp` handle the jump between Julian and Gregorian calendar. Postgres uses proleptic Gregorian calendar, so the resulting conversion will be inaccurate.

### Fix
Postgres `timestamp` and `timestamptz` types are read as `String`. Conversion will take place for each independently, therefore avoiding the usage of `java.sql.Timestamp` altogether.
<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
