### PR TITLE
debezium/dbz#2031 Apply back-off strategy on XStream attach retries

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.oracle.xstream;
 
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +32,7 @@ import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
+import io.debezium.util.DelayStrategy;
 
 import oracle.sql.NUMBER;
 import oracle.streams.StreamsException;
@@ -170,6 +172,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
 
     private OracleConnection connectAndAttachWithRetries(JdbcConfiguration jdbcConfig, byte[] startPosition) throws Exception {
         OracleConnection connection = null;
+        final DelayStrategy retryStrategy = DelayStrategy.exponential(Duration.ofSeconds(1), Duration.ofMinutes(1));
         for (int attempt = 1; attempt <= DEFAULT_MAX_ATTACH_RETRIES; attempt++) {
             XStreamOut out = null;
             try {
@@ -187,6 +190,9 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
                     }
                     throw e;
                 }
+
+                LOGGER.warn("Failed to attach to outbound server - attempt {} / {}", attempt, DEFAULT_MAX_ATTACH_RETRIES);
+                retryStrategy.sleepWhen(true);
             }
             finally {
                 // If we failed to attach and connection isn't null, close and clear it


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2031

## Description
While working on downstream mining, I found that the reattach loop was occurring too frequently, causing tests to fail more often during reattachment. Adding a back-off to the retry loop solves the issue.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
