### PR TITLE
debezium/dbz#1437 Document the isostring time.precision.mode option

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -834,3 +834,4 @@ Davyd Eliosidze
 梁嘉成
 林石培
 Aleksandr Pavlyuk
+Roshni R

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -426,7 +426,10 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
                     + "'adaptive' (the default) bases the precision of time, date, and timestamp values on the database column's precision; "
                     + "'adaptive_time_microseconds' like 'adaptive' mode, but TIME fields always use microseconds precision; "
                     + "'connect' always represents time, date, and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, "
-                    + "which uses millisecond precision regardless of the database columns' precision.");
+                    + "which uses millisecond precision regardless of the database columns' precision; "
+                    + "'isostring' represents time, date, and timestamp values as ISO-8601 formatted strings at the UTC time zone; "
+                    + "'microseconds' always represents time, date, and timestamp values using microsecond precision; "
+                    + "'nanoseconds' always represents time, date, and timestamp values using nanosecond precision.");
 
     public static final Field SNAPSHOT_LOCK_TIMEOUT_MS = Field.create("snapshot.lock.timeout.ms")
             .withDisplayName("Snapshot lock timeout (ms)")

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1790,6 +1790,7 @@ The following sections describe these mappings:
 
 * xref:db2-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
 * xref:db2-time-precision-mode-connect[`time.precision.mode=connect`]
+* xref:db2-time-precision-mode-isostring[`time.precision.mode=isostring`]
 
 [[db2-time-precision-mode-adaptive]]
 .`time.precision.mode=adaptive`
@@ -1862,6 +1863,37 @@ Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond prec
 |`org.apache.kafka.connect.data.Timestamp` +
  +
 Represents the number of milliseconds since the epoch, and does not include timezone information.
+
+|===
+
+[[db2-time-precision-mode-isostring]]
+.`time.precision.mode=isostring`
+Set the `time.precision.mode` property to `isostring` to configure the connector to map temporal values as ISO-8601 formatted strings at the UTC time zone.
+When you apply this setting, the connector uses the semantic types `io.debezium.time.IsoDate`, `io.debezium.time.IsoTime`, and `io.debezium.time.IsoTimestamp` to map date, time, and timestamp values.
+Because the values are represented as strings, this mode avoids the loss of precision that can occur in `connect` mode when the fractional second precision is greater than 3.
+
+.Mappings when `time.precision.mode` is `isostring`
+[cols="25%a,20%a,55%a",options="header"]
+|===
+|Db2 data type |Literal type (schema type) |Semantic type (schema name) and Notes
+
+|`DATE`
+|`STRING`
+|`io.debezium.time.IsoDate` +
+ +
+Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
+
+|`TIME([P])`
+|`STRING`
+|`io.debezium.time.IsoTime` +
+ +
+Represents time values in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
+
+|`DATETIME`
+|`STRING`
+|`io.debezium.time.IsoTimestamp` +
+ +
+Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1879,20 +1879,20 @@ Because the values are represented as strings, this mode avoids the loss of prec
 
 |`DATE`
 |`STRING`
-|`io.debezium.time.IsoDate` +
- +
+|`io.debezium.time.IsoDate`
+
 Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
 
 |`TIME([P])`
 |`STRING`
-|`io.debezium.time.IsoTime` +
- +
+|`io.debezium.time.IsoTime`
+
 Represents time values in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
 
 |`DATETIME`
 |`STRING`
-|`io.debezium.time.IsoTimestamp` +
- +
+|`io.debezium.time.IsoTimestamp`
+
 Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -1718,6 +1718,7 @@ The following sections describe these mappings:
 
 * xref:informix-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
 * xref:informix-time-precision-mode-connect[`time.precision.mode=connect`]
+* xref:informix-time-precision-mode-isostring[`time.precision.mode=isostring`]
 
 [[informix-time-precision-mode-adaptive]]
 .`time.precision.mode=adaptive`
@@ -1764,6 +1765,30 @@ Represents the number of days since the epoch.
 |`org.apache.kafka.connect.data.Timestamp`
 
 Represents the number of milliseconds since the epoch, and does not include timezone information.
