### PR TITLE
Dbz 9910 remove hard line breaks from db2.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -199,8 +199,8 @@ If you configure a different snapshot mode, the connector completes the snapshot
 
 5. Capture the schema of all tables or all tables that are designated for capture.
 The connector persists schema information in its internal database schema history topic.
-The schema history provides information about the structure that is in effect when a change event occurs. +
-+
+The schema history provides information about the structure that is in effect when a change event occurs.
+
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
@@ -346,7 +346,7 @@ For information about capturing data from a new table that has undergone structu
 2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
 For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
-+
+
 [WARNING]
 ====
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
@@ -354,15 +354,15 @@ This operation is potentially destructive, and should be performed only as a las
 ====
 4. Apply the following changes to the connector configuration:
 .. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
-This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables. +
-+
+This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables.
+
 [NOTE]
 ====
 Snapshots that capture the schema for all tables require more time to complete.
 ====
 .. Add the tables that you want the connector to capture to xref:{context}-property-table-include-list[`table.include.list`].
 .. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to one of the following values:
-`initial`:: When you restart the connector, it takes a full snapshot of the database that captures the table data and table structures. +
+`initial`:: When you restart the connector, it takes a full snapshot of the database that captures the table data and table structures.
 If you select this option, consider setting the value of the xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] property to `false` to enable the connector to capture the schema of all tables.
 `no_data`:: When you restart the connector, it takes a snapshot that captures only the table schema.
 Unlike a full data snapshot, this option does not capture any table data.
@@ -373,7 +373,7 @@ The connector completes the type of snapshot specified by the `snapshot.mode`.
 6. (Optional) If the connector performed a `no_data` snapshot, after the snapshot completes, initiate an xref:debezium-db2-incremental-snapshots[incremental snapshot] to capture data from the tables that you added.
 The connector runs the snapshot while it continues to stream real-time changes from the tables.
 Running an incremental snapshot captures the following data changes:
-+
+
 * For tables that the connector previously captured, the incremental snapsot captures changes that occur while the connector was down, that is, in the interval between the time that the connector was stopped, and the current restart.
 * For newly added tables, the incremental snapshot captures all existing table rows.
 
@@ -409,7 +409,7 @@ You can then initiate an incremental snapshot to enable the connector to synchro
 2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
 For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
-+
+
 [WARNING]
 ====
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
@@ -789,7 +789,8 @@ In the source object, `ts_ms` indicates the time that the change was made in the
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |2
-|`databaseName` +
+a|`databaseName`
+
 `schemaName`
 |Identifies the database and the schema that contain the change.
 
@@ -997,10 +998,10 @@ If you use the JSON converter and you configure it to produce all four basic cha
 
 |1
 |`schema`
-|The first `schema` field is part of the event key.
+a|The first `schema` field is part of the event key.
 It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion.
-In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
- +
+In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed.
+
 It is possible to override the table's primary key by setting the xref:db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
@@ -1114,10 +1115,10 @@ A value in the key's payload field is optional when a table does not have a prim
 |`mydatabase.MYSCHEMA.CUSTOMERS.Key`
 a|Name of the schema that defines the structure of the key's payload.
 This schema describes the structure of the primary key for the table that was changed.
-Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: +
+Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example:
 
-* `mydatabase` is the name of the connector that generated this event. +
-* `MYSCHEMA` is the database schema that contains the table that was changed. +
+* `mydatabase` is the name of the connector that generated this event.
+* `MYSCHEMA` is the database schema that contains the table that was changed.
 * `CUSTOMERS` is the table that was updated.
 
 |5
@@ -1372,12 +1373,12 @@ A change event's value schema is the same in every change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
- +
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
+
 `mydatabase.MYSCHEMA.CUSTOMERS.Value` is the schema for the payload's `before` and `after` fields.
 This schema is specific to the `customers` table.
-The connector uses this schema for all rows in the `MYSCHEMA.CUSTOMERS` table. +
- +
+The connector uses this schema for all rows in the `MYSCHEMA.CUSTOMERS` table.
+
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database.
 This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
