### PR TITLE
debezium/dbz#1554 Fix data loss on restart when multiple events share the same LSN

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -37,6 +37,7 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
 
     public static final String LAST_COMPLETELY_PROCESSED_LSN_KEY = "lsn_proc";
     public static final String LAST_COMMIT_LSN_KEY = "lsn_commit";
+    public static final String LSN_EVENTS_PROCESSED_KEY = "lsn_events_processed";
 
     private final Schema sourceInfoSchema;
     private boolean lastSnapshotRecord;
@@ -45,6 +46,8 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
     private Lsn streamingStoppingLsn = null;
     private final TransactionContext transactionContext;
     private final IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
+    private long lsnEventsProcessed;
+    private Lsn previousLsn;
 
     private PostgresOffsetContext(PostgresConnectorConfig connectorConfig, Lsn lsn, Lsn lastCompletelyProcessedLsn, Lsn lastCommitLsn, Long txId, Operation messageType,
                                   Instant time,
@@ -99,6 +102,9 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
         }
         if (sourceInfo.messageType() != null) {
             result.put(SourceInfo.MSG_TYPE_KEY, sourceInfo.messageType().toString());
+        }
+        if (lsnEventsProcessed > 0) {
+            result.put(LSN_EVENTS_PROCESSED_KEY, lsnEventsProcessed);
         }
         return sourceInfo.isSnapshot() ? result : incrementalSnapshotContext.store(transactionContext.store(result));
     }
@@ -176,6 +182,33 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
         return sourceInfo.messageType();
     }
 
