### PR TITLE
Dbz 9921 remove hard line breaks from mariadb mysql partials

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -30,7 +30,7 @@ include::{snippetsdir}/{context}-frag-signaling-fq-table-formats.adoc[leveloffse
 
 The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 The following table describes the parameters in the example:
-
++
 .Descriptions of fields in a SQL command for sending a stop incremental snapshot signal to the signaling {data-collection}
 [cols="1,2,6",options="header"]
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -622,10 +622,10 @@ The following settings are available:
 `minimal`:::: The connector holds the global read lock for only the initial phase of the snapshot during which it reads the database schemas and other metadata.
 During the next phase of the snapshot, the connector releases the lock as it selects all rows from each table.
 To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction.
-Although the release of the global read lock permits other {connector-name} clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction. +
+Although the release of the global read lock permits other {connector-name} clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction.
 
 `extended`:::: Blocks all write operations for the duration of the snapshot.
-Use this setting if clients submit concurrent operations that are incompatible with the REPEATABLE READ isolation level in {connector-name}. +
+Use this setting if clients submit concurrent operations that are incompatible with the REPEATABLE READ isolation level in {connector-name}.
 
 `none`:::: Prevents the connector from acquiring any table locks during the snapshot.
 Although this option is allowed with all snapshot modes, it is safe to use _only_ if no schema changes occur while the snapshot is running.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -135,7 +135,7 @@ For example, to mask keys the contain the strings `api.key` or `token`, set this
 +
 If you set this property for the connector, {prodname} masks any matching instances of configuration key values that it returns for display, logging, or in response to API calls.
 A string of asterisks replaces the original values, for example,  `pass:[********]`.
-
++
 [IMPORTANT]
 ====
 The pattern that you specify for the `custom.sanitize.pattern` property overrides the default {prodname} masking pattern; the specified value does not extend or augment the default pattern.
@@ -869,12 +869,12 @@ If a table is listed in the main property but its corresponding secondary proper
 Example configuration::::
 +
 The following example shows how to configure the `snapshot.select.statement.overrides` property to perform a snapshot of the `customers.orders` table that includes only records that are not soft-deleted; that is, the value of the soft-delete field, `delete_flag`, is set to `0`.
-====
++
 ----
 "snapshot.select.statement.overrides": "customer.orders",
 "snapshot.select.statement.overrides.customer.orders": "SELECT * FROM customers.orders WHERE delete_flag = 0 ORDER BY id DESC"
 ----
-====
+
 
 [id="{context}-property-snapshot-tables-order-by-row-count"]
 xref:{context}-property-snapshot-tables-order-by-row-count[`snapshot.tables.order.by.row.count`]::
@@ -915,16 +915,16 @@ Description:::
 Specifies whether the connector collects advanced statistical metrics for streaming metrics, such as quantiles.
 +
 When set to `true`, the connector collects the following statistics:
-
++
 * Minimum value
 * Maximum value
 * Average value
 * P50 (median) percentile
 * P95 percentile
 * P99 percentile
-
++
 NOTE: Currently only `MilliSecondsBehindSource` metric supports collecting quantiles.
-
++
 The statistics are computed using a probabilistic data structure (DDSketch) that provides approximate quantile values with 1% relative accuracy.
 +
 When set to `false`, the connector does not collect quantiles, and the quantile JMX metrics return `null` values.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -60,14 +60,14 @@ If you include this property in the configuration, do not also set the `column.i
 [id="{context}-property-column-include-list"]
 xref:{context}-property-column-include-list[`column.include.list`]::
 
-Default value:::  _empty string_ +
+Default value:::  _empty string_
 
 Description::: An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values.
 Other columns are omitted from the event record.
 Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 +
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name. +
+That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name.
 If you include this property in the configuration, do not set the `column.exclude.list` property.
 
 
@@ -88,7 +88,7 @@ In the resulting change event record, the values for the specified columns are r
 +
 A pseudonym consists of the hashed value that results from applying the specified _hashAlgorithm_ and _salt_.
 Based on the hash function that is used, referential integrity is maintained, while column values are replaced with pseudonyms.
-Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation. +
+Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
 +
 In the following example, `CzQMA0cB5K` is a randomly selected salt.
 +
@@ -99,7 +99,7 @@ column.mask.hash.SHA-256.with.salt.CzQMA0cB5K = inventory.orders.customerName, i
 If necessary, the pseudonym is automatically shortened to the length of the column.
 The connector configuration can include multiple properties that specify different hash algorithms and salts.
 +
-Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked. +
+Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked.
 +
 Hashing strategy version 2 ensures fidelity of values that are hashed in different places or systems.
 
@@ -298,12 +298,12 @@ Specifies how the connector handles values for `DECIMAL` and `NUMERIC` columns i
 +
 Set one of the following options:
 
-`precise`::: Uses `java.math.BigDecimal` values in binary form to represent values precisely.
+`precise`:::: Uses `java.math.BigDecimal` values in binary form to represent values precisely.
 
-`double`::: Uses the `double` data type to represent values.
+`double`:::: Uses the `double` data type to represent values.
 This option can result in a loss of precision, but it is easier for most consumers to use.
 
-`string`::: Encodes values as formatted strings.
+`string`:::: Encodes values as formatted strings.
 This option is easy to consume, but can result in the loss of semantic information about the real type.
 
 
@@ -347,7 +347,7 @@ Set one of the following options:
 
 `none`:::: No adjustment.
 `avro`:::: Replaces characters that are not valid in Avro names with underscore characters.
-`avro_unicode`:::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx`. +
+`avro_unicode`:::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx`.
 +
 [NOTE]
 ====
@@ -528,7 +528,7 @@ Set one of the following options:
 `avro`:::: Replaces characters that are not valid in Avro names with underscore characters.
 `avro_unicode`:::: Replaces underscore characters or characters that cannot be used in Avro names with corresponding unicode, such as `$$_$$uxxxx.`
 +
-NOTE: `_` is an escape sequence, similar to a backslash in Java
+NOTE: The underscore character (`'_'`) represents an escape sequence, similar to a backslash in Java.
 
 
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -3173,9 +3173,10 @@ As a result, the replacement tasks might regenerate some events that were proces
 
 Each change event message includes source-specific information that you can use to identify duplicate events, for example:
 
-* Event origin
-* {connector-name} server's event time
-* The binlog file name and position
+* Event origin.
+* {connector-name} server's event time.
+* The binlog file name and position.
+
 include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=kc-process-crash-gtid-in-change-event-msg]
 
 [id="debezium-{context}-kafka-process-becomes-unavailable"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -43,9 +43,9 @@ The {prodname} {connector-name} connector supports the following {connector-name
 
 Standalone::
 When a single {connector-name} server is used, the server must have the binlog enabled so the {prodname} {connector-name} connector can monitor the server.
- +
+
 include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-standalone-backupdoc]
- +
+
 In this case, the {connector-name} connector always connects to and follows this standalone {connector-name} server instance.
 
 Primary and replica::
@@ -61,7 +61,7 @@ include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-ha]
 
 Multi-primary::
 include::{snippetsdir}/frag-{context}-props-snippets.adoc[tags=sup-topo-multi-primary]
- +
+
 A {prodname} {connector-name} connector can use these multi-primary {connector-name} replicas as sources, and can fail over to different multi-primary {connector-name} replicas as long as the new replica is caught up to the old replica.
 That is, the new replica has all transactions that were seen on the first replica.
 This works even if the connector is using only a subset of databases and/or tables, because the connector can be configured to include or exclude specific GTID sources when attempting to reconnect to a new multi-primary {connector-name} replica and find the correct position in the binlog.
@@ -431,8 +431,8 @@ After the snapshot completes, the connector continues to stream data for the spe
 If you want the connector to capture data only from specific tables you can direct the connector to capture the data for only a subset of tables or table elements by setting properties such as xref:{context}-property-table-include-list[`table.include.list`] or xref:{context}-property-table-exclude-list[`table.exclude.list`].
 
 |3
-|Obtain a global read lock on the tables to be captured to block _writes_ by other database clients. +
- +
+|Obtain a global read lock on the tables to be captured to block _writes_ by other database clients.
+
 The snapshot itself does not prevent other clients from applying DDL that might interfere with the connector's attempt to read the binlog position and table schemas.
 The connector retains the global read lock while it reads the binlog position, and releases the lock as described in a later step.
 
@@ -450,9 +450,9 @@ If the snapshot takes too long to complete, consider using a different isolation
 
 |6
 a|Capture the structure of all tables in the database, or all tables that are designated for capture.
-The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements. +
+The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements.
 The schema history provides information about the structure that is in effect when a change event occurs.
- +
+
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
@@ -537,9 +537,9 @@ a|Read the current binlog position.
 
 |6
 a|Read the schema of the databases and tables for which the connector is configured to capture changes.
-The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements. +
+The connector persists schema information in its internal database schema history topic, including all necessary `DROP...` and `CREATE...` DDL statements.
 The schema history provides information about the structure that is in effect when a change event occurs.
- +
+
 [NOTE]
 ====
 By default, the connector captures the schema of every table in the database, including tables that are not configured for capture.
@@ -604,8 +604,8 @@ After the snapshot completes, the connector stops, and does not stream event rec
 |`recovery`
 |Set this option to restore a database schema history topic that is lost or corrupted.
 After a restart, the connector runs a snapshot that rebuilds the topic from the source tables.
-You can also set the property to periodically prune a database schema history topic that experiences unexpected growth. +
- +
+You can also set the property to periodically prune a database schema history topic that experiences unexpected growth.
+
 WARNING: Do not use this mode to perform a snapshot if schema changes were committed to the database after the last connector shutdown.
 
 |`when_needed`
@@ -1801,9 +1801,9 @@ a|_n/a_
 
 |`BIT(>1)`
 |`BYTES`
-a|`io.debezium.data.Bits` +
- +
-The `length` schema parameter contains an integer that represents the number of bits. The `byte[]` contains the bits in _little-endian_ form and is sized to contain the specified number of bits. For example, where `n` is bits: +
+a|`io.debezium.data.Bits`
+
+The `length` schema parameter contains an integer that represents the number of bits. The `byte[]` contains the bits in _little-endian_ form and is sized to contain the specified number of bits. For example, where `n` is bits:
 `numBytes = n/8 + (n%8== 0 ? 0 : 1)`
 
 |`TINYINT`
@@ -1852,20 +1852,20 @@ a|_n/a_
 
 |`BINARY(M)]`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`VARBINARY(M)]`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYBLOB`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYTEXT`
@@ -1874,22 +1874,22 @@ a|_n/a_
 
 |`BLOB`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
- +
+a|_n/a_
+
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`TEXT`
 |`STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`MEDIUMBLOB`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`MEDIUMTEXT`