@@ -1394,8 +1395,8 @@ a|`mydatabase.MYSCHEMA.CUSTOMERS.Envelope` is the schema for the overall structu
 |5
 |`payload`
 |The value's actual data.
-This information shows how the operation changes data in the record. +
- +
+This information shows how the operation changes data in the record.
+
 The size of the JSON representation of an event might be larger than you would expect for the source row.
 The increased size results because JSON representations of events include both the schema and payload portions of messages.
 You can decrease the size of the messages that the connector streams to Kafka topics by converting the messages to Avro format.
@@ -1440,8 +1441,8 @@ Valid values are:
 |10
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task. +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task.
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
@@ -1533,8 +1534,8 @@ In an _update_ event value, the `op` field value is `u`, signifying that this ro
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task. +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task.
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
@@ -1626,8 +1627,8 @@ The `op` field value is `d`, signifying that this row was deleted.
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task. +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task.
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
@@ -1712,8 +1713,8 @@ Consider using a different type.
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 String representation of a timestamp without timezone information
 
 |`DECFLOAT`
@@ -1746,14 +1747,14 @@ String representation of a timestamp without timezone information
 
 |`TIME`
 |`INT32`
-|`io.debezium.time.Time` +
- +
+|`io.debezium.time.Time`
+
 String representation of a time without timezone information
 
 |`TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp` +
- +
+|`io.debezium.time.MicroTimestamp`
+
 String representation of a timestamp without timezone information
 
 |`VARBINARY`
@@ -1770,8 +1771,8 @@ String representation of a timestamp without timezone information
 
 |`XML`
 |`STRING`
-|`io.debezium.data.Xml` +
- +
+|`io.debezium.data.Xml`
+
 String representation of an XML document
 |===
 
@@ -1804,32 +1805,32 @@ This ensures that events _exactly_ represent the values in the database.
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME(0)`, `TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
-|`io.debezium.time.Time` +
- +
+|`io.debezium.time.Time`
+
 Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
-|`io.debezium.time.MicroTime` +
- +
+|`io.debezium.time.MicroTime`
+
 Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIME(7)`
 |`INT64`
-|`io.debezium.time.NanoTime` +
- +
+|`io.debezium.time.NanoTime`
+
 Represents the number of nanoseconds past midnight, and does not include timezone information.
 
 |`DATETIME`
 |`INT64`
-|`io.debezium.time.Timestamp` +
- +
+|`io.debezium.time.Timestamp`
+
 Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |===
@@ -1847,21 +1848,21 @@ However, since Db2 supports tenth of a microsecond precision, the events generat
 
 |`DATE`
 |`INT32`
-|`org.apache.kafka.connect.data.Date` +
- +
+|`org.apache.kafka.connect.data.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Time` +
- +
+|`org.apache.kafka.connect.data.Time`
+
 Represents the number of milliseconds since midnight, and does not include timezone information.
 Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`DATETIME`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp` +
- +
+|`org.apache.kafka.connect.data.Timestamp`
+
 Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |===
