### PR TITLE
dbz#1672 MariaDB gtid comparison should ignore server id

### DIFF
--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/gtid/MariaDbGtidSet.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/gtid/MariaDbGtidSet.java
@@ -66,8 +66,10 @@ public class MariaDbGtidSet implements GtidSet {
         }
 
         final MariaDbGtidSet theOther = (MariaDbGtidSet) other;
+        // MariaDB tracks GTID progress per domain ID only, not also per server ID, so containment
+        // must be compared per domain (see commit message, debezium#1672).
         for (Map.Entry<MariaDbGtidStreamId, MariaDbStreamSet> entry : streamSets.entrySet()) {
-            MariaDbStreamSet thatSet = theOther.forStreamId(entry.getKey());
+            MariaDbStreamSet thatSet = theOther.forDomain(entry.getKey().getDomainId());
             if (!entry.getValue().isContainedWith(thatSet)) {
                 return false;
             }
@@ -148,6 +150,28 @@ public class MariaDbGtidSet implements GtidSet {
 
     public MariaDbStreamSet forStreamId(MariaDbGtidStreamId streamId) {
         return streamSets.get(streamId);
+    }
+
+    /**
+     * Returns the combined set of GTIDs for the given replication {@code domainId}, merging the
+     * GTIDs of every server that has written within that domain.
+     *
+     * <p>MariaDB orders transactions by sequence within a domain regardless of which server wrote
+     * them, so position comparisons must be made per domain rather than per {@code (domain, server)}
+     * stream (see {@link #isContainedWithin(GtidSet)}). Returns {@code null} when no GTIDs exist for
+     * the domain.
+     */
+    public MariaDbStreamSet forDomain(long domainId) {
+        MariaDbStreamSet merged = null;
+        for (Map.Entry<MariaDbGtidStreamId, MariaDbStreamSet> entry : streamSets.entrySet()) {
+            if (entry.getKey().getDomainId() == domainId) {
+                if (merged == null) {
+                    merged = new MariaDbStreamSet();
+                }
+                merged.addAll(entry.getValue());
+            }
+        }
+        return merged;
     }
 
     public static MariaDbGtid parse(String gtid) {

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbGtidSetTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbGtidSetTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.mariadb.gtid.MariaDbGtidSet;
+import io.debezium.doc.FixFor;
 
 /**
  * MariaDB-specific global transaction identifier tests.
@@ -28,4 +29,72 @@ public class MariaDbGtidSetTest {
         assertThat(gtids.forStreamId(new MariaDbGtidSet.MariaDbGtidStreamId(1, 2)).hasSequence(3)).isTrue();
     }
 
+    @Test
+    void shouldBeContainedWithinWhenSequenceIsBehindOnSameStream() {
+        assertThat(new MariaDbGtidSet("0-1-3").isContainedWithin(new MariaDbGtidSet("0-1-5"))).isTrue();
+        assertThat(new MariaDbGtidSet("0-1-5").isContainedWithin(new MariaDbGtidSet("0-1-5"))).isTrue();
+    }
+
+    @Test
+    void shouldNotBeContainedWithinWhenSequenceIsAheadOnSameStream() {
+        assertThat(new MariaDbGtidSet("0-1-5").isContainedWithin(new MariaDbGtidSet("0-1-3"))).isFalse();
+    }
+
+    /**
+     * A MariaDB primary failover/switchover changes the server id that writes a domain, while the
+     * domain's sequence keeps advancing monotonically. The earlier position written by the old
+     * server must still be considered contained within the later position written by the new
+     * server, because they belong to the same domain. Regression test for debezium#1672, where
+     * recovery skipped every schema-history record after a failover and the connector failed with
+     * "no changes will be captured".
+     */
+    @Test
+    @FixFor("debezium/dbz#1672")
+    void shouldBeContainedWithinAcrossServerIdChangeWithinSameDomain() {
+        // history was written under server id 2; the connector offset is now under server id 1
+        MariaDbGtidSet history = new MariaDbGtidSet("0-2-892554529");
+        MariaDbGtidSet offset = new MariaDbGtidSet("0-1-964871206");
+        assertThat(history.isContainedWithin(offset)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1672")
+    void shouldNotBeContainedWithinWhenSequenceIsAheadAcrossServerIdChange() {
+        // a position ahead of the offset must not be considered contained, even on a new server id
+        MariaDbGtidSet ahead = new MariaDbGtidSet("0-1-964871206");
+        MariaDbGtidSet behind = new MariaDbGtidSet("0-2-892554529");
+        assertThat(ahead.isContainedWithin(behind)).isFalse();
+    }
+
+    @Test
+    void shouldNotBeContainedWithinWhenDomainIsAbsentInOther() {
+        // domain 0 is not present in the other set, so it cannot be contained
+        assertThat(new MariaDbGtidSet("0-1-100").isContainedWithin(new MariaDbGtidSet("1-1-100"))).isFalse();
+    }
+
+    @Test
+    void shouldBeContainedWithinAcrossMultipleDomainsIgnoringServerId() {
+        // every domain is behind-or-equal in the other set, despite different server ids
+        MariaDbGtidSet history = new MariaDbGtidSet("0-2-100,1-2-50");
+        MariaDbGtidSet offset = new MariaDbGtidSet("0-1-200,1-3-80");
+        assertThat(history.isContainedWithin(offset)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeContainedWithinWhenAnyDomainIsAhead() {
+        // domain 1 is ahead in 'history' (90 > 80), so the whole set is not contained
+        MariaDbGtidSet history = new MariaDbGtidSet("0-2-100,1-2-90");
+        MariaDbGtidSet offset = new MariaDbGtidSet("0-1-200,1-3-80");
+        assertThat(history.isContainedWithin(offset)).isFalse();
+    }
+
+    @Test
+    void shouldMergeServersOfSameDomainWhenLookingUpByDomain() {
+        MariaDbGtidSet gtidSet = new MariaDbGtidSet("0-1-100,0-2-200");
+        MariaDbGtidSet.MariaDbStreamSet domain0 = gtidSet.forDomain(0);
+        assertThat(domain0).isNotNull();
+        assertThat(domain0.hasSequence(100)).isTrue();
+        assertThat(domain0.hasSequence(200)).isTrue();
+        assertThat(gtidSet.forDomain(9)).isNull();
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1672

## Description
<!-- Briefly describe your changes here. -->
MariaDB GTID comparison in restart use to happen on domain id + server id. It caused crash task, if server id was changed (could be due to failover, or similar things) with no schema match error, server id signifies who wrote the event, not anything on lines, if we should capture it or not. Hence, comparison should happen on domain id only.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
