### PR TITLE
debezium/dbz#2100 Preserve PostgreSQL TIME and TIMETZ boundary values

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MicroTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MicroTimeType.java
@@ -18,7 +18,7 @@ class MicroTimeType extends io.debezium.connector.jdbc.type.debezium.MicroTimeTy
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMicroseconds(value)) {
             return PostgresTimeBoundary.TIME_QUERY_BINDING;
         }
         return super.getQueryBinding(column, schema, value);
@@ -26,7 +26,7 @@ class MicroTimeType extends io.debezium.connector.jdbc.type.debezium.MicroTimeTy
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMicroseconds(value)) {
             return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
         }
         return super.getDefaultValueBinding(schema, value);
@@ -34,13 +34,9 @@ class MicroTimeType extends io.debezium.connector.jdbc.type.debezium.MicroTimeTy
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMicroseconds(value)) {
             return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
         }
         return super.bind(index, schema, value);
-    }
-
-    private boolean isBoundary(Object value) {
-        return value instanceof Number && PostgresTimeBoundary.isBoundaryMicroseconds((Number) value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MicroTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MicroTimeType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+class MicroTimeType extends io.debezium.connector.jdbc.type.debezium.MicroTimeType {
+
+    public static final MicroTimeType INSTANCE = new MicroTimeType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return PostgresTimeBoundary.TIME_QUERY_BINDING;
+        }
+        return super.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
+        }
+        return super.bind(index, schema, value);
+    }
+
+    private boolean isBoundary(Object value) {
+        return value instanceof Number && PostgresTimeBoundary.isBoundaryMicroseconds((Number) value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/NanoTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/NanoTimeType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+class NanoTimeType extends io.debezium.connector.jdbc.type.debezium.NanoTimeType {
+
+    public static final NanoTimeType INSTANCE = new NanoTimeType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return PostgresTimeBoundary.TIME_QUERY_BINDING;
+        }
+        return super.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
+        }
+        return super.bind(index, schema, value);
+    }
+
+    private boolean isBoundary(Object value) {
+        return value instanceof Number && PostgresTimeBoundary.isBoundaryNanoseconds((Number) value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/NanoTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/NanoTimeType.java
@@ -18,7 +18,7 @@ class NanoTimeType extends io.debezium.connector.jdbc.type.debezium.NanoTimeType
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryNanoseconds(value)) {
             return PostgresTimeBoundary.TIME_QUERY_BINDING;
         }
         return super.getQueryBinding(column, schema, value);
@@ -26,7 +26,7 @@ class NanoTimeType extends io.debezium.connector.jdbc.type.debezium.NanoTimeType
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryNanoseconds(value)) {
             return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
         }
         return super.getDefaultValueBinding(schema, value);
@@ -34,13 +34,9 @@ class NanoTimeType extends io.debezium.connector.jdbc.type.debezium.NanoTimeType
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryNanoseconds(value)) {
             return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
         }
         return super.bind(index, schema, value);
