### PR TITLE
GitHub action for Oracle Testing farm

### DIFF
--- a/.github/actions/build-debezium-oracle-tf/action.yml
+++ b/.github/actions/build-debezium-oracle-tf/action.yml
@@ -1,0 +1,43 @@
+name: "Test Oracle on Testing Farm"
+description: "Runs Oracle connector integration tests on Testing Farm"
+
+inputs:
+  compose:
+    description: "Testing Farm compose (pre-built Oracle image, e.g. debezium-tf-1930)"
+    required: true
+  oracle-version:
+    description: "Oracle version (e.g. 19.3.0, 21.3.0, 23.3.0.0)"
+    required: true
+  oracle-registry:
+    description: "Oracle container image registry"
+    required: false
+    default: "quay.io/rh_integration/dbz-oracle"
+  oracle-profile-args:
+    description: "Additional Maven profile args (e.g. -Poracle-infinispan-buffer -pl debezium-connector-oracle)"
+    required: false
+    default: ""
+  oracle-args:
+    description: "Additional Oracle args (e.g. -Poracle-xstream)"
+    required: false
+    default: ""
+  pull-request-status-name:
+    description: "Name shown in PR status checks"
+    required: true
+  tf-api-key:
+    description: "Testing Farm API key"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Schedule test on Testing Farm
+      uses: sclorg/testing-farm-as-github-action@v4
+      with:
+        api_key: ${{ inputs.tf-api-key }}
+        tmt_plan_regex: "oracle"
+        git_ref: ${{ github.event.pull_request.head.sha }}
+        compose: ${{ inputs.compose }}
+        variables: "ORACLE_VERSION=${{ inputs.oracle-version }};ORACLE_REGISTRY=${{ inputs.oracle-registry }};TEST_PROFILE=oracle;ORACLE_PROFILE_ARGS=${{ inputs.oracle-profile-args }};ORACLE_ARG=${{ inputs.oracle-args }}"
+        pull_request_status_name: ${{ inputs.pull-request-status-name }}
+        update_pull_request_status: "true"
+        create_github_summary: "true"

--- a/.github/actions/build-debezium-oracle-tf/action.yml
+++ b/.github/actions/build-debezium-oracle-tf/action.yml
@@ -39,5 +39,6 @@ runs:
         compose: ${{ inputs.compose }}
         variables: "ORACLE_VERSION=${{ inputs.oracle-version }};ORACLE_REGISTRY=${{ inputs.oracle-registry }};TEST_PROFILE=oracle;ORACLE_PROFILE_ARGS=${{ inputs.oracle-profile-args }};ORACLE_ARG=${{ inputs.oracle-args }}"
         pull_request_status_name: ${{ inputs.pull-request-status-name }}
-        update_pull_request_status: "true"
-        create_github_summary: "true"
+        update_pull_request_status: "false"
+        create_issue_comment: "false"
+        create_github_summary: "false"

