### PR TITLE
debezium/dbz#2046 Allow Oracle buffered transaction creation to be deferred until first DML

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -716,16 +716,29 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     public static final Field SIGNAL_DATA_COLLECTION = CommonConnectorConfig.SIGNAL_DATA_COLLECTION
             .withValidation(OracleConnectorConfig::validateSignalDataCollection);
 
-    public static final Field LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START = Field.createInternal("log.mining.buffer.memory.legacy.transaction.start")
-            .withDisplayName("Use legacy transaction start behavior")
+    public static final Field LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START = Field.create("log.mining.buffer.deferred.transaction.start")
+            .withDisplayName("Use deferred transaction start behavior")
             .withType(Type.BOOLEAN)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDefault(false)
-            .withValidation(OracleConnectorConfig::validateIncludeTransactionStartEvents)
-            .withDescription("Controls whether transaction start events are buffered when using the heap/memory buffer type. " +
-                    "true: transaction start events are not buffered; " +
-                    "false: (the default) transaction start events are buffered");
+            .withValidation(OracleConnectorConfig::validateDeferredTransactionStart)
+            .withDescription("Controls whether transaction start events are deferred when using buffered LogMiner. " +
+                    "When enabled, transaction start events are stored in a lightweight metadata map. " +
+                    "Transactions are only promoted to the transaction cache when a DML event is observed. " +
+                    "The mining window is not pinned by transactions, allowing a block-by-block sliding window.")
+            .withDeprecatedAliases("log.mining.buffer.memory.legacy.transaction.start");
+
+    public static final Field LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS = Field.create("log.mining.buffer.deferred.transaction.retention.ms")
+            .withDisplayName("Deferred transaction retention")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(TimeUnit.HOURS.toMillis(24))
+            .withValidation(Field::isNonNegativeLong)
+            .withDescription("Duration in milliseconds to retain deferred transaction metadata for transactions that never " +
+                    "emit a DML event. By default, deferred transaction metadata is retained for 24 hours. " +
+                    "This is independent of log.mining.transaction.retention.ms which governs cached transactions with events.");
 
     public static final Field LEGACY_DECIMAL_HANDLING_STRATEGY = Field.create("legacy.decimal.handling.strategy")
             .withDisplayName("Use legacy decimal handling strategy")
@@ -863,7 +876,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_CLIENTID_INCLUDE_LIST,
                     LOG_MINING_CLIENTID_EXCLUDE_LIST,
                     LOG_MINING_RESUME_POSITION_INTERVAL_MS,
-                    LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START,
+                    LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START,
+                    LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS,
                     LOG_MINING_PATH_DICTIONARY,
                     LOG_MINING_READONLY_HOSTNAME,
                     LEGACY_DECIMAL_HANDLING_STRATEGY,
@@ -951,6 +965,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final boolean logMiningBufferTrackUsername;
     private final boolean logMiningBufferTrackCommitTimestamp;
     private final boolean logMiningBufferTrackStartTimestamp;
+    private final boolean logMiningDeferredTransactionStart;
+    private final Duration logMiningDeferredTransactionRetention;
 
     private final String openLogReplicatorSource;
     private final String openLogReplicatorHostname;
@@ -1041,6 +1057,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningBufferTrackUsername = config.getBoolean(LOG_MINING_BUFFER_TRACK_USERNAME);
         this.logMiningBufferTrackCommitTimestamp = config.getBoolean(LOG_MINING_BUFFER_TRACK_COMMIT_TIMESTAMP);
         this.logMiningBufferTrackStartTimestamp = config.getBoolean(LOG_MINING_BUFFER_TRACK_START_TIMESTAMP);
+        this.logMiningDeferredTransactionStart = config.getBoolean(LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START);
+        this.logMiningDeferredTransactionRetention = Duration.ofMillis(config.getLong(LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS));
 
         this.logMiningEhCacheConfiguration = config.subset("log.mining.buffer.ehcache", false);
 
@@ -2147,15 +2165,21 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     }
 
     /**
-     * Whether legacy LogMiner heap transaction start event non-buffering is enabled
+     * Whether deferred LogMiner transaction start behavior is enabled.
+     * When enabled, transactions are stored in a lightweight metadata map until a DML event is observed.
      */
