### PR TITLE
debezium/dbz#2102 Handle MySQL ENUM and SET literal escaping

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -47,6 +47,7 @@ import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMo
 import io.debezium.connector.binlog.BinlogGeometry;
 import io.debezium.connector.binlog.BinlogUnsignedIntegerConverter;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
+import io.debezium.data.EnumeratedValues;
 import io.debezium.data.Json;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.vector.FloatVector;
@@ -600,7 +601,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
     }
 
     protected String extractEnumAndSetOptionsAsString(Column column) {
-        return Strings.join(",", extractEnumAndSetOptions(column));
+        return EnumeratedValues.toCommaSeparatedString(extractEnumAndSetOptions(column));
     }
 
     protected String convertSetValue(Column column, long indexes, List<String> options) {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
@@ -1570,6 +1570,9 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         assertParseEnumAndSetOptions("ENUM('a\\'','b','c')", "a'", "b", "c");
         assertParseEnumAndSetOptions("ENUM(\"a\\\"\",'b','c')", "a\\\"", "b", "c");
         assertParseEnumAndSetOptions("ENUM(\"a\"\"\",'b','c')", "a\"\"", "b", "c");
+        assertParseEnumAndSetOptions(
+                "ENUM('a,b','back\\\\slash','back\\\\,comma','ends\\\\')",
+                "a,b", "back\\\\slash", "back\\\\,comma", "ends\\\\");
     }
 
     @Test

