### PR TITLE
debezium/dbz#2095 Fix recovery procedure for PostgreSQL with failover slot

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2763,7 +2763,7 @@ You cannot configure logical replication on replica servers in the cluster.
 Consequently, the {prodname} PostgreSQL connector can connect and communicate only with the primary server.
 If the primary server fails, the connector stops.
 To recover from a failure, you must repair the cluster and then either promote the original primary server to `primary`, or promote a different PostgreSQL server to `primary`.
-For more information, see xref:postgresql-cluster-failures-capturing-from-new-pg15-primary[Capturing data from a new primary after a failure].
+For more information, see xref:postgresql-cluster-failures-capturing-from-new-pg16-primary[Capturing data from a new primary after a failure].
 
 // Type: concept
 [id="postgresql-supported-topologies-pg16"]
@@ -4839,28 +4839,40 @@ endif::product[]
 
 // Type: procedure
 [id="postgresql-cluster-failures-recovering-from-failures-pg17-cluster"]
-==== Recovering from failures in a PostgreSQL 17 cluster
+==== Recovering from primary server failures in a PostgreSQL 17 cluster with failover replication slots
 
 Environments that run PostgreSQL 17 or later support the use of failover replication slots.
-If a failure occurs in a PostgreSQL 17 or later cluster, and a standby is configured with a failover replication slot, complete the following steps to enable {prodname} to resume capture:
+If a primary server failure occurs in a PostgreSQL 17 or later cluster, and a standby is configured with a failover replication slot, complete the following steps to enable {prodname} to resume capture.
+For information about configuring a failover replication slot, see xref:enabling-postgresql-failover-slots[Enable failover slots for the PostgreSQL connector].
 
-. Pause {prodname} until you can verify that you have an intact replication slot that has not lost data.
+[WARNING]
+====
+Do not drop or re-create the failover replication slot.
+The slot preserves the position that {prodname} uses to resume streaming after failover.
+====
 
-. Re-create the {prodname} replication slot before applications begin to write to the *new* primary.
-Although the connector can normally create a missing slot automatically after it starts, to prevent the connector from missing change events after failover recovery, you must re-create a missing slot manually before clients resume writing to the database.
+. Pause Debezium until you can verify that you have an intact replication slot that has not lost data.
+For information about verifying whether a replication slot is ready for failover, see link:https://www.postgresql.org/docs/current/logical-replication-failover.html[PostgreSQL documentation].
+. Update the values of properties in the connector configuration to reflect the details of the new primary server if necessary.
+For example, verify that the configuration includes the correct values for the following properties:
 
-. Restart the connector.
+* xref:postgresql-property-database-hostname[`database.hostname`]
+* xref:postgresql-property-database-port[`database.port`]
+* xref:postgresql-property-database-dbname[`database.dbname`]
+* xref:postgresql-property-database-user[`database.user`]
+* xref:postgresql-property-database-password[`database.password`]
 
-. Verify that {prodname} can read the LSN from the replication slot for any change that occurred before the original primary failed.
- +
-For example, recover a backup of the failed primary from the point immediately before failure, and identify the last position that is recorded in the slot.
-Although retrieving backup data can be administratively difficult, inspecting the backup provides a mechanism for reliably determining whether {prodname} has consumed all changes.
+. Promote the standby PostgreSQL node to primary.
+. Resume the connector.
+
+You might also need to restore redundancy, for example, by recovering the original primary server and adding it back to the cluster as a new standby.
+
 
 // Type: procedure
-[id="postgresql-cluster-failures-capturing-from-new-pg15-primary"]
-==== Capturing data from a new primary server after a failure in a PostgreSQL 15 or earlier cluster
+[id="postgresql-cluster-failures-capturing-from-new-pg16-primary"]
+==== Capturing data from a new primary server after a failure in a PostgreSQL 16 or earlier cluster, or in a PostgreSQL 17 or later cluster that does not use failover replication slots
 
-Following the failure of the primary server in a PostgreSQL 15 or earlier cluster, you might decide to configure {prodname} to capture data from one of the former replica servers rather than from the original primary server.
+Following the failure of the primary server in a PostgreSQL 16 or earlier cluster, or in a PostgreSQL 17 or later cluster that does not use failover replication slots, you might decide to configure {prodname} to capture data from one of the former replica servers rather than from the original primary server.
 To enable {prodname} to capture data from a former replica server, complete the following procedure.
 
 .Procedure

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2578,15 +2578,15 @@ Failover-enabled replication slots enable {prodname} to continue reading changes
 +
 This setting enables the connector to create failover-enabled replication slots.
 
-. On the PostgreSQL primary server, configure the `synchronized_standby_slots` parameter to include the name of the replication slot that the connector uses.
+. On the PostgreSQL primary server, configure the `synchronized_standby_slots` parameter to include the name of the physical replication slot for the standby server.
 +
-The primary server uses this parameter to synchronize the replication slot state with standby servers.
+The primary server uses this parameter to synchronize the replication slot state with the standby servers.
 +
-For example, if your replication slot is named `debezium`, add the following configuration to the `postgresql.conf` file:
+For example, if the physical replication slot for the standby server is named `standby1_slot`, add the following configuration to the `postgresql.conf` file:
 +
 [source,properties]
 ----
-synchronized_standby_slots = 'debezium'
+synchronized_standby_slots = 'standby1_slot'
 ----
 
 . Restart the PostgreSQL server to apply the configuration changes.
@@ -2604,7 +2604,7 @@ WHERE slot_name = 'debezium';
 
 .Results
 
-When the `slot.failover` property is enabled and the slot is listed in `synchronized_standby_slots`, if the primary server fails and a standby replica is promoted to primary, {prodname} continues to read changes from the specified failover slot on the new primary.
+When the `slot.failover` property is enabled and the physical replication slot for the standby server is listed in `synchronized_standby_slots`, if the primary server fails and a standby server is promoted to primary, {prodname} continues to read changes from the specified failover slot on the new primary.
 
 .Additional resources
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2095

## Description
<!-- Briefly describe your changes here. -->
Commit 32e94290a0 updates the recovery procedure for PostgreSQL 17 clusters that use failover replication slots.

Commit b0f4cc232b1 fixes the procedure linked from that update. The previous text could be read as instructing users to set `synchronized_standby_slots` to the replication slot name used by Debezium. However, `synchronized_standby_slots` should reference the physical replication slot used for standby synchronization, so this commit updates the wording and example accordingly.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
I think the latter commit is "tightly coupled" with the former one, but if you think it should be handled separately, feel free to exclude it from this PR.
- [x] Do a rebase on upstream `main`