-    public boolean isLegacyLogMinerHeapTransactionStartBehaviorEnabled() {
-        if (LogMiningBufferType.MEMORY.equals(getLogMiningBufferType())) {
-            // This only applies when using the heap buffer type
-            // Other buffer types always included the transaction start events regardless
-            return getConfig().getBoolean(LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START);
+    public boolean isDeferredLogMinerTransactionStartBehaviorEnabled() {
+        if (ConnectorAdapter.LOG_MINER.equals(getConnectorAdapter())) {
+            return logMiningDeferredTransactionStart;
         }
         return false;
+    }
+
+    /**
+     * @return the duration for which deferred transaction metadata is retained for transactions that never emit events.
+     */
+    public Duration getLogMiningDeferredTransactionRetention() {
+        return logMiningDeferredTransactionRetention;
     }
 
     /**
@@ -2442,13 +2466,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return 0;
     }
 
-    public static int validateIncludeTransactionStartEvents(Configuration config, Field field, ValidationOutput problems) {
-        final boolean includeTransactionStarts = config.getBoolean(LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START);
-        if (includeTransactionStarts && isBufferedLogMiner(config)) {
-            final LogMiningBufferType bufferType = LogMiningBufferType.parse(config.getString(LOG_MINING_BUFFER_TYPE));
-            if (!LogMiningBufferType.MEMORY.equals(bufferType)) {
-                LOGGER.warn("'{}' only applies to buffered LogMiner with buffer type 'memory', setting will be ignored.",
-                        LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START.name());
+    public static int validateDeferredTransactionStart(Configuration config, Field field, ValidationOutput problems) {
+        if (config.getBoolean(LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START)) {
+            if (config.getBoolean(LOB_ENABLED)) {
+                problems.accept(field, true, String.format(
+                        "The configuration property '%s' cannot be enabled when '%s' is set to true.",
+                        field.name(), LOB_ENABLED.name()));
+                return 1;
             }
         }
         return 0;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerQueryBuilder.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer.buffered;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -153,18 +152,6 @@ public class BufferedLogMinerQueryBuilder extends AbstractLogMinerQueryBuilder {
             return isCteQuery ? CTE_OPERATION_CODES_LOB : OPERATION_CODES_LOB;
         }
 
-        final List<Integer> nonLobOperations = isCteQuery ? CTE_OPERATION_CODES_NO_LOB : OPERATION_CODES_NO_LOB;
-
-        if (connectorConfig.isLegacyLogMinerHeapTransactionStartBehaviorEnabled()) {
-            // The legacy behavior skipped START events as a performance optimization to avoid adding
-            // extra objects to the transaction cache. Without these, the username and client id
-            // filter options and source information block fields won't work in some corner cases if
-            // the transaction start is in a prior archive log.
-            final List<Integer> operationCodes = new ArrayList<>(nonLobOperations);
-            operationCodes.removeIf(operationCode -> operationCode == 6);
-            return operationCodes;
-        }
-
-        return nonLobOperations;
+        return isCteQuery ? CTE_OPERATION_CODES_NO_LOB : OPERATION_CODES_NO_LOB;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -12,7 +12,9 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +76,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     private static final Logger WINDOW_ADVANCED = LoggerFactory.getLogger(BufferedLogMinerStreamingChangeEventSource.class.getName() + ".WindowAdvanced");
 
     private static final String NO_SEQUENCE_TRX_ID_SUFFIX = "ffffffff";
+    private static final int ORACLE_TRANSACTION_ID_PREFIX_LENGTH = 8;
 
     private final String queryString;
     private final CacheProvider<Transaction> cacheProvider;
@@ -82,6 +85,28 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     private Instant lastProcessedScnChangeTime = null;
     private Scn lastProcessedScn = Scn.NULL;
     private Scn lastLoggedWindowAdvanceScn = Scn.NULL;
+
+    private final Map<String, DeferredTransaction> deferredTransactions = new HashMap<>();
+
+    /**
+     * Lightweight metadata record for a deferred transaction that has not yet emitted any DML events.
+     */
+    private record DeferredTransaction(String transactionId, Scn startScn, Instant changeTime,
+            String userName, String clientId, int redoThreadId) {
+    }
+
+    private record MatchedTransaction(String transactionId, Scn startScn, Instant changeTime, boolean deferred) {
+    }
+
+    private Transaction createTransaction(DeferredTransaction deferredTransaction) {
+        return transactionFactory.createTransaction(
+                deferredTransaction.transactionId(),
+                deferredTransaction.startScn(),
+                deferredTransaction.changeTime(),
+                deferredTransaction.userName(),
+                deferredTransaction.redoThreadId(),
+                deferredTransaction.clientId());
+    }
 
     public BufferedLogMinerStreamingChangeEventSource(OracleConnectorConfig connectorConfig,
                                                       OracleConnection jdbcConnection,
@@ -373,6 +398,15 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
     protected void handleStartEvent(LogMinerEventRow event) {
         final String transactionId = event.getTransactionId();
         if (!isRecentlyProcessed(transactionId)) {
+            if (getConfig().isDeferredLogMinerTransactionStartBehaviorEnabled() && !Strings.isNullOrEmpty(transactionId)) {
+                deferredTransactions.computeIfAbsent(transactionId, id -> {
+                    LOGGER.trace("Deferring transaction {} start event.", id);
+                    return new DeferredTransaction(id, event.getScn(), event.getChangeTime(),
+                            event.getUserName(), event.getClientId(), event.getThread());
+                });
+                return;
+            }
+
             final Transaction transaction = getTransactionCache().getTransaction(transactionId);
             if (transaction == null) {
                 getTransactionCache().addTransaction(transactionFactory.createTransaction(event));
@@ -394,7 +428,14 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
         }
 
         final Transaction transaction = getTransactionCache().getAndRemoveTransaction(transactionId);
+        boolean removedDeferredTransaction = false;
         if (transaction == null) {
+            // Check if the transaction was deferred and never promoted
+            if (!Strings.isNullOrEmpty(transactionId) && deferredTransactions.remove(transactionId) != null) {
+                LOGGER.debug("Transaction {} was deferred with no DML events, removing on commit.", transactionId);
+                removedDeferredTransaction = true;
+            }
+
             if (!getOffsetContext().getCommitScn().hasEventScnBeenHandled(row)) {
                 LOGGER.debug("Transaction {} not found in cache with SCN {}, no events to commit.", transactionId, row.getScn());
             }
@@ -568,6 +609,11 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
             getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
         }
+        else if (removedDeferredTransaction) {
+            getEventDispatcher().dispatchHeartbeatEvent(getPartition(), getOffsetContext());
+            getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+            getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
+        }
 
         updateCommitMetrics(row, Duration.between(start, Instant.now()), numEvents);
     }
@@ -581,44 +627,52 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
             getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
         }
+        else if (removeDeferredTransaction(transactionId)) {
+            LOGGER.debug("Transaction {} was in deferred state, removed on rollback.", transactionId);
+        }
         else {
             LOGGER.debug("Transaction {} not found in cache, no events to rollback.", transactionId);
 
-            if (transactionId.endsWith(NO_SEQUENCE_TRX_ID_SUFFIX)) {
+            if (!Strings.isNullOrEmpty(transactionId) && transactionId.endsWith(NO_SEQUENCE_TRX_ID_SUFFIX)) {
                 // This means that Oracle LogMiner found a rollback that should be applied but its
                 // corresponding transaction was read in a prior mining session and the transaction's
                 // sequence could not be resolved. We need to search for a matching transaction by prefix.
-                final String prefix = transactionId.substring(0, 8);
+                final String prefix = transactionId.substring(0, ORACLE_TRANSACTION_ID_PREFIX_LENGTH);
                 LOGGER.debug("Rollback event refers to a transaction '{}' with no explicit sequence; checking all transactions with prefix '{}'",
                         transactionId, prefix);
 
-                // Collect all matching transactions to determine if we can safely identify a single one
-                final List<Transaction> matchingTransactions = getTransactionCache().streamTransactionsAndReturn(
-                        stream -> stream.filter(t -> t.getTransactionId().startsWith(prefix))
-                                .toList());
+                final List<MatchedTransaction> matchingTransactions = getMatchingTransactionsByPrefix(prefix);
 
                 if (matchingTransactions.isEmpty()) {
-                    LOGGER.debug("No matching transaction found in cache for partial transaction '{}' with prefix '{}'",
+                    LOGGER.debug("No matching transaction found for partial transaction '{}' with prefix '{}'",
                             transactionId, prefix);
                 }
                 else if (matchingTransactions.size() == 1) {
-                    // Exactly one match - safe to rollback
-                    final Transaction matched = matchingTransactions.get(0);
-                    LOGGER.warn("Matched partial transaction '{}' to cached transaction '{}' (startScn={}, changeTime={}). " +
+                    final MatchedTransaction matched = matchingTransactions.get(0);
+                    LOGGER.warn("Matched partial transaction '{}' to {} transaction '{}' (startScn={}, changeTime={}). " +
                             "Rolling back the matched transaction.",
-                            transactionId, matched.getTransactionId(), matched.getStartScn(), matched.getChangeTime());
-                    finalizeTransaction(matched.getTransactionId(), event.getScn(), true);
-                    getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
-                    getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
+                            transactionId,
+                            matched.deferred() ? "deferred" : "cached",
+                            matched.transactionId(),
+                            matched.startScn(),
+                            matched.changeTime());
+                    if (matched.deferred()) {
+                        removeDeferredTransaction(matched.transactionId());
+                    }
+                    else {
+                        finalizeTransaction(matched.transactionId(), event.getScn(), true);
+                        getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+                        getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
+                    }
                 }
                 else {
                     // Multiple matches - ambiguous, cannot determine which to rollback
                     // TODO: Investigate whether this scenario is possible and if so, how to disambiguate
-                    LOGGER.warn("Unable to match partial transaction '{}' to a single cached transaction. Found {} transactions " +
+                    LOGGER.warn("Unable to match partial transaction '{}' to a single transaction. Found {} transactions " +
                             "with prefix '{}'. Cannot determine which transaction to rollback. " +
                             "Manual investigation required. Transactions: {}",
                             transactionId, matchingTransactions.size(), prefix,
-                            matchingTransactions.stream().map(Transaction::getTransactionId).collect(Collectors.joining(", ")));
+                            matchingTransactions.stream().map(MatchedTransaction::transactionId).collect(Collectors.joining(", ")));
                 }
             }
 
@@ -631,6 +685,30 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
         getMetrics().incrementRolledBackTransactionCount();
         getMetrics().addRolledBackTransactionId(transactionId);
         getBatchMetrics().rollbackObserved();
+    }
+
+    private boolean removeDeferredTransaction(String transactionId) {
+        return !Strings.isNullOrEmpty(transactionId) && deferredTransactions.remove(transactionId) != null;
+    }
+
+    private List<MatchedTransaction> getMatchingTransactionsByPrefix(String prefix) {
+        final List<MatchedTransaction> matches = new ArrayList<>();
+        matches.addAll(getTransactionCache().streamTransactionsAndReturn(
+                stream -> stream.filter(t -> t.getTransactionId().startsWith(prefix))
+                        .map(t -> new MatchedTransaction(t.getTransactionId(), t.getStartScn(), t.getChangeTime(), false))
+                        .toList()));
+        matches.addAll(deferredTransactions.values().stream()
+                .filter(t -> t.transactionId().startsWith(prefix))
+                .map(t -> new MatchedTransaction(t.transactionId(), t.startScn(), t.changeTime(), true))
+                .toList());
+        return matches;
+    }
+
+    private Scn getOldestDeferredTransactionStartScn() {
+        return deferredTransactions.values().stream()
+                .map(DeferredTransaction::startScn)
+                .min(Scn::compareTo)
+                .orElse(Scn.NULL);
     }
 
     @Override
@@ -742,6 +820,10 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
         abandonTransactions(getConfig().getLogMiningTransactionRetention());
 
+        if (getConfig().isDeferredLogMinerTransactionStartBehaviorEnabled()) {
+            cleanupDeferredTransactions(getConfig().getLogMiningDeferredTransactionRetention());
+        }
+
         // Cleanup caches based on current state of the transaction cache
         final Scn minCacheScn;
         final Instant minCacheScnChangeTime;
@@ -770,6 +852,35 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
         }
 
         getMetrics().setOldestScnDetails(minCacheScn, minCacheScnChangeTime);
+
+        if (getConfig().isDeferredLogMinerTransactionStartBehaviorEnabled()) {
+            // When using deferred transaction start behavior, the mining window should not be pinned
+            // by transactions in the cache. Always use a sliding window block-by-block.
+            final Scn miningSessionStartScn = endScn.subtract(Scn.ONE);
+
+            // The offset SCN must not advance past the oldest deferred transaction's start SCN.
+            // This ensures that on restart, the connector goes back far enough to re-mine the START
+            // events of deferred transactions and reconstruct their metadata.
+            final Scn oldestDeferredScn = getOldestDeferredTransactionStartScn();
+            final Scn offsetScn;
+            if (!oldestDeferredScn.isNull() && !maxCommittedScn.isNull() && oldestDeferredScn.compareTo(maxCommittedScn) < 0) {
+                offsetScn = oldestDeferredScn;
+            }
+            else if (!maxCommittedScn.isNull()) {
+                offsetScn = maxCommittedScn;
+            }
+            else {
+                offsetScn = Scn.NULL;
+            }
+
+            if (!offsetScn.isNull()) {
+                getOffsetContext().setScn(offsetScn);
+                getEventDispatcher().dispatchHeartbeatEvent(getPartition(), getOffsetContext());
+            }
+
+            getMetrics().setOffsetScn(getOffsetContext().getScn());
+            return new ProcessResult(miningSessionStartScn, endScn);
+        }
 
         if (!minCacheScn.isNull()) {
             // Cache have values
@@ -915,7 +1026,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             // This means that Oracle LogMiner found an event that should be undone but its corresponding
             // undo entry was read in a prior mining session and the transaction's sequence could not be
             // resolved.
-            final String prefix = row.getTransactionId().substring(0, 8);
+            final String prefix = row.getTransactionId().substring(0, ORACLE_TRANSACTION_ID_PREFIX_LENGTH);
             LOGGER.debug("Undo change refers to a transaction that has no explicit sequence, '{}'", row.getTransactionId());
             LOGGER.debug("Checking all transactions with prefix '{}'", prefix);
 
@@ -1058,11 +1169,24 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
         Transaction transaction = getTransactionCache().getTransaction(transactionId);
         if (transaction == null) {
-            LOGGER.trace("Transaction {} is not in cache, creating.", transactionId);
-            transaction = transactionFactory.createTransaction(event);
-            getTransactionCache().addTransaction(transaction);
+            // Check if this transaction is in the deferred state and promote it
+            if (!Strings.isNullOrEmpty(transactionId)) {
+                final DeferredTransaction deferred = deferredTransactions.remove(transactionId);
+                if (deferred != null) {
+                    LOGGER.trace("Promoting deferred transaction {} to the transaction cache.", transactionId);
+                    transaction = createTransaction(deferred);
+                    getTransactionCache().addTransaction(transaction);
+                    getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+                }
+            }
 
-            getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+            if (transaction == null) {
+                LOGGER.trace("Transaction {} is not in cache, creating.", transactionId);
+                transaction = transactionFactory.createTransaction(event);
+                getTransactionCache().addTransaction(transaction);
+
+                getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+            }
         }
 
         final int eventId = transaction.getNextEventId();
@@ -1176,6 +1300,33 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                 }
                 getEventDispatcher().dispatchHeartbeatEvent(getPartition(), getOffsetContext());
             }
+        }
+    }
+
+    /**
+     * Cleans up deferred transaction metadata that has been retained longer than the configured retention period.
+     * <p>
+     * This removes lightweight metadata for transactions that never emitted a DML event,
+     * preventing memory leaks in the deferred transaction map.
+     *
+     * @param retention the retention duration, should not be {@code null}
+     */
+    private void cleanupDeferredTransactions(Duration retention) {
+        if (Duration.ZERO.equals(retention) || deferredTransactions.isEmpty()) {
+            return;
+        }
+
+        final Optional<Scn> lastScnToAbandon = getLastScnToAbandon(getConnection(), retention);
+        if (lastScnToAbandon.isEmpty()) {
+            return;
+        }
+
+        final Scn thresholdScn = lastScnToAbandon.get();
+        final int removedBefore = deferredTransactions.size();
+        deferredTransactions.values().removeIf(deferred -> deferred.startScn().compareTo(thresholdScn) <= 0);
+        final int removed = removedBefore - deferredTransactions.size();
+        if (removed > 0) {
+            LOGGER.debug("Cleaned up {} deferred transactions with start SCN <= {}", removed, thresholdScn);
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/TransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/TransactionFactory.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.oracle.logminer.buffered;
 
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 
 /**
@@ -20,4 +23,17 @@ public interface TransactionFactory<T extends Transaction> {
      * @return the constructed transaction instance, never {@code null}
      */
     T createTransaction(LogMinerEventRow event);
+
+    /**
+     * Create a transaction from explicit metadata.
+     *
+     * @param transactionId the transaction identifier, should not be {@code null}
+     * @param startScn the transaction start scn, should not be {@code null}
+     * @param changeTime the transaction change time, should not be {@code null}
+     * @param userName the transaction user name, may be {@code null}
+     * @param redoThreadId the redo thread id, may be {@code null}
+     * @param clientId the transaction client id, may be {@code null}
+     * @return the constructed transaction instance, never {@code null}
+     */
+    T createTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThreadId, String clientId);
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheTransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheTransactionFactory.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.oracle.logminer.buffered.ehcache;
 
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.buffered.TransactionFactory;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 
@@ -18,5 +21,10 @@ public class EhcacheTransactionFactory implements TransactionFactory<EhcacheTran
     public EhcacheTransaction createTransaction(LogMinerEventRow event) {
         return new EhcacheTransaction(event.getTransactionId(), event.getScn(), event.getChangeTime(),
                 event.getUserName(), event.getThread(), event.getClientId());
+    }
+
+    @Override
+    public EhcacheTransaction createTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThreadId, String clientId) {
+        return new EhcacheTransaction(transactionId, startScn, changeTime, userName, redoThreadId, clientId);
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanTransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanTransactionFactory.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.oracle.logminer.buffered.infinispan;
 
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.buffered.TransactionFactory;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 
@@ -18,5 +21,10 @@ public class InfinispanTransactionFactory implements TransactionFactory<Infinisp
     public InfinispanTransaction createTransaction(LogMinerEventRow event) {
         return new InfinispanTransaction(event.getTransactionId(), event.getScn(), event.getChangeTime(),
                 event.getUserName(), event.getThread(), event.getClientId());
+    }
+
+    @Override
+    public InfinispanTransaction createTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThreadId, String clientId) {
+        return new InfinispanTransaction(transactionId, startScn, changeTime, userName, redoThreadId, clientId);
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryTransactionFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryTransactionFactory.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.oracle.logminer.buffered.memory;
 
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.buffered.TransactionFactory;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 
@@ -18,5 +21,10 @@ public class MemoryTransactionFactory implements TransactionFactory<MemoryTransa
     public MemoryTransaction createTransaction(LogMinerEventRow event) {
         return new MemoryTransaction(event.getTransactionId(), event.getScn(), event.getChangeTime(),
                 event.getUserName(), event.getThread(), event.getClientId());
+    }
+
+    @Override
+    public MemoryTransaction createTransaction(String transactionId, Scn startScn, Instant changeTime, String userName, Integer redoThreadId, String clientId) {
+        return new MemoryTransaction(transactionId, startScn, changeTime, userName, redoThreadId, clientId);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -390,4 +390,72 @@ public class OracleConnectorConfigTest {
         final Configuration config = Configuration.create().with(SIGNAL_DATA_COLLECTION, "db.schema.table").build();
         assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
     }
+
+    @Test
+    public void shouldFailValidationWhenDeferredTransactionStartEnabledWithLob() {
+        List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START);
+        final Configuration config = Configuration.create()
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                .build();
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    public void shouldPassValidationWhenDeferredTransactionStartEnabledWithoutLob() {
+        List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START);
+        final Configuration config = Configuration.create()
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                .with(OracleConnectorConfig.LOB_ENABLED, false)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                .build();
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
+    }
+
+    @Test
+    public void shouldDisableDeferredTransactionStartWithUnbufferedAdapter() {
+        final Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer_unbuffered")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                .build();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.isDeferredLogMinerTransactionStartBehaviorEnabled()).isFalse();
+    }
+
+    @Test
+    public void shouldResolveDeferredTransactionStartViaDeprecatedAlias() {
+        List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START);
+        final Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE, OracleConnectorConfig.LogMiningBufferType.MEMORY)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                .build();
+
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.isDeferredLogMinerTransactionStartBehaviorEnabled()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnDefaultDeferredTransactionRetention() {
+        final Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .build();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.getLogMiningDeferredTransactionRetention()).isEqualTo(Duration.ofHours(24));
+    }
+
+    @Test
+    public void shouldReturnCustomDeferredTransactionRetention() {
+        final Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS, 3_600_000L)
+                .build();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.getLogMiningDeferredTransactionRetention()).isEqualTo(Duration.ofHours(1));
+    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -108,9 +108,9 @@ public class LogMinerQueryBuilderTest {
     }
 
     @Test
