### PR TITLE
[docs] Fix MongoDB connector docs that incorrectly state it always streams from the primary

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -82,7 +82,7 @@ In this case, after a restart the connector detects the missing oplog operations
 
 The MongoDB connector is also quite tolerant of changes in membership and leadership of the replica sets, of additions or removals of shards within a sharded cluster, and network problems that might cause communication failures.
 By default, the connector streams changes from the replica set's primary node, but you can configure it to stream from a secondary by setting the xref:read-preference[read preference] in the connection string.
-If the member that the connector reads from becomes unavailable -- for example, because the replica set elects a new primary -- the connector stops streaming and automatically reconnects to another suitable member based on the configured read preference.
+If the replica set member that the connector reads from becomes unavailable -- for example, because the replica set elects a new primary -- the connector stops streaming and automatically reconnects to another suitable member based on the configured read preference.
 Similarly, if the connector is unable to communicate with the replica set, it attempts to reconnect by using exponential backoff so as to not overwhelm the network or replica set.
 After connection is reestablished, the connector continues to stream changes from the last event that it captured.
 In this way the connector dynamically adjusts to changes in replica set membership, and automatically handles communication disruptions.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -109,8 +109,11 @@ You specify the replica member that the connector reads from by configuring the 
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
 To reduce the load on the primary, it's possible to configure the connector to read from a secondary node, by setting `readPreference=secondaryPreferred`.
-However, because change streams emit only majority-committed events, be aware that replication delay results in secondary nodes lagging behind the primary.
-As a result, events captured from a secondary can arrive later than they would from the primary.
+Under normal operating conditions, configuring the connector to read from a secondary node does not significantly increase data-capture latency. 
+However, events captured from a secondary can arrive later than they would from the primary due to resource contention or network latency.
+Additional latency can also occur because change streams emit events only after changes are majority committed. 
+A change is majority committed when a majority of voting replica set members confirm that they have written the change to their journals. 
+As a result, a secondary node can emit an event only after it receives confirmation that the change has been majority committed.
 
 // Type: assembly
 // ModuleID: how-debezium-mongodb-connectors-work

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -103,7 +103,8 @@ In this way the connector dynamically adjusts to changes in replica set membersh
 [id="read-preference"]
 === Read Preference
 
-The connector captures changes by using MongoDB change streams, which can be served by any member of a replica set.
+The connector uses MongoDB change streams to capture changes.
+Because the change streams API can read data from secondary nodes, you can configure the connector to capture changes from any member of the replica set.
 You specify the replica member that the connector reads from by configuring the MongoDB link:https://www.mongodb.com/docs/manual/core/read-preference/[`readPreference`] parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -429,7 +429,7 @@ To avoid unexpected results, consumers must be able to handle duplicate messages
 As described in xref:read-preference[read preferences], the connector streams changes from the replica set member that is specified by the `readPreference` parameter in the MongoDB connection string.
 By default, the connector captures from the primary node, which result in capture operations with the lowest latency.
 Optionally, you can configure the connector to read from a secondary, but capturing from a secondary can introduce additional latency due to replication lag.
-If the member that the connector is reading from becomes unavailable -- for example, when the replica set elects a new primary -- the connector stops streaming changes, reconnects to another suitable member, and resumes streaming from the same position.
+If the replica set member that the connector reads from becomes unavailable, the connector stops streaming changes, reconnects to another suitable member, and resumes streaming from the same position.
 Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off.
 In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -107,7 +107,7 @@ The connector captures changes by using MongoDB change streams, which can be ser
 You specify the replica member that the connector reads from by configuring the MongoDB link:https://www.mongodb.com/docs/manual/core/read-preference/[`readPreference`] parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
-Reading from a secondary (for example, `readPreference=secondaryPreferred`) can reduce load on the primary.
+Configuring the connector to read from a secondary node, for example, by setting `readPreference=secondaryPreferred`, can reduce the load on the primary.
 However, because change streams emit only majority-committed events, be aware that replication delay results in secondary nodes lagging behind the primary.
 As a result, events captured from a secondary can arrive later than they would from the primary.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -108,7 +108,7 @@ Because the change streams API can read data from secondary nodes, you can confi
 You specify the replica member that the connector reads from by configuring the MongoDB link:https://www.mongodb.com/docs/manual/core/read-preference/[`readPreference`] parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
-Configuring the connector to read from a secondary node, for example, by setting `readPreference=secondaryPreferred`, can reduce the load on the primary.
+To reduce the load on the primary, it's possible to configure the connector to read from a secondary node, by setting `readPreference=secondaryPreferred`.
 However, because change streams emit only majority-committed events, be aware that replication delay results in secondary nodes lagging behind the primary.
 As a result, events captured from a secondary can arrive later than they would from the primary.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -429,6 +429,7 @@ To avoid unexpected results, consumers must be able to handle duplicate messages
 As described in xref:read-preference[read preferences], the connector streams changes from the replica set member that is specified by the `readPreference` parameter in the MongoDB connection string.
 By default, the connector captures from the primary node, which result in capture operations with the lowest latency.
 Optionally, you can configure the connector to read from a secondary, but capturing from a secondary can introduce additional latency due to replication lag.
