### PR TITLE
debezium/dbz#2049 Exclude private redo thread changes

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/RedoThreadState.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/RedoThreadState.java
@@ -69,6 +69,8 @@ public class RedoThreadState {
 
         private static final String OPEN = "OPEN";
         private static final String DISABLED = "DISABLED";
+        private static final String PUBLIC = "PUBLIC";
+        private static final String PRIVATE = "PRIVATE";
 
         private final Integer threadId;
         private final String status;
@@ -202,6 +204,14 @@ public class RedoThreadState {
 
         public boolean isDisabled() {
             return DISABLED.equals(enabled);
+        }
+
+        public boolean isPublic() {
+            return PUBLIC.equals(enabled);
+        }
+
+        public boolean isPrivate() {
+            return PRIVATE.equals(enabled);
         }
 
         @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -35,6 +35,7 @@ import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleSchemaChangeEventEmitter;
 import io.debezium.connector.oracle.RedoThreadState;
+import io.debezium.connector.oracle.RedoThreadState.RedoThread;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
 import io.debezium.connector.oracle.logminer.LogFileSessionSelector.SessionLogSelection;
@@ -125,6 +126,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     private boolean sequenceUnavailable = false;
     private List<LogFile> currentLogFiles;
     private List<LogFile> sessionLogFiles;
+    private RedoThreadState currentRedoThreadState;
     private LogFileSessionSelector logFileSessionSelector;
     private boolean sessionLogFilesChanged = false;
     private List<BigInteger> currentRedoLogSequences;
@@ -474,7 +476,31 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      * @return true if the event should be skipped, false otherwise
      */
     protected boolean isEventSkipped(LogMinerEventRow event) {
-        return false;
+        final RedoThread threadState = currentRedoThreadState.getRedoThread(event.getThread());
+        return threadState != null && threadState.isPrivate();
+    }
+
+    /**
+     * Detects redo thread state transitions between PUBLIC and PRIVATE and logs warnings.
+     * Updates {@link #currentRedoThreadState} to the new state.
+     *
+     * @param newRedoThreadState the new redo thread state, should not be {@code null}
+     */
+    protected void detectRedoThreadTransitions(RedoThreadState newRedoThreadState) {
+        if (currentRedoThreadState != null) {
+            for (RedoThread thread : newRedoThreadState.getThreads()) {
+                final RedoThread currentThreadInfo = currentRedoThreadState.getRedoThread(thread.getThreadId());
+                if (currentThreadInfo != null) {
+                    if (currentThreadInfo.isPrivate() && thread.isPublic()) {
+                        LOGGER.warn("Redo Thread {} just changed from PRIVATE to PUBLIC, which can lead to unexpected results.", thread.getThreadId());
+                    }
+                    else if (currentThreadInfo.isPublic() && thread.isPrivate()) {
+                        LOGGER.warn("Redo Thread {} just changed from PUBLIC to PRIVATE, which can lead to data loss and unexpected results.", thread.getThreadId());
+                    }
+                }
+            }
+        }
+        currentRedoThreadState = newRedoThreadState;
     }
 
     /**
@@ -907,8 +933,8 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         Scn minOpenRedoThreadLastScn = jdbcConnection.getRedoThreadState()
                 .getThreads()
                 .stream()
-                .filter(RedoThreadState.RedoThread::isOpen)
-                .map(RedoThreadState.RedoThread::getLastRedoScn)
+                .filter(RedoThread::isOpen)
+                .map(RedoThread::getLastRedoScn)
                 .min(Scn::compareTo)
                 .orElse(Scn.NULL);
 
@@ -1098,6 +1124,8 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     protected Scn collectLogsAndFinalUpperBoundary(Scn lowerBoundsScn, Scn upperBoundsScn) throws SQLException {
         final LogFilesResult logFilesResult = logCollector.getLogs(lowerBoundsScn);
         currentLogFiles = logFilesResult.logFiles();
+
+        detectRedoThreadTransitions(logFilesResult.redoThreadState());
 
         Scn upperBoundaryScn = upperBoundsScn;
         if (!useContinuousMining) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -341,6 +341,10 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
     @Override
     protected boolean isEventSkipped(LogMinerEventRow event) {
+        if (super.isEventSkipped(event)) {
+            return true;
+        }
+
         // Check whether the row has a table reference and if so, is the reference included by the filter.
         // If the reference isn't included, the row will be skipped entirely.
         if (event.getTableId() != null) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -318,6 +318,9 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
 
     @Override
     protected boolean isEventSkipped(LogMinerEventRow event) {
+        if (super.isEventSkipped(event)) {
+            return true;
+        }
         return skipCurrentTransaction || isEventIncludedInSnapshot(event) || isNonSchemaChangeEventSkipped(event);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/AbstractBufferedLogMinerStreamingChangeEventSourceTest.java
@@ -44,8 +44,10 @@ import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleTaskContext;
 import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.RedoThreadState;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
+import io.debezium.connector.oracle.logminer.AbstractLogMinerStreamingChangeEventSource;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.logminer.OffsetActivityMonitor;
 import io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerStreamingChangeEventSource.ProcessResult;
@@ -54,6 +56,7 @@ import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
@@ -626,6 +629,80 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
         }
     }
 
+    @Test
+    @FixFor("dbz#2049")
+    void testEventFromPublicThreadIsNotSkipped() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.setCurrentRedoThreadState(buildRedoThreadState(1, "PUBLIC"));
+
+            final LogMinerEventRow start = getStartLogMinerEventRow(1, TRANSACTION_ID_1);
+            Mockito.when(start.getThread()).thenReturn(1);
+            source.processEvent(start);
+
+            final LogMinerEventRow insert = getInsertLogMinerEventRow(2, TRANSACTION_ID_1);
+            Mockito.when(insert.getThread()).thenReturn(1);
+            source.processEvent(insert);
+
+            assertThat(source.getTransactionCache().isEmpty()).isFalse();
+        }
+    }
+
+    @Test
+    @FixFor("dbz#2049")
+    void testEventFromPrivateThreadIsSkipped() throws Exception {
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.setCurrentRedoThreadState(buildTwoThreadRedoThreadState(1, "PUBLIC", 2, "PRIVATE"));
+
+            final LogMinerEventRow start1 = getStartLogMinerEventRow(1, TRANSACTION_ID_1);
+            Mockito.when(start1.getThread()).thenReturn(2);
+            source.processEvent(start1);
+
+            final LogMinerEventRow insert1 = getInsertLogMinerEventRow(2, TRANSACTION_ID_1);
+            Mockito.when(insert1.getThread()).thenReturn(2);
+            source.processEvent(insert1);
+
+            final LogMinerEventRow start2 = getStartLogMinerEventRow(3, TRANSACTION_ID_2);
+            Mockito.when(start2.getThread()).thenReturn(1);
+            source.processEvent(start2);
+
+            final LogMinerEventRow insert2 = getInsertLogMinerEventRow(4, TRANSACTION_ID_2);
+            Mockito.when(insert2.getThread()).thenReturn(1);
+            source.processEvent(insert2);
+
+            assertThat(source.getTransactionCache().isEmpty()).isFalse();
+            assertThat(source.getTransactionCache().getTransaction(TRANSACTION_ID_1)).isNull();
+            assertThat(source.getTransactionCache().getTransaction(TRANSACTION_ID_2)).isNotNull();
+        }
+    }
+
+    @Test
+    @FixFor("dbz#2049")
+    void testRedoThreadTransitionFromPublicToPrivateLogsWarning() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(AbstractLogMinerStreamingChangeEventSource.class);
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.setCurrentRedoThreadState(buildRedoThreadState(1, "PUBLIC"));
+            source.detectRedoThreadTransitions(buildRedoThreadState(1, "PRIVATE"));
+
+            assertThat(logInterceptor.containsWarnMessage(
+                    "Redo Thread 1 just changed from PUBLIC to PRIVATE, which can lead to data loss and unexpected results."))
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @FixFor("dbz#2049")
+    void testRedoThreadTransitionFromPrivateToPublicLogsWarning() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(AbstractLogMinerStreamingChangeEventSource.class);
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.setCurrentRedoThreadState(buildRedoThreadState(1, "PRIVATE"));
+            source.detectRedoThreadTransitions(buildRedoThreadState(1, "PUBLIC"));
+
+            assertThat(logInterceptor.containsWarnMessage(
+                    "Redo Thread 1 just changed from PRIVATE to PUBLIC, which can lead to unexpected results."))
+                    .isTrue();
+        }
+    }
+
     private OracleDatabaseSchema createOracleDatabaseSchema() throws Exception {
         Configuration configuration = getConfig().build();
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(configuration);
@@ -817,7 +894,87 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
 
         source.init(offsetContext);
 
+        try {
+            source.setCurrentRedoThreadState(buildRedoThreadState(1, "PUBLIC"));
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to set redo thread state", e);
+        }
+
         return source;
+    }
+
+    private static RedoThreadState buildRedoThreadState(int threadId, String enabled) {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(threadId)
+                .status("OPEN")
+                .enabled(enabled)
+                .logGroups(2L)
+                .instanceName("ORCLCDB")
+                .openTime(Instant.now())
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .checkpointScn(Scn.valueOf(1))
+                .checkpointTime(Instant.now())
+                .enabledScn(Scn.valueOf(1))
+                .enabledTime(Instant.now())
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoBlock(1L)
+                .lastRedoScn(Scn.valueOf(1))
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
+    }
+
+    private static RedoThreadState buildTwoThreadRedoThreadState(int threadId1, String enabled1, int threadId2, String enabled2) {
+        return RedoThreadState.builder()
+                .thread()
+                .threadId(threadId1)
+                .status("OPEN")
+                .enabled(enabled1)
+                .logGroups(2L)
+                .instanceName("ORCLCDB1")
+                .openTime(Instant.now())
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .checkpointScn(Scn.valueOf(1))
+                .checkpointTime(Instant.now())
+                .enabledScn(Scn.valueOf(1))
+                .enabledTime(Instant.now())
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoBlock(1L)
+                .lastRedoScn(Scn.valueOf(1))
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .thread()
+                .threadId(threadId2)
+                .status("OPEN")
+                .enabled(enabled2)
+                .logGroups(2L)
+                .instanceName("ORCLCDB2")
+                .openTime(Instant.now())
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .checkpointScn(Scn.valueOf(1))
+                .checkpointTime(Instant.now())
+                .enabledScn(Scn.valueOf(1))
+                .enabledTime(Instant.now())
+                .disabledScn(Scn.valueOf(0))
+                .disabledTime(null)
+                .lastRedoSequenceNumber(1L)
+                .lastRedoBlock(1L)
+                .lastRedoScn(Scn.valueOf(1))
+                .lastRedoTime(Instant.now())
+                .conId(0L)
+                .build()
+                .build();
     }
 
     // Helper class that permits exposing some protected methods for mocking
@@ -861,6 +1018,17 @@ public abstract class AbstractBufferedLogMinerStreamingChangeEventSourceTest ext
         public void processEvent(LogMinerEventRow event) throws SQLException, InterruptedException {
             // Necessary for mock purposes only
             super.processEvent(event);
+        }
+
+        public void setCurrentRedoThreadState(RedoThreadState state) throws Exception {
+            var field = AbstractLogMinerStreamingChangeEventSource.class.getDeclaredField("currentRedoThreadState");
+            field.setAccessible(true);
+            field.set(this, state);
+        }
+
+        @Override
+        public void detectRedoThreadTransitions(RedoThreadState newRedoThreadState) {
+            super.detectRedoThreadTransitions(newRedoThreadState);
         }
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -87,7 +87,7 @@ endif::product[]
 // ModuleID: descriptions-of-debezium-oracle-connector-adapters
 // Title: Descriptions of {prodname} Oracle connector adapters
 [[oracle-adapter-modes]]
-== Adapter Modes
+=== Adapter Modes
 
 The {prodname} Oracle connector supports multiple adapters for capturing changes from the Oracle database transaction logs.
 You can configure the connector to use a specific adapter by setting the xref:oracle-property-database-connection-adapter[`database.connection.adapter`] configuration property.
@@ -1087,6 +1087,24 @@ The connector reports a failure only if both Oracle LogMiner and the connector a
 ====
 You cannot use the `hybrid` mining strategy if the xref:oracle-property-lob-enabled[`lob.enabled`] property is set to `true`.
 If you require streaming `CLOB`, `BLOB`, or `XML` data, only the `online_catalog` or `redo_log_catalog` (deprecated) strategies can be used.
+====
+
+[[oracle-logminer-private-redo-threads]]
+=== LogMiner and Private Redo Threads
+
+In Oracle RAC environments, each redo thread is associated with an instance and is classified as either `PUBLIC` or `PRIVATE`.
+A `PUBLIC` redo thread is available for use by any instance, while a `PRIVATE` redo thread is reserved for a specific instance and is not shared across the cluster.
+
+When the {prodname} Oracle connector detects that a redo thread is marked as `PRIVATE`, the connector automatically skips all change events originating from that thread.
+Because private redo threads are not shared across instances, their changes are not visible to other nodes and cannot be reliably consumed by a change data capture process.
+
+[IMPORTANT]
+====
+Do not change a redo thread from `PUBLIC` to `PRIVATE` or from `PRIVATE` to `PUBLIC` while a connector is deployed.
+Transitioning a thread from `PUBLIC` to `PRIVATE` can result in data loss, because the connector will begin skipping events from that thread.
+Transitioning a thread from `PRIVATE` to `PUBLIC` can lead to unexpected results, because the connector may process events that were previously excluded.
+
+If a redo thread transition is required, a re-snapshot of data may be required to avoid data loss and to remain consistent.
 ====
 
 ifdef::community[]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2049

## Description
Previously, the Oracle connector only prevented consistency validation for private threads but continued to emit changes for them. This change ensures that any event from a private thread is automatically skipped and won't participate in any connector logic or state tracking. 

In addition, redo threads that transition between public and private, or vice versa, will log a warning in the logs, indicating that this could lead to unexpected outcomes. A section was added to the documentation clarifying this fact.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
