### PR TITLE
debezium/dbz#1988 Quote identifiers in rowCountForTableChunked to fix SQL syntax error on hyphenated database names

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -600,6 +600,7 @@ Ruslan Gibaiev
 Russell Ballard
 Russell Mora
 Ruud H.G. van Tol
+Ryan D'Souza
 Ryan van Huuksloot
 Sage Pierce
 Sairam Polavarapu

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
@@ -12,13 +12,17 @@ import java.util.List;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.AbstractChunkedSnapshotTest;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 /**
  * Abstract binlog chunked table snapshot integration tests.
@@ -124,5 +128,42 @@ public abstract class BinlogChunkedSnapshotIT<T extends SourceConnector>
     @Override
     protected String getFullyQualifiedTableName(String tableName) {
         return DATABASE.qualifiedTableName(tableName);
+    }
+
+    /**
+     * Regression test for DBZ-1988: rowCountForTableChunked uses getQualifiedTableName (unquoted)
+     * instead of quotedTableIdString, causing a SQL syntax error when the database name contains
+     * hyphens (e.g. "my-db" becomes the expression `my - db` in MySQL).
+     */
+    @FixFor("debezium/dbz#1988")
+    @Test
+    public void shouldSnapshotTableInDatabaseWithHyphenatedName() throws Exception {
+        final String hyphenDb = "debezium-hyphen-test";
+        final int rowCount = 10;
+
+        try {
+            connection.execute(
+                    "CREATE DATABASE IF NOT EXISTS `" + hyphenDb + "`",
+                    "CREATE TABLE `" + hyphenDb + "`.`items` (id INT PRIMARY KEY, name VARCHAR(50))",
+                    "INSERT INTO `" + hyphenDb + "`.`items` VALUES " +
+                            "(1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f'),(7,'g'),(8,'h'),(9,'i'),(10,'j')");
+
+            final Configuration config = DATABASE.defaultConfig()
+                    .with(BinlogConnectorConfig.DATABASE_INCLUDE_LIST, hyphenDb)
+                    .with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, hyphenDb + ".items")
+                    .with(CommonConnectorConfig.SNAPSHOT_MAX_THREADS, 2)
+                    .build();
+
+            start(getConnectorClass(), config);
+            assertConnectorIsRunning();
+            waitForSnapshotToBeCompleted();
+
+            final var records = consumeRecordsByTopic(rowCount);
+            assertThat(records.allRecordsInOrder()).hasSize(rowCount);
+        }
+        finally {
+            connection.execute("DROP DATABASE IF EXISTS `" + hyphenDb + "`");
+            stopConnector();
+        }
     }
 }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
@@ -160,6 +160,9 @@ public abstract class BinlogChunkedSnapshotIT<T extends SourceConnector>
             assertConnectorIsRunning();
             waitForSnapshotToBeCompleted();
 
+            // Hyphenated database names produce schema names like "ps_test.debezium-hyphen-test.items.Key"
+            // which are invalid Avro identifiers; skip that validation since this test targets the SQL fix.
+            skipAvroValidation();
             final var records = consumeRecordsByTopic(rowCount);
             assertThat(records.allRecordsInOrder()).hasSize(rowCount);
         }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogChunkedSnapshotIT.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.binlog;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -1106,7 +1106,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
         // todo: snapshot select overrides?
         return jdbcConnection.queryAndMap(
-                "SELECT COUNT(1) FROM %s".formatted(jdbcConnection.getQualifiedTableName(tableId)),
+                "SELECT COUNT(1) FROM %s".formatted(jdbcConnection.quotedTableIdString(tableId)),
                 rs -> rs.next() ? rs.getLong(1) : 0L);
     }
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -228,6 +228,7 @@ faihofu,Fai Ho Fu
 j2gg0s,Yanjie Wang
 REMY David,David Remy
 tyrantlucifer,Chao Tian
+ryandsouzaappfolio,Ryan D'Souza
 ryanvanhuuksloot,Ryan van Huuksloot
 vsantona,Vincenzo Santonastaso
 “vsantonastaso”,Vincenzo Santonastaso


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1988

## Description
When snapshot.max.threads > 1 and internal.legacy.snapshot.max.threads=false (the default chunked snapshot path), rowCountForTableChunked generates a COUNT query using getQualifiedTableName(), which returns an unquoted catalog.table string. MySQL database names that contain hyphens (e.g. "my-database") cause MySQL to interpret the hyphen as arithmetic subtraction, producing a SQLSyntaxErrorException and stopping the connector.

Fix: use quotedTableIdString() instead, which the binlog connector overrides to return `catalog`.`table` with backtick quoting.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ ] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