+For more information, see xref:read-preference[Read preferences].
 If the replica set member that the connector reads from becomes unavailable, the connector stops streaming changes, reconnects to another suitable member, and resumes streaming from the same position.
 Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off.
 In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -424,7 +424,7 @@ To avoid unexpected results, consumers must be able to handle duplicate messages
 
 As described in xref:read-preference[read preferences], the connector streams changes from the replica set member that is specified by the `readPreference` parameter in the MongoDB connection string.
 By default, the connector captures from the primary node, which result in capture operations with the lowest latency.
-Optionally, you can configure the connector to read from a secondary, but capturing from a secondary typically results in additional latency due to replication lag.
+Optionally, you can configure the connector to read from a secondary, but capturing from a secondary can introduce additional latency due to replication lag.
 If the member that the connector is reading from becomes unavailable -- for example, when the replica set elects a new primary -- the connector stops streaming changes, reconnects to another suitable member, and resumes streaming from the same position.
 Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off.
 In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -81,8 +81,9 @@ Of course, MongoDB oplogs are usually capped at a maximum size, so if the connec
 In this case, after a restart the connector detects the missing oplog operations, performs a snapshot, and then proceeds to stream changes.
 
 The MongoDB connector is also quite tolerant of changes in membership and leadership of the replica sets, of additions or removals of shards within a sharded cluster, and network problems that might cause communication failures.
-The connector always uses the replica set's primary node to stream changes, so when the replica set undergoes an election and a different node becomes primary, the connector will immediately stop streaming changes, connect to the new primary, and start streaming changes using the new primary node.
-Similarly, if connector is unable to communicate with the replica set primary, it attempts to reconnect (using exponential backoff so as to not overwhelm the network or replica set).
+By default, the connector streams changes from the replica set's primary node, but you can configure it to stream from a secondary by setting the xref:read-preference[read preference] in the connection string.
+If the member that the connector reads from becomes unavailable -- for example, because the replica set elects a new primary -- the connector stops streaming and automatically reconnects to another suitable member based on the configured read preference.
+Similarly, if the connector is unable to communicate with the replica set, it attempts to reconnect by using exponential backoff so as to not overwhelm the network or replica set.
 After connection is reestablished, the connector continues to stream changes from the last event that it captured.
 In this way the connector dynamically adjusts to changes in replica set membership, and automatically handles communication disruptions.
 
@@ -102,7 +103,13 @@ In this way the connector dynamically adjusts to changes in replica set membersh
 [id="read-preference"]
 === Read Preference
 
-You specify read preferences for a MongoDB connection by setting the `readPreference` parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
+The connector captures changes by using MongoDB change streams, which can be served by any member of a replica set.
+You specify the replica member that the connector reads from by configuring the MongoDB link:https://www.mongodb.com/docs/manual/core/read-preference/[`readPreference`] parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
+If you do not specify a read preference, the driver default of `primary` applies, so the connector streams changes from the primary node.
+
+Reading from a secondary (for example, `readPreference=secondaryPreferred`) can reduce load on the primary.
+However, because change streams emit only majority-committed events, be aware that replication delay results in secondary nodes lagging behind the primary.
+As a result, events captured from a secondary can arrive later than they would from the primary.
 
 // Type: assembly
 // ModuleID: how-debezium-mongodb-connectors-work
@@ -397,7 +404,10 @@ include::{partialsdir}/modules/all-connectors/con-connector-blocking-snapshot.ad
 [[mongodb-tailing-the-oplog]]
 
 After the connector task for a replica set records an offset, it uses the offset to determine the position in the oplog where it should start streaming changes.
-The task then (depending on the configuration) either connects to the replica set's primary node or connects to a replica-set-wide change stream and starts streaming changes from that position.
+The task then opens a MongoDB change stream and starts streaming changes from the offset position.
+Depending on the value of the xref:mongodb-property-capture-scope[`capture.scope`] setting, the task streams changes from the deployment, a specific database, or a collection.
+The change stream is served by the replica set member that matches the configured read preference (the primary, by default).
+For more information, see xref:read-preference[read-preference].
 It processes all of create, insert, and delete operations, and converts them into {prodname} xref:mongodb-events[change events].
 Each change event includes the position in the oplog where the operation was found, and the connector periodically records this as its most recent offset.
 The interval at which the offset is recorded is governed by link:https://kafka.apache.org/documentation/#offset.flush.interval.ms[`offset.flush.interval.ms`], which is a Kafka Connect worker configuration property.
