### PR TITLE
debezium/dbz#1869 Add credentials.json to PASSWORD_PATTERN for log masking

### DIFF
--- a/debezium-config/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-config/src/main/java/io/debezium/config/Configuration.java
@@ -64,7 +64,7 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
+    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
             Pattern.CASE_INSENSITIVE);
 
     String CUSTOM_SANITIZE_PATTERN_KEY = "custom.sanitize.pattern";

--- a/debezium-config/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-config/src/main/java/io/debezium/config/Configuration.java
@@ -64,7 +64,8 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
+    Pattern PASSWORD_PATTERN = Pattern.compile(
+            ".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
             Pattern.CASE_INSENSITIVE);
 
     String CUSTOM_SANITIZE_PATTERN_KEY = "custom.sanitize.pattern";


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1869

## Description

Add `.*credentials\.json$` to `PASSWORD_PATTERN` in `Configuration.java` so that config keys ending in `credentials.json` (e.g., `gcp.spanner.credentials.json`) are masked when configurations are logged through Debezium's `Configuration` class.

Currently, `PASSWORD_PATTERN` matches keys ending in `secret`, `password`, `sasl.jaas.config`, `basic.auth.user.info`, and `registry.auth.client-secret`, but does not cover credential JSON keys - allowing them to be printed in plaintext in logs.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
