### PR TITLE
debezium/dbz#1850 Add YashanDB connector documentation

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -81,6 +81,7 @@ asciidoc:
     link-informix-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-informix&v=LATEST&c=plugin&e=tar.gz'
     link-cockroachdb-connector: 'connectors/cockroachdb.adoc'
     link-cockroachdb-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-cockroachdb&v=LATEST&c=plugin&e=tar.gz'
+    link-yashandb-plugin-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-yashandb&v=LATEST&c=plugin&e=tar.gz'
     link-server-snapshot: 'https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-server-dist&v=LATEST&e=tar.gz'
     link-kafka-docs: 'https://kafka.apache.org/documentation'
     link-java7-standard-names: 'https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest'

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -26,6 +26,7 @@
 ** xref:connectors/spanner.adoc[Spanner]
 ** xref:connectors/informix.adoc[Informix]
 ** xref:connectors/cockroachdb.adoc[CockroachDB]
+** xref:connectors/yashandb.adoc[YashanDB]
 * Sink Connectors
 ** xref:connectors/index-sink.adoc[Overview]
 ** xref:connectors/jdbc.adoc[JDBC]

--- a/documentation/modules/ROOT/pages/connectors/yashandb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/yashandb.adoc
@@ -1,0 +1,2087 @@
+[id="debezium-connector-for-yashandb"]
+= {prodname} Connector for YashanDB
+
+:context: yashandb
+:data-collection: table
+:database-port: 1688
+:mbean-name: {context}
+:connector-class: YashanDb
+:connector-file: {context}
+:connector-name: YashanDB
+:include-list-example: inventory.customers
+:collection-container: database.schema
+
+:toc:
+:toc-placement: macro
+:linkattrs:
+:icons: font
+
+toc::[]
+
+[[yashandb-overview]]
+== Overview
+
+YashanDB is a next-generation database management system independently developed by the Shenzhen Institute of Computing Sciences.
+Based on classical database theory, it integrates original computing paradigms including bounded computation, approximate computation, parallel scalability, and cross-modal fusion computing.
+This enables YashanDB to meet the demanding requirements of core industries such as finance, government, and energy for high performance, high concurrency, and high security.
+
+The {prodname} YashanDB connector captures and records row-level changes that occur in databases on a YashanDB server, including tables that are added while the connector is running.
+You can configure the connector to emit change events for specific subsets of schemas and tables, synchronizing the change events to Kafka.
+
+For information about the YashanDB versions that are compatible with this connector, see the {prodname} release overview.
+
+{prodname} can ingest change events from YashanDB by using the native YStream database package.
+For more information about YashanDB and YStream, see the https://www.yashandb.com/[YashanDB website^].
+
+[[how-the-debezium-yashandb-connector-works]]
+== How the {prodname} YashanDB connector works
+
+To optimally configure and run a {prodname} YashanDB connector, it is helpful to understand how the connector works.
+
+[[yashandb-ystream-mechanism]]
+=== YStream Mechanism
+
+The {prodname} YashanDB connector uses the YashanDB YStream interface to capture changes from the database transaction logs.
+YStream is the native Change Data Capture (CDC) engine in YashanDB.
+
+The YashanDB connector works as follows:
+
+1. The connector connects to the YashanDB database via JDBC.
+2. The connector establishes a connection to the specified YStream service and uses the YStream client API to obtain committed transaction data in real time.
+3. The connector first performs an initial snapshot, capturing the current state of the specified tables.
+4. After the snapshot completes, the connector switches to streaming mode and continuously captures incremental data changes through YStream.
+
+[[yashandb-snapshots]]
+=== Snapshots
+
+The redo logs on a YashanDB server are typically configured to not retain the complete history of the database.
+As a result, the {prodname} YashanDB connector cannot retrieve the entire history of the database from the logs.
+To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
+
+[[yashandb-snapshot-mode-options]]
+.Settings for `snapshot.mode` connector configuration property
+[cols="30%a,70%a",options="header"]
+|===
+|Setting |Description
+
+|`always`
+|Perform a snapshot on each connector start.
+After the snapshot completes, the connector begins to stream event records for subsequent database changes.
+
+|`initial`
+|The connector performs a database snapshot.
+After the snapshot completes, the connector begins to stream event records for subsequent database changes.
+
+|`initial_only`
+|The connector performs a database snapshot and stops before streaming any change event records.
+The connector does not capture any change events that occur after the snapshot.
+
+|`no_data`
+|The connector captures the structure of all relevant tables, performing all of the steps described in the default snapshot workflow, except that it does not create `READ` events to represent the data set at the point of the connector's start-up.
+
+|`recovery`
+|Set this option to restore a database schema history topic that is lost or corrupted.
+After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.
+
+|`when_needed`
+|After the connector starts, it performs a snapshot only if it detects one of the following circumstances:
+
+* It cannot detect any topic offsets.
+* A previously recorded offset specifies a log position that is not available on the server.
+
+|===
+[[yashandb-custom-snapshotter-spi]]
+=== Custom snapshotter SPI
+
+include::{partialsdir}/modules/all-connectors/custom-snapshotter-spi.adoc[leveloffset=+3]
+
+For more information, see xref:yashandb-property-snapshot-mode[`snapshot.mode`] in the table of connector configuration properties.
+
+[[yashandb-topic-names]]
+=== Topic names
+
+By default, the YashanDB connector writes change events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic that is specific to that table.
+The connector uses the following convention to name change event topics:
+
+_topicPrefix.schemaName.tableName_
+
+The following list provides definitions for the components of the default name:
+
+_topicPrefix_:: The topic prefix as specified by the xref:yashandb-property-topic-prefix[`topic.prefix`] connector configuration property.
+
+_schemaName_:: The name of the schema in which the operation occurred.
+
+_tableName_:: The name of the table in which the operation occurred.
+
+For example, if `fulfillment` is the server name, `inventory` is the schema name, and the database contains tables with the names `orders`, `customers`, and `products`, the {prodname} YashanDB connector emits events to the following Kafka topics, one for each table in the database:
+
+----
+fulfillment.inventory.orders
+fulfillment.inventory.customers
+fulfillment.inventory.products
+----
+
+The connector applies similar naming conventions to label its internal database schema history topics, xref:yashandb-schema-change-topic[schema change topics], and xref:yashandb-transaction-metadata[transaction metadata topics].
+
+If the default topic name does not meet your requirements, you can configure custom topic names.
+To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+
+[[yashandb-schema-history-topic]]
+=== Schema history topic
+
+When a database client queries a database, the client uses the database's current schema.
+However, the database schema can change at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
+Also, a connector cannot necessarily apply the current schema to every event.
+If an event is relatively old, it's possible that it was recorded before the current schema was applied.
+
+To ensure correct processing of events that occur after a schema change, YashanDB includes in the log not only the row-level changes that affect the data, but also the DDL statements that are applied to the database.
+As the connector encounters these DDL statements in the log, it parses them and updates an in-memory representation of each table's schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database schema history Kafka topic, the connector records all DDL statements along with the position in the log where each DDL statement appeared.
+
+When the connector restarts after either a crash or a graceful stop, it starts reading the log from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database schema history Kafka topic and parsing all DDL statements up to the point in the log where the connector is starting.
+
+This database schema history topic is for internal connector use only.
+Optionally, the connector can also xref:yashandb-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+
+[[yashandb-schema-change-topic]]
+=== Schema change topic
+
+You can configure a {prodname} YashanDB connector to produce schema change events that describe structural changes that are applied to tables in the database.
+The connector writes schema change events to a Kafka topic named `_<serverName>_`, where `_serverName_` is the namespace that is specified in the xref:yashandb-property-topic-prefix[`topic.prefix`] configuration property.
+
+{prodname} emits a new message to the schema change topic whenever it streams data from a new table, or when the structure of the table is altered.
+
+Messages that the connector sends to the schema change topic contain a payload, and, optionally, also contain the schema of the change event message.
+
+The schema for the schema change event has the following elements:
+
+`name`:: The name of the schema change event message.
+`type`:: The type of the change event message.
+`version`:: The version of the schema.
+The version is an integer that is incremented each time the schema is changed.
+`fields`:: The fields that are included in the change event message.
+
+.Example: Schema of the YashanDB connector schema change topic
+The following example shows a typical schema in JSON format.
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "databaseName"
+      }
+    ],
+    "optional": false,
+    "name": "io.debezium.connector.yashandb.SchemaChangeKey",
+    "version": 1
+  },
+  "payload": {
+    "databaseName": "inventory"
+  }
+}
+----
+
+The payload of a schema change event message includes the following elements:
+
+`ddl`:: Provides the SQL `CREATE`, `ALTER`, or `DROP` statement that results in the schema change.
+`databaseName`:: The name of the database to which the statements are applied.
+The value of `databaseName` serves as the message key.
+`schemaName`:: The name of the schema to which the statements are applied.
+`tableChanges`:: A structured representation of the entire table schema after the schema change.
+The `tableChanges` field contains an array that includes entries for each column of the table.
+Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
+
+[IMPORTANT]
+====
+When the connector is configured to capture a table, it stores the history of the table's schema changes not only in the schema change topic, but also in an internal database schema history topic.
+The internal database schema history topic is for connector use only and it is not intended for direct use by consuming applications.
+Ensure that applications that require notifications about schema changes consume that information only from the schema change topic.
+====
+
+[IMPORTANT]
+====
+Never partition the database schema history topic.
+For the database schema history topic to function correctly, it must maintain a consistent, global order of the event records that the connector emits to it.
+
+To ensure that the topic is not split among partitions, set the partition count for the topic by using one of the following methods:
+
+* If you create the database schema history topic manually, specify a partition count of `1`.
+* If you use the Apache Kafka broker to create the database schema history topic automatically, the topic is created, set the value of link:{link-kafka-docs}/#brokerconfigs_num.partitions[Kafka `num.partitions`] configuration option to `1`.
+====
+
+
+.Example: Message emitted to the YashanDB connector schema change topic
+The following example shows a typical schema change message in JSON format.
+The message contains a logical representation of the table schema.
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+  "schema": {
+  ...
+  },
+  "payload": {
+    "source": {
+      "version": "{debezium-version}",
+      "connector": "yashandb",
+      "name": "server1",
+      "ts_ms": 1780017300692,
+      "snapshot": "false",
+      "db": "",
+      "sequence": null,
+      "ts_us": 1780017300692853,
+      "ts_ns": 1780017300692853000,
+      "schema": "DEBEZIUM",
+      "table": "CUSTOMERS",
+      "txId": "131072047",
+      "scn": "828249295637925888",
+      "batch_row_id": 0,
+      "position_scn": 828249295637925888,
+      "group_lsn": 3692924,
+      "group_offset": 220,
+      "instance_id": "0"
+    },
+    "ts_ms": 1780045807728, // <1>
+    "databaseName": "inventory", // <2>
+    "schemaName": "DEBEZIUM", // <3>
+    "ddl": "CREATE TABLE \"DEBEZIUM\".\"CUSTOMERS\" \n   (    \"ID\" NUMBER(9,0) NOT NULL ENABLE, \n    \"NAME\" VARCHAR2(255) \n   )", // <4>
+    "tableChanges": [ // <5>
+      {
+        "type": "CREATE", // <6>
+        "id": "\"DEBEZIUM\".\"CUSTOMERS\"", // <7>
+        "table": { // <8>
+          "defaultCharsetName": null,
+          "primaryKeyColumnNames": [ // <9>
+            "ID"
+          ],
+          "columns": [ // <10>
+            {
+              "name": "ID",
+              "jdbcType": 2,
+              "nativeType": null,
+              "typeName": "NUMBER",
+              "typeExpression": "NUMBER",
+              "charsetName": null,
+              "length": 9,
+              "scale": 0,
+              "position": 1,
+              "optional": false,
+              "autoIncremented": false,
+              "generated": false
+            },
+            {
+              "name": "NAME",
+              "jdbcType": 12,
+              "nativeType": null,
+              "typeName": "VARCHAR2",
+              "typeExpression": "VARCHAR2",
+              "charsetName": null,
+              "length": 255,
+              "scale": null,
+              "position": 2,
+              "optional": true,
+              "autoIncremented": false,
+              "generated": false
+            }
+          ],
+          "attributes": [ // <11>
+            {
+              "customAttribute": "attributeValue"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+----
+
+.Descriptions of fields in messages emitted to the schema change topic
+[cols="1,4,5",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`ts_ms`
+|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|2
+|`databaseName`
+|Identifies the database that contains the change.
+
+|3
+|`schemaName`
+|Identifies the schema that contains the change.
+
+|4
+|`ddl`
+|This field contains the DDL that is responsible for the schema change.
+
+|5
+|`tableChanges`
+|An array of one or more items that contain the schema changes generated by a DDL command.
+
+|6
+|`type`
+a|Describes the kind of change.
+The `type` can be set to one of the following values:
+
+`CREATE`:: Table created.
+`ALTER`:: Table modified.
+`DROP`:: Table deleted.
+
+|7
+|`id`
+|Full identifier of the table that was created, altered, or dropped.
+In the case of a table rename, this identifier is a concatenation of `_<old>_,_<new>_` table names.
+
+|8
+|`table`
+|Represents table metadata after the applied change.
+
+|9
+|`primaryKeyColumnNames`
+|List of columns that compose the table's primary key.
+
+|10
+|`columns`
+|Metadata for each column in the changed table.
+
+|11
+|`attributes`
+|Custom attribute metadata for each table change.
+
+|===
+
+In messages that the connector sends to the schema change topic, the message key is the name of the database that contains the schema change.
+In the following example, the `payload` field contains the `databaseName` key:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "databaseName"
+      }
+    ],
+    "optional": false,
+    "name": "io.debezium.connector.yashandb.SchemaChangeKey",
+    "version": 1
+  },
+  "payload": {
+    "databaseName": "inventory"
+  }
+}
+----
+
+[[yashandb-transaction-metadata]]
+=== Transaction metadata
+
+{prodname} can generate events that represent transaction metadata boundaries and that enrich data change event messages.
+
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
+Database transactions are represented by a statement block that is enclosed between the `BEGIN` and `END` keywords.
+{prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
+Transaction boundary events contain the following fields:
+
+`status`:: `BEGIN` or `END`.
+`id`:: String representation of the unique transaction identifier.
+`ts_ms`:: The time of a transaction boundary event (`BEGIN` or `END` event) at the data source.
+`event_count` (for `END` events):: Total number of events emitted by the transaction.
+`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` elements that indicates the number of events that the connector emits for changes that originate from a data collection.
+
+The following example shows a typical transaction boundary message:
+
+.Example: YashanDB connector transaction boundary event
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+  "status": "BEGIN",
+  "id": "5.6.641",
+  "ts_ms": 1486500577125,
+  "event_count": null,
+  "data_collections": null
+}
+
+{
+  "status": "END",
+  "id": "5.6.641",
+  "ts_ms": 1486500577691,
+  "event_count": 2,
+  "data_collections": [
+    {
+      "data_collection": "inventory.DEBEZIUM.CUSTOMERS",
+      "event_count": 1
+    },
+    {
+      "data_collection": "inventory.DEBEZIUM.ORDERS",
+      "event_count": 1
+    }
+  ]
+}
+----
+
+[[yashandb-events]]
+== Data change events
+
+Every data change event that the YashanDB connector emits has a key and a value.
+The structures of the key and value depend on the table from which the change events originate.
+For information about how {prodname} constructs topic names, see xref:yashandb-topic-names[Topic names].
+
+[WARNING]
+====
+The {prodname} YashanDB connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names].
+To qualify as a valid Avro schema name, the logical server name must start with an alphabetic character or an underscore ([a-z,A-Z,\_]).
+The remaining characters in the logical server name, and all characters in the schema and table names, must be alphanumeric characters or underscores ([a-z,A-Z,0-9,\_]).
+The connector automatically replaces invalid characters with an underscore character.
+
+Unexpected naming conflicts can result when the only distinguishing characters between multiple logical server names, schema names, or table names are not valid characters, and those characters are replaced with underscores.
+====
+
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_.
+However, the structure of these events might change over time, which can be difficult for topic consumers to handle.
+To facilitate the processing of mutable event structures, each event in Kafka Connect is self-contained.
+Every message key and value has two parts: a _schema_ and _payload_.
+The schema describes the structure of the payload, while the payload contains the actual data.
+
+[[yashandb-change-event-keys]]
+=== Change event keys
+
+For each changed table, the change event key is structured such that a field exists for each column in the primary key (or unique key constraint) of the table at the time when the event is created.
+
+For example, consider the following SQL for a `customers` table that is defined in the `inventory` database schema:
+
+[source,sql,indent=0]
+----
+CREATE TABLE customers (
+  ID INT NOT NULL PRIMARY KEY,
+  NAME VARCHAR(255)
+);
+----
+
+If the value of the xref:yashandb-property-topic-prefix[`_<topic.prefix>_`]`.transaction` configuration property is set to `server1`,
+the JSON representation for every change event that occurs in the `customers` table in the database features the following key structure:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": {
+        "type": "struct",
+        "fields": [
+            {
+                "type": "int32",
+                "optional": false,
+                "field": "ID"
+            }
+        ],
+        "optional": false,
+        "name": "server1.inventory.customers.Key"
+    },
+    "payload": {
+        "ID": 1001
+    }
+}
+----
+
+The `schema` portion of the key contains a Kafka Connect schema that describes the content of the key portion.
+In the preceding example, the `payload` value is not optional, the structure is defined by a schema named `server1.inventory.customers.Key`, and there is one required field named `ID` of type `int32`.
+The value of the key's `payload` field indicates that it is indeed a structure (which in JSON is just an object) with a single `ID` field, whose value is `1001`.
+
+Therefore, you can interpret this key as describing the row in the `inventory.customers` table (output from the connector named `server1`) whose `ID` primary key column had a value of `1001`.
+
+[[yashandb-change-event-values]]
+=== Change event values
+
+The structure of a value in a change event message mirrors the structure of the xref:yashandb-change-event-keys[message key in the change event] in the message, and contains both a _schema_ section and a _payload_ section.
+
+.Payload of a change event value
+An _envelope_ structure in the payload sections of a change event value contains the following fields:
+
+`op`:: A mandatory field that contains a string value describing the type of operation.
+The `op` field in the payload of a YashanDB connector change event value contains one of the following values: `c` (create or insert), `u` (update), `d` (delete), or `r` (read, which indicates a snapshot).
+`before`:: An optional field that, if present, describes the state of the row _before_ the event occurred.
+The structure is described by the `server1.inventory.customers.Value` Kafka Connect schema, which the `server1` connector uses for all rows in the `inventory.customers` table.
+`after`:: An optional field that, if present, contains the state of a row _after_ a change occurs.
+The structure is described by the same `server1.inventory.customers.Value` Kafka Connect schema that is used for the `before` field.
+`source`:: A mandatory field that contains a structure that describes the source metadata for the event.
+In the case of the YashanDB connector, the structure includes the following fields:
++
+* The {prodname} version.
+* The connector type and name.
+* Timestamps (`ts_ms`, `ts_us`, `ts_ns`) that represent when the connector processed the event, based on the system clock of the JVM running the Kafka Connect task.
+  For snapshots, the timestamp indicates when the snapshot occurred.
+* Whether the event is part of an ongoing snapshot or not.
+* Database and schema names.
+* Table name.
+* The transaction ID (`txId`), not included for snapshots.
+* Row sequence number within a batch operation such as batch insert (`batch_row_id`).
+* Commit SCN of the transaction to which the logical log entry belongs (`position_scn`).
+* SCN of the log group to which the logical log entry belongs (`group_lsn`).
+* Physical offset of the logical log entry within its log group (`group_offset`).
+* Instance identifier of the instance to which the transaction belongs (`instance_id`).
+`ts_ms`:: Provides the timestamp in milliseconds.
+`ts_us`:: Provides the timestamp in microseconds.
+`ts_ns`:: Provides the timestamp in nanoseconds.
+
+.Schema of a change event value
+The _schema_ portion of the event message's value contains a schema that describes the envelope structure of the payload and the nested fields within it.
+
+[[yashandb-create-events]]
+=== _create_ events
+
+The following example shows the value of a _create_ event value from the `customers` table that is described in the xref:yashandb-change-event-keys[change event keys] example:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": {
+        "type": "struct",
+        "fields": [
+            {
+                "type": "struct",
+                "fields": [
+                    {
+                        "type": "int32",
+                        "optional": false,
+                        "field": "ID"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "NAME"
+                    }
+                ],
+                "optional": true,
+                "name": "server1.inventory.customers.Value",
+                "field": "before"
+            },
+            {
+                "type": "struct",
+                "fields": [
+                    {
+                        "type": "int32",
+                        "optional": false,
+                        "field": "ID"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "NAME"
+                    }
+                ],
+                "optional": true,
+                "name": "server1.inventory.customers.Value",
+                "field": "after"
+            },
+            {
+                "type": "struct",
+                "fields": [
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "version"
+                    },
+                    {
+                        "type": "string",
+                        "optional": false,
+                        "field": "connector"
+                    },
+                    {
+                        "type": "string",
+                        "optional": false,
+                        "field": "name"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "ts_ms"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "snapshot"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "db"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "sequence"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "ts_us"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "ts_ns"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "schema"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "table"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "txId"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "batch_row_id"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "position_scn"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "group_lsn"
+                    },
+                    {
+                        "type": "int64",
+                        "optional": true,
+                        "field": "group_offset"
+                    },
+                    {
+                        "type": "string",
+                        "optional": true,
+                        "field": "instance_id"
+                    }
+                ],
+                "optional": false,
+                "name": "io.debezium.connector.yashandb.Source",
+                "field": "source"
+            },
+            {
+                "type": "string",
+                "optional": false,
+                "field": "op"
+            },
+            {
+                "type": "int64",
+                "optional": true,
+                "field": "ts_ms"
+            },
+            {
+                "type": "int64",
+                "optional": true,
+                "field": "ts_us"
+            },
+            {
+                "type": "int64",
+                "optional": true,
+                "field": "ts_ns"
+            }
+        ],
+        "optional": false,
+        "name": "server1.inventory.customers.Envelope"
+    },
+    "payload": {
+        "before": null,
+        "after": {
+            "ID": 1001,
+            "NAME": "Test Record"
+        },
+        "source": {
+            "version": "{debezium-version}",
+            "connector": "yashandb",
+            "name": "server1",
+            "ts_ms": 1780017300692,
+            "snapshot": "false",
+            "db": "",
+            "sequence": null,
+            "ts_us": 1780017300692853,
+            "ts_ns": 1780017300692853000,
+            "schema": "DEBEZIUM",
+            "table": "CUSTOMERS",
+            "txId": "131072047",
+            "batch_row_id": 0,
+            "position_scn": 828249295637925888,
+            "group_lsn": 3692924,
+            "group_offset": 220,
+            "instance_id": "0"
+        },
+        "op": "c",
+        "ts_ms": 1688252618953,
+        "ts_us": 1688252618953000,
+        "ts_ns": 1688252618953000000
+    }
+}
+----
+
+The following list describes select fields in the value portion of the preceding `create` event message:
+
+`schema`::
+Specifies the schema of the event value.
+The schema describes the structure of the value's payload.
+Every change event that {prodname} emits for a table uses the same value schema, as long as the table schema remains unchanged.
+
+`name`::
+The `schema` section can contain multiple `name` fields.
+Each `name` field specifies the schema for a field in the payload of the event value.
++
+`server1.inventory.customers.Value` is the schema for the payload's `before` and `after` fields.
+This schema is specific to the `customers` table.
++
+The schema names of the `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`.
+This format ensures that schema names are unique within the database.
+In environments that use the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], having unique schema names ensures that the Avro schema for each table in each logical source has its own evolution and history.
+
+`"name": "io.debezium.connector.yashandb.Source"`::
+`io.debezium.connector.yashandb.Source` is the schema for the payload's `source` field.
+This schema is specific to the YashanDB connector.
+The connector uses it for all events that it generates.
+
+`"name": "server1.inventory.customers.Envelope"`::
+Specifies the name of the schema for the overall structure of the payload.
+The schema name is made up of the following elements:
++
+`server1`::: Specifies the name of the connector that generated this event.
+`inventory`::: Specifies the database that contains the table that was changed.
+`customers`::: Specifies the table that was changed.
+
+`payload`::
+Specifies the actual data for the row that was changed.
++
+Because the JSON representation of an event includes both the schema and the payload portions of the message, it is often larger than the row that it describes.
+To reduce the size of the messages that the connector streams to Kafka topics, you can use the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter].
+
+`op`::
+Specifies the type of operation that caused the connector to generate the event.
+In this example, `c` indicates that a `create` operation was performed resulting in a new row.
+This field can contain one of the following values:
++
+[horizontal]
+`c`::: Create a row.
+`u`::: Update a row.
+`d`::: Delete a row.
+`r`::: Read a row (applies to only snapshots).
+
+`ts_ms`, `ts_us`, `ts_ns`::
+Displays timestamps in milliseconds, microseconds, and nanoseconds that indicate when the connector processed the event.
+The time is based on the system clock in the JVM that runs the Kafka Connect task.
+
+`before`::
+An optional field that specifies the state of the row before the event occurred.
+Because the `op` field in the preceding example is `c` (create), this change event describes new data, so the value of the `before` field is `null`.
+
+`after`::
+An optional field that specifies the state of the row after the event occurred.
+In this example, the `after` field contains the values of the new row's `ID` and `NAME` columns.
+
+`source`::
+Mandatory field that describes the source metadata for the event.
+This field contains information that you can use to compare this event to other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction.
+The source metadata provides the following information:
++
+`version`::: {prodname} version.
+`connector`::: The type of connector.
+`name`::: Connector name.
+`ts_ms`, `ts_us`, `ts_ns`::: Displays timestamps in milliseconds, microseconds, and nanoseconds that indicate when the change was made in the database.
+`snapshot`::: Specifies whether the event resulted from a snapshot operation.
+`db`::: Name of the database that contains the new row.
+`schema`::: Name of the schema that contains the new row.
+`table`::: Name of the table that contains the new row.
+`txId`::: Transaction identifier.
+`batch_row_id`::: Row sequence number within a batch operation such as batch insert.
+`position_scn`::: Commit SCN of the transaction to which the logical log entry belongs.
+`group_lsn`::: SCN of the log group to which the logical log entry belongs.
+`group_offset`::: Physical offset of the logical log entry within its log group.
+`instance_id`::: Instance identifier of the instance to which the transaction belongs.
+
+[[yashandb-update-events]]
+=== _update_ events
+
+The following example shows an _update_ change event that the connector captures from the same table as the preceding _create_ event.
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": {
+            "ID": 1001,
+            "NAME": "Test Record"
+        },
+        "after": {
+            "ID": 1001,
+            "NAME": "Updated Record"
+        },
+        "source": {
+            "version": "{debezium-version}",
+            "connector": "yashandb",
+            "name": "server1",
+            "ts_ms": 1780017300692,
+            "snapshot": "false",
+            "db": "",
+            "sequence": null,
+            "ts_us": 1780017300692853,
+            "ts_ns": 1780017300692853000,
+            "schema": "DEBEZIUM",
+            "table": "CUSTOMERS",
+            "txId": "131072047",
+            "batch_row_id": 0,
+            "position_scn": 828249295637925888,
+            "group_lsn": 3692924,
+            "group_offset": 220,
+            "instance_id": "0"
+        },
+        "op": "u",
+        "ts_ms": 1688252619000,
+        "ts_us": 1688252619000000,
+        "ts_ns": 1688252619000000000
+    }
+}
+----
+
+The payload has the same structure as the payload of a _create_ (insert) event, but the following values are different:
+
+* The value of the `op` field is `u`, signifying that this row changed because of an update.
+* The `before` field shows the former state of the row with the values that were present before the update database commit.
+* The `after` field shows the updated state of the row, with the `NAME` value now set to `Updated Record`.
+* The structure of the `source` field includes the same fields as before, but the values are different, because the connector captured the event from a different position in the log.
+* The `ts_ms` field shows the timestamp that indicates when {prodname} processed the event.
+
+The `payload` section reveals several other useful pieces of information.
+For example, by comparing the `before` and `after` structures, we can determine how a row changed as the result of a commit.
+The `source` structure provides information about YashanDB's record of this change, providing traceability.
+It also gives us insight into when this event occurred in relation to other events in this topic and in other topics.
+Did it occur before, after, or as part of the same commit as another event?
+
+[[yashandb-delete-events]]
+=== _delete_ events
+
+The following example shows a _delete_ event for the table that is shown in the preceding _create_ and _update_ event examples.
+The `schema` portion of the _delete_ event is identical to the `schema` portion for those events.
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": {
+            "ID": 1001,
+            "NAME": "Updated Record"
+        },
+        "after": null,
+        "source": {
+            "version": "{debezium-version}",
+            "connector": "yashandb",
+            "name": "server1",
+            "ts_ms": 1780017300692,
+            "snapshot": "false",
+            "db": "",
+            "sequence": null,
+            "ts_us": 1780017300692853,
+            "ts_ns": 1780017300692853000,
+            "schema": "DEBEZIUM",
+            "table": "CUSTOMERS",
+            "txId": "131072047",
+            "batch_row_id": 0,
+            "position_scn": 828249295637925888,
+            "group_lsn": 3692924,
+            "group_offset": 220,
+            "instance_id": "0"
+        },
+        "op": "d",
+        "ts_ms": 1688252620000,
+        "ts_us": 1688252620000000,
+        "ts_ns": 1688252620000000000
+    }
+}
+----
+
+The payload shows a row with the same key as the preceding _create_ and _update_ events, but contains different values:
+
+* The `op` field is `d`, signifying that this row was deleted.
+* The `before` field contains the values that were present in the row before it was deleted with the database commit.
+* The `after` field is `null`, indicating that the row no longer exists.
+* The `source` field has the same structure as the `source` field in _create_ events, but some field values are different.
+* The `ts_ms` shows a timestamp that indicates when {prodname} processed this event.
+
+The _delete_ event provides consumers with the information that they require to process the removal of this row.
+
+The YashanDB connector's events are designed to work with https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction[Kafka log compaction],
+which allows for the removal of some older messages as long as at least the most recent message for every key is kept.
+This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
+
+When a row is deleted, the _delete_ event value shown in the preceding example still works with log compaction, because Kafka is able to remove all earlier messages that use the same key.
+The message value must be set to `null` to instruct Kafka to remove _all messages_ that share the same key.
+To make this possible, by default, the {prodname} YashanDB connector always follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
+
+[[yashandb-truncate-events]]
+=== _truncate_ events
+
+A _truncate_ change event signals that a table has been truncated.
+The message key is `null` in this case, the message value looks like this:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": null,
+        "after": null,
+        "source": { // <1>
+            "version": "{debezium-version}",
+            "connector": "yashandb",
+            "name": "my_topic",
+            "ts_ms": 1780017300692,
+            "snapshot": "false",
+            "db": "",
+            "sequence": null,
+            "ts_us": 1780017300692853,
+            "ts_ns": 1780017300692853000,
+            "schema": "DEBEZIUM",
+            "table": "CUSTOMERS",
+            "txId": "131072047",
+            "batch_row_id": 0,
+            "position_scn": 828249295637925888,
+            "group_lsn": 3692924,
+            "group_offset": 220,
+            "instance_id": "0"
+        },
+        "op": "t", // <2>
+        "ts_ms": 1688252630000, // <3>
+        "ts_us": 1688252630000000, // <3>
+        "ts_ns": 1688252630000000000 // <3>
+    }
+}
+----
+
+.Descriptions of _truncate_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`source`
+a|Mandatory field that describes the source metadata for the event. In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata:
+
+* {prodname} version
+* Connector type and name
+* Timestamps (`ts_ms`, `ts_us`, `ts_ns`) for when the change was made in the database
+* Whether the event is part of a snapshot (always `false` for _truncate_ events)
+* Database and schema that contains the table
+* Table name
+* Transaction identifier (`txId`)
+* Row sequence number within a batch operation such as batch insert (`batch_row_id`)
+* Commit SCN of the transaction to which the logical log entry belongs (`position_scn`)
+* SCN of the log group to which the logical log entry belongs (`group_lsn`)
+* Physical offset of the logical log entry within its log group (`group_offset`)
+* Instance identifier of the instance to which the transaction belongs (`instance_id`)
+
+|2
+|`op`
+a|Mandatory string that describes the type of operation.
+The `op` field value is `t`, signifying that this table was truncated.
+
+|3
+|`ts_ms`, `ts_us`, `ts_ns`
+a|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task. +
+
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|===
+
+If a single `TRUNCATE` operation affects multiple tables, the connector emits one _truncate_ change event record for each truncated table.
+
+[NOTE]
+====
+A _truncate_ event represents a change that is made to an entire table and it has no message key.
+As a result, for topics with multiple partitions, there is no ordering guarantee for the change events (_create_, _update_, and so forth), or _truncate_ events that pertain to a table.
+For example, if a consumer reads events for a table from multiple partitions, it might receive an _update_ event for a table from one partition after it receives a _truncate_ event that deletes all of the data in the table from another partition.
+Ordering is guaranteed only for topics that use a single partition.
+====
+
+If you do not want the connector to capture _truncate_ events, set the xref:yashandb-property-skipped-operations[`skipped.operations`] option to filter them out.
+
+[[yashandb-data-types]]
+== Data type mapping
+
+When the {prodname} YashanDB connector detects that a value in a table row has changed, it emits a change event that represents that change.
+Each change event record has the same structure as the original table, and the event record contains a field for each column value.
+The data type of the table column determines how the connector represents the column's value in the change event field.
+
+For each column in the table, {prodname} maps the source data type to a literal type.
+
+Literal types describe how {prodname} represents values literally, using one of the following Kafka Connect schema types: `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, `STRUCT`.
+
+[NOTE]
+====
+If a column is not mapped, the connector ignores changes to the column.
+The connector maps all other columns in the table and generates change events for those columns.
+If a column is not mapped, it is not included in the change event.
+====
+
+[id="yashandb-character-types"]
+=== Character types
+
+The following table describes how the connector maps character data types.
+
+.Mappings for YashanDB character types
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|YashanDB data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`CHAR[(M)]`
+|`STRING`
+|n/a
+
+|`NCHAR[(M)]`
+|`STRING`
+|n/a
+
+|`VARCHAR[(M)]`
+|`STRING`
+|n/a
+
+|`NVARCHAR[(M)]`
+|`STRING`
+|n/a
+
+|===
+
+[id="yashandb-binary-character-lob-types"]
+=== Binary and Character LOB types
+
+The following table describes how the connector maps binary and character large object (LOB) data types.
+
+.Mappings for YashanDB binary and character LOB types
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|YashanDB data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`BLOB`
+|`BYTES`
+|Depending on the setting of the xref:yashandb-property-lob-enabled[`lob.enabled`] property in the connector configuration, the connector maps LOB values of this type to raw bytes or a base64-encoded string.
+
+|`CLOB`
+|`STRING`
+|n/a
+
+|`NCLOB`
+|`STRING`
+|n/a
+
+|`RAW`
+|`BYTES`
+|Depending on the setting of the xref:yashandb-property-lob-enabled[`lob.enabled`] property in the connector configuration, the connector maps LOB values of this type to raw bytes or a base64-encoded string.
+
+|===
+
+[id="yashandb-numeric-types"]
+=== Numeric types
+
+The following table describes how the connector maps numeric data types.
+
+.Mappings for YashanDB numeric types
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|YashanDB data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`TINYINT`
+|`INT8`
+|n/a
+
+|`SMALLINT`
+|`INT16`
+|n/a
+
+|`INT`
+|`INT32`
+|n/a
+
+|`BIGINT`
+|`INT64`
+|n/a
+
+|`FLOAT`
+|`FLOAT32`
+|n/a
+
+|`DOUBLE`
+|`FLOAT64`
+|n/a
+
+|`NUMBER`
+|`BYTES` / `INT8` / `INT16` / `INT32` / `INT64`
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+Depending on the value of the xref:yashandb-property-decimal-handling-mode[`decimal.handling.mode`] property, the connector maps `NUMBER` to a `BYTES` representation, or one of the `INT` types.
+For `NUMBER` with a negative scale, use `decimal.handling.mode=string` to avoid serialization issues.
+
+|`BIT(1)`
+|`BOOLEAN`
+|n/a
+
+|`BIT(n)`
+|`BYTES`
+|n/a
+
+|`BOOLEAN`
+|`BOOLEAN`
+|n/a
+
+|===
+
+[id="yashandb-temporal-types"]
+=== Temporal types
+
+The following table describes how the connector maps temporal data types.
+The way that the connector converts temporal types depends on the `time.precision.mode` configuration property.
+
+.Mappings for YashanDB temporal types when `time.precision.mode` is `connect`
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|YashanDB data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`DATE`
+|`INT64`
+|`io.debezium.time.Timestamp`
+
+Represents the number of milliseconds since the UNIX epoch.
+
+|`TIME`
+|`INT64`
+|`io.debezium.time.MicroTime`
+
+Represents the number of microseconds past midnight.
+
+|`TIMESTAMP`
+|`INT64`
+|`io.debezium.time.MicroTimestamp`
+
+Represents the number of microseconds since the UNIX epoch.
+
+|`INTERVAL YEAR TO MONTH`
+|`FLOAT64`
+|`io.debezium.time.MicroDuration`
+
+Represents the number of months in the interval, expressed as years with decimal precision.
+
+|`INTERVAL DAY TO SECOND`
+|`FLOAT64`
+|`io.debezium.time.MicroDuration`
+
+Represents the number of microseconds in the interval.
+
+|===
+
+[id="yashandb-other-types"]
+=== Other types
+
+The following table describes how the connector maps other data types.
+
+.Mappings for YashanDB other types
+[cols="20%a,15%a,55%a",options="header"]
+|===
+|YashanDB data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`ROWID`
+|`STRING`
+|n/a
+
+|===
+
+[[yashandb-lob-handling]]
+=== LOB handling
+
+YashanDB only supplies column values for `CLOB`, `NCLOB`, and `BLOB` data types, as well as `VARCHAR`, `NVARCHAR`, and `RAW` data types with a size exceeding 32000, if they are explicitly set or changed in a SQL statement.
+For LOB columns that are not changed, the connector does not include the values of these columns in the change event.
+
+To capture LOB values and serialize them in change events, set the xref:yashandb-property-lob-enabled[`lob.enabled`] option to `true`.
+When LOB handling is enabled, the connector incurs some performance overhead when emitting LOB data.
+
+[[yashandb-decimal-handling]]
+=== Decimal handling
+
+You can modify the way that the connector maps `NUMBER` data types by changing the value of the connector's xref:yashandb-property-decimal-handling-mode[`decimal.handling.mode`] configuration property.
+
+When the property is set to its default value of `precise`, the connector maps these data types to the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type.
+
+When the property value is set to `double` or `string`, the connector uses alternate mappings.
+
+.Mappings for numeric data types
+[cols="25%a,25%a,25%a,25%a",options="header"]
+|===
+|YashanDB data type |`precise` |`double` |`string`
+
+|`NUMBER`
+|`org.apache.kafka.connect.data.Decimal`
+|`FLOAT64`
+|`STRING`
+
+|===
+
+DATE, TIME, and TIMESTAMP types are mapped to `INT64` (timestamp form) by default.
+If you want to map them to a fixed format string such as `yyyy-MM-dd HH:mm:ss.SSSSSS`, refer to the <<yashandb-custom-converters,Data type conversion>> section.
+
+[[yashandb-custom-converters]]
+=== Custom converters
+
+By default, the {prodname} YashanDB connector provides several `CustomConverter` implementations specific to YashanDB data types.
+These custom converters provide alternative mappings for specific data types based on the connector configuration.
+To add a `CustomConverter` to the connector, follow the instructions in the {link-prefix}:{link-custom-converters}#custom-converters.adoc[Custom Converters documentation].
+
+The {prodname} YashanDB connector provides the following custom converters:
+
+* xref:yashandb-custom-converters-timestamp-to-string[`TimestampToStringConverter`]
+* xref:yashandb-custom-converters-date-to-string[`DateToStringConverter`]
+* xref:yashandb-custom-converters-time-to-string[`TimeToStringConverter`]
+
+[[yashandb-custom-converters-timestamp-to-string]]
+=== `TimestampToStringConverter`
+
+The `TimestampToStringConverter` converts `TIMESTAMP` type data to a string in a customized format.
+
+.Converter configuration
+[cols="40%a,60%a",options="header"]
+|===
+|Property |Description
+
+|`yashandb_timestamp_formatter.type`
+|`io.debezium.connector.yashandb.converters.TimestampToStringConverter`
+
+|`yashandb_timestamp_formatter.format.datetime`
+|Date format, for example: `yyyy-MM-dd HH:mm:ss.SSSSSS`
+
+|===
+
+[[yashandb-custom-converters-date-to-string]]
+=== `DateToStringConverter`
+
+The `DateToStringConverter` converts `DATE` type data to a string in a customized format.
+
+.Converter configuration
+[cols="40%a,60%a",options="header"]
+|===
+|Property |Description
+
+|`yashandb_date_formatter.type`
+|`io.debezium.connector.yashandb.converters.DateToStringConverter`
+
+|`yashandb_date_formatter.format.date`
+|Date format, for example: `yyyy-MM-dd`
+
+|===
+
+[[yashandb-custom-converters-time-to-string]]
+=== `TimeToStringConverter`
+
+The `TimeToStringConverter` converts `TIME` type data to a string in a customized format.
+
+.Converter configuration
+[cols="40%a,60%a",options="header"]
+|===
+|Property |Description
+
+|`yashandb_time_formatter.type`
+|`io.debezium.connector.yashandb.converters.TimeToStringConverter`
+
+|`yashandb_time_formatter.format.time`
+|Time format, for example: `HH:mm:ss.SSSSSS`
+
+|===
+
+[[yashandb-custom-converters-usage-example]]
+=== Usage example
+
+Specify the following in the configuration:
+
+[source,properties,indent=0]
+----
+# Name two converters: yashandb_timestamp_formatter for TIMESTAMP, yashandb_date_formatter for DATE
+"converters": "yashandb_timestamp_formatter,yashandb_date_formatter"
+# Bind yashandb_timestamp_formatter to TimestampToStringConverter class
+"yashandb_timestamp_formatter.type": "io.debezium.connector.yashandb.converters.TimestampToStringConverter"
+# Format TIMESTAMP data as yyyy-MM-dd HH:mm:ss.SSSSSS
+"yashandb_timestamp_formatter.format.datetime": "yyyy-MM-dd HH:mm:ss.SSSSSS"
+# Bind yashandb_date_formatter to DateToStringConverter class
+"yashandb_date_formatter.type": "io.debezium.connector.yashandb.converters.DateToStringConverter"
+# Format DATE data as yyyy-MM-dd
+"yashandb_date_formatter.format.date": "yyyy-MM-dd"
+----
+
+
+[[setting-up-yashandb]]
+== Setting up YashanDB
+
+Before deploying and running the {prodname} YashanDB connector, adjust the YashanDB database configuration to ensure compatibility.
+
+[[yashandb-excluded-schemas]]
+=== Schemas excluded from capture
+
+When the {prodname} YashanDB connector captures tables, it automatically excludes tables from the following schemas:
+
+* `SYS`
+* `MDSYS`
+* `XA_SYS`
+
+To enable the connector to capture changes from a table, the table must use a schema that is not named in the preceding list.
+
+[[yashandb-ystream-pool]]
+=== Configure the YStream memory pool
+
+Incremental data depends on YStream to obtain committed data from YashanDB in real time.
+When you use YashanDB as the source for tasks that include incremental synchronization, you must first allocate a memory pool for YStream on YashanDB:
+
+[source,sql,indent=0]
+----
+ALTER SYSTEM SET STREAM_POOL_SIZE = '512M';
+----
+
+[CAUTION]
+====
+Failure to configure this parameter can cause the task to fail.
+This parameter is a global parameter.
+For more information, see the https://doc.yashandb.com/en/[YashanDB documentation].
+====
+
+[[yashandb-supplemental-logging]]
+=== Enable supplemental logging
+
+Reading incremental data changes requires supplemental logging to be enabled.
+
+==== Database-level supplemental logging
+
+To permit the connector to monitor all objects in the database, including new objects, enable database-level supplemental logging in YashanDB:
+
+[source,sql,indent=0]
+----
+ALTER DATABASE ADD SUPPLEMENTAL LOG TABLE TYPE (HEAP);
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+----
+
+==== Table-level supplemental logging
+
+If you want the connector to monitor only specific tables, enable table-level supplemental logging in YashanDB:
+
+[source,sql,indent=0]
+----
+ALTER TABLE tablename ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+----
+
+[CAUTION]
+====
+It is important to note that failing to enable supplemental logging, or enabling it incorrectly, can result in data loss or task failure.
+====
+
+[[yashandb-create-user]]
+=== Creating a user account for the connector
+
+For the {prodname} YashanDB connector to capture change events, it must run as a YashanDB user that has specific permissions.
+
+The YashanDB connector user requires the following permissions for normal operation:
+
+[source,sql,indent=0]
+----
+-- Create user
+CREATE USER username IDENTIFIED BY password;
+
+-- Session permissions
+GRANT CREATE SESSION TO username;
+GRANT ALTER SESSION TO username;
+
+-- Debezium specific permissions
+GRANT SELECT ANY TABLE TO username;
+GRANT LOCK ANY TABLE TO username;
+GRANT FLASHBACK ANY TABLE TO username;
+GRANT SELECT ON V_$DATABASE TO username;
+GRANT SELECT ON V_$TRANSACTION TO username;
+GRANT SELECT ON V_$YSTREAM_SERVER TO username;
+
+-- YStream permissions
+GRANT YSTREAM_CAPTURE TO username;
+----
+
+[[yashandb-ystream-service]]
+=== Configure the YStream service
+
+The YashanDB connector requires a YStream service to obtain incremental data.
+The following are the steps to configure the YStream service.
+
+==== Create a YStream service
+
+Use the link:https://doc.yashandb.com/yashandb/23.5/zh/SQL-Guide/Built-in-Packages/DBMS_YSTREAM_ADM.html#create[`DBMS_YSTREAM_ADM.CREATE` procedure] to create a YStream service:
+
+[source,sql,indent=0]
+----
+DBMS_YSTREAM_ADM.CREATE(
+    server_name  IN VARCHAR(64),
+    connect_user IN VARCHAR(64) DEFAULT NULL,
+    start_scn    IN BIGINT DEFAULT NULL);
+----
+
+The `start_scn` is obtained by querying `SELECT CURRENT_SCN FROM V$DATABASE`.
+
+[source,sql,indent=0]
+----
+EXEC DBMS_YSTREAM_ADM.CREATE('serverName', 'connect_user', start_scn);
+----
+
+==== Add tables to the YStream service
+
+Use the link:https://doc.yashandb.com/yashandb/23.5/zh/SQL-Guide/Built-in-Packages/DBMS_YSTREAM_ADM.html#add-tables[`DBMS_YSTREAM_ADM.ADD_TABLES` procedure] to add tables to be captured to the YStream service:
+
+[source,sql,indent=0]
+----
+DBMS_YSTREAM_ADM.ADD_TABLES(
+    server_name IN VARCHAR(64),
+    table_names IN VARCHAR(4096),
+    schemas     IN VARCHAR(4096));
+----
+
+[NOTE]
+====
+The table names and schemas that you add to the service must be the same as those that the connector is configured to capture.
+====
+
+==== Set YStream service parameters
+
+.Prerequisites
+* The YStream service is available to configure.
+Query the `V$YSTREAM_SERVER` view to obtain the service status.
+
+Use the link:https://doc.yashandb.com/yashandb/23.5/zh/SQL-Guide/Built-in-Packages/DBMS_YSTREAM_ADM.html#set-parameter[`DBMS_YSTREAM_ADM.SET_PARAMETER` procedure] to set parameters for an existing service:
+
+[source,sql,indent=0]
+----
+DBMS_YSTREAM_ADM.SET_PARAMETER(
+    server_name IN VARCHAR(64),
+    parameter   IN VARCHAR(64),
+    value       IN VARCHAR(64));
+----
+
+==== Start the YStream service
+
+Use the link:https://doc.yashandb.com/yashandb/23.5/zh/SQL-Guide/Built-in-Packages/DBMS_YSTREAM_ADM.html#start[`DBMS_YSTREAM_ADM.START` procedure] to start the YStream service:
+
+[source,sql,indent=0]
+----
+DBMS_YSTREAM_ADM.START(server_name IN VARCHAR(64));
+----
+
+NOTE: If you need to connect to YStream using a standby database, you must start the YStream service on the standby database node.
+
+[[deploying-yashandb-connector]]
+== Deploying the YashanDB connector
+
+To deploy a {prodname} YashanDB connector, you install the {prodname} YashanDB connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
+
+.Prerequisites
+* link:http://kafka.apache.org/[Apache Kafka] and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
+* YashanDB is installed, and is xref:setting-up-yashandb[configured to work with the {prodname} connector].
+
+.Procedure
+
+. Download the {prodname} YashanDB connector plug-in archive.
+. Extract all files into your Kafka Connect environment.
+. Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
+. Restart your Kafka Connect process to pick up the new JAR files.
+
+.Next steps
+
+* xref:yashandb-example-configuration[Configure the connector] and xref:yashandb-adding-connector-configuration[add the configuration to your Kafka Connect cluster].
+
+[[yashandb-example-configuration]]
+=== {prodname} YashanDB connector configuration
+
+Typically, you register a {prodname} YashanDB connector by submitting a JSON request that specifies the configuration properties for the connector.
+The following example shows a JSON request for registering an instance of the {prodname} YashanDB connector with logical name `server1` at port 1688:
+
+.Example: {prodname} YashanDB connector configuration
+[source,json,indent=0,subs="+quotes"]
+----
+{
+    "name": "inventory-connector",  // <1>
+    "config": {
+        "connector.class" : "io.debezium.connector.yashandb.YashanDbConnector",  // <2>
+        "database.hostname" : "<YASHANDB_IP_ADDRESS>",  // <3>
+        "database.port" : "1688",  // <4>
+        "database.user" : "username",  // <5>
+        "database.password" : "password",   // <6>
+        "database.dbname" : "dbname",  // <7>
+        "topic.prefix" : "server1",  // <8>
+        "tasks.max" : "1",  // <9>
+        "database.ystream.server.name" : "server1",  // <10>
+        "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092", // <11>
+        "schema.history.internal.kafka.topic": "schema-changes.inventory"  // <12>
+    }
+}
+----
+<1> The name that is assigned to the connector when you register it with a Kafka Connect service.
+<2> The name of this YashanDB connector class.
+<3> The address of the YashanDB instance.
+<4> The port number of the YashanDB instance.
+<5> The name of the YashanDB user, as specified in xref:yashandb-create-user[Creating a user account for the connector].
+<6> The password for the YashanDB user, as specified in xref:yashandb-create-user[Creating a user account for the connector].
+<7> The name of the database to capture changes from.
+<8> Topic prefix that identifies and provides a namespace for the YashanDB database server from which the connector captures changes.
+<9> The maximum number of tasks to create for this connector.
+<10> The name of the YStream service that the connector uses to capture changes.
+<11> The list of Kafka brokers that this connector uses to write and recover DDL statements to the database schema history topic.
+<12> The name of the database schema history topic where the connector writes and recovers DDL statements.
+This topic is for internal use only and should not be used by consumers.
+
+For the complete list of the configuration properties that you can set for the {prodname} YashanDB connector, see xref:yashandb-properties[Connector configuration properties].
+
+You can send this configuration with a `POST` command to a running Kafka Connect service.
+The service records the configuration and starts a connector task that performs the following operations:
+
+* Connects to the YashanDB database.
+* Reads the redo logs of the database.
+* Emits change events for every operation that occurs in the tables that you specify.
+* Streams change event records to Kafka topics.
+
+[[yashandb-adding-connector-configuration]]
+=== Adding connector configuration
+
+To start running a {prodname} YashanDB connector, create a connector configuration, and add the configuration to your Kafka Connect cluster.
+
+.Prerequisites
+
+* xref:setting-up-yashandb[YashanDB is configured for use with {prodname}].
+* The {prodname} YashanDB connector is installed.
+
+.Procedure
+
+. Create a xref:yashandb-example-configuration[configuration] for the YashanDB connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
+
+.Results
+
+After the connector starts, it xref:yashandb-snapshots[performs a consistent snapshot] of the YashanDB databases that the connector is configured for.
+The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
+
+[[yashandb-properties]]
+== Connector properties
+
+The {prodname} YashanDB connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
+
+* xref:yashandb-properties-required[Required {prodname} YashanDB connector configuration properties]
+* xref:debezium-yashandb-connector-optional-configuration-properties[Optional {prodname} YashanDB configuration properties]
+* xref:debezium-yashandb-connector-database-history-configuration-properties[{prodname} YashanDB connector database schema history configuration properties]
+** xref:debezium-yashandb-connector-pass-through-properties[Pass-through YashanDB connector configuration properties]
+** xref:debezium-yashandb-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through properties for configuring how producer and consumer clients interact with schema history topics]
+** xref:debezium-yashandb-connector-pass-through-kafka-signals-configuration-properties[Pass-through properties for configuring how the YashanDB connector interacts with the Kafka signaling topic]
+** xref:debezium-yashandb-connector-pass-through-signals-kafka-consumer-client-configuration-properties[Pass-through properties for configuring the Kafka consumer client for the signaling channel]
+** xref:debezium-yashandb-connector-pass-through-kafka-sink-notification-configuration-properties[Pass-through properties for configuring the YashanDB connector sink notification channel]
+** xref:debezium-yashandb-connector-pass-through-database-driver-configuration-properties[{prodname} connector pass-through database driver configuration properties]
+
+
+
+
+[[yashandb-properties-required]]
+=== Required {prodname} YashanDB connector configuration properties
+
+The {prodname} YashanDB connector uses numerous configuration properties to create the connector instance.
+Descriptions of these properties are organized as follows:
+
+* xref:required-debezium-yashandb-connector-configuration-properties[Required configuration properties]
+* xref:debezium-yashandb-connector-optional-configuration-properties[Optional configuration properties]
+
+[id="required-debezium-yashandb-connector-configuration-properties"]
+==== Required configuration properties
+
+[cols="30%a,25%a,45%a"]
+|===
+|Property
+|Default
+|Description
+
+|[[yashandb-property-name]]<<yashandb-property-name, `+name+`>>
+|No default
+|Unique name for the connector.
+You can use the specified name to register a connector only once.
+Registration fails if you attempt to reuse a connector name.
+(This property is required by all Kafka Connect connectors.)
+
+|[[yashandb-property-connector-class]]<<yashandb-property-connector-class, `+connector.class+`>>
+|No default
+|The name of the Java class for the connector.
+Always use the following value for the YashanDB connector:
+
+`io.debezium.connector.yashandb.YashanDbConnector`
+
+|[[yashandb-property-tasks-max]]<<yashandb-property-tasks-max, `+tasks.max+`>>
+|`1`
+|The maximum number of tasks to create for this connector.
+The YashanDB connector always uses a single task and therefore does not use this value, so the default is always acceptable.
+
+|[[yashandb-property-database-hostname]]<<yashandb-property-database-hostname, `+database.hostname+`>>
+|No default
+|IP address or hostname of the YashanDB database server.
+
+|[[yashandb-property-database-port]]<<yashandb-property-database-port, `+database.port+`>>
+|No default
+|Integer port number of the YashanDB database server.
+
+|[[yashandb-property-database-user]]<<yashandb-property-database-user, `+database.user+`>>
+|No default
+|Name of the YashanDB user account that the connector uses to connect to the YashanDB database server.
+
+|[[yashandb-property-database-password]]<<yashandb-property-database-password, `+database.password+`>>
+|No default
+|Password to use when connecting to the YashanDB database server.
+
+|[[yashandb-property-database-dbname]]<<yashandb-property-database-dbname, `+database.dbname+`>>
+|No default
+|The name of the YashanDB database.
+
+|[[yashandb-property-database-url]]<<yashandb-property-database-url, `+database.url+`>>
+|No default
+|The JDBC URL for the YashanDB database. Format: `jdbc:yasdb://<host>:1688/<dbname>`.
+
+|[[yashandb-property-ystream-server-name]]<<yashandb-property-ystream-server-name, `+database.ystream.server.name+`>>
+|No default
+|The name of the YStream service on the YashanDB database.
+Specify the YStream service name created in the "Configure YStream service" step.
+
+|[[yashandb-property-topic-prefix]]<<yashandb-property-topic-prefix, `+topic.prefix+`>>
+|No default
+|Topic prefix that provides a namespace for the YashanDB database server from which the connector captures changes.
+The value that you set is used as the prefix for all Kafka topic names that the connector emits.
+Specify a topic prefix that is unique across all connectors in your {prodname} environment.
+Valid characters include alphanumeric characters, hyphens, dots, and underscores.
+
+|[[yashandb-property-schema-history-internal-kafka-bootstrap-servers]]<<yashandb-property-schema-history-internal-kafka-bootstrap-servers, `+schema.history.internal.kafka.bootstrap.servers+`>>
+|No default
+|A list of Kafka brokers that the connector uses to write and recover DDL statements to the database schema history topic.
+
+|[[yashandb-property-schema-history-internal-kafka-topic]]<<yashandb-property-schema-history-internal-kafka-topic, `+schema.history.internal.kafka.topic+`>>
+|No default
+|The name of the database schema history topic where the connector writes and recovers DDL statements.
+This topic is for internal use only and should not be used by consumers.
+
+|===
+
+[id="debezium-yashandb-connector-optional-configuration-properties"]
+==== Optional configuration properties
+
+[cols="30%a,25%a,45%a"]
+|===
+|Property
+|Default
+|Description
+
+|[[yashandb-property-ystream-blocking-queue-size]]<<yashandb-property-ystream-blocking-queue-size, `+ystream.blocking.queue.size+`>>
+|`128`
+|The size of the built-in blocking queue in the YStream client.
+Incremental logical logs are obtained directly from this queue.
+
+|[[yashandb-property-ystream-poll-timeout]]<<yashandb-property-ystream-poll-timeout, `+ystream.poll.timeout+`>>
+|`10`
+|The timeout in seconds for obtaining the next result from the blocking queue.
+
+|[[yashandb-property-ystream-client-response-timeout]]<<yashandb-property-ystream-client-response-timeout, `+ystream.client.response.timeout+`>>
+|`60`
+|The maximum time in seconds that the YStream server waits for the YStream client to respond.
+
+|[[yashandb-property-schema-include-list]]<<yashandb-property-schema-include-list, `+schema.include.list+`>>
+|No default
+|An optional comma-separated list of regular expressions that match the names of schemas for which you want to capture changes.
+The connector captures changes for any schema  whose name is not included in `schema.exclude.list` , except for system schemas.
+By default, changes for all non-system schemas are captured.
+To match schema names, {prodname} applies the regular expressions you specify as anchored regular expressions.
+
+|[[yashandb-property-schema-exclude-list]]<<yashandb-property-schema-exclude-list, `+schema.exclude.list+`>>
+|No default
+|An optional comma-separated list of regular expressions that match the names of schemas for which you do not want to capture changes.
+The connector captures changes for any schema  whose name is not included in `schema.exclude.list` , except for system schemas.
+
+|[[yashandb-property-table-include-list]]<<yashandb-property-table-include-list, `+table.include.list+`>>
+|No default
+|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be captured.
+When this property is set, the connector captures changes only from the specified tables.
+Each table identifier uses the following format: `<schema_name>.<table_name>`.
+By default, the connector monitors every non-system table in each captured database schema.
+
+To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+
+|[[yashandb-property-table-exclude-list]]<<yashandb-property-table-exclude-list, `+table.exclude.list+`>>
+|No default
+|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring.
+The connector captures change events from any table that is not specified in the exclude list.
+Specify each table identifier using the following format: `<schema_name>.<table_name>`.
+
+To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
+
+|[[yashandb-property-max-batch-size]]<<yashandb-property-max-batch-size, `+max.batch.size+`>>
+|`2048`
+|A positive integer value that specifies the maximum size of each batch of events to be processed during each iteration of this connector.
+
+|[[yashandb-property-max-queue-size]]<<yashandb-property-max-queue-size, `+max.queue.size+`>>
+|`8192`
+|A positive integer value that specifies the maximum number of records that the blocking queue can hold.
+When {prodname} reads the stream of events from the database, it places them in a blocking queue before writing the events to Kafka.
+The blocking queue prevents data loss in situations where the connector receives messages faster than it can write them to Kafka, or when Kafka is unavailable.
+
+|[[yashandb-property-max-queue-size-in-bytes]]<<yashandb-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
+|`0` (disabled)
+|A long integer value that specifies the maximum capacity of the blocking queue in bytes.
+By default, no volume limit is specified for the blocking queue.
+To specify the number of bytes the queue can consume, set this property to a positive long value.
+If `max.queue.size` is also set, writes to the queue are blocked when the queue size reaches the limit specified by either property.
+
+|[[yashandb-property-poll-interval-ms]]<<yashandb-property-poll-interval-ms, `+poll.interval.ms+`>>
+|`500` (0.5 seconds)
+|A positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear during each iteration.
+
+|[[yashandb-property-skipped-operations]]<<yashandb-property-skipped-operations, `+skipped.operations+`>>
+|`t`
+|A comma-separated list of operation types that you want the connector to skip during streaming.
+You can configure the connector to skip the following types of operations: `c` (insert/create), `u` (update), `d` (delete), `t` (truncate).
+By default, only truncate operations are skipped.
+
+|[[yashandb-property-snapshot-mode]]<<yashandb-property-snapshot-mode, `+snapshot.mode+`>>
+|`initial`
+|Specifies the mode that the connector uses to perform a snapshot of the captured tables.
+You can set the following values:
+
+`always`:: Perform a snapshot every time the connector starts.
+`initial`:: Perform an initial snapshot when the connector starts.
+`initial_only`:: Perform only the initial snapshot, without streaming subsequent changes.
+`no_data`:: Capture only table structures, not data.
+`recovery`:: Restore a lost or corrupted schema history topic.
+`when_needed`:: Perform a snapshot only when needed.
+
+|[[yashandb-property-snapshot-fetch-size]]<<yashandb-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
+|`10000`
+|Specifies the maximum number of rows to read from each table at a time during a snapshot.
+The connector reads table contents in multiple batches of the specified size.
+
+|[[yashandb-property-snapshot-max-threads]]<<yashandb-property-snapshot-max-threads, `+snapshot.max.threads+`>>
+|`1`
+|Specifies the number of threads the connector uses when performing the initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables simultaneously.
+
+This feature is incubating and is subject to change.
+
+|[[yashandb-property-snapshot-locking-mode]]<<yashandb-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
+|No default
+|Specifies whether the connector uses locking mode to prevent DDL changes before synchronizing snapshot data.
+Set one of the following values:
+
+[horizontal]
+`none`:: No locks are acquired.
+`shared`:: Shared locks are acquired.
+
+|[[yashandb-property-lob-enabled]]<<yashandb-property-lob-enabled, `+lob.enabled+`>>
+|`false`
+|Specifies whether large object (CLOB or BLOB, and so on.) column values are emitted in change events.
+By default, change events have large object columns, but these columns do not contain values.
+There is some overhead when processing and managing large object column types and payloads.
+To capture large object values and serialize them in change events, set this option to `true`.
+
+|[[yashandb-property-decimal-handling-mode]]<<yashandb-property-decimal-handling-mode, `+decimal.handling.mode+`>>
+|`precise`
+|Specifies how the connector should handle floating-point values for `NUMBER` columns.
+You can set one of the following options:
+
+`precise`:: (default) Use `java.math.BigDecimal` to represent values precisely.
+Represented in binary form in change events.
+`double`:: Use `FLOAT64` (double-precision floating-point) to represent values.
+`string`:: Use `STRING` to represent values.
+
+|[[yashandb-property-unavailable-value-placeholder]]<<yashandb-property-unavailable-value-placeholder, `+unavailable.value.placeholder+`>>
+|`__debezium_unavailable_value`
+|Specifies the constant provided by the connector to indicate that the original value was not changed and is not provided by the database.
+For example, if a LOB fails to be retrieved, this placeholder is used instead.
+
+|[[yashandb-property-signal-data-collection]]<<yashandb-property-signal-data-collection, `+signal.data.collection+`>>
+|No default
+|The fully qualified name of the data collection used to send signals to the connector.
+Specify the collection name using the following format: `<databaseName>.<schemaName>.<tableName>`.
+
+|[[yashandb-property-signal-enabled-channels]]<<yashandb-property-signal-enabled-channels, `+signal.enabled.channels+`>>
+|`source`
+|The list of signal channel names enabled for the connector.
+By default, the following channels are available: `source`, `kafka`, `file`, `jmx`.
+
+|[[yashandb-property-notification-enabled-channels]]<<yashandb-property-notification-enabled-channels, `+notification.enabled.channels+`>>
+|No default
+|The list of notification channel names enabled for the connector.
+By default, the following channels are available: `sink`, `log`, `jmx`.
+
+|[[yashandb-property-incremental-snapshot-chunk-size]]<<yashandb-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|`1024`
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
+Increasing the chunk size can provide higher efficiency because the snapshot runs fewer snapshot queries, but the queries are larger.
+However, larger chunk sizes also require more memory to buffer snapshot data.
+Tune the chunk size to a value that provides optimal performance in your environment.
+
+|[[yashandb-property-topic-naming-strategy]]<<yashandb-property-topic-naming-strategy, `+topic.naming.strategy+`>>
+|`io.debezium.schema.SchemaTopicNamingStrategy`
+|The name of the class used to determine topic names for data changes, schema changes, transactions, heartbeat events, and so on.
+Defaults to `SchemaTopicNamingStrategy`.
+
+|[[yashandb-property-topic-delimiter]]<<yashandb-property-topic-delimiter, `+topic.delimiter+`>>
+|`.`
+|Specifies the delimiter for topic names.
+Defaults to a dot (`.`).
+
+|[[yashandb-property-converters]]<<yashandb-property-converters, `+converters+`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the custom converter instances that the connector can use.
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
+
+|[[yashandb-property-converter-type]]<<yashandb-property-converter-type, `+<converter_name>.type+`>>
+|No default
+|Configures the class name of a custom converter for {prodname}.
+
+|[[yashandb-property-converter-param]]<<yashandb-property-converter-param, `+<converter_name>.<param_name>+`>>
+|No default
+|Configuration for custom converters, set according to how the converter is used.
+
+|[[yashandb-property-query-fetch-size]]<<yashandb-property-query-fetch-size, `+query.fetch.size+`>>
+|`10000`
+|The fetch size for JDBC queries.
+
+|[[yashandb-property-ddl-parse-fail-retry-read-table]]<<yashandb-property-ddl-parse-fail-retry-read-table, `+ddl.parse.fail.retry.read.table+`>>
+|`false`
+|After incremental DDL parsing fails, fully read the source table structure for analysis when processing DML events.
+This property takes effect when both `schema.history.internal.skip.unparseable.ddl` and `ddl.parse.fail.retry.read.table` are set to `true`.
+
+|[[yashandb-property-schema-history-internal-class]]<<yashandb-property-schema-history-internal-class, `+schema.history.internal+`>>
+|No default
+|The name of the class that handles schema changes for the connector.
+For YashanDB, use `io.debezium.relational.history.KafkaSchemaHistory`.
+
+|[[yashandb-property-schema-history-internal-store-only-captured-tables-ddl]]<<yashandb-property-schema-history-internal-store-only-captured-tables-ddl, `+schema.history.internal.store.only.captured.tables.ddl+`>>
+|`false`
+|Specifies whether the connector records the DDL statements for all tables in the database, or only for tables that are captured.
+Set to `true` to store DDL only for captured tables.
+
+|===
+
+[id="debezium-yashandb-connector-database-history-configuration-properties"]
+==== {prodname} YashanDB connector database schema history configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-yashandb-connector-pass-through-properties"]
+==== Pass-through YashanDB connector configuration properties
+
+The connector supports _pass-through_ properties that enable {prodname} to specify custom configuration options for fine-tuning the behavior of the Apache Kafka producer and consumer.
+For information about the full range of configuration properties for Kafka producers and consumers, see the {link-kafka-docs}/#configuration[Kafka documentation].
+
+[id="debezium-yashandb-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients"]
+===== Pass-through properties for configuring how producer and consumer clients interact with schema history topics
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients.adoc[leveloffset=+1]
+
+[id="debezium-yashandb-connector-pass-through-kafka-signals-configuration-properties"]
+===== Pass-through properties for configuring how the YashanDB connector interacts with the Kafka signaling topic
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-signals-configuration-properties.adoc[leveloffset=+1]
+
+[id="debezium-yashandb-connector-pass-through-signals-kafka-consumer-client-configuration-properties"]
+===== Pass-through properties for configuring the Kafka consumer client for the signaling channel
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-signals-kafka-consumer-client-configuration-properties.adoc[leveloffset=+1]
+
+[id="debezium-yashandb-connector-pass-through-kafka-sink-notification-configuration-properties"]
+===== Pass-through properties for configuring the YashanDB connector sink notification channel
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-kafka-sink-notification-configuration-properties.adoc[leveloffset=+1]
+
+[id="debezium-yashandb-connector-pass-through-database-driver-configuration-properties"]
+===== {prodname} connector pass-through database driver configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
+
+
+[[monitoring-yashandb-connector]]
+== Monitoring
+
+The {prodname} YashanDB connector provides three metric types in addition to the built-in support for JMX metrics that Apache Kafka and Kafka Connect have.
+
+* xref:yashandb-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots
+* xref:yashandb-streaming-metrics[Streaming metrics] for monitoring the connector when processing change events
+* xref:yashandb-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history
+
+For details about how to expose use JMX to expose metrics, see the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] .
+
+=== Customized MBean names
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=mbeans-shared]
+
+[[yashandb-snapshot-metrics]]
+=== Snapshot Metrics
+
+[[yashandb-monitoring-snapshots]]
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-snapshot]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
+
+[[yashandb-streaming-metrics]]
+=== Streaming Metrics
+
+[[yashandb-monitoring-streaming]]
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-streaming]
+
+==== Common streaming metrics
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
+
+==== YStream streaming metrics
+
+The {prodname} YashanDB connector provides the following additional streaming metrics that are specific to the YStream adapter:
+
+.Descriptions of YStream-specific streaming metrics
+[cols="45%a,25%a,30%a"]
+|===
+|Attributes
+|Type
+|Description
+
+|[[yashandb-streaming-metrics-errorcount]]<<yashandb-streaming-metrics-errorcount, `+ErrorCount+`>>
+|`long`
+|The number of errors detected by the connector during the streaming phase.
+
+|[[yashandb-streaming-metrics-warningcount]]<<yashandb-streaming-metrics-warningcount, `+WarningCount+`>>
+|`long`
+|The number of warnings detected by the connector during the streaming phase.
+
+|===
+
+
+[[yashandb-schema-history-metrics]]
+=== Schema History Metrics
+
+include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-schema-history]
+
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
+
+[[yashandb-faq]]
+== Frequently Asked Questions
+
+[[yashandb-faq-ystream-server-not-found]]
+*Error: YashanDB does not yet have the YStream server 'serverxx' or check option 'database.ystream.server.name' if the parameters are filled in correctly.*::
++
+The YStream server corresponding to the `database.ystream.server.name` parameter does not exist in the YashanDB database.
+Create the relevant YStream server as described in xref:yashandb-ystream-service[Configure the YStream service].
+
+[[yashandb-faq-ystream-server-not-started]]
+*Error: YashanDB YStream server status is xxx. Please execute 'DBMS_YSTREAM_ADM.START(...)' start YStream server.*::
++
+The YStream server corresponding to the `database.ystream.server.name` parameter is not in a running state.
+Please execute the following command in the database to start the YStream service:
++
+[source,sql,indent=0]
+----
+EXEC DBMS_YSTREAM_ADM.START('server1');
+----
+
+[[yashandb-faq-decimal-serialization]]
+*After Decimal values are synchronized to Kafka, why is the serialized data incorrect?*::
++
+{prodname} performs special handling for Decimals with negative scale.
+To work around this issue, use the parameter `decimal.handling.mode=string`.
+
+[[yashandb-faq-timestamp-format]]
+*After DATE/TIME/TIMESTAMP values are synchronized to Kafka, why are they in timestamp form rather than 'yyyy-MM-dd HH:mm:ss.SSSSSS' form?*::
++
+By default, {prodname} maps temporal types to `INT64`.
+For information about how to map temporal types to a fixed format string, configure custom converters, as described in the <<yashandb-custom-converters,Data type conversion>> section.
+
+[[yashandb-faq-resume-from-checkpoint]]
+*Does the YashanDB Connector support resuming from a checkpoint? After a task stops or fails, can it capture incremental data from the last committed position?*::
++
+Yes, the YashanDB Connector supports resuming from a checkpoint.
+Based on Kafka's two-phase commit, after a task stops or fails, the last successfully committed log position is recorded in Kafka's metadata.
+When the task is resumed, the connector obtains the last committed log position and starts capturing data from that position, ensuring exactly-once data synchronization to Kafka topics.
+
+[[yashandb-faq-schema-capture-scope]]
+*The YashanDB Connector captures the metadata structure of all tables in the database in the task logs. Is there a way to make the connector only capture the metadata structure for configured tables (schema.include.list and table.include.list)?*::
++
+By default, {prodname} captures the structure of all tables in the database.
+You can set `schema.history.internal.store.only.captured.tables.ddl=true` in the task configuration to capture only the structure of configured tables.
+
+[[yashandb-faq-schema-not-captured-after-recreate]]
+*After deleting and recreating a task, the table metadata structure is not captured upon restart (for example, "Capturing structure of table" does not appear in the logs). What causes this?*::
++
+The connector stores table metadata in the Kafka topic specified by the `schema.history.internal.kafka.topic` property.
+When you delete and recreate a task with the same name, the connector reads the existing metadata from the schema history topic rather than capturing a new snapshot of the table structures, provided that the schema history topic has not been deleted.
+To capture the table metadata again, either delete the schema history topic or change the task name.
+
+[[yashandb-faq-unsupported-types]]
+*The documentation states that custom data types, XMLTYPE, and JSON data types are not supported, yet XMLTYPE and JSON data can still be synchronized to Kafka topics. Why?*::
++
+The type support of the YashanDB Connector depends on the support range of YashanDB YStream.
+XMLTYPE and JSON data can be synchronized normally, but the correctness of the data cannot be guaranteed and depends on YStream's support.
+
+[[yashandb-faq-skip-ddl]]
+*A DDL on the YashanDB source caused the task to fail when parsing this DDL. How can I skip this failed DDL?*::
++
+{prodname} provides a feature to skip failed DDL parsing.
+You can enable this feature by modifying the task configuration to set `schema.history.internal.skip.unparseable.ddl=true`.
+
+[[yashandb-faq-ctas-failure]]
+*The YashanDB source executed a DDL like "CREATE TABLE ... AS SELECT", and subsequent DML data parsing for this table fails. How should this be handled?*::
++
+This type of DDL cannot be parsed to obtain the table's metadata, causing subsequent DML data parsing to fail.
+The {prodname} Oracle Connector has the same issue.
+If you encouter this problem, restart a new synchronization task.
+
+*Incremental DDL created using stored procedure packages (such as `DBMS_STATS.CREATE_STAT_TABLE`) cannot be identified for specific DDL statements. What causes this and how can it be handled?*::
++
+The connector cannot identify DDL statements created through stored procedure packages as specific DDL statements.
+As a result metadata mismatches might occur during data synchronization, which can lead to synchronization errors.
+To avoid this issue, execute DDL statements directly rather than through stored procedure packages.