@@ -1915,15 +1916,15 @@ The timezone of the JVM running Kafka Connect and {prodname} does not affect thi
 
 |`NUMERIC[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
+|`org.apache.kafka.connect.data.Decimal`
+
 The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 
 |`DECIMAL[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
+|`org.apache.kafka.connect.data.Decimal`
+
 The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that  represents the precision of the given decimal value.
 
@@ -2214,7 +2215,7 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 * xref:openshift-streams-db2-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+* xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 This Containerfile deployment method is deprecated.
 The instructions for this method are scheduled for removal in future versions of the documentation.
 
@@ -2353,7 +2354,7 @@ docker push _<myregistry.io>_/debezium-container-for-db2:latest
 
 .. Create a new {prodname} Db2 `KafkaConnect` custom resource (CR).
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -2652,8 +2653,8 @@ endif::community[]
 |No default
 |Topic prefix which provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the topic prefix name.
-The topic prefix should be unique across all other connectors, since this topic prefix is used for all Kafka topics that receive records from this connector. +
- +
+The topic prefix should be unique across all other connectors, since this topic prefix is used for all Kafka topics that receive records from this connector.
+
 [WARNING]
 ====
 Do not change the value of this property.
@@ -2665,26 +2666,26 @@ The connector is also unable to recover its database schema history topic.
 |No default
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want the connector to capture.
 When this property is set, the connector captures changes only from the specified tables.
-Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table. +
+Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the table it does not match substrings that might be present in a table name. +
+That is, the specified expression is matched against the entire name string of the table it does not match substrings that might be present in a table name.
 If you include this property in the configuration, do not also set the `table.exclude.list` property.
 
 |[[db2-property-table-exclude-list]]<<db2-property-table-exclude-list, `+table.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want the connector to capture.
 The connector captures changes in each non-system table that is not included in the exclude list.
-Each identifier is of the form _schemaName_._tableName_. +
+Each identifier is of the form _schemaName_._tableName_.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the table it does not match substrings that might be present in a table name. +
+That is, the specified expression is matched against the entire name string of the table it does not match substrings that might be present in a table name.
 If you include this property in the configuration, do not also set the `table.include.list` property.
 
 |[[db2-property-column-include-list]]<<db2-property-column-include-list, `+column.include.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values.
-Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name.
@@ -2693,7 +2694,7 @@ If you include this property in the configuration, do not also set the `column.e
 |[[db2-property-column-exclude-list]]<<db2-property-column-exclude-list, `+column.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event values.
-Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name.
@@ -2703,32 +2704,32 @@ If you include this property in the configuration, do not set the `column.includ
 |[[db2-property-column-mask-hash]]<<db2-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.
-Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 To match the name of a column {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 In the resulting change event record, the values for the specified columns are replaced with pseudonyms.
 
 A pseudonym consists of the hashed value that results from applying the specified _hashAlgorithm_ and _salt_.
 Based on the hash function that is used, referential integrity is maintained, while column values are replaced with pseudonyms.
-Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation. +
- +
-In the following example, `CzQMA0cB5K` is a randomly selected salt. +
+Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
+
+In the following example, `CzQMA0cB5K` is a randomly selected salt.
 
 ----
 column.mask.hash.SHA-256.with.salt.CzQMA0cB5K = inventory.orders.customerName, inventory.shipment.customerName
 ----
 
 If necessary, the pseudonym is automatically shortened to the length of the column.
-The connector configuration can include multiple properties that specify different hash algorithms and salts. +
- +
+The connector configuration can include multiple properties that specify different hash algorithms and salts.
+
 Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked.
 
 |[[db2-property-time-precision-mode]]<<db2-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision: +
- +
-`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
- +
+| Time, date, and timestamps can be represented with different kinds of precision:
+
+`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type.
+
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision.
 For more information, see xref:db2-temporal-types[temporal types].
 
@@ -2768,7 +2769,7 @@ Set this property if you want the connector to mask the values for a set of colu
 Set `_length_` to a positive integer to replace data in the specified columns with the number of asterisk (`*`) characters specified by the _length_ in the property name.
 Set _length_ to `0` (zero) to replace data in the specified columns with an empty string.
 
-The fully-qualified name of a column observes the following format: _schemaName_._tableName_._columnName_. +
+The fully-qualified name of a column observes the following format: _schemaName_._tableName_._columnName_.
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 
@@ -2779,14 +2780,14 @@ You can specify multiple properties with different lengths in a single configura
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns for which you want the connector to emit extra parameters that represent column metadata.
 When this property is set, the connector adds the following fields to the schema of event records:
 
-* `pass:[_]pass:[_]debezium.source.column.type` +
-* `pass:[_]pass:[_]debezium.source.column.length` +
-* `pass:[_]pass:[_]debezium.source.column.scale` +
+* `pass:[_]pass:[_]debezium.source.column.type`
+* `pass:[_]pass:[_]debezium.source.column.length`
+* `pass:[_]pass:[_]debezium.source.column.scale`
 
-These parameters propagate a column's original type name and length (for variable-width types), respectively. +
+These parameters propagate a column's original type name and length (for variable-width types), respectively.
 Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases.
 
-The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
+The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 
@@ -2795,14 +2796,14 @@ That is, the specified expression is matched against the entire name string of t
 |An optional, comma-separated list of regular expressions that specify the fully-qualified names of data types that are defined for columns in a database.
 When this property is set, for columns with matching data types, the connector emits event records that include the following extra fields in their schema:
 
-* `pass:[_]pass:[_]debezium.source.column.type` +
-* `pass:[_]pass:[_]debezium.source.column.length` +
-* `pass:[_]pass:[_]debezium.source.column.scale` +
+* `pass:[_]pass:[_]debezium.source.column.type`
+* `pass:[_]pass:[_]debezium.source.column.length`
+* `pass:[_]pass:[_]debezium.source.column.scale`
 
-These parameters propagate a column's original type name and length (for variable-width types), respectively. +
+These parameters propagate a column's original type name and length (for variable-width types), respectively.
 Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases.
 
-The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
+The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
 To match the name of a data type, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the data type; the expression does not match substrings that might be present in a type name.
 
@@ -2813,25 +2814,25 @@ For the list of Db2-specific data type names, see the xref:db2-data-types[Db2 da
 |A list of expressions that specify the columns that the connector uses to form custom message keys for change event records that it publishes to the Kafka topics for specified tables.
 
 By default, {prodname} uses the primary key column of a table as the message key for records that it emits.
-In place of the default, or to specify a key for tables that lack a primary key, you can configure custom message keys based on one or more columns. +
- +
-To establish a custom message key for a table, list the table, followed by the columns to use as the message key.
-Each list entry takes the following format: +
- +
-`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_` +
- +
-To base a table key on multiple column names, insert commas between the column names. +
-Each fully-qualified table name is a regular expression in the following format: +
+In place of the default, or to specify a key for tables that lack a primary key, you can configure custom message keys based on one or more columns.
 
-`_<schemaName>_._<tableName>_` +
+To establish a custom message key for a table, list the table, followed by the columns to use as the message key.
+Each list entry takes the following format:
+
+`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_`
+
+To base a table key on multiple column names, insert commas between the column names.
+Each fully-qualified table name is a regular expression in the following format:
+
+`_<schemaName>_._<tableName>_`
 
 The property can list entries for multiple tables.
-Use a semicolon to separate entries for different tables in the list. +
- +
-The following example sets the message key for the tables `inventory.customers` and `purchaseorders`: +
- +
-`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4` +
- +
+Use a semicolon to separate entries for different tables in the list.
+
+The following example sets the message key for the tables `inventory.customers` and `purchaseorders`:
+
+`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4`
+
 In the preceding example, the columns `pk1` and `pk2` are specified as the message key for the table `inventory.customer`.
 For `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as the message key.
 
@@ -2840,20 +2841,20 @@ For `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as 
 |Specifies how schema names should be adjusted for compatibility with the message converter used by the connector.
 Possible settings:
 
-* `none` does not apply any adjustment. +
-* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment.
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore.
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx.
-Note: _ is an escape sequence like backslash in Java +
+Note: _ is an escape sequence like backslash in Java
 
 |[[db2-property-field-name-adjustment-mode]]<<db2-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
 |none
 |Specifies how field names should be adjusted for compatibility with the message converter used by the connector.
 Possible settings:
 
-* `none` does not apply any adjustment. +
-* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment.
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore.
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx.
-Note: _ is an escape sequence like backslash in Java +
+Note: _ is an escape sequence like backslash in Java
 
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
@@ -2871,30 +2872,30 @@ The following _advanced_ configuration properties have defaults that work in mos
 |[[db2-property-converters]]<<db2-property-converters, `converters`>>
 |No default
 |Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
-For example, +
+For example,
 
 `isbn`
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
 For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
-The `.type` property uses the following format: +
+The `.type` property uses the following format:
 
-`_<converterSymbolicName>_.type` +
+`_<converterSymbolicName>_.type`
 
-For example, +
+For example,
 
  isbn.type: io.debezium.test.IsbnConverter
 
 If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
-To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter. +
-For example, +
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter.
+For example,
 
  isbn.schema.name: io.debezium.db2.type.Isbn
 
 |[[db2-property-snapshot-mode]]<<db2-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
-|Specifies the criteria for performing a snapshot when the connector starts: +
+|Specifies the criteria for performing a snapshot when the connector starts:
 
 `always`:: The connector performs a snapshot every time that it starts.
 The snapshot includes the structure and data of the captured tables.
@@ -2914,7 +2915,7 @@ It does not transition to streaming event records for subsequent database change
 
 `recovery`:: Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.
-You can also set the property to periodically prune a database schema history topic that experiences unexpected growth. +
+You can also set the property to periodically prune a database schema history topic that experiences unexpected growth.
 +
 WARNING: Do not use this mode to perform a snapshot if schema changes were committed to the database after the last connector shutdown.
 
@@ -2962,7 +2963,7 @@ endif::community[]
 ifdef::community[]
 |[[db2-property-snapshot-mode-configuration-based-snapshot-on-data-error]]<<db2-property-configuration-based-snapshot-on-data-error, `+snapshot.mode.configuration.based.snapshot.on.data.error+`>>
 |false
-|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log. +
+|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log.
 Set the value to `true` to instruct the connector to perform a new snapshot.
 endif::community[]
 
@@ -2980,7 +2981,7 @@ a|Controls whether and for how long the connector holds a table lock.
 Table locks prevent other database clients from performing certain table operations during a snapshot.
 You can set the following values:
 
-`exclusive`:: Controls how the connector holds locks on tables while performing the schema snapshot when `snapshot.isolation.mode` is `REPEATABLE_READ` or `EXCLUSIVE`. +
+`exclusive`:: Controls how the connector holds locks on tables while performing the schema snapshot when `snapshot.isolation.mode` is `REPEATABLE_READ` or `EXCLUSIVE`.
 The connector holds a table lock that ensures exclusive table access during only the initial phase of the snapshot in which the connector reads the database schema and other metadata.
 In subsequent phases of the snapshot, the connector uses a flashback query, which requires no locks, to select all rows from each table.
 If you prefer snapshots to run without setting any locks, set the following option, `none`.
@@ -3001,13 +3002,13 @@ endif::community[]
 
 |[[db2-property-snapshot-query-mode]]<<db2-property-snapshot-query-mode, `+snapshot.query.mode+`>>
 |`select_all`
-|Specifies how the connector queries data while performing a snapshot. +
+|Specifies how the connector queries data while performing a snapshot.
 Set one of the following options:
 
 `select_all`:: The connector performs a `select all` query by default, optionally adjusting the columns selected based on the column include and exclude list configurations.
 
 ifdef::community[]
-`custom`:: The connector performs a snapshot query according to the implementation specified by the xref:db2-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface. +
+`custom`:: The connector performs a snapshot query according to the implementation specified by the xref:db2-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface.
 endif::community[]
 
 This setting enables you to manage snapshot content in a more flexible manner compared to using the xref:db2-property-snapshot-select-statement-overrides[`snapshot.select.statement.overrides`] property.
@@ -3022,19 +3023,19 @@ endif::community[]
 |[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |`repeatable_read`
 |During a snapshot, controls the transaction isolation level and how long the connector locks the tables that are in capture mode.
-The possible values are: +
- +
+The possible values are:
+
 `read_uncommitted` - Does not prevent other transactions from updating table rows during an initial snapshot.
-This mode has no data consistency guarantees; some data might be lost or corrupted. +
- +
+This mode has no data consistency guarantees; some data might be lost or corrupted.
+
 `read_committed` - Does not prevent other transactions from updating table rows during an initial snapshot.
 It is possible for a new record to appear twice: once in the initial snapshot and once in the streaming phase.
-However, this consistency level is appropriate for data mirroring. +
- +
+However, this consistency level is appropriate for data mirroring.
+
 `repeatable_read` - Prevents other transactions from updating table rows during an initial snapshot.
 It is possible for a new record to appear twice: once in the initial snapshot and once in the streaming phase.
-However, this consistency level is appropriate for data mirroring. +
- +
+However, this consistency level is appropriate for data mirroring.
+
 `exclusive` - Uses repeatable read isolation level but takes an  exclusive lock for all tables to be read.
 This mode prevents other transactions from updating table rows during an initial snapshot.
 Only `exclusive` mode guarantees full consistency; the initial snapshot and streaming logs constitute a linear history.
@@ -3042,20 +3043,20 @@ Only `exclusive` mode guarantees full consistency; the initial snapshot and stre
 |[[db2-property-event-processing-failure-handling-mode]]<<db2-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 |Specifies how the connector handles exceptions during processing of events.
-The possible values are: +
- +
-`fail` - The connector logs the offset of the problematic event and stops processing. +
- +
-`warn` - The connector logs the offset of the problematic event and continues processing with the next event. +
- +
+The possible values are:
+
+`fail` - The connector logs the offset of the problematic event and stops processing.
+
+`warn` - The connector logs the offset of the problematic event and continues processing with the next event.
+
 `skip` - The connector skips the problematic event and continues processing with the next event.
 
 |[[db2-property-poll-interval-ms]]<<db2-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`500` (0.5 seconds)
-|Positive integer value that specifies the number of milliseconds that the connector waits before it checks the database for new change events. +
- +
+|Positive integer value that specifies the number of milliseconds that the connector waits before it checks the database for new change events.
+
 The value that you specify influences the behavior of xref:db2-property-heartbeat-interval-ms[`heartbeat.interval.ms`].
-The connector can emit heartbeat messages only during the specified polling cycle. +
+The connector can emit heartbeat messages only during the specified polling cycle.
 
 To prevent this setting from delaying heartbeat emissions, set it to a value that is less than or equal to the value of `heartbeat.interval.ms`.
 
@@ -3076,20 +3077,20 @@ Always set the value of `max.queue.size` to be larger than the value of xref:{co
 |`0`
 |A long integer value that specifies the maximum volume of the blocking queue in bytes.
 By default, volume limits are not specified for the blocking queue.
-To specify the number of bytes that the queue can consume, set this property to a positive long value. +
+To specify the number of bytes that the queue can consume, set this property to a positive long value.
 If xref:db2-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
 |[[db2-property-heartbeat-interval-ms]]<<db2-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
-|Specifies an interval in milliseconds that determines how frequently the connector sends messages to a Kafka heartbeat topic, regardless of whether changes occur in the database. +
-By default, the connector does not send heartbeat messages. +
- +
+|Specifies an interval in milliseconds that determines how frequently the connector sends messages to a Kafka heartbeat topic, regardless of whether changes occur in the database.
+By default, the connector does not send heartbeat messages.
+
 Setting this property can help to confirm whether the connector is still receiving change events from the database.
 This can be especially important in databases where captured tables remain unchanged for long periods.
 When a database experiences frequent long intervals during which changes no changes occur in captured tables, although the connector continues to read the transaction log as usual, it only rarely commits offset values to Kafka.
-As a result, after a connector restart, because the offset value is stale, the connector must send a high number of change events. +
- +
+As a result, after a connector restart, because the offset value is stale, the connector must send a high number of change events.
+
 By contrast, when you configure the connector to send regular heartbeat messages, it can update the offset in Kafka more frequently.
 Because the offset values in Kafka remain current, fewer change events must be re-sent after a connector restarts.
 
@@ -3137,8 +3138,8 @@ Set a delay value that is higher than the value of the {link-kafka-docs}/#connec
 | All tables specified in `table.include.list`
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>.<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:db2-property-table-include-list[`table.include.list`] property.
-This property takes effect only if the connector's xref:db2-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`. +
-This property does not affect the behavior of incremental snapshots. +
+This property takes effect only if the connector's xref:db2-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`.
+This property does not affect the behavior of incremental snapshots.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
@@ -3153,10 +3154,10 @@ This property specifies the maximum number of rows in a batch.
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
 If the connector cannot acquire table locks in this interval, the snapshot fails.
 xref:db2-snapshots[How the connector performs snapshots] provides details.
-Other possible settings are: +
- +
-`0` -  The connector immediately fails when it cannot obtain a lock. +
- +
+Other possible settings are:
+
+`0` -  The connector immediately fails when it cannot obtain a lock.
+
 `-1` - The connector waits infinitely.
 
 |[[db2-property-snapshot-select-statement-overrides]]<<db2-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
@@ -3264,7 +3265,7 @@ Adjust the chunk size to a value that provides the best performance in your envi
 
 |[[db2-property-incremental-snapshot-watermarking-strategy]]<<db2-property-incremental-snapshot-watermarking-strategy, `+incremental.snapshot.watermarking.strategy+`>>
 |`insert_insert`
-|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes. +
+|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes.
 You can specify one of the following options:
 
 `insert_insert`:: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.
@@ -3290,46 +3291,46 @@ This cache will help to determine the topic name corresponding to a given data c
 |[[db2-property-topic-heartbeat-prefix]]<<db2-property-topic-heartbeat-prefix, `+topic.heartbeat.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the name of the topic to which the connector sends heartbeat messages.
-The topic name has this pattern: +
- +
-_topic.heartbeat.prefix_._topic.prefix_ +
- +
-For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`. +
- +
+The topic name has this pattern:
+
+_topic.heartbeat.prefix_._topic.prefix_
+
+For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
+
 This property is ignored if `topic.heartbeat.name` is set.
 
 |[[db2-property-topic-heartbeat-name]]<<db2-property-topic-heartbeat-name, `+topic.heartbeat.name+`>>
 |_empty_
-|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`. +
- +
-When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics. +
- +
-For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`. +
- +
+|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`.
+
+When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
+
+For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`.
+
 If this property is empty or unset, the connector falls back to the default behavior: _topic.heartbeat.prefix_._topic.prefix_.
 
 |[[db2-property-topic-transaction]]<<db2-property-topic-transaction, `topic.transaction`>>
 |`transaction`
 |Controls the name of the topic to which the connector sends transaction metadata messages.
-The topic name has this pattern: +
- +
-_topic.prefix_._topic.transaction_ +
- +
+The topic name has this pattern:
+
+_topic.prefix_._topic.transaction_
+
 For example, if the topic prefix is `fulfillment`, the default topic name is `fulfillment.transaction`.
 
 |[[db2-property-snapshot-max-threads]]<<db2-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Specifies the number of threads that the connector uses when performing an initial snapshot.
+a|Specifies the number of threads that the connector uses when performing an initial snapshot.
 To enable parallel initial snapshots, set the property to a value greater than 1.
 In a parallel initial snapshot, the connector processes multiple tables concurrently.
- +
+
 [NOTE]
 ====
 When you enable parallel initial snapshots, the threads that perform each table snapshot can require varying times to complete their work.
 If a snapshot for one table requires significantly more time to complete than the snapshots for other tables, threads that have completed their work sit idle.
 In some environments, a network device such as a load balancer or firewall, terminates connections that remain idle for an extended interval.
-After the snapshot completes, the connector is unable to close the connection, resulting in an exception, and an incomplete snapshot, even in cases where the connector successfully transmitted all snapshot data. +
- +
+After the snapshot completes, the connector is unable to close the connection, resulting in an exception, and an incomplete snapshot, even in cases where the connector successfully transmitted all snapshot data.
+
 If you experience this problem, revert the value of `snapshot.max.threads` to `1`, and retry the snapshot.
 ====
 
@@ -3369,7 +3370,7 @@ The pattern that you specify for the `custom.sanitize.pattern` property override
 
 |[[db2-property-errors-max-retires]]<<db2-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error.
 Set one of the following options:
 
 `-1`:: No limit.
@@ -3539,8 +3540,8 @@ For other UDFs, use the SQL `CALL` statement.
 |`VALUES ASNCDC.ASNCDCSERVICES('status','asncdc');`
 
 |[[debezium-db2-put-capture-mode]]<<debezium-db2-put-capture-mode,Put a table into capture mode>>
-|`CALL ASNCDC.ADDTABLE('MYSCHEMA', 'MYTABLE');` +
- +
+a|`CALL ASNCDC.ADDTABLE('MYSCHEMA', 'MYTABLE');`
+
 Replace `MYSCHEMA`  with the name of the schema that contains the table you want to put into capture mode.
 Likewise, replace `MYTABLE` with the name of the table to put into capture mode.
 
@@ -3548,8 +3549,8 @@ Likewise, replace `MYTABLE` with the name of the table to put into capture mode.
 |`CALL ASNCDC.REMOVETABLE('MYSCHEMA', 'MYTABLE');`
 
 |[[debezium-db2-reinitialize-asn-service]]<<debezium-db2-reinitialize-asn-service,Reinitialize the ASN service>>
-|`VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');` +
- +
+a|`VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');`
+
 Do this after you put a table into capture mode or after you remove a table from capture mode.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -200,7 +200,7 @@ If you configure a different snapshot mode, the connector completes the snapshot
 5. Capture the schema of all tables or all tables that are designated for capture.
 The connector persists schema information in its internal database schema history topic.
 The schema history provides information about the structure that is in effect when a change event occurs.
-
++
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database that is in capture mode, including tables that are not configured for capture.
@@ -346,7 +346,7 @@ For information about capturing data from a new table that has undergone structu
 2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
 For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
-
++
 [WARNING]
 ====
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
@@ -355,7 +355,7 @@ This operation is potentially destructive, and should be performed only as a las
 4. Apply the following changes to the connector configuration:
 .. (Optional) Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.captured.tables.ddl`] to `false`.
 This setting causes the snapshot to capture the schema for all tables, and guarantees that, in the future, the connector can reconstruct the schema history for all tables.
-
++
 [NOTE]
 ====
 Snapshots that capture the schema for all tables require more time to complete.
@@ -409,12 +409,13 @@ You can then initiate an incremental snapshot to enable the connector to synchro
 2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Clear the offsets in the configured Kafka Connect link:{link-kafka-docs}/#connectconfigs_offset.storage.topic[`offset.storage.topic`].
 For more information about how to remove offsets, see the link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[{prodname} community FAQ].
-
++
 [WARNING]
 ====
 Removing offsets should be performed only by advanced users who have experience in manipulating internal Kafka Connect data.
 This operation is potentially destructive, and should be performed only as a last resort.
 ====
+
 4. Set values for properties in the connector configuration as described in the following steps:
 .. Set the value of the xref:{context}-property-snapshot-mode[`snapshot.mode`] property to `no_data`.
 .. Edit the xref:{context}-property-table-include-list[`table.include.list`] to add the tables that you want to capture.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -42,8 +42,8 @@ Information and procedures for using a {prodname} PostgreSQL connector is organi
 * xref:how-debezium-postgresql-connectors-work[]
 * xref:descriptions-of-debezium-postgresql-connector-data-change-events[]
 * xref:how-debezium-postgresql-connectors-map-data-types[]
-* xref:setting-up-postgresql-to-run-a-debezium-connector[]
 * xref:custom-postgres-connector-converters[]
+* xref:setting-up-postgresql-to-run-a-debezium-connector[]
 * xref:deployment-of-debezium-postgresql-connectors[]
 * xref:monitoring-debezium-postgresql-connector-performance[]
 * xref:how-debezium-postgresql-connectors-handle-faults-and-problems[]
@@ -2185,6 +2185,7 @@ Support for the propagation of default values exists primarily to allow for safe
 This behaviour may be unexpected, but it is still safe. Only the schema definition is affected, while the real values present in the message will remain consistent with what was written to the source database.
 ====
 
+// Type: concept
 [[custom-postgres-connector-converters]]
 == Custom converters
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9910](https://redhat.atlassian.net/browse/DBZ-9910)

## Description
Removes hard line breaks from the upstream Db2 connector file to prepare it for DITA migration.

Tested in a local Antora and downstream builds. 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
