### PR TITLE
debezium/dbz#2047 Implement schema history buffering in KafkaSchemaHistory with related workload test

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
@@ -55,6 +55,7 @@ import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.RelationalTableFilters;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
+import io.debezium.relational.history.SchemaHistory;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
@@ -614,24 +615,31 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
             throws Exception {
         tryStartingSnapshot(snapshotContext);
 
-        for (final SchemaChangeEvent event : schemaEvents) {
-            if (!sourceContext.isRunning()) {
-                throw new InterruptedException("Interrupted while processing event " + event);
-            }
+        final SchemaHistory schemaHistory = databaseSchema.getSchemaHistory();
+        schemaHistory.startBuffering();
+        try {
+            for (final SchemaChangeEvent event : schemaEvents) {
+                if (!sourceContext.isRunning()) {
+                    throw new InterruptedException("Interrupted while processing event " + event);
+                }
 
-            if (databaseSchema.skipSchemaChangeEvent(event)) {
-                continue;
-            }
+                if (databaseSchema.skipSchemaChangeEvent(event)) {
+                    continue;
+                }
 
-            LOGGER.debug("Processing schema event {}", event);
+                LOGGER.debug("Processing schema event {}", event);
 
-            final TableId tableId = event.getTables().isEmpty() ? null : event.getTables().iterator().next().id();
-            if (snapshottingTask.isOnDemand() && !snapshotContext.capturedTables.contains(tableId)) {
-                LOGGER.debug("Event {} will be skipped since it's not related to blocking snapshot captured table {}", event, snapshotContext.capturedTables);
-                continue;
+                final TableId tableId = event.getTables().isEmpty() ? null : event.getTables().iterator().next().id();
+                if (snapshottingTask.isOnDemand() && !snapshotContext.capturedTables.contains(tableId)) {
+                    LOGGER.debug("Event {} will be skipped since it's not related to blocking snapshot captured table {}", event, snapshotContext.capturedTables);
+                    continue;
+                }
+                snapshotContext.offset.event(tableId, getClock().currentTime());
+                dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> receiver.schemaChangeEvent(event));
             }
-            snapshotContext.offset.event(tableId, getClock().currentTime());
-            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> receiver.schemaChangeEvent(event));
+        }
+        finally {
+            schemaHistory.stopBuffering();
         }
 
         // Make schema available for snapshot source

--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -492,7 +492,8 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
                 "schema.history.internal.kafka.recovery.poll.interval.ms",
                 "schema.history.internal.connector.id",
                 "schema.history.internal.kafka.recovery.attempts",
-                "schema.history.internal.kafka.query.timeout.ms"));
+                "schema.history.internal.kafka.query.timeout.ms",
+                "schema.history.internal.kafka.buffer.batch.size"));
     }
 
     @Test

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -66,6 +66,7 @@ import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.SnapshotTablesRowCountOrder;
+import io.debezium.relational.history.SchemaHistory;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
@@ -453,41 +454,49 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         if (!schema.isHistorized()) {
             return;
         }
