### PR TITLE
debezium/dbz#248 Resolve CREATE TABLE LIKE schema when reference table not in cache

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -837,3 +837,4 @@ Davyd Eliosidze
 林石培
 Aleksandr Pavlyuk
 Roshni R
+刘镕通

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -527,6 +527,18 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "'warn' the problematic event and its binlog position will be logged and the event will be skipped; "
                     + "'ignore' the problematic event will be skipped.");
 
+    public static final Field RESOLVE_LIKE_TABLE_SCHEMA = Field.create("resolve.create.table.like.schema")
+            .withDisplayName("Resolve CREATE TABLE LIKE reference schema")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withDefault(false)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withGroup(Field.createGroupEntry(Field.Group.ADVANCED))
+            .withDescription("When a CREATE TABLE ... LIKE statement reference a table " +
+                    "whose schema is not in the internal cache(e.g., excluded by table filters), " +
+                    "automatically fetch the reference table's schema via SHOW CREATE TABLE " +
+                    "and retry DDL parsing. Default: false.");
+
     public static final Field INCONSISTENT_SCHEMA_HANDLING_MODE = Field.create("inconsistent.schema.handling.mode")
             .withDisplayName("Inconsistent schema failure handling")
             .withEnum(EventProcessingFailureHandlingMode.class, EventProcessingFailureHandlingMode.FAIL)
@@ -637,7 +649,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .group(Field.Group.FILTERS, TABLES_IGNORE_BUILTIN, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST)
-            .group(Field.Group.ADVANCED, EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE)
+            .group(Field.Group.ADVANCED, EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE, INCONSISTENT_SCHEMA_HANDLING_MODE, RESOLVE_LIKE_TABLE_SCHEMA)
             .create();
 
     private final Configuration config;
@@ -648,6 +660,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
     private final BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode;
     private final boolean readOnlyConnection;
     private final boolean ignoreGtidOnRecovery;
+    private final boolean resolveLikeTableSchema;
 
     /**
      * Create a binlog-based connector configuration.
@@ -674,6 +687,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
         this.inconsistentSchemaFailureHandlingMode = EventProcessingFailureHandlingMode.parse(config.getString(INCONSISTENT_SCHEMA_HANDLING_MODE));
         this.bigIntUnsignedHandlingMode = BigIntUnsignedHandlingMode.parse(config.getString(BIGINT_UNSIGNED_HANDLING_MODE));
         this.ignoreGtidOnRecovery = config.getBoolean(IGNORE_GTID_ON_RECOVERY);
+        this.resolveLikeTableSchema = config.getBoolean(RESOLVE_LIKE_TABLE_SCHEMA);
     }
 
     @Override
@@ -710,6 +724,13 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
      */
     public EventProcessingFailureHandlingMode getInconsistentSchemaFailureHandlingMode() {
         return inconsistentSchemaFailureHandlingMode;
+    }
+
+    /**
+     * @return whether to resolve CREATE TABLE LIKE reference table schema via JDBC when missing from cache
+     */
+    public boolean isResolveLikeTableSchema() {
+        return resolveLikeTableSchema;
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.KeyManager;
@@ -114,6 +115,17 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
     private static final String DML_DELETE_PREFIX = "DELETE ";
     private static final String DML_REPLACE_PREFIX = "REPLACE ";
 
+    /**
+     * Regex to detect Create TABLE ... LIKE statements and extract both the new table and the
+     * reference (template) table.
+     */
+    private static final Pattern CREATE_TABLE_LIKE_PATTERN = Pattern.compile(
+            "(?i)CREATE\\s+TABLE\\s+"
+                    + "(?:IF\\s+NOT\\s+EXISTS\\s+)?"
+                    + "(?:(`[^`]+`|[^.`\\s]+)\\.)?(`[^`]+`|[^.`\\s]+)"
+                    + "\\s+LIKE\\s+"
+                    + "(?:(`[^`]+`|[^.`\\s;]+)\\.)?(`[^`]+`|[^.\\s;]+)");
+
     private final BinaryLogClient client;
     private final BinlogStreamingChangeEventSourceMetrics<?, P> metrics;
     // todo: can we go back to accessing schema via task context? issue is all the generics :/
@@ -126,6 +138,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
     private final ErrorHandler errorHandler;
     private final EventProcessingFailureHandlingMode eventDeserializationFailureHandlingMode;
     private final EventProcessingFailureHandlingMode inconsistentSchemaHandlingMode;
+    private final boolean resolveLikeTableSchema;
     private final SnapshotterService snapshotterService;
     private final Predicate<String> gtidDmlSourceFilter;
     private final boolean isGtidModeEnabled;
@@ -164,6 +177,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         this.metrics = metrics;
         this.eventDeserializationFailureHandlingMode = connectorConfig.getEventProcessingFailureHandlingMode();
         this.inconsistentSchemaHandlingMode = connectorConfig.getInconsistentSchemaFailureHandlingMode();
+        this.resolveLikeTableSchema = connectorConfig.isResolveLikeTableSchema();
         this.snapshotterService = snapshotterService;
         this.client = client;
         configureBinaryLogClient(client, connectorConfig, binaryLogClientThreads, connection);
@@ -784,8 +798,17 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                     BinlogConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER.name());
         }
 
