### PR TITLE
debezium/dbz#1941 Add missing test coverage for Property defaultValue

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -741,6 +741,7 @@ Yanjie Wang
 Yannick Eisenschmidt
 yangrong688
 yangsanity
+Yash Priyadarshan
 Yashashree Chopada
 Yauheni Ramanovich
 Yevhenii Lopatenko

--- a/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/model/debezium/Property.java
+++ b/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/model/debezium/Property.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Configuration property.
-  * Exposes default value for UI rendering.
+ * Exposes default value for UI rendering.
  */
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/debezium-schema-generator/src/test/java/io/debezium/schemagenerator/schema/debezium/DebeziumDescriptorSchemaCreatorTest.java
+++ b/debezium-schema-generator/src/test/java/io/debezium/schemagenerator/schema/debezium/DebeziumDescriptorSchemaCreatorTest.java
@@ -373,6 +373,101 @@ class DebeziumDescriptorSchemaCreatorTest {
                 .contains("Default: 42");
     }
 
+     @Test
+    void shouldExposeDefaultValueAsField() {
+        ComponentMetadata metadata = new ComponentMetadata() {
+            @Override
+            public ComponentDescriptor getComponentDescriptor() {
+                return new ComponentDescriptor("io.debezium.test.TestConnector", "1.0.0");
+            }
+
+            @Override
+            public Field.Set getComponentFields() {
+                Field field = Field.create("port.field")
+                        .withDisplayName("Port")
+                        .withType(ConfigDef.Type.INT)
+                        .withImportance(ConfigDef.Importance.HIGH)
+                        .withDescription("The port of the database")
+                        .withDefault(5432)
+                        .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 0));
+
+                return Field.setOf(field);
+            }
+        };
+
+        DebeziumDescriptorSchemaCreator creator = new DebeziumDescriptorSchemaCreator(metadata, f -> true);
+
+        io.debezium.schemagenerator.model.debezium.ComponentDescriptor descriptor = creator.buildDescriptor();
+
+        Property property = findProperty(descriptor, "port.field");
+
+        assertThat(property).isNotNull();
+        assertThat(property.defaultValue()).isEqualTo("5432");
+    }
+
+    @Test
+    void shouldExposeStringDefaultValueAsField() {
+        ComponentMetadata metadata = new ComponentMetadata() {
+            @Override
+            public ComponentDescriptor getComponentDescriptor() {
+                return new ComponentDescriptor("io.debezium.test.TestConnector", "1.0.0");
+            }
+
+            @Override
+            public Field.Set getComponentFields() {
+                Field field = Field.create("mode.field")
+                        .withDisplayName("Snapshot Mode")
+                        .withType(ConfigDef.Type.STRING)
+                        .withImportance(ConfigDef.Importance.MEDIUM)
+                        .withDescription("The snapshot mode to use")
+                        .withDefault("initial")
+                        .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 0));
+
+                return Field.setOf(field);
+            }
+        };
+
+        DebeziumDescriptorSchemaCreator creator = new DebeziumDescriptorSchemaCreator(metadata, f -> true);
+
+        io.debezium.schemagenerator.model.debezium.ComponentDescriptor descriptor = creator.buildDescriptor();
+
+        Property property = findProperty(descriptor, "mode.field");
+
+        assertThat(property).isNotNull();
+        assertThat(property.defaultValue()).isEqualTo("initial");
+    }
+
+    @Test
+    void shouldExposeNullWhenNoDefault() {
+        ComponentMetadata metadata = new ComponentMetadata() {
+            @Override
+            public ComponentDescriptor getComponentDescriptor() {
+                return new ComponentDescriptor("io.debezium.test.TestConnector", "1.0.0");
+            }
+
+            @Override
+            public Field.Set getComponentFields() {
+                Field field = Field.create("hostname.field")
+                        .withDisplayName("Hostname")
+                        .withType(ConfigDef.Type.STRING)
+                        .withImportance(ConfigDef.Importance.HIGH)
+                        .withDescription("The hostname of the database server")
+                        .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 0));
+
+                return Field.setOf(field);
+            }
+        };
+
+        DebeziumDescriptorSchemaCreator creator = new DebeziumDescriptorSchemaCreator(metadata, f -> true);
+
+        io.debezium.schemagenerator.model.debezium.ComponentDescriptor descriptor = creator.buildDescriptor();
+
+        Property property = findProperty(descriptor, "hostname.field");
+
+        assertThat(property).isNotNull();
+        assertThat(property.defaultValue()).isNull();
+    }
+
     @Test
     void shouldReplaceExistingDefaultText() {
         ComponentMetadata metadata = new ComponentMetadata() {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -373,3 +373,4 @@ Tony N,Tony Nyurkin
 OctoberWithYou,梁嘉成
 Tlinian,林石培
 Alex-pvl,Aleksandr Pavlyuk
+yashpriyadarshan,Yash Priyadarshan


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1941

## Description
The `default` field was recently added to the `Property` record in the schema descriptor API so that default configuration values can be properly exposed to the UI (e.g., for pre-filling connector forms). While the backend correctly populates this via `field.defaultValueAsString()`, there were no unit tests verifying this translation.

This PR adds three tests to `DebeziumDescriptorSchemaCreatorTest` to explicitly verify that the `defaultValue` is exposed correctly for:
1. Integer default values
2. String default values
3. Optional fields where the default is `null`

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
