### PR TITLE
debezium/dbz#2151 Fix deferred offset SCN to account for promoted trasactions in the cache

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -859,13 +859,26 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
             // by transactions in the cache. Always use a sliding window block-by-block.
             final Scn miningSessionStartScn = endScn.subtract(Scn.ONE);
 
-            // The offset SCN must not advance past the oldest deferred transaction's start SCN.
-            // This ensures that on restart, the connector goes back far enough to re-mine the START
-            // events of deferred transactions and reconstruct their metadata.
+            // The offset SCN must not advance past the oldest in-flight transaction's start SCN,
+            // considering both the deferred metadata map and the promoted (DML-bearing) transaction
+            // cache. This ensures that on restart the connector goes back far enough to re-mine
+            // the START events of deferred transactions and to reconstruct any non-persisted
+            // transactions that were already promoted into the cache.
             final Scn oldestDeferredScn = getOldestDeferredTransactionStartScn();
+            final Scn oldestScn;
+            if (oldestDeferredScn.isNull()) {
+                oldestScn = minCacheScn;
+            }
+            else if (minCacheScn.isNull()) {
+                oldestScn = oldestDeferredScn;
+            }
+            else {
+                oldestScn = oldestDeferredScn.compareTo(minCacheScn) <= 0 ? oldestDeferredScn : minCacheScn;
+            }
+
             final Scn offsetScn;
-            if (!oldestDeferredScn.isNull() && !maxCommittedScn.isNull() && oldestDeferredScn.compareTo(maxCommittedScn) < 0) {
-                offsetScn = oldestDeferredScn;
+            if (!oldestScn.isNull() && !maxCommittedScn.isNull() && oldestScn.compareTo(maxCommittedScn) < 0) {
+                offsetScn = oldestScn.subtract(Scn.ONE);
             }
             else if (!maxCommittedScn.isNull()) {
                 offsetScn = maxCommittedScn;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -304,7 +304,10 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
-    public void testOffsetScnPinnedToOldestDeferredTransaction() throws Exception {
+    // Verifies the getOldestDeferredTransactionStartScn() helper's lifecycle (add on START,
+    // stays min after rollback, NULL when empty). Offset behaviour that consumes this helper
+    // is covered by testOffsetScnPinnedToMinOfDeferredAndCachedTransactions.
+    public void testOldestDeferredTransactionStartScnLifecycle() throws Exception {
         try (var source = getChangeEventSource(getConfig().build())) {
             source.processEvent(getStartLogMinerEventRow(100, TRANSACTION_ID_1));
             source.processEvent(getStartLogMinerEventRow(150, TRANSACTION_ID_2));
@@ -318,6 +321,65 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
             source.processEvent(getRollbackLogMinerEventRow(170, TRANSACTION_ID_1));
 
             assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.NULL);
+        }
+    }
+
+    @Test
+    public void testOffsetScnPinnedToMinOfDeferredAndCachedTransactions() throws Exception {
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, false);
+        Mockito.when(rs.getString(1)).thenReturn("200");
+        Mockito.when(rs.getString(2)).thenReturn(
+                "insert into \"DEBEZIUM\".\"ABC\"(\"ID\",\"DATA\") values ('3','test3');");
+        Mockito.when(rs.getInt(3)).thenReturn(EventType.INSERT.getValue());
+        Mockito.when(rs.getTimestamp(eq(4), any(Calendar.class))).thenReturn(Timestamp.valueOf(LocalDateTime.now()));
+        Mockito.when(rs.getString(7)).thenReturn("ABC");
+        Mockito.when(rs.getString(8)).thenReturn("DEBEZIUM");
+        Mockito.when(rs.getString(10)).thenReturn("AAAAAAAAAAAAAAAAAD");
+        Mockito.when(rs.getBytes(5)).thenReturn(new byte[]{ 0x12, 0x34, 0x56, 0x78 });
+
+        final PreparedStatement ps = Mockito.mock(PreparedStatement.class);
+        Mockito.when(ps.executeQuery()).thenReturn(rs);
+
+        Mockito.when(commitScn.getMaxCommittedScn()).thenReturn(Scn.valueOf(500));
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            final BufferedStreamingChangeEventSource mock = Mockito.spy(source);
+            Mockito.doReturn(ps).when(mock).createQueryStatement();
+
+            final OracleConnection mainConnection = connectionFactory.streamingConnectionFactory().mainConnection();
+            Mockito.when(mainConnection.getTableMetadataDdl(Mockito.any(TableId.class)))
+                    .thenReturn("CREATE TABLE DEBEZIUM.ABC (ID primary key(9,0), data varchar2(50))");
+
+            final Table table = Table.editor()
+                    .tableId(TableId.parse("ORCLPDB1.DEBEZIUM.ABC"))
+                    .addColumn(Column.editor().name("ID").create())
+                    .addColumn(Column.editor().name("DATA").create())
+                    .setPrimaryKeyNames("ID").create();
+
+            Mockito.doReturn(table)
+                    .when(mock)
+                    .dispatchSchemaChangeEventAndGetTableForNewConfiguredTable(Mockito.any(TableId.class));
+
+            // Promote TRANSACTION_ID_1 into the cache with startScn=100
+            source.processEvent(getStartLogMinerEventRow(100, TRANSACTION_ID_1));
+            source.processEvent(getInsertLogMinerEventRow(110, TRANSACTION_ID_1));
+
+            // Leave TRANSACTION_ID_2 in the deferred map with startScn=150
+            source.processEvent(getStartLogMinerEventRow(150, TRANSACTION_ID_2));
+
+            assertThat(source.getTransactionCache().containsTransaction(TRANSACTION_ID_1)).isTrue();
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(1);
+
+            // process() triggers calculateNewStartScn. The offset SCN should be
+            // min(oldestDeferredScn=150, minCacheScn=100) - 1 = 99, not just 150.
+            // The subtract(ONE) matches the non-deferred path so the START event at
+            // the oldest SCN is included by the mining query's exclusive SCN > ? bound.
+            final ProcessResult result = mock.process(Scn.valueOf(100), Scn.valueOf(100), Scn.valueOf(200));
+
+            Mockito.verify(offsetContext).setScn(Scn.valueOf(99));
+            assertThat(result.miningSessionStartScn()).isEqualTo(Scn.valueOf(199));
+            assertThat(result.readStartScn()).isEqualTo(Scn.valueOf(200));
         }
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2151

## Description
The original deferred transaction start PR didn't account for minCacheScn which it needs to in order to accurately determine the low watermark.  This PR resolves by factoring in both caches and retaining the MaxCommitedScn fallback

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
