### PR TITLE
debezium/dbz#2102 Preserve MySQL BIGINT UNSIGNED in JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedType.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} that provides support for {@code BIGINT UNSIGNED} data types.
+ */
+class BigIntUnsignedType extends AbstractType {
+
+    public static final BigIntUnsignedType INSTANCE = new BigIntUnsignedType();
+    private static final String[] REGISTRATION_KEYS = new String[]{ "BIGINT UNSIGNED", "BIGINT UNSIGNED ZEROFILL", "INT8 UNSIGNED", "INT8 UNSIGNED ZEROFILL" };
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return REGISTRATION_KEYS;
+    }
+
+    public boolean matchesSourceColumnType(Schema schema) {
+        if (schema.parameters() == null) {
+            return false;
+        }
+
+        final String columnType = schema.parameters().get("__debezium.source.column.type");
+        if (columnType == null) {
+            return false;
+        }
+
+        for (String registrationKey : REGISTRATION_KEYS) {
+            if (registrationKey.equalsIgnoreCase(columnType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "bigint unsigned";
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return toUnsignedBigInt(value).toString();
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return super.bind(index, schema, null);
+        }
+        return List.of(new ValueBindDescriptor(index, toUnsignedBigInt(value)));
+    }
+
+    private BigDecimal toUnsignedBigInt(Object value) {
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof BigInteger integer) {
+            return new BigDecimal(integer);
+        }
+        if (value instanceof Long longValue) {
+            return new BigDecimal(Long.toUnsignedString(longValue));
+        }
+        if (value instanceof Number number) {
+            return new BigDecimal(number.toString());
+        }
+        if (value instanceof String string) {
+            return new BigDecimal(string);
+        }
+
+        throwUnexpectedValue(value);
+        return null;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -35,6 +35,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
 import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Strings;
@@ -108,6 +109,7 @@ public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
         super.registerTypes();
 
         registerType(BooleanType.INSTANCE);
+        registerType(BigIntUnsignedType.INSTANCE);
         registerType(BitType.INSTANCE);
         registerType(BytesType.INSTANCE);
         registerType(EnumType.INSTANCE);
@@ -125,6 +127,14 @@ public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
 
         registerType(FloatVectorType.INSTANCE);
         registerType(DoubleVectorType.INSTANCE);
+    }
+
+    @Override
+    public JdbcType getSchemaType(Schema schema) {
+        if (BigIntUnsignedType.INSTANCE.matchesSourceColumnType(schema)) {
+            return BigIntUnsignedType.INSTANCE;
+        }
+        return super.getSchemaType(schema);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedTypeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the MySQL {@link BigIntUnsignedType} handler.
+ */
+@Tag("UnitTests")
+class BigIntUnsignedTypeTest {
+
+    private static final String UNSIGNED_LONG_MAX_VALUE = "18446744073709551615";
+
+    private final BigIntUnsignedType type = BigIntUnsignedType.INSTANCE;
+
+    @Test
+    @DisplayName("Should register for MySQL unsigned bigint source column types")
+    void shouldRegisterForUnsignedBigIntSourceColumnTypes() {
+        assertThat(type.getRegistrationKeys()).containsExactly(
+                "BIGINT UNSIGNED",
+                "BIGINT UNSIGNED ZEROFILL",
+                "INT8 UNSIGNED",
+                "INT8 UNSIGNED ZEROFILL");
+    }
+
+    @Test
+    @DisplayName("Should resolve to MySQL unsigned bigint")
+    void shouldResolveToUnsignedBigInt() {
+        final Schema schema = SchemaBuilder.int64()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("bigint unsigned");
+        assertThat(type.getTypeName(schema, true)).isEqualTo("bigint unsigned");
+    }
+
+    @Test
+    @DisplayName("Should match MySQL unsigned bigint source column types")
+    void shouldMatchUnsignedBigIntSourceColumnTypes() {
+        final Schema schema = SchemaBuilder.int64()
+                .parameter("__debezium.source.column.type", "bigint unsigned")
+                .build();
+
+        assertThat(type.matchesSourceColumnType(schema)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should not match unrelated source column types")
+    void shouldNotMatchUnrelatedSourceColumnTypes() {
+        final Schema schema = SchemaBuilder.bytes()
+                .name(org.apache.kafka.connect.data.Decimal.LOGICAL_NAME)
+                .parameter("__debezium.source.column.type", "money")
+                .parameter("scale", "4")
+                .build();
+
+        assertThat(type.matchesSourceColumnType(schema)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should bind negative long values as unsigned bigint values")
+    void shouldBindNegativeLongAsUnsignedBigInt() {
+        final Schema schema = SchemaBuilder.int64()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .build();
+
+        final var bindings = type.bind(1, schema, -1L);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getIndex()).isEqualTo(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo(new BigDecimal(UNSIGNED_LONG_MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("Should bind decimal values unchanged")
+    void shouldBindDecimalValuesUnchanged() {
+        final Schema schema = SchemaBuilder.bytes()
+                .name(org.apache.kafka.connect.data.Decimal.LOGICAL_NAME)
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .parameter("scale", "0")
+                .build();
+        final var value = new BigDecimal(UNSIGNED_LONG_MAX_VALUE);
+
+        final var bindings = type.bind(1, schema, value);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("Should bind negative long default values as unsigned bigint values")
+    void shouldBindNegativeLongDefaultsAsUnsignedBigInt() {
+        final Schema schema = SchemaBuilder.int64()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .build();
+
+        assertThat(type.getDefaultValueBinding(schema, -1L)).isEqualTo(UNSIGNED_LONG_MAX_VALUE);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -89,7 +89,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-2102")
+    @FixFor("debezium/dbz#2102")
     public void testShouldCreateAndWriteUnsignedBigIntColumnType(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -7,10 +7,14 @@ package io.debezium.connector.jdbc.integration.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +39,8 @@ import io.debezium.doc.FixFor;
 @Tag("it-mysql")
 @ExtendWith(MySqlSinkDatabaseContextProvider.class)
 public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
+
+    private static final String UNSIGNED_LONG_MAX_VALUE = "18446744073709551615";
 
     public JdbcSinkColumnTypeMappingIT(Sink sink) {
         super(sink);
@@ -77,6 +83,52 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getBytes(2)).isEqualTo(new byte[]{ 1, 2, 3 });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-2102")
+    public void testShouldCreateAndWriteUnsignedBigIntColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema unsignedBigIntSchema = SchemaBuilder.int64()
+                .optional()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .build();
+        final Schema preciseUnsignedBigIntSchema = Decimal.builder(0)
+                .optional()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .parameter("connect.decimal.precision", "20")
+                .build();
+        final BigDecimal unsignedLongMaxValue = new BigDecimal(UNSIGNED_LONG_MAX_VALUE);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("data", "precise_data"),
+                List.of(unsignedBigIntSchema, preciseUnsignedBigIntSchema),
+                List.of(-1L, unsignedLongMaxValue),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "BIGINT UNSIGNED");
+        getSink().assertColumn(destinationTable, "precise_data", "BIGINT UNSIGNED");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getBigDecimal(2)).isEqualTo(unsignedLongMaxValue);
+            assertThat(rs.getBigDecimal(3)).isEqualTo(unsignedLongMaxValue);
             return null;
         });
     }


### PR DESCRIPTION
## Problem

Fixes debezium/dbz#2102.

For MySQL source to MySQL JDBC sink pipelines, `BIGINT UNSIGNED` could lose its target type and value semantics when source type metadata was propagated.

| Source mode / sink setup | Kafka Connect representation | Behavior before this change | Impact |
|---|---|---|---|
| `bigint.unsigned.handling.mode=long` with auto-DDL | `INT64`, for example `-1L` for `18446744073709551615` | JDBC sink created a signed `bigint` | The MySQL unsigned type was not preserved |
| `bigint.unsigned.handling.mode=long` with a pre-created `bigint unsigned` sink column | `INT64`, for example `-1L` for `18446744073709551615` | JDBC sink bound the negative signed value | Overflow-range unsigned values could be written incorrectly |
| `bigint.unsigned.handling.mode=precise` with auto-DDL | Decimal scale 0, for example `BigDecimal("18446744073709551615")` | JDBC sink resolved the Debezium Decimal schema before propagated source metadata and created `decimal(20,0)` | The value was preserved, but the MySQL unsigned type was not |

## Solution

This change:

* adds a MySQL JDBC sink type handler for propagated `BIGINT UNSIGNED` and `INT8 UNSIGNED` source column metadata
* handles that source metadata in the MySQL dialect only, so the general schema logical-name precedence remains unchanged for other dialects and types
* binds signed long payloads with `Long.toUnsignedString(...)` so overflow-range values are written as the intended unsigned decimal value
* adds unit and MySQL integration coverage for `long` and `precise` unsigned bigint records

The MySQL-specific handling is intentionally narrow. Other logical schemas, such as Kafka Connect `Decimal`, continue to resolve through the normal logical schema path unless the target dialect explicitly handles the propagated source type.

## Testing

```bash
./mvnw -pl debezium-connector-jdbc process-sources

./mvnw -pl debezium-connector-jdbc -DskipITs -Dtest=io.debezium.connector.jdbc.dialect.mysql.BigIntUnsignedTypeTest test

./mvnw -pl debezium-connector-jdbc -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=io.debezium.connector.jdbc.integration.mysql.JdbcSinkColumnTypeMappingIT#testShouldCreateAndWriteUnsignedBigIntColumnType verify

./mvnw -pl debezium-connector-jdbc -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=io.debezium.connector.jdbc.e2e.JdbcSinkPipelineToPostgresIT#testMoneyDataType -Dfailsafe.failIfNoSpecifiedTests=false -Dtest.tags=e2e-postgresql -Dsource.connectors=sqlserver verify
```

The last command verifies that source column type propagation no longer causes SQL Server `money` to be auto-created as PostgreSQL `money`; it remains `NUMERIC(19,4)` through the Decimal logical schema path.

Also verified with Docker Compose using `.experiment/precision-mode-avro/docker-compose.yml`, a local `3.6.0-SNAPSHOT` JDBC sink plugin, JSON converter and Avro/Schema Registry, and both `long` and `precise` source modes. The sink auto-created `bigint unsigned` and stored `18446744073709551615` in all four combinations.

## Non-blocking follow-up

This PR only fixes the JDBC sink behavior and intentionally leaves the MySQL source connector default `bigint.unsigned.handling.mode=long` unchanged.

Separately from this PR, would it be worth discussing whether `precise` should become the default in the future? `long` preserves the existing source schema, but values in `9223372036854775808` through `18446744073709551615` are represented as negative INT64 values in Kafka Connect. `precise` avoids that at the source, although it would change the emitted schema and Java value type, so I am raising it only as a follow-up topic.
