### PR TITLE
dbz#2009 - fix bug where errors.max.retries is not being used

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -198,6 +198,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private final Map<Map<String, ?>, Map<String, ?>> lastOffsets = new HashMap<>();
 
     private Duration retriableRestartWait;
+    private int maxRestartRetries;
+    private int restartRetries;
 
     private final ElapsedTimeStrategy pollOutputDelay;
 
@@ -264,6 +266,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
                     DebeziumTaskState.INITIAL);
 
             retriableRestartWait = config.getDuration(CommonConnectorConfig.RETRIABLE_RESTART_WAIT, ChronoUnit.MILLIS);
+            maxRestartRetries = config.getInteger(CommonConnectorConfig.MAX_RETRIES_ON_ERROR);
+            restartRetries = 0;
             // need to reset the delay or you only get one delayed restart
             restartDelay = null;
             if (!config.validateAndRecord(getAllConfigurationFields(), LOGGER::error)) {
@@ -469,13 +473,25 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
                 // we're in restart mode... check if it's time to restart
                 if (restartDelay.hasElapsed()) {
-                    LOGGER.info("Attempting to restart task.");
-                    preStart(config);
-                    this.coordinator = start(config);
-                    LOGGER.info("Successfully restarted task");
-                    restartDelay = null;
-                    setTaskState(DebeziumTaskState.RUNNING);
-                    result = true;
+                    try {
+                        LOGGER.info("Attempting to restart task.");
+                        preStart(config);
+                        this.coordinator = start(config);
+                        LOGGER.info("Successfully restarted task");
+                        restartDelay = null;
+                        restartRetries = 0;
+                        setTaskState(DebeziumTaskState.RUNNING);
+                        result = true;
+                    }
+                    catch (RetriableException e) {
+                        restartRetries++;
+                        if (maxRestartRetries != ErrorHandler.RETRIES_UNLIMITED && restartRetries >= maxRestartRetries) {
+                            LOGGER.error("The maximum number of {} restart retries has been reached. Failing the connector.", maxRestartRetries);
+                            throw new ConnectException("The maximum number of restart retries has been reached", e);
+                        }
+                        LOGGER.warn("Failed to restart connector (attempt {} of {}), will re-attempt during next polling.",
+                                restartRetries, maxRestartRetries == ErrorHandler.RETRIES_UNLIMITED ? "unlimited" : maxRestartRetries, e);
+                    }
                 }
                 else {
                     LOGGER.info("Awaiting end of restart backoff period after a retriable error");

--- a/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -148,7 +150,30 @@ class BaseSourceTaskTest {
     }
 
     @Test
-    void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
+    public void verifyRestartFailsWhenMaxRetriesExhausted() throws InterruptedException {
+        MyBaseSourceTask baseSourceTask = new MyBaseSourceTask() {
+            @Override
+            protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
+                ChangeEventSourceCoordinator<Partition, OffsetContext> result = super.start(config);
+                throw new RetriableException("Connection refused");
+            }
+        };
+
+        baseSourceTask.initialize(mock(SourceTaskContext.class));
+        Map<String, String> config = Map.of(
+                CommonConnectorConfig.RETRIABLE_RESTART_WAIT.name(), "1",
+                CommonConnectorConfig.ERRORS_MAX_RETRIES, "2");
+        baseSourceTask.start(config);
+        assertEquals(DebeziumTaskState.RESTARTING, baseSourceTask.getTaskState());
+        sleep(1);
+        baseSourceTask.poll(); // restart attempt 1
+        assertEquals(DebeziumTaskState.RESTARTING, baseSourceTask.getTaskState());
+        sleep(1);
+        assertThrows(ConnectException.class, () -> baseSourceTask.poll()); // restart attempt 2, max reached
+    }
+
+    @Test
+    public void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
         baseSourceTask.start(new HashMap<>());
         assertEquals(DebeziumTaskState.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2009

## Description
Fixes an issue where errors.max.retries was not being used. 

When a source connector enters RESTARTING after a retriable error, BaseSourceTask tries to restart the connector using start(). If start() then throws a RetriableException, like if the source DB is still unavailable, the exception propagates unhandled, and errors.max.retries has no effect on the number of restart attempts.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