--- a/documentation/modules/ROOT/pages/install.adoc
+++ b/documentation/modules/ROOT/pages/install.adoc
@@ -42,6 +42,7 @@ ifeval::['{page-version}' == 'master']
 * {link-jdbc-plugin-snapshot}[JDBC sink plugin archive]
 * {link-informix-plugin-snapshot}[Informix plugin archive] (incubating)
 * {link-cockroachdb-plugin-snapshot}[CockroachDB plugin archive] (incubating)
+* {link-yashandb-plugin-snapshot}[YashanDB plugin archive] (incubating)
 
 NOTE: All above links are to nightly snapshots of the {prodname} main branch.  If you are looking for non-snapshot versions, please select the appropriate version in the top right.
 endif::[]
@@ -61,6 +62,7 @@ ifeval::['{page-version}' != 'master']
 * https://repo1.maven.org/maven2/io/debezium/debezium-connector-jdbc/{debezium-version}/debezium-connector-jdbc-{debezium-version}-plugin.tar.gz[JDBC sink plugin archive]
 * https://repo1.maven.org/maven2/io/debezium/debezium-connector-informix/{debezium-version}/debezium-connector-informix-{debezium-version}-plugin.tar.gz[Informix plugin archive] (incubating)
 * https://repo1.maven.org/maven2/io/debezium/debezium-connector-cockroachdb/{debezium-version}/debezium-connector-cockroachdb-{debezium-version}-plugin.tar.gz[CockroachDB plugin archive] (incubating)