+
+|===
+
+[[informix-time-precision-mode-isostring]]
+.`time.precision.mode=isostring`
+Set the `time.precision.mode` property to `isostring` to configure the connector to map temporal values as ISO-8601 formatted strings at the UTC time zone.
+When you apply this setting, the connector uses the semantic types `io.debezium.time.IsoDate` and `io.debezium.time.IsoTimestamp` to map date and timestamp values.
+
+.Mappings when `time.precision.mode` is `isostring`
+[cols="25%a,20%a,55%a",options="header"]
+|===
+|Informix data type |Literal type (schema type) |Semantic type (schema name) and Notes
+
+|`DATE`
+|`STRING`
+|`io.debezium.time.IsoDate`
+
+Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
+
+|`DATETIME`
+|`STRING`
+|`io.debezium.time.IsoTimestamp`
+
+Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2428,6 +2428,27 @@ A string representation of a timestamp in UTC.
 
 |===
 
+When the `time.precision.mode` configuration property is set to `isostring`, the connector maps temporal values to ISO-8601 formatted strings at the UTC time zone, using the `io.debezium.time.IsoTimestamp` semantic type.
+Because Oracle `DATE` and `TIMESTAMP` values include a time component, both are represented as timestamps:
+
+[cols="25%a,20%a,55%a",options="header"]
+|===
+|Oracle data type |Literal type (schema type) |Semantic type (schema name) and Notes
+
+|`DATE`
+|`STRING`
+|`io.debezium.time.IsoTimestamp` +
+ +
+Represents the timestamp value in UTC format, according to the ISO 8601 standard, for example, `2018-03-27T00:00:00Z`.
+
+|`TIMESTAMP(0 - 9)`
+|`STRING`
+|`io.debezium.time.IsoTimestamp` +
+ +
+Represents the timestamp value in UTC format, according to the ISO 8601 standard, for example, `2018-03-27T12:34:56.125456789Z`.
+
+|===
+
 [id="oracle-rowid-types"]
 === ROWID types
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2437,14 +2437,14 @@ Because Oracle `DATE` and `TIMESTAMP` values include a time component, both are 
 
 |`DATE`
 |`STRING`
-|`io.debezium.time.IsoTimestamp` +
- +
+|`io.debezium.time.IsoTimestamp`
+
 Represents the timestamp value in UTC format, according to the ISO 8601 standard, for example, `2018-03-27T00:00:00Z`.
 
 |`TIMESTAMP(0 - 9)`
 |`STRING`
-|`io.debezium.time.IsoTimestamp` +
- +
+|`io.debezium.time.IsoTimestamp`
+
 Represents the timestamp value in UTC format, according to the ISO 8601 standard, for example, `2018-03-27T12:34:56.125456789Z`.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1834,20 +1834,20 @@ Because the values are represented as strings, this mode avoids the loss of prec
 
 |`DATE`
 |`STRING`
-|`io.debezium.time.IsoDate` +
- +
+|`io.debezium.time.IsoDate`
+
 Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
 
 |`TIME([P])`
 |`STRING`
-|`io.debezium.time.IsoTime` +
- +
+|`io.debezium.time.IsoTime`
+
 Represents time values in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
 
 |`DATETIME`, `SMALLDATETIME`, `DATETIME2`
 |`STRING`
-|`io.debezium.time.IsoTimestamp` +
- +
+|`io.debezium.time.IsoTimestamp`
+
 Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1823,6 +1823,35 @@ Represents the number of milliseconds since the epoch, and does not include time
 
 |===
 
