### PR TITLE
debezium/dbz#2002 add cache in ReselectColumnPostProcessor

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -10,7 +10,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -257,7 +257,7 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             }
         }
 
-        final List<String> requiredColumnSelections = getRequiredColumnSelections(tableId, after);
+        final Set<String> requiredColumnSelections = getRequiredColumnSelections(tableId, after);
 
         // Resolve the row-scoped cache view once, keyed by the event's message key struct, so the row
         // identity is resolved a single time and reused for every column of this row. Using the key struct
@@ -364,14 +364,13 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
      * @param requiredColumnSelections columns being re-selected this event, which are skipped here since
      *                                 they will be cached after re-selection below.
      */
-    private void cacheModifiedColumns(ReselectColumnCache.RowCache rowCache, TableId tableId, Struct after, List<String> requiredColumnSelections) {
+    private void cacheModifiedColumns(ReselectColumnCache.RowCache rowCache, TableId tableId, Struct after, Set<String> requiredColumnSelections) {
         if (rowCache == null) {
             return;
         }
-        final Set<String> requiredColumnSelectionsSet = new HashSet<>(requiredColumnSelections);
         for (org.apache.kafka.connect.data.Field field : after.schema().fields()) {
             final String columnName = field.name();
-            if (requiredColumnSelectionsSet.contains(columnName)) {
+            if (requiredColumnSelections.contains(columnName)) {
                 continue;
             }
             final String fullyQualifiedName = jdbcConnection.getQualifiedTableName(tableId) + ":" + columnName;
@@ -418,8 +417,8 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
         return key.get(field);
     }
 
-    private List<String> getRequiredColumnSelections(TableId tableId, Struct after) {
-        final List<String> columnSelections = new ArrayList<>();
+    private Set<String> getRequiredColumnSelections(TableId tableId, Struct after) {
+        final Set<String> columnSelections = new LinkedHashSet<>();
         for (org.apache.kafka.connect.data.Field field : after.schema().fields()) {
             final Object value = after.get(field);
             if (reselectUnavailableValues && isUnavailableValueHolder(field, value)) {

--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -9,8 +9,12 @@ import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -29,6 +33,7 @@ import io.debezium.common.annotation.Incubating;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
+import io.debezium.config.Instantiator;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.data.Json;
@@ -36,6 +41,8 @@ import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.function.Predicates;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.processors.reselect.cache.MemoryReselectColumnCache;
+import io.debezium.processors.reselect.cache.ReselectColumnCache;
 import io.debezium.processors.spi.PostProcessor;
 import io.debezium.relational.Column;
 import io.debezium.relational.CustomConverterRegistry;
@@ -68,10 +75,26 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
     private static final String RESELECT_NULL_VALUES = "reselect.null.values";
     private static final String RESELECT_USE_EVENT_KEY = "reselect.use.event.key";
 
+    // Optional caching of re-selected values. Caching is OFF by default: re-selection exists to fetch the
+    // latest committed row state, so caching trades freshness for fewer database round-trips. It is most
+    // useful when the same rows are re-selected repeatedly (e.g. TOAST/LOB columns re-queried on every
+    // unrelated update). The cache is invalidated on modify (see apply()), so correctness does not depend
+    // on the cache's TTL.
+    //
+    // The cache is pluggable via a strategy: 'reselect.cache.enabled' turns it on and 'reselect.cache.type'
+    // selects the implementation class (defaulting to an in-memory cache). Alternative implementations
+    // (e.g. an embedded key/value store) can be supplied without changing this post-processor.
+    private static final String RESELECT_CACHE_ENABLED = "reselect.cache.enabled";
+    private static final String RESELECT_CACHE_TYPE = "reselect.cache.type";
+
+    private static final boolean DEFAULT_RESELECT_CACHE_ENABLED = false;
+    private static final String DEFAULT_RESELECT_CACHE_TYPE = MemoryReselectColumnCache.class.getName();
+
     private Predicate<String> selector;
     private boolean reselectUnavailableValues;
     private boolean reselectNullValues;
     private boolean reselectUseEventKeyFields;
+    private ReselectColumnCache reselectCache;
     private JdbcConnection jdbcConnection;
     private ValueConverterProvider valueConverterProvider;
     private String unavailableValuePlaceholder;
@@ -149,11 +172,24 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
         if (!(this.reselectNullValues || this.reselectUnavailableValues)) {
             LOGGER.warn("Reselect post-processor disables both null and unavailable columns, no-reselection will occur.");
         }
+
+        if (config.getBoolean(RESELECT_CACHE_ENABLED, DEFAULT_RESELECT_CACHE_ENABLED)) {
+            final String cacheType = config.getString(RESELECT_CACHE_TYPE, DEFAULT_RESELECT_CACHE_TYPE);
+            this.reselectCache = Instantiator.getInstance(cacheType);
+            this.reselectCache.configure(config);
+            LOGGER.info("Reselect cache enabled using strategy '{}'.", cacheType);
+        }
     }
 
     @Override
     public void close() {
-        // nothing to do
+        if (reselectCache != null) {
+            reselectCache.close();
+        }
+    }
+
+    private boolean isCacheEnabled() {
+        return reselectCache != null;
     }
 
     public void apply(Object messageKey, Struct value) {
@@ -204,12 +240,8 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             return;
         }
 
-        final List<String> requiredColumnSelections = getRequiredColumnSelections(tableId, after);
-        if (requiredColumnSelections.isEmpty()) {
-            LOGGER.debug("No columns require re-selection.");
-            return;
-        }
-
+        // Resolve the key columns/values once so cache reads, writes and invalidation all share the
+        // exact same row identity (whether the event key or the primary key is used).
         final List<String> keyColumns = new ArrayList<>();
         final List<Object> keyValues = new ArrayList<>();
         if (reselectUseEventKeyFields) {
@@ -225,34 +257,127 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
             }
         }
 
-        try {
-            boolean found = jdbcConnection.reselectColumns(table, requiredColumnSelections, keyColumns, keyValues, source, rs -> {
-                // Iterate re-selection columns and override old values
-                for (String columnName : requiredColumnSelections) {
-                    final Column column = table.columnWithName(columnName);
-                    final org.apache.kafka.connect.data.Field field = after.schema().field(columnName);
+        final List<String> requiredColumnSelections = getRequiredColumnSelections(tableId, after);
 
-                    final Object convertedValue = getConvertedValue(tableId, column, field, rs.getObject(columnName));
-                    if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace("Replaced field {} value {} with {}", field.name(), value.get(field), convertedValue);
-                    }
-                    after.put(field.name(), convertedValue);
+        // Resolve the row-scoped cache view once, keyed by the event's message key struct, so the row
+        // identity is resolved a single time and reused for every column of this row. Using the key struct
+        // means schema/DDL/default-value changes naturally produce a cache miss rather than a false hit.
+        final ReselectColumnCache.RowCache rowCache = isCacheEnabled() ? reselectCache.forRow(key) : null;
+
+        // Cache-on-modify: any column that arrived with a real (non-placeholder) value reflects the row's
+        // current state, so refresh the cache with it. A later event that does not modify that column
+        // (e.g. an unchanged TOAST/LOB re-emitted as a placeholder) can then be served from the cache
+        // instead of re-querying. This also keeps the cache correct across row modifications without
+        // depending on the TTL.
+        if (isCacheEnabled()) {
+            cacheModifiedColumns(rowCache, tableId, after, requiredColumnSelections);
+        }
+
+        if (requiredColumnSelections.isEmpty()) {
+            LOGGER.debug("No columns require re-selection.");
+            return;
+        }
+
+        // Per-column cache lookup. Each required column is cached independently under this row, so events
+        // touching different placeholder subsets of the same row reuse each other's results. Cached
+        // values are the final converted values, so a hit is applied to the event directly. A hit may
+        // carry a null value, distinguished from a miss by the Hit holder.
+        final Map<String, Object> selections = new HashMap<>();
+        final List<String> columnsToQuery = new ArrayList<>();
+        if (rowCache != null) {
+            for (String columnName : requiredColumnSelections) {
+                final Optional<ReselectColumnCache.Hit> cached = rowCache.get(columnName);
+                if (cached.isPresent()) {
+                    selections.put(columnName, cached.get().value());
                 }
-            });
-            if (!found) {
-                if (errorHandlingMode == ErrorHandlingMode.FAIL) {
-                    throw new DebeziumException("Failed to find row in table " + tableId + " with key " + key);
+                else {
+                    columnsToQuery.add(columnName);
                 }
-                LOGGER.warn("Failed to find row in table {} with key {}.", tableId, key);
-                return;
             }
         }
-        catch (SQLException e) {
-            if (errorHandlingMode == ErrorHandlingMode.FAIL) {
-                throw new DebeziumException("Failed to re-select columns for table " + tableId + " and key " + keyValues, e);
+        else {
+            columnsToQuery.addAll(requiredColumnSelections);
+        }
+
+        if (!columnsToQuery.isEmpty()) {
+            final Map<String, Object> rawValues = new HashMap<>();
+            try {
+                final boolean found = jdbcConnection.reselectColumns(table, columnsToQuery, keyColumns, keyValues, source, rs -> {
+                    for (String columnName : columnsToQuery) {
+                        rawValues.put(columnName, rs.getObject(columnName));
+                    }
+                });
+                if (!found) {
+                    if (errorHandlingMode == ErrorHandlingMode.FAIL) {
+                        throw new DebeziumException("Failed to find row in table " + tableId + " with key " + key);
+                    }
+                    LOGGER.warn("Failed to find row in table {} with key {}.", tableId, key);
+                    return;
+                }
             }
-            LOGGER.warn("Failed to re-select columns for table {} and key {}", tableId, keyValues, e);
+            catch (SQLException e) {
+                if (errorHandlingMode == ErrorHandlingMode.FAIL) {
+                    throw new DebeziumException("Failed to re-select columns for table " + tableId + " and key " + keyValues, e);
+                }
+                LOGGER.warn("Failed to re-select columns for table {} and key {}", tableId, keyValues, e);
+                return;
+            }
+
+            // Convert freshly queried raw values once, then both apply and cache the converted value so
+            // cache hits and freshly queried values are handled identically.
+            for (String columnName : columnsToQuery) {
+                if (!rawValues.containsKey(columnName)) {
+                    continue;
+                }
+                final Column column = table.columnWithName(columnName);
+                final org.apache.kafka.connect.data.Field field = after.schema().field(columnName);
+                final Object convertedValue = getConvertedValue(tableId, column, field, rawValues.get(columnName));
+                selections.put(columnName, convertedValue);
+                if (rowCache != null) {
+                    rowCache.put(columnName, convertedValue);
+                }
+            }
+        }
+
+        // Iterate re-selection columns and override placeholder values with the re-selected (cached or
+        // freshly queried) converted values.
+        for (String columnName : requiredColumnSelections) {
+            if (!selections.containsKey(columnName)) {
+                continue;
+            }
+            final org.apache.kafka.connect.data.Field field = after.schema().field(columnName);
+            final Object convertedValue = selections.get(columnName);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Replaced field {} value {} with {}", field.name(), value.get(field), convertedValue);
+            }
+            after.put(field.name(), convertedValue);
+        }
+    }
+
+    /**
+     * Refresh the cache with columns in this event that carry a real value (i.e. are not placeholders and
+     * therefore are not being re-selected). Caching the current value lets a subsequent event that does
+     * not modify the column be served from the cache, and keeps the cache correct across modifications so
+     * a long TTL never serves a value that has since changed. Only columns eligible for re-selection (per
+     * the column selector) are cached, so unrelated columns do not bloat the cache.
+     *
+     * @param requiredColumnSelections columns being re-selected this event, which are skipped here since
+     *                                 they will be cached after re-selection below.
+     */
+    private void cacheModifiedColumns(ReselectColumnCache.RowCache rowCache, TableId tableId, Struct after, List<String> requiredColumnSelections) {
+        if (rowCache == null) {
             return;
+        }
+        final Set<String> requiredColumnSelectionsSet = new HashSet<>(requiredColumnSelections);
+        for (org.apache.kafka.connect.data.Field field : after.schema().fields()) {
+            final String columnName = field.name();
+            if (requiredColumnSelectionsSet.contains(columnName)) {
+                continue;
+            }
+            final String fullyQualifiedName = jdbcConnection.getQualifiedTableName(tableId) + ":" + columnName;
+            if (selector.test(fullyQualifiedName)) {
+                rowCache.put(columnName, after.get(field));
+            }
         }
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/cache/MemoryReselectColumnCache.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/cache/MemoryReselectColumnCache.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.processors.reselect.cache;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.util.BoundedConcurrentHashMap;
+import io.debezium.util.BoundedConcurrentHashMap.Eviction;
+
+/**
+ * An in-memory, per-process {@link ReselectColumnCache} backed by a bounded, LRU-evicting map of rows,
+ * each holding its own per-column map. Organising the cache as {@code row -> column} means the row
+ * identity is resolved once per {@link #forRow(Struct)} call and reused for all of that row's columns.
+ * <p>
+ * The row identity is the event's message key {@link Struct}, used directly as the outer map key. The
+ * {@code Struct} {@code equals}/{@code hashCode} contract compares the key schema together with the
+ * (deep, content-based) field values, so binary key values are compared by content and any change to the
+ * key's schema (DDL, primary-key reordering, default-value changes, etc.) yields a different key and a
+ * natural cache miss rather than a false hit.
+ * <p>
+ * Entries are bounded by an LRU limit on the number of cached rows and by a per-value time-to-live;
+ * because the post-processor refreshes entries on modification, the TTL only bounds memory retention for
+ * rows that are no longer being updated and is not the mechanism that guarantees freshness.
+ *
+ * @author Gaurav Miglani
+ */
+public class MemoryReselectColumnCache implements ReselectColumnCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MemoryReselectColumnCache.class);
+
+    public static final String MAX_SIZE = "reselect.cache.max.size";
+    public static final String TTL_MS = "reselect.cache.ttl.ms";
+    public static final String MAX_COLUMNS_PER_ROW = "reselect.cache.max.columns.per.row";
+
+    private static final int DEFAULT_MAX_SIZE = 10_000;
+    private static final long DEFAULT_TTL_MS = 600_000L;
+    private static final int DEFAULT_MAX_COLUMNS_PER_ROW = 200;
+
+    private long ttlMs;
+    private int maxColumnsPerRow;
+    // message key struct -> (column -> value). Both maps are bounded/LRU to guard against
+    // wide tables (500-1000 columns) inflating the per-row inner map without bound.
+    private BoundedConcurrentHashMap<Struct, Map<String, CachedValue>> rows;
+
+    @Override
+    public void configure(Configuration config) {
+        final int maxSize = config.getInteger(MAX_SIZE, DEFAULT_MAX_SIZE);
+        this.ttlMs = config.getLong(TTL_MS, DEFAULT_TTL_MS);
+        this.maxColumnsPerRow = config.getInteger(MAX_COLUMNS_PER_ROW, DEFAULT_MAX_COLUMNS_PER_ROW);
+        this.rows = new BoundedConcurrentHashMap<>(maxSize, 16, Eviction.LRU);
+        LOGGER.info("Initialized in-memory reselect cache with max {} rows, max {} columns per row, and TTL {} ms.", maxSize, maxColumnsPerRow, ttlMs);
+    }
+
+    @Override
+    public RowCache forRow(Struct messageKey) {
+        return new MemoryRowCache(messageKey);
+    }
+
+    @Override
+    public void close() {
+        if (rows != null) {
+            rows.clear();
+        }
+    }
+
+    private final class MemoryRowCache implements RowCache {
+
+        private final Struct rowKey;
+
+        private MemoryRowCache(Struct rowKey) {
+            this.rowKey = rowKey;
+        }
+
+        @Override
+        public Optional<Hit> get(String column) {
+            final Map<String, CachedValue> columns = rows.get(rowKey);
+            if (columns == null) {
+                return Optional.empty();
+            }
+            final CachedValue cached = columns.get(column);
+            if (cached == null || cached.isExpired(System.currentTimeMillis(), ttlMs)) {
+                return Optional.empty();
+            }
+            // A present entry is a hit even when its value is null; the Hit holder preserves that.
+            return Optional.of(new Hit(cached.value));
+        }
+
+        @Override
+        public void put(String column, Object value) {
+            rows.computeIfAbsent(rowKey, k -> new BoundedConcurrentHashMap<>(maxColumnsPerRow, 4, Eviction.LRU))
+                    .put(column, new CachedValue(value, System.currentTimeMillis()));
+        }
+
+        @Override
+        public void invalidate(String column) {
+            final Map<String, CachedValue> columns = rows.get(rowKey);
+            if (columns != null) {
+                // Leave an emptied row map in place; the outer LRU bounds the number of rows. Removing it
+                // here would race with a concurrent put() for the same row.
+                columns.remove(column);
+            }
+        }
+    }
+
+    /**
+     * A single cached column value tagged with the wall-clock time it was stored, used to enforce TTL.
+     * The value itself may be {@code null}; presence of the {@code CachedValue} (not the value) denotes a
+     * cache hit.
+     */
+    private static final class CachedValue {
+        private final Object value;
+        private final long timestampMs;
+
+        private CachedValue(Object value, long timestampMs) {
+            this.value = value;
+            this.timestampMs = timestampMs;
+        }
+
+        private boolean isExpired(long nowMs, long ttlMs) {
+            return nowMs - timestampMs >= ttlMs;
+        }
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/cache/ReselectColumnCache.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/cache/ReselectColumnCache.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.processors.reselect.cache;
+
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.common.annotation.Incubating;
+import io.debezium.config.Configuration;
+
+/**
+ * A strategy contract for caching re-selected column values, organised hierarchically as
+ * {@code row -> column}. The reselect post-processor consults the cache before issuing a database query
+ * and stores the results afterwards, allowing repeated re-selections of the same column to be served
+ * from the cache.
+ * <p>
+ * Access is row-scoped: a caller first resolves a {@link RowCache} for a given row via
+ * {@link #forRow(Struct)} and then performs per-column operations on it. This lets implementations
+ * resolve the (potentially expensive) row identity once per event and amortise it across all columns of
+ * that row, rather than re-deriving it for every column.
+ * <p>
+ * The row identity is the event's message key {@link Struct}. Using the key {@code Struct} directly means
+ * the cache identity is governed by the same factors that determine the key on the topic: a primary-key
+ * reordering, a DDL change, a default-value change or any other change that alters the key's schema or
+ * serialized values yields a different key and therefore a natural cache miss, never a false hit against a
+ * stale entry. This is important for persistent backends (e.g. an embedded key/value store) where a
+ * reliable, self-describing key is required.
+ * <p>
+ * Cached values are the <em>final converted</em> values as they appear in the event's {@code after}
+ * struct, so a cache hit can be applied to the event directly without re-conversion. A cached value may be
+ * {@code null} (e.g. a {@code null} LOB column); implementations must preserve and return such values
+ * rather than treating them as a miss, which is why {@link RowCache#get(String)} returns a {@link Hit}
+ * holder instead of the value directly.
+ * <p>
+ * Implementations decide how values are stored (e.g. in-memory, embedded key/value store) and how they
+ * expire. Implementations are obtained via a no-argument constructor and then {@link #configure(Configuration)}
+ * is invoked, following the standard Debezium configurable lifecycle.
+ * <p>
+ * Implementations must be thread-safe.
+ *
+ * @author Gaurav Miglani
+ */
+@Incubating
+public interface ReselectColumnCache extends AutoCloseable {
+
+    /**
+     * Configure the cache. Invoked once after construction, before any other method.
+     *
+     * @param config the connector configuration, including any cache-specific properties
+     */
+    void configure(Configuration config);
+
+    /**
+     * Resolve a row-scoped view of the cache for the row identified by the given message key. The row
+     * identity is resolved once here and reused for all subsequent per-column operations on the returned
+     * handle.
+     *
+     * @param messageKey the event's message key struct identifying the row; may not be null
+     * @return a row-scoped cache handle
+     */
+    RowCache forRow(Struct messageKey);
+
+    /**
+     * Release any resources held by the cache. Invoked when the post-processor is closed.
+     */
+    @Override
+    void close();
+
+    /**
+     * A row-scoped view of the cache, bound to a single row. All operations act on columns of that one row.
+     */
+    interface RowCache {
+
+        /**
+         * Return the cached value for the given column, if present and still valid.
+         * <p>
+         * A returned {@link Hit} signals a cache hit and carries the cached value, which may itself be
+         * {@code null}. {@link Optional#empty()} signals a cache miss. This distinction lets a genuinely
+         * cached {@code null} value be reused rather than re-queried.
+         *
+         * @param column the column name
+         * @return a {@link Hit} on a cache hit, or {@link Optional#empty()} on a miss
+         */
+        Optional<Hit> get(String column);
+
+        /**
+         * Store the value for the given column. The value is the final converted value as it appears in
+         * the event's {@code after} struct and may be {@code null}.
+         *
+         * @param column the column name
+         * @param value the value to cache; may be null
+         */
+        void put(String column, Object value);
+
+        /**
+         * Evict the cached value for the given column, if any.
+         *
+         * @param column the column name
+         */
+        void invalidate(String column);
+    }
+
+    /**
+     * Holder returned by {@link RowCache#get(String)} on a cache hit. Distinguishes a cached value (which
+     * may be {@code null}) from a cache miss (an empty {@link Optional}).
+     *
+     * @param value the cached value; may be null
+     */
+    record Hit(Object value) {
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/processors/reselect/ReselectColumnsPostProcessorCacheTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/processors/reselect/ReselectColumnsPostProcessorCacheTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.processors.reselect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import io.debezium.bean.StandardBeanNames;
+import io.debezium.bean.spi.BeanRegistry;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.jdbc.JdbcConnection.ResultSetConsumer;
+import io.debezium.relational.Column;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.RelationalDatabaseSchema;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.ValueConverterProvider;
+import io.debezium.service.spi.ServiceRegistry;
+
+/**
+ * Unit tests for the optional per-column local re-selection cache in {@link ReselectColumnsPostProcessor}.
+ * The JDBC layer is mocked and the {@link ResultSetConsumer} callback is driven against a mocked
+ * {@link ResultSet}, so the tests assert which columns are queried (and how often) without a real
+ * database connection.
+ *
+ * @author Gaurav Miglani
+ */
+public class ReselectColumnsPostProcessorCacheTest {
+
+    private static final String DB = "testdb";
+    private static final String SCHEMA = "s1";
+    private static final String TABLE = "t1";
+    private static final String UNAVAILABLE = "__debezium_unavailable_value";
+
+    private JdbcConnection jdbcConnection;
+    private RelationalDatabaseSchema relationalSchema;
+    private RelationalDatabaseConnectorConfig connectorConfig;
+    private ValueConverterProvider valueConverterProvider;
+    private CustomConverterRegistry customConverterRegistry;
+    private BeanRegistry beanRegistry;
+    private ServiceRegistry serviceRegistry;
+
+    private Table table;
+    private TableId tableId;
+    private Schema valueSchema;
+
+    @BeforeEach
+    public void before() throws Exception {
+        tableId = new TableId(DB, SCHEMA, TABLE);
+
+        final Column id = Column.editor().name("id").optional(false).create();
+        final Column data = Column.editor().name("data").create();
+        final Column name = Column.editor().name("name").create();
+        table = Table.editor()
+                .tableId(tableId)
+                .addColumn(id)
+                .addColumn(data)
+                .addColumn(name)
+                .setPrimaryKeyNames("id")
+                .create();
+
+        jdbcConnection = mock(JdbcConnection.class);
+        relationalSchema = mock(RelationalDatabaseSchema.class);
+        connectorConfig = mock(RelationalDatabaseConnectorConfig.class);
+        valueConverterProvider = mock(ValueConverterProvider.class);
+        customConverterRegistry = mock(CustomConverterRegistry.class);
+        beanRegistry = mock(BeanRegistry.class);
+        serviceRegistry = mock(ServiceRegistry.class);
+
+        when(jdbcConnection.createTableId(DB, SCHEMA, TABLE)).thenReturn(tableId);
+        when(jdbcConnection.getQualifiedTableName(tableId)).thenReturn(SCHEMA + "." + TABLE);
+
+        // Drive the ResultSetConsumer with a mocked ResultSet that returns "db-<column>" per column,
+        // and report the row as found so we can assert exactly which columns reached the database.
+        when(jdbcConnection.reselectColumns(eq(table), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class)))
+                .thenAnswer(this::answerReselect);
+
+        when(connectorConfig.getUnavailableValuePlaceholder()).thenReturn(UNAVAILABLE.getBytes());
+        when(connectorConfig.isSignalDataCollection(any(TableId.class))).thenReturn(false);
+        when(relationalSchema.tableFor(tableId)).thenReturn(table);
+        when(valueConverterProvider.converter(any(Column.class), any())).thenReturn(null);
+        when(customConverterRegistry.getValueConverter(any(TableId.class), any(Column.class))).thenReturn(Optional.empty());
+
+        when(beanRegistry.lookupByName(StandardBeanNames.CONNECTOR_CONFIG, RelationalDatabaseConnectorConfig.class))
+                .thenReturn(connectorConfig);
+        when(beanRegistry.lookupByName(StandardBeanNames.VALUE_CONVERTER, ValueConverterProvider.class))
+                .thenReturn(valueConverterProvider);
+        when(beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, JdbcConnection.class))
+                .thenReturn(jdbcConnection);
+        when(beanRegistry.lookupByName(StandardBeanNames.DATABASE_SCHEMA, RelationalDatabaseSchema.class))
+                .thenReturn(relationalSchema);
+        when(serviceRegistry.tryGetService(CustomConverterRegistry.class)).thenReturn(customConverterRegistry);
+
+        valueSchema = buildValueSchema();
+    }
+
+    @Test
+    public void cacheDisabledQueriesDatabaseEveryTime() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(false, 1000, 5000);
+
+        processor.apply(buildKey(), placeholderEvent(true, false));
+        processor.apply(buildKey(), placeholderEvent(true, false));
+
+        verify(jdbcConnection, times(2)).reselectColumns(eq(table), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void cacheEnabledSecondApplyServedFromCache() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        final Struct first = placeholderEvent(true, false);
+        processor.apply(buildKey(), first);
+        assertThat(first.getStruct(Envelope.FieldName.AFTER).get("data")).isEqualTo("db-data");
+
+        final Struct second = placeholderEvent(true, false);
+        processor.apply(buildKey(), second);
+        assertThat(second.getStruct(Envelope.FieldName.AFTER).get("data")).isEqualTo("db-data");
+
+        verify(jdbcConnection, times(1)).reselectColumns(eq(table), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void partialHitServesQueryAndModifyCachedColumnsWithoutRequery() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        // Event 1: 'data' is a placeholder -> queried and cached as "db-data". 'name' arrives with a
+        // real value ("real-name") and is cached on modify (see cacheModifiedColumns).
+        processor.apply(buildKey(), placeholderEvent(true, false));
+        // Event 2: both 'data' and 'name' are placeholders -> 'data' hits the query-cache and 'name'
+        // hits the modify-cache, so neither column is re-queried. Serving the cached "real-name" is
+        // correct: 'name' re-emitted as a placeholder means it was unchanged, so its prior real value
+        // is still the row's current state.
+        final Struct second = placeholderEvent(true, true);
+        processor.apply(buildKey(), second);
+
+        assertThat(second.getStruct(Envelope.FieldName.AFTER).get("data")).isEqualTo("db-data");
+        assertThat(second.getStruct(Envelope.FieldName.AFTER).get("name")).isEqualTo("real-name");
+
+        // 'data' was queried exactly once (event 1); 'name' was never queried (served from cache).
+        verify(jdbcConnection).reselectColumns(eq(table), eq(List.of("data")), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+        verify(jdbcConnection, never()).reselectColumns(eq(table), eq(List.of("name")), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void modifiedColumnIsCachedAndServedToLaterPlaceholderEvent() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        // Event 1: 'data' placeholder -> queried and cached as "db-data".
+        processor.apply(buildKey(), placeholderEvent(true, false));
+
+        // Event 2: 'data' arrives with a REAL value (modified) -> the new value is cached directly,
+        // refreshing the entry without a query.
+        final Struct modify = new Struct(valueSchema)
+                .put(Envelope.FieldName.AFTER, afterStruct(1, "BBB", "real-name"))
+                .put(Envelope.FieldName.SOURCE, sourceStruct())
+                .put(Envelope.FieldName.OPERATION, Envelope.Operation.UPDATE.code());
+        processor.apply(buildKey(), modify);
+
+        // Event 3: 'data' placeholder again -> served from the cache with the modified value, no re-query.
+        final Struct third = placeholderEvent(true, false);
+        processor.apply(buildKey(), third);
+
+        assertThat(third.getStruct(Envelope.FieldName.AFTER).get("data")).isEqualTo("BBB");
+        // Only Event 1 hit the database for 'data'; Events 2 and 3 were served/refreshed from the cache.
+        verify(jdbcConnection, times(1)).reselectColumns(eq(table), eq(List.of("data")), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void cachedNullValueIsServedWithoutRequery() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        // Event 1: 'data' arrives with a real null value -> cached as null.
+        final Struct modify = new Struct(valueSchema)
+                .put(Envelope.FieldName.AFTER, afterStruct(1, null, "real-name"))
+                .put(Envelope.FieldName.SOURCE, sourceStruct())
+                .put(Envelope.FieldName.OPERATION, Envelope.Operation.UPDATE.code());
+        processor.apply(buildKey(), modify);
+
+        // Event 2: 'data' placeholder -> the cached null is a hit and is served without a query.
+        final Struct second = placeholderEvent(true, false);
+        processor.apply(buildKey(), second);
+
+        assertThat(second.getStruct(Envelope.FieldName.AFTER).get("data")).isNull();
+        verify(jdbcConnection, never()).reselectColumns(eq(table), eq(List.of("data")), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void cacheEntryExpiresAfterTtl() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 50);
+
+        processor.apply(buildKey(), placeholderEvent(true, false));
+        Thread.sleep(80); // exceed the 50ms TTL
+        processor.apply(buildKey(), placeholderEvent(true, false));
+
+        verify(jdbcConnection, times(2)).reselectColumns(eq(table), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void differentKeysDoNotShareCacheEntry() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        processor.apply(buildKey(1), placeholderEvent(1, true, false));
+        processor.apply(buildKey(2), placeholderEvent(2, true, false));
+
+        verify(jdbcConnection, times(2)).reselectColumns(eq(table), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    @Test
+    public void readEventsAreNeverReselected() throws Exception {
+        final ReselectColumnsPostProcessor processor = newProcessor(true, 1000, 60_000);
+
+        final Struct read = new Struct(valueSchema)
+                .put(Envelope.FieldName.AFTER, afterStruct(1, UNAVAILABLE, "n"))
+                .put(Envelope.FieldName.SOURCE, sourceStruct())
+                .put(Envelope.FieldName.OPERATION, Envelope.Operation.READ.code());
+        processor.apply(buildKey(), read);
+
+        verify(jdbcConnection, never()).reselectColumns(any(Table.class), anyList(), anyList(), anyList(), any(Struct.class), any(ResultSetConsumer.class));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private boolean answerReselect(InvocationOnMock invocation) throws Exception {
+        final List<String> columns = invocation.getArgument(1);
+        final ResultSetConsumer consumer = invocation.getArgument(5);
+        final ResultSet rs = mock(ResultSet.class);
+        for (String column : columns) {
+            when(rs.getObject(column)).thenReturn("db-" + column);
+        }
+        consumer.accept(rs);
+        return true;
+    }
+
+    private ReselectColumnsPostProcessor newProcessor(boolean cacheEnabled, int maxSize, long ttlMs) {
+        final ReselectColumnsPostProcessor processor = new ReselectColumnsPostProcessor();
+        final Map<String, Object> props = new HashMap<>();
+        props.put("reselect.null.values", "false");
+        props.put("reselect.unavailable.values", "true");
+        props.put("reselect.cache.enabled", String.valueOf(cacheEnabled));
+        props.put("reselect.cache.max.size", String.valueOf(maxSize));
+        props.put("reselect.cache.ttl.ms", String.valueOf(ttlMs));
+        processor.configure(props);
+        processor.injectBeanRegistry(beanRegistry);
+        processor.injectServiceRegistry(serviceRegistry);
+        return processor;
+    }
+
+    private Schema buildValueSchema() {
+        final Schema afterSchema = SchemaBuilder.struct().name("after")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("data", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        final Schema sourceSchema = SchemaBuilder.struct().name("source")
+                .field(AbstractSourceInfo.DATABASE_NAME_KEY, Schema.STRING_SCHEMA)
+                .field(AbstractSourceInfo.SCHEMA_NAME_KEY, Schema.STRING_SCHEMA)
+                .field(AbstractSourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
+                .build();
+        return SchemaBuilder.struct().name("envelope")
+                .field(Envelope.FieldName.AFTER, afterSchema)
+                .field(Envelope.FieldName.SOURCE, sourceSchema)
+                .field(Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    private Struct buildKey() {
+        return buildKey(1);
+    }
+
+    private Struct buildKey(int id) {
+        final Schema keySchema = SchemaBuilder.struct().name("key").field("id", Schema.INT32_SCHEMA).build();
+        return new Struct(keySchema).put("id", id);
+    }
+
+    private Struct placeholderEvent(boolean dataToast, boolean nameToast) {
+        return placeholderEvent(1, dataToast, nameToast);
+    }
+
+    private Struct placeholderEvent(int id, boolean dataToast, boolean nameToast) {
+        final Object data = dataToast ? UNAVAILABLE : "real-data";
+        final Object name = nameToast ? UNAVAILABLE : "real-name";
+        return new Struct(valueSchema)
+                .put(Envelope.FieldName.AFTER, afterStruct(id, data, name))
+                .put(Envelope.FieldName.SOURCE, sourceStruct())
+                .put(Envelope.FieldName.OPERATION, Envelope.Operation.UPDATE.code());
+    }
+
+    private Struct afterStruct(int id, Object data, Object name) {
+        return new Struct(valueSchema.field(Envelope.FieldName.AFTER).schema())
+                .put("id", id)
+                .put("data", data)
+                .put("name", name);
+    }
+
+    private Struct sourceStruct() {
+        return new Struct(valueSchema.field(Envelope.FieldName.SOURCE).schema())
+                .put(AbstractSourceInfo.DATABASE_NAME_KEY, DB)
+                .put(AbstractSourceInfo.SCHEMA_NAME_KEY, SCHEMA)
+                .put(AbstractSourceInfo.TABLE_NAME_KEY, TABLE);
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/processors/reselect/cache/MemoryReselectColumnCacheTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/processors/reselect/cache/MemoryReselectColumnCacheTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.processors.reselect.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.processors.reselect.cache.ReselectColumnCache.Hit;
+import io.debezium.processors.reselect.cache.ReselectColumnCache.RowCache;
+
+/**
+ * Unit tests for {@link MemoryReselectColumnCache}, exercising the row-scoped get/put/invalidate
+ * contract, TTL expiry, key isolation across rows and columns, content-based comparison of binary key
+ * values, schema-driven cache misses, and caching of {@code null} values.
+ *
+ * @author Gaurav Miglani
+ */
+public class MemoryReselectColumnCacheTest {
+
+    private static final Schema INT_KEY = SchemaBuilder.struct().name("key").field("id", Schema.INT32_SCHEMA).build();
+    private static final Schema BYTES_KEY = SchemaBuilder.struct().name("key").field("id", Schema.BYTES_SCHEMA).build();
+
+    private MemoryReselectColumnCache cache;
+
+    @BeforeEach
+    public void before() {
+        cache = new MemoryReselectColumnCache();
+        cache.configure(Configuration.create()
+                .with("reselect.cache.max.size", 1000)
+                .with("reselect.cache.ttl.ms", 60_000)
+                .build());
+    }
+
+    private static Struct intKey(int id) {
+        return new Struct(INT_KEY).put("id", id);
+    }
+
+    private RowCache row(int id) {
+        return cache.forRow(intKey(id));
+    }
+
+    @Test
+    public void getReturnsEmptyOnMiss() {
+        assertThat(row(1).get("data")).isEmpty();
+    }
+
+    @Test
+    public void putThenGetReturnsValue() {
+        row(1).put("data", "AAA");
+        assertThat(row(1).get("data")).map(Hit::value).contains("AAA");
+    }
+
+    @Test
+    public void invalidateRemovesEntry() {
+        row(1).put("data", "AAA");
+        row(1).invalidate("data");
+        assertThat(row(1).get("data")).isEmpty();
+    }
+
+    @Test
+    public void differentColumnsAndRowsAreIsolated() {
+        row(1).put("data", "AAA");
+        row(1).put("name", "BBB");
+        row(2).put("data", "CCC");
+
+        assertThat(row(1).get("data")).map(Hit::value).contains("AAA");
+        assertThat(row(1).get("name")).map(Hit::value).contains("BBB");
+        assertThat(row(2).get("data")).map(Hit::value).contains("CCC");
+    }
+
+    @Test
+    public void invalidatingOneColumnLeavesOthersIntact() {
+        final RowCache r = row(1);
+        r.put("data", "AAA");
+        r.put("name", "BBB");
+
+        r.invalidate("data");
+
+        assertThat(r.get("data")).isEmpty();
+        assertThat(r.get("name")).map(Hit::value).contains("BBB");
+    }
+
+    @Test
+    public void nullValuesAreCachedAndDistinguishedFromMiss() {
+        row(1).put("data", null);
+
+        // A cached null is a hit carrying a null value, not a miss.
+        assertThat(row(1).get("data")).isPresent();
+        assertThat(row(1).get("data").get().value()).isNull();
+
+        // A column that was never cached is still a miss.
+        assertThat(row(1).get("name")).isEmpty();
+    }
+
+    @Test
+    public void binaryKeyValuesAreComparedByContent() {
+        cache.forRow(new Struct(BYTES_KEY).put("id", new byte[]{ 1, 2, 3 })).put("data", "AAA");
+        // A distinct byte[] instance with the same content must resolve to the same entry.
+        assertThat(cache.forRow(new Struct(BYTES_KEY).put("id", new byte[]{ 1, 2, 3 })).get("data"))
+                .map(Hit::value).contains("AAA");
+        assertThat(cache.forRow(new Struct(BYTES_KEY).put("id", new byte[]{ 9, 9, 9 })).get("data")).isEmpty();
+    }
+
+    @Test
+    public void differentKeySchemaDoesNotShareEntry() {
+        // Same logical id value but a different key schema (e.g. after a DDL change) is a distinct key
+        // and must not return the earlier entry, avoiding a false hit against stale data.
+        final Schema renamed = SchemaBuilder.struct().name("key").field("pk", Schema.INT32_SCHEMA).build();
+        cache.forRow(intKey(1)).put("data", "AAA");
+
+        assertThat(cache.forRow(new Struct(renamed).put("pk", 1)).get("data")).isEmpty();
+    }
+
+    @Test
+    public void columnBoundEvictsLruColumnWhenExceeded() {
+        final MemoryReselectColumnCache bounded = new MemoryReselectColumnCache();
+        bounded.configure(Configuration.create()
+                .with("reselect.cache.max.size", 1000)
+                .with("reselect.cache.ttl.ms", 60_000)
+                .with("reselect.cache.max.columns.per.row", 3)
+                .build());
+
+        final RowCache r = bounded.forRow(intKey(99));
+        r.put("col1", "A");
+        r.put("col2", "B");
+        r.put("col3", "C");
+        // col4 pushes col1 out (LRU eviction on the inner map)
+        r.put("col4", "D");
+
+        // col4, col3, col2 should still be present; col1 was the LRU entry and was evicted
+        assertThat(r.get("col4")).map(Hit::value).contains("D");
+        assertThat(r.get("col3")).map(Hit::value).contains("C");
+        assertThat(r.get("col2")).map(Hit::value).contains("B");
+        assertThat(r.get("col1")).isEmpty();
+    }
+
+    @Test
+    public void entryExpiresAfterTtl() throws Exception {
+        final MemoryReselectColumnCache shortTtl = new MemoryReselectColumnCache();
+        shortTtl.configure(Configuration.create()
+                .with("reselect.cache.max.size", 1000)
+                .with("reselect.cache.ttl.ms", 50)
+                .build());
+
+        shortTtl.forRow(intKey(1)).put("data", "AAA");
+        assertThat(shortTtl.forRow(intKey(1)).get("data")).map(Hit::value).contains("AAA");
+
+        Thread.sleep(80); // exceed the 50ms TTL
+        assertThat(shortTtl.forRow(intKey(1)).get("data")).isEmpty();
+    }
+}

--- a/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
@@ -170,6 +170,46 @@ By default, the post-processor logs a warning message when the row cannot be fou
  +
 When set to `FAIL`, the connector will stop processing changes if the row no longer exists at the time of reselection or if there is a database failure when reselecting the row.
 
+|[[reselect-columns-post-processor-property-reselect-cache-enabled]]<<reselect-columns-post-processor-property-reselect-cache-enabled, `+post.processors.reselect.cache.enabled+`>>
+|`false`
+|Enables an optional, per-column cache of reselected values. +
+ +
+By default the post processor queries the database for every event that requires reselection.
+When set to `true`, reselected column values are cached per row and column, keyed by the event's message key, and subsequent events that require the same column are served from the cache instead of querying the database.
+The cache is refreshed on modification: any event that carries a real (non-placeholder) value for a column updates that column's cache entry with the current value, so a later event that does not modify the column can be served from the cache, and a cached value is never served after the column has changed.
+Because the row identity is the message key, a change to the key's schema (for example, a DDL change or a primary-key reordering) yields a different key and a natural cache miss rather than a stale hit.
+This is most useful for large, rarely-changing columns (such as TOAST or LOB values) on frequently-updated rows.
+
+|[[reselect-columns-post-processor-property-reselect-cache-type]]<<reselect-columns-post-processor-property-reselect-cache-type, `+post.processors.reselect.cache.type+`>>
+|`io.debezium.processors.reselect.cache.MemoryReselectColumnCache`
+|The fully-qualified name of the `io.debezium.processors.reselect.cache.ReselectColumnCache` implementation used to store reselected values. +
+ +
+Defaults to an in-memory implementation.
+Provide a custom class to plug in an alternative cache backend.
+Applies only when `reselect.cache.enabled` is `true`.
+
+|[[reselect-columns-post-processor-property-reselect-cache-max-size]]<<reselect-columns-post-processor-property-reselect-cache-max-size, `+post.processors.reselect.cache.max.size+`>>
+|`10000`
+|The maximum number of cached rows retained in the reselection cache. +
+ +
+When the limit is reached, the least-recently-used entries are evicted.
+Applies only to the default in-memory cache, when `reselect.cache.enabled` is `true`.
+
+|[[reselect-columns-post-processor-property-reselect-cache-ttl-ms]]<<reselect-columns-post-processor-property-reselect-cache-ttl-ms, `+post.processors.reselect.cache.ttl.ms+`>>
+|`600000`
+|The time-to-live, in milliseconds, of a cached reselection value. +
+ +
+Because the cache is refreshed on modification, this value only bounds how long entries for rows that are no longer being updated are retained in memory; it is not the mechanism that guarantees freshness.
+Applies only to the default in-memory cache, when `reselect.cache.enabled` is `true`.
+
+|[[reselect-columns-post-processor-property-reselect-cache-max-columns-per-row]]<<reselect-columns-post-processor-property-reselect-cache-max-columns-per-row, `+post.processors.reselect.cache.max.columns.per.row+`>>
+|`200`
+|The maximum number of columns cached per row in the reselection cache. +
+ +
+When the limit is reached, the least-recently-used column entries for that row are evicted.
+This bound guards against wide tables (for example, tables with 500–1000 columns) growing the per-row inner map without limit.
+Applies only to the default in-memory cache, when `reselect.cache.enabled` is `true`.
+
 
 |===
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2002
## Description

Adds an optional, **pluggable per-column cache** to the `ReselectColumnsPostProcessor`
(`debezium-connector-common`).

Today, every event carrying an unavailable-value placeholder (e.g. unchanged PostgreSQL TOAST
columns, Oracle LOBs) or a `null` to refresh triggers a `SELECT` against the source database. For
frequently-updated rows with large, rarely-changing out-of-line columns, this produces many repeated,
identical re-selection queries for the same `(table, key, column)` tuple, adding avoidable load and
latency (notably on managed databases such as Aurora reader endpoints).

This change lets reselected values be reused across events:

- Cache exposed behind a **strategy interface** (`ReselectColumnCache`) so alternative backends (e.g.
  an embedded key/value store such as RocksDB, or a user-custom implementation) can be plugged in
  without changing the post-processor. A default in-memory implementation (`MemoryReselectColumnCache`)
  is provided and is selected via `reselect.cache.type`.
- **Hierarchical `table -> row -> column` layout.** The post-processor resolves a row-scoped handle
  once per event (`forRow(tableId, keyValues)`), so the table and row-key identity are serialized a
  single time and reused for every column of that row, instead of being re-serialized per column. This
  keeps the cost proportional to one row + N columns for a row with N LOB/TOAST columns.
- On a qualifying event, only the **cache misses** are queried (in a single `SELECT`); hits are served
  from the cache.
- **Invalidate-on-modify**: any event that carries a real (non-placeholder) value for a column evicts
  that column's cache entry, so a cached value is never served after the column has changed.
  Correctness therefore does **not** depend on the TTL.
- The default in-memory cache is bounded by size (LRU on the number of cached rows) via the existing
  `io.debezium.util.BoundedConcurrentHashMap` — **no new dependency** — and by a per-value TTL that
  only bounds memory retention for cold rows.
- Cached values are the **raw** JDBC values; the existing `getConvertedValue(...)` conversion is
  applied uniformly to both cache hits and freshly queried values.

New configuration (all optional, **cache disabled by default** — no behavioural change for existing
users):

| Property | Default | Description |
|---|---|---|
| `reselect.cache.enabled` | `false` | Enable the re-selection cache. |
| `reselect.cache.type` | `MemoryReselectColumnCache` | `ReselectColumnCache` implementation class. |
| `reselect.cache.max.size` | `10000` | Max cached rows (LRU). Default in-memory cache only. |
| `reselect.cache.ttl.ms` | `600000` | Entry time-to-live (ms). Default in-memory cache only. |

Includes unit tests for the post-processor (cache hit/miss, partial-hit single-column query,
invalidate-on-modify, TTL expiry, key isolation, read-event skip) and for the in-memory cache
(get/put/invalidate, TTL expiry, binary-key isolation), plus documentation for the new properties in
`reselect-columns.adoc`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
