### PR TITLE
debezium/dbz#2033 Compare absolute values of the lag behind the source

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
@@ -321,15 +321,20 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
 
         // Check streaming statistics
         Testing.print("****ASSERTIONS****");
-        final Long milliSecondsBehindSourceMinValue = (Long) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
-                "MilliSecondsBehindSourceMinValue");
-        final Long milliSecondsBehindSourceMaxValue = (Long) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
-                "MilliSecondsBehindSourceMaxValue");
-        final Double milliSecondsBehindSourceAverageValue = (Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
-                "MilliSecondsBehindSourceAverageValue");
-        final Double milliSecondsBehindSourceP50 = (Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP50");
-        final Double milliSecondsBehindSourceP95 = (Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP95");
-        final Double milliSecondsBehindSourceP99 = (Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP99");
+        // Lag between database and Debezium can be negative (see dbz#2033), possibly when Db time is ahead of local DBZ time.
+        // As the values are compared in the test, compare the absolute values.
+        final Long milliSecondsBehindSourceMinValue = Math.abs((Long) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
+                "MilliSecondsBehindSourceMinValue"));
+        final Long milliSecondsBehindSourceMaxValue = Math.abs((Long) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
+                "MilliSecondsBehindSourceMaxValue"));
+        final Double milliSecondsBehindSourceAverageValue = Math.abs((Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(),
+                "MilliSecondsBehindSourceAverageValue"));
+        final Double milliSecondsBehindSourceP50 = Math
+                .abs((Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP50"));
+        final Double milliSecondsBehindSourceP95 = Math
+                .abs((Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP95"));
+        final Double milliSecondsBehindSourceP99 = Math
+                .abs((Double) mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "MilliSecondsBehindSourceP99"));
 
         Testing.print("MilliSecondsBehindSourceMinValue: " + milliSecondsBehindSourceMinValue);
         Testing.print("MilliSecondsBehindSourceMaxValue: " + milliSecondsBehindSourceMaxValue);


### PR DESCRIPTION
Fixes debezium/dbz#2033

## Description
The lag can be negative, e.g. when the DB time is ahead of local time and as a results the comparison in this test would fail.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
