### PR TITLE
debezium/dbz#2122 Populate table before starting connector

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -42,6 +42,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
+import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.EqualityCheck;
 import io.debezium.junit.SkipWhenConnectorUnderTest;
@@ -420,20 +421,16 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     @Test
     public void snapshotOnlyWithRestart() throws Exception {
         // Testing.Print.enable();
-
         final int ROW_COUNT_LOCAL = ROW_COUNT * 10;
+        populateTable(ROW_COUNT_LOCAL);
 
         final Configuration config = config()
-                // This makes SQL server to run very slowly. Keeping it here as a future reproducer for dbz#2122.
-                // .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
+                .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, 5000)
                 .build();
         startAndConsumeTillEnd(connectorClass(), config);
         waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
 
-        populateTable(ROW_COUNT_LOCAL);
-        consumeRecords(ROW_COUNT_LOCAL);
         consumedLines.clear();
-
         sendAdHocSnapshotSignal();
 
         final AtomicInteger recordCounter = new AtomicInteger();


### PR DESCRIPTION
Fixes debezium/dbz#2122

## Description

Number of the records consumed by the connector may vary across the connectors. E.g. SQL server connector tests enable CDC for given table after populating the table, so the number of consumed records would be either zero or only heartbeats. To unify the behavior, populate the table before starting the connector.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
