### PR TITLE
DBZ-2113 Reduce MySQL poll conversion overhead

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -6,11 +6,11 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -298,8 +298,12 @@ public class MySqlConnectorTask extends BinlogSourceTask<MySqlPartition, MySqlOf
 
     @Override
     public List<SourceRecord> doPoll() throws InterruptedException {
-        final List<DataChangeEvent> records = queue.poll();
-        return records.stream().map(DataChangeEvent::getRecord).collect(Collectors.toList());
+        final var records = queue.poll();
+        final List<SourceRecord> sourceRecords = new ArrayList<>(records.size());
+        for (final DataChangeEvent record : records) {
+            sourceRecords.add(record.getRecord());
+        }
+        return sourceRecords;
     }
 
     @Override

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/connector/mysql/MySqlConnectorTaskPollPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/connector/mysql/MySqlConnectorTaskPollPerf.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.connector.mysql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.debezium.pipeline.DataChangeEvent;
+
+/**
+ * Compares the SourceRecord extraction path used by MySqlConnectorTask#doPoll().
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class MySqlConnectorTaskPollPerf {
+
+    @Param({ "1", "4", "16", "64", "256", "1024", "2048", "4096", "16384", "65536" })
+    private int batchSize;
+
+    private List<DataChangeEvent> records;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        records = createRecords(batchSize);
+    }
+
+    @Benchmark
+    public List<SourceRecord> stream() {
+        return streamConvert(records);
+    }
+
+    @Benchmark
+    public List<SourceRecord> loop() {
+        return loopConvert(records);
+    }
+
+    private static List<DataChangeEvent> createRecords(int batchSize) {
+        final List<DataChangeEvent> events = new ArrayList<>(batchSize);
+        for (int i = 0; i < batchSize; i++) {
+            events.add(new DataChangeEvent(new SourceRecord(Collections.emptyMap(), Collections.emptyMap(),
+                    "dummy", Schema.STRING_SCHEMA, "Change Data Capture Event via Debezium")));
+        }
+        return List.copyOf(events);
+    }
+
+    private static List<SourceRecord> streamConvert(List<DataChangeEvent> records) {
+        return records.stream().map(DataChangeEvent::getRecord).collect(Collectors.toList());
+    }
+
+    private static List<SourceRecord> loopConvert(List<DataChangeEvent> records) {
+        final List<SourceRecord> sourceRecords = new ArrayList<>(records.size());
+        for (final DataChangeEvent record : records) {
+            sourceRecords.add(record.getRecord());
+        }
+        return sourceRecords;
+    }
+
+    @State(Scope.Thread)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Fork(1)
+    @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    public static class Sustained {
+
+        private static final int POLLS_PER_INVOCATION = 1_000;
+
+        @Param({ "2048", "16384", "65536" })
+        private int batchSize;
+
+        private List<DataChangeEvent> records;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            records = createRecords(batchSize);
+        }
+
+        @Benchmark
+        @OperationsPerInvocation(POLLS_PER_INVOCATION)
+        public void stream(Blackhole blackhole) {
+            for (int i = 0; i < POLLS_PER_INVOCATION; i++) {
+                blackhole.consume(streamConvert(records));
+            }
+        }
+
+        @Benchmark
+        @OperationsPerInvocation(POLLS_PER_INVOCATION)
+        public void loop(Blackhole blackhole) {
+            for (int i = 0; i < POLLS_PER_INVOCATION; i++) {
+                blackhole.consume(loopConvert(records));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR reduces allocation and CPU overhead in `MySqlConnectorTask#doPoll()`.

The method is on the repeated Kafka Connect source task poll path. It does not read the binlog or produce records to Kafka directly. At this point, Debezium has already created `DataChangeEvent` objects and `doPoll()` only unwraps their underlying `SourceRecord` values.

The previous implementation used a sequential stream and `Collectors.toList()` for this simple one-to-one conversion. This PR replaces that path with a pre-sized `ArrayList` and a direct loop.

This preserves behavior:

- record order is unchanged
- the same `SourceRecord` instances are returned
- connector configuration is unchanged
- emitted records and schemas are unchanged
- the returned list remains mutable, like the current `Collectors.toList()` result

Closes debezium/dbz#2113

## Benchmark

I added a JMH benchmark for the MySQL poll batch conversion path.

Environment used for the reported local benchmark:

- JDK: Amazon Corretto 17.0.11
- JMH: 1.37
- Profiler: `-prof gc`
- Mode: average time
- Benchmark type: sustained repeated conversion, 1,000 poll conversions per invocation

The benchmark numbers below were produced by running the JMH benchmark directly with the GC profiler after compiling the benchmark module:

```bash
./mvnw -pl debezium-microbenchmark -am -DskipTests clean compile -U

java -cp "<benchmark classpath>" org.openjdk.jmh.Main \
  'io.debezium.performance.connector.mysql.MySqlConnectorTaskPollPerf.*' \
  -prof gc
```

<img width="2812" height="1411" alt="mysql-poll-benchmark-comparison-detailed-logscale" src="https://github.com/user-attachments/assets/6ee339da-d4a7-4226-967b-ea424b630f2c" />


Detailed benchmark setup, chart, and single-poll results are in debezium/dbz#2113.

### Sustained repeated conversion

| batch size | loop | stream | time reduction | loop allocation | stream allocation | allocation reduction |
|---:|---:|---:|---:|---:|---:|---:|
| 2048 | 5.465 us/op | 7.926 us/op | 31.1% | 8,232 B/op | 33,776 B/op | 75.6% |
| 16384 | 28.244 us/op | 48.891 us/op | 42.2% | 65,576 B/op | 253,576 B/op | 74.1% |
| 65536 | 114.714 us/op | 192.932 us/op | 40.5% | 262,185 B/op | 854,369 B/op | 69.3% |

For the default `max.batch.size=2048`, allocation decreased from about `33.8 KB/op` to about `8.2 KB/op` in the sustained benchmark.

This does not claim an end-to-end connector throughput improvement by itself. The goal is to remove unnecessary allocation and CPU overhead from a hot poll conversion path.

## Verification

```bash
./mvnw -pl debezium-connector-mysql -am -DskipITs -Dtest=MySqlConnectorConfigTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl debezium-microbenchmark -am -DskipTests clean compile -U
```