@@ -412,8 +422,10 @@ However, when things go wrong, Kafka can only guarantee that consumers receive e
 To avoid unexpected results, consumers must be able to handle duplicate messages.
 ====
 
-As mentioned earlier, the connector tasks always use the replica set's primary node to stream changes from the oplog, ensuring that the connector sees the most up-to-date operations as possible and can capture the changes with lower latency than if secondaries were to be used instead.
-When the replica set elects a new primary, the connector immediately stops streaming changes, connects to the new primary, and starts streaming changes from the new primary node at the same position.
+As described in xref:read-preference[read preferences], the connector streams changes from the replica set member that is specified by the `readPreference` parameter in the MongoDB connection string.
+By default, the connector captures from the primary node, which result in capture operations with the lowest latency.
+Optionally, you can configure the connector to read from a secondary, but capturing from a secondary typically results in additional latency due to replication lag.
+If the member that the connector is reading from becomes unavailable -- for example, when the replica set elects a new primary -- the connector stops streaming changes, reconnects to another suitable member, and resumes streaming from the same position.
 Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off.
 In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.
 
@@ -2443,7 +2455,8 @@ In these cases, the error will have more details about the problem and possibly 
 [id="mongodb-becomes-unavailable-while-debezium-is-running"]
 === MongoDB becomes unavailable
 
-Once the connector is running, if the primary node of any of the MongoDB replica sets become unavailable or unreachable, the connector will repeatedly attempt to reconnect to the primary node, using exponential backoff to prevent saturating the network or servers. If the primary remains unavailable after the configurable number of connection attempts, the connector will fail.
+If the connector is running and the replica set member that it reads from becomes unavailable, it keeps trying to reconnect to another suitable member, using exponential backoff to avoid overloading the network or servers.
+If the connector is unable to connect to a replica set member after the configured number of connection attempts, the connector fails.
 
 The attempts to reconnect are controlled by three properties:
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -105,7 +105,7 @@ In this way the connector dynamically adjusts to changes in replica set membersh
 
 The connector captures changes by using MongoDB change streams, which can be served by any member of a replica set.
 You specify the replica member that the connector reads from by configuring the MongoDB link:https://www.mongodb.com/docs/manual/core/read-preference/[`readPreference`] parameter in the xref:mongodb-property-mongodb-connection-string[`mongodb.connection.string`].
-If you do not specify a read preference, the driver default of `primary` applies, so the connector streams changes from the primary node.
+If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
 Reading from a secondary (for example, `readPreference=secondaryPreferred`) can reduce load on the primary.
 However, because change streams emit only majority-committed events, be aware that replication delay results in secondary nodes lagging behind the primary.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes https://github.com/debezium/dbz/issues/2022

## Description
## What

Several places in the MongoDB connector docs state that the connector *always*
streams changes from the replica set's primary node. That is no longer accurate:
The connector reads from whichever replica set member the configured read
preference selects, and the primary is only the default.

The page also contradicts itself — the "Streaming changes" section already
references a change-stream path, while the overview and a later paragraph still
assert the old oplog-tailing, primary-only behavior. The "either connects to the
primary or to a replica-set-wide change stream" wording is left over from the
removed `mongodb.connection.mode` / `mongodb.connection.string.shard.params`
configuration and no longer describes any current code path.

## Why

- The connector captures changes via MongoDB change streams, which can be served
  by any replica set member according to read preference; it does not tail the
  oplog on the primary.
- The connector has honored the `readPreference` from the connection string since
  Debezium 2.4.
- With the default read preference (`primary`), the old wording is *accidentally*
  correct, which is likely why it was never updated — but it is wrong as soon as a
  user sets `secondaryPreferred` or similar.

## Changes (docs only — no code or behavior change)

1. Overview fault-tolerance paragraph: replace "always uses the primary" with
   read-preference-aware wording; generalize reconnect from "primary" to a
   "suitable member".
2. **Read Preference** section: expand the single sentence to explain the
   change-stream mechanism, the `primary` default, and the secondary-read
   tradeoff (majority-committed events + replication lag).
3. "Streaming changes" opener: replace the obsolete "either primary or change
   stream" wording with a change-stream + `capture.scope` + read-preference
   description.
4. "As mentioned earlier…" paragraph: drop the "always primary from the oplog"
   claim and the primary-only failover description.
5. "MongoDB becomes unavailable" failure section: generalize reconnect from the
   primary node to the member matching the read preference.

The new wording is consistent with the existing **Read Preference** section and
the `capture.scope` property.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ x] One feature/change per PR unless tightly coupled
- [ x] Do a rebase on upstream `main`
