### PR TITLE
debezium/dbz#2163 Replace throwing helper with exception factory to remove dead code

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BigIntUnsignedType.java
@@ -81,7 +81,6 @@ class BigIntUnsignedType extends AbstractType {
             return new BigDecimal(string);
         }
 
-        throwUnexpectedValue(value);
-        return null;
+        throw unexpectedValue(value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BitType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/BitType.java
@@ -58,8 +58,7 @@ class BitType extends AbstractType {
     private String toBitString(Object value, int length) {
         final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(value);
         if (bytes == null) {
-            throwUnexpectedValue(value);
-            return null;
+            throw unexpectedValue(value);
         }
 
         final BitSet bits = BitSet.valueOf(bytes);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractType.java
@@ -92,8 +92,8 @@ public abstract class AbstractType implements JdbcType {
         return Optional.empty();
     }
 
-    protected void throwUnexpectedValue(Object value) throws ConnectException {
-        throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
+    protected ConnectException unexpectedValue(Object value) {
+        return new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
                 value.toString(), value.getClass().getName()));
     }
 
@@ -102,8 +102,7 @@ public abstract class AbstractType implements JdbcType {
             return data;
         }
 
-        throwUnexpectedValue(value);
-        return null;
+        throw unexpectedValue(value);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectDecimalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectDecimalType.java
@@ -63,7 +63,6 @@ public class ConnectDecimalType extends AbstractType {
         if (value instanceof Number) {
             return value.toString();
         }
-        throwUnexpectedValue(value);
-        return null;
+        throw unexpectedValue(value);
     }
 }


### PR DESCRIPTION
## Summary

`AbstractType.throwUnexpectedValue(Object)` in the JDBC sink was declared `void` but always threw a `ConnectException`. Because the compiler cannot know the method never returns, every value-returning caller had to append an unreachable `return null;`.

This replaces the throwing helper with an exception factory:

```java
protected ConnectException unexpectedValue(Object value) {
    return new ConnectException(...);
}
```

Callers now use `throw unexpectedValue(value);`. The `throw` statement makes control-flow termination explicit to the compiler, so the four unreachable `return null;` statements are removed. Behavior is unchanged — the same `ConnectException` is thrown.

## Changes (4 files)
- `type/AbstractType.java`: `void throwUnexpectedValue(...)` → `ConnectException unexpectedValue(...)` (returns the exception instead of throwing; drops the now-unnecessary `throws` clause). `requireStruct` uses `throw unexpectedValue(value)`.
- `type/connect/ConnectDecimalType.java`, `dialect/mysql/BigIntUnsignedType.java`, `dialect/mysql/BitType.java`: `throwUnexpectedValue(value); return null;` → `throw unexpectedValue(value);`.

In `BitType.toBitString` the removed `return null;` was true dead code (unreachable statement inside an `if` block already followed by a normal return).

## Notes
- The helper is `protected` in `AbstractType`; it is referenced only at these four call sites and is not overridden anywhere, so the rename is safe.

## Validation
- `mvn -pl debezium-connector-jdbc -am compile` passes
- Unit tests pass: `BitTypeTest`, `BigIntUnsignedTypeTest` (mysql + postgres) — 19 tests, 0 failures
- `checkstyle:check` and `impsort` pass; `git diff --check` clean

Closes debezium/dbz#2163