-    }
-
-    private boolean isBoundary(Object value) {
-        return value instanceof Number && PostgresTimeBoundary.isBoundaryNanoseconds((Number) value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -255,6 +255,9 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
     protected void registerTypes() {
         super.registerTypes();
 
+        registerType(TimeType.INSTANCE);
+        registerType(MicroTimeType.INSTANCE);
+        registerType(NanoTimeType.INSTANCE);
         registerType(TimeWithTimezoneType.INSTANCE);
         registerType(ZonedTimestampType.INSTANCE);
         registerType(IntervalType.INSTANCE);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresTimeBoundary.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresTimeBoundary.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * Boundary helpers for PostgreSQL {@code TIME} values.
+ */
+final class PostgresTimeBoundary {
+
+    static final String BOUNDARY_TIME = "24:00:00";
+    static final String BOUNDARY_TIME_WITH_TIMEZONE = "24:00:00Z";
+    static final String TIME_QUERY_BINDING = "cast(? as time)";
+    static final String TIME_WITH_TIMEZONE_QUERY_BINDING = "cast(? as time with time zone)";
+
+    private static final long DAY_MILLIS = TimeUnit.DAYS.toMillis(1);
+    private static final long DAY_MICROS = TimeUnit.DAYS.toMicros(1);
+    private static final long DAY_NANOS = TimeUnit.DAYS.toNanos(1);
+    private static final Pattern BOUNDARY_TIME_WITH_TIMEZONE_PATTERN = Pattern.compile("^24:00:00(?:\\.0{1,6})?(?:Z|[+-]00(?::?00)?)$");
+
+    static boolean isBoundaryMilliseconds(Number value) {
+        return value.longValue() == DAY_MILLIS;
+    }
+
+    static boolean isBoundaryMicroseconds(Number value) {
+        return value.longValue() == DAY_MICROS;
+    }
+
+    static boolean isBoundaryNanoseconds(Number value) {
+        return value.longValue() == DAY_NANOS;
+    }
+
+    static boolean isBoundaryTimeWithTimezone(Object value) {
+        return value instanceof String && BOUNDARY_TIME_WITH_TIMEZONE_PATTERN.matcher((String) value).matches();
+    }
+
+    private PostgresTimeBoundary() {
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresTimeBoundary.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresTimeBoundary.java
@@ -23,20 +23,20 @@ final class PostgresTimeBoundary {
     private static final long DAY_NANOS = TimeUnit.DAYS.toNanos(1);
     private static final Pattern BOUNDARY_TIME_WITH_TIMEZONE_PATTERN = Pattern.compile("^24:00:00(?:\\.0{1,6})?(?:Z|[+-]00(?::?00)?)$");
 
-    static boolean isBoundaryMilliseconds(Number value) {
-        return value.longValue() == DAY_MILLIS;
+    static boolean isBoundaryMilliseconds(Object value) {
+        return value instanceof Number number && number.longValue() == DAY_MILLIS;
     }
 
-    static boolean isBoundaryMicroseconds(Number value) {
-        return value.longValue() == DAY_MICROS;
+    static boolean isBoundaryMicroseconds(Object value) {
+        return value instanceof Number number && number.longValue() == DAY_MICROS;
     }
 
-    static boolean isBoundaryNanoseconds(Number value) {
-        return value.longValue() == DAY_NANOS;
+    static boolean isBoundaryNanoseconds(Object value) {
+        return value instanceof Number number && number.longValue() == DAY_NANOS;
     }
 
     static boolean isBoundaryTimeWithTimezone(Object value) {
-        return value instanceof String && BOUNDARY_TIME_WITH_TIMEZONE_PATTERN.matcher((String) value).matches();
+        return value instanceof String string && BOUNDARY_TIME_WITH_TIMEZONE_PATTERN.matcher(string).matches();
     }
 
     private PostgresTimeBoundary() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeType.java
@@ -18,7 +18,7 @@ class TimeType extends io.debezium.connector.jdbc.type.debezium.TimeType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMilliseconds(value)) {
             return PostgresTimeBoundary.TIME_QUERY_BINDING;
         }
         return super.getQueryBinding(column, schema, value);
@@ -26,7 +26,7 @@ class TimeType extends io.debezium.connector.jdbc.type.debezium.TimeType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMilliseconds(value)) {
             return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
         }
         return super.getDefaultValueBinding(schema, value);
@@ -34,13 +34,9 @@ class TimeType extends io.debezium.connector.jdbc.type.debezium.TimeType {
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (isBoundary(value)) {
+        if (PostgresTimeBoundary.isBoundaryMilliseconds(value)) {
             return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
         }
         return super.bind(index, schema, value);
-    }
-
-    private boolean isBoundary(Object value) {
-        return value instanceof Number && PostgresTimeBoundary.isBoundaryMilliseconds((Number) value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+class TimeType extends io.debezium.connector.jdbc.type.debezium.TimeType {
+
+    public static final TimeType INSTANCE = new TimeType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return PostgresTimeBoundary.TIME_QUERY_BINDING;
+        }
+        return super.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return "'" + PostgresTimeBoundary.BOUNDARY_TIME + "'";
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (isBoundary(value)) {
+            return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME));
+        }
+        return super.bind(index, schema, value);
+    }
+
+    private boolean isBoundary(Object value) {
+        return value instanceof Number && PostgresTimeBoundary.isBoundaryMilliseconds((Number) value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeWithTimezoneType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TimeWithTimezoneType.java
@@ -15,6 +15,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.ZonedTimeType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.ZonedTime;
 
@@ -33,10 +34,30 @@ class TimeWithTimezoneType extends ZonedTimeType {
     }
 
     @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        if (PostgresTimeBoundary.isBoundaryTimeWithTimezone(value)) {
+            return PostgresTimeBoundary.TIME_WITH_TIMEZONE_QUERY_BINDING;
+        }
+        return super.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (PostgresTimeBoundary.isBoundaryTimeWithTimezone(value)) {
+            return "'" + PostgresTimeBoundary.BOUNDARY_TIME_WITH_TIMEZONE + "'";
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
 
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
+        }
+
+        if (PostgresTimeBoundary.isBoundaryTimeWithTimezone(value)) {
+            return List.of(new ValueBindDescriptor(index, PostgresTimeBoundary.BOUNDARY_TIME_WITH_TIMEZONE));
         }
 
         if (value instanceof String) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/TimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/TimeTypeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.MicroTime;
+import io.debezium.time.NanoTime;
+import io.debezium.time.Time;
+import io.debezium.time.ZonedTime;
+
+/**
+ * Unit tests for PostgreSQL time boundary values.
+ */
+@Tag("UnitTests")
+class TimeTypeTest {
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should bind Debezium Time boundary value as PostgreSQL time literal")
+    void testBindTimeBoundaryValue() {
+        assertTimeBoundary(TimeType.INSTANCE, Time.schema(), (int) TimeUnit.DAYS.toMillis(1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should bind Debezium MicroTime boundary value as PostgreSQL time literal")
+    void testBindMicroTimeBoundaryValue() {
+        assertTimeBoundary(MicroTimeType.INSTANCE, MicroTime.schema(), TimeUnit.DAYS.toMicros(1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should bind Debezium NanoTime boundary value as PostgreSQL time literal")
+    void testBindNanoTimeBoundaryValue() {
+        assertTimeBoundary(NanoTimeType.INSTANCE, NanoTime.schema(), TimeUnit.DAYS.toNanos(1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should bind Debezium ZonedTime boundary value as PostgreSQL time with time zone literal")
+    void testBindTimeWithTimezoneBoundaryValue() {
+        final List<ValueBindDescriptor> descriptors = TimeWithTimezoneType.INSTANCE.bind(1, ZonedTime.schema(), "24:00:00Z");
+
+        assertThat(TimeWithTimezoneType.INSTANCE.getQueryBinding(null, ZonedTime.schema(), "24:00:00Z")).isEqualTo("cast(? as time with time zone)");
+        assertThat(descriptors).hasSize(1);
+        assertThat(descriptors.get(0).getIndex()).isEqualTo(1);
+        assertThat(descriptors.get(0).getValue()).isEqualTo("24:00:00Z");
+        assertThat(descriptors.get(0).getTargetSqlType()).isNull();
+    }
+
+    private void assertTimeBoundary(io.debezium.connector.jdbc.type.JdbcType type, Schema schema, Number value) {
+        final List<ValueBindDescriptor> descriptors = type.bind(1, schema, value);
+
+        assertThat(type.getQueryBinding(null, schema, value)).isEqualTo("cast(? as time)");
+        assertThat(descriptors).hasSize(1);
+        assertThat(descriptors.get(0).getIndex()).isEqualTo(1);
+        assertThat(descriptors.get(0).getValue()).isEqualTo("24:00:00");
+        assertThat(descriptors.get(0).getTargetSqlType()).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToPostgresIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToPostgresIT.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.e2e;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +23,8 @@ import io.debezium.connector.jdbc.junit.jupiter.e2e.ForSource;
 import io.debezium.connector.jdbc.junit.jupiter.e2e.WithTemporalPrecisionMode;
 import io.debezium.connector.jdbc.junit.jupiter.e2e.source.Source;
 import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourceType;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.spatial.GeometryBytes;
 import io.debezium.util.HexConverter;
 
@@ -247,6 +250,40 @@ public class JdbcSinkPipelineToPostgresIT extends AbstractJdbcSinkPipelineIT {
                     assertColumn(sink, record, "data0", dataType, 8);
                     assertColumn(sink, record, "data1", dataType, 16);
                     assertColumn(sink, record, "data2", dataType, 24);
+                },
+                ResultSet::getString);
+    }
+
+    @TestTemplate
+    @FixFor("debezium/dbz#2100")
+    @ForSource(value = SourceType.POSTGRES, reason = "PostgreSQL TIME allows 24:00:00 as a boundary value")
+    @WithTemporalPrecisionMode(include = {
+            TemporalPrecisionMode.ADAPTIVE,
+            TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS,
+            TemporalPrecisionMode.MICROSECONDS,
+            TemporalPrecisionMode.NANOSECONDS
+    })
+    public void testTimeDataTypeWithBoundaryValue(Source source, Sink sink) throws Exception {
+        final List<String> typeNames = List.of("time(0)", "time(1)", "time(2)", "time(3)", "time(4)", "time(5)", "time(6)");
+        final List<String> values = List.of(
+                "'23:59:59.999999'",
+                "'23:59:59.999999'",
+                "'23:59:59.999999'",
+                "'23:59:59.999999'",
+                "'23:59:59.999999'",
+                "'23:59:59.999999'",
+                "'24:00:00'");
+
+        assertDataTypes2(source,
+                sink,
+                typeNames,
+                values,
+                Collections.nCopies(14, "24:00:00"),
+                (record) -> {
+                    for (int i = 0; i < typeNames.size(); ++i) {
+                        assertColumn(sink, record, "id" + i, getTimeType(source, true, i));
+                        assertColumn(sink, record, "data" + i, getTimeType(source, false, i));
+                    }
                 },
                 ResultSet::getString);
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTimeBoundary.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTimeBoundary.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * Boundary helpers for PostgreSQL temporal values.
+ */
+public final class PostgresTimeBoundary {
+
+    public static final String TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC = "24:00:00Z";
+
+    private static final long DAY_MICROS = TimeUnit.DAYS.toMicros(1);
+    private static final Pattern TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC_PATTERN = Pattern.compile("^24:00:00(?:\\.0{1,6})?(?:Z|[+-]00(?::?00)?)$");
+
+    public static boolean isTimeWithTimeZoneBoundaryAtUtc(String value) {
+        return value != null && TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC_PATTERN.matcher(value).matches();
+    }
+
+    public static boolean isBoundaryMicroseconds(long value) {
+        return value == DAY_MICROS;
+    }
+
+    private PostgresTimeBoundary() {
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -1141,14 +1141,14 @@ public class PostgresValueConverter extends JdbcValueConverters {
                         .map(elementConverter::convert)
                         .collect(Collectors.toList()));
             }
-            else if (data instanceof PgArray) {
+            else if (data instanceof PgArray array) {
                 try {
                     final List<Object> converted;
                     if (elementType.getOid() == PgOid.TIMETZ) {
-                        converted = convertTimeWithTimeZoneArray((PgArray) data, elementType, elementConverter);
+                        converted = convertTimeWithTimeZoneArray(array, elementType, elementConverter);
                     }
                     else {
-                        final Object[] values = (Object[]) ((PgArray) data).getArray();
+                        final Object[] values = (Object[]) array.getArray();
                         converted = new ArrayList<>(values.length);
                         for (Object value : values) {
                             converted.add(elementConverter.convert(resolveArrayValue(value, elementType)));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -1010,14 +1010,14 @@ public class PostgresValueConverter extends JdbcValueConverters {
     @Override
     protected Object convertTimeWithZone(Column column, Field fieldDefn, Object data) {
         // during snapshotting; already receiving OffsetTime @ UTC during streaming
-        if (data instanceof String) {
-            if (PostgresTimeBoundary.isTimeWithTimeZoneBoundaryAtUtc((String) data)) {
+        if (data instanceof String value) {
+            if (PostgresTimeBoundary.isTimeWithTimeZoneBoundaryAtUtc(value)) {
                 return PostgresTimeBoundary.TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC;
             }
 
             // The TIMETZ column is returned as a String which we initially parse here
             // The parsed offset-time potentially has a zone-offset from the data, shift it after to GMT.
-            final OffsetTime offsetTime = OffsetTime.parse((String) data, TIME_WITH_TIMEZONE_FORMATTER);
+            final OffsetTime offsetTime = OffsetTime.parse(value, TIME_WITH_TIMEZONE_FORMATTER);
             data = offsetTime.withOffsetSameInstant(ZoneOffset.UTC);
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -1010,6 +1011,10 @@ public class PostgresValueConverter extends JdbcValueConverters {
     protected Object convertTimeWithZone(Column column, Field fieldDefn, Object data) {
         // during snapshotting; already receiving OffsetTime @ UTC during streaming
         if (data instanceof String) {
+            if (PostgresTimeBoundary.isTimeWithTimeZoneBoundaryAtUtc((String) data)) {
+                return PostgresTimeBoundary.TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC;
+            }
+
             // The TIMETZ column is returned as a String which we initially parse here
             // The parsed offset-time potentially has a zone-offset from the data, shift it after to GMT.
             final OffsetTime offsetTime = OffsetTime.parse((String) data, TIME_WITH_TIMEZONE_FORMATTER);
@@ -1138,10 +1143,16 @@ public class PostgresValueConverter extends JdbcValueConverters {
             }
             else if (data instanceof PgArray) {
                 try {
-                    final Object[] values = (Object[]) ((PgArray) data).getArray();
-                    final List<Object> converted = new ArrayList<>(values.length);
-                    for (Object value : values) {
-                        converted.add(elementConverter.convert(resolveArrayValue(value, elementType)));
+                    final List<Object> converted;
+                    if (elementType.getOid() == PgOid.TIMETZ) {
+                        converted = convertTimeWithTimeZoneArray((PgArray) data, elementType, elementConverter);
+                    }
+                    else {
+                        final Object[] values = (Object[]) ((PgArray) data).getArray();
+                        converted = new ArrayList<>(values.length);
+                        for (Object value : values) {
+                            converted.add(elementConverter.convert(resolveArrayValue(value, elementType)));
+                        }
                     }
                     r.deliver(converted);
                 }
@@ -1150,6 +1161,16 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 }
             }
         });
+    }
+
+    private List<Object> convertTimeWithTimeZoneArray(PgArray data, PostgresType elementType, ValueConverter elementConverter) throws SQLException {
+        final List<Object> converted = new ArrayList<>();
+        try (ResultSet values = data.getResultSet()) {
+            while (values.next()) {
+                converted.add(elementConverter.convert(resolveArrayValue(values.getString(2), elementType)));
+            }
+        }
+        return converted;
     }
 
     private Object resolveArrayValue(Object value, PostgresType elementType) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -59,6 +59,11 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
+    public Object asTimeWithTimeZone() {
+        return asString();
+    }
+
+    @Override
     public OffsetDateTime asOffsetDateTimeAtUtc() {
         if ("infinity".equals(asString())) {
             return PostgresValueConverter.POSITIVE_INFINITY_OFFSET_DATE_TIME;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -113,6 +113,10 @@ public interface ReplicationMessage {
 
         OffsetTime asOffsetTimeUtc();
 
+        default Object asTimeWithTimeZone() {
+            return asOffsetTimeUtc();
+        }
+
         byte[] asByteArray();
 
         PGbox asBox();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -117,7 +117,7 @@ public class ReplicationMessageColumnValueResolver {
 
             case "time with time zone":
             case "timetz":
-                return value.asOffsetTimeUtc();
+                return value.asTimeWithTimeZone();
 
             case "bytea":
                 return value.asByteArray();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.PgOid;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
+import io.debezium.connector.postgresql.PostgresTimeBoundary;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
@@ -191,6 +192,19 @@ public class PgProtoColumnValue extends AbstractColumnValue<PgProto.DatumMessage
     }
 
     @Override
+    public Object asTimeWithTimeZone() {
+        if (value.hasDatumDouble()) {
+            final long micros = (long) value.getDatumDouble();
+            if (PostgresTimeBoundary.isBoundaryMicroseconds(micros)) {
+                return PostgresTimeBoundary.TIME_WITH_TIMEZONE_BOUNDARY_AT_UTC;
+            }
+            return Conversions.toInstantFromMicros(micros).atOffset(ZoneOffset.UTC).toOffsetTime();
+        }
+
+        return super.asTimeWithTimeZone();
+    }
+
+    @Override
     public OffsetDateTime asOffsetDateTimeAtUtc() {
         if (value.hasDatumInt64()) {
             if (value.getDatumInt64() >= TIMESTAMP_MAX) {
@@ -327,6 +341,10 @@ public class PgProtoColumnValue extends AbstractColumnValue<PgProto.DatumMessage
             }
             String dataString = new String(data, Charset.forName("UTF-8"));
             PgArray arrayData = new PgArray(connection.get(), (int) value.getColumnType(), dataString);
+            if (type.getElementType().getOid() == PgOid.TIMETZ) {
+                return arrayData;
+            }
+
             Object deserializedArray = arrayData.getArray();
             return Arrays.asList((Object[]) deserializedArray);
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -57,6 +57,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingM
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
 import io.debezium.time.MicroTimestamp;
+import io.debezium.time.ZonedTime;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Collect;
 
@@ -650,6 +651,49 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
         final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.time_table", schemaAndValuesForDateTimeTypes());
+
+        consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    public void shouldGenerateSnapshotForTwentyFourHourTimeWithTimeZone() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE TABLE timetz_boundary_table (pk SERIAL, ttz0 TIME(0) WITH TIME ZONE, ttz6 TIME(6) WITH TIME ZONE, PRIMARY KEY(pk));");
+        TestHelper.execute("INSERT INTO timetz_boundary_table (ttz0, ttz6) VALUES ('23:59:59.999999+00'::TIMETZ, '24:00:00+00'::TIMETZ);");
+
+        buildNoStreamProducer(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.timetz_boundary_table"));
+
+        TestConsumer consumer = testConsumer(1, "public");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.timetz_boundary_table",
+                Arrays.asList(
+                        new SchemaAndValueField("ttz0", ZonedTime.builder().optional().build(), "24:00:00Z"),
+                        new SchemaAndValueField("ttz6", ZonedTime.builder().optional().build(), "24:00:00Z")));
+
+        consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    public void shouldGenerateSnapshotForTwentyFourHourTimeWithTimeZoneArray() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE TABLE timetz_boundary_array_table (pk SERIAL, ttz TIMETZ[] NOT NULL, PRIMARY KEY(pk));");
+        TestHelper.execute("INSERT INTO timetz_boundary_array_table (ttz) VALUES ("
+                + "ARRAY['23:59:59.999999+00'::TIMETZ(0), '24:00:00+00'::TIMETZ, '00:00:00+00'::TIMETZ, NULL::TIMETZ]);");
+
+        buildNoStreamProducer(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.timetz_boundary_array_table"));
+
+        TestConsumer consumer = testConsumer(1, "public");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.timetz_boundary_array_table",
+                Collections.singletonList(new SchemaAndValueField("ttz",
+                        SchemaBuilder.array(ZonedTime.builder().optional().build()).build(),
+                        Arrays.asList("24:00:00Z", "24:00:00Z", "00:00:00Z", null))));
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -253,6 +253,45 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2100")
+    public void shouldReceiveTwentyFourHourTimeWithTimeZone() throws Exception {
+        TestHelper.execute("CREATE TABLE timetz_boundary_table (pk SERIAL, ttz0 TIME(0) WITH TIME ZONE, ttz6 TIME(6) WITH TIME ZONE, PRIMARY KEY(pk));");
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.timetz_boundary_table"), false);
+        waitForStreamingToStart();
+
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO timetz_boundary_table (ttz0, ttz6) VALUES ('23:59:59.999999+00'::TIMETZ, '24:00:00+00'::TIMETZ);");
+
+        final SourceRecord rec = assertRecordInserted("public.timetz_boundary_table", PK_FIELD, 1);
+        assertRecordSchemaAndValues(Arrays.asList(
+                new SchemaAndValueField("ttz0", ZonedTime.builder().optional().build(), "24:00:00Z"),
+                new SchemaAndValueField("ttz6", ZonedTime.builder().optional().build(), "24:00:00Z")), rec, Envelope.FieldName.AFTER);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    public void shouldReceiveTwentyFourHourTimeWithTimeZoneArray() throws Exception {
+        TestHelper.execute("CREATE TABLE timetz_boundary_array_table (pk SERIAL, ttz TIMETZ[] NOT NULL, PRIMARY KEY(pk));");
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.timetz_boundary_array_table"), false);
+        waitForStreamingToStart();
+
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO timetz_boundary_array_table (ttz) VALUES ("
+                + "ARRAY['23:59:59.999999+00'::TIMETZ(0), '24:00:00+00'::TIMETZ, '00:00:00+00'::TIMETZ, NULL::TIMETZ]);");
+
+        final SourceRecord rec = assertRecordInserted("public.timetz_boundary_array_table", PK_FIELD, 1);
+        assertRecordSchemaAndValues(Collections.singletonList(new SchemaAndValueField("ttz",
+                SchemaBuilder.array(ZonedTime.builder().optional().build()).build(),
+                Arrays.asList("24:00:00Z", "24:00:00Z", "00:00:00Z", null))), rec, Envelope.FieldName.AFTER);
+    }
+
+    @Test
     @FixFor("DBZ-766")
     public void shouldReceiveChangesAfterConnectionRestart() throws Exception {
         TestHelper.dropDefaultReplicationSlot();


### PR DESCRIPTION
## Description

Fixes debezium/dbz#2100.

PostgreSQL `time` and `time with time zone` can represent the boundary value `24:00:00`. This differs from the Java time objects used in the connector paths: `LocalTime` supports `00:00:00` through `23:59:59.999999999`, and `OffsetTime` uses `LocalTime` internally. Because of that range mismatch, PostgreSQL values that are valid at the database level can fail during conversion or be normalized to `00:00:00Z` when routed through Java time objects.

This change preserves PostgreSQL `TIME` and `TIMETZ` boundary values in the affected PostgreSQL source and JDBC sink paths.

Specifically, this PR:

* handles JDBC sink `TIME` values that represent `24:00:00` without converting them through `LocalTime`;
* preserves scalar PostgreSQL `TIMETZ 24:00:00+00` as `24:00:00Z` instead of normalizing it to `00:00:00Z`;
* preserves `TIMETZ[]` elements by reading array elements from the raw `PgArray` result set representation, avoiding `PgArray#getArray()` conversion to `java.sql.Time`, which loses the distinction between `24:00:00+00` and `00:00:00+00`.

The scope is intentionally limited to preserving PostgreSQL boundary values in the existing Debezium temporal mappings.

## Testing

Verified with focused unit and integration coverage for the affected paths:

* JDBC sink `TIME` boundary coverage for PostgreSQL target columns;
* PostgreSQL snapshot and streaming coverage for scalar `TIMETZ 24:00:00+00`;
* PostgreSQL snapshot and streaming coverage for `TIMETZ[]` boundary values;
* existing PostgreSQL time array regression coverage;
* JDBC connector module compile check.
