### PR TITLE
debezium/dbz#1479 Reset RemainingTableCount metric when data snapshot is skipped

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -199,6 +199,12 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             else {
                 LOGGER.info("Snapshot step 7 - Skipping snapshotting of data");
                 releaseDataSnapshotLocks(ctx);
+                // debezium/dbz#1479: no data is snapshotted (e.g. snapshot.mode=no_data/schema_only), so mark every
+                // captured table as completed with zero rows; otherwise the RemainingTableCount metric would
+                // stay at the full captured-table count forever, since only the data snapshot drains it.
+                for (TableId tableId : ctx.capturedTables) {
+                    snapshotProgressListener.dataCollectionSnapshotCompleted(ctx.partition, tableId, 0);
+                }
                 ctx.offset.preSnapshotCompletion();
                 ctx.offset.postSnapshotCompletion();
             }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+/**
+ * Unit tests for {@link SnapshotMeter}, in particular the {@code TotalTableCount}/{@code RemainingTableCount}
+ * bookkeeping that backs the snapshot JMX metrics.
+ */
+public class SnapshotMeterTest {
+
+    private final SnapshotMeter meter = new SnapshotMeter(Clock.system());
+
+    private static final TableId TABLE_A = TableId.parse("db.schema.a");
+    private static final TableId TABLE_B = TableId.parse("db.schema.b");
+
+    @Test
+    public void shouldTrackRemainingTablesAsDataSnapshotCompletes() {
+        meter.monitoredDataCollectionsDetermined(List.of(TABLE_A, TABLE_B));
+        assertThat(meter.getTotalTableCount()).isEqualTo(2);
+        assertThat(meter.getRemainingTableCount()).isEqualTo(2);
+
+        meter.dataCollectionSnapshotCompleted(TABLE_A, 10);
+        assertThat(meter.getRemainingTableCount()).isEqualTo(1);
+
+        meter.dataCollectionSnapshotCompleted(TABLE_B, 20);
+        assertThat(meter.getRemainingTableCount()).isEqualTo(0);
+        // The total (captured) count is unaffected by completion.
+        assertThat(meter.getTotalTableCount()).isEqualTo(2);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1479")
+    public void shouldReportNoRemainingTablesWhenDataIsNotSnapshotted() {
+        // Reproduces the snapshot.mode=no_data path: tables are monitored (so TotalTableCount/CapturedTables
+        // are populated), but no data snapshot runs. Marking each captured table completed with zero rows must
+        // drain RemainingTableCount to 0, while leaving the captured-table count intact.
+        meter.monitoredDataCollectionsDetermined(List.of(TABLE_A, TABLE_B));
+        assertThat(meter.getRemainingTableCount()).isEqualTo(2);
+
+        for (TableId tableId : List.of(TABLE_A, TABLE_B)) {
+            meter.dataCollectionSnapshotCompleted(tableId, 0);
+        }
+
+        assertThat(meter.getRemainingTableCount()).isEqualTo(0);
+        assertThat(meter.getTotalTableCount()).isEqualTo(2);
+        assertThat(meter.getCapturedTables()).containsExactlyInAnyOrder(TABLE_A.identifier(), TABLE_B.identifier());
+    }
+}

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
@@ -284,6 +284,8 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
         // Check snapshot metrics
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "TotalNumberOfEventsSeen")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotCompleted")).isEqualTo(snapshotCompleted());
+        // debezium/dbz#1479: with snapshot.mode=no_data no table is data-snapshotted, so no tables remain
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "RemainingTableCount")).isEqualTo(0);
     }
 
     protected void assertStreamingMetrics(boolean checkAdvancedMetrics, long expectedEvents) throws Exception {


### PR DESCRIPTION
Fixes debezium/dbz#1479

## Description

When a connector runs with `snapshot.mode=no_data` (or `schema_only`), the `RemainingTableCount` JMX metric stays at the full captured-table count forever, even though no table is ever data-snapshotted.

**Root cause:** during the snapshot, `RelationalSnapshotChangeEventSource.doExecute()` always calls `SnapshotProgressListener.monitoredDataCollectionsDetermined(...)`, which populates both the captured-table set (backing `TotalTableCount`/`CapturedTables`) and the remaining-table set (backing `RemainingTableCount`). The remaining-table set is only ever drained by `dataCollectionSnapshotCompleted(...)`, which is invoked exclusively from `createDataEvents(...)` — i.e. only while data is being snapshotted. With `no_data`, the "Snapshot step 7 - Snapshotting data" stage is skipped, so the remaining-table set is never drained and the metric is stuck at the captured-table count.

**Fix:** when the data snapshot step is skipped, mark every captured table as completed with zero rows. This drains `RemainingTableCount` to `0` while leaving `TotalTableCount`/`CapturedTables` intact. This mirrors the existing handling for tables without a snapshot select query (which already calls `dataCollectionSnapshotCompleted(..., 0)`).

The fix lives in the shared `RelationalSnapshotChangeEventSource`, so it applies uniformly to all relational connectors (MySQL, MariaDB, PostgreSQL, Oracle, SQL Server, Db2). Modes that skip the snapshot entirely (e.g. `never`) are unaffected, since they never enter `doExecute()`.

### Tests
- Added an assertion to the shared `AbstractMetricsTest.assertSnapshotNotExecutedMetrics()` that `RemainingTableCount == 0` for streaming-only (`no_data`) connectors. Each relational connector's metrics IT maps `noSnapshot` to `NO_DATA`, so this exercises the path on all of them. Verified RED (`expected: 0 but was: 1`) without the fix and GREEN with it on `MySqlMetricsIT#testStreamingOnlyMetrics`.
- Added `SnapshotMeterTest`, a unit test covering the `TotalTableCount`/`RemainingTableCount` bookkeeping (previously untested).
