### PR TITLE
debezium/dbz#2100 Preserve PostgreSQL MONEY snapshot precision

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -23,7 +23,6 @@ import org.postgresql.geometric.PGpoint;
 import org.postgresql.geometric.PGpolygon;
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGInterval;
-import org.postgresql.util.PGtokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,21 +137,7 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
 
     @Override
     public BigDecimal asMoney() {
-        final String value = asString();
-        if (value == null) {
-            return null;
-        }
-        try {
-            if (value.startsWith("-")) {
-                final String negativeMoney = "(" + value.substring(1) + ")";
-                return new BigDecimal(removeCurrencySymbol(negativeMoney));
-            }
-            return new BigDecimal(removeCurrencySymbol(value));
-        }
-        catch (final Exception e) {
-            LOGGER.error("Failed to parse money value '{}': {}", value, e.getMessage());
-            throw new ConnectException("Failed to parse money value: " + value, e);
-        }
+        return PostgresMoney.parse(asString());
     }
 
     @Override
@@ -218,29 +203,4 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
         return null;
     }
 
-    /**
-     * Remove any () (for negative) & currency symbol (for example: $,)
-     */
-    protected String removeCurrencySymbol(String currency) {
-        String s1;
-        boolean negative;
-
-        negative = (currency.charAt(0) == '(');
-
-        // Remove any surrounding parentheses (for negative accounting format)
-        s1 = PGtokenizer.removePara(currency);
-
-        if (s1.length() > 0 && !Character.isDigit(s1.charAt(0)) && s1.charAt(0) != '.') {
-            s1 = s1.substring(1);
-        }
-
-        // Strip out any thousands-separator commas in currency
-        int pos = s1.indexOf(',');
-        while (pos != -1) {
-            s1 = s1.substring(0, pos) + s1.substring(pos + 1);
-            pos = s1.indexOf(',');
-        }
-
-        return negative ? "-" + s1 : s1;
-    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -31,7 +31,6 @@ import org.postgresql.core.BaseConnection;
 import org.postgresql.jdbc.PgConnection;
 import org.postgresql.jdbc.TimestampUtils;
 import org.postgresql.replication.LogSequenceNumber;
-import org.postgresql.util.PGmoney;
 import org.postgresql.util.PSQLState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -761,17 +760,8 @@ public class PostgresConnection extends JdbcConnection {
 
             switch (type.getOid()) {
                 case PgOid.MONEY:
-                    // TODO author=Horia Chiorean date=14/11/2016 description=workaround for https://github.com/pgjdbc/pgjdbc/issues/100
                     final String sMoney = rs.getString(columnIndex);
-                    if (sMoney == null) {
-                        return sMoney;
-                    }
-                    if (sMoney.startsWith("-")) {
-                        // PGmoney expects negative values to be provided in the format of "($XXXXX.YY)"
-                        final String negativeMoney = "(" + sMoney.substring(1) + ")";
-                        return new PGmoney(negativeMoney).val;
-                    }
-                    return new PGmoney(sMoney).val;
+                    return PostgresMoney.parse(sMoney);
                 case PgOid.BIT:
                     return rs.getString(columnIndex);
                 case PgOid.NUMERIC:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresMoney.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresMoney.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql.connection;
+
+import java.math.BigDecimal;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.util.PGtokenizer;
+
+final class PostgresMoney {
+
+    private PostgresMoney() {
+    }
+
+    static BigDecimal parse(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(removeCurrencySymbol(value));
+        }
+        catch (final Exception e) {
+            throw new ConnectException("Failed to parse money value: " + value, e);
+        }
+    }
+
+    /**
+     * Remove any parentheses, currency symbol, and thousands separators.
+     */
+    private static String removeCurrencySymbol(String currency) {
+        final boolean negative = currency.charAt(0) == '(' || currency.charAt(0) == '-';
+
+        String value = currency.charAt(0) == '-'
+                ? "(" + currency.substring(1) + ")"
+                : currency;
+
+        value = PGtokenizer.removePara(value);
+
+        if (!value.isEmpty() && !Character.isDigit(value.charAt(0)) && value.charAt(0) != '.') {
+            value = value.substring(1);
+        }
+
+        value = value.replace(",", "");
+
+        return negative ? "-" + value : value;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
@@ -244,7 +244,7 @@ public class PgProtoColumnValue extends AbstractColumnValue<PgProto.DatumMessage
     @Override
     public BigDecimal asMoney() {
         if (value.hasDatumInt64()) {
-            return new BigDecimal(value.getDatumInt64()).divide(new BigDecimal(100.0));
+            return BigDecimal.valueOf(value.getDatumInt64(), 2);
         }
         return super.asMoney();
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -724,6 +726,23 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
         final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.cash_table", schemaAndValuesForNullMoneyTypes());
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    public void shouldGenerateSnapshotForLargeNegativeMoneyWithoutPrecisionLoss() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+        TestHelper.execute("INSERT INTO cash_table (csh) VALUES ('-92233720368547758.08'::money)");
+
+        buildNoStreamProducer(TestHelper.defaultConfig().with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.cash_table"));
+
+        TestConsumer consumer = testConsumer(1, "public");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final List<SchemaAndValueField> expected = Collections.singletonList(new SchemaAndValueField("csh", Decimal.builder(2).optional().build(),
+                new BigDecimal("-92233720368547758.08")));
+        consumer.process(record -> assertReadRecord(record, Collect.hashMapOf("public.cash_table", expected)));
     }
 
     @Test


### PR DESCRIPTION
## Problem

Fixes debezium/dbz#2100.

PostgreSQL `MONEY` values read during snapshots were converted through `PGmoney.val`, which is a `double`. For large values this can lose precision before Debezium emits the snapshot record.

This was observed in a PostgreSQL source to PostgreSQL JDBC sink pipeline where the source value `-92233720368547758.08` was written to the sink as `-92233720368547760.00`. The sink made the precision loss visible, but the lossy conversion happened earlier in the PostgreSQL source snapshot path.

## Solution

Parse PostgreSQL `MONEY` string values directly into `BigDecimal` instead of converting through `double`.

This change:

* adds a shared PostgreSQL MONEY parser for snapshot and replication fallback paths
* updates the snapshot `PgOid.MONEY` path to use the shared parser
* updates the pgproto int64 MONEY path to use `BigDecimal.valueOf(value, 2)`
* adds a snapshot regression test for the large negative boundary value

## Testing

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH ./mvnw -U -pl debezium-connector-postgres -am -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=PostgresMoneyIT -Dfailsafe.failIfNoSpecifiedTests=false verify

JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH ./mvnw -U -pl debezium-connector-postgres -am clean verify -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=RecordsSnapshotProducerIT#shouldGenerateSnapshotForPositiveMoney+shouldGenerateSnapshotForNegativeMoney+shouldGenerateSnapshotForNullMoney+shouldGenerateSnapshotForLargeNegativeMoneyWithoutPrecisionLoss -Dfailsafe.failIfNoSpecifiedTests=false
```