### PR TITLE
DBZ-1977: Reconnect stale pool connections before snapshotting a table

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -252,8 +252,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                     .flatMap(tableId -> getSnapshotConnectionFirstSelect(ctx, tableId));
 
             for (int i = 1; i < snapshotMaxThreads; i++) {
-                JdbcConnection conn = jdbcConnectionFactory.newConnection().setAutoCommit(false);
-                conn.connection().setTransactionIsolation(jdbcConnection.connection().getTransactionIsolation());
+                JdbcConnection conn = jdbcConnectionFactory.newConnection();
+                initializePooledConnection(conn);
                 connectionPoolConnectionCreated(ctx, conn);
                 connectionPool.add(conn);
                 if (firstQuery.isPresent()) {
@@ -264,6 +264,11 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
         LOGGER.info("Created connection pool with {} threads", connectionPool.size());
         return connectionPool;
+    }
+
+    private void initializePooledConnection(JdbcConnection connection) throws SQLException {
+        connection.setAutoCommit(false);
+        connection.connection().setTransactionIsolation(jdbcConnection.connection().getTransactionIsolation());
     }
 
     public Connection createSnapshotConnection() throws SQLException {
@@ -1391,6 +1396,11 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         return () -> {
             final JdbcConnection connection = connectionPool.poll();
             final O offset = offsetPool.poll();
+            if (!connection.isValid()) {
+                LOGGER.warn("Snapshot pool connection is no longer valid, attempting reconnect. Snapshot consistency for subsequent tables may be affected.");
+                connection.reconnect();
+                initializePooledConnection(connection);
+            }
             try {
                 work.execute(connection, offset);
             }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1977

## Description
Validates snapshot pool connections before use in createPooledResourceCallable and reconnects if stale. Fixes snapshot failure when connections go idle long enough to be killed by the database server or an intermediate network device during stage 6 (schema history persistence).

The snapshot connection pool (ConcurrentLinkedQueue<JdbcConnection>) has no validate-on-borrow, idle eviction, or keepalive — standard features in every mainstream JDBC pool (HikariCP keepaliveTime (https://github.com/brettwooldridge/HikariCP#frequently-used), Tomcat JDBC testOnBorrow (https://tomcat.apache.org/tomcat-9.0-doc/jdbc-pool.html), DBCP2 testOnBorrow (https://commons.apache.org/proper/commons-dbcp/configuration.html) — enabled by default).

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
