### PR TITLE
DBZ-9911 Remove hard line breaks from Informix connector documentation

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -2807,18 +2807,18 @@ The resulting topic name has the following pattern:
 
 `_topic.heartbeat.prefix_._topic.prefix_`
 
-For example, if the topic prefix is `fulfillment`, based on the default value of the prefix, the connector assigns the following name to the heartbeat topic : `__debezium-heartbeat.fulfillment`. +
- +
+For example, if the topic prefix is `fulfillment`, based on the default value of the prefix, the connector assigns the following name to the heartbeat topic : `__debezium-heartbeat.fulfillment`.
+
 This property is ignored if `topic.heartbeat.name` is set.
 
 |[[informix-property-topic-heartbeat-name]]<<informix-property-topic-heartbeat-name, `+topic.heartbeat.name+`>>
 |_empty_
-|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`. +
- +
-When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics. +
- +
-For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`. +
- +
+|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`.
+
+When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
+
+For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`.
+
 If this property is empty or unset, the connector falls back to the default behavior: _topic.heartbeat.prefix_._topic.prefix_.
 
 |[[informix-property-topic-transaction]]<<informix-property-topic-transaction, `topic.transaction`>>

--- a/documentation/modules/ROOT/pages/connectors/informix.adoc
+++ b/documentation/modules/ROOT/pages/connectors/informix.adoc
@@ -426,7 +426,6 @@ The {prodname} connector for Informix does not support schema changes while an i
 ====
 
 // Type: procedure
-// ModuleID: debezium-informix-triggering-an-incremental-snapshot
 [id="informix-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
@@ -440,21 +439,18 @@ include::{partialsdir}/modules/all-connectors/proc-running-an-ad-hoc-snapshot-wi
 
 
 // Type: procedure
-// ModuleID: debezium-informix-using-the-kafka-signaling-channel-to-trigger-an-incremental-snapshot
 [id="informix-triggering-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to trigger an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc[leveloffset=+1]
 
 // Type: procedure
-// ModuleID: debezium-informix-stopping-an-incremental-snapshot
 [id="informix-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
 include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+1]
 
 // Type: procedure
-// ModuleID: debezium-informix-using-the-kafka-signaling-channel-to-stop-an-incremental-snapshot
 [id="informix-stopping-an-incremental-snapshot-kafka"]
 ==== Using the Kafka signaling channel to stop an incremental snapshot
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9911](https://redhat.atlassian.net/browse/DBZ-9911)

## Description
Removes hard line breaks from the upstream Informix connector file to prepare it for DITA migration.

* Removed all trailing ' +' hard line break sequences from table cells
* Preserved all bare '+' AsciiDoc list continuation markers unchanged

Tested in a local Antora build.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