-        for (Iterator<TableId> iterator = getTablesForSchemaChange(snapshotContext).iterator(); iterator.hasNext();) {
-            final TableId tableId = iterator.next();
-            if (!sourceContext.isRunning()) {
-                throw new InterruptedException("Interrupted while capturing schema of table " + tableId);
-            }
 
-            LOGGER.info("Capturing structure of table {}", tableId);
-
-            snapshotContext.offset.event(tableId, getClock().currentTime());
-
-            // If data are not snapshotted then the last schema change must set last snapshot flag
-            if (!snapshottingTask.snapshotData() && !iterator.hasNext()) {
-                lastSnapshotRecord(snapshotContext);
-            }
-
-            final Table table = snapshotContext.tables.forTable(tableId);
-            if (table == null) {
-                throw new DebeziumException("Unable to find relational table model for '" + tableId +
-                        "', there may be an issue with your include/exclude list configuration.");
-            }
-
-            SchemaChangeEvent event = getCreateTableEvent(snapshotContext, table);
-            if (HistorizedRelationalDatabaseSchema.class.isAssignableFrom(schema.getClass()) &&
-                    ((HistorizedRelationalDatabaseSchema) schema).skipSchemaChangeEvent(event)) {
-                continue;
-            }
-
-            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> {
-                try {
-                    receiver.schemaChangeEvent(event);
+        final SchemaHistory schemaHistory = ((HistorizedRelationalDatabaseSchema) schema).getSchemaHistory();
+        schemaHistory.startBuffering();
+        try {
+            for (Iterator<TableId> iterator = getTablesForSchemaChange(snapshotContext).iterator(); iterator.hasNext();) {
+                final TableId tableId = iterator.next();
+                if (!sourceContext.isRunning()) {
+                    throw new InterruptedException("Interrupted while capturing schema of table " + tableId);
                 }
-                catch (Exception e) {
-                    throw new DebeziumException(e);
+
+                LOGGER.info("Capturing structure of table {}", tableId);
+
+                snapshotContext.offset.event(tableId, getClock().currentTime());
+
+                // If data are not snapshotted then the last schema change must set last snapshot flag
+                if (!snapshottingTask.snapshotData() && !iterator.hasNext()) {
+                    lastSnapshotRecord(snapshotContext);
                 }
-            });
+
+                final Table table = snapshotContext.tables.forTable(tableId);
+                if (table == null) {
+                    throw new DebeziumException("Unable to find relational table model for '" + tableId +
+                            "', there may be an issue with your include/exclude list configuration.");
+                }
+
+                SchemaChangeEvent event = getCreateTableEvent(snapshotContext, table);
+                if (HistorizedRelationalDatabaseSchema.class.isAssignableFrom(schema.getClass()) &&
+                        ((HistorizedRelationalDatabaseSchema) schema).skipSchemaChangeEvent(event)) {
+                    continue;
+                }
+
+                dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> {
+                    try {
+                        receiver.schemaChangeEvent(event);
+                    }
+                    catch (Exception e) {
+                        throw new DebeziumException(e);
+                    }
+                });
+            }
+        }
+        finally {
+            schemaHistory.stopBuffering();
         }
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -243,4 +243,26 @@ public interface SchemaHistory {
     default void checkStorageSettings() {
         return;
     }
+
+    /**
+     * Starts buffering write operations. While buffering is active, calls to
+     * {@link #record(Map, Map, String, String) record()} may defer persistence
+     * to improve throughput. When buffering is not active, each record is
+     * persisted and acknowledged individually before returning.
+     *
+     * Callers must guarantee that {@link #stopBuffering()} is called in a
+     * finally block to flush and verify all pending writes.
+     */
+    default void startBuffering() {
+    }
+
+    /**
+     * Stops buffering and ensures all pending writes are flushed and verified
+     * before returning. After this call, subsequent {@link #record(Map, Map, String, String) record()}
+     * calls revert to the default behavior of persisting each record individually.
+     *
+     * @throws SchemaHistoryException if any pending writes failed
+     */
+    default void stopBuffering() {
+    }
 }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -8,8 +8,10 @@ package io.debezium.storage.kafka.history;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -73,6 +75,13 @@ import io.debezium.util.Threads;
 /**
  * A {@link SchemaHistory} implementation that records schema changes as normal {@link SourceRecord}s on the specified topic,
  * and that recovers the history by establishing a Kafka Consumer re-processing all messages on that topic.
+ *
+ * This implementation supports two write modes. In the default mode (streaming), each call to
+ * {@link #storeRecord} sends the record to Kafka, flushes the producer, and blocks until the
+ * broker acknowledges the write. In buffered mode, activated by {@link #startBuffering()},
+ * records are sent without blocking and futures are collected into a bounded list. The list is
+ * drained and verified when it reaches its configured capacity or when {@link #stopBuffering()}
+ * is called. This avoids per-record round-trip latency during snapshot schema persistence.
  *
  * @author Randall Hauch
  */
@@ -167,8 +176,21 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
             .withDefault(Duration.ofSeconds(30).toMillis())
             .withValidation(Field::isPositiveInteger);
 
+    public static final Field BUFFER_BATCH_SIZE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "kafka.buffer.batch.size")
+            .withDisplayName("Buffered writes batch size")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("The maximum number of schema history records to accumulate in the buffer before "
+                    + "draining and verifying the pending writes. Only applies when buffering is active "
+                    + "(between startBuffering/stopBuffering calls). A larger value reduces the number of "
+                    + "blocking drain operations but increases memory usage.")
+            .withDefault(1024)
+            .withValidation(Field::isPositiveInteger);
+
     public static Field.Set ALL_FIELDS = Field.setOf(TOPIC, BOOTSTRAP_SERVERS, NAME, RECOVERY_POLL_INTERVAL_MS,
-            RECOVERY_POLL_ATTEMPTS, INTERNAL_CONNECTOR_CLASS, INTERNAL_CONNECTOR_ID, KAFKA_QUERY_TIMEOUT_MS);
+            RECOVERY_POLL_ATTEMPTS, INTERNAL_CONNECTOR_CLASS, INTERNAL_CONNECTOR_ID, KAFKA_QUERY_TIMEOUT_MS,
+            BUFFER_BATCH_SIZE);
 
     private static final String CONSUMER_PREFIX = CONFIGURATION_FIELD_PREFIX_STRING + "consumer.";
     private static final String PRODUCER_PREFIX = CONFIGURATION_FIELD_PREFIX_STRING + "producer.";