+    public long lsnEventsProcessed() {
+        return lsnEventsProcessed;
+    }
+
+    /**
+     * Increments the per-LSN event counter. If the LSN has changed since the last call,
+     * the counter resets to 1. This enables precise restart recovery when multiple events
+     * share the same LSN (e.g. COPY or batched inserts).
+     */
+    public void incrementLsnEventsProcessed(Lsn currentLsn) {
+        if (previousLsn != null && previousLsn.equals(currentLsn)) {
+            lsnEventsProcessed++;
+        }
+        else {
+            lsnEventsProcessed = 1;
+            previousLsn = currentLsn;
+        }
+    }
+
+    /**
+     * Resets the per-LSN event counter, typically called on transaction commit
+     * when the LSN is fully processed.
+     */
+    public void resetLsnEventsProcessed() {
+        lsnEventsProcessed = 0;
+    }
+
     /**
      * Returns the LSN that the streaming phase should stream events up to or null if
      * a stopping point is not set. If set during the streaming phase, any event with
@@ -224,13 +257,17 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
             final SnapshotType snapshot = loadSnapshot(offset).orElse(null);
             boolean snapshotCompleted = loadSnapshotCompleted(offset);
             final boolean lastSnapshotRecord = (boolean) ((Map<String, Object>) offset).getOrDefault(SourceInfo.LAST_SNAPSHOT_RECORD_KEY, Boolean.FALSE);
-            return new PostgresOffsetContext(connectorConfig, lsn,
+            final long lsnEventsProcessed = ((Number) ((Map<String, Object>) offset).getOrDefault(LSN_EVENTS_PROCESSED_KEY, 0L)).longValue();
+            final PostgresOffsetContext context = new PostgresOffsetContext(connectorConfig, lsn,
                     lastCompletelyProcessedLsn, lastCommitLsn, txId, messageType, useconds, snapshot, lastSnapshotRecord,
                     snapshotCompleted,
                     TransactionContext.load(offset),
                     connectorConfig.isReadOnlyConnection()
                             ? PostgresReadOnlyIncrementalSnapshotContext.load(offset)
                             : SignalBasedIncrementalSnapshotContext.load(offset, false));
+            context.lsnEventsProcessed = lsnEventsProcessed;
+            context.previousLsn = lsn;
+            return context;
         }
 
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -171,7 +171,8 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                         : this.effectiveOffset.lsn();
                 final Operation lastProcessedMessageType = this.effectiveOffset.lastProcessedMessageType();
                 LOGGER.info("Retrieved latest position from stored offset '{}'", lsn);
-                walPosition = new WalPositionLocator(this.effectiveOffset.lastCommitLsn(), lsn, lastProcessedMessageType);
+                walPosition = new WalPositionLocator(this.effectiveOffset.lastCommitLsn(), lsn, lastProcessedMessageType,
+                        this.effectiveOffset.lsnEventsProcessed());
                 replicationStream.compareAndSet(null, replicationConnection.startStreaming(lsn, walPosition));
             }
             else {
@@ -339,6 +340,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 // Don't skip on BEGIN message as it would flush LSN for the whole transaction
                 // too early
                 if (message.getOperation() == Operation.COMMIT) {
+                    offsetContext.resetLsnEventsProcessed();
                     commitMessage(partition, offsetContext, lsn);
                     dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, message.getCommitTime());
                 }
@@ -349,6 +351,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 dispatcher.dispatchTransactionStartedEvent(partition, toString(message.getTransactionId()), offsetContext, message.getCommitTime());
             }
             else if (message.getOperation() == Operation.COMMIT) {
+                offsetContext.resetLsnEventsProcessed();
                 commitMessage(partition, offsetContext, lsn);
                 dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, message.getCommitTime());
             }
@@ -361,6 +364,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             // non-transactional message that will not be followed by a COMMIT message
             if (message.isLastEventForLsn()) {
+                offsetContext.resetLsnEventsProcessed();
                 commitMessage(partition, offsetContext, lsn);
             }
 
@@ -392,6 +396,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 Objects.requireNonNull(tableId);
             }
 
+            offsetContext.incrementLsnEventsProcessed(lsn);
             offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, message.getCommitTime(), toLong(message.getTransactionId()),
                     getSlotXmin(),
                     tableId,
@@ -432,7 +437,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 noMessageIterations = 0;
             }
             else {
-                dispatcher.dispatchHeartbeatEventAlsoToIncrementalSnapshot(partition, offsetContext);
+                dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                 noMessageIterations++;
                 if (noMessageIterations >= THROTTLE_NO_MESSAGE_BEFORE_PAUSE) {
                     noMessageIterations = 0;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -39,6 +39,7 @@ public class WalPositionLocator {
     private final Lsn lastCommitStoredLsn;
     private final Lsn lastEventStoredLsn;
     private final Operation lastProcessedMessageType;
+    private final long lastEventStoredLsnEventsProcessed;
     private Lsn txStartLsn = null;
     private Lsn lsnAfterLastEventStoredLsn = null;
     private Lsn firstLsnReceived = null;
@@ -46,20 +47,28 @@ public class WalPositionLocator {
     private Lsn startStreamingLsn = null;
     private boolean storeLsnAfterLastEventStoredLsn = false;
     private Set<Lsn> lsnSeen = new HashSet<>(1_000);
+    private long currentLsnEventCount = 0;
+    private long startStreamingEventsToSkip = 0;
 
     public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn, Operation lastProcessedMessageType) {
+        this(lastCommitStoredLsn, lastEventStoredLsn, lastProcessedMessageType, 0);
+    }
+
+    public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn, Operation lastProcessedMessageType, long lsnEventsProcessed) {
         this.lastCommitStoredLsn = lastCommitStoredLsn;
         this.lastEventStoredLsn = lastEventStoredLsn;
         this.lastProcessedMessageType = lastProcessedMessageType;
+        this.lastEventStoredLsnEventsProcessed = lsnEventsProcessed;
 
-        LOGGER.info("Looking for WAL restart position for last commit LSN '{}' and last change LSN '{}'",
-                lastCommitStoredLsn, lastEventStoredLsn);
+        LOGGER.info("Looking for WAL restart position for last commit LSN '{}' and last change LSN '{}', events processed at LSN '{}'",
+                lastCommitStoredLsn, lastEventStoredLsn, lsnEventsProcessed);
     }
 
     public WalPositionLocator() {
         this.lastCommitStoredLsn = null;
         this.lastEventStoredLsn = null;
         this.lastProcessedMessageType = null;
+        this.lastEventStoredLsnEventsProcessed = 0;
 
         LOGGER.info("WAL position will not be searched");
     }
@@ -81,6 +90,29 @@ public class WalPositionLocator {
             // Event that immediately follows the last event seen
             // We can resume streaming from it
             if (currentLsn.equals(lastEventStoredLsn)) {
+                // Multiple events can share the same LSN (e.g. COPY or batched inserts).
+                // Count events at this LSN to find the precise resume point.
+                currentLsnEventCount++;
+
+                // Same-LSN skip logic only applies when multiple DML events share the same LSN
+                // (e.g. COPY or batched inserts). When lsnEventsProcessed is 1, the existing
+                // "find next different LSN" logic handles restart correctly.
+                if (lastEventStoredLsnEventsProcessed > 1 && currentLsnEventCount <= lastEventStoredLsnEventsProcessed) {
+                    LOGGER.trace("At LSN '{}', event count {} <= processed count {}, continuing search",
+                            currentLsn, currentLsnEventCount, lastEventStoredLsnEventsProcessed);
+                    return Optional.empty();
+                }
+
+                // We've passed all processed events at this LSN and there are more events remaining.
+                // Resume from this LSN, skipping the already-processed events during the replay phase.
+                if (lastEventStoredLsnEventsProcessed > 1) {
+                    startStreamingLsn = lastEventStoredLsn;
+                    startStreamingEventsToSkip = lastEventStoredLsnEventsProcessed;
+                    LOGGER.info("Will restart from LSN '{}' skipping first {} already-processed events",
+                            startStreamingLsn, startStreamingEventsToSkip);
+                    return Optional.of(startStreamingLsn);
+                }
+
                 // BEGIN and first message after change have the same LSN
                 if (txStartLsn != null
                         && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN || lastProcessedMessageType == Operation.COMMIT)) {
@@ -99,6 +131,15 @@ public class WalPositionLocator {
         }
         if (currentLsn.equals(lastEventStoredLsn)) {
             storeLsnAfterLastEventStoredLsn = true;
+            // Start counting events at this LSN
+            currentLsnEventCount = 1;
+
+            // If we have a counter and this is not the last event at this LSN, stay in searching mode
+            if (lastEventStoredLsnEventsProcessed > 1) {
+                LOGGER.trace("At LSN '{}', starting same-LSN event count, processed count is {}",
+                        currentLsn, lastEventStoredLsnEventsProcessed);
+                return Optional.empty();
+            }
         }
 
         if (lastCommitStoredLsn == null) {
@@ -169,6 +210,11 @@ public class WalPositionLocator {
             return false;
         }
         if (startStreamingLsn == null || startStreamingLsn.equals(lsn)) {
+            if (startStreamingEventsToSkip > 0) {
+                startStreamingEventsToSkip--;
+                LOGGER.debug("Message with LSN '{}' skipped, {} events remaining to skip", lsn, startStreamingEventsToSkip);
+                return true;
+            }
             LOGGER.info("Message with LSN '{}' arrived, switching off the filtering", lsn);
             passMessages = true;
             lsnSeen = new HashSet<>(); // Empty the Map as it might be large and is no longer needed
@@ -209,9 +255,11 @@ public class WalPositionLocator {
     @Override
     public String toString() {
         return "WalPositionLocator [lastCommitStoredLsn=" + lastCommitStoredLsn + ", lastEventStoredLsn="
-                + lastEventStoredLsn + ", lastProcessedMessageType=" + lastProcessedMessageType + ", txStartLsn="
+                + lastEventStoredLsn + ", lastProcessedMessageType=" + lastProcessedMessageType
+                + ", lastEventStoredLsnEventsProcessed=" + lastEventStoredLsnEventsProcessed + ", txStartLsn="
                 + txStartLsn + ", lsnAfterLastEventStoredLsn=" + lsnAfterLastEventStoredLsn + ", firstLsnReceived="
                 + firstLsnReceived + ", passMessages=" + passMessages + ", startStreamingLsn=" + startStreamingLsn
-                + ", storeLsnAfterLastEventStoredLsn=" + storeLsnAfterLastEventStoredLsn + "]";
+                + ", storeLsnAfterLastEventStoredLsn=" + storeLsnAfterLastEventStoredLsn + ", startStreamingEventsToSkip="
+                + startStreamingEventsToSkip + "]";
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -4839,7 +4839,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         startConnector(config -> config
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_copy"),
-                true,
+                false,
                 record -> {
                     if (!"test_server.public.test_copy.Envelope".equals(record.valueSchema().name())) {
                         return false;
@@ -4849,7 +4849,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                     final Integer pk = after.getInt32("pk");
                     return pk == stopAtPk;
                 });
-        waitForStreamingToStart();
 
         final String topicName = topicName("public.test_copy");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -4825,6 +4825,66 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertThat(((Struct) insert2.value()).getStruct("after").getInt32("aa")).isEqualTo(2);
     }
 
+    @Test
+    @FixFor("debezium/dbz#1554")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Only supported on PgOutput")
+    public void shouldNotLoseEventsWhenMultipleDmlEventsShareSameLsn() throws Exception {
+        // Testing.Print.enable();
+        final int numberOfEvents = 20;
+        final int stopAtPk = 10;
+
+        TestHelper.execute("DROP TABLE IF EXISTS test_copy;",
+                "CREATE TABLE test_copy (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_copy"),
+                true,
+                record -> {
+                    if (!"test_server.public.test_copy.Envelope".equals(record.valueSchema().name())) {
+                        return false;
+                    }
+                    final Struct envelope = (Struct) record.value();
+                    final Struct after = envelope.getStruct("after");
+                    final Integer pk = after.getInt32("pk");
+                    return pk == stopAtPk;
+                });
+        waitForStreamingToStart();
+
+        final String topicName = topicName("public.test_copy");
+
+        final String inserts = IntStream.rangeClosed(1, numberOfEvents)
+                .boxed()
+                .map(i -> "INSERT INTO test_copy (data) VALUES ('row" + i + "')")
+                .collect(Collectors.joining(";"));
+
+        final int expectFirstRun = stopAtPk - 1;
+        final int expectSecondRun = numberOfEvents - stopAtPk + 1;
+
+        consumer = testConsumer(expectFirstRun);
+        executeAndWait(inserts);
+
+        for (int i = 0; i < expectFirstRun; i++) {
+            final SourceRecord record = consumer.remove();
+            assertEquals(topicName, record.topic());
+            VerifyRecord.isValidInsert(record, PK_FIELD, i + 1);
+        }
+
+        waitForEngineShutdown();
+        cleanupTestFwkState();
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_copy"), false);
+        consumer.expects(expectSecondRun);
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        for (int i = 0; i < expectSecondRun; i++) {
+            final SourceRecord record = consumer.remove();
+            assertEquals(topicName, record.topic());
+            VerifyRecord.isValidInsert(record, PK_FIELD, stopAtPk + i);
+        }
+    }
+
     private String getMessagePrefix(SourceRecord record) {
         Struct message = ((Struct) record.value()).getStruct(LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_KEY);
         return message.getString(LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_PREFIX_KEY);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/WALPositionLocatorTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/WALPositionLocatorTest.java
@@ -18,6 +18,7 @@ import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.connector.postgresql.connection.TransactionMessage;
 import io.debezium.connector.postgresql.connection.WalPositionLocator;
+import io.debezium.doc.FixFor;
 
 /**
  * @author Pranav Tiwari
@@ -342,6 +343,233 @@ public class WALPositionLocatorTest {
 
         assertThat(result).contains("firstLsnReceived=" + lsn)
                 .contains("startStreamingLsn=" + lsn);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenMultipleEventsShareSameLsnShouldResumeAfterProcessedCount() {
+        // Simulate: 5 events all at LSN 140, we processed 3 before crash
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final long lsnEventsProcessed = 3;
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, lsnEventsProcessed);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn commitLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+        final var commitMessage = createCommitMessage(2L);
+
+        // Search phase: find the resume position
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #1
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #2
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #3 (matches count)
+
+        // Event #4 exceeds processed count, resume from stored LSN with skip
+        final Optional<Lsn> result = locator.resumeFromLsn(sameLsn, insertMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(sameLsn);
+
+        // Replay phase: enableFiltering then skipMessage should skip first 3 events at this LSN
+        locator.enableFiltering();
+
+        // Events before stored LSN are filtered by lsnSeen
+        assertThat(locator.skipMessage(beginLsn)).isTrue();
+
+        // First 3 events at stored LSN are skipped (already processed)
+        assertThat(locator.skipMessage(sameLsn)).isTrue(); // skip #1
+        assertThat(locator.skipMessage(sameLsn)).isTrue(); // skip #2
+        assertThat(locator.skipMessage(sameLsn)).isTrue(); // skip #3
+
+        // Events 4 and 5 should pass through (not yet processed)
+        assertThat(locator.skipMessage(sameLsn)).isFalse(); // event #4 passes
+        assertThat(locator.skipMessage(sameLsn)).isFalse(); // event #5 passes
+        assertThat(locator.skipMessage(commitLsn)).isFalse(); // COMMIT passes
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenAllSameLsnEventsProcessedShouldResumeFromNextLsn() {
+        // All 3 events at LSN 140 were processed, then crash after COMMIT
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, 3);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn commitLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+        final var commitMessage = createCommitMessage(2L);
+
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #1
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #2
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #3
+
+        // No more events at this LSN, next different LSN arrives
+        final Optional<Lsn> result = locator.resumeFromLsn(commitLsn, commitMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(commitLsn);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenLsnEventsProcessedIsZeroShouldReplayAllEventsAtThatLsn() {
+        // Backward compatibility: old offsets without counter (effectively 0)
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, 0);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn nextLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty();
+
+        // Next different LSN should resume from here (original behavior preserved)
+        final Optional<Lsn> result = locator.resumeFromLsn(nextLsn, insertMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(nextLsn);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenLsnEventsProcessedIsOneShouldUseNormalResumeLogic() {
+        // Normal case: single event at each LSN, counter is 1.
+        // Should NOT trigger skip logic, should use existing "next different LSN" behavior.
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, 1);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn eventLsn = Lsn.valueOf(140L);
+        final Lsn nextLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(eventLsn, insertMessage)).isEmpty();
+
+        // Next different LSN triggers resume (normal behavior, no skip)
+        final Optional<Lsn> result = locator.resumeFromLsn(nextLsn, insertMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(nextLsn);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenExactlyTwoEventsShareSameLsnShouldSkipCorrectly() {
+        // Boundary case: lsnEventsProcessed=2 is the minimum value that triggers
+        // the same-LSN skip logic (threshold is > 1).
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, 2);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn commitLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #1
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #2 (matches count)
+
+        // Event #3 exceeds count, triggers resume
+        final Optional<Lsn> result = locator.resumeFromLsn(sameLsn, insertMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(sameLsn);
+
+        locator.enableFiltering();
+        assertThat(locator.skipMessage(beginLsn)).isTrue();
+        assertThat(locator.skipMessage(sameLsn)).isTrue(); // skip #1
+        assertThat(locator.skipMessage(sameLsn)).isTrue(); // skip #2
+        assertThat(locator.skipMessage(sameLsn)).isFalse(); // event #3 passes
+        assertThat(locator.skipMessage(commitLsn)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenAllSameLsnEventsProcessedAndNoMoreAtThatLsnShouldResumeFromCommit() {
+        // Edge case: processed exactly all events at the stored LSN, and the next
+        // message is a COMMIT (no unprocessed events remain at that LSN).
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, 2);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn commitLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+        final var commitMessage = createCommitMessage(2L);
+
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #1
+        assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty(); // event #2 (matches count)
+
+        // Next message is COMMIT at different LSN: all events at stored LSN were processed,
+        // so we resume from the commit LSN (next different LSN path)
+        final Optional<Lsn> result = locator.resumeFromLsn(commitLsn, commitMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(commitLsn);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1554")
+    void whenSameLsnEventsSpanMultipleResumeCallsSkipCountShouldDecrementCorrectly() {
+        // Verify that skipMessage skip counter decrements to exactly zero and then
+        // all subsequent messages at the same LSN pass through.
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(140L);
+        final long processed = 4;
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn,
+                ReplicationMessage.Operation.INSERT, processed);
+
+        final Lsn beginLsn = Lsn.valueOf(110L);
+        final Lsn sameLsn = Lsn.valueOf(140L);
+        final Lsn commitLsn = Lsn.valueOf(150L);
+
+        final var beginMessage = createBeginMessage(1L);
+        final var insertMessage = createInsertMessage(2L);
+
+        // Search phase
+        assertThat(locator.resumeFromLsn(beginLsn, beginMessage)).isEmpty();
+        for (int i = 0; i < processed; i++) {
+            assertThat(locator.resumeFromLsn(sameLsn, insertMessage)).isEmpty();
+        }
+        // Event after processed count triggers resume
+        final Optional<Lsn> result = locator.resumeFromLsn(sameLsn, insertMessage);
+        assertThat(result).isPresent();
+
+        // Replay phase: exactly 4 skips, then all pass
+        locator.enableFiltering();
+        assertThat(locator.skipMessage(beginLsn)).isTrue();
+        for (int i = 0; i < processed; i++) {
+            assertThat(locator.skipMessage(sameLsn)).isTrue();
+        }
+        // Remaining events at same LSN should all pass
+        assertThat(locator.skipMessage(sameLsn)).isFalse();
+        assertThat(locator.skipMessage(sameLsn)).isFalse();
+        assertThat(locator.skipMessage(commitLsn)).isFalse();
     }
 
     // =============================================================================


### PR DESCRIPTION
Fixes debezium/dbz#1554

## Description

When using PostgreSQL COPY or batched multi-row inserts, multiple DML events can share
the same LSN within a transaction. Previously, PgOutputReplicationMessage.isLastEventForLsn()
always returned true, causing the connector to mark the LSN as fully processed after the
first event. On restart, remaining events at that LSN would be skipped, resulting in data loss.

This fix introduces a per-LSN event counter in the connector offsets that tracks how many
events at the current LSN have been successfully processed. On restart, WalPositionLocator
uses this counter to resume precisely after the last processed event within a same-LSN group.

Changes:
- PgOutputReplicationMessage.isLastEventForLsn() now returns false for DML events
- Added lsn_events_processed field to PostgresOffsetContext (backward compatible, defaults to 0)
- Updated WalPositionLocator to use LSN + event count for resume point calculation
- PostgresStreamingChangeEventSource increments counter per DML, resets on COMMIT
- Added unit tests for same-LSN multi-event restart scenarios

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
