### PR TITLE
debezium/dbz#1868 Oracle XStream Downstream Mining Support

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -250,9 +250,11 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withEnum(CaptureMode.class, CaptureMode.PRIMARY)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
+            .withValidation(OracleConnectorConfig::validateCaptureMode)
             .withDescription("Specifies the capture mode used to capture streaming changes from Oracle" +
                     "'primary' (the default) captures changes from the primary, specified by database.* configurations, " +
-                    "'physical_standby' captures changes from a read-only physical standby, specified by secondary.* configurations.");
+                    "'physical_standby' captures changes from a read-only physical standby, specified by secondary.* configurations, " +
+                    "'downstream' captures changes from a downstream real-time mining database, specified by secondary.* configurations.");
 
     public static final Field SECONDARY_DATABASE = Field.create(OracleJdbcConfiguration.SECONDARY_DATABASE.name())
             .withDisplayName("The secondary Oracle instance database name")
@@ -2369,6 +2371,15 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOGGER.warn("The property '{}' is set, but is ignored due to using read-only mode.", RAC_NODES.name());
                 }
             }
+        }
+        return 0;
+    }
+
+    public static int validateCaptureMode(Configuration config, Field field, ValidationOutput problems) {
+        final CaptureMode captureMode = CaptureMode.parse(config.getString(CAPTURE_MODE));
+        if (CaptureMode.DOWNSTREAM.equals(captureMode) && isLogMiner(config)) {
+            problems.accept(CAPTURE_MODE, config.getString(CAPTURE_MODE), "Downstream mining is currently only supported by XStream");
+            return 1;
         }
         return 0;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jdbc/CaptureMode.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jdbc/CaptureMode.java
@@ -21,7 +21,12 @@ public enum CaptureMode implements EnumeratedValue {
     /**
      * Captures changes from a physical standby instance.
      */
-    PHYSICAL_STANDBY("physical_standby");
+    PHYSICAL_STANDBY("physical_standby"),
+
+    /**
+     * Downstream mining instance.
+     */
+    DOWNSTREAM("downstream");
 
     private final String value;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jdbc/OracleConnectionFactoryProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jdbc/OracleConnectionFactoryProvider.java
@@ -43,7 +43,11 @@ public final class OracleConnectionFactoryProvider {
         switch (connectorConfig.getCaptureMode()) {
             case PHYSICAL_STANDBY -> {
                 LOGGER.info("Using DUAL connection factory - Streams from Physical Standby");
-                return new DualOracleConnectionFactory(connectorConfig, new PhysicalStandbyConnectionFactory(connectorConfig));
+                return new DualOracleConnectionFactory(connectorConfig, new ReadOnlySecondaryConnectionFactory(connectorConfig));
+            }
+            case DOWNSTREAM -> {
+                LOGGER.info("Using DUAL connection factory - Streams from Downstream Mining Instance");
+                return new DualOracleConnectionFactory(connectorConfig, new ReadOnlySecondaryConnectionFactory(connectorConfig));
             }
             default -> {
                 LOGGER.info("Using STANDARD connection factory - Streams from Primary");
@@ -53,15 +57,15 @@ public final class OracleConnectionFactoryProvider {
     }
 
     /**
-     * An internal factory for Physical Standby databases.
+     * An internal factory for read-only streaming connections.
      * <p>
-     * This creates a connection to the standby instance in read-only mode to stream changes.
+     * This creates a connection to the standby or downstream mining instance in read-only mode to stream changes.
      */
-    private static class PhysicalStandbyConnectionFactory extends AbstractSecondaryConnectionFactory {
+    private static class ReadOnlySecondaryConnectionFactory extends AbstractSecondaryConnectionFactory {
         private final ConnectionFactory<OracleConnection> delegate;
         private final OracleConnection connection;
 
-        PhysicalStandbyConnectionFactory(OracleConnectorConfig connectorConfig) {
+        ReadOnlySecondaryConnectionFactory(OracleConnectorConfig connectorConfig) {
             this.delegate = () -> new ReadOnlyConnectionDecorator(secondaryConfig(connectorConfig), false);
             this.connection = delegate.newConnection();
         }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1107,12 +1107,11 @@ Transitioning a thread from `PRIVATE` to `PUBLIC` can lead to unexpected results
 If a redo thread transition is required, a re-snapshot of data may be required to avoid data loss and to remain consistent.
 ====
 
-////
 ifdef::community[]
-[[oracle-logminer-mining-database]]
+[[oracle-downstream-mining-database]]
 === Using a downstream mining database
 
-You can use the {prodname} Oracle connector to capture changes from an Oracle Database mining database.
+You can use the {prodname} Oracle connector to capture changes from a real-time Oracle downstream mining database.
 Log mining operations consume system resources and increase the load on a database, which can result in decreased performance.
 Configuring the connector to perform change data capture processing on a secondary mining database, can reduce the load on the primary database.
 
@@ -1124,35 +1123,41 @@ Please let us know your specific requirements or if you encounter any problems w
 
 .Prerequisites
 
-* An Oracle downstream mining database is configured and synchronized with the primary instance.
-* The downstream mining database has access to the external dictionary file that the primary database instance generates.
-* The connector configuration includes following key properties:
-`log.mining.strategy`:: This property is set to `dictionary_from_file`.
-`log.mining.read.only`:: This property is set to `true` to enable capturing changes from a downstream mining database, rather than from the primary instance.
-`secondary.dbname`:: Specifies the database name of the downstream mining database from which you want the {prodname} Oracle connector to read and capture transaction logs.
-`secondary.hostname`:: Specifies the hostname of the downstream mining database from which you want the {prodname} Oracle connector to read and capture transaction logs.
-Because the connector uses this downstream mining instance to capture changes, changes must be replicated from the primary to the downstream instance before {prodname} can emit change events.
-`secondary.port`:: Specifies the port of the downstream mining database, if it differs from the primary instance port.
-`secondary.url`:: Specifies the full JDBC connection string to the downstream mining database. Use this as an alternative to `secondary.hostname`, `secondary.port`, and `secondary.dbname` when the connection string requires additional parameters.
-`log.mining.path.dictionary`:: Specifies the absolute file path on the downstream mining database server where Oracle LogMiner can access the data dictionary file that is exported from the primary Oracle instance.
-The LogMiner process on the downstream database must have access to the specified path.
+* An Oracle downstream mining database is configured as `STANDBY SNAPSHOT` to use real-time synchronization with the primary instance. The using of a flat-file extract dictionary file is not supported, as this mode requires the explicit use of `redo_log_catalog` to function.
+* The use of a `PRIMARY` with `NOREGISTER` for Oracle RFS is not supported.
+* All transaction logs should be automatically registered with the downstream mining database using Oracle RFS for real-time data capture.
+* Database administrators should seed the downstream mining database with its first data dictionary build using the `DBMS_LOGMNR_D.BUILD` PL/SQL package before deploying {prodname}.
+* The {prodname} connector must be deployed using XStream, LogMiner is not currently supported.
+
+[IMPORTANT]
+====
+The Oracle downstream database must be configured as a `STANDBY SNAPSHOT` with auto-registered transaction logs.
+Using a `PRIMARY` downstream database is known as an archive-log-mode downstream database and is not supported.
+====
+
+The connector configuration includes following key properties:
+
+`capture.mode`:: Specifies the capture mode, which should be set to `downstream` to activate downstream mining.
+`secondary.dbname`:: Specifies the database name of the downstream mining database instance.
+`secondary.hostname`:: Specifies the hostname of the downstream mining database instance.
+`secondary.port`:: Specifies the port of the downstream mining database instance.
+`secondary.url`:: Specifies the full JDBC connection string to the downstream mining database. Use this as an alternative to `secondary.hostname`, `secondary.port`, and `secondary.dbname`.
 
 ==== How this works
 
 When {prodname} Oracle connector is configured to capture changes from a downstream mining database, the connector operates as follows:
 
-1. The primary Oracle instance generates an external dictionary file containing the database schema and metadata information.
-2. This dictionary file is made available to the downstream mining database at the specified path.
-3. The connector connects to the downstream mining database and uses LogMiner with the external dictionary file to read transaction logs.
-4. Changes are captured from the downstream mining database without impacting the primary database performance.
+1. Periodically, the primary Oracle instance will be asked to extract its data dictionary to the online redo logs.
+2. The connector connects to the primary to perform the snapshot and/or any write operations required for signals.
+3. The connector connects to the downstream mining database to read the transaction logs.
+4. Changes are captured with minimal impact to the primary database performance.
 
 ==== Important considerations
 
-* Ensure that network and file access settings permit the mining database to access the dictionary file and redo logs on the primary database.
-* Keep the dictionary file on the primary instance updated to ensure that it properly reflects schema changes.
-* To prevent issues with schema change detection, keep the dictionary file on the mining database synchronized with the file on the primary.
+* All transaction logs must be registered with the Oracle downstream database. When Oracle RFS replicates changes, this should happen automatically when using a real-time downstream mining configuration. {prodname} does not perform any log registration.
+* When a log fails to register and a gap in log sequences occurs, the {prodname} connector will pause the capture. A database administrator will be required to review the registered logs and register any missing logs to close the gap. In an ideal deployment, this should only be necessary during the initial set up and synchronization with the primary.
+
 endif::community[]
-////
 
 [[oracle-logminer-query-modes]]
 === Query Modes
@@ -4485,6 +4490,7 @@ Required when `log.mining.strategy` is set to `dictionary_from_file`.
 
 `primary`:: Captures and streams changes from the primary instance.
 `physical_standby`:: Captures and streams changes from a physical standby instance.
+`downstream`:: Captures and streams changes from a downstream mining database.
 
 |[[oracle-property-secondary-hostname]]<<oracle-property-secondary-hostname, `+secondary.hostname+`>>
 |No default


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1868

## Description
Support for downstream mining of real-time changes, compatible with XStream. LogMiner will be introduced in a future pass after we address all required adapter code changes.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

This builds on top of the work from #7502 for physical standbys.