### PR TITLE
debezium/dbz#2102 Preserve MySQL BIT values in JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BitType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BitType.java
@@ -5,12 +5,17 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
+import java.math.BigInteger;
+import java.util.BitSet;
+import java.util.List;
+
 import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.data.Bits;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
  * An implementation of {@link JdbcType} for {@link Bits} types.
@@ -28,13 +33,46 @@ class BitType extends AbstractType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return String.format(getDialect().getByteArrayFormat(), ByteArrayUtils.getByteArrayAsHex(value));
+        return String.format("b'%s'", toBitString(value, getBitSize(schema)));
     }
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final int bitSize = Integer.parseInt(schema.parameters().get(Bits.LENGTH_FIELD));
+        final int bitSize = getBitSize(schema);
         return String.format("bit(%d)", bitSize);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+
+        return List.of(new ValueBindDescriptor(index, new BigInteger(toBitString(value, getBitSize(schema)), 2)));
+    }
+
+    private int getBitSize(Schema schema) {
+        return Integer.parseInt(schema.parameters().get(Bits.LENGTH_FIELD));
+    }
+
+    private String toBitString(Object value, int length) {
+        final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(value);
+        if (bytes == null) {
+            throwUnexpectedValue(value);
+            return null;
+        }
+
+        final BitSet bits = BitSet.valueOf(bytes);
+        final int width = length == Integer.MAX_VALUE ? bits.length() : length;
+        if (width == 0) {
+            return "0";
+        }
+
+        final StringBuilder builder = new StringBuilder(width);
+        for (int i = width - 1; i >= 0; --i) {
+            builder.append(bits.get(i) ? '1' : '0');
+        }
+        return builder.toString();
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/BitTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/BitTypeTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Bits;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the MySQL {@link BitType} handler.
+ */
+@Tag("UnitTests")
+class BitTypeTest {
+
+    private static final BigInteger UNSIGNED_64BIT_MAX_VALUE = new BigInteger("18446744073709551615");
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should bind one-bit boundary values")
+    void shouldBindOneBitBoundaryValues() {
+        assertBindValue(Bits.schema(1), new byte[]{ 0x00 }, BigInteger.ZERO);
+        assertBindValue(Bits.schema(1), new byte[]{ 0x01 }, BigInteger.ONE);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should bind multi-byte bit values using Debezium Bits byte order")
+    void shouldBindMultiByteBitValues() {
+        assertBindValue(Bits.schema(9), new byte[]{ 0x55, 0x01 }, new BigInteger("341"));
+        assertBindValue(Bits.schema(16), new byte[]{ 0x02, 0x01 }, new BigInteger("258"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should bind ByteBuffer bit values from Avro converter")
+    void shouldBindByteBufferBitValues() {
+        assertBindValue(Bits.schema(9), ByteBuffer.wrap(new byte[]{ 0x55, 0x01 }), new BigInteger("341"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should bind values with the high bit set as unsigned values")
+    void shouldBindHighBitValuesAsUnsignedValues() {
+        assertBindValue(Bits.schema(8), new byte[]{ (byte) 0x80 }, new BigInteger("128"));
+        assertBindValue(Bits.schema(8), new byte[]{ (byte) 0xff }, new BigInteger("255"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should bind the maximum MySQL BIT width")
+    void shouldBindMaximumBitWidth() {
+        assertBindValue(Bits.schema(64), new byte[]{ 0x00 }, BigInteger.ZERO);
+        assertBindValue(Bits.schema(64),
+                new byte[]{ (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff },
+                UNSIGNED_64BIT_MAX_VALUE);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should format default values using MySQL bit literals")
+    void shouldFormatDefaultValuesAsBitLiterals() {
+        assertThat(BitType.INSTANCE.getDefaultValueBinding(Bits.schema(9), new byte[]{ 0x55, 0x01 })).isEqualTo("b'101010101'");
+        assertThat(BitType.INSTANCE.getDefaultValueBinding(Bits.schema(8), new byte[]{ (byte) 0x80 })).isEqualTo("b'10000000'");
+        assertThat(BitType.INSTANCE.getDefaultValueBinding(Bits.schema(64),
+                new byte[]{ (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff }))
+                .isEqualTo("b'1111111111111111111111111111111111111111111111111111111111111111'");
+    }
+
+    private void assertBindValue(Schema schema, Object value, BigInteger expected) {
+        final List<ValueBindDescriptor> descriptors = BitType.INSTANCE.bind(1, schema, value);
+
+        assertThat(descriptors).hasSize(1);
+        assertThat(descriptors.get(0).getIndex()).isEqualTo(1);
+        assertThat(descriptors.get(0).getValue()).isEqualTo(expected);
+        assertThat(descriptors.get(0).getTargetSqlType()).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -27,6 +27,7 @@ import io.debezium.connector.jdbc.junit.jupiter.MySqlSinkDatabaseContextProvider
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.Bits;
 import io.debezium.doc.FixFor;
 
 /**
@@ -40,7 +41,7 @@ import io.debezium.doc.FixFor;
 @ExtendWith(MySqlSinkDatabaseContextProvider.class)
 public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
-    private static final String UNSIGNED_LONG_MAX_VALUE = "18446744073709551615";
+    private static final BigDecimal UNSIGNED_64BIT_MAX_VALUE = new BigDecimal("18446744073709551615");
 
     public JdbcSinkColumnTypeMappingIT(Sink sink) {
         super(sink);
@@ -109,7 +110,6 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
                 .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
                 .parameter("connect.decimal.precision", "20")
                 .build();
-        final BigDecimal unsignedLongMaxValue = new BigDecimal(UNSIGNED_LONG_MAX_VALUE);
 
         final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
         final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
@@ -117,7 +117,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
                 (byte) 1,
                 List.of("data", "precise_data"),
                 List.of(unsignedBigIntSchema, preciseUnsignedBigIntSchema),
-                List.of(-1L, unsignedLongMaxValue),
+                List.of(-1L, UNSIGNED_64BIT_MAX_VALUE),
                 config);
 
         final String destinationTable = destinationTableName(createRecord);
@@ -127,8 +127,58 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertColumn(destinationTable, "data", "BIGINT UNSIGNED");
         getSink().assertColumn(destinationTable, "precise_data", "BIGINT UNSIGNED");
         getSink().assertRows(destinationTable, rs -> {
-            assertThat(rs.getBigDecimal(2)).isEqualTo(unsignedLongMaxValue);
-            assertThat(rs.getBigDecimal(3)).isEqualTo(unsignedLongMaxValue);
+            assertThat(rs.getBigDecimal(2)).isEqualTo(UNSIGNED_64BIT_MAX_VALUE);
+            assertThat(rs.getBigDecimal(3)).isEqualTo(UNSIGNED_64BIT_MAX_VALUE);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2102")
+    public void testShouldCreateAndWriteMultiByteBitColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema bit9Schema = Bits.schema(9);
+        final Schema bit8Schema = Bits.schema(8);
+        final Schema bit1Schema = Bits.schema(1);
+        final Schema bit64Schema = Bits.schema(64);
+        final byte[] bit9Value = new byte[]{ 0x55, 0x01 };
+        final byte[] bit8HighValue = new byte[]{ (byte) 0xff };
+        final byte[] bit64MaxValue = new byte[]{ (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("data_zero", "data_one", "data_bytes", "data_buffer", "data_high", "data_max"),
+                List.of(bit1Schema, bit1Schema, bit9Schema, bit9Schema, bit8Schema, bit64Schema),
+                List.of(new byte[]{ 0x00 }, new byte[]{ 0x01 }, bit9Value, ByteBuffer.wrap(bit9Value), bit8HighValue, bit64MaxValue),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data_zero", "BIT", 1);
+        getSink().assertColumn(destinationTable, "data_one", "BIT", 1);
+        getSink().assertColumn(destinationTable, "data_bytes", "BIT", 9);
+        getSink().assertColumn(destinationTable, "data_buffer", "BIT", 9);
+        getSink().assertColumn(destinationTable, "data_high", "BIT", 8);
+        getSink().assertColumn(destinationTable, "data_max", "BIT", 64);
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(2)).isZero();
+            assertThat(rs.getInt(3)).isEqualTo(1);
+            assertThat(rs.getInt(4)).isEqualTo(341);
+            assertThat(rs.getInt(5)).isEqualTo(341);
+            assertThat(rs.getInt(6)).isEqualTo(255);
+            assertThat(rs.getBigDecimal(7)).isEqualTo(UNSIGNED_64BIT_MAX_VALUE);
             return null;
         });
     }


### PR DESCRIPTION
## Problem

Fixes debezium/dbz#2102.

In a MySQL source to MySQL JDBC sink pipeline, MySQL `BIT` values were not converted back into MySQL `BIT` values before being written by the sink.

The MySQL source connector emits multi-bit `BIT(n)` columns as Kafka Connect `io.debezium.data.Bits` values. That payload is not a SQL-ready MySQL bit literal such as `b'101010101'`. It is Debezium's `Bits` byte representation. With AvroConverter, the same logical value arrives at the sink as a `ByteBuffer`.

Before this change, the MySQL JDBC sink had a `BitType` handler for type names and default values, but it did not override runtime value binding. The generic binding path therefore passed the raw Java value to the MySQL driver.

| MySQL source value | Expected sink value | Numeric readback | Value bound before this change | Resulting problem |
|---|---|---|---|---|
| `BIT(8)` `b'11111111'` | `BIT(8)` `b'11111111'` | `255` | `byte[] { (byte) 0xff }`, or Avro `HeapByteBuffer[pos=0 lim=1 cap=1]` | The sink did not explicitly bind a value representing the original `BIT(8)` pattern |
| `BIT(9)` `b'101010101'` | `BIT(9)` `b'101010101'` | `341` | `byte[] { 0x55, 0x01 }`, or Avro `HeapByteBuffer[pos=0 lim=2 cap=2]` | The raw Debezium little-endian `Bits` bytes were passed through instead of being decoded back to the original `BIT(9)` pattern; this can be rejected by MySQL as an oversized binary value for `BIT(9)` |
| `BIT(16)` `b'0000000100000010'` | `BIT(16)` `b'0000000100000010'` | `258` | `byte[] { 0x02, 0x01 }` | The raw byte order is not the MySQL bit pattern itself; it must be decoded from Debezium `Bits` first |
| `BIT(64)` all bits set | `BIT(64)` with all bits set | `18446744073709551615` | eight raw `0xff` bytes | The high-bit payload needed unsigned conversion before binding |

This affects both sink table setups:

| Sink table setup | Why it is affected |
|---|---|
| Auto-created sink table | The sink may create `BIT(n)`, but the row value still used the generic raw-value binding path |
| Pre-created sink table | The column type is already correct, but inserts/upserts still depend on the same broken runtime binding path |

## Root Cause

`io.debezium.data.Bits` uses `BitSet` byte-array semantics. That representation must be decoded using the schema bit width before it can be written to a MySQL `BIT` column.

The MySQL JDBC sink `BitType` previously inherited `AbstractType.bind(...)`, whose behavior is effectively:

```java
return List.of(new ValueBindDescriptor(index, value));
```

So for a source value like `BIT(9) b'101010101'`, the sink attempted to bind the raw payload `byte[] { 0x55, 0x01 }` instead of binding a value representing the original MySQL bit pattern. When read numerically, that bit pattern is `341`. With Avro and Schema Registry, it attempted to bind the corresponding `ByteBuffer` object, which the generic binding path cannot write as a MySQL `BIT` value.

## Solution

This change updates the MySQL JDBC sink `BitType` to:

* normalize `byte[]` and Avro `ByteBuffer` payloads through `ByteArrayUtils.getByteArrayFromValue(...)`
* decode Debezium `Bits` payloads with `BitSet.valueOf(...)`
* use the schema `length` parameter so bounded values such as `BIT(9)` preserve their width and byte order
* bind the decoded bit pattern as a positive `BigInteger`; for example, `byte[] { 0x55, 0x01 }` is decoded back to `BIT(9) b'101010101'`, which MySQL reads numerically as `341`
* format default values as MySQL bit literals, for example `b'101010101'`, instead of byte-array hex literals

## Testing

```bash
./mvnw -pl debezium-connector-jdbc process-sources

./mvnw -pl debezium-connector-jdbc -DskipITs -Dtest=io.debezium.connector.jdbc.dialect.mysql.BitTypeTest test

./mvnw -pl debezium-connector-jdbc -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=io.debezium.connector.jdbc.integration.mysql.JdbcSinkColumnTypeMappingIT#testShouldCreateAndWriteMultiByteBitColumnType verify
```

The new unit coverage checks:

* `BIT(1)` zero and one values
* multi-byte `BIT(9)` and `BIT(16)` byte order
* Avro `ByteBuffer` values
* high-bit `BIT(8)` values such as `0x80` and `0xff`
* maximum-width `BIT(64)` values, including all bits set
* default value formatting as MySQL bit literals

The MySQL integration test verifies JDBC sink auto-DDL and writes for `BIT(1)`, `BIT(8)`, `BIT(9)`, and `BIT(64)`.

Also verified with Docker Compose using `.experiment/precision-mode-avro/docker-compose.yml`, a local `3.6.0-SNAPSHOT` JDBC sink plugin, AvroConverter, and Schema Registry. Both auto-created and pre-created MySQL sink tables preserved these MySQL source values. The table below shows numeric readback from MySQL:

```text
id  b1  b8   b9   b64
1   1   255  341  18446744073709551615
2   0   128  511  0
```