--- a/.github/workflows/connector-oracle-tf-workflow.yml
+++ b/.github/workflows/connector-oracle-tf-workflow.yml
@@ -1,0 +1,98 @@
+name: Oracle Testing Farm
+on:
+  workflow_call:
+    secrets:
+      TF_PUBLIC_API_KEY:
+        description: "Testing Farm API key"
+        required: true
+
+jobs:
+  test-oracle-tf:
+    name: "Oracle TF -- ${{ matrix.identifier }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: "oracle-19"
+            compose: "debezium-tf-1930"
+            oracle-version: "19.3.0"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: ""
+            oracle-args: ""
+          - identifier: "oracle-19-unbuffered"
+            compose: "debezium-tf-1930"
+            oracle-version: "19.3.0"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: "-Poracle-logminer-unbuffered -pl debezium-connector-oracle"
+            oracle-args: ""
+          - identifier: "oracle-19-xs"
+            compose: "debezium-tf-1930-xs"
+            oracle-version: "19.3.0-xs"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: ""
+            oracle-args: "-Poracle-xstream"
+          - identifier: "oracle-19-ispn"
+            compose: "debezium-tf-1930"
+            oracle-version: "19.3.0"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: "-Poracle-infinispan-buffer -pl debezium-connector-oracle"
+            oracle-args: ""
+          - identifier: "oracle-19-ehcache"
+            compose: "debezium-tf-1930"
+            oracle-version: "19.3.0"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: "-Poracle-ehcache -pl debezium-connector-oracle"
+            oracle-args: ""
+          - identifier: "oracle-19-se"
+            compose: "debezium-tf-1930-se"
+            oracle-version: "19.3.0-se"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: ""
+            oracle-args: ""
+          - identifier: "oracle-19-se-xs"
+            compose: "debezium-tf-1930-se-xs"
+            oracle-version: "19.3.0-se-xs"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: ""
+            oracle-args: "-Poracle-xstream"
+          - identifier: "oracle-21"
+            compose: "debezium-tf-2130"
+            oracle-version: "21.3.0"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: ""
+            oracle-args: ""
+          - identifier: "oracle-23"
+            compose: "debezium-tf-2330"
+            oracle-version: "23.3.0.0"
+            oracle-registry: "container-registry.oracle.com/database/free"
+            oracle-profile-args: "-Poracle-23 -pl debezium-connector-oracle"
+            oracle-args: ""
+          - identifier: "oracle-26"
+            compose: "debezium-tf-2326"
+            oracle-version: "23.26.1"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: "-Poracle-26"
+            oracle-args: ""
+          - identifier: "oracle-26-xs"
+            compose: "debezium-tf-2326-xs"
+            oracle-version: "23.26.1-xs"
+            oracle-registry: "quay.io/rh_integration/dbz-oracle"
+            oracle-profile-args: "-Poracle-26,oracle-xstream"
+            oracle-args: "-Poracle-xstream,oracle-26"
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v6
+
+      - uses: ./.github/actions/build-debezium-oracle-tf
+        with:
+          compose: ${{ matrix.compose }}
+          oracle-version: ${{ matrix.oracle-version }}
+          oracle-registry: ${{ matrix.oracle-registry }}
+          oracle-profile-args: ${{ matrix.oracle-profile-args }}
+          oracle-args: ${{ matrix.oracle-args }}
+          pull-request-status-name: "Oracle Testing Farm -- ${{ matrix.identifier }}"
+          tf-api-key: ${{ secrets.TF_PUBLIC_API_KEY }}

--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -472,12 +472,15 @@ jobs:
     name: Oracle
     needs: [ check_style, file_changes, build_core ]
     if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.oracle-changed == 'true' || needs.file_changes.outputs.oracle-ddl-parser-changed == 'true' || needs.file_changes.outputs.schema-generator-changed == 'true' || needs.file_changes.outputs.debezium-testing-changed == 'true' }}
-    steps:
-      - uses: ./.github/workflows/connector-oracle-workflow.yml
-        with:
-          maven-cache-key: maven-debezium-test-build
-      - name: "Oracle Testing Farm"
-        uses: ./.github/workflows/connector-oracle-tf-workflow.yml
+    uses: ./.github/workflows/connector-oracle-workflow.yml
+    with:
+      maven-cache-key: maven-debezium-test-build
+
+  build_oracle_tf:
+    name: "Oracle Testing Farm"
+    needs: [ check_style, file_changes, build_core ]
+    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.oracle-changed == 'true' || needs.file_changes.outputs.oracle-ddl-parser-changed == 'true' || needs.file_changes.outputs.schema-generator-changed == 'true' || needs.file_changes.outputs.debezium-testing-changed == 'true' }}
+    uses: ./.github/workflows/connector-oracle-tf-workflow.yml
     secrets:
       TF_PUBLIC_API_KEY: ${{ secrets.TF_PUBLIC_API_KEY }}
 

--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -472,9 +472,14 @@ jobs:
     name: Oracle
     needs: [ check_style, file_changes, build_core ]
     if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.oracle-changed == 'true' || needs.file_changes.outputs.oracle-ddl-parser-changed == 'true' || needs.file_changes.outputs.schema-generator-changed == 'true' || needs.file_changes.outputs.debezium-testing-changed == 'true' }}
-    uses: ./.github/workflows/connector-oracle-workflow.yml
-    with:
-      maven-cache-key: maven-debezium-test-build
+    steps:
+      - uses: ./.github/workflows/connector-oracle-workflow.yml
+        with:
+          maven-cache-key: maven-debezium-test-build
+      - name: "Oracle Testing Farm"
+        uses: ./.github/workflows/connector-oracle-tf-workflow.yml
+    secrets:
+      TF_PUBLIC_API_KEY: ${{ secrets.TF_PUBLIC_API_KEY }}
 
   build_postgresql:
     name: PostgreSQL


### PR DESCRIPTION
GH action to trigger Oracle tests on Testing farm automatically for all PRs which modify source code used by Oracle connector.

Same as https://github.com/debezium/debezium/pull/7501, trying to create PR from Debezium repo, if it solves issues with secrets.