### PR TITLE
debezium/dbz#2004 Fix duplicate transactional logical messages after connector restart

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -355,12 +355,13 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             maybeWarnAboutGrowingWalBacklog(true);
         }
         else if (message.getOperation() == Operation.MESSAGE) {
-            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, message.getCommitTime(), toLong(message.getTransactionId()),
+            final LogicalDecodingMessage logicalMessage = (LogicalDecodingMessage) message;
+            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, logicalMessage.getCommitTime(), toLong(logicalMessage.getTransactionId()),
                     getSlotXmin(),
-                    message.getOperation());
+                    logicalMessage.getOperation());
 
             // non-transactional message that will not be followed by a COMMIT message
-            if (message.isLastEventForLsn()) {
+            if (!logicalMessage.isTransactional()) {
                 commitMessage(partition, offsetContext, lsn);
             }
 
@@ -368,7 +369,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     partition,
                     offsetContext,
                     clock.currentTimeAsInstant().toEpochMilli(),
-                    (LogicalDecodingMessage) message);
+                    logicalMessage);
 
             maybeWarnAboutGrowingWalBacklog(true);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/LogicalDecodingMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/LogicalDecodingMessage.java
@@ -35,7 +35,7 @@ public class LogicalDecodingMessage implements ReplicationMessage {
 
     @Override
     public boolean isLastEventForLsn() {
-        return !isTransactional;
+        return true;
     }
 
     @Override
@@ -74,5 +74,9 @@ public class LogicalDecodingMessage implements ReplicationMessage {
 
     public byte[] getContent() {
         return content;
+    }
+
+    public boolean isTransactional() {
+        return isTransactional;
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4177,6 +4177,46 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         });
     }
 
+    @Test
+    @FixFor("debezium/dbz#2004")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
+    public void shouldNotReemitConsumedLogicalMessageAfterRestart() throws Exception {
+        // The issue only occurred for transactional logical messages, where the first
+        // parameter of pg_logical_emit_message() is set to true.
+        TestHelper.dropAllSchemas();
+        TestHelper.dropPublication("cdc");
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false")
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.NO_TABLES.getValue());
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
+
+        TestHelper.execute("BEGIN; SELECT pg_logical_emit_message(true, 'foo', 'msg1'); COMMIT;");
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.allRecordsInOrder().size()).isEqualTo(1);
+
+        TestHelper.execute("BEGIN; SELECT pg_logical_emit_message(true, 'foo', 'msg2'); COMMIT;");
+        SourceRecords recordsBeforeRestart = consumeRecordsByTopic(1);
+        assertThat(recordsBeforeRestart.allRecordsInOrder().size()).isEqualTo(1);
+
+        stopConnector();
+        assertConnectorNotRunning();
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+
+        // Since 'msg2' has been already consumed before restart, verify that no records can
+        // be consumed after restart.
+        // Note consumeRecordsByTopic(1) is expected to return due to consumer timeout rather
+        // than receiving a record.
+        SourceRecords recordsAfterRestart = consumeRecordsByTopic(1);
+        assertThat(recordsAfterRestart.allRecordsInOrder().size()).isEqualTo(0);
+    }
+
     /**
      * Postgres override for getting TX ID, as due to DBZ-5329 Postgres TX ID is in form of {@code txId:LSN}.
      */


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2004

## Description

Looking at the logs when the issue occurs, I see the following message:

 ```
 INFO Last processed event was MESSAGE operation at LSN 'LSN{1/E41D9A90}', will restart from first LSN 'LSN{1/E41D9A90}' (io.debezium.connector.postgresql.connection.WalPositionLocator:113)
 ```

According to the comments in the code, this path is intended only for non-transactional MESSAGE operations:

```java
109:        // For non-transactional MESSAGE operations, lastCommitStoredLsn equals lastEventStoredLsn
110:        // (both set to the MESSAGE's LSN). Since the MESSAGE was fully processed and committed,
111:        // we can safely resume from the first LSN received after restart.
112:        if (lastProcessedMessageType == Operation.MESSAGE && lastCommitStoredLsn.equals(lastEventStoredLsn)) {
113:            LOGGER.info("Last processed event was MESSAGE operation at LSN '{}', will restart from first LSN '{}'",
```

However, in this case the message was emitted using `pg_logical_emit_message(true, ...)`, i.e. a transactional message, so I would not expect this condition to match.

I am not yet sure whether the following is the best fix, but my current understanding is that transactional logical messages should be handled similarly to regular DML operations such as INSERT and UPDATE.

For INSERT/UPDATE events, `isLastEventForLsn()` always returns true:

https://github.com/debezium/debezium/blob/6034037b802cee1fb04656e16883d2c5d7d97477/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java#L218-L220

In contrast, the implementation for `pg_logical_emit_message()` currently returns `!isTransactional`.

When I change it to always return `true`, the duplicate-message issue no longer occurs.
In that case, WalPositionLocator follows the same startup path as regular DML events and emits:

```
INFO LSN after last stored change LSN 'LSN{1/E41D9DD0}' received (io.debezium.connector.postgresql.connection.WalPositionLocator:96)
```

What do you think?

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
