### PR TITLE
debezium/dbz#2117 Cleanly close caches when thread interrupted

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheCacheProvider.java
@@ -94,22 +94,30 @@ public class EhcacheCacheProvider extends AbstractCacheProvider<EhcacheTransacti
 
     @Override
     public void close() throws Exception {
-        if (cacheManager != null) {
-            if (dropBufferOnStop) {
-                LOGGER.info("Clearing Ehcache caches");
-                transactionCache.clear();
-                schemaChangesCache.clear();
-                processedTransactionsCache.clear();
+        final boolean wasInterrupted = Thread.interrupted();
+        try {
+            if (cacheManager != null) {
+                if (dropBufferOnStop) {
+                    LOGGER.info("Clearing Ehcache caches");
+                    transactionCache.clear();
+                    schemaChangesCache.clear();
+                    processedTransactionsCache.clear();
 
-                cacheManager.removeCache(TRANSACTIONS_CACHE_NAME);
-                cacheManager.removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
-                cacheManager.removeCache(SCHEMA_CHANGES_CACHE_NAME);
-                cacheManager.removeCache(EVENTS_CACHE_NAME);
-                cacheManager.removeCache(ROLLBACKS_CACHE_NAME);
+                    cacheManager.removeCache(TRANSACTIONS_CACHE_NAME);
+                    cacheManager.removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
+                    cacheManager.removeCache(SCHEMA_CHANGES_CACHE_NAME);
+                    cacheManager.removeCache(EVENTS_CACHE_NAME);
+                    cacheManager.removeCache(ROLLBACKS_CACHE_NAME);
+                }
+
+                LOGGER.info("Shutting down Ehcache embedded caches");
+                cacheManager.close();
             }
-
-            LOGGER.info("Shutting down Ehcache embedded caches");
-            cacheManager.close();
+        }
+        finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/EmbeddedInfinispanCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/EmbeddedInfinispanCacheProvider.java
@@ -79,21 +79,29 @@ public class EmbeddedInfinispanCacheProvider extends AbstractCacheProvider<Infin
 
     @Override
     public void close() throws Exception {
-        if (dropBufferOnStop) {
-            LOGGER.info("Clearing infinispan caches");
-            transactionCache.clear();
-            schemaChangesCache.clear();
-            processedTransactionsCache.clear();
+        final boolean wasInterrupted = Thread.interrupted();
+        try {
+            if (dropBufferOnStop) {
+                LOGGER.info("Clearing infinispan caches");
+                transactionCache.clear();
+                schemaChangesCache.clear();
+                processedTransactionsCache.clear();
 
-            // this block should only be used by tests, should we wrap this in case admin rights aren't given?
-            cacheManager.administration().removeCache(TRANSACTIONS_CACHE_NAME);
-            cacheManager.administration().removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
-            cacheManager.administration().removeCache(SCHEMA_CHANGES_CACHE_NAME);
-            cacheManager.administration().removeCache(EVENTS_CACHE_NAME);
-            cacheManager.administration().removeCache(ROLLBACKS_CACHE_NAME);
+                // this block should only be used by tests, should we wrap this in case admin rights aren't given?
+                cacheManager.administration().removeCache(TRANSACTIONS_CACHE_NAME);
+                cacheManager.administration().removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
+                cacheManager.administration().removeCache(SCHEMA_CHANGES_CACHE_NAME);
+                cacheManager.administration().removeCache(EVENTS_CACHE_NAME);
+                cacheManager.administration().removeCache(ROLLBACKS_CACHE_NAME);
+            }
+            LOGGER.info("Shutting down infinispan embedded caches");
+            cacheManager.close();
         }
-        LOGGER.info("Shutting down infinispan embedded caches");
-        cacheManager.close();
+        finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private InfinispanLogMinerTransactionCache createTransactionCache(OracleConnectorConfig connectorConfig) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/RemoteInfinispanCacheProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/RemoteInfinispanCacheProvider.java
@@ -85,21 +85,29 @@ public class RemoteInfinispanCacheProvider extends AbstractCacheProvider<Infinis
 
     @Override
     public void close() throws Exception {
-        if (dropBufferOnStop) {
-            LOGGER.info("Clearing infinispan caches");
-            transactionCache.clear();
-            schemaChangesCache.clear();
-            processedTransactionsCache.clear();
+        final boolean wasInterrupted = Thread.interrupted();
+        try {
+            if (dropBufferOnStop) {
+                LOGGER.info("Clearing infinispan caches");
+                transactionCache.clear();
+                schemaChangesCache.clear();
+                processedTransactionsCache.clear();
 
-            // this block should only be used by tests, should we wrap this in case admin rights aren't given?
-            cacheManager.administration().removeCache(TRANSACTIONS_CACHE_NAME);
-            cacheManager.administration().removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
-            cacheManager.administration().removeCache(SCHEMA_CHANGES_CACHE_NAME);
-            cacheManager.administration().removeCache(EVENTS_CACHE_NAME);
-            cacheManager.administration().removeCache(ROLLBACKS_CACHE_NAME);
+                // this block should only be used by tests, should we wrap this in case admin rights aren't given?
+                cacheManager.administration().removeCache(TRANSACTIONS_CACHE_NAME);
+                cacheManager.administration().removeCache(PROCESSED_TRANSACTIONS_CACHE_NAME);
+                cacheManager.administration().removeCache(SCHEMA_CHANGES_CACHE_NAME);
+                cacheManager.administration().removeCache(EVENTS_CACHE_NAME);
+                cacheManager.administration().removeCache(ROLLBACKS_CACHE_NAME);
+            }
+            LOGGER.info("Shutting down infinispan remote caches");
+            cacheManager.close();
         }
-        LOGGER.info("Shutting down infinispan remote caches");
-        cacheManager.close();
+        finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private <C, V> RemoteCache<C, V> createCache(String cacheName, OracleConnectorConfig connectorConfig, Field field) {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2117

## Description
A recent issue was noticed, at least in the Oracle ISPN tests, where, when the thread is interrupted, ISPN does not clean up caches and close the cache manager properly because the futures are not awaited internally due to the interrupt flag being set. This left SIFS file locks in play and caused future tests to repeatedly fail.

This PR clears the interrupt before shutting down the cache providers, so they shut down cleanly, and then restores the interrupt afterward if applicable.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
