### PR TITLE
debezium/dbz#1369 Don't warn on null outbox payload with expand.json.payload

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -161,9 +161,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         // Check to expand JSON string into real JSON.
         if (expandJsonPayload) {
-            if (payload instanceof String) {
-                final String payloadString = (String) payload;
-
+            if (payload instanceof String payloadString) {
                 try {
                     // Parse and get Jackson JsonNode.
                     final JsonNode jsonPayload = parseJsonPayload(payloadString);

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -161,10 +161,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         // Check to expand JSON string into real JSON.
         if (expandJsonPayload) {
-            if (!(payload instanceof String)) {
-                LOGGER.warn("Expand JSON payload is turned on but payload is not a string in {}", maybeRedactSensitiveData(r.key()));
-            }
-            else {
+            if (payload instanceof String) {
                 final String payloadString = (String) payload;
 
                 try {
@@ -178,6 +175,11 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
                     LOGGER.warn("JSON expansion failed", e);
                 }
             }
+            else if (payload != null) {
+                LOGGER.warn("Expand JSON payload is turned on but payload is not a string in {}", maybeRedactSensitiveData(r.key()));
+            }
+            // A null payload (for example, a NULL JSON column) is left untouched; it is handled
+            // below as a potential tombstone and must not produce a warning.
         }
 
         final Schema structValueSchema = onlyHeadersInOutputMessage ? null

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -999,7 +999,7 @@ public class EventRouterTest {
     }
 
     @Test
-    @FixFor("DBZ-9210")
+    @FixFor("debezium/dbz#1369")
     public void shouldNotWarnOnNullPayloadWhenExpandJsonPayloadEnabled() {
         final LogInterceptor logInterceptor = new LogInterceptor(EventRouterDelegate.class);
 

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -31,6 +31,7 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.time.Timestamp;
 
 /**
@@ -995,6 +996,40 @@ public class EventRouterTest {
         assertThat(petObjects.size()).isEqualTo(2);
         assertThat(asStruct(petObjects.get(0)).get("type")).isEqualTo("dog");
         assertThat(asStruct(petObjects.get(1)).get("type")).isEqualTo("cat");
+    }
+
+    @Test
+    @FixFor("DBZ-9210")
+    public void shouldNotWarnOnNullPayloadWhenExpandJsonPayloadEnabled() {
+        final LogInterceptor logInterceptor = new LogInterceptor(EventRouterDelegate.class);
+
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(
+                EventRouterConfigDefinition.EXPAND_JSON_PAYLOAD.name(),
+                "true");
+        config.put(
+                EventRouterConfigDefinition.ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD.name(),
+                "true");
+        router.configure(config);
+
+        // A nullable JSON payload column set to NULL must produce a tombstone without logging a
+        // warning about the payload not being a string.
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                SchemaBuilder.string(),
+                "UserCreated",
+                SchemaBuilder.string(),
+                "10711fa5",
+                "User",
+                SchemaBuilder.string().optional(),
+                null,
+                new HashMap<>(),
+                new HashMap<>());
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        VerifyRecord.isValidTombstone(eventRouted);
+        assertThat(logInterceptor.containsWarnMessage("Expand JSON payload is turned on but payload is not a string")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#1369

## Description

When the outbox `EventRouter` runs with `table.expand.json.payload=true` and the JSON payload column is `NULL`, the connector emits the correct tombstone but logs a spurious warning for every such record:

> Expand JSON payload is turned on but payload is not a string in Struct{...}

A `null` payload is legitimate — it becomes a tombstone via `route.tombstone.on.empty.payload`, so it shouldn't warn. The previous check `!(payload instanceof String)` lumped `null` together with genuinely unexpected non-string types.

## Fix

In `EventRouterDelegate`, expand only when the payload is a `String`, leave a `null` payload untouched (it's handled downstream as a tombstone), and warn only for a non-null, non-`String` payload. ~10 lines, behavior changes only for the null-payload case (the warning is no longer logged).

## Tests

Added `EventRouterTest.shouldNotWarnOnNullPayloadWhenExpandJsonPayloadEnabled` (`@FixFor("DBZ-9210")`): with `expand.json.payload` and `route.tombstone.on.empty.payload` enabled and a null payload, it asserts a valid tombstone is produced and that the warning is **not** logged (via `LogInterceptor`).

Verified the test fails against the previous code and passes with the fix. The full `debezium-connect-plugins` module test suite is green (307 tests, 0 failures, 0 errors).

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
