### PR TITLE
debezium/dbz#2032 Assign history topic partition during recovery instead of subscribing

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -11,15 +11,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -113,6 +117,75 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
         // Create the empty topic ...
         KafkaClusterUtils.createTopic(topicName, 1, (short) 1, kafkaCluster.getBootstrapServers());
         testHistoryTopicContent(topicName, false);
+    }
+
+    @Test
+    @FixFor("DBZ-2032")
+    void shouldRecoverWhenAnotherConsumerHoldsTheGroupPartition() throws Exception {
+        String topicName = "concurrent-recovery-schema-changes";
+        String historyName = "my-db-history";
+
+        KafkaClusterUtils.createTopic(topicName, 1, (short) 1, kafkaCluster.getBootstrapServers());
+
+        Configuration config = recoveryConfig(topicName, historyName);
+
+        history.configure(config, null, SchemaHistoryMetrics.NOOP, true);
+        history.start();
+        history.initializeStorage();
+        setLogPosition(0);
+        String ddl = "CREATE TABLE foo ( name VARCHAR(255) NOT NULL PRIMARY KEY);";
+        history.record(offsets.getTheOnlyPartition().getSourcePartition(), offsets.getTheOnlyOffset().getOffset(), "db1", ddl);
+        history.stop();
+
+        DdlParser ddlParser = getDdlParser();
+        ddlParser.setCurrentSchema("db1");
+        Tables expected = new Tables();
+        ddlParser.parse(ddl, expected);
+        assertThat(expected.size()).isEqualTo(1);
+
+        // Another consumer joins the recovery group (group.id == history name) and claims the
+        // partition, as a second task would during a Connect rebalance.
+        Configuration squatterConfig = Configuration.create()
+                .with(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers())
+                .with(ConsumerConfig.GROUP_ID_CONFIG, historyName)
+                .with(ConsumerConfig.CLIENT_ID_CONFIG, "squatter")
+                .with(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .build();
+
+        try (KafkaConsumer<String, String> squatter = new KafkaConsumer<>(squatterConfig.asProperties())) {
+            squatter.subscribe(Collections.singletonList(topicName));
+            long deadline = System.currentTimeMillis() + 30000;
+            while (squatter.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+                squatter.poll(Duration.ofMillis(100));
+            }
+            assertThat(squatter.assignment()).isNotEmpty();
+
+            history = new KafkaSchemaHistory();
+            history.configure(config, null, SchemaHistoryListener.NOOP, true);
+            Tables recovered = new Tables();
+            setLogPosition(100);
+            history.recover(offsets, recovered, getDdlParser());
+
+            assertThat(recovered).isEqualTo(expected);
+        }
+    }
+
+    private Configuration recoveryConfig(String topicName, String historyName) {
+        return Configuration.create()
+                .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, kafkaCluster.getBootstrapServers())
+                .with(KafkaSchemaHistory.TOPIC, topicName)
+                .with(SchemaHistory.NAME, historyName)
+                .with(KafkaSchemaHistory.RECOVERY_POLL_INTERVAL_MS, 500)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), 100)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), 50000)
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_CLASS, "org.apache.kafka.connect.source.SourceConnector")
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_ID, "dbz-test")
+                .build();
     }
 
     protected abstract P createPartition(String serverName, String databaseName);

--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
     }
 
     @Test
-    @FixFor("DBZ-2032")
+    @FixFor("debezium/dbz#2032")
     void shouldRecoverWhenAnotherConsumerHoldsTheGroupPartition() throws Exception {
         String topicName = "concurrent-recovery-schema-changes";
         String historyName = "my-db-history";

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -306,9 +306,12 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
     @Override
     protected void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException {
         try (KafkaConsumer<String, String> historyConsumer = new KafkaConsumer<>(consumerConfig.asProperties())) {
-            // Subscribe to the only partition for this topic, and seek to the beginning of that partition ...
-            LOGGER.debug("Subscribing to database schema history topic '{}'", topicName);
-            historyConsumer.subscribe(Collect.arrayListOf(topicName));
+            // Assign the single partition directly instead of subscribing, so overlapping recovery
+            // instances don't contend for a group assignment.
+            LOGGER.debug("Assigning the partition of database schema history topic '{}'", topicName);
+            TopicPartition topicPartition = new TopicPartition(topicName, PARTITION);
+            historyConsumer.assign(Collect.arrayListOf(topicPartition));
+            historyConsumer.seekToBeginning(Collect.arrayListOf(topicPartition));
 
             // Read all messages in the topic ...
             long lastProcessedOffset = UNLIMITED_VALUE;


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2032

## Description

### Problem
- `KafkaSchemaHistory` recovery uses a consumer-group `subscribe()` to read the single-partition history topic; `group.id` is the schema-history name.
- During a multi-worker Connect rebalance, multiple recovery instances of the same connector join the same group to read the single partition. Kafka assigns the partition to only one consumer; the others get an empty assignment (`partitions=[]`).
- The unassigned consumers poll zero records, exhaust `recovery.attempts`, and the task fails with `The database schema history couldn't be recovered.`

### Fix
- Replace `subscribe()` with `assign()` on the single partition followed by `seekToBeginning()`.
- Recovery is a full single-partition read that needs no group coordination, so pinning the consumer to the partition removes the group-assignment contention entirely - overlapping recovery instances can each read independently.
- Fix lives in the shared `debezium-storage-kafka` module, so it applies to all connectors that do schema history recovery from Kafka.

### Test Plan
New test in `AbstractKafkaSchemaHistoryTest`
- `shouldRecoverWhenAnotherConsumerHoldsTheGroupPartition` - populates the history topic, has a separate consumer join the recovery group (`group.id == history name`) and claim the partition, then runs recovery and asserts the schema is fully recovered. Fails on `subscribe()`, passes with `assign()`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
