### PR TITLE
[docs] Warn about BIGINT UNSIGNED overflow with default long mode

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -11,12 +11,18 @@ Specifies how the connector represents BIGINT UNSIGNED columns in change events.
 Set one of the following options:
 
 `long`:::: Uses Java `long` data types to represent BIGINT UNSIGNED column values.
-Although the `long` type does not offer the greatest precision, it is easy implement in most consumers.
-In most environments, this is the preferred setting.
+Although the `long` type is easy to consume in most clients, it cannot represent the full range of BIGINT UNSIGNED values.
++
+[WARNING]
+====
+Because `long` is the default value, the connector uses signed `long` semantics for BIGINT UNSIGNED columns unless you set this property to `precise`.
+Values greater than 2^63 - 1 overflow and are emitted to change events as negative numbers, which results in silent data corruption that the connector does not report as an error.
+If a BIGINT UNSIGNED column can hold values larger than 2^63 - 1, set `bigint.unsigned.handling.mode` to `precise`.
+====
 
 `precise`:::: Uses `java.math.BigDecimal` data types to represent values.
 The connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` data type to represent values in encoded binary format.
-Set this option if the connector typically works with values larger than 2^63.
+Set this option if the connector can work with values larger than 2^63 - 1.
 The `long` data type cannot convey values of that size.
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -11,7 +11,7 @@ Specifies how the connector represents BIGINT UNSIGNED columns in change events.
 Set one of the following options:
 
 `long`:::: Uses Java `long` data types to represent BIGINT UNSIGNED column values.
-Although the `long` type is easy to consume in most clients, it cannot represent the full range of BIGINT UNSIGNED values.
+Although the `long` type is easy for most clients to consume, it cannot represent the full range of BIGINT UNSIGNED values.
 +
 [WARNING]
 ====

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -24,7 +24,7 @@ If BIGINT UNSIGNED columns in the source database hold values larger than 2^63 -
 
 `precise`:::: Uses `java.math.BigDecimal` data types to represent values.
 The connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` data type to represent values in encoded binary format.
-Set this option if the connector can work with values larger than 2^63 - 1.
+Set this option to enable the connector to process BIGINT values larger than 2^63 - 1.
 The `long` data type cannot convey values of that size.
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -15,9 +15,11 @@ Although the `long` type is easy for most clients to consume, it cannot represen
 +
 [WARNING]
 ====
-Because `long` is the default value, the connector uses signed `long` semantics for BIGINT UNSIGNED columns unless you set this property to `precise`.
-Values greater than 2^63 - 1 overflow and are emitted to change events as negative numbers, which results in silent data corruption that the connector does not report as an error.
-If a BIGINT UNSIGNED column can hold values larger than 2^63 - 1, set `bigint.unsigned.handling.mode` to `precise`.
+The `long` type represents BIGINT UNSIGNED columns as 64-bit signed integers.
+Because the maximum value for a signed Java long is 2^63 - 1, values that exceed that size are not represented correctly.
+If a value in a BIGINT UNSIGNED column exceeds the maximum size of a Java long, the connector emits the column value as a negative number.
+Because the connector does not report an error, the mapping can result in silent data corruption.
+If BIGINT UNSIGNED columns in the source database hold values larger than 2^63 - 1, set `bigint.unsigned.handling.mode` to `precise`.
 ====
 
 `precise`:::: Uses `java.math.BigDecimal` data types to represent values.


### PR DESCRIPTION
## Summary

Adds a warning to the MySQL/MariaDB connector configuration docs about the silent overflow risk of the default `long` mode for `bigint.unsigned.handling.mode`.

When a `BIGINT UNSIGNED` column holds values greater than `2^63 - 1`, the default `long` mode overflows and emits those values to change events as negative numbers, with no error reported by the connector. This is easy to miss until data corruption is noticed downstream.

The previous wording described `long` as "the preferred setting in most environments", which conflicts with this risk, so it is softened accordingly.

The change touches only the shared partial `ref-mariadb-mysql-rqd-connector-cfg-props.adoc`, which is included by both the MySQL and MariaDB connector docs. No code or default-value changes.

## Context

Requested by @jpechane in review discussion. Maintainers agreed that changing the default to `precise` makes sense for a future major release (4.0), and that the current docs should warn about the potential problem in the meantime.

## Validation

- `git diff --check` passes (no whitespace errors)