### PR TITLE
debezium/dbz#1639 Add CockroachDB dialect to the JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import java.util.Set;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.dialect.CockroachDialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.TransactionSerializationException;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
+import io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect;
+
+/**
+ * A {@link DatabaseDialect} implementation for CockroachDB.
+ *
+ * <p>CockroachDB speaks the PostgreSQL wire protocol and supports {@code INSERT ... ON CONFLICT},
+ * so it reuses {@link PostgresDatabaseDialect}. The distinct dialect exists because Hibernate maps
+ * CockroachDB to {@link CockroachDialect}, which is not a {@code PostgreSQLDialect}; without a
+ * matching provider the resolver falls back to the general dialect, which does not support upsert.</p>
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBDatabaseDialect extends PostgresDatabaseDialect {
+
+    public static class CockroachDBDatabaseDialectProvider implements DatabaseDialectProvider {
+        @Override
+        public boolean supports(Dialect dialect) {
+            return dialect instanceof CockroachDialect;
+        }
+
+        @Override
+        public Class<?> name() {
+            return CockroachDBDatabaseDialect.class;
+        }
+
+        @Override
+        public DatabaseDialect instantiate(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
+            return new CockroachDBDatabaseDialect(config, sessionFactory);
+        }
+    }
+
+    protected CockroachDBDatabaseDialect(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
+        super(config, sessionFactory);
+    }
+
+    /**
+     * Transient transaction-conflict exceptions CockroachDB raises that the client is expected to
+     * retry. CockroachDB runs SERIALIZABLE isolation by default and signals conflicts with SQLSTATE
+     * 40001 (serialization failure) and 40P01 (deadlock); Hibernate maps these to
+     * {@link TransactionSerializationException} and {@link LockAcquisitionException} respectively.
+     * The two are siblings under {@code JDBCException}, so both must be listed.
+     */
+    static final Set<Class<? extends Exception>> RETRIABLE_CONFLICT_EXCEPTIONS = Set.of(
+            TransactionSerializationException.class,
+            LockAcquisitionException.class);
+
+    @Override
+    public Set<Class<? extends Exception>> getCommunicationExceptions() {
+        // Add CockroachDB's retriable transaction-conflict exceptions so the configured flush retries
+        // (flush.max.retries / flush.retry.delay.ms) handle them rather than failing the task.
+        final Set<Class<? extends Exception>> exceptions = super.getCommunicationExceptions();
+        exceptions.addAll(RETRIABLE_CONFLICT_EXCEPTIONS);
+        return exceptions;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -56,7 +56,7 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         }
     }
 