-    @FixFor("DBZ-8884")
-    public void testLegacyTransactionStartBufferingBehavior() {
-        assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_MEMORY_LEGACY_TRANSACTION_START, false).build());
+    @FixFor("debezium/dbz#1663")
+    public void testDeferredTransactionStartBufferingBehavior() {
+        assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, false).build());
     }
 
     @Test
@@ -272,9 +272,7 @@ public class LogMinerQueryBuilderTest {
 
         final String codes = config.isLobEnabled()
                 ? "1,2,3,6,7,9,10,11,27,29,34,36,68,70,71,91,92,93,255"
-                : config.isLegacyLogMinerHeapTransactionStartBehaviorEnabled()
-                        ? "1,2,3,7,27,34,36,255"
-                        : "1,2,3,6,7,27,34,36,255";
+                : "1,2,3,6,7,27,34,36,255";
 
         query += "(";
         query += "OPERATION_CODE IN (" + codes + ")";

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UsernameFilterIT.java
@@ -19,6 +19,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -33,6 +34,8 @@ import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
+
+import ch.qos.logback.classic.Level;
 
 /**
  * Integration tests for various LogMiner username include/exclude list scenarios.
@@ -291,6 +294,71 @@ public class UsernameFilterIT extends AbstractAsyncEngineConnectorTest {
         }
         finally {
             TestHelper.dropTable(connection, "dbz8884");
+        }
+    }
+
+    @Test
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_BUFFERED, reason = "Deferred transaction start only applies to buffered mode")
+    public void shouldIncludeEventsByUsernameFilterWithDeferredTransactionStart() throws Exception {
+        final LogInterceptor processorLogging = TestHelper.getAbstractEventProcessorLogInterceptor();
+        processorLogging.setLoggerLevel(AbstractLogMinerStreamingChangeEventSource.class, Level.DEBUG);
+
+        TestHelper.dropTable(connection, "dbz9998");
+        TestHelper.dropTable(connection, "dbz9999");
+        try {
+            connection.execute("CREATE TABLE dbz9998 (id number(9,0), data varchar2(50), primary key(id))");
+            connection.execute("CREATE TABLE dbz9999 (id number(9,0), data varchar2(50), primary key(id))");
+            TestHelper.streamTable(connection, "dbz9998");
+            TestHelper.streamTable(connection, "dbz9999");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ9999")
+                    .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "DEBEZIUM")
+                    .with(OracleConnectorConfig.LOB_ENABLED, false)
+                    .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                    // This test expects the filtering to occur in the connector, not the query
+                    .with(OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE, "none")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            final int batchesBeforeTransactionStart = processorLogging.getLogEntriesThatContainsMessage("Processed in ").size();
+
+            // Start the transaction on a table that is not captured and wait for the connector to complete
+            // a mining iteration. This ensures the START event is mined before the captured table DML occurs.
+            connection.executeWithoutCommitting("INSERT INTO dbz9998 (id,data) values (0,'seed')");
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(TestHelper.defaultMessageConsumerPollTimeout()))
+                    .until(() -> processorLogging.getLogEntriesThatContainsMessage("Processed in ").size() > batchesBeforeTransactionStart);
+
+            for (int i = 1; i <= 10; i++) {
+                connection.executeWithoutCommitting(String.format(
+                        "INSERT INTO dbz9999 (id,data) values (%d,'Test%d')", i, i));
+            }
+
+            connection.execute("COMMIT");
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(10);
+
+            List<SourceRecord> records = sourceRecords.recordsForTopic(topicName("DEBEZIUM", "DBZ9999"));
+            assertThat(records).hasSize(10);
+
+            for (int i = 1; i <= 10; i++) {
+                SourceRecord record = records.get(i - 1);
+                assertThat(getAfter(record).get("ID")).isEqualTo(i);
+                assertThat(getAfter(record).get("DATA")).isEqualTo(String.format("Test%d", i));
+                assertThat(getSource(record).get("user_name")).isEqualTo("DEBEZIUM");
+            }
+
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz9998");
+            TestHelper.dropTable(connection, "dbz9999");
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -49,6 +49,7 @@ import io.debezium.connector.oracle.OracleValueConverters;
 import io.debezium.connector.oracle.RedoThreadState;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.AbstractLogMinerStreamingChangeEventSource;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.logminer.OffsetActivityMonitor;
@@ -77,6 +78,7 @@ import oracle.sql.CharacterSet;
  *
  * @author Debezium Authors
  */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER_BUFFERED)
 public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncEngineConnectorTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeferredMemoryStreamingChangeEventSourceTest.class);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -1,0 +1,635 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.buffered;
