### PR TITLE
debezium/dbz#523 Wait for streaming to start after restart

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -388,6 +388,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
                         start(connectorClass(), config);
                         waitForConnectorToStart();
+                        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
                         restarted.set(true);
                     }
                 });
@@ -444,6 +445,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
                         start(connectorClass(), config);
                         waitForConnectorToStart();
+                        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
                         restarted.set(true);
                     }
                 });
@@ -490,6 +492,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
                             start(connectorClass(), config);
                             waitForConnectorToStart();
+                            waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
                             restarted.set(true);
                         }
                     }
@@ -1027,6 +1030,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
                         start(connectorClass(), config);
                         waitForConnectorToStart();
+                        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
                         restarted.set(true);
                     }
                 });


### PR DESCRIPTION
This should prevent empty polls after restart.

Fixes debezium/dbz#523

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
