### PR TITLE
debezium/dbz#1756 Confirm skipped events during start SCN skip to advance OLR position

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -829,3 +829,4 @@ Dana Stott
 Davyd Eliosidze
 梁嘉成
 林石培
+Aleksandr Pavlyuk

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/olr/client/OlrNetworkClient.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/olr/client/OlrNetworkClient.java
@@ -147,6 +147,7 @@ public class OlrNetworkClient {
             event = readNextEvent();
             // todo: what if we restart mid-transaction?
             if (event.getScn().compareTo(startScn) < 0) {
+                this.confirm(event.getCheckpointScn(), event.getCheckpointIndex());
                 if (notifySkip) {
                     LOGGER.info("Advancing change stream to SCN {}", startScn);
                     notifySkip = false;

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -372,3 +372,4 @@ rigadon,Davyd Eliosidze
 Tony N,Tony Nyurkin
 OctoberWithYou,梁嘉成
 Tlinian,林石培
+Alex-pvl,Aleksandr Pavlyuk


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1756

## Description

When the OpenLogReplicator (OLR) streaming adapter reconnects to an OLR
instance that was restarted from a checkpoint behind the connector's resume
position, OLR replays historical events. In `OlrNetworkClient.readNextEventWithStartScnSkip()`
the connector skips every event with `scn < startScn`, but previously did so
**without confirming** them back to OLR.

OLR keeps unconfirmed events in an internal queue (default `65536`). Once the
queue fills, OLR stops sending new data and the connector blocks forever in the
skip loop — streaming never resumes after an OLR restart.

This change confirms each skipped event using its checkpoint SCN/index, which
advances OLR's confirmed position and drains the queue, so the connector can
finish skipping and continue streaming.

## Testing
Reproduced and verified with OracleConnectorIT#shouldContinueWithStreamingAfterSnapshotAndRestart:

- 1st run (fresh OLR, no checkpoint) passed before and after the change.
- 2nd run (OLR restarted from checkpoint) hangs without this fix and passes with it.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