--- a/debezium-connector-common/src/main/java/io/debezium/data/Enum.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/Enum.java
@@ -11,7 +11,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.schema.SchemaFactory;
-import io.debezium.util.Strings;
 
 /**
  * A semantic type for an enumeration, where the string values are one of the enumeration's values.
@@ -43,10 +42,7 @@ public class Enum {
      * @return the schema builder
      */
     public static SchemaBuilder builder(List<String> allowedValues) {
-        if (allowedValues == null) {
-            return builder("");
-        }
-        return builder(Strings.join(",", allowedValues));
+        return builder(EnumeratedValues.toCommaSeparatedString(allowedValues));
     }
 
     /**
@@ -68,9 +64,6 @@ public class Enum {
      * @see #builder(String)
      */
     public static Schema schema(List<String> allowedValues) {
-        if (allowedValues == null) {
-            return builder("").build();
-        }
-        return builder(Strings.join(",", allowedValues)).build();
+        return builder(allowedValues).build();
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/data/EnumSet.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/EnumSet.java
@@ -11,7 +11,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.schema.SchemaFactory;
-import io.debezium.util.Strings;
 
 /**
  * A semantic type for a set of enumerated values, where the string values contain comma-separated values from an enumeration.
@@ -43,10 +42,7 @@ public class EnumSet {
      * @return the schema builder
      */
     public static SchemaBuilder builder(List<String> allowedValues) {
-        if (allowedValues == null) {
-            return builder("");
-        }
-        return builder(Strings.join(",", allowedValues));
+        return builder(EnumeratedValues.toCommaSeparatedString(allowedValues));
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/data/EnumeratedValues.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/EnumeratedValues.java
@@ -38,10 +38,12 @@ public final class EnumeratedValues {
         for (int i = 0; i != values.length(); ++i) {
             final char c = values.charAt(i);
             if (escaped) {
-                if (c != ',') {
-                    value.append('\\');
+                if (c == ',' || c == '\\') {
+                    value.append(c);
                 }
-                value.append(c);
+                else {
+                    value.append('\\').append(c);
+                }
                 escaped = false;
             }
             else if (c == '\\') {
@@ -63,6 +65,6 @@ public final class EnumeratedValues {
     }
 
     private static String escape(String value) {
-        return value.replace(",", "\\,");
+        return value.replace("\\", "\\\\").replace(",", "\\,");
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/data/EnumeratedValues.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/EnumeratedValues.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.debezium.util.Strings;
+
+/**
+ * Utility methods for encoding and decoding comma-separated enumerated value lists.
+ */
+public final class EnumeratedValues {
+
+    private EnumeratedValues() {
+    }
+
+    public static String toCommaSeparatedString(List<String> values) {
+        if (values == null) {
+            return "";
+        }
+        return Strings.join(",", values.stream()
+                .map(EnumeratedValues::escape)
+                .toList());
+    }
+
+    public static List<String> fromCommaSeparatedString(String values) {
+        if (values == null) {
+            return Collections.emptyList();
+        }
+        final List<String> result = new ArrayList<>();
+        final StringBuilder value = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i != values.length(); ++i) {
+            final char c = values.charAt(i);
+            if (escaped) {
+                if (c != ',') {
+                    value.append('\\');
+                }
+                value.append(c);
+                escaped = false;
+            }
+            else if (c == '\\') {
+                escaped = true;
+            }
+            else if (c == ',') {
+                result.add(value.toString());
+                value.setLength(0);
+            }
+            else {
+                value.append(c);
+            }
+        }
+        if (escaped) {
+            value.append('\\');
+        }
+        result.add(value.toString());
+        return result;
+    }
+
+    private static String escape(String value) {
+        return value.replace(",", "\\,");
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/data/EnumSetTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/EnumSetTest.java
@@ -20,6 +20,7 @@ public class EnumSetTest {
     public void shouldCreateSchemaBuilderFromValues() {
         assertBuilder(EnumSet.builder(Arrays.asList("a", "b", "c")), "a,b,c");
         assertBuilder(EnumSet.builder(Arrays.asList("a")), "a");
+        assertBuilder(EnumSet.builder(Arrays.asList("a,b", "c")), "a\\,b,c");
         assertBuilder(EnumSet.builder(Collections.EMPTY_LIST), "");
         assertBuilder(EnumSet.builder((List<String>) null), "");
     }
@@ -28,6 +29,7 @@ public class EnumSetTest {
     public void shouldCreateSchemaFromValues() {
         assertSchema(EnumSet.schema(Arrays.asList("a", "b", "c")), "a,b,c");
         assertSchema(EnumSet.schema(Arrays.asList("a")), "a");
+        assertSchema(EnumSet.schema(Arrays.asList("a,b", "c")), "a\\,b,c");
         assertSchema(EnumSet.schema(Collections.EMPTY_LIST), "");
         assertSchema(EnumSet.schema((List<String>) null), "");
     }

--- a/debezium-connector-common/src/test/java/io/debezium/data/EnumTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/EnumTest.java
@@ -21,6 +21,7 @@ public class EnumTest {
     public void shouldCreateSchemaBuilderFromValues() {
         assertBuilder(Enum.builder(Arrays.asList("a", "b", "c")), "a,b,c");
         assertBuilder(Enum.builder(Arrays.asList("a")), "a");
+        assertBuilder(Enum.builder(Arrays.asList("a,b", "c")), "a\\,b,c");
         assertBuilder(Enum.builder(Collections.EMPTY_LIST), "");
         assertBuilder(Enum.builder((List<String>) null), "");
     }
@@ -29,6 +30,7 @@ public class EnumTest {
     public void shouldCreateSchemaFromValues() {
         assertSchema(Enum.schema(Arrays.asList("a", "b", "c")), "a,b,c");
         assertSchema(Enum.schema(Arrays.asList("a")), "a");
+        assertSchema(Enum.schema(Arrays.asList("a,b", "c")), "a\\,b,c");
         assertSchema(Enum.schema(Collections.EMPTY_LIST), "");
         assertSchema(Enum.schema((List<String>) null), "");
     }

--- a/debezium-connector-common/src/test/java/io/debezium/data/EnumeratedValuesTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/EnumeratedValuesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class EnumeratedValuesTest {
+
+    @Test
+    void shouldEncodeValuesAsCommaSeparatedString() {
+        assertThat(EnumeratedValues.toCommaSeparatedString(Arrays.asList("a", "b,c", "d"))).isEqualTo("a,b\\,c,d");
+    }
+
+    @Test
+    void shouldDecodeCommaSeparatedString() {
+        assertThat(EnumeratedValues.fromCommaSeparatedString("a,b\\,c,d")).containsExactly("a", "b,c", "d");
+    }
+
+    @Test
+    void shouldPreserveWhitespaceWhenDecodingCommaSeparatedString() {
+        assertThat(EnumeratedValues.fromCommaSeparatedString(" a\\, b, c ")).containsExactly(" a, b", " c ");
+    }
+
+    @Test
+    void shouldDecodeEmptyStringAsEmptyValue() {
+        assertThat(EnumeratedValues.fromCommaSeparatedString("")).containsExactly("");
+    }
+
+    @Test
+    void shouldDecodeNullAsEmptyList() {
+        assertThat(EnumeratedValues.fromCommaSeparatedString(null)).isEmpty();
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/data/EnumeratedValuesTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/EnumeratedValuesTest.java
@@ -24,6 +24,33 @@ class EnumeratedValuesTest {
     }
 
     @Test
+    void shouldPreserveBackslashWhenEncodingAndDecodingCommaSeparatedString() {
+        final String values = EnumeratedValues.toCommaSeparatedString(Arrays.asList("plain", "back\\slash"));
+
+        assertThat(values).isEqualTo("plain,back\\\\slash");
+        assertThat(EnumeratedValues.fromCommaSeparatedString(values)).containsExactly("plain", "back\\slash");
+    }
+
+    @Test
+    void shouldPreserveBackslashBeforeCommaWhenEncodingAndDecodingCommaSeparatedString() {
+        final String values = EnumeratedValues.toCommaSeparatedString(Arrays.asList("plain", "back\\,comma", "tail"));
+
+        assertThat(EnumeratedValues.fromCommaSeparatedString(values)).containsExactly("plain", "back\\,comma", "tail");
+    }
+
+    @Test
+    void shouldPreserveBackslashBeforeDelimiterWhenEncodingAndDecodingCommaSeparatedString() {
+        final String values = EnumeratedValues.toCommaSeparatedString(Arrays.asList("ends\\", "next"));
+
+        assertThat(EnumeratedValues.fromCommaSeparatedString(values)).containsExactly("ends\\", "next");
+    }
+
+    @Test
+    void shouldPreserveLegacyUnescapedBackslashWhenDecodingCommaSeparatedString() {
+        assertThat(EnumeratedValues.fromCommaSeparatedString("plain,back\\slash")).containsExactly("plain", "back\\slash");
+    }
+
+    @Test
     void shouldPreserveWhitespaceWhenDecodingCommaSeparatedString() {
         assertThat(EnumeratedValues.fromCommaSeparatedString(" a\\, b, c ")).containsExactly(" a, b", " c ");
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/EnumType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/EnumType.java
@@ -5,9 +5,7 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
-import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
@@ -36,10 +34,9 @@ class EnumType extends AbstractType {
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
         // Debezium passes parameter called "allowed" which contains the value-set for the ENUM.
-        final Optional<String> allowedValues = getSchemaParameter(schema, "allowed");
+        final Optional<String> allowedValues = getSchemaParameter(schema, Enum.VALUES_FIELD);
         if (allowedValues.isPresent()) {
-            final String[] values = allowedValues.get().split(",");
-            return "enum(" + Arrays.stream(values).map(v -> "'" + v + "'").collect(Collectors.joining(",")) + ")";
+            return MySqlEnumSetTypeSupport.getTypeName("enum", allowedValues.get());
         }
         LOGGER.warn("ENUM was detected without any allowed values.");
         return "enum()";

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlEnumSetTypeSupport.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlEnumSetTypeSupport.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import java.util.stream.Collectors;
+
+import io.debezium.data.EnumeratedValues;
+
+final class MySqlEnumSetTypeSupport {
+
+    private MySqlEnumSetTypeSupport() {
+    }
+
+    static String getTypeName(String typeName, String allowedValues) {
+        return typeName + "(" + EnumeratedValues.fromCommaSeparatedString(allowedValues).stream()
+                .map(MySqlEnumSetTypeSupport::quote)
+                .collect(Collectors.joining(",")) + ")";
+    }
+
+    private static String quote(String value) {
+        return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'";
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/SetType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/SetType.java
@@ -5,9 +5,7 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
-import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
@@ -36,10 +34,9 @@ class SetType extends AbstractType {
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
         // Debezium passes parameter called "allowed" which contains the value-set for the SET.
-        final Optional<String> allowedValues = getSchemaParameter(schema, "allowed");
+        final Optional<String> allowedValues = getSchemaParameter(schema, EnumSet.VALUES_FIELD);
         if (allowedValues.isPresent()) {
-            final String[] values = allowedValues.get().split(",");
-            return "set(" + Arrays.stream(values).map(v -> "'" + v + "'").collect(Collectors.joining(",")) + ")";
+            return MySqlEnumSetTypeSupport.getTypeName("set", allowedValues.get());
         }
         LOGGER.warn("SET was detected without any allowed values.");
         return "set()";

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/EnumTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/EnumTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Enum;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the MySQL {@link EnumType} handler.
+ */
+@Tag("UnitTests")
+class EnumTypeTest {
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should render escaped enum values")
+    void shouldRenderEscapedEnumValues() {
+        assertThat(EnumType.INSTANCE.getTypeName(Enum.schema(Arrays.asList("plain", "a,b", "it's")), false))
+                .isEqualTo("enum('plain','a,b','it''s')");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should render escaped enum values from allowed parameter")
+    void shouldRenderEscapedEnumValuesFromAllowedParameter() {
+        assertThat(EnumType.INSTANCE.getTypeName(Enum.schema("plain,a\\,b,it's"), false))
+                .isEqualTo("enum('plain','a,b','it''s')");
+    }
+
+    @Test
+    @DisplayName("Should render empty enum type without allowed values")
+    void shouldRenderEmptyEnumTypeWithoutAllowedValues() {
+        assertThat(EnumType.INSTANCE.getTypeName(SchemaBuilder.string().name(Enum.LOGICAL_NAME).build(), false))
+                .isEqualTo("enum()");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/EnumTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/EnumTypeTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.data.Enum;
+import io.debezium.data.EnumeratedValues;
 import io.debezium.doc.FixFor;
 
 /**
@@ -27,16 +28,22 @@ class EnumTypeTest {
     @FixFor("debezium/dbz#2102")
     @DisplayName("Should render escaped enum values")
     void shouldRenderEscapedEnumValues() {
-        assertThat(EnumType.INSTANCE.getTypeName(Enum.schema(Arrays.asList("plain", "a,b", "it's")), false))
-                .isEqualTo("enum('plain','a,b','it''s')");
+        final var schema = Enum.schema(Arrays.asList(
+                "plain", "a,b", "it's", "back\\slash", "back\\,comma", "ends\\", ""));
+
+        assertThat(EnumType.INSTANCE.getTypeName(schema, false))
+                .isEqualTo("enum('plain','a,b','it''s','back\\\\slash','back\\\\,comma','ends\\\\','')");
     }
 
     @Test
     @FixFor("debezium/dbz#2102")
     @DisplayName("Should render escaped enum values from allowed parameter")
     void shouldRenderEscapedEnumValuesFromAllowedParameter() {
-        assertThat(EnumType.INSTANCE.getTypeName(Enum.schema("plain,a\\,b,it's"), false))
-                .isEqualTo("enum('plain','a,b','it''s')");
+        final String allowedValues = EnumeratedValues.toCommaSeparatedString(Arrays.asList(
+                "plain", "a,b", "it's", "back\\slash", "back\\,comma", "ends\\", ""));
+
+        assertThat(EnumType.INSTANCE.getTypeName(Enum.schema(allowedValues), false))
+                .isEqualTo("enum('plain','a,b','it''s','back\\\\slash','back\\\\,comma','ends\\\\','')");
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/SetTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/SetTypeTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.data.EnumSet;
+import io.debezium.data.EnumeratedValues;
 import io.debezium.doc.FixFor;
 
 /**
@@ -27,16 +28,21 @@ class SetTypeTest {
     @FixFor("debezium/dbz#2102")
     @DisplayName("Should render escaped set values")
     void shouldRenderEscapedSetValues() {
-        assertThat(SetType.INSTANCE.getTypeName(EnumSet.schema(Arrays.asList("plain", "a,b", "it's")), false))
-                .isEqualTo("set('plain','a,b','it''s')");
+        final var schema = EnumSet.schema(Arrays.asList("plain", "it's", "back\\slash", "ends\\"));
+
+        assertThat(SetType.INSTANCE.getTypeName(schema, false))
+                .isEqualTo("set('plain','it''s','back\\\\slash','ends\\\\')");
     }
 
     @Test
     @FixFor("debezium/dbz#2102")
     @DisplayName("Should render escaped set values from allowed parameter")
     void shouldRenderEscapedSetValuesFromAllowedParameter() {
-        assertThat(SetType.INSTANCE.getTypeName(EnumSet.schema("plain,a\\,b,it's"), false))
-                .isEqualTo("set('plain','a,b','it''s')");
+        final String allowedValues = EnumeratedValues.toCommaSeparatedString(
+                Arrays.asList("plain", "it's", "back\\slash", "ends\\"));
+
+        assertThat(SetType.INSTANCE.getTypeName(EnumSet.schema(allowedValues), false))
+                .isEqualTo("set('plain','it''s','back\\\\slash','ends\\\\')");
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/SetTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/SetTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.EnumSet;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the MySQL {@link SetType} handler.
+ */
+@Tag("UnitTests")
+class SetTypeTest {
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should render escaped set values")
+    void shouldRenderEscapedSetValues() {
+        assertThat(SetType.INSTANCE.getTypeName(EnumSet.schema(Arrays.asList("plain", "a,b", "it's")), false))
+                .isEqualTo("set('plain','a,b','it''s')");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    @DisplayName("Should render escaped set values from allowed parameter")
+    void shouldRenderEscapedSetValuesFromAllowedParameter() {
+        assertThat(SetType.INSTANCE.getTypeName(EnumSet.schema("plain,a\\,b,it's"), false))
+                .isEqualTo("set('plain','a,b','it''s')");
+    }
+
+    @Test
+    @DisplayName("Should render empty set type without allowed values")
+    void shouldRenderEmptySetTypeWithoutAllowedValues() {
+        assertThat(SetType.INSTANCE.getTypeName(SchemaBuilder.string().name(EnumSet.LOGICAL_NAME).build(), false))
+                .isEqualTo("set()");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -28,6 +28,8 @@ import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.Bits;
+import io.debezium.data.Enum;
+import io.debezium.data.EnumSet;
 import io.debezium.doc.FixFor;
 
 /**
@@ -179,6 +181,45 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getInt(5)).isEqualTo(341);
             assertThat(rs.getInt(6)).isEqualTo(255);
             assertThat(rs.getBigDecimal(7)).isEqualTo(UNSIGNED_64BIT_MAX_VALUE);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2102")
+    public void testShouldCreateAndWriteEnumAndSetColumnTypesWithEscapedValues(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema enumSchema = Enum.schema(List.of(
+                "plain", "a,b", "it's", "back\\slash", "back\\,comma", "ends\\", ""));
+        final Schema setSchema = EnumSet.schema(List.of("plain", "it's", "back\\slash", "ends\\"));
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("enum_data", "set_data"),
+                List.of(enumSchema, setSchema),
+                List.of("a,b", "it's,back\\slash"),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "enum_data", "ENUM");
+        getSink().assertColumn(destinationTable, "set_data", "SET");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("enum_data")).isEqualTo("a,b");
+            assertThat(rs.getString("set_data")).isEqualTo("it's,back\\slash");
             return null;
         });
     }

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -436,7 +436,7 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     }
 
     /**
-     * Extracts the enumeration values properly parsed and escaped.
+     * Extracts the enumeration values properly parsed and unescaped.
      *
      * @param enumValues the raw enumeration values from the parsed column definition
      * @return the list of options allowed for the {@code ENUM} or {@code SET}; never null.
@@ -449,10 +449,9 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     }
 
     public static String escapeOption(String option) {
-        // Replace comma to backslash followed by comma (this escape sequence implies comma is part of the option)
-        // Replace backlash+single-quote to a single-quote.
+        // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
-        return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
+        return option.replace("\\'", "'").replace("''", "'");
     }
 
     public Tables.TableFilter getTableFilter() {

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -444,11 +444,11 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     public static List<String> extractEnumAndSetOptions(List<String> enumValues) {
         return enumValues.stream()
                 .map(MariaDbAntlrDdlParser::withoutQuotes)
-                .map(MariaDbAntlrDdlParser::escapeOption)
+                .map(MariaDbAntlrDdlParser::unescapeOption)
                 .collect(Collectors.toList());
     }
 
-    public static String escapeOption(String option) {
+    public static String unescapeOption(String option) {
         // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
         return option.replace("\\'", "'").replace("''", "'");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -474,7 +474,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     }
 
     /**
-     * Extracts the enumeration values properly parsed and escaped.
+     * Extracts the enumeration values properly parsed and unescaped.
      *
      * @param enumValues the raw enumeration values from the parsed column definition
      * @return the list of options allowed for the {@code ENUM} or {@code SET}; never null.
@@ -487,10 +487,9 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     }
 
     public static String escapeOption(String option) {
-        // Replace comma to backslash followed by comma (this escape sequence implies comma is part of the option)
-        // Replace backlash+single-quote to a single-quote.
+        // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
-        return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
+        return option.replace("\\'", "'").replace("''", "'");
     }
 
     public TableFilter getTableFilter() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -482,11 +482,11 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     public static List<String> extractEnumAndSetOptions(List<String> enumValues) {
         return enumValues.stream()
                 .map(MySqlAntlrDdlParser::withoutQuotes)
-                .map(MySqlAntlrDdlParser::escapeOption)
+                .map(MySqlAntlrDdlParser::unescapeOption)
                 .collect(Collectors.toList());
     }
 
-    public static String escapeOption(String option) {
+    public static String unescapeOption(String option) {
         // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
         return option.replace("\\'", "'").replace("''", "'");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
@@ -419,7 +419,7 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
     }
 
     /**
-     * Extracts the enumeration values properly parsed and escaped.
+     * Extracts the enumeration values properly parsed and unescaped.
      *
      * @param enumValues the raw enumeration values from the parsed column definition
      * @return the list of options allowed for the {@code ENUM} or {@code SET}; never null.
@@ -432,10 +432,9 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
     }
 
     public static String escapeOption(String option) {
-        // Replace comma to backslash followed by comma (this escape sequence implies comma is part of the option)
-        // Replace backlash+single-quote to a single-quote.
+        // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
-        return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
+        return option.replace("\\'", "'").replace("''", "'");
     }
 
     public TableFilter getTableFilter() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
@@ -427,11 +427,11 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
     public static List<String> extractEnumAndSetOptions(List<String> enumValues) {
         return enumValues.stream()
                 .map(MySqlPtAntlrDdlParser::withoutQuotes)
-                .map(MySqlPtAntlrDdlParser::escapeOption)
+                .map(MySqlPtAntlrDdlParser::unescapeOption)
                 .collect(Collectors.toList());
     }
 
-    public static String escapeOption(String option) {
+    public static String unescapeOption(String option) {
         // Replace backslash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
         return option.replace("\\'", "'").replace("''", "'");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -22,6 +22,7 @@ import io.debezium.connector.mysql.charset.MySqlCharsetRegistry;
 import io.debezium.connector.mysql.jdbc.MySqlDefaultValueConverter;
 import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
 import io.debezium.connector.mysql.util.MySqlValueConvertersFactory;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
@@ -160,6 +161,41 @@ public class MySqlAntlrDdlParserTest
         assertThat(c2).isNotNull();
         assertThat(c2.defaultValueExpression()).isPresent();
         assertThat(c2.defaultValueExpression().get()).isEqualTo("0");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    public void shouldParseEnumOptionsWithCommaQuoteAndBackslash() {
+        final String ddl = "CREATE TABLE enum_literals ("
+                + "e ENUM('plain','a,b','it''s','back\\\\slash','back\\\\,comma','ends\\\\','')"
+                + ");";
+
+        parser.parse(ddl, tables);
+
+        final Table table = tables.forTable(null, null, "enum_literals");
+        assertThat(table).isNotNull();
+        final Column column = table.columnWithName("e");
+        assertThat(column).isNotNull();
+        assertThat(MySqlAntlrDdlParser.extractEnumAndSetOptions(column.enumValues()))
+                .containsExactly(
+                        "plain", "a,b", "it's", "back\\\\slash", "back\\\\,comma", "ends\\\\", "");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2102")
+    public void shouldParseSetOptionsWithQuoteAndBackslash() {
+        final String ddl = "CREATE TABLE set_literals ("
+                + "s SET('plain','it''s','back\\\\slash')"
+                + ");";
+
+        parser.parse(ddl, tables);
+
+        final Table table = tables.forTable(null, null, "set_literals");
+        assertThat(table).isNotNull();
+        final Column column = table.columnWithName("s");
+        assertThat(column).isNotNull();
+        assertThat(MySqlAntlrDdlParser.extractEnumAndSetOptions(column.enumValues()))
+                .containsExactly("plain", "it's", "back\\\\slash");
     }
 
     public static class MySqlDdlParserWithSimpleTestListener extends MySqlAntlrDdlParser {


### PR DESCRIPTION
Fixes debezium/dbz#2102

## Description
This change improves MySQL and MariaDB ENUM/SET allowed value handling by keeping parser output as parsed option values and moving schema-parameter escaping to the common enumerated-values helper.

It also updates MySQL JDBC sink type rendering tests to cover comma, quote, backslash, trailing backslash, and empty ENUM labels.

## Testing
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ./mvnw -pl debezium-connector-common test -Dtest=io.debezium.data.EnumeratedValuesTest`