-    private PostgresDatabaseDialect(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
+    protected PostgresDatabaseDialect(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
         super(config, sessionFactory);
     }
 

--- a/debezium-connector-jdbc/src/main/resources/META-INF/services/io.debezium.connector.jdbc.dialect.DatabaseDialectProvider
+++ b/debezium-connector-jdbc/src/main/resources/META-INF/services/io.debezium.connector.jdbc.dialect.DatabaseDialectProvider
@@ -3,5 +3,6 @@ io.debezium.connector.jdbc.dialect.db2.Db2DatabaseDialect$Db2DatabaseProvider
 io.debezium.connector.jdbc.dialect.mysql.MariaDbDatabaseDialect$MariaDbDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.mysql.MySqlDatabaseDialect$MySqlDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.oracle.OracleDatabaseDialect$OracleDatabaseDialectProvider
+io.debezium.connector.jdbc.dialect.cockroachdb.CockroachDBDatabaseDialect$CockroachDBDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect$PostgresDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.sqlserver.SqlServerDatabaseDialect$SqlServerDatabaseDialectProvider

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialectTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialectTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ServiceLoader;
+
+import org.hibernate.dialect.CockroachDialect;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.TransactionSerializationException;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
+import io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect;
+
+/**
+ * Unit tests for {@link CockroachDBDatabaseDialect}'s provider resolution. CockroachDB maps to
+ * Hibernate's {@link CockroachDialect}, which is not a {@code PostgreSQLDialect}, so without a
+ * dedicated provider the sink falls back to the general dialect (no upsert support).
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBDatabaseDialectTest {
+
+    private final CockroachDBDatabaseDialect.CockroachDBDatabaseDialectProvider provider = new CockroachDBDatabaseDialect.CockroachDBDatabaseDialectProvider();
+
+    @Test
+    void providerSupportsCockroachDialect() {
+        assertThat(provider.supports(new CockroachDialect()))
+                .as("CockroachDB provider should support Hibernate's CockroachDialect")
+                .isTrue();
+    }
+
+    @Test
+    void providerDoesNotClaimPlainPostgres() {
+        assertThat(provider.supports(new PostgreSQLDialect()))
+                .as("CockroachDB provider should not claim a plain PostgreSQL dialect")
+                .isFalse();
+    }
+
+    @Test
+    void providerNameIsCockroachDbDialect() {
+        assertThat(provider.name()).isEqualTo(CockroachDBDatabaseDialect.class);
+    }
+
+    @Test
+    void postgresProviderDoesNotClaimCockroach() {
+        // This is the gap dbz#1639 closes: the Postgres provider only matches PostgreSQLDialect, so
+        // CockroachDialect would otherwise fall through to the general dialect (no upsert).
+        assertThat(new PostgresDatabaseDialect.PostgresDatabaseDialectProvider().supports(new CockroachDialect()))
+                .as("Postgres provider must not match CockroachDialect")
+                .isFalse();
+    }
+
+    @Test
+    void providerIsRegisteredViaServiceLoader() {
+        boolean found = false;
+        for (DatabaseDialectProvider p : ServiceLoader.load(DatabaseDialectProvider.class)) {
+            if (p instanceof CockroachDBDatabaseDialect.CockroachDBDatabaseDialectProvider) {
+                found = true;
+                break;
+            }
+        }
+        assertThat(found)
+                .as("CockroachDB provider should be registered in META-INF/services")
+                .isTrue();
+    }
+
+    @Test
+    void retriableSetCoversSerializationAndDeadlockConflicts() {
+        // CockroachDB SQLSTATE 40001 -> TransactionSerializationException and 40P01 -> LockAcquisitionException.
+        // They are siblings under JDBCException (40001 is NOT a LockAcquisitionException), so both must be
+        // declared retriable for the sink's isRetriable() to cover serialization failures and deadlocks.
+        assertThat(CockroachDBDatabaseDialect.RETRIABLE_CONFLICT_EXCEPTIONS)
+                .contains(TransactionSerializationException.class, LockAcquisitionException.class);
+        assertThat(LockAcquisitionException.class.isAssignableFrom(TransactionSerializationException.class))
+                .as("40001 is a sibling of LockAcquisitionException, not a subclass")
+                .isFalse();
+    }
+
+    @Test
+    void exactlyOneRegisteredProviderSupportsCockroach() {
+        CockroachDialect dialect = new CockroachDialect();
+        long matches = 0;
+        Class<?> matchName = null;
+        for (DatabaseDialectProvider p : ServiceLoader.load(DatabaseDialectProvider.class)) {
+            if (p.supports(dialect)) {
+                matches++;
+                matchName = p.name();
+            }
+        }
+        assertThat(matches)
+                .as("Exactly one provider should resolve CockroachDialect")
+                .isEqualTo(1);
+        assertThat(matchName)
+                .as("The resolving provider should be the CockroachDB dialect")
+                .isEqualTo(CockroachDBDatabaseDialect.class);
+    }
+}


### PR DESCRIPTION
Closes debezium/dbz#1639.

Draft: opening for CI and maintainer input on the approach (extend `PostgresDatabaseDialect` vs a dedicated dialect, how much CockroachDB-specific type coverage to add, and whether to gate serialization retries behind a config flag).

## Problem

The JDBC sink resolves the database dialect from the Hibernate dialect. CockroachDB maps to Hibernate's `CockroachDialect`, which is not a `PostgreSQLDialect`, so no `DatabaseDialectProvider` matches and the sink falls back to `GeneralDatabaseDialect`. That dialect does not implement `getUpsertStatement`, so upsert and delete against CockroachDB fail with:

```
java.lang.UnsupportedOperationException: Upsert configurations are not supported for this dialect
  at io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect.getUpsertStatement
```

The current workaround is to force `hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect`.

## Change

- Add `CockroachDBDatabaseDialect` and its provider (matching Hibernate's `CockroachDialect`), extending `PostgresDatabaseDialect` since CockroachDB speaks the PostgreSQL wire protocol and supports `INSERT ... ON CONFLICT`.
- Make `PostgresDatabaseDialect`'s constructor `protected` so the CockroachDB dialect can extend it.
- Register the provider in `META-INF/services`.
- Treat CockroachDB serialization and deadlock conflicts (SQLSTATE `40001` and `40P01`, which Hibernate maps to `LockAcquisitionException`) as retriable so the configured flush retries (`flush.max.retries` / `flush.retry.delay.ms`) handle them.

## Verification

- Unit tests: the provider resolves `CockroachDialect` (and not a plain PostgreSQL dialect), is registered via `ServiceLoader`, and a `40001` `TransactionSerializationException` is covered by the `LockAcquisitionException` retriable class.
- Behavior validated separately end to end: a CockroachDB to CockroachDB pipeline with `insert.mode=upsert` and `delete.enabled=true` replicates correctly when the PostgreSQL dialect is selected, which this change makes automatic for CockroachDB targets.