### PR TITLE
debezium/dbz#1995 Don't commit during snapshot

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
@@ -223,7 +223,7 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
             // Choose how we create statements based on the # of rows.
             // This is approximate and less accurate then COUNT(*),
             // but far more efficient for large InnoDB tables.
-            execute("USE `" + tableId.catalog() + "`;");
+            executeWithoutCommitting("USE `" + tableId.catalog() + "`;");
             return queryAndMap("SHOW TABLE STATUS LIKE '" + tableId.table() + "';", rs -> {
                 if (rs.next()) {
                     return OptionalLong.of((rs.getLong(5)));


### PR DESCRIPTION
Commit during snapshot would finish current transaction and thus may lead to inconsistent snapshot.

Previous change was done due to
https://github.com/debezium/dbz/issues/1977 but other changes in original fix, namely disabling autocommit, should be sufficient to mitigate dbz#1977.

Fixes debezium/dbz#1995

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
