### PR TITLE
debezium/dbz#2057 Add `ORA-25303` to list of retriable Oracle exceptions

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleErrorHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleErrorHandler.java
@@ -41,7 +41,8 @@ public class OracleErrorHandler extends ErrorHandler {
             "ORA-00310", // archived log contains sequence *; sequence * required
             "ORA-01343", // LogMiner encountered corruption in the logstream
             "ORA-01371", // Complete LogMiner dictionary not found
-            "ORA-01001"); // Invalid cursor
+            "ORA-01001", // Invalid cursor
+            "ORA-25303"); // Buffered operation only allowed on owner instance, when DBZXOUT moves instances
 
     /**
      * Contents of this set should be any type of error message text;


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2057

## Description
Add `ORA-25303` to the list of retriable exceptions. This is thrown when an Outbound XStream Server is forcefully moved from instance A to instance B without the instance A node going offline. In this case, this error is raised, but is considered a hard fault and does not allow the runtime to retry a reconnect.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