+When the `time.precision.mode` configuration property is set to `isostring`, the connector maps temporal values to ISO-8601 formatted strings at the UTC time zone, using the `io.debezium.time.IsoDate`, `io.debezium.time.IsoTime`, and `io.debezium.time.IsoTimestamp` semantic types.
+Because the values are represented as strings, this mode avoids the loss of precision that can occur in `connect` mode when the fractional second precision is greater than 3:
+
+[cols="30%a,25%a,45%a",options="header"]
+|===
+|SQL Server data type
+|Literal type (schema type)
+|Semantic type (schema name) and Notes
+
+|`DATE`
+|`STRING`
+|`io.debezium.time.IsoDate` +
+ +
+Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
+
+|`TIME([P])`
+|`STRING`
+|`io.debezium.time.IsoTime` +
+ +
+Represents time values in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
+
+|`DATETIME`, `SMALLDATETIME`, `DATETIME2`
+|`STRING`
+|`io.debezium.time.IsoTimestamp` +
+ +
+Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
+
+|===
+
 [[sql-server-timestamp-values]]
 ===== Timestamp values
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -604,6 +604,7 @@ ifdef::community[]
 `adaptive`::::  (deprecated) The connector captures time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the data type of the column.
 endif::community[]
 `connect`:::: The connector always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.
+`isostring`:::: The connector represents time, date, and datetime values as ISO-8601 formatted strings at the UTC time zone, using the `io.debezium.time.IsoDate`, `io.debezium.time.IsoTime`, and `io.debezium.time.IsoTimestamp` semantic types.
 
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2042,17 +2042,20 @@ Because the values are represented as strings, this mode preserves the fractiona
 
 |`DATE`
 |`STRING`
-a|`io.debezium.time.IsoDate` +
+a|`io.debezium.time.IsoDate`
+
 Represents the date value in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
 
 |`TIME[(M)]`
 |`STRING`
-a|`io.debezium.time.IsoTime` +
+a|`io.debezium.time.IsoTime`
+
 Represents the time value in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
 
 |`DATETIME[(M)]`
 |`STRING`
-a|`io.debezium.time.IsoTimestamp` +
+a|`io.debezium.time.IsoTimestamp`
+
 Represents the datetime value in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2030,6 +2030,32 @@ a|`org.apache.kafka.connect.data.Timestamp` +
 Represents the number of milliseconds since the epoch, and does not include time zone information.
 
 |===
+
+time.precision.mode=isostring::
+The {connector-name} connector represents date, time, and datetime values as ISO-8601 formatted strings at the UTC time zone.
+Because the values are represented as strings, this mode preserves the fractional-second precision that the `connect` mode can lose.
++
+.Mappings when `time.precision.mode=isostring`
+[cols="25%a,20%a,55%a",options="header",subs="+attributes"]
+|===
+|{connector-name} type |Literal type |Semantic type
+
+|`DATE`
+|`STRING`
+a|`io.debezium.time.IsoDate` +
+Represents the date value in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
+
+|`TIME[(M)]`
+|`STRING`
+a|`io.debezium.time.IsoTime` +
+Represents the time value in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
+
+|`DATETIME[(M)]`
+|`STRING`
+a|`io.debezium.time.IsoTimestamp` +
+Represents the datetime value in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
+
+|===
 end::temporal-data-types[]
 
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -377,3 +377,4 @@ KmohnishM,Kodukulla Mohnish Mythreya
 yashi.srivastava,Yashi Srivastava
 Tayler,Tayler Dunn
 vincadrn,Vincentius Adrian
+Roshr2211,Roshni R


### PR DESCRIPTION
Fixes debezium/dbz#1437

## Description

The `isostring` value of `time.precision.mode` was documented only for the PostgreSQL and Vitess connectors, even though it is supported by all relational connectors through the shared `JdbcValueConverters`. This PR documents it everywhere it was missing:

* **db2.adoc**, **informix.adoc**, **oracle.adoc**, **sqlserver.adoc** — add an `isostring` section and temporal-type mapping table, following each page's existing structure.
* **MySQL / MariaDB** shared partials — add the `isostring` mapping table and list it as a `time.precision.mode` option.
* **RelationalDatabaseConnectorConfig** — the `time.precision.mode` field description listed only `adaptive`, `adaptive_time_microseconds`, and `connect`; it now also covers `isostring`, `microseconds`, and `nanoseconds`.

Docs/description only — no behavior change.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
