### PR TITLE
DBZ-1976: set autoCommit=false on connection init; use execute() in getEstimatedTableSize

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
@@ -55,9 +55,13 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
     private final BinlogFieldReader fieldReader;
 
     public BinlogConnectorConnection(ConnectionConfiguration configuration, BinlogFieldReader fieldReader) {
-        super(configuration.config(), configuration.factory(), QUOTED_CHARACTER, QUOTED_CHARACTER);
+        super(configuration.config(), configuration.factory(), initialOperations(), QUOTED_CHARACTER, QUOTED_CHARACTER);
         this.connectionConfig = configuration;
         this.fieldReader = fieldReader;
+    }
+
+    private static Operations initialOperations() {
+        return statement -> statement.getConnection().setAutoCommit(false);
     }
 
     @Override
@@ -219,7 +223,7 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
             // Choose how we create statements based on the # of rows.
             // This is approximate and less accurate then COUNT(*),
             // but far more efficient for large InnoDB tables.
-            executeWithoutCommitting("USE `" + tableId.catalog() + "`;");
+            execute("USE `" + tableId.catalog() + "`;");
             return queryAndMap("SHOW TABLE STATUS LIKE '" + tableId.table() + "';", rs -> {
                 if (rs.next()) {
                     return OptionalLong.of((rs.getLong(5)));


### PR DESCRIPTION

Fixes [debezium/dbz#1976](https://github.com/debezium/dbz/issues/1976)

## Description
getEstimatedTableSize() calls executeWithoutCommitting("USE db"). That method guards against auto-commit being enabled and throws DebeziumException (a RuntimeException) if it is. But getEstimatedTableSize() only catches SQLException, so DebeziumException escapes uncaught and kills the snapshot.

Auto-commit is enabled on the connection when the connection drops and is re-established between steps 6 and 7 — new connections default to `auto-commit=true`. With `locking.mode=none` on RDS, no table locks are held so the connection can go fully idle during the long schema history write in step 6, making reconnection likely in production.

executeWithoutCommitting is wrong here: USE db has no transactional semantics. It doesn't need to run inside a transaction. executeWithoutCommitting is intended for statements that must run within an existing transaction (e.g. LOCK TABLES). execute() is the correct method — it works regardless of auto-commit state.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