@@ -188,6 +210,8 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
     private ExecutorService checkTopicSettingsExecutor;
     private Duration kafkaQueryTimeout;
     private Duration kafkaCreateTimeout;
+    private int bufferBatchSize;
+    private List<Future<RecordMetadata>> pendingFutures;
 
     private static final boolean USE_KAFKA_24_NEW_TOPIC_CONSTRUCTOR = hasNewTopicConstructorWithOptionals();
 
@@ -212,6 +236,7 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         this.maxRecoveryAttempts = config.getInteger(RECOVERY_POLL_ATTEMPTS);
         this.kafkaQueryTimeout = Duration.ofMillis(config.getLong(KAFKA_QUERY_TIMEOUT_MS));
         this.kafkaCreateTimeout = Duration.ofMillis(config.getLong(KAFKA_CREATE_TIMEOUT_MS));
+        this.bufferBatchSize = config.getInteger(BUFFER_BATCH_SIZE);
 
         String bootstrapServers = config.getString(BOOTSTRAP_SERVERS);
         // Copy the relevant portions of the configuration and add useful defaults ...
@@ -271,6 +296,23 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
     }
 
     @Override
+    public void startBuffering() {
+        LOGGER.info("Starting buffered writes for schema history (batch size: {})", bufferBatchSize);
+        pendingFutures = new ArrayList<>();
+    }
+
+    @Override
+    public void stopBuffering() {
+        LOGGER.info("Stopping buffered writes for schema history — draining {} pending writes", pendingFutures != null ? pendingFutures.size() : 0);
+        try {
+            drainFutures();
+        }
+        finally {
+            pendingFutures = null;
+        }
+    }
+
+    @Override
     protected void storeRecord(HistoryRecord record) throws SchemaHistoryException {
         if (this.producer == null) {
             throw new IllegalStateException("No producer is available. Ensure that 'start()' is called before storing database schema history records.");
@@ -279,16 +321,50 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         try {
             ProducerRecord<String, String> produced = new ProducerRecord<>(topicName, PARTITION, null, record.toString());
             Future<RecordMetadata> future = this.producer.send(produced);
-            // Flush and then wait ...
-            this.producer.flush();
-            RecordMetadata metadata = future.get(); // block forever since we have to be sure this gets recorded
-            if (metadata != null) {
-                LOGGER.debug("Stored record in topic '{}' partition {} at offset {} ",
-                        metadata.topic(), metadata.partition(), metadata.offset());
+
+            if (pendingFutures != null) {
+                pendingFutures.add(future);
+                if (pendingFutures.size() >= bufferBatchSize) {
+                    LOGGER.debug("Snapshot batch size reached ({}), draining pending writes", bufferBatchSize);
+                    drainFutures();
+                }
+            }
+            else {
+                this.producer.flush();
+                RecordMetadata metadata = future.get();
+                if (metadata != null) {
+                    LOGGER.debug("Stored record in topic '{}' partition {} at offset {} ",
+                            metadata.topic(), metadata.partition(), metadata.offset());
+                }
             }
         }
         catch (InterruptedException e) {
             LOGGER.trace("Interrupted before record was written into database schema history: {}", record);
+            Thread.currentThread().interrupt();
+            throw new SchemaHistoryException(e);
+        }
+        catch (ExecutionException e) {
+            throw new SchemaHistoryException(e);
+        }
+    }
+
+    private void drainFutures() throws SchemaHistoryException {
+        if (pendingFutures == null || pendingFutures.isEmpty()) {
+            return;
+        }
+        try {
+            this.producer.flush();
+            for (Future<RecordMetadata> future : pendingFutures) {
+                RecordMetadata metadata = future.get();
+                if (metadata != null) {
+                    LOGGER.trace("Stored record in topic '{}' partition {} at offset {} ",
+                            metadata.topic(), metadata.partition(), metadata.offset());
+                }
+            }
+            LOGGER.debug("Drained {} pending schema history writes", pendingFutures.size());
+            pendingFutures.clear();
+        }
+        catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new SchemaHistoryException(e);
         }

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -103,6 +103,11 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-storage-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/KafkaSchemaHistoryWorkloadIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/KafkaSchemaHistoryWorkloadIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.kafka.KafkaClusterUtils;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryMetrics;
+import io.debezium.storage.kafka.history.KafkaSchemaHistory;
+import io.debezium.util.Collect;
+import io.debezium.util.Testing;
+import io.strimzi.test.container.StrimziKafkaCluster;
+
+/**
+ * Workload test for {@link KafkaSchemaHistory} validating the buffered write
+ * mode used during snapshot schema persistence (debezium/dbz#2047).
+ * <p>
+ * Writes 5000 DDL records (10 databases x 500 tables)
+ * <p>
+ * Two scenarios are tested: a single broker with acks=1 as a baseline, and
+ * 3 brokers with acks=all and min.insync.replicas=2 to simulate production-like
+ * replication overhead.
+ */
+public class KafkaSchemaHistoryWorkloadIT {
+
+    private static final int NUM_DATABASES = 10;
+    private static final int TABLES_PER_DATABASE = 500;
+    private static final int TOTAL_RECORDS = NUM_DATABASES * TABLES_PER_DATABASE;
+
+    private static StrimziKafkaCluster kafkaCluster;
+
+    private KafkaSchemaHistory history;
+
+    private final Map<String, Object> source = Collect.linkMapOf("server", "workload-server");
+
+    @BeforeAll
+    static void startKafka() {
+        Map<String, String> props = new HashMap<>();
+        props.put("auto.create.topics.enable", "false");
+
+        kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withAdditionalKafkaConfiguration(props)
+                .withSharedNetwork()
+                .build();
+
+        kafkaCluster.start();
+    }
+
+    @AfterAll
+    static void stopKafka() {
+        if (kafkaCluster != null) {
+            kafkaCluster.stop();
+        }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        history = new KafkaSchemaHistory();
+    }
+
+    @AfterEach
+    void afterEach() {
+        try {
+            if (history != null) {
+                history.stop();
+            }
+        }
+        finally {
+            history = null;
+        }
+    }
+
+    @Test
+    @DisplayName("Buffered schema history writes with single broker (acks=1)")
+    void shouldMeasureSchemaHistoryBatchWritePerformance() throws Exception {
+        String topicName = "workload-schema-history-" + UUID.randomUUID().toString().substring(0, 8);
+
+        KafkaClusterUtils.createTopic(topicName, 1, (short) 1, kafkaCluster.getBootstrapServers());
+
+        Configuration config = historyConfig(topicName).build();
+
+        runSnapshotWorkload(config, "1 broker, acks=1");
+    }
+
+    @Test
+    @DisplayName("Buffered schema history writes with 3 brokers (acks=all, min.insync.replicas=2)")
+    void shouldMeasureSchemaHistoryBatchWritePerformanceWithReplication() throws Exception {
+        String topicName = "workload-replicated-" + UUID.randomUUID().toString().substring(0, 8);
+
+        Map<String, String> topicConfigs = new HashMap<>();
+        topicConfigs.put("min.insync.replicas", "2");
+
+        createReplicatedTopicWithConfig(topicName, topicConfigs);
+
+        Configuration config = historyConfig(topicName)
+                .with("schema.history.internal.producer." + ProducerConfig.ACKS_CONFIG, "all")
+                .build();
+
+        runSnapshotWorkload(config, "3 brokers, acks=all, min.insync.replicas=2");
+    }
+
+    private Configuration.Builder historyConfig(String topicName) {
+        return Configuration.create()
+                .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, kafkaCluster.getBootstrapServers())
+                .with(KafkaSchemaHistory.TOPIC, topicName)
+                .with(SchemaHistory.NAME, "workload-db-history")
+                .with(KafkaSchemaHistory.RECOVERY_POLL_INTERVAL_MS, 500)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), 100)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), 50000)
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_CLASS,
+                        "org.apache.kafka.connect.source.SourceConnector")
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_ID, "dbz-workload-test");
+    }
+
+    private void runSnapshotWorkload(Configuration config, String description) {
+        history.configure(config, null, SchemaHistoryMetrics.NOOP, true);
+        history.start();
+        history.initializeStorage();
+
+        history.startBuffering();
+        long startTime = System.nanoTime();
+        try {
+            writeSchemaHistoryRecords();
+        }
+        finally {
+            history.stopBuffering();
+        }
+        long endTime = System.nanoTime();
+
+        long durationMs = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+        double recordsPerSecond = (TOTAL_RECORDS * 1000.0) / durationMs;
+        double avgRecordMs = (double) durationMs / TOTAL_RECORDS;
+
+        final String workloadReport = """
+
+                KafkaSchemaHistory Workload (debezium/dbz#2047):
+                  Scenario:           %s
+                  Records written:    %,d
+                  Total time:         %,d ms (%.1f s)
+                  Avg per record:     %.2f ms
+                  Throughput:         %.0f records/sec
+                """.formatted(
+                description,
+                TOTAL_RECORDS, durationMs, durationMs / 1000.0,
+                avgRecordMs, recordsPerSecond);
+        Testing.Print.enable();
+        Testing.print(workloadReport);
+
+        assertThat(avgRecordMs)
+                .as("Average ms per schema history record write (%s)", description)
+                .isLessThan(5.0);
+    }
+
+    private void writeSchemaHistoryRecords() {
+        int logPos = 0;
+        for (int db = 0; db < NUM_DATABASES; db++) {
+            String dbName = "db_" + db;
+            for (int table = 0; table < TABLES_PER_DATABASE; table++) {
+                String tableName = "table_" + table;
+                String ddl = """
+                        CREATE TABLE %s (\
+                        id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, \
+                        name VARCHAR(255) NOT NULL, \
+                        description TEXT, \
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, \
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, \
+                        status INT DEFAULT 0, \
+                        INDEX idx_%s_name (name), \
+                        INDEX idx_%s_status (status)\
+                        );\
+                        """.formatted(tableName, tableName, tableName);
+
+                Map<String, Object> position = Collect.linkMapOf("file", "workload.log", "position", logPos++);
+                history.record(source, position, dbName, ddl);
+            }
+        }
+    }
+
+    private void createReplicatedTopicWithConfig(String topicName, Map<String, String> topicConfigs)
+            throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers());
+        adminProps.setProperty(AdminClientConfig.CLIENT_ID_CONFIG, "workload-admin-" + UUID.randomUUID());
+
+        try (AdminClient admin = AdminClient.create(adminProps)) {
+            NewTopic topic = new NewTopic(topicName, 1, (short) 3);
+            topic.configs(topicConfigs);
+            admin.createTopics(Collections.singleton(topic)).all().get(30, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
closes https://github.com/debezium/dbz/issues/2047

## Description
Fix the per-record flush() + get() bottleneck in KafkaSchemaHistory.storeRecord() during snapshot step 6 ("Persisting schema history") by introducing a buffered write mode.

Add startBuffering() / stopBuffering() lifecycle methods to the SchemaHistory interface with no-op defaults, keeping the contract storage-agnostic In KafkaSchemaHistory, when buffering is active, records are sent without blocking and futures are collected into a configurable bounded list (_schema.history.internal.kafka.buffer.batch.size, default 1024_). 
The list is drained and verified when full or when stopBuffering() is called. During
  streaming (the default), the existing per-record send() + flush() + get() behavior is unchanged

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