-        final List<SchemaChangeEvent> schemaChangeEvents = schema.parseStreamingDdl(partition, sql,
+        List<SchemaChangeEvent> schemaChangeEvents = schema.parseStreamingDdl(partition, sql,
                 command.getDatabase(), offsetContext, eventTime);
+
+        // DBZ-1496: Resolve-and-retry for CREATE TABLE ... LIKE statements.
+        // If parsing produced no schema change events and the DDL is a LIKE statement,
+        // try to resolve the reference table's schema via JDBC and try parsing.
+        if (schemaChangeEvents.isEmpty() && resolveLikeTableSchema) {
+            schemaChangeEvents = resolveCreateTableLikeAndRetry(partition, offsetContext, sql,
+                    command.getDatabase(), eventTime);
+        }
+
         try {
             for (SchemaChangeEvent schemaChangeEvent : schemaChangeEvents) {
                 if (schema.skipSchemaChangeEvent(schemaChangeEvent)) {
@@ -818,6 +841,87 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
 
     private String removeSetStatement(String sql) {
         return sql.replaceAll(SET_STATEMENT_REGEX, "").trim();
+    }
+
+    private List<SchemaChangeEvent> resolveCreateTableLikeAndRetry(P partition, O offsetContext,
+                                                                   String sql, String database, Instant eventTime) {
+        final TableId[] likeTables = extractLikeTables(sql, database);
+        if (likeTables == null || likeTables.length == 0) {
+            return List.of();
+        }
+        final TableId newTableId = likeTables[0];
+        final TableId refTableId = likeTables[1];
+
+        // An empty parse result can have several causes;only resolve when the reference schema is
+        // genuinely missing from the cache and the new table is one we are configured to capture.
+        // Otherwise(e.g. the new table is itself filtered out) there is nothing useful to do, and
+        // we avoid an unnecessary SHOW CREATE TABLE round-trip on the streaming thread.
+        if (schema.tableFor(refTableId) != null) {
+            return List.of();
+        }
+        if (!connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(newTableId)) {
+            return List.of();
+        }
+
+        LOGGER.info("Detected CREATE TABLE ... LIKE: new table {} referencing {}; attempting to resolve schema",
+                newTableId, refTableId);
+
+        final String refCreateDdl = fetchShowCreateTable(refTableId);
+        if (refCreateDdl == null) {
+            LOGGER.warn("Failed to resolve reference table schema for {}; " +
+                    "the new table {} will not be tracked until its schema is resolved", refTableId, newTableId);
+            return List.of();
+        }
+
+        final String syntheticDdl = refCreateDdl.replaceFirst(
+                "(?i)CREATE\\s+TABLE\\s+`?" + Pattern.quote(refTableId.table()) + "`?",
+                Matcher.quoteReplacement("CREATE TABLE `" + newTableId.table() + "`"));
+
+        LOGGER.info("Resolved schema for {} via SHOW CREATE TABLE on {}; parsing synthetic DDL", newTableId, refTableId);
+
+        // Parse the synthetic DDL to register the new table's schema
+        return schema.parseStreamingDdl(partition, syntheticDdl, newTableId.catalog(), offsetContext, eventTime);
+    }
+
+    /**
+     * Extract the new table and reference (template) table from a {@code CREATE TABLE ... LIKE}
+     * statement
+     */
+    static TableId[] extractLikeTables(String sql, String currentDatabase) {
+        final String stripped = sql.replaceFirst("(?s)^\\s*/\\*.*?\\*/\\s*", "");
+        final Matcher matcher = CREATE_TABLE_LIKE_PATTERN.matcher(stripped);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        final TableId newTableId = new TableId(unquote(matcher.group(1), currentDatabase), null, unquote(matcher.group(2), null));
+        final TableId refTableId = new TableId(unquote(matcher.group(3), currentDatabase), null, unquote(matcher.group(4), null));
+        return new TableId[]{ newTableId, refTableId };
+    }
+
+    private static String unquote(String identifier, String fallback) {
+        return identifier == null ? fallback : identifier.replace("`", "");
+    }
+
+    private String fetchShowCreateTable(TableId tableId) {
+        String quotedRef = (tableId.catalog() != null)
+                ? "`" + tableId.catalog() + "`.`" + tableId.table() + "`"
+                : "`" + tableId.table() + "`";
+
+        try {
+            return connection.queryAndMap(
+                    "SHOW CREATE TABLE " + quotedRef,
+                    rs -> {
+                        if (rs.next()) {
+                            return rs.getString(2);
+                        }
+                        return null;
+                    });
+        }
+        catch (SQLException e) {
+            LOGGER.warn("SHOW CREATE TABLE {} FAILED, {}", tableId, e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -119,12 +119,13 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
      * Regex to detect Create TABLE ... LIKE statements and extract both the new table and the
      * reference (template) table.
      */
-    private static final Pattern CREATE_TABLE_LIKE_PATTERN = Pattern.compile(
-            "(?i)CREATE\\s+TABLE\\s+"
-                    + "(?:IF\\s+NOT\\s+EXISTS\\s+)?"
-                    + "(?:(`[^`]+`|[^.`\\s]+)\\.)?(`[^`]+`|[^.`\\s]+)"
-                    + "\\s+LIKE\\s+"
-                    + "(?:(`[^`]+`|[^.`\\s;]+)\\.)?(`[^`]+`|[^.\\s;]+)");
+    private static final Pattern CREATE_TABLE_LIKE_PATTERN = Pattern.compile("""
+            (?i)CREATE\\s+TABLE\\s+\
+            (?:IF\\s+NOT\\s+EXISTS\\s+)?\
+            (?:(`[^`]+`|[^.`\\s]+)\\.)?(`[^`]+`|[^.`\\s]+)\
+            \\s+LIKE\\s+\
+            (?:(`[^`]+`|[^.`\\s;]+)\\.)?(`[^`]+`|[^.\\s;]+)\
+            """);
 
     private final BinaryLogClient client;
     private final BinlogStreamingChangeEventSourceMetrics<?, P> metrics;
@@ -801,7 +802,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         List<SchemaChangeEvent> schemaChangeEvents = schema.parseStreamingDdl(partition, sql,
                 command.getDatabase(), offsetContext, eventTime);
 
-        // DBZ-1496: Resolve-and-retry for CREATE TABLE ... LIKE statements.
+        // DBZ-248: Resolve-and-retry for CREATE TABLE ... LIKE statements.
         // If parsing produced no schema change events and the DDL is a LIKE statement,
         // try to resolve the reference table's schema via JDBC and try parsing.
         if (schemaChangeEvents.isEmpty() && resolveLikeTableSchema) {
@@ -874,8 +875,8 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         }
 
         final String syntheticDdl = refCreateDdl.replaceFirst(
-                "(?i)CREATE\\s+TABLE\\s+`?" + Pattern.quote(refTableId.table()) + "`?",
-                Matcher.quoteReplacement("CREATE TABLE `" + newTableId.table() + "`"));
+                "(?i)CREATE\\s+TABLE\\s+`?%s`?".formatted(Pattern.quote(refTableId.table())),
+                Matcher.quoteReplacement("CREATE TABLE `%s`".formatted(newTableId.table())));
 
         LOGGER.info("Resolved schema for {} via SHOW CREATE TABLE on {}; parsing synthetic DDL", newTableId, refTableId);
 
@@ -905,8 +906,8 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
 
     private String fetchShowCreateTable(TableId tableId) {
         String quotedRef = (tableId.catalog() != null)
-                ? "`" + tableId.catalog() + "`.`" + tableId.table() + "`"
-                : "`" + tableId.table() + "`";
+                ? "`%s`.`%s`".formatted(tableId.catalog(), tableId.table())
+                : "`%s`".formatted(tableId.table());
 
         try {
             return connection.queryAndMap(

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.util.BinlogTestConnection;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.history.SchemaHistory;
+
+/**
+ * @author leosanqing
+ */
+public abstract class BinlogCreateTableLikeSchemaResolutionIT<C extends SourceConnector>
+        extends AbstractBinlogConnectorIT<C> {
+
+    private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-create-table-like.txt")
+            .toAbsolutePath();
+
+    private final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase("like_resolution_it", "create_table_like_test")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    private Configuration.Builder configWithCredentials(Configuration.Builder builder) {
+        return builder
+                .with(BinlogConnectorConfig.USER, System.getProperty("database.user", "snapper"))
+                .with(BinlogConnectorConfig.PASSWORD, System.getProperty("database.password", "snapperpass"));
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1496")
+    public void shouldResolveCreateTableLikeWithFilteredReferenceTable() throws Exception {
+        // Configure connector to capture only shard_* tables (exclude template_table).
+        config = configWithCredentials(DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)
+                .with("snapshot.locking.mode", "none")
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("shard_.*"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.RESOLVE_LIKE_TABLE_SCHEMA, true))
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
+                .build();
+
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName(), getStreamingNamespace());
+
+        // During streaming, execute CREATE TABLE shard_002 LIKE template_table
+        // followed by an INSERT into shard_002.
+        try (BinlogTestConnection connection = getTestDatabaseConnection(DATABASE.getDatabaseName())) {
+            connection.execute(
+                    "CREATE TABLE `shard_002` LIKE `template_table`",
+                    "INSERT INTO `shard_002` (`name`, `status`) VALUES ('from_like_table', 2)");
+        }
+
+        waitForAvailableRecords(10, TimeUnit.SECONDS);
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        List<SourceRecord> shard002Records = streamingRecords.recordsForTopic(DATABASE.topicForTable("shard_002"));
+        assertThat(shard002Records).isNotNull().hasSize(1);
+
+        Struct value = (Struct) shard002Records.get(0).value();
+        assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+
+        Struct after = value.getStruct("after");
+        assertThat(after.getString("name")).isEqualTo("from_like_table");
+        assertThat(after.getInt32("status")).isEqualTo(2);
+
+        stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-1496")
+    public void shouldResolveCreateTableLikeWithCrossDatabaseReference() throws Exception {
+        // Test cross-database CREATE TABLE LIKE: shard_004 like <db>.template_table
+        config = configWithCredentials(DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)
+                .with("snapshot.locking.mode", "none")
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("shard_.*"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.RESOLVE_LIKE_TABLE_SCHEMA, true))
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
+                .build();
+
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName(), getStreamingNamespace());
+
+        String qualifiedRef = "`" + DATABASE.getDatabaseName() + "`.`template_table`";
+        try (BinlogTestConnection connection = getTestDatabaseConnection(DATABASE.getDatabaseName())) {
+            connection.execute(
+                    "CREATE TABLE `shard_004` LIKE " + qualifiedRef,
+                    "INSERT INTO `shard_004` (`name`, `status`) VALUES ('cross_db_ref', 4)");
+        }
+
+        // Should capture the INSERT because schema was resolved
+        waitForAvailableRecords(10, TimeUnit.SECONDS);
+        SourceRecords streamingRecords = consumeRecordsByTopic(1);
+        List<SourceRecord> shard004Records = streamingRecords.recordsForTopic(DATABASE.topicForTable("shard_004"));
+        assertThat(shard004Records).isNotNull().hasSize(1);
+
+        Struct value = (Struct) shard004Records.get(0).value();
+        assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+
+        Struct after = value.getStruct("after");
+        assertThat(after.getString("name")).isEqualTo("cross_db_ref");
+        assertThat(after.getInt32("status")).isEqualTo(4);
+
+        stopConnector();
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionIT.java
@@ -65,7 +65,7 @@ public abstract class BinlogCreateTableLikeSchemaResolutionIT<C extends SourceCo
     }
 
     @Test
-    @FixFor("DBZ-1496")
+    @FixFor("DBZ-248")
     public void shouldResolveCreateTableLikeWithFilteredReferenceTable() throws Exception {
         // Configure connector to capture only shard_* tables (exclude template_table).
         config = configWithCredentials(DATABASE.defaultConfig()
@@ -104,7 +104,7 @@ public abstract class BinlogCreateTableLikeSchemaResolutionIT<C extends SourceCo
     }
 
     @Test
-    @FixFor("DBZ-1496")
+    @FixFor("DBZ-248")
     public void shouldResolveCreateTableLikeWithCrossDatabaseReference() throws Exception {
         // Test cross-database CREATE TABLE LIKE: shard_004 like <db>.template_table
         config = configWithCredentials(DATABASE.defaultConfig()

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogCreateTableLikeSchemaResolutionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+
+public class BinlogCreateTableLikeSchemaResolutionTest {
+
+    private TableId extractViaPattern(String sql, String currentDatabase) {
+        TableId[] tables = BinlogStreamingChangeEventSource.extractLikeTables(sql, currentDatabase);
+        return tables == null ? null : tables[1];
+    }
+
+    private TableId extractNewTable(String sql, String currentDatabase) {
+        TableId[] tables = BinlogStreamingChangeEventSource.extractLikeTables(sql, currentDatabase);
+        return tables == null ? null : tables[0];
+    }
+
+    @Test
+    public void shouldExtractSimpleLikeReference() {
+        TableId ref = extractViaPattern("CREATE TABLE new_shard LIKE template_table", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldExtractBacktickQuotedReference() {
+        TableId ref = extractViaPattern("CREATE TABLE `new_shard` LIKE `template_table`", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldExtractCrossDatabaseReference() {
+        TableId ref = extractViaPattern("CREATE TABLE `db1`.`new_shard` LIKE `db2`.`template_table`", "db1");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("db2");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldExtractCrossDatabaseReferenceWithoutBackticks() {
+        TableId ref = extractViaPattern("CREATE TABLE db1.new_shard LIKE db2.template_table", "db1");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("db2");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldExtractIfNotExistsLikeReference() {
+        TableId ref = extractViaPattern("CREATE TABLE IF NOT EXISTS new_shard LIKE template_table", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldBeCaseInsensitive() {
+        TableId ref = extractViaPattern("create table new_shard like template_table", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldHandleLeadingSqlComment() {
+        TableId ref = extractViaPattern("/* Test Mock */ CREATE TABLE new_shard LIKE template_table", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldHandleTrailingSqlComment() {
+        TableId ref = extractViaPattern("CREATE TABLE new_shard LIKE template_table;", "test_db");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("test_db");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldReturnNullForNonLikeDdl() {
+        assertThat(extractViaPattern("CREATE TABLE t(id INT PRIMARY KEY)", "test_db")).isNull();
+        assertThat(extractViaPattern("ALTER TABLE t ADD COLUMN c INT", "test_db")).isNull();
+        assertThat(extractViaPattern("DROP TABLE t", "test_db")).isNull();
+        assertThat(extractViaPattern("INSERT INTO t VALUES (1)", "test_db")).isNull();
+    }
+
+    @Test
+    public void shouldReturnNullForCreateTableAsSelect() {
+        assertThat(extractViaPattern(
+                "CREATE TABLE new_table AS SELECT * FROM old_table", "test_db")).isNull();
+    }
+
+    @Test
+    public void shouldExtraWithMixedQuoting() {
+        TableId ref = extractViaPattern("CREATE TABLE `db1`.new_shard LIKE `db2`.template_table", "db1");
+        assertThat(ref).isNotNull();
+        assertThat(ref.catalog()).isEqualTo("db2");
+        assertThat(ref.table()).isEqualTo("template_table");
+    }
+
+    @Test
+    public void shouldExtraNewTableAndDatabase() {
+        TableId newTable = extractNewTable("CREATE TABLE `db1`.new_shard LIKE `db2`.template_table", "db1");
+        assertThat(newTable).isNotNull();
+        assertThat(newTable.catalog()).isEqualTo("db1");
+        assertThat(newTable.table()).isEqualTo("new_shard");
+    }
+
+    @Test
+    public void shouldFallBackToCurrentDatabaseForUnqualifiedNewTable() {
+        TableId newTable = extractNewTable("CREATE TABLE new_shard LIKE template_table", "db1");
+        assertThat(newTable).isNotNull();
+        assertThat(newTable.catalog()).isEqualTo("db1");
+        assertThat(newTable.table()).isEqualTo("new_shard");
+    }
+
+    @Test
+    public void shouldExtraIdentifiersContainingDollarSign() {
+        TableId[] tables = BinlogStreamingChangeEventSource.extractLikeTables(
+                "CREATE TABLE new_shard$2 LIKE template$table", "test_db");
+        assertThat(tables).isNotNull();
+        assertThat(tables[0].table()).isEqualTo("new_shard$2");
+        assertThat(tables[1].table()).isEqualTo("template$table");
+    }
+
+}

--- a/debezium-connector-binlog/src/test/resources/ddl/create_table_like_test.sql
+++ b/debezium-connector-binlog/src/test/resources/ddl/create_table_like_test.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `template_table`
+(
+    `id`        INT          NOT NULL AUTO_INCREMENT,
+    `name`      VARCHAR(255) NOT NULL,
+    `status`    INT      DEFAULT 0,
+    `create_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `shard_001`
+(
+    `id`        INT          NOT NULL AUTO_INCREMENT,
+    `name`      VARCHAR(255) NOT NULL,
+    `status`    INT      DEFAULT 0,
+    `create_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+INSERT INTO `shard_001` (`name`, `status`)
+VALUES ('initial_record', 1);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlCreateTableLikeSchemaResolutionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlCreateTableLikeSchemaResolutionIT.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.binlog.BinlogCreateTableLikeSchemaResolutionIT;
+
+public class MySqlCreateTableLikeSchemaResolutionIT
+        extends BinlogCreateTableLikeSchemaResolutionIT<MySqlConnector>
+        implements MySqlCommon {
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -379,3 +379,4 @@ Tayler,Tayler Dunn
 vincadrn,Vincentius Adrian
 Roshr2211,Roshni R
 sagnghos,Sagnik Ghosh
+leosanqing,刘镕通


### PR DESCRIPTION

Fixes debezium/dbz#248
## Description
Resolve CREATE TABLE LIKE schema when reference table not in cache

## Implementation / Solution
Due to the limitation of the `store.only.captured.databases.ddl` parameter, a "table not found" exception occurs if the referenced table falls outside the regex rules. This happens because the regex for the template table does not always match the regex for the fact table.

* Used string replacement to fully complete the DDL of the created table. 
* The newly created tables are now stored in memory for independent management.

When the template table is updated, newly created tables will still fetch and apply the most up-to-date DDL.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
