### PR TITLE
debezium/dbz#2039 Update docs for collection.field.additional.missing…

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -406,6 +406,14 @@ The second value is the placement and it must always be `header` or `envelope`.
 
 Configuration examples are in xref:mongodb-outbox-emitting-messages-with-additional-fields[emitting additional fields in {prodname} outbox messages].
 
+|[[mongodb-outbox-event-router-property-collection-field-additional-missing]]<<mongodb-outbox-event-router-property-collection-field-additional-missing, `collection.field.additional.missing`>>
+|`error`
+|Collection, Envelope
+a|Determines the behavior of the SMT when a field specified by the `collection.fields.additional.placement` property is not found in the outbox payload. Possible settings are:
+
+* `error` - The SMT throws an exception if a configured additional field is missing.
+* `ignore` - The SMT silently skips the missing field.
+
 |[[mongodb-outbox-event-router-property-collection-field-event-schema-version]]<<mongodb-outbox-event-router-property-collection-field-event-schema-version, `collection.field.event.schema.version`>>
 |
 |Collection, Schema

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -466,10 +466,13 @@ The second value is the placement and it must always be `header` or `envelope`.
 
 Configuration examples are in xref:emitting-messages-with-additional-fields[emitting additional fields in {prodname} outbox messages].
 
-|[[outbox-event-router-property-table-fields-additional-error-on-missing]]<<outbox-event-router-property-table-fields-additional-error-on-missing, `table.fields.additional.error.on.missing`>>
-|`true`
+|[[outbox-event-router-property-table-field-additional-missing]]<<outbox-event-router-property-table-field-additional-missing, `table.field.additional.missing`>>
+|`error`
 |Table, Envelope
-a|Specifies whether this transformation throws an error if a field specified by the `table.fields.additional.placement` property is not found in the Outbox payload.
+a|Determines the behavior of the SMT when a field specified by the `table.fields.additional.placement` property is not found in the outbox payload. Possible settings are:
+
+* `error` - The SMT throws an exception if a configured additional field is missing.
+* `ignore` - The SMT silently skips the missing field.
 
 |[[outbox-event-router-property-table-field-event-schema-version]]<<outbox-event-router-property-table-field-event-schema-version, `table.field.event.schema.version`>>
 |


### PR DESCRIPTION
… and table.field.additional.missing

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2039

## Description
<!-- Briefly describe your changes here. -->


This PR updates the Outbox SMT documentation to detail the new properties introduced in PR #7254 (Fixes DBZ-1342) for handling missing additional fields.

**Key Changes:**
* **MongoDB Outbox SMT:** Added documentation for the `collection.field.additional.missing` property, which supports `error` and `ignore` enum values.
* **SQL Outbox SMT:** Updated the docs to replace the old boolean `table.fields.additional.error.on.missing` with the new enum-based `table.field.additional.missing` property.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
