### PR TITLE
debezium/dbz#1970 Propagate skipped.operations into PostgreSQL publication statements

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -822,3 +822,4 @@ Zahid Iqbal
 Rajender Passi
 Anny Dang
 Dana Stott
+Davyd Eliosidze

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.ReplicaIdentityMapper;
@@ -460,6 +461,9 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     private String buildPublishOptionValue() {
+        if (!connectorConfig.getConfig().hasKey(CommonConnectorConfig.SKIPPED_OPERATIONS)) {
+            return null;
+        }
         Set<Envelope.Operation> skipped = connectorConfig.getSkippedOperations();
         if (skipped.isEmpty()) {
             return null;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -16,8 +16,10 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -45,6 +47,7 @@ import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.ReplicaIdentityMapper;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcConnectionException;
@@ -237,9 +240,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                 case DISABLED:
                                     throw new ConnectException("Publication autocreation is disabled, please create one and restart the connector.");
                                 case ALL_TABLES:
-                                    String createPublicationStmt = connectorConfig.isPublishViaPartitionRoot()
-                                            ? String.format("CREATE PUBLICATION %s FOR ALL TABLES WITH (publish_via_partition_root = true);", publicationName)
-                                            : String.format("CREATE PUBLICATION %s FOR ALL TABLES;", publicationName);
+                                    String createPublicationStmt = String.format("CREATE PUBLICATION %s FOR ALL TABLES%s;",
+                                            publicationName, buildWithClause());
                                     LOGGER.info("Creating Publication with statement '{}'", createPublicationStmt);
                                     // Publication doesn't exist, create it.
                                     if (!isOnlyRead) {
@@ -268,9 +270,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                     }
                                     break;
                                 case NO_TABLES:
-                                    final String createPublicationWithNoTablesStmt = connectorConfig.isPublishViaPartitionRoot()
-                                            ? String.format("CREATE PUBLICATION %s WITH (publish_via_partition_root = true);", publicationName)
-                                            : String.format("CREATE PUBLICATION %s;", publicationName);
+                                    final String createPublicationWithNoTablesStmt = String.format("CREATE PUBLICATION %s%s;",
+                                            publicationName, buildWithClause());
                                     LOGGER.info("Creating publication with statement '{}'", createPublicationWithNoTablesStmt);
                                     try {
                                         executeWithTimeout(stmt, createPublicationWithNoTablesStmt);
@@ -458,6 +459,44 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
     }
 
+    private String buildPublishOptionValue() {
+        Set<Envelope.Operation> skipped = connectorConfig.getSkippedOperations();
+        if (skipped.isEmpty()) {
+            return null;
+        }
+        List<String> ops = new ArrayList<>();
+        if (!skipped.contains(Envelope.Operation.CREATE)) {
+            ops.add("insert");
+        }
+        if (!skipped.contains(Envelope.Operation.UPDATE)) {
+            ops.add("update");
+        }
+        if (!skipped.contains(Envelope.Operation.DELETE)) {
+            ops.add("delete");
+        }
+        if (!skipped.contains(Envelope.Operation.TRUNCATE)) {
+            ops.add("truncate");
+        }
+        return String.join(",", ops);
+    }
+
+    private String buildWithClause() {
+        List<String> options = new ArrayList<>();
+        if (connectorConfig.isPublishViaPartitionRoot()) {
+            options.add("publish_via_partition_root = true");
+        }
+        String publishValue = buildPublishOptionValue();
+        if (publishValue != null) {
+            options.add(String.format("publish = '%s'", publishValue));
+        }
+        return options.isEmpty() ? "" : " WITH (" + String.join(", ", options) + ")";
+    }
+
+    private String buildAlterPublishClause() {
+        String publishValue = buildPublishOptionValue();
+        return publishValue != null ? String.format(" WITH (publish = '%s')", publishValue) : "";
+    }
+
     private void createOrUpdatePublicationModeFiltered(Statement stmt, boolean isUpdate) {
         String tableFilterString = null;
         String createOrUpdatePublicationStmt;
@@ -468,12 +507,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 throw new DebeziumException(String.format("No table filters found for filtered publication %s", publicationName));
             }
             if (isUpdate) {
-                createOrUpdatePublicationStmt = String.format("ALTER PUBLICATION %s SET TABLE %s;", publicationName, tableFilterString);
+                createOrUpdatePublicationStmt = String.format("ALTER PUBLICATION %s SET TABLE %s%s;",
+                        publicationName, tableFilterString, buildAlterPublishClause());
             }
             else {
-                createOrUpdatePublicationStmt = connectorConfig.isPublishViaPartitionRoot()
-                        ? String.format("CREATE PUBLICATION %s FOR TABLE %s WITH (publish_via_partition_root = true);", publicationName, tableFilterString)
-                        : String.format("CREATE PUBLICATION %s FOR TABLE %s;", publicationName, tableFilterString);
+                createOrUpdatePublicationStmt = String.format("CREATE PUBLICATION %s FOR TABLE %s%s;",
+                        publicationName, tableFilterString, buildWithClause());
             }
             LOGGER.info(isUpdate ? "Updating Publication with statement '{}'" : "Creating Publication with statement '{}'", createOrUpdatePublicationStmt);
             try {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javax.management.InstanceNotFoundException;
 
@@ -56,6 +57,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.postgresql.util.PSQLState;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -3112,6 +3116,59 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertTrue(TestHelper.publicationExists("cdc"));
     }
 
+    static Stream<Envelope.Operation> skippableOperationsForAlter() {
+        return Stream.of(Envelope.Operation.CREATE, Envelope.Operation.UPDATE, Envelope.Operation.DELETE, Envelope.Operation.TRUNCATE);
+    }
+
+    @ParameterizedTest(name = "skipped.operations={0}")
+    @MethodSource("skippableOperationsForAlter")
+    @FixFor("DBZ-1970")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
+    public void shouldPropagateSkippedOperationsWhenUpdatingFilteredPublication(Envelope.Operation skippedOp) throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(PostgresReplicationConnection.class);
+
+        TestHelper.dropAllSchemas();
+        TestHelper.dropPublication("cdc");
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+        TestHelper.execute(SETUP_TABLES_STMT);
+
+        Configuration.Builder initialConfigBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.a")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.FILTERED.getValue())
+                .with(PostgresConnectorConfig.SKIPPED_OPERATIONS, skippedOp.code());
+
+        start(PostgresConnector.class, initialConfigBuilder.build());
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
+        consumeRecordsByTopic(1);
+        stopConnector();
+
+        // Build the expected publish value: all ops except the skipped one
+        List<String> publishOps = new ArrayList<>(Arrays.asList("insert", "update", "delete", "truncate"));
+        publishOps.remove(skippedOp == Envelope.Operation.CREATE ? "insert"
+                : skippedOp == Envelope.Operation.UPDATE ? "update"
+                        : skippedOp == Envelope.Operation.DELETE ? "delete" : "truncate");
+        String expectedPublish = String.join(",", publishOps);
+
+        Configuration.Builder updatedConfigBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.a,s2.a")
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.FILTERED.getValue())
+                .with(PostgresConnectorConfig.SKIPPED_OPERATIONS, skippedOp.code());
+
+        start(PostgresConnector.class, updatedConfigBuilder.build());
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
+        consumeRecordsByTopic(2);
+
+        stopConnector(value -> assertTrue(
+                logInterceptor.containsMessage(String.format(
+                        "Updating Publication with statement 'ALTER PUBLICATION cdc SET TABLE \"s1\".\"a\", \"s2\".\"a\" WITH (publish = '%s');'",
+                        expectedPublish))));
+    }
+
     @Test
     @FixFor("DBZ-1813")
     @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
