### PR TITLE
debezium/dbz#2070: fix parsing single quoted values in logminer

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -312,6 +312,12 @@ public class LogMinerDmlParser implements DmlParser {
                 }
                 else if (lookAhead == '\'') {
                     collectedValue.append('\'');
+                    // In relaxed mode, '' before an end-of-value boundary means (lone ') + (closing ').
+                    // Check whether the following after '' chars signal end-of-value.
+                    lookAhead = (index + 2 < sqlLength) ? sql.charAt(index + 2) : 0;
+                    if (useRelaxedQuotes && (lookAhead == ',' || lookAhead == ')')) {
+                        continue;
+                    }
                     index = index + 1;
                     continue;
                 }
@@ -425,6 +431,13 @@ public class LogMinerDmlParser implements DmlParser {
                 else {
                     if (lookAhead == '\'') {
                         collectedValue.append('\'');
+                        // In relaxed mode, '' before an end-of-value boundary means (lone ') + (closing ').
+                        // Check whether the following after '' chars signal end-of-value.
+                        if (useRelaxedQuotes && (sql.startsWith(", \"", index + 2) ||
+                                sql.startsWith(" where ", index + 2) ||
+                                (lookAhead2 == ';' && lookAhead3 == 0))) {
+                            continue;
+                        }
                         index = index + 1;
                         continue;
                     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
@@ -753,4 +753,39 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getNewValues()[1]).isEqualTo(
                 "Hypersignal du LCA probablement séquellaire d'une ancienne entorse ou d'une dégénérescence mucoïde. Présence d'un kyste arthrosynovial à développement postéro-latéral en arrière du condyle fémoral externe polylobulé et aussi un 2ème kyste arthrosynovial");
     }
+
+    @Test
+    @FixFor("DBZ-2070")
+    public void shouldEmitInsertUpdateRelaxedQuoteDetectionSingleQuotedValues() throws Exception {
+        final Properties properties = new Properties();
+        properties.put("internal.log.mining.sql.relaxed.quote.detection", "true");
+
+        final LogMinerDmlParser parser = new LogMinerDmlParser(new OracleConnectorConfig(Configuration.from(properties)));
+        final Table table = Table.editor()
+                .tableId(TableId.parse("SCHEMA.TAB"))
+                .addColumn(Column.editor().name("NAME").create())
+                .addColumn(Column.editor().name("DATA1").create())
+                .addColumn(Column.editor().name("DATA2").create())
+                .create();
+
+        String sql = "insert into \"SCHEMA\".\"TAB\"(\"NAME\",\"DATA1\",\"DATA2\") values ('Test',''Insert1'',''Insert2'');";
+
+        LogMinerDmlEntry entry = parser.parse(sql, table);
+        assertThat(entry.getEventType()).isEqualTo(EventType.INSERT);
+        assertThat(entry.getOldValues()).isEmpty();
+        assertThat(entry.getNewValues()[0]).isEqualTo("Test");
+        assertThat(entry.getNewValues()[1]).isEqualTo("'Insert1'");
+        assertThat(entry.getNewValues()[2]).isEqualTo("'Insert2'");
+
+        sql = "update \"SCHEMA\".\"TAB\" set \"DATA1\" = ''Update1'', \"DATA2\" = ''Update2'' where \"NAME\" = 'Test' and \"DATA1\" = '''Insert1''' and \"DATA2\" = '''Insert2''';";
+
+        entry = parser.parse(sql, table);
+        assertThat(entry.getEventType()).isEqualTo(EventType.UPDATE);
+        assertThat(entry.getOldValues()[0]).isEqualTo("Test");
+        assertThat(entry.getOldValues()[1]).isEqualTo("'Insert1'");
+        assertThat(entry.getOldValues()[2]).isEqualTo("'Insert2'");
+        assertThat(entry.getNewValues()[0]).isEqualTo("Test");
+        assertThat(entry.getNewValues()[1]).isEqualTo("'Update1'");
+        assertThat(entry.getNewValues()[2]).isEqualTo("'Update2'");
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2070

## Description
The PR fixes the parsing of string values that end with `'` when `internal.log.mining.sql.relaxed.quote.detection` is enabled.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
