### PR TITLE
debezium/dbz#2055 Revert Fix read-only snapshotOnlyWithRestart

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -42,7 +42,6 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.EqualityCheck;
 import io.debezium.junit.SkipWhenConnectorUnderTest;
@@ -422,9 +421,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotOnlyWithRestart() throws Exception {
         // Testing.Print.enable();
 
-        final Configuration config = config()
-                .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
-                .build();
+        final Configuration config = config().build();
         startAndConsumeTillEnd(connectorClass(), config);
         waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 


### PR DESCRIPTION
Fixes debezium/dbz#2055

This reverts commit c4870265f43c54ca03ec952bbf2b3a668cd38d74.

Claude suggests that the test hangs due to heartbeats (as a result of reusing thread-unsafe JDBC connection). This explanation seems to be plausible. Moreover, we started to observe hanged test short after merging c4870265 which added heartbeats into the test.

Summary of the root cause from Claude:

    ReadOnlyIncrementalSnapshotIT hangs due to thread-unsafe shared JDBC connection.

    The signal processor thread and streaming thread both use the same
    mainConnection instance returned by `DefaultMainConnectionProvidingConnectionFactory`.
    When a snapshot signal arrives, the signal processor calls `readChunk()`
    (executing `SELECT` queries and `pg_current_snapshot()`) while the streaming
    thread concurrently calls `connection.commit()` on the same connection.
    This race corrupts the JDBC connection state, causing subsequent snapshot
    operations to hang. The hang is sustained because heartbeat records
    (when enabled) keep resetting the test's empty-poll counter, preventing
    the test from ever timing out.

Aforemention timeout should eventually happen in
`AbstractSnapshotTest#consumeMixedWithIncrementalSnapshot` which uses `for (;;)` without any timeout or any other guardrails (and which is another place for possible improvements).


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