@@ -3295,6 +3352,59 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         VerifyRecord.isValidInsert(recs.get(0), PK_FIELD, 1);
         VerifyRecord.isValidInsert(recs.get(1), PK_FIELD, 501);
+    }
+
+    static Stream<Arguments> skippedOperationsArguments() {
+        return Stream.of(
+                Arguments.of(Envelope.Operation.CREATE.code(), List.of(Envelope.Operation.CREATE.code())),
+                Arguments.of(Envelope.Operation.UPDATE.code(), List.of(Envelope.Operation.UPDATE.code())),
+                Arguments.of(Envelope.Operation.DELETE.code(), List.of(Envelope.Operation.DELETE.code())),
+                Arguments.of(Envelope.Operation.TRUNCATE.code(), List.of(Envelope.Operation.TRUNCATE.code())),
+                Arguments.of(Envelope.Operation.DELETE.code() + "," + Envelope.Operation.TRUNCATE.code(),
+                        List.of(Envelope.Operation.DELETE.code(), Envelope.Operation.TRUNCATE.code())));
+    }
+
+    @ParameterizedTest(name = "skipped.operations={0}")
+    @MethodSource("skippedOperationsArguments")
+    @FixFor("DBZ-1970")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication publish option only available for PGOUTPUT decoder")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "TRUNCATE events only supported in PG11+ PGOUTPUT plugin")
+    void shouldNotReceiveSkippedOperationsFromPublication(String skippedOps, List<String> skippedOpCodes) throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.dropPublication("cdc");
+        TestHelper.execute(SETUP_TABLES_STMT);
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.a")
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.FILTERED.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.SKIPPED_OPERATIONS, skippedOps)
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO s1.a VALUES(301, 1);");
+        TestHelper.execute("UPDATE s1.a SET aa=100 WHERE pk=301;");
+        TestHelper.execute("DELETE FROM s1.a WHERE pk=301;");
+        TestHelper.execute("TRUNCATE TABLE s1.a;");
+        TestHelper.execute("INSERT INTO s1.a VALUES(302, 2);");
+
+        int expectedCount = 4 - skippedOpCodes.size();
+        SourceRecords records = consumeRecordsByTopic(expectedCount);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("s1.a"));
+
+        assertThat(recordsForTopic).hasSize(expectedCount);
+        recordsForTopic.forEach(record -> {
+            String op = ((Struct) record.value()).getString("op");
+            skippedOpCodes.forEach(skipped -> assertNotEquals(skipped, op));
+        });
+
+        assertNoRecordsToConsume();
+        stopConnector();
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -3160,7 +3160,6 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         start(PostgresConnector.class, updatedConfigBuilder.build());
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted();
         consumeRecordsByTopic(2);
 
         stopConnector(value -> assertTrue(
@@ -3381,11 +3380,20 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                 .with(PostgresConnectorConfig.SKIPPED_OPERATIONS, skippedOps)
+                .with(CommonConnectorConfig.TOMBSTONES_ON_DELETE, false)
                 .build();
 
         start(PostgresConnector.class, config);
         assertConnectorIsRunning();
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        // SQL sequence: INSERT(c), UPDATE(u), DELETE(d), TRUNCATE(t), INSERT(c) — 5 records before skipping
+        List<String> executedOps = Arrays.asList(
+                Envelope.Operation.CREATE.code(),
+                Envelope.Operation.UPDATE.code(),
+                Envelope.Operation.DELETE.code(),
+                Envelope.Operation.TRUNCATE.code(),
+                Envelope.Operation.CREATE.code());
 
         TestHelper.execute("INSERT INTO s1.a VALUES(301, 1);");
         TestHelper.execute("UPDATE s1.a SET aa=100 WHERE pk=301;");
@@ -3393,7 +3401,8 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         TestHelper.execute("TRUNCATE TABLE s1.a;");
         TestHelper.execute("INSERT INTO s1.a VALUES(302, 2);");
 
-        int expectedCount = 4 - skippedOpCodes.size();
+        int expectedCount = (int) executedOps.stream().filter(op -> !skippedOpCodes.contains(op)).count();
+
         SourceRecords records = consumeRecordsByTopic(expectedCount);
         List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("s1.a"));
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3725,6 +3725,10 @@ If a publication does not exist, the connector creates a publication for all tab
 The connector runs the following SQL command to create a publication: +
  +
 `CREATE PUBLICATION <__publication_name__> FOR ALL TABLES;`
+ +
+If the xref:postgresql-property-skipped-operations[`skipped.operations`] property is configured, the connector appends a `WITH (publish = '...')` clause to restrict the publication to non-skipped operation types: +
+ +
+`CREATE PUBLICATION <__publication_name__> FOR ALL TABLES WITH (publish = '<__allowed_operations__>');`
 
 `disabled`::
 The connector does not attempt to create a publication.
@@ -3741,6 +3745,8 @@ The resulting publication includes tables that match the current filter configur
 If the publication exists, the connector updates the publication for tables that match the current filter configuration by running a SQL command in the following format: +
  +
 `ALTER PUBLICATION <publication_name> SET TABLE <tbl1, tbl2, tbl3>`.
+ +
+In both cases, if the xref:postgresql-property-skipped-operations[`skipped.operations`] property is configured, the connector appends a `WITH (publish = '...')` clause to restrict the publication to non-skipped operation types.
 
 `no_tables`::
 If a publication exists, the connector uses it.
@@ -4373,6 +4379,9 @@ You can configure the connector to skip the following types of operations:
 * `t` (truncate)
 
 Set the value to `none` if you do not want the connector to skip any operations.
+
+When you use the `pgoutput` plug-in and the xref:postgresql-publication-autocreate-mode[`publication.autocreate.mode`] property is set to `all_tables` or `filtered`, the connector propagates the configured skipped operations into the PostgreSQL publication by setting the `publish` option accordingly.
+For example, if `skipped.operations=d`, the connector creates or updates the publication with `WITH (publish = 'insert,update,truncate')`, so that PostgreSQL omits the skipped operations from the replication stream entirely, reducing unnecessary WAL traffic.
 
 |[[postgresql-property-signal-data-collection]]<<postgresql-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -368,3 +368,4 @@ akhilm,Mohammad Akhil
 100maygupta,Saumay Gupta
 huongcb_dep_trai,Cao Ba Huong
 Matei-Gatin,Matei Alexandru Gatin
+rigadon,Davyd Eliosidze


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#<the Debezium Issue Number>

## Description
When Debezium auto-creates or updates a PostgreSQL publication, it now propagates the `skipped.operations` configuration into the publication's `publish` option. Previously, the generated publication always
  published all operation types, meaning PostgreSQL still produced WAL entries for operations Debezium was configured to skip — resulting in unnecessary replication traffic and processing overhead.
  
  The mapping is:
  - `c` (create) → omits `insert` from the publication
  - `u` (update) → omits `update` from the publication
  - `d` (delete) → omits `delete` from the publication
  - `t` (truncate) → omits `truncate` from the publication
  
  For example, with `skipped.operations=d`, the generated statement becomes:
  ```sql    
  CREATE PUBLICATION <name> FOR TABLE <tables> WITH (publish = 'insert,update,truncate');
```

  This applies to all autocreate modes (ALL_TABLES, FILTERED) for both CREATE PUBLICATION and ALTER PUBLICATION statements. The publish_via_partition_root option is preserved and combined in the same WITH
  clause when both are set.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ ] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`

Fixes debezium/dbz#1970