+* https://repo1.maven.org/maven2/io/debezium/debezium-connector-yashandb/{debezium-version}/debezium-connector-yashandb-{debezium-version}-plugin.tar.gz[YashanDB plugin archive] (incubating)
 endif::[]
 
 NOTE: If you are interested in Debezium Server, please check the installation instructions xref:operations/debezium-server.adoc#_installation[here].
@@ -110,6 +112,7 @@ xref:connectors/vitess.adoc#vitess-deploying-a-connector[Vitess Connector],
 xref:connectors/spanner.adoc#spanner-deploying-a-connector[Spanner Connector],
 xref:connectors/jdbc.adoc#jdbc-deployment[JDBC sink Connector],
 xref:connectors/informix.adoc#informix-deploying-a-connector[Informix Connector],
+xref:connectors/yashandb.adoc#deploying-yashandb-connector[YashanDB Connector],
 and use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that
 connector configuration to your Kafka Connect cluster. When the connector starts, it will connect to the source and produce events
 for each inserted, updated, and deleted row or document.


### PR DESCRIPTION
Fixes debezium/dbz#1850

  ## Description

  This PR adds comprehensive documentation for the Debezium YashanDB connector.

  YashanDB is a next-generation database management system independently developed by the Shenzhen Institute of
  Computing Sciences. The connector uses YashanDB's native **YStream** CDC mechanism to capture and stream row-level
   change events to Kafka.

  The documentation covers the following areas:

  - **Overview** — Introduction to YashanDB and the Debezium connector
  - **How the connector works** — YStream mechanism, snapshot modes, topic naming, schema history/change topics,
  transaction metadata
  - **Data change events** — Structure and examples for _create_, _update_, _delete_, and _truncate_ events
  - **Data type mapping** — Mapping from YashanDB types to Kafka Connect schema types
  - **Setting up YashanDB** — Prerequisites and database configuration for CDC
  - **Deployment** — How to deploy the connector
  - **Configuration properties** — Detailed reference of all connector configuration options
  - **Monitoring** — Connector metrics and performance monitoring
  - **FAQ** — Frequently asked questions

  ## PR Checklist
  - [√] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md)
  and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
  - [√] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or
  refactoring to existing code)
  - [√] One feature/change per PR unless tightly coupled
  - [√] Do a rebase on upstream `main`