@@ -1898,34 +1898,34 @@ a|_n/a_
 
 |`LONGBLOB`
 |`BYTES` or `STRING`
-a|_n/a_ +
- +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
- +
+a|_n/a_
+
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`LONGTEXT`
 |`STRING`
-a|_n/a_ +
- +
+a|_n/a_
+
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`JSON`
 |`STRING`
-a|`io.debezium.data.Json` +
- +
+a|`io.debezium.data.Json`
+
 Contains the string representation of a `JSON` document, array, or scalar.
 
 |`ENUM`
 |`STRING`
-a|`io.debezium.data.Enum` +
- +
+a|`io.debezium.data.Enum`
+
 The `allowed` schema parameter contains the comma-separated list of allowed values.
 
 |`SET`
 |`STRING`
-a|`io.debezium.data.EnumSet` +
- +
+a|`io.debezium.data.EnumSet`
+
 The `allowed` schema parameter contains the comma-separated list of allowed values.
 
 |`YEAR[(2\|4)]`
@@ -1934,8 +1934,8 @@ The `allowed` schema parameter contains the comma-separated list of allowed valu
 
 |`TIMESTAMP[(M)]`
 |`STRING`
-a|`io.debezium.time.ZonedTimestamp` +
- +
+a|`io.debezium.time.ZonedTimestamp`
+
 In link:https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601] format with microsecond precision.
 {connector-name} allows `M` to be in the range of `0-6`.
 