+
+import static io.debezium.config.CommonConnectorConfig.DEFAULT_MAX_BATCH_SIZE;
+import static io.debezium.config.CommonConnectorConfig.DEFAULT_MAX_QUEUE_SIZE;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.base.DefaultQueueProvider;
+import io.debezium.connector.oracle.CommitScn;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.OracleDefaultValueConverter;
+import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
+import io.debezium.connector.oracle.OracleTaskContext;
+import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.RedoThreadState;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
+import io.debezium.connector.oracle.logminer.AbstractLogMinerStreamingChangeEventSource;
+import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.logminer.OffsetActivityMonitor;
+import io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerStreamingChangeEventSource.ProcessResult;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.relational.Column;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.schema.SchemaTopicNamingStrategy;
+import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.util.Clock;
+
+import oracle.jdbc.OracleTypes;
+import oracle.sql.CharacterSet;
+
+/**
+ * Unit tests for deferred transaction start behavior in buffered LogMiner with memory buffer type.
+ *
+ * @author Debezium Authors
+ */
+public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncEngineConnectorTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeferredMemoryStreamingChangeEventSourceTest.class);
+
+    private static final int OFFSET_ACTIVITY_MONITOR_INACTIVE_THRESHOLD_MS = 25;
+    private static final String TRANSACTION_ID_1 = "1234567890";
+    private static final String TRANSACTION_ID_2 = "9876543210";
+
+    private ChangeEventSourceContext context;
+    private EventDispatcher<OraclePartition, TableId> dispatcher;
+    private OracleDatabaseSchema schema;
+    private LogMinerStreamingChangeEventSourceMetrics metrics;
+    private OracleOffsetContext offsetContext;
+    private OracleConnection connection;
+    private CommitScn commitScn;
+
+    @BeforeEach
+    @SuppressWarnings({ "unchecked" })
+    public void before() throws Exception {
+        this.context = Mockito.mock(ChangeEventSourceContext.class);
+        Mockito.when(this.context.isRunning()).thenReturn(true);
+
+        this.dispatcher = (EventDispatcher<OraclePartition, TableId>) Mockito.mock(EventDispatcher.class);
+        this.offsetContext = Mockito.mock(OracleOffsetContext.class);
+        this.commitScn = Mockito.spy(CommitScn.valueOf((String) null));
+        Mockito.when(this.offsetContext.getCommitScn()).thenReturn(commitScn);
+        Mockito.when(this.offsetContext.getSnapshotScn()).thenReturn(Scn.valueOf("1"));
+        this.connection = createOracleConnection(false);
+        this.schema = createOracleDatabaseSchema();
+        this.metrics = createMetrics(schema);
+    }
+
+    @AfterEach
+    void after() {
+        if (schema != null) {
+            try {
+                schema.close();
+            }
+            finally {
+                schema = null;
+            }
+        }
+    }
+
+    private Configuration.Builder getConfig() {
+        return TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE, OracleConnectorConfig.LogMiningBufferType.MEMORY)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, true)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_DROP_ON_STOP, true);
+    }
+
+    @Test
+    public void testStartEventDoesNotAddTransactionToCache() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testInsertEventPromotesDeferredTransactionToCache() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isFalse();
+            assertThat(source.getTransactionCache().containsTransaction(TRANSACTION_ID_1)).isTrue();
+        }
+    }
+
+    @Test
+    public void testPromotedTransactionRetainsDeferredStartMetadata() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            final Instant startTime = Instant.now().minusSeconds(30);
+            final LogMinerEventRow startEvent = getStartLogMinerEventRow(10, TRANSACTION_ID_1, startTime);
+            final LogMinerEventRow insertEvent = getInsertLogMinerEventRow(20, TRANSACTION_ID_1, Instant.now());
+            Mockito.when(insertEvent.getUserName()).thenReturn(null);
+            Mockito.when(insertEvent.getClientId()).thenReturn("client-from-dml");
+            Mockito.when(insertEvent.getThread()).thenReturn(7);
+
+            source.processEvent(startEvent);
+            source.processEvent(insertEvent);
+
+            final Transaction transaction = source.getTransactionCache().getTransaction(TRANSACTION_ID_1);
+            assertThat(transaction).isNotNull();
+            assertThat(transaction.getStartScn()).isEqualTo(Scn.valueOf(10));
+            assertThat(transaction.getChangeTime()).isEqualTo(startTime);
+            assertThat(transaction.getUserName()).isEqualTo(TestHelper.SCHEMA_USER);
+            assertThat(transaction.getClientId()).isNull();
+            assertThat(transaction.getRedoThreadId()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void testCacheIsEmptyWhenDeferredTransactionIsCommittedWithNoDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getCommitLogMinerEventRow(2, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+            Mockito.verify(commitScn).recordCommit(any(LogMinerEventRow.class));
+        }
+    }
+
+    @Test
+    public void testCacheIsEmptyWhenDeferredTransactionIsRolledBackWithNoDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getRollbackLogMinerEventRow(2, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testPartialRollbackMatchesDeferredTransactionByPrefix() throws Exception {
+        final String deferredTransactionId = "12345678abcdef01";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, deferredTransactionId));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(1);
+
+            source.processEvent(getRollbackLogMinerEventRow(2, "12345678ffffffff"));
+
+            assertThat(source.getDeferredTransactionCount()).isZero();
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testCacheIsEmptyWhenDeferredTransactionIsCommittedAfterDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1));
+            source.processEvent(getCommitLogMinerEventRow(3, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testCacheIsEmptyWhenDeferredTransactionIsRolledBackAfterDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1));
+            source.processEvent(getRollbackLogMinerEventRow(3, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+            assertThat(metrics.getRolledBackTransactionIds()).containsExactly(TRANSACTION_ID_1);
+        }
+    }
+
+    @Test
+    public void testCacheIsNotEmptyWhenFirstDeferredTransactionIsRolledBackAndSecondHasDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(2, TRANSACTION_ID_1));
+            source.processEvent(getStartLogMinerEventRow(3, TRANSACTION_ID_2));
+            source.processEvent(getInsertLogMinerEventRow(4, TRANSACTION_ID_2));
+            source.processEvent(getRollbackLogMinerEventRow(5, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().isEmpty()).isFalse();
+            assertThat(source.getTransactionCache().getTransaction(TRANSACTION_ID_1)).isNull();
+            assertThat(source.getTransactionCache().getTransaction(TRANSACTION_ID_2)).isNotNull();
+            assertThat(metrics.getRolledBackTransactionIds()).containsExactly(TRANSACTION_ID_1);
+        }
+    }
+
+    @Test
+    public void testMiningWindowIsNotPinnedByCachedTransactions() throws Exception {
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, true, false);
+        Mockito.when(rs.getString(1)).thenReturn("101", "200");
+        Mockito.when(rs.getString(2)).thenReturn(
+                "insert into \"DEBEZIUM\".\"ABC\"(\"ID\",\"DATA\") values ('1','test1');",
+                "insert into \"DEBEZIUM\".\"ABC\"(\"ID\",\"DATA\") values ('2','test2');");
+        Mockito.when(rs.getInt(3)).thenReturn(EventType.INSERT.getValue());
+        Mockito.when(rs.getTimestamp(eq(4), any(Calendar.class))).thenReturn(Timestamp.valueOf(LocalDateTime.now()));
+        Mockito.when(rs.getString(7)).thenReturn("ABC");
+        Mockito.when(rs.getString(8)).thenReturn("DEBEZIUM");
+        Mockito.when(rs.getString(10)).thenReturn("AAAAAAAAAAAAAAAAAB", "AAAAAAAAAAAAAAAAAC");
+        Mockito.when(rs.getBytes(5)).thenReturn(new byte[]{ 0x12, 0x34, 0x56, 0x78 });
+
+        final PreparedStatement ps = Mockito.mock(PreparedStatement.class);
+        Mockito.when(ps.executeQuery()).thenReturn(rs);
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            final BufferedStreamingChangeEventSource mock = Mockito.spy(source);
+            Mockito.doReturn(ps).when(mock).createQueryStatement();
+
+            Mockito.doReturn("CREATE TABLE DEBEZIUM.ABC (ID primary key(9,0), data varchar2(50))")
+                    .when(connection)
+                    .getTableMetadataDdl(Mockito.any(TableId.class));
+
+            final Table table = Table.editor()
+                    .tableId(TableId.parse("ORCLPDB1.DEBEZIUM.ABC"))
+                    .addColumn(Column.editor().name("ID").create())
+                    .addColumn(Column.editor().name("DATA").create())
+                    .setPrimaryKeyNames("ID").create();
+
+            Mockito.doReturn(table)
+                    .when(mock)
+                    .dispatchSchemaChangeEventAndGetTableForNewConfiguredTable(Mockito.any(TableId.class));
+
+            // Process a transaction with two DML events in the same mining window.
+            // The transaction is promoted to the cache on the first DML.
+            // Because there is no START event in the window, the transaction's startScn in the cache
+            // is the first DML's SCN (101). In non-deferred mode, the mining window would pin to
+            // the oldest transaction (101 - 1 = 100). In deferred mode, it should advance block-by-block
+            // because lastProcessedScn (200) is not less than endScn (200), so endScn stays at 200
+            // and miningSessionStartScn = 200 - 1 = 199.
+            final ProcessResult result = mock.process(Scn.valueOf(100), Scn.valueOf(100), Scn.valueOf(200));
+
+            assertThat(result.miningSessionStartScn()).isEqualTo(Scn.valueOf(199));
+            assertThat(result.readStartScn()).isEqualTo(Scn.valueOf(200));
+        }
+    }
+
+    @Test
+    public void testOffsetScnPinnedToOldestDeferredTransaction() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(100, TRANSACTION_ID_1));
+            source.processEvent(getStartLogMinerEventRow(150, TRANSACTION_ID_2));
+
+            assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.valueOf(100));
+
+            source.processEvent(getRollbackLogMinerEventRow(160, TRANSACTION_ID_2));
+
+            assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.valueOf(100));
+
+            source.processEvent(getRollbackLogMinerEventRow(170, TRANSACTION_ID_1));
+
+            assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.NULL);
+        }
+    }
+
+    @Test
+    public void testMultipleDeferredTransactionsOnlyPromotedOnDml() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getStartLogMinerEventRow(2, TRANSACTION_ID_2));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+
+            source.processEvent(getInsertLogMinerEventRow(3, TRANSACTION_ID_1));
+
+            assertThat(source.getTransactionCache().containsTransaction(TRANSACTION_ID_1)).isTrue();
+            assertThat(source.getTransactionCache().containsTransaction(TRANSACTION_ID_2)).isFalse();
+        }
+    }
+
+    @Test
+    public void testDeferredTransactionsAreCleanedUpByRetention() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));
+            source.processEvent(getStartLogMinerEventRow(3, TRANSACTION_ID_2));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(2);
+
+            source.cleanupDeferredTransactionsForTest(Duration.ofHours(1));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(1);
+            assertThat(source.hasDeferredTransaction(TRANSACTION_ID_1)).isFalse();
+            assertThat(source.hasDeferredTransaction(TRANSACTION_ID_2)).isTrue();
+        }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private OracleDatabaseSchema createOracleDatabaseSchema() throws Exception {
+        Configuration configuration = getConfig().build();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(configuration);
+        final TopicNamingStrategy topicNamingStrategy = SchemaTopicNamingStrategy.create(connectorConfig);
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
+        final OracleValueConverters converters = connectorConfig.getAdapter().getValueConverter(connectorConfig, connection);
+        final OracleDefaultValueConverter defaultValueConverter = new OracleDefaultValueConverter(converters, connection);
+        final TableNameCaseSensitivity sensitivity = connectorConfig.getAdapter().getTableNameCaseSensitivity(connection);
+
+        final OracleDatabaseSchema schema = new OracleDatabaseSchema(connectorConfig,
+                converters,
+                defaultValueConverter,
+                schemaNameAdjuster,
+                topicNamingStrategy,
+                sensitivity,
+                false, new CustomConverterRegistry(emptyList()), new OracleTaskContext(configuration, connectorConfig));
+
+        Table table = Table.editor()
+                .tableId(TableId.parse("ORCLPDB1.DEBEZIUM.TEST_TABLE"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("DATA").create())
+                .create();
+
+        Table lobTable = Table.editor()
+                .tableId(TableId.parse("ORCLPDB1.DEBEZIUM.TEST_LOB_TABLE"))
+                .addColumn(Column.editor().name("ID").type("VARCHAR2(50)").create())
+                .addColumn(Column.editor().name("DATA").type("CLOB").jdbcType(OracleTypes.CLOB).create())
+                .setPrimaryKeyNames("ID")
+                .create();
+
+        schema.refresh(table);
+        schema.refresh(lobTable);
+        return schema;
+    }
+
+    private OracleConnection createOracleConnection(boolean singleOptionalValueThrowException) throws Exception {
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true);
+        Mockito.when(rs.getFloat(1)).thenReturn(2.f);
+
+        final PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
+        Mockito.when(stmt.executeQuery()).thenReturn(rs);
+
+        final Connection conn = Mockito.mock(Connection.class);
+        Mockito.when(conn.prepareStatement(Mockito.any())).thenReturn(stmt);
+
+        OracleConnection connection = Mockito.mock(OracleConnection.class);
+        Mockito.when(connection.connection(Mockito.anyBoolean())).thenReturn(conn);
+        Mockito.when(connection.connection()).thenReturn(conn);
+        Mockito.when(connection.getNationalCharacterSet()).thenReturn(CharacterSet.make(CharacterSet.UTF8_CHARSET));
+        Mockito.when(connection.getDatabaseCharacterSet()).thenReturn(CharacterSet.make(CharacterSet.AL32UTF8_CHARSET));
+        if (!singleOptionalValueThrowException) {
+            Mockito.when(connection.singleOptionalValue(anyString(), any())).thenReturn(BigInteger.TWO);
+        }
+        else {
+            Mockito.when(connection.singleOptionalValue(anyString(), any()))
+                    .thenThrow(new SQLException("ORA-01555 Snapshot too old", null, 1555));
+        }
+        Mockito.when(connection.isArchiveLogDestinationValid(eq("LOG_ARCHIVE_DEST_1"))).thenReturn(true);
+        return connection;
+    }
+
+    private LogMinerStreamingChangeEventSourceMetrics createMetrics(OracleDatabaseSchema schema) throws Exception {
+        final Configuration config = getConfig().build();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        final OracleTaskContext taskContext = new OracleTaskContext(config, connectorConfig);
+
+        final ChangeEventQueue<DataChangeEvent> queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .pollInterval(Duration.of(DEFAULT_MAX_QUEUE_SIZE, ChronoUnit.MILLIS))
+                .maxBatchSize(DEFAULT_MAX_BATCH_SIZE)
+                .maxQueueSize(DEFAULT_MAX_QUEUE_SIZE)
+                .queueProvider(createDefaultQueueProvider(DEFAULT_MAX_QUEUE_SIZE))
+                .build();
+
+        return new LogMinerStreamingChangeEventSourceMetrics(taskContext, queue, null, connectorConfig, Collections::emptyList);
+    }
+
+    private static DefaultQueueProvider<DataChangeEvent> createDefaultQueueProvider(int maxQueueSize) {
+        DefaultQueueProvider<DataChangeEvent> provider = new DefaultQueueProvider<>();
+        provider.configure(Map.of("max.queue.size", String.valueOf(maxQueueSize)));
+        return provider;
+    }
+
+    private LogMinerEventRow getStartLogMinerEventRow(long scn, String transactionId) {
+        return getStartLogMinerEventRow(scn, transactionId, Instant.now());
+    }
+
+    private LogMinerEventRow getStartLogMinerEventRow(long scn, String transactionId, Instant changeTime) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.START);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(changeTime);
+        Mockito.when(row.getUserName()).thenReturn(TestHelper.SCHEMA_USER);
+        Mockito.when(row.getClientId()).thenReturn(null);
+        Mockito.when(row.getThread()).thenReturn(1);
+        return row;
+    }
+
+    private LogMinerEventRow getCommitLogMinerEventRow(long scn, String transactionId) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.COMMIT);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(Instant.now());
+        Mockito.when(row.getThread()).thenReturn(1);
+        return row;
+    }
+
+    private LogMinerEventRow getRollbackLogMinerEventRow(long scn, String transactionId) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.ROLLBACK);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(Instant.now());
+        Mockito.when(row.getThread()).thenReturn(1);
+        return row;
+    }
+
+    private LogMinerEventRow getInsertLogMinerEventRow(long scn, String transactionId) {
+        return getInsertLogMinerEventRow(scn, transactionId, Instant.now());
+    }
+
+    private LogMinerEventRow getInsertLogMinerEventRow(long scn, String transactionId, Instant changeTime) {
+        return getInsertLogMinerEventRow(scn, transactionId, changeTime, "TEST_TABLE", "AAAAAAAAAAAAAAAAAB", "'Test'");
+    }
+
+    private LogMinerEventRow getInsertLogMinerEventRow(long scn, String transactionId, Instant changeTime, String tableName, String rowId, String dataValue) {
+        LogMinerEventRow row = Mockito.mock(LogMinerEventRow.class);
+        Mockito.when(row.getEventType()).thenReturn(EventType.INSERT);
+        Mockito.when(row.getTransactionId()).thenReturn(transactionId);
+        Mockito.when(row.getScn()).thenReturn(Scn.valueOf(scn));
+        Mockito.when(row.getChangeTime()).thenReturn(changeTime);
+        Mockito.when(row.getRowId()).thenReturn(rowId);
+        Mockito.when(row.getOperation()).thenReturn("INSERT");
+        Mockito.when(row.getTableName()).thenReturn(tableName);
+        Mockito.when(row.getTableId()).thenReturn(TableId.parse("ORCLPDB1.DEBEZIUM." + tableName));
+        Mockito.when(row.getRedoSql()).thenReturn("insert into \"DEBEZIUM\".\"%s\"(\"ID\",\"DATA\") values ('1',%s);".formatted(tableName, dataValue));
+        Mockito.when(row.getRsId()).thenReturn("A.B.C");
+        Mockito.when(row.getTablespaceName()).thenReturn("DEBEZIUM");
+        Mockito.when(row.getUserName()).thenReturn(TestHelper.SCHEMA_USER);
+        Mockito.when(row.getClientId()).thenReturn(null);
+        Mockito.when(row.getThread()).thenReturn(1);
+        return row;
+    }
+
+    private static RedoThreadState buildRedoThreadState(int threadId, String enabled) {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(threadId)
+                .status("OPEN")
+                .enabled(enabled)
+                .logGroups(2L)
+                .instanceName("ORCLCDB")
+                .openTime(Instant.now())
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .checkpointScn(Scn.valueOf(1))
+                .checkpointTime(Instant.now())
+                .enabledScn(Scn.valueOf(1))
+                .enabledTime(Instant.now())
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoBlock(1L)
+                .lastRedoScn(Scn.valueOf(1))
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
+    }
+
+    protected BufferedStreamingChangeEventSource getChangeEventSource(Configuration config) throws Exception {
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error)).isTrue();
+
+        final BufferedStreamingChangeEventSource source = new BufferedStreamingChangeEventSource(
+                connectorConfig,
+                connection,
+                dispatcher,
+                schema,
+                metrics,
+                context,
+                offsetContext);
+
+        source.init(offsetContext);
+
+        source.setCurrentRedoThreadState(buildRedoThreadState(1, "PUBLIC"));
+
+        return source;
+    }
+
+    // Helper class that permits exposing some protected methods for mocking
+    protected static class BufferedStreamingChangeEventSource extends BufferedLogMinerStreamingChangeEventSource {
+
+        private final ChangeEventSourceContext context;
+        private final OffsetActivityMonitor offsetActivityMonitor;
+
+        public BufferedStreamingChangeEventSource(
+                                                  OracleConnectorConfig connectorConfig,
+                                                  OracleConnection connection,
+                                                  EventDispatcher<OraclePartition, TableId> dispatcher,
+                                                  OracleDatabaseSchema schema,
+                                                  LogMinerStreamingChangeEventSourceMetrics metrics,
+                                                  ChangeEventSourceContext context,
+                                                  OracleOffsetContext offsetContext) {
+            super(connectorConfig, connection, dispatcher, null, Clock.SYSTEM, schema, connectorConfig.getJdbcConfig(), metrics);
+            this.context = context;
+            this.offsetActivityMonitor = new OffsetActivityMonitor(OFFSET_ACTIVITY_MONITOR_INACTIVE_THRESHOLD_MS, offsetContext, metrics);
+        }
+
+        @Override
+        protected ChangeEventSourceContext getContext() {
+            // Necessary for mock purposes only
+            return context;
+        }
+
+        @Override
+        protected OffsetActivityMonitor getOffsetActivityMonitor() {
+            // Necessary for mock purposes only
+            return offsetActivityMonitor;
+        }
+
+        @Override
+        public Table dispatchSchemaChangeEventAndGetTableForNewConfiguredTable(TableId tableId) throws SQLException, InterruptedException {
+            // Necessary for mock purposes only
+            return super.dispatchSchemaChangeEventAndGetTableForNewConfiguredTable(tableId);
+        }
+
+        @Override
+        public void processEvent(LogMinerEventRow event) throws SQLException, InterruptedException {
+            // Necessary for mock purposes only
+            super.processEvent(event);
+        }
+
+        public void setCurrentRedoThreadState(RedoThreadState state) throws Exception {
+            var field = AbstractLogMinerStreamingChangeEventSource.class.getDeclaredField("currentRedoThreadState");
+            field.setAccessible(true);
+            field.set(this, state);
+        }
+
+        public int getDeferredTransactionCount() {
+            return getDeferredTransactionsForTest().size();
+        }
+
+        public boolean hasDeferredTransaction(String transactionId) {
+            return getDeferredTransactionsForTest().containsKey(transactionId);
+        }
+
+        public Scn getOldestDeferredTransactionStartScn() {
+            try {
+                final var method = BufferedLogMinerStreamingChangeEventSource.class.getDeclaredMethod("getOldestDeferredTransactionStartScn");
+                method.setAccessible(true);
+                return (Scn) method.invoke(this);
+            }
+            catch (ReflectiveOperationException e) {
+                throw new AssertionError("Unable to invoke getOldestDeferredTransactionStartScn", e);
+            }
+        }
+
+        public void cleanupDeferredTransactionsForTest(Duration retention) {
+            try {
+                final var method = BufferedLogMinerStreamingChangeEventSource.class.getDeclaredMethod("cleanupDeferredTransactions", Duration.class);
+                method.setAccessible(true);
+                method.invoke(this, retention);
+            }
+            catch (ReflectiveOperationException e) {
+                throw new AssertionError("Unable to invoke deferred transaction cleanup", e);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private Map<String, ?> getDeferredTransactionsForTest() {
+            try {
+                final var field = BufferedLogMinerStreamingChangeEventSource.class.getDeclaredField("deferredTransactions");
+                field.setAccessible(true);
+                return (Map<String, ?>) field.get(this);
+            }
+            catch (ReflectiveOperationException e) {
+                throw new AssertionError("Unable to read deferred transaction state", e);
+            }
+        }
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1199,6 +1199,9 @@ The default buffer type is configured using `memory`.
 Under the default `memory` setting, the connector uses the heap memory of the JVM process to allocate and manage buffered event records.
 If you use the `memory` buffer setting, be sure that the amount of memory that you allocate to the Java process can accommodate long-running and large transactions in your environment.
 
+When you set xref:oracle-property-log-mining-buffer-deferred-transaction-start[`log.mining.buffer.deferred.transaction.start`] to `true`, the connector retains lightweight metadata for transactions that emit only a `START` event until a DML event promotes the transaction into the main cache.
+To limit how long the connector retains metadata for transactions that never emit DML, set xref:oracle-property-log-mining-buffer-deferred-transaction-retention-ms[`log.mining.buffer.deferred.transaction.retention.ms`].
+
 ifdef::community[]
 [[oracle-event-buffering-infinispan]]
 ==== Infinispan
@@ -4616,6 +4619,13 @@ The degree of latency depends on how frequently the database is configured to ar
 |The number of milliseconds the connector will sleep in between polling to determine if the starting system change number is in the archive logs.
 If `log.mining.archive.log.only.mode` is not enabled, this setting is not used.
 
+|[[oracle-property-log-mining-buffer-deferred-transaction-start]]<<oracle-property-log-mining-buffer-deferred-transaction-start, `log.mining.buffer.deferred.transaction.start`>>
+|`false`
+|Boolean value that specifies whether the connector defers creating buffered LogMiner transactions until the first DML or DDL event is observed.
+When set to `true`, the connector stores only lightweight transaction metadata after a `START` event and promotes the transaction into the main cache only after the first data-bearing event arrives.
+
+This option cannot be enabled when xref:oracle-property-lob-enabled[`lob.enabled`] is set to `true`.
+
 |[[oracle-property-log-mining-transaction-retention-ms]]<<oracle-property-log-mining-transaction-retention-ms, `log.mining.transaction.retention.ms`>>
 |`0`
 |Positive integer value that specifies the number of milliseconds to retain long running transactions between redo log switches.
@@ -4625,6 +4635,14 @@ By default, the LogMiner adapter maintains an in-memory buffer of all running tr
 Because all of the DML operations that are part of a transaction are buffered until a commit or rollback is detected,
 long-running transactions should be avoided in order to not overflow that buffer.
 Any transaction that exceeds this configured value is discarded entirely, and the connector does not emit any messages for the operations that were part of the transaction.
+
+|[[oracle-property-log-mining-buffer-deferred-transaction-retention-ms]]<<oracle-property-log-mining-buffer-deferred-transaction-retention-ms, `log.mining.buffer.deferred.transaction.retention.ms`>>
+|`86400000`
+|Positive integer value that specifies the number of milliseconds to retain deferred transaction metadata for buffered LogMiner transactions that emit a `START` event but do not yet emit DML.
+When set to `0`, the connector retains the deferred metadata until a commit or rollback is detected.
+
+Use this setting with deferred transaction start behavior to bound the amount of memory used by transactions that never progress beyond `START`.
+This setting does not affect transactions that have already been promoted into the main transaction cache.
 
 ifdef::community[]
 |[[oracle-property-log-mining-window-max-ms]]<<oracle-property-log-mining-window-max-ms, `log.mining.window.max.ms`>>


### PR DESCRIPTION
Fixes debezium/dbz#2046

## Description
The goal of this change is to reintroduce an approximation of the deferred transaction start that was first worked on here:  https://github.com/debezium/debezium/pull/5252

The PR creates a new map that stores required metadata.  A transaction stays in this deferred state until new DML is seen at which point it is promoted to a "real" transaction.  This change allows for a sliding window similar to Debezium behaviour in versions prior to 3.2.4.  It tries to approximate the previous behaviour of the internal config log.mining.buffer.memory.legacy.transaction.start but without losing metadata like user_name and clientid.

In this implementation, the lower bound of the session window does not get pinned by in-flight transactions.  The offset scn though is impacted by both deferred and true transactions.  This is to prevent metadata being lost on connector restart.  There is a configuration that allows clean up of the deferred map.  By default, it allows transactions to be stored there for 24 hours which seems like a reasonable amount of time to store in this map (in practice you'd likely want this window to be much smaller as this means that there has been no DML on the transaction in 24 hours).

In log.mining.buffer.memory.legacy.transaction.start it explicitly excluded the non-memory types.  Given that in this new mode we capture the transaction starts, I can't think of any reason not to allow infinispan and ehcache to make use of it and so the naming reflects that.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
