### PR TITLE
debezium/dbz#2097 Preserve MicroDuration microseconds for PostgreSQL interval

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/IntervalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/IntervalType.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
@@ -42,8 +43,7 @@ class IntervalType extends AbstractType {
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
         if (value instanceof Long) {
-            final double doubleValue = ((Long) value).doubleValue() / 1_000_000d;
-            return String.format("'%d seconds'", (long) doubleValue);
+            return String.format("'%s'", getIntervalSeconds((Long) value));
         }
         // apply no default
         return null;
@@ -53,10 +53,13 @@ class IntervalType extends AbstractType {
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
 
         if (value != null && Long.class.isAssignableFrom(value.getClass())) {
-            final double doubleValue = ((Long) value).doubleValue() / 1_000_000d;
-            return List.of(new ValueBindDescriptor(index, ((long) doubleValue) + " seconds"));
+            return List.of(new ValueBindDescriptor(index, getIntervalSeconds((Long) value)));
         }
 
         return super.bind(index, schema, value);
+    }
+
+    private String getIntervalSeconds(long durationMicros) {
+        return BigDecimal.valueOf(durationMicros, 6).stripTrailingZeros().toPlainString() + " seconds";
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/IntervalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/IntervalTypeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.MicroDuration;
+
+/**
+ * Unit tests for the PostgreSQL {@link IntervalType} handler.
+ */
+@Tag("UnitTests")
+class IntervalTypeTest {
+
+    private IntervalType intervalType;
+
+    @BeforeEach
+    void setUp() {
+        intervalType = IntervalType.INSTANCE;
+    }
+
+    @Test
+    @DisplayName("Should register for MicroDuration logical name")
+    void testRegistrationKeys() {
+        final String[] keys = intervalType.getRegistrationKeys();
+        assertThat(keys).containsExactly(MicroDuration.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should preserve microseconds when binding interval values")
+    void testBindPreservesMicroseconds() {
+        assertBindValue(1_123_456L, "1.123456 seconds");
+        assertBindValue(45_296_123_456L, "45296.123456 seconds");
+        assertBindValue(-1L, "-0.000001 seconds");
+        assertBindValue(3_020_398_999_999L, "3020398.999999 seconds");
+        assertBindValue(-3_020_398_999_999L, "-3020398.999999 seconds");
+        assertBindValue(1_000_000L, "1 seconds");
+        assertBindValue(0L, "0 seconds");
+    }
+
+    @Test
+    @DisplayName("Should preserve microseconds in default value bindings")
+    void testDefaultValueBindingPreservesMicroseconds() {
+        assertThat(intervalType.getDefaultValueBinding(MicroDuration.schema(), 45_296_123_456L))
+                .isEqualTo("'45296.123456 seconds'");
+        assertThat(intervalType.getDefaultValueBinding(MicroDuration.schema(), -1L))
+                .isEqualTo("'-0.000001 seconds'");
+    }
+
+    @Test
+    @DisplayName("Should use interval cast query binding")
+    void testQueryBinding() {
+        assertThat(intervalType.getQueryBinding(null, null, null)).isEqualTo("cast(? as interval)");
+    }
+
+    private void assertBindValue(long durationMicros, String expectedValue) {
+        final List<ValueBindDescriptor> bindings = intervalType.bind(1, MicroDuration.schema(), durationMicros);
+        assertThat(bindings).hasSize(1);
+
+        final ValueBindDescriptor binding = bindings.get(0);
+        assertThat(binding.getIndex()).isEqualTo(1);
+        assertThat(binding.getValue()).isEqualTo(expectedValue);
+        assertThat(binding.getTargetSqlType()).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -2391,8 +2391,8 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
             assertDataTypeNonKeyOnly(source,
                     sink,
                     "interval",
-                    List.of("'P1Y2M3DT4H5M6.78S'::INTERVAL"),
-                    List.of("10303:05:06"),
+                    List.of("'P1Y2M3DT4H5M6.123456S'::INTERVAL"),
+                    List.of("10303:05:06.123456"),
                     (config) -> config.with("interval.handling.mode", "numeric"),
                     (record) -> assertColumn(sink, record, "data", getIntervalType(source, true)),
                     ResultSet::getString);
@@ -2401,8 +2401,8 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
             assertDataTypeNonKeyOnly(source,
                     sink,
                     "interval",
-                    List.of("'P1Y2M3DT4H5M6.78S'::INTERVAL"),
-                    List.of(MicroDuration.durationMicros(1, 2, 3, 4, 5, 6.78, 365.25 / 12.0)),
+                    List.of("'P1Y2M3DT4H5M6.123456S'::INTERVAL"),
+                    List.of(MicroDuration.durationMicros(1, 2, 3, 4, 5, 6.123456, 365.25 / 12.0)),
                     (config) -> config.with("interval.handling.mode", "numeric"),
                     (record) -> assertColumn(sink, record, "data", getIntervalType(source, true)),
                     ResultSet::getLong);
@@ -2431,7 +2431,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                     sink,
                     "interval day to second",
                     List.of("TO_DSINTERVAL('P10DT50H99M1000.365S')"),
-                    List.of("291:55:40"),
+                    List.of("291:55:40.365"),
                     (config) -> config.with("interval.handling.mode", "numeric"),
                     (record) -> assertColumn(sink, record, "data", getIntervalType(source, true)),
                     ResultSet::getString);


### PR DESCRIPTION
https://github.com/debezium/dbz/issues/2097

This change fixes PostgreSQL JDBC sink binding for `io.debezium.time.MicroDuration` values.

Previously, the PostgreSQL interval binding converted microseconds to seconds using floating point division and then cast the result to `long`. That dropped any fractional seconds before the value was bound to PostgreSQL, causing microsecond precision loss.

The binding now formats the microsecond value as decimal seconds without truncating the fractional part.

Test coverage added/updated:

* Added unit coverage for PostgreSQL `IntervalType` binding and default value binding
* Updated PostgreSQL interval numeric E2E expectations to retain fractional seconds
* Updated interval day-to-second E2E expectations for PostgreSQL interval sinks

Manual Docker Compose verification:

```text
PostgreSQL interval source
-> Debezium PostgreSQL source connector
-> Kafka io.debezium.time.MicroDuration payload
-> JDBC sink
-> PostgreSQL interval target
```

Before the change:

```text
1 | 00:00:01
2 | 12:34:56
3 | 00:00:00
4 | 838:59:58
```

After the change:

```text
1 | 00:00:01.123456
2 | 12:34:56.123456
3 | -00:00:00.000001
4 | 838:59:58.999999
```

Verification run locally:

```text
JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH ./mvnw -pl debezium-connector-jdbc -am -Dtest=IntervalTypeTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test

JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH ./mvnw -pl debezium-connector-jdbc -am -Dtest=IntervalTypeTest -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=JdbcSinkPipelineToPostgresIT#testIntervalDataTypeIntervalHandlingModeNumeric -Dfailsafe.failIfNoSpecifiedTests=false -Dtest.tags=e2e-postgresql -Dsource.connectors=postgres verify
```

Fixes debezium/dbz#2097
