### PR TITLE
debezium/dbz#2099 Preserve PostgreSQL BIT and VARBIT values in JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BitType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BitType.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.data.Bits;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -84,7 +85,7 @@ class BitType extends AbstractType {
         }
 
         final int length = Integer.parseInt(schema.parameters().get(Bits.LENGTH_FIELD));
-        return List.of(new ValueBindDescriptor(index, toBitString((byte[]) value, length)));
+        return List.of(new ValueBindDescriptor(index, toBitString(ByteArrayUtils.getByteArrayFromValue(value), length)));
     }
 
     private boolean isBitOne(Schema schema) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BitType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BitType.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
-import java.math.BigInteger;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,7 +17,6 @@ import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.data.Bits;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
-import io.debezium.util.Strings;
 
 /**
  * An implementation of {@link JdbcType} for {@link Bits} types.
@@ -85,16 +84,21 @@ class BitType extends AbstractType {
         }
 
         final int length = Integer.parseInt(schema.parameters().get(Bits.LENGTH_FIELD));
-        final String binaryBitString = new BigInteger((byte[]) value).toString(2);
-        if (length == Integer.MAX_VALUE) {
-            return List.of(new ValueBindDescriptor(index, binaryBitString));
-        }
-
-        return List.of(new ValueBindDescriptor(index, Strings.justifyRight(binaryBitString, length, '0')));
+        return List.of(new ValueBindDescriptor(index, toBitString((byte[]) value, length)));
     }
 
     private boolean isBitOne(Schema schema) {
         return Objects.isNull(schema.name());
+    }
+
+    private String toBitString(byte[] value, int length) {
+        final BitSet bits = BitSet.valueOf(value);
+        final int width = length == Integer.MAX_VALUE ? bits.length() : length;
+        final StringBuilder builder = new StringBuilder(width);
+        for (int i = width - 1; i >= 0; --i) {
+            builder.append(bits.get(i) ? '1' : '0');
+        }
+        return builder.toString();
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/BitTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/BitTypeTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.dialect.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
@@ -41,6 +42,14 @@ class BitTypeTest {
 
     @Test
     @FixFor("debezium/dbz#2099")
+    @DisplayName("Should bind ByteBuffer bit values from Avro converter")
+    void testBindByteBufferBitValues() {
+        assertBindValue(Bits.schema(16), ByteBuffer.wrap(new byte[]{ 0x02, 0x01 }), "0000000100000010");
+        assertBindValue(Bits.schema(24), ByteBuffer.wrap(new byte[]{ 0x01, 0x02, 0x03 }), "000000110000001000000001");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2099")
     @DisplayName("Should bind values with the high bit set as unsigned bit strings")
     void testBindHighBitValues() {
         assertBindValue(Bits.schema(8), new byte[]{ (byte) 0x80 }, "10000000");
@@ -63,7 +72,7 @@ class BitTypeTest {
         assertBindValue(Bits.schema(Integer.MAX_VALUE), new byte[]{ 0x05 }, "101");
     }
 
-    private void assertBindValue(Schema schema, byte[] value, String expected) {
+    private void assertBindValue(Schema schema, Object value, String expected) {
         final List<ValueBindDescriptor> descriptors = BitType.INSTANCE.bind(1, schema, value);
 
         assertThat(descriptors).hasSize(1);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/BitTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/BitTypeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Bits;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the PostgreSQL {@link BitType} handler.
+ */
+@Tag("UnitTests")
+class BitTypeTest {
+
+    @Test
+    @FixFor("debezium/dbz#2099")
+    @DisplayName("Should register for Debezium Bits and PostgreSQL bit type names")
+    void testRegistrationKeys() {
+        assertThat(BitType.INSTANCE.getRegistrationKeys()).containsExactly(Bits.LOGICAL_NAME, "BIT", "VARBIT");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2099")
+    @DisplayName("Should bind multi-byte bit values using Debezium Bits byte order")
+    void testBindMultiByteBitValues() {
+        assertBindValue(Bits.schema(16), new byte[]{ 0x02, 0x01 }, "0000000100000010");
+        assertBindValue(Bits.schema(24), new byte[]{ 0x01, 0x02, 0x03 }, "000000110000001000000001");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2099")
+    @DisplayName("Should bind values with the high bit set as unsigned bit strings")
+    void testBindHighBitValues() {
+        assertBindValue(Bits.schema(8), new byte[]{ (byte) 0x80 }, "10000000");
+        assertBindValue(Bits.schema(8), new byte[]{ (byte) 0xff }, "11111111");
+        assertBindValue(Bits.schema(8), new byte[]{ (byte) 0x81 }, "10000001");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2099")
+    @DisplayName("Should preserve leading zeroes for bounded bit values")
+    void testBindBoundedValuesWithLeadingZeroes() {
+        assertBindValue(Bits.schema(2), new byte[]{}, "00");
+        assertBindValue(Bits.schema(7), new byte[]{ 0x40 }, "1000000");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2099")
+    @DisplayName("Should bind unbounded varbit values using the payload bit length")
+    void testBindUnboundedVarbitValue() {
+        assertBindValue(Bits.schema(Integer.MAX_VALUE), new byte[]{ 0x05 }, "101");
+    }
+
+    private void assertBindValue(Schema schema, byte[] value, String expected) {
+        final List<ValueBindDescriptor> descriptors = BitType.INSTANCE.bind(1, schema, value);
+
+        assertThat(descriptors).hasSize(1);
+        assertThat(descriptors.get(0).getIndex()).isEqualTo(1);
+        assertThat(descriptors.get(0).getValue()).isEqualTo(expected);
+        assertThat(descriptors.get(0).getTargetSqlType()).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToPostgresIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToPostgresIT.java
@@ -219,6 +219,39 @@ public class JdbcSinkPipelineToPostgresIT extends AbstractJdbcSinkPipelineIT {
     }
 
     @TestTemplate
+    @ForSource(value = SourceType.POSTGRES, reason = "PostgreSQL source emits multi-byte BIT values as Debezium Bits")
+    public void testBitDataTypeWithMultiByteValues(Source source, Sink sink) throws Exception {
+        assertDataTypesNonKeyOnly(source,
+                sink,
+                List.of("bit(8)", "bit(16)", "bit(24)"),
+                List.of("B'11111111'", "B'0000000100000010'", "B'000000110000001000000001'"),
+                List.of("11111111", "0000000100000010", "000000110000001000000001"),
+                (record) -> {
+                    assertColumn(sink, record, "data0", getBitsDataType(), 8);
+                    assertColumn(sink, record, "data1", getBitsDataType(), 16);
+                    assertColumn(sink, record, "data2", getBitsDataType(), 24);
+                },
+                ResultSet::getString);
+    }
+
+    @TestTemplate
+    @ForSource(value = SourceType.POSTGRES, reason = "PostgreSQL source emits multi-byte VARBIT values as Debezium Bits")
+    public void testBitVaryingDataTypeWithMultiByteValues(Source source, Sink sink) throws Exception {
+        assertDataTypesNonKeyOnly(source,
+                sink,
+                List.of("bit varying(8)", "bit varying(16)", "bit varying(24)"),
+                List.of("B'11111111'", "B'0000000100000010'", "B'000000110000001000000001'"),
+                List.of("11111111", "0000000100000010", "000000110000001000000001"),
+                (record) -> {
+                    final String dataType = source.getOptions().isColumnTypePropagated() ? "VARBIT" : getBitsDataType();
+                    assertColumn(sink, record, "data0", dataType, 8);
+                    assertColumn(sink, record, "data1", dataType, 16);
+                    assertColumn(sink, record, "data2", dataType, 24);
+                },
+                ResultSet::getString);
+    }
+
+    @TestTemplate
     @ForSource(value = { SourceType.POSTGRES }, reason = "The infinity value is valid only for PostgreSQL")
     @WithTemporalPrecisionMode
     @Override


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2099

The PostgreSQL JDBC sink converted Debezium `Bits` payloads with `BigInteger(byte[])`. Debezium `Bits` uses `BitSet` byte-array semantics, while `BigInteger` interprets bytes as signed big-endian values. This could silently reverse multi-byte `BIT`/`VARBIT` values or fail for high-bit bytes such as `0xff`.

This change binds PostgreSQL bit values by decoding the payload with `BitSet.valueOf(byte[])` and emitting the bit string from the schema width. It also adds unit coverage for byte order, high-bit bytes, and bounded leading zeroes, plus PostgreSQL source-to-sink e2e coverage for `bit(8/16/24)` and `bit varying(8/16/24)`.

Testing:

* Ran `BitTypeTest` for PostgreSQL BIT/VARBIT binding, covering byte order, high-bit bytes, bounded leading zeroes, and unbounded VARBIT payloads.
* Ran PostgreSQL source-to-PostgreSQL sink e2e tests for `bit(8/16/24)` and `bit varying(8/16/24)` across the JDBC sink pipeline source option combinations.
* Built a local JDBC connector plugin and verified a Docker Compose PostgreSQL-to-PostgreSQL pipeline. The sink preserved `0000000100000010`, `000000110000001000000001`, `10000000`, and `11111111` for `BIT` and `VARBIT` columns.
