### PR TITLE
debezium/dbz#1174 Add JMX metrics to the JDBC sink connector

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -35,6 +35,7 @@ import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.field.FieldDescriptor;
+import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;
@@ -57,15 +58,17 @@ public class DefaultRecordWriter implements RecordWriter {
     private final DatabaseDialect dialect;
     private final int flushMaxRetries;
     private final Duration flushRetryDelay;
+    private final SinkProgressListener progressListener;
 
     protected DefaultRecordWriter(SharedSessionContract session, QueryBinderResolver queryBinderResolver,
-                                  JdbcSinkConnectorConfig config, DatabaseDialect dialect) {
+                                  JdbcSinkConnectorConfig config, DatabaseDialect dialect, SinkProgressListener progressListener) {
         this.session = session;
         this.queryBinderResolver = queryBinderResolver;
         this.config = config;
         this.dialect = dialect;
         this.flushMaxRetries = config.getFlushMaxRetries();
         this.flushRetryDelay = Duration.of(config.getFlushRetryDelayMs(), ChronoUnit.MILLIS);
+        this.progressListener = progressListener;
     }
 
     protected SharedSessionContract getSession() {
@@ -147,6 +150,7 @@ public class DefaultRecordWriter implements RecordWriter {
             transaction.rollback();
             throw e;
         }
+        progressListener.tableCreated();
 
         return readTable(collectionId);
     }
@@ -201,6 +205,7 @@ public class DefaultRecordWriter implements RecordWriter {
             transaction.rollback();
             throw e;
         }
+        progressListener.tableAltered();
 
         return readTable(collectionId);
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -33,6 +33,7 @@ import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.openlineage.dataset.DatasetMetadata;
 import io.debezium.sink.DebeziumSinkRecord;
 import io.debezium.sink.spi.ChangeEventSink;
+import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.util.Stopwatch;
 
 /**
@@ -52,14 +53,16 @@ public class JdbcChangeEventSink implements ChangeEventSink {
 
     private final RecordWriter recordWriter;
     private final ConnectorContext connectorContext;
+    private final SinkProgressListener progressListener;
 
     public JdbcChangeEventSink(JdbcSinkConnectorConfig config, StatelessSession session, DatabaseDialect dialect, RecordWriter recordWriter,
-                               ConnectorContext connectorContext) {
+                               ConnectorContext connectorContext, SinkProgressListener progressListener) {
         this.config = config;
         this.dialect = dialect;
         this.session = session;
         this.recordWriter = recordWriter;
         this.connectorContext = connectorContext;
+        this.progressListener = progressListener;
 
         final DatabaseVersion version = this.dialect.getVersion();
         LOGGER.info("Database version {}.{}.{}", version.getMajor(), version.getMinor(), version.getMicro());
@@ -75,6 +78,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
 
             if (record.isSchemaChange()) {
                 SCHEMA_CHANGE_LOGGER.warn("Ignored schema change event for topic '{}'. " + FOUND_SCHEMA_CHANGE_RECORD_MSG, record.topicName());
+                progressListener.filtered();
                 continue;
             }
 
@@ -82,12 +86,14 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             if (null == collectionId) {
                 LOGGER.warn("Ignored to write record from topic '{}' partition '{}' offset '{}'. No resolvable table name", record.topicName(), record.partition(),
                         record.offset());
+                progressListener.filtered();
                 continue;
             }
 
             if (record.isTruncate()) {
                 if (!config.isTruncateEnabled()) {
                     LOGGER.debug("Truncates are not enabled, skipping truncate for topic '{}'", record.topicName());
+                    progressListener.filtered();
                     continue;
                 }
 
@@ -98,6 +104,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 try {
                     final TableDescriptor table = recordWriter.checkAndApplyTableChangesIfNeeded(collectionId, record);
                     recordWriter.writeTruncate(table.getId());
+                    progressListener.truncated();
                     continue;
                 }
                 catch (SQLException | JDBCException e) {
@@ -108,6 +115,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
             if (record.isDelete() || record.isTombstone()) {
                 if (!config.isDeleteEnabled()) {
                     LOGGER.debug("Deletes are not enabled, skipping delete for topic '{}'", record.topicName());
+                    progressListener.filtered();
                     continue;
                 }
 
@@ -124,6 +132,7 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 }
 
                 flushBufferRecordsWithRetries(collectionId, getRecordsToFlush(deleteBufferByTable, collectionId, record));
+                progressListener.deleted();
             }
             else {
                 final Buffer deleteBufferToFlush = deleteBufferByTable.get(collectionId);
@@ -139,11 +148,20 @@ public class JdbcChangeEventSink implements ChangeEventSink {
                 }
 
                 flushBufferRecordsWithRetries(collectionId, getRecordsToFlush(upsertBufferByTable, collectionId, record));
+                recordWriteOperation();
             }
         }
 
         flushBuffers(upsertBufferByTable);
         flushBuffers(deleteBufferByTable);
+    }
+
+    private void recordWriteOperation() {
+        switch (config.getInsertMode()) {
+            case INSERT -> progressListener.inserted();
+            case UPDATE -> progressListener.updated();
+            case UPSERT -> progressListener.upserted();
+        }
     }
 
     private BufferFlushRecords getRecordsToFlush(Map<CollectionId, Buffer> bufferMap, CollectionId collectionId, JdbcSinkRecord record) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -42,6 +42,7 @@ import io.debezium.connector.common.DebeziumTaskState;
 import io.debezium.connector.common.UUIDUtils;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectResolver;
+import io.debezium.connector.jdbc.metrics.JdbcSinkConnectorMetrics;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.openlineage.dataset.DatasetDataExtractor;
@@ -74,6 +75,7 @@ public class JdbcSinkConnectorTask extends SinkTask {
     private final ReentrantLock stateLock = new ReentrantLock();
 
     private JdbcChangeEventSink changeEventSink;
+    private JdbcSinkConnectorMetrics metrics;
     private final Set<TopicPartition> assignedPartitions = new HashSet<>();
     private final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
     private Throwable previousPutException;
@@ -108,7 +110,7 @@ public class JdbcSinkConnectorTask extends SinkTask {
 
         try {
             final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(props);
-            String connectorName = props.get(ConfigurationNames.CONNECTOR_NAME_PROPERTY);
+            String connectorName = Strings.defaultIfBlank(props.get(ConfigurationNames.CONNECTOR_NAME_PROPERTY), config.getConnectorName());
             String taskId = props.getOrDefault(TASK_ID_PROPERTY_NAME, "0");
             connectorContext = new ConnectorContext(connectorName, Module.name(), taskId, Module.version(), UUIDUtils.generateNewUUID(),
                     getMaskedConfigurationMap(props));
@@ -133,7 +135,11 @@ public class JdbcSinkConnectorTask extends SinkTask {
             // Instantiate the appropriate RecordWriter based on dialect and configuration
             RecordWriter recordWriter = createRecordWriter(session, queryBinderResolver, config, dialect);
 
-            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext);
+            metrics = new JdbcSinkConnectorMetrics(connectorName, taskId);
+            metrics.register();
+            metrics.connected(true);
+
+            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics);
             DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING);
         }
         finally {
@@ -243,6 +249,10 @@ public class JdbcSinkConnectorTask extends SinkTask {
     public void stop() {
         stateLock.lock();
         try {
+            if (metrics != null) {
+                metrics.connected(false);
+                metrics.unregister();
+            }
             if (changeEventSink != null) {
                 changeEventSink.close();
                 try {
@@ -267,6 +277,7 @@ public class JdbcSinkConnectorTask extends SinkTask {
             if (changeEventSink != null) {
                 changeEventSink = null;
             }
+            metrics = null;
             stateLock.unlock();
             DebeziumOpenLineageEmitter.cleanup(connectorContext);
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -47,6 +47,7 @@ import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.openlineage.dataset.DatasetDataExtractor;
 import io.debezium.openlineage.dataset.DatasetMetadata;
+import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.util.Stopwatch;
 import io.debezium.util.Strings;
 
@@ -132,12 +133,12 @@ public class JdbcSinkConnectorTask extends SinkTask {
             DatabaseDialect dialect = DatabaseDialectResolver.resolve(config, sessionFactory);
             QueryBinderResolver queryBinderResolver = new QueryBinderResolver();
 
-            // Instantiate the appropriate RecordWriter based on dialect and configuration
-            RecordWriter recordWriter = createRecordWriter(session, queryBinderResolver, config, dialect);
-
             metrics = new JdbcSinkConnectorMetrics(connectorName, taskId);
             metrics.register();
             metrics.connected(true);
+
+            // Instantiate the appropriate RecordWriter based on dialect and configuration
+            RecordWriter recordWriter = createRecordWriter(session, queryBinderResolver, config, dialect, metrics);
 
             changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics);
             DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING);
@@ -196,16 +197,16 @@ public class JdbcSinkConnectorTask extends SinkTask {
      * otherwise returns StandardRecordWriter.
      */
     private RecordWriter createRecordWriter(StatelessSession session, QueryBinderResolver queryBinderResolver,
-                                            JdbcSinkConnectorConfig config, DatabaseDialect databaseDialect) {
+                                            JdbcSinkConnectorConfig config, DatabaseDialect databaseDialect, SinkProgressListener progressListener) {
         // Use UNNEST writer when explicitly enabled (opt-in)
         // This allows any PostgreSQL-compatible dialect to use UNNEST without code changes
         if (config.isPostgresUnnestInsertEnabled()) {
             LOGGER.info("Using UnnestRecordWriter for UNNEST optimization");
-            return new UnnestRecordWriter(session, queryBinderResolver, config, databaseDialect);
+            return new UnnestRecordWriter(session, queryBinderResolver, config, databaseDialect, progressListener);
         }
 
         LOGGER.info("Using DefaultRecordWriter for standard JDBC batching");
-        return new DefaultRecordWriter(session, queryBinderResolver, config, databaseDialect);
+        return new DefaultRecordWriter(session, queryBinderResolver, config, databaseDialect, progressListener);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
@@ -27,6 +27,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.util.Stopwatch;
 
 /**
@@ -46,8 +47,8 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
     private static final Logger LOGGER = LoggerFactory.getLogger(UnnestRecordWriter.class);
 
     public UnnestRecordWriter(SharedSessionContract session, QueryBinderResolver queryBinderResolver,
-                              JdbcSinkConnectorConfig config, DatabaseDialect dialect) {
-        super(session, queryBinderResolver, config, dialect);
+                              JdbcSinkConnectorConfig config, DatabaseDialect dialect, SinkProgressListener progressListener) {
+        super(session, queryBinderResolver, config, dialect, progressListener);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
@@ -41,6 +41,8 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     private final AtomicLong totalNumberOfDeleteEventsSeen = new AtomicLong();
     private final AtomicLong totalNumberOfTruncateEventsSeen = new AtomicLong();
     private final AtomicLong numberOfFilteredEvents = new AtomicLong();
+    private final AtomicLong totalNumberOfTablesCreated = new AtomicLong();
+    private final AtomicLong totalNumberOfTablesAltered = new AtomicLong();
     private final AtomicBoolean connected = new AtomicBoolean();
 
     public JdbcSinkConnectorMetrics(String connectorName, String taskId) {
@@ -92,6 +94,16 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     }
 
     @Override
+    public void tableCreated() {
+        totalNumberOfTablesCreated.incrementAndGet();
+    }
+
+    @Override
+    public void tableAltered() {
+        totalNumberOfTablesAltered.incrementAndGet();
+    }
+
+    @Override
     public void connected(boolean connected) {
         this.connected.set(connected);
     }
@@ -124,6 +136,16 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     @Override
     public long getNumberOfFilteredEvents() {
         return numberOfFilteredEvents.get();
+    }
+
+    @Override
+    public long getTotalNumberOfTablesCreated() {
+        return totalNumberOfTablesCreated.get();
+    }
+
+    @Override
+    public long getTotalNumberOfTablesAltered() {
+        return totalNumberOfTablesAltered.get();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.metrics;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.apache.kafka.common.utils.Sanitizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.pipeline.JmxUtils;
+import io.debezium.sink.spi.SinkProgressListener;
+
+/**
+ * JMX metrics for the JDBC sink connector. Counters are updated on the record-processing path and
+ * exposed under the {@code debezium.jdbc:type=connector-metrics,context=sink,...} object name,
+ * consistent with how Debezium source connectors expose their metrics.
+ *
+ */
+@ThreadSafe
+public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean, SinkProgressListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcSinkConnectorMetrics.class);
+
+    private static final String JMX_OBJECT_NAME_FORMAT = "debezium.jdbc:type=connector-metrics,context=sink,server=%s,task=%s";
+
+    private final ObjectName objectName;
+
+    private final AtomicLong totalNumberOfInsertEventsSeen = new AtomicLong();
+    private final AtomicLong totalNumberOfUpdateEventsSeen = new AtomicLong();
+    private final AtomicLong totalNumberOfUpsertEventsSeen = new AtomicLong();
+    private final AtomicLong totalNumberOfDeleteEventsSeen = new AtomicLong();
+    private final AtomicLong totalNumberOfTruncateEventsSeen = new AtomicLong();
+    private final AtomicLong numberOfFilteredEvents = new AtomicLong();
+    private final AtomicBoolean connected = new AtomicBoolean();
+
+    public JdbcSinkConnectorMetrics(String connectorName, String taskId) {
+        final String name = String.format(JMX_OBJECT_NAME_FORMAT, Sanitizer.jmxSanitize(connectorName), Sanitizer.jmxSanitize(taskId));
+        try {
+            this.objectName = new ObjectName(name);
+        }
+        catch (MalformedObjectNameException e) {
+            throw new DebeziumException("Invalid metric name '" + name + "'", e);
+        }
+    }
+
+    public void register() {
+        JmxUtils.registerMXBean(objectName, this);
+    }
+
+    public void unregister() {
+        JmxUtils.unregisterMXBean(objectName);
+    }
+
+    @Override
+    public void inserted() {
+        totalNumberOfInsertEventsSeen.incrementAndGet();
+    }
+
+    @Override
+    public void updated() {
+        totalNumberOfUpdateEventsSeen.incrementAndGet();
+    }
+
+    @Override
+    public void upserted() {
+        totalNumberOfUpsertEventsSeen.incrementAndGet();
+    }
+
+    @Override
+    public void deleted() {
+        totalNumberOfDeleteEventsSeen.incrementAndGet();
+    }
+
+    @Override
+    public void truncated() {
+        totalNumberOfTruncateEventsSeen.incrementAndGet();
+    }
+
+    @Override
+    public void filtered() {
+        numberOfFilteredEvents.incrementAndGet();
+    }
+
+    @Override
+    public void connected(boolean connected) {
+        this.connected.set(connected);
+    }
+
+    @Override
+    public long getTotalNumberOfInsertEventsSeen() {
+        return totalNumberOfInsertEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfUpdateEventsSeen() {
+        return totalNumberOfUpdateEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfUpsertEventsSeen() {
+        return totalNumberOfUpsertEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfDeleteEventsSeen() {
+        return totalNumberOfDeleteEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfTruncateEventsSeen() {
+        return totalNumberOfTruncateEventsSeen.get();
+    }
+
+    @Override
+    public long getNumberOfFilteredEvents() {
+        return numberOfFilteredEvents.get();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected.get();
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
@@ -53,6 +53,18 @@ public interface JdbcSinkConnectorMetricsMXBean {
     long getNumberOfFilteredEvents();
 
     /**
+     * @return the total number of tables the sink created in the target database; only increases
+     *         when {@code schema.evolution} is enabled
+     */
+    long getTotalNumberOfTablesCreated();
+
+    /**
+     * @return the total number of tables the sink altered in the target database; only increases
+     *         when {@code schema.evolution} is enabled
+     */
+    long getTotalNumberOfTablesAltered();
+
+    /**
      * @return {@code true} if the connection to the target database is currently established
      */
     boolean isConnected();

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.metrics;
+
+/**
+ * Metrics exposed by the JDBC sink connector over JMX.
+ * <p>
+ * Kafka Connect already exposes record-throughput and batch metrics for every sink task (e.g.
+ * {@code sink-record-send-rate}, {@code put-batch-avg-time-ms}). Those stop at the connector's
+ * {@code put()} boundary and say nothing about the target database. These metrics intentionally
+ * complement them by describing what the sink actually applied to the target: the number of
+ * insert/update/upsert/delete/truncate operations, how many records were skipped, and whether the
+ * connection to the target database is currently established.
+ * <p>
+ * Insert, update, and upsert operations are counted according to the connector's configured
+ * {@code insert.mode}, which determines the SQL statement that is used for non-delete records.
+ *
+ */
+public interface JdbcSinkConnectorMetricsMXBean {
+
+    /**
+     * @return the total number of insert operations applied to the target database
+     */
+    long getTotalNumberOfInsertEventsSeen();
+
+    /**
+     * @return the total number of update operations applied to the target database
+     */
+    long getTotalNumberOfUpdateEventsSeen();
+
+    /**
+     * @return the total number of upsert operations applied to the target database
+     */
+    long getTotalNumberOfUpsertEventsSeen();
+
+    /**
+     * @return the total number of delete operations applied to the target database
+     */
+    long getTotalNumberOfDeleteEventsSeen();
+
+    /**
+     * @return the total number of truncate operations applied to the target database
+     */
+    long getTotalNumberOfTruncateEventsSeen();
+
+    /**
+     * @return the number of records that were skipped without being applied (e.g. unresolvable
+     *         table, deletes/truncates disabled, schema-change events)
+     */
+    long getNumberOfFilteredEvents();
+
+    /**
+     * @return {@code true} if the connection to the target database is currently established
+     */
+    boolean isConnected();
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import org.hibernate.StatelessSession;
+import org.hibernate.dialect.DatabaseVersion;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.InsertMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.util.DebeziumSinkRecordFactory;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.metadata.CollectionId;
+import io.debezium.openlineage.ConnectorContext;
+import io.debezium.sink.spi.SinkProgressListener;
+
+@Tag("UnitTests")
+class JdbcChangeEventSinkTest {
+
+    private static final SinkRecordFactory RECORD_FACTORY = new DebeziumSinkRecordFactory();
+
+    @ParameterizedTest
+    @EnumSource(InsertMode.class)
+    void shouldReportWriteOperationUsingConfiguredInsertMode(InsertMode insertMode) throws Exception {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BATCH_SIZE, "1",
+                JdbcSinkConnectorConfig.INSERT_MODE, insertMode.getValue()));
+        final CollectionId collectionId = new CollectionId(null, null, "database_schema_table");
+        final TableDescriptor table = TableDescriptor.builder()
+                .tableName("database_schema_table")
+                .build();
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        final DatabaseVersion databaseVersion = mock(DatabaseVersion.class);
+        final RecordWriter recordWriter = mock(RecordWriter.class);
+        final SinkProgressListener progressListener = mock(SinkProgressListener.class);
+        final ConnectorContext connectorContext = new ConnectorContext("jdbc-sink", "jdbc", "0", "test", UUID.randomUUID(), Map.of());
+
+        when(databaseVersion.getMajor()).thenReturn(1);
+        when(databaseVersion.getMinor()).thenReturn(0);
+        when(databaseVersion.getMicro()).thenReturn(0);
+        when(dialect.getVersion()).thenReturn(databaseVersion);
+        when(dialect.getCollectionId("database_schema_table")).thenReturn(collectionId);
+        when(dialect.resolveMissingFields(any(), any())).thenReturn(Set.of());
+        when(recordWriter.checkAndApplyTableChangesIfNeeded(any(), any())).thenReturn(table);
+        when(recordWriter.executeWithRetries(anyString(), any())).thenAnswer(invocation -> {
+            final Callable<?> callable = invocation.getArgument(1);
+            return callable.call();
+        });
+
+        final JdbcChangeEventSink sink = new JdbcChangeEventSink(config, mock(StatelessSession.class), dialect, recordWriter, connectorContext, progressListener);
+        sink.execute(List.of(RECORD_FACTORY.createRecord("database.schema.table", config).getOriginalKafkaRecord()));
+
+        verifyWriteOperationReported(insertMode, progressListener);
+    }
+
+    private static void verifyWriteOperationReported(InsertMode insertMode, SinkProgressListener progressListener) {
+        switch (insertMode) {
+            case INSERT -> verify(progressListener).inserted();
+            case UPDATE -> verify(progressListener).updated();
+            case UPSERT -> verify(progressListener).upserted();
+        }
+        verifyNoMoreInteractions(progressListener);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkMetricsTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkMetricsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.config.ConfigurationNames;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.InsertMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.SchemaEvolutionMode;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.SinkConnectorConfig.PrimaryKeyMode;
+
+/**
+ * Integration tests verifying the JDBC sink connector's JMX metrics.
+ *
+ */
+public abstract class AbstractJdbcSinkMetricsTest extends AbstractJdbcSinkTest {
+
+    private static final String CONNECTOR_NAME = "jdbc-sink-metrics-it";
+    private static final MBeanServer MBEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
+
+    public AbstractJdbcSinkMetricsTest(Sink sink) {
+        super(sink);
+    }
+
+    private ObjectName sinkMetricsObjectName() throws Exception {
+        return new ObjectName("debezium.jdbc:type=connector-metrics,context=sink,server=" + CONNECTOR_NAME + ",task=0");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-7261")
+    public void testSinkMetricsCountUpsertModeAndDelete(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(ConfigurationNames.CONNECTOR_NAME_PROPERTY, CONNECTOR_NAME);
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final ObjectName objectName = sinkMetricsObjectName();
+        assertThat(MBEAN_SERVER.isRegistered(objectName)).isTrue();
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "Connected")).isEqualTo(true);
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+
+        // two upsert-mode writes (insert + update of the same key) and one delete
+        consume(factory.createRecord(topicName, (byte) 1, config));
+        consume(factory.updateRecord(topicName, config));
+        consume(factory.deleteRecord(topicName, config));
+
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfInsertEventsSeen")).isEqualTo(0L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfUpdateEventsSeen")).isEqualTo(0L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfUpsertEventsSeen")).isEqualTo(2L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfDeleteEventsSeen")).isEqualTo(1L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTruncateEventsSeen")).isEqualTo(0L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-7261")
+    public void testSinkMetricsUnregisteredOnStop(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(ConfigurationNames.CONNECTOR_NAME_PROPERTY, CONNECTOR_NAME);
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final ObjectName objectName = sinkMetricsObjectName();
+        assertThat(MBEAN_SERVER.isRegistered(objectName)).isTrue();
+
+        stopSinkConnector();
+
+        assertThat(MBEAN_SERVER.isRegistered(objectName)).isFalse();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkMetricsTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkMetricsTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
@@ -74,6 +75,39 @@ public abstract class AbstractJdbcSinkMetricsTest extends AbstractJdbcSinkTest {
         assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfUpsertEventsSeen")).isEqualTo(2L);
         assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfDeleteEventsSeen")).isEqualTo(1L);
         assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTruncateEventsSeen")).isEqualTo(0L);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-7261")
+    public void testSinkMetricsCountSchemaChanges(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(ConfigurationNames.CONNECTOR_NAME_PROPERTY, CONNECTOR_NAME);
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final ObjectName objectName = sinkMetricsObjectName();
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+
+        // First record for a table that does not exist yet: the sink creates it
+        consume(factory.createRecord(topicName, (byte) 1, config));
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesCreated")).isEqualTo(1L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesAltered")).isEqualTo(0L);
+
+        // Record carrying a new optional field: the sink alters the table to add the column
+        consume(factory.updateRecordWithSchemaValue(topicName, (byte) 1, "extra", Schema.OPTIONAL_STRING_SCHEMA, "v1", config));
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesCreated")).isEqualTo(1L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesAltered")).isEqualTo(1L);
+
+        // Record whose columns already exist: no schema change is applied and the counters stay put
+        consume(factory.createRecord(topicName, (byte) 2, config));
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesCreated")).isEqualTo(1L);
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "TotalNumberOfTablesAltered")).isEqualTo(1L);
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkMetricsIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkMetricsIT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.mysql;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkMetricsTest;
+import io.debezium.connector.jdbc.junit.jupiter.MySqlSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * JMX metrics tests for MySQL.
+ *
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-mysql")
+@ExtendWith(MySqlSinkDatabaseContextProvider.class)
+public class JdbcSinkMetricsIT extends AbstractJdbcSinkMetricsTest {
+
+    public JdbcSinkMetricsIT(Sink sink) {
+        super(sink);
+    }
+
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
@@ -42,6 +42,18 @@ class JdbcSinkConnectorMetricsTest {
     }
 
     @Test
+    void shouldCountCreatedAndAlteredTables() {
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+
+        metrics.tableCreated();
+        metrics.tableAltered();
+        metrics.tableAltered();
+
+        assertThat(metrics.getTotalNumberOfTablesCreated()).isEqualTo(1);
+        assertThat(metrics.getTotalNumberOfTablesAltered()).isEqualTo(2);
+    }
+
+    @Test
     void shouldCountFilteredEvents() {
         final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link JdbcSinkConnectorMetrics}.
+ *
+ */
+class JdbcSinkConnectorMetricsTest {
+
+    @Test
+    void shouldCountInsertUpdateUpsertDeleteAndTruncateOperations() {
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+
+        metrics.inserted();
+        metrics.updated();
+        metrics.updated();
+        metrics.upserted();
+        metrics.upserted();
+        metrics.deleted();
+        metrics.truncated();
+        metrics.truncated();
+        metrics.truncated();
+
+        assertThat(metrics.getTotalNumberOfInsertEventsSeen()).isEqualTo(1);
+        assertThat(metrics.getTotalNumberOfUpdateEventsSeen()).isEqualTo(2);
+        assertThat(metrics.getTotalNumberOfUpsertEventsSeen()).isEqualTo(2);
+        assertThat(metrics.getTotalNumberOfDeleteEventsSeen()).isEqualTo(1);
+        assertThat(metrics.getTotalNumberOfTruncateEventsSeen()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldCountFilteredEvents() {
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+
+        metrics.filtered();
+        metrics.filtered();
+
+        assertThat(metrics.getNumberOfFilteredEvents()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldToggleConnectedState() {
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+        assertThat(metrics.isConnected()).isFalse();
+
+        metrics.connected(true);
+        assertThat(metrics.isConnected()).isTrue();
+
+        metrics.connected(false);
+        assertThat(metrics.isConnected()).isFalse();
+    }
+
+    @Test
+    void shouldRegisterAndUnregisterMBeanUnderDebeziumJdbcDomain() throws Exception {
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName objectName = new ObjectName("debezium.jdbc:type=connector-metrics,context=sink,server=my-sink,task=0");
+
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+        try {
+            metrics.register();
+            assertThat(server.isRegistered(objectName)).isTrue();
+
+            metrics.inserted();
+            metrics.updated();
+            metrics.upserted();
+            assertThat(server.getAttribute(objectName, "TotalNumberOfInsertEventsSeen")).isEqualTo(1L);
+            assertThat(server.getAttribute(objectName, "TotalNumberOfUpdateEventsSeen")).isEqualTo(1L);
+            assertThat(server.getAttribute(objectName, "TotalNumberOfUpsertEventsSeen")).isEqualTo(1L);
+        }
+        finally {
+            metrics.unregister();
+        }
+        assertThat(server.isRegistered(objectName)).isFalse();
+    }
+}

--- a/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.sink.spi;
+
+/**
+ * Invoked whenever an important event or change of state happens during sink record processing.
+ */
+public interface SinkProgressListener {
+
+    void connected(boolean connected);
+
+    void inserted();
+
+    void updated();
+
+    void upserted();
+
+    void deleted();
+
+    void truncated();
+
+    void filtered();
+
+    static SinkProgressListener NO_OP() {
+        return new SinkProgressListener() {
+
+            @Override
+            public void connected(boolean connected) {
+            }
+
+            @Override
+            public void inserted() {
+            }
+
+            @Override
+            public void updated() {
+            }
+
+            @Override
+            public void upserted() {
+            }
+
+            @Override
+            public void deleted() {
+            }
+
+            @Override
+            public void truncated() {
+            }
+
+            @Override
+            public void filtered() {
+            }
+        };
+    }
+}

--- a/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
@@ -24,6 +24,10 @@ public interface SinkProgressListener {
 
     void filtered();
 
+    void tableCreated();
+
+    void tableAltered();
+
     static SinkProgressListener NO_OP() {
         return new SinkProgressListener() {
 
@@ -53,6 +57,14 @@ public interface SinkProgressListener {
 
             @Override
             public void filtered() {
+            }
+
+            @Override
+            public void tableCreated() {
+            }
+
+            @Override
+            public void tableAltered() {
             }
         };
     }

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1436,6 +1436,56 @@ The service records the configuration and starts a sink connector task(s) that p
 endif::community[]
 
 // Type: assembly
+// Title: Monitoring {prodname} JDBC sink connector performance
+// ModuleID: monitoring-debezium-jdbc-sink-connector-performance
+[[jdbc-monitoring]]
+== Monitoring
+
+In addition to the built-in JMX metrics that Kafka Connect provides for every sink task (for example, record-throughput and batch metrics), the {prodname} JDBC sink connector exposes its own metrics under the `debezium.jdbc` JMX domain.
+These metrics describe what the connector applies to the target database, which the Kafka Connect metrics do not report.
+For non-delete records, the connector increments the insert, update, or upsert metric according to the configured xref:jdbc-property-insert-mode[`insert.mode`] value.
+
+The connector registers the following MBean while the task is running:
+
+`debezium.jdbc:type=connector-metrics,context=sink,server=__<connector_name>__,task=__<task_id>__`
+
+The following table describes the available metrics.
+
+[cols="30%a,20%a,50%a",options="header"]
+|===
+|Attribute |Type |Description
+
+|`TotalNumberOfInsertEventsSeen`
+|`long`
+|The total number of insert operations that the connector applied to the target database when xref:jdbc-property-insert-mode[`insert.mode`] is set to `insert`.
+
+|`TotalNumberOfUpdateEventsSeen`
+|`long`
+|The total number of update operations that the connector applied to the target database when xref:jdbc-property-insert-mode[`insert.mode`] is set to `update`.
+
+|`TotalNumberOfUpsertEventsSeen`
+|`long`
+|The total number of upsert operations that the connector applied to the target database when xref:jdbc-property-insert-mode[`insert.mode`] is set to `upsert`.
+
+|`TotalNumberOfDeleteEventsSeen`
+|`long`
+|The total number of delete operations that the connector applied to the target database.
+
+|`TotalNumberOfTruncateEventsSeen`
+|`long`
+|The total number of truncate operations that the connector applied to the target database.
+
+|`NumberOfFilteredEvents`
+|`long`
+|The number of records that the connector skipped without applying them, for example because the table name could not be resolved, deletes or truncates are disabled, or the record is a schema-change event.
+
+|`Connected`
+|`boolean`
+|Indicates whether the connector currently has a connection to the target database.
+
+|===
+
+// Type: assembly
 // Title: Descriptions of {prodname} JDBC connector configuration properties
 // ModuleID: debezium-jdbc-connector-descriptions-of-connector-configuration-properties
 [[jdbc-connector-properties]]

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1479,6 +1479,14 @@ The following table describes the available metrics.
 |`long`
 |The number of records that the connector skipped without applying them, for example because the table name could not be resolved, deletes or truncates are disabled, or the record is a schema-change event.
 
+|`TotalNumberOfTablesCreated`
+|`long`
+|The total number of tables that the connector created in the target database. This metric increases only when xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`.
+
+|`TotalNumberOfTablesAltered`
+|`long`
+|The total number of tables that the connector altered in the target database, for example to add a column for a newly appearing field. This metric increases only when xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`.
+
 |`Connected`
 |`boolean`
 |Indicates whether the connector currently has a connection to the target database.


### PR DESCRIPTION
Fixes debezium/dbz#1174

## Description

The JDBC sink connector currently exposes no Debezium JMX metrics. Kafka Connect already provides built-in sink-task metrics (e.g. `sink-record-send-rate`, `put-batch-avg-time-ms`), but those stop at the connector's `put()` boundary and report nothing about the **target database** — they cannot tell you what was actually applied, nor whether the target connection is up. This PR adds Debezium-domain metrics for the JDBC sink so it offers a uniform view alongside the other Debezium connectors.

### Metrics

Registered while the task runs, under:

```
debezium.jdbc:type=connector-metrics,context=sink,server=<connector>,task=<id>
```

| Attribute | Description |
|---|---|
| `TotalNumberOfUpsertEventsSeen` | upsert (insert/update) operations applied to the target |
| `TotalNumberOfDeleteEventsSeen` | delete operations applied to the target |
| `TotalNumberOfTruncateEventsSeen` | truncate operations applied to the target |
| `NumberOfFilteredEvents` | records skipped without being applied (unresolvable table, deletes/truncates disabled, schema-change events) |
| `Connected` | whether the target database connection is established |

**Why upsert (not insert/update split):** the sink models a change as delete / truncate / otherwise-upsert. It cannot reliably distinguish an insert from an update — flattened records (the common `ExtractNewRecordState` setup) carry no `op` field, and the sink applies both `c` and `u` as an upsert. Counting upserts reflects what the connector actually does and stays consistent regardless of flattening.

**Why not throughput/batch counts:** those duplicate Kafka Connect's built-in sink-task metrics, so they are intentionally omitted. The metrics here are limited to what Connect does not provide (target-side operation breakdown and connection health).

### Implementation

- New `io.debezium.connector.jdbc.metrics` package: `JdbcSinkConnectorMetricsMXBean` + `JdbcSinkConnectorMetrics` (thread-safe `AtomicLong`/`AtomicBoolean` counters).
- Registration reuses `io.debezium.pipeline.JmxUtils`, so the MBean lives in the standard `debezium.<type>` domain and benefits from the existing re-registration retry handling on connector restarts.
- Wired into `JdbcSinkConnectorTask` (register/`connected(true)` on start, unregister/`connected(false)` on stop) and `JdbcChangeEventSink.execute()` (counts at the record-classification points).
- Connector name and task id are taken from the standard connector properties (`name`, `task.id`).

### Tests
- `JdbcSinkConnectorMetricsTest` — unit tests for the counters and the JMX register/unregister round-trip (no database).
- `AbstractJdbcSinkMetricsTest` + `mysql/JdbcSinkMetricsIT` — integration test that drives the real sink task against a Testcontainers MySQL, consumes create/update/delete records, asserts the metric values via `MBeanServer.getAttribute(...)`, and verifies the MBean is unregistered on stop.

Documentation: added a Monitoring section to `connectors/jdbc.adoc`.