### PR TITLE
 debezium/dbz#2055 Process heartbeats also during WAL search

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -432,7 +432,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 noMessageIterations = 0;
             }
             else {
-                dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
+                dispatcher.dispatchHeartbeatEventAlsoToIncrementalSnapshot(partition, offsetContext);
                 noMessageIterations++;
                 if (noMessageIterations >= THROTTLE_NO_MESSAGE_BEFORE_PAUSE) {
                     noMessageIterations = 0;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -52,7 +52,6 @@ import io.debezium.doc.FixFor;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.SkipWhenDatabaseVersion;
-import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
@@ -330,8 +329,6 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     void shouldStreamAfterSnapshot() throws Exception {
-
-        LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
@@ -354,7 +351,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
         consumer.clear();
 
-        assertThat(logInterceptor.containsMessage("Processing messages")).isTrue();
+        waitForStreamingToStart();
     }
 
     @Test

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -42,7 +42,6 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
-import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.EqualityCheck;
 import io.debezium.junit.SkipWhenConnectorUnderTest;
@@ -425,7 +424,8 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         final int ROW_COUNT_LOCAL = ROW_COUNT * 10;
 
         final Configuration config = config()
-                .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
+                // This makes SQL server to run very slowly. Keeping it here as a future reproducer for dbz#2122.
+                // .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
                 .build();
         startAndConsumeTillEnd(connectorClass(), config);
         waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -422,22 +422,23 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     public void snapshotOnlyWithRestart() throws Exception {
         // Testing.Print.enable();
 
+        final int ROW_COUNT_LOCAL = ROW_COUNT * 10;
+
         final Configuration config = config()
                 .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
                 .build();
         startAndConsumeTillEnd(connectorClass(), config);
         waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
-        populateTable();
-        consumeRecords(ROW_COUNT);
+        populateTable(ROW_COUNT_LOCAL);
+        consumeRecords(ROW_COUNT_LOCAL);
         consumedLines.clear();
 
         sendAdHocSnapshotSignal();
 
-        final int expectedRecordCount = ROW_COUNT;
         final AtomicInteger recordCounter = new AtomicInteger();
         final AtomicBoolean restarted = new AtomicBoolean();
-        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount, x -> true,
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(ROW_COUNT_LOCAL, x -> true,
                 x -> {
                     if (recordCounter.addAndGet(x.size()) > 50 && !restarted.get()) {
                         stopConnector();
@@ -449,7 +450,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
                         restarted.set(true);
                     }
                 });
-        for (int i = 0; i < expectedRecordCount; i++) {
+        for (int i = 0; i < ROW_COUNT_LOCAL; i++) {
             assertThat(dbChanges).contains(entry(i + 1, i));
         }
     }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -97,8 +97,12 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
     }
 
     protected void populateTable(JdbcConnection connection, String tableName) throws SQLException {
+        populateTable(connection, tableName, ROW_COUNT);
+    }
+
+    protected void populateTable(JdbcConnection connection, String tableName, int count) throws SQLException {
         connection.setAutoCommit(false);
-        for (int i = 0; i < ROW_COUNT; i++) {
+        for (int i = 0; i < count; i++) {
             connection.executeWithoutCommitting(String.format("INSERT INTO %s (%s, aa) VALUES (%s, %s)",
                     tableName, connection.quoteIdentifier(pkFieldName()), i + 1, i));
         }
@@ -118,6 +122,12 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
     protected void populateTable() throws SQLException {
         try (JdbcConnection connection = databaseConnection()) {
             populateTable(connection);
+        }
+    }
+
+    protected void populateTable(int count) throws SQLException {
+        try (JdbcConnection connection = databaseConnection()) {
+            populateTable(connection, tableName(), count);
         }
     }
 


### PR DESCRIPTION
Process heartbeats also during WAL search, otherwise read-only incremental snapshot on Postgres may get stuck after restart.

Fixes debezium/dbz#2055

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