@@ -1981,23 +1981,23 @@ The {connector-name} connector determines the literal type and semantic type bas
 
 |`DATE`
 |`INT32`
-a|`io.debezium.time.Date` +
+a|`io.debezium.time.Date`
 Represents the number of days since the epoch.
 
 |`TIME[(M)]`
 |`INT64`
-a|`io.debezium.time.MicroTime` +
+a|`io.debezium.time.MicroTime`
 Represents the time value in microseconds and does not include time zone information.
 {connector-name} allows `M` to be in the range of `0-6`.
 
 |`DATETIME, DATETIME(0), DATETIME(1), DATETIME(2), DATETIME(3)`
 |`INT64`
-a|`io.debezium.time.Timestamp` +
+a|`io.debezium.time.Timestamp`
 Represents the number of milliseconds past the epoch and does not include time zone information.
 
 |`DATETIME(4), DATETIME(5), DATETIME(6)`
 |`INT64`
-a|`io.debezium.time.MicroTimestamp` +
+a|`io.debezium.time.MicroTimestamp`
 Represents the number of microseconds past the epoch and does not include time zone information.
 
 |===
@@ -2016,17 +2016,17 @@ The `connect` setting is expected to be removed in a future version of {prodname
 
 |`DATE`
 |`INT32`
-a|`org.apache.kafka.connect.data.Date` +
+a|`org.apache.kafka.connect.data.Date`
 Represents the number of days since the epoch.
 
 |`TIME[(M)]`
 |`INT64`
-a|`org.apache.kafka.connect.data.Time` +
+a|`org.apache.kafka.connect.data.Time`
 Represents the time value in microseconds since midnight and does not include time zone information.
 
 |`DATETIME[(M)]`
 |`INT64`
-a|`org.apache.kafka.connect.data.Timestamp` +
+a|`org.apache.kafka.connect.data.Timestamp`
 Represents the number of milliseconds since the epoch, and does not include time zone information.
 
 |===
@@ -2089,12 +2089,12 @@ decimal.handling.mode=precise::
 
 |`NUMERIC[(M[,D])]`
 |`BYTES`
-a|`org.apache.kafka.connect.data.Decimal` +
+a|`org.apache.kafka.connect.data.Decimal`
 The `scale` schema parameter contains an integer that represents how many digits the decimal point shifted.
 
 |`DECIMAL[(M[,D])]`
 |`BYTES`
-a|`org.apache.kafka.connect.data.Decimal` +
+a|`org.apache.kafka.connect.data.Decimal`
 The `scale` schema parameter contains an integer that represents how many digits the decimal point shifted.
 
 |===
@@ -2150,7 +2150,7 @@ During snapshots, {prodname} executes `SHOW CREATE TABLE` to obtain table defini
 To enable you to convert source columns to Boolean data types, {prodname} provides a `TinyIntOneToBooleanConverter` {link-prefix}:{link-custom-converters}#custom-converters[custom converter] that you can use in one of the following ways:
 
 * Map all `TINYINT(1)` or `TINYINT(1) UNSIGNED` columns to `BOOLEAN` types.
-* Enumerate a subset of columns by using a comma-separated list of regular expressions. +
+* Enumerate a subset of columns by using a comma-separated list of regular expressions.
 To use this type of conversion, you must set the xref:{context}-property-converters[`converters`] configuration property with the `selector` parameter, as shown in the following example:
 +
 [source]
@@ -2199,7 +2199,7 @@ Currently, the {prodname} {connector-name} connector supports the following spat
 
 `GEOMETRYCOLLECTION`
 |`STRUCT`
-a|`io.debezium.data.geometry.Geometry` +
+a|`io.debezium.data.geometry.Geometry`
 Contains a structure with two fields:
 
 * `srid (INT32`: spatial reference system ID that defines the type of geometry object stored in the structure
@@ -2721,7 +2721,7 @@ You can use either of the following methods to deploy a {prodname} {connector-na
 * xref:openshift-streams-{context}-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Containerfile]. +
+* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Containerfile].
 This Containerfile deployment method is deprecated.
 The instructions for this method are scheduled for removal in future versions of the documentation.
 
@@ -2825,7 +2825,7 @@ docker push _<myregistry.io>_/debezium-container-for-{context}:latest
 
 .. Create a new {prodname} {connector-name} `KafkaConnect` custom resource (CR).
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 =====================================================================
 [source,yaml,subs="+attributes"]

--- a/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/frag-mysql-props-snippets.adoc
@@ -129,5 +129,5 @@ end::snapshot-fetch-size-note[]
 
 
 tag::kc-process-crash-gtid-in-change-event-msg[]
-* GTIDs, if used
+* GTIDs, if used.
 end::kc-process-crash-gtid-in-change-event-msg[]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9921](https://redhat.atlassian.net/browse/DBZ-9921)
## Description
Removes hard line break characters from the shared files used in the MariaDB and MySQL documentation.
No content changes.

Tested in a local Antora build.
Test rendering in local downstream build.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
