### PR TITLE
debezium/dbz#2020 Fix incremental snapshot on tables with generated columns

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -91,15 +91,18 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     }
 
     protected String buildProjection(Table table) {
-        String projection = "*";
-        if (connectorConfig.isColumnsFiltered()) {
-            TableId tableId = table.id();
-            projection = table.columns().stream()
-                    .filter(column -> columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
-                    .map(column -> jdbcConnection.quoteIdentifier(column.name()))
-                    .collect(Collectors.joining(", "));
-        }
-        return projection;
+        // DBZ-2020: always build an explicit column list from the in-memory Table, same pattern as
+        // the initial snapshot (getPreparedColumnNames). Generated columns that were removed from the
+        // Table by refreshFromIncrementalSnapshot are already absent; any still marked isGenerated()
+        // (e.g. connectors that mark but do not remove) are filtered here.
+        final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
+        final TableId tableId = table.id();
+        return table.columns().stream()
+                .filter(column -> !column.isGenerated())
+                .filter(column -> !columnsFiltered
+                        || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
+                .map(column -> jdbcConnection.quoteIdentifier(column.name()))
+                .collect(Collectors.joining(", "));
     }
 
     protected void addLowerBound(IncrementalSnapshotContext<T> context, Table table, Object[] boundaryKey, StringBuilder sql) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -91,18 +91,40 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     }
 
     protected String buildProjection(Table table) {
-        // DBZ-2020: always build an explicit column list from the in-memory Table, same pattern as
-        // the initial snapshot (getPreparedColumnNames). Generated columns that were removed from the
-        // Table by refreshFromIncrementalSnapshot are already absent; any still marked isGenerated()
-        // (e.g. connectors that mark but do not remove) are filtered here.
+        // DBZ-2020: only fall back to an explicit column list when we actually need to drop
+        // columns from the projection (generated columns, or column include/exclude filters).
+        // In the common case where neither applies, keep emitting SELECT * so we do not widen
+        // the schemaChanges race window observed in DBZ-6000 / DBZ-7532.
         final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
+        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(Column::isGenerated)
+                || hasAdditionalGeneratedColumns(table);
+        if (!columnsFiltered && !hasGeneratedColumns) {
+            return "*";
+        }
         final TableId tableId = table.id();
         return table.columns().stream()
                 .filter(column -> !column.isGenerated())
+                .filter(column -> !isAdditionalGeneratedColumn(table, column.name()))
                 .filter(column -> !columnsFiltered
                         || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                 .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Hook for connectors that track generated columns outside the in-memory {@link Table}
+     * (for example after {@code refreshFromIncrementalSnapshot} has pruned them). Default is none.
+     */
+    protected boolean hasAdditionalGeneratedColumns(Table table) {
+        return false;
+    }
+
+    /**
+     * Hook for connectors that track generated columns outside the in-memory {@link Table}.
+     * Default is never generated.
+     */
+    protected boolean isAdditionalGeneratedColumn(Table table, String columnName) {
+        return false;
     }
 
     protected void addLowerBound(IncrementalSnapshotContext<T> context, Table table, Object[] boundaryKey, StringBuilder sql) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -96,19 +96,29 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
         // In the common case where neither applies, keep emitting SELECT * so we do not widen
         // the schemaChanges race window observed in DBZ-6000 / DBZ-7532.
         final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
-        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(Column::isGenerated)
+        // MySQL/MariaDB mark AUTO_INCREMENT (and SERIAL / ON UPDATE) as both autoIncremented and
+        // generated. Only treat "true" generated columns as ones we must omit from the projection.
+        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(this::isGeneratedNonAutoIncrementColumn)
                 || hasAdditionalGeneratedColumns(table);
         if (!columnsFiltered && !hasGeneratedColumns) {
             return "*";
         }
         final TableId tableId = table.id();
         return table.columns().stream()
-                .filter(column -> !column.isGenerated())
+                .filter(column -> !isGeneratedNonAutoIncrementColumn(column))
                 .filter(column -> !isAdditionalGeneratedColumn(table, column.name()))
                 .filter(column -> !columnsFiltered
                         || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                 .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * True when the column is generated and not auto-incremented. MySQL/MariaDB set both flags for
+     * {@code AUTO_INCREMENT}, so those columns must remain in the chunk projection.
+     */
+    private boolean isGeneratedNonAutoIncrementColumn(Column column) {
+        return column.isGenerated() && !column.isAutoIncremented();
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -93,15 +93,18 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     }
 
     protected String buildProjection(Table table) {
-        String projection = "*";
-        if (connectorConfig.isColumnsFiltered()) {
-            TableId tableId = table.id();
-            projection = table.columns().stream()
-                    .filter(column -> columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
-                    .map(column -> jdbcConnection.quoteIdentifier(column.name()))
-                    .collect(Collectors.joining(", "));
-        }
-        return projection;
+        // DBZ-2020: always build an explicit column list from the in-memory Table, same pattern as
+        // the initial snapshot (getPreparedColumnNames). Generated columns that were removed from the
+        // Table by refreshFromIncrementalSnapshot are already absent; any still marked isGenerated()
+        // (e.g. connectors that mark but do not remove) are filtered here.
+        final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
+        final TableId tableId = table.id();
+        return table.columns().stream()
+                .filter(column -> !column.isGenerated())
+                .filter(column -> !columnsFiltered
+                        || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
+                .map(column -> jdbcConnection.quoteIdentifier(column.name()))
+                .collect(Collectors.joining(", "));
     }
 
     public void addLowerBound(List<Column> pkColumns, Object[] boundaryKey, StringBuilder condition, boolean inclusiveFinal) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -93,34 +93,19 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     }
 
     protected String buildProjection(Table table) {
-        // DBZ-2020: only fall back to an explicit column list when we actually need to drop
-        // columns from the projection (generated columns, or column include/exclude filters).
-        // In the common case where neither applies, keep emitting SELECT * so we do not widen
-        // the schemaChanges race window observed in DBZ-6000 / DBZ-7532.
+        // DBZ-2020: keep SELECT * unless column filters apply or a connector opts in via the hooks
+        // below (Postgres pgoutput), so we avoid widening the schemaChanges race window (DBZ-6000).
         final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
-        // MySQL/MariaDB mark AUTO_INCREMENT (and SERIAL / ON UPDATE) as both autoIncremented and
-        // generated. Only treat "true" generated columns as ones we must omit from the projection.
-        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(this::isGeneratedNonAutoIncrementColumn)
-                || hasAdditionalGeneratedColumns(table);
-        if (!columnsFiltered && !hasGeneratedColumns) {
+        if (!columnsFiltered && !hasAdditionalGeneratedColumns(table)) {
             return "*";
         }
         final TableId tableId = table.id();
         return table.columns().stream()
-                .filter(column -> !isGeneratedNonAutoIncrementColumn(column))
                 .filter(column -> !isAdditionalGeneratedColumn(table, column.name()))
                 .filter(column -> !columnsFiltered
                         || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                 .collect(Collectors.joining(", "));
-    }
-
-    /**
-     * True when the column is generated and not auto-incremented. MySQL/MariaDB set both flags for
-     * {@code AUTO_INCREMENT}, so those columns must remain in the chunk projection.
-     */
-    private boolean isGeneratedNonAutoIncrementColumn(Column column) {
-        return column.isGenerated() && !column.isAutoIncremented();
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -93,18 +93,40 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
     }
 
     protected String buildProjection(Table table) {
-        // DBZ-2020: always build an explicit column list from the in-memory Table, same pattern as
-        // the initial snapshot (getPreparedColumnNames). Generated columns that were removed from the
-        // Table by refreshFromIncrementalSnapshot are already absent; any still marked isGenerated()
-        // (e.g. connectors that mark but do not remove) are filtered here.
+        // DBZ-2020: only fall back to an explicit column list when we actually need to drop
+        // columns from the projection (generated columns, or column include/exclude filters).
+        // In the common case where neither applies, keep emitting SELECT * so we do not widen
+        // the schemaChanges race window observed in DBZ-6000 / DBZ-7532.
         final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
+        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(Column::isGenerated)
+                || hasAdditionalGeneratedColumns(table);
+        if (!columnsFiltered && !hasGeneratedColumns) {
+            return "*";
+        }
         final TableId tableId = table.id();
         return table.columns().stream()
                 .filter(column -> !column.isGenerated())
+                .filter(column -> !isAdditionalGeneratedColumn(table, column.name()))
                 .filter(column -> !columnsFiltered
                         || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                 .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Hook for connectors that track generated columns outside the in-memory {@link Table}
+     * (for example after {@code refreshFromIncrementalSnapshot} has pruned them). Default is none.
+     */
+    protected boolean hasAdditionalGeneratedColumns(Table table) {
+        return false;
+    }
+
+    /**
+     * Hook for connectors that track generated columns outside the in-memory {@link Table}.
+     * Default is never generated.
+     */
+    protected boolean isAdditionalGeneratedColumn(Table table, String columnName) {
+        return false;
     }
 
     public void addLowerBound(List<Column> pkColumns, Object[] boundaryKey, StringBuilder condition, boolean inclusiveFinal) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractChunkQueryBuilder.java
@@ -98,19 +98,29 @@ public abstract class AbstractChunkQueryBuilder<T extends DataCollectionId>
         // In the common case where neither applies, keep emitting SELECT * so we do not widen
         // the schemaChanges race window observed in DBZ-6000 / DBZ-7532.
         final boolean columnsFiltered = connectorConfig.isColumnsFiltered();
-        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(Column::isGenerated)
+        // MySQL/MariaDB mark AUTO_INCREMENT (and SERIAL / ON UPDATE) as both autoIncremented and
+        // generated. Only treat "true" generated columns as ones we must omit from the projection.
+        final boolean hasGeneratedColumns = table.columns().stream().anyMatch(this::isGeneratedNonAutoIncrementColumn)
                 || hasAdditionalGeneratedColumns(table);
         if (!columnsFiltered && !hasGeneratedColumns) {
             return "*";
         }
         final TableId tableId = table.id();
         return table.columns().stream()
-                .filter(column -> !column.isGenerated())
+                .filter(column -> !isGeneratedNonAutoIncrementColumn(column))
                 .filter(column -> !isAdditionalGeneratedColumn(table, column.name()))
                 .filter(column -> !columnsFiltered
                         || columnFilter.matches(tableId.catalog(), tableId.schema(), tableId.table(), column.name()))
                 .map(column -> jdbcConnection.quoteIdentifier(column.name()))
                 .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * True when the column is generated and not auto-incremented. MySQL/MariaDB set both flags for
+     * {@code AUTO_INCREMENT}, so those columns must remain in the chunk projection.
+     */
+    private boolean isGeneratedNonAutoIncrementColumn(Column column) {
+        return column.isGenerated() && !column.isAutoIncremented();
     }
 
     /**

--- a/debezium-connector-common/src/main/java/io/debezium/relational/Column.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/Column.java
@@ -129,6 +129,20 @@ public interface Column extends Comparable<Column> {
     boolean isGenerated();
 
     /**
+     * Determine whether this column is invisible to clients. An invisible column is part of the table definition
+     * but is omitted from {@code SELECT *} projections and from change event payloads. Examples include Oracle
+     * {@code INVISIBLE} columns and MySQL {@code INVISIBLE} columns.
+     *
+     * <p>This is declared as a default method returning {@code false} to preserve binary compatibility with custom
+     * {@link Column} implementations.</p>
+     *
+     * @return {@code true} if the column is invisible, or {@code false} otherwise
+     */
+    default boolean isInvisible() {
+        return false;
+    }
+
+    /**
      * Get the database-specific complete expression defining the column's default value.
      *
      * @return the complete type expression

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditor.java
@@ -115,6 +115,17 @@ public interface ColumnEditor {
     boolean isGenerated();
 
     /**
+     * Determine whether this column is invisible to clients. See {@link Column#isInvisible()}.
+     *
+     * <p>Default implementation returns {@code false} to preserve binary compatibility with custom editors.</p>
+     *
+     * @return {@code true} if the column is invisible, or {@code false} otherwise
+     */
+    default boolean isInvisible() {
+        return false;
+    }
+
+    /**
      * Get the database-specific complete expression defining the column's default value.
      *
      * @return the complete type expression
@@ -239,6 +250,18 @@ public interface ColumnEditor {
      * @return this editor so callers can chain methods together
      */
     ColumnEditor generated(boolean generated);
+
+    /**
+     * Set whether the column is invisible to clients. See {@link Column#isInvisible()}.
+     *
+     * <p>Default implementation is a no-op returning {@code this} to preserve binary compatibility with custom editors.</p>
+     *
+     * @param invisible {@code true} if the column is invisible, or {@code false} otherwise
+     * @return this editor so callers can chain methods together
+     */
+    default ColumnEditor invisible(boolean invisible) {
+        return this;
+    }
 
     /**
      * Set the position of the column within the table definition.

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -27,6 +27,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     private boolean optional = true;
     private boolean autoIncremented = false;
     private boolean generated = false;
+    private boolean invisible = false;
     private String defaultValueExpression = null;
     private boolean hasDefaultValue = false;
     private List<String> enumValues;
@@ -98,6 +99,11 @@ final class ColumnEditorImpl implements ColumnEditor {
     @Override
     public boolean isGenerated() {
         return generated;
+    }
+
+    @Override
+    public boolean isInvisible() {
+        return invisible;
     }
 
     @Override
@@ -196,6 +202,12 @@ final class ColumnEditorImpl implements ColumnEditor {
     @Override
     public ColumnEditorImpl generated(boolean generated) {
         this.generated = generated;
+        return this;
+    }
+
+    @Override
+    public ColumnEditorImpl invisible(boolean invisible) {
+        this.invisible = invisible;
         return this;
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -262,7 +262,7 @@ final class ColumnEditorImpl implements ColumnEditor {
                 Interner.intern(typeName), Interner.intern(typeExpression),
                 Interner.intern(charsetName), Interner.intern(tableCharsetName),
                 length, scale, enumValues == null ? null : Interner.intern(Collections.unmodifiableList(enumValues)),
-                optional, autoIncremented, generated,
+                optional, autoIncremented, generated, invisible,
                 Interner.intern(defaultValueExpression), hasDefaultValue,
                 Interner.intern(comment));
         return Interner.intern(column);

--- a/debezium-connector-common/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -25,6 +25,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
     private final boolean optional;
     private final boolean autoIncremented;
     private final boolean generated;
+    private final boolean invisible;
     private final String defaultValueExpression;
     private final boolean hasDefaultValue;
     private final List<String> enumValues;
@@ -34,19 +35,28 @@ final class ColumnImpl implements Column, Comparable<Column> {
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          boolean optional, boolean autoIncremented, boolean generated) {
         this(columnName, position, jdbcType, componentType, typeName, typeExpression, charsetName,
-                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, null, false, null);
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, false, null, false, null);
     }
 
     protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          boolean optional, boolean autoIncremented, boolean generated, String defaultValueExpression, boolean hasDefaultValue) {
         this(columnName, position, jdbcType, nativeType, typeName, typeExpression, charsetName,
-                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, defaultValueExpression, hasDefaultValue, null);
+                defaultCharsetName, columnLength, columnScale, null, optional, autoIncremented, generated, false, defaultValueExpression, hasDefaultValue, null);
     }
 
     protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
                          String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
                          List<String> enumValues, boolean optional, boolean autoIncremented, boolean generated,
+                         String defaultValueExpression, boolean hasDefaultValue, String comment) {
+        this(columnName, position, jdbcType, nativeType, typeName, typeExpression, charsetName,
+                defaultCharsetName, columnLength, columnScale, enumValues, optional, autoIncremented, generated, false,
+                defaultValueExpression, hasDefaultValue, comment);
+    }
+
+    protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
+                         String charsetName, String defaultCharsetName, int columnLength, Integer columnScale,
+                         List<String> enumValues, boolean optional, boolean autoIncremented, boolean generated, boolean invisible,
                          String defaultValueExpression, boolean hasDefaultValue, String comment) {
         this.name = columnName;
         this.position = position;
@@ -65,6 +75,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
         this.optional = optional;
         this.autoIncremented = autoIncremented;
         this.generated = generated;
+        this.invisible = invisible;
         this.defaultValueExpression = defaultValueExpression;
         this.hasDefaultValue = hasDefaultValue;
         this.enumValues = enumValues == null ? new ArrayList<>() : enumValues;
@@ -133,6 +144,11 @@ final class ColumnImpl implements Column, Comparable<Column> {
     }
 
     @Override
+    public boolean isInvisible() {
+        return invisible;
+    }
+
+    @Override
     public Optional<String> defaultValueExpression() {
         return Optional.ofNullable(defaultValueExpression);
     }
@@ -175,6 +191,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                     this.isOptional() == that.isOptional() &&
                     this.isAutoIncremented() == that.isAutoIncremented() &&
                     this.isGenerated() == that.isGenerated() &&
+                    this.isInvisible() == that.isInvisible() &&
                     Objects.equals(this.defaultValueExpression(), that.defaultValueExpression()) &&
                     this.hasDefaultValue() == that.hasDefaultValue() &&
                     this.enumValues().equals(that.enumValues());
@@ -205,6 +222,9 @@ final class ColumnImpl implements Column, Comparable<Column> {
         if (generated) {
             sb.append(" GENERATED");
         }
+        if (invisible) {
+            sb.append(" INVISIBLE");
+        }
         if (hasDefaultValue() && defaultValueExpression == null) {
             sb.append(" DEFAULT VALUE NULL");
         }
@@ -231,6 +251,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                 .optional(isOptional())
                 .autoIncremented(isAutoIncremented())
                 .generated(isGenerated())
+                .invisible(isInvisible())
                 .enumValues(enumValues)
                 .comment(comment);
         if (hasDefaultValue()) {

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/ConnectTableChangeSerializer.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/ConnectTableChangeSerializer.java
@@ -44,6 +44,7 @@ public class ConnectTableChangeSerializer implements TableChanges.TableChangesSe
     public static final String OPTIONAL_KEY = "optional";
     public static final String AUTO_INCREMENTED_KEY = "autoIncremented";
     public static final String GENERATED_KEY = "generated";
+    public static final String INVISIBLE_KEY = "invisible";
     public static final String COMMENT_KEY = "comment";
     public static final String DEFAULT_VALUE_EXPRESSION = "defaultValueExpression";
     public static final String ENUM_VALUES = "enumValues";
@@ -121,6 +122,7 @@ public class ConnectTableChangeSerializer implements TableChanges.TableChangesSe
         struct.put(OPTIONAL_KEY, column.isOptional());
         struct.put(AUTO_INCREMENTED_KEY, column.isAutoIncremented());
         struct.put(GENERATED_KEY, column.isGenerated());
+        struct.put(INVISIBLE_KEY, column.isInvisible());
         struct.put(COMMENT_KEY, column.comment());
 
         column.defaultValueExpression().ifPresent(d -> struct.put(DEFAULT_VALUE_EXPRESSION, d));

--- a/debezium-connector-common/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
@@ -105,6 +105,7 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
         document.setBoolean("optional", column.isOptional());
         document.setBoolean("autoIncremented", column.isAutoIncremented());
         document.setBoolean("generated", column.isGenerated());
+        document.setBoolean("invisible", column.isInvisible());
         document.setString("comment", column.comment());
         document.setBoolean("hasDefaultValue", column.hasDefaultValue());
 
@@ -205,6 +206,12 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
                             .optional(v.getBoolean("optional"))
                             .autoIncremented(v.getBoolean("autoIncremented"))
                             .generated(v.getBoolean("generated"));
+
+                    // 'invisible' was added later; default to false when reading older schema history records.
+                    Boolean invisible = v.getBoolean("invisible");
+                    if (Boolean.TRUE.equals(invisible)) {
+                        columnEditor.invisible(true);
+                    }
 
                     return columnEditor.create();
                 })

--- a/debezium-connector-common/src/main/java/io/debezium/schema/SchemaFactory.java
+++ b/debezium-connector-common/src/main/java/io/debezium/schema/SchemaFactory.java
@@ -234,6 +234,7 @@ public class SchemaFactory {
                 .field(ConnectTableChangeSerializer.OPTIONAL_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
                 .field(ConnectTableChangeSerializer.AUTO_INCREMENTED_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
                 .field(ConnectTableChangeSerializer.GENERATED_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                .field(ConnectTableChangeSerializer.INVISIBLE_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
                 .field(ConnectTableChangeSerializer.COMMENT_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(ConnectTableChangeSerializer.DEFAULT_VALUE_EXPRESSION, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(ConnectTableChangeSerializer.ENUM_VALUES, SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -96,11 +96,11 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -117,11 +117,11 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -141,11 +141,11 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -166,11 +166,11 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -192,11 +192,11 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
                 .isEqualTo(
-                        "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                        "SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -216,7 +216,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -231,7 +231,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -246,7 +246,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -262,7 +262,7 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -329,14 +329,14 @@ public class DefaultChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -351,7 +351,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(new Object[]{ null, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NOT NULL) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -381,14 +381,14 @@ public class DefaultChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? OR \"pk2\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -403,7 +403,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(new Object[]{ null, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND 1 = 0) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -441,13 +441,13 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
 
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -483,7 +483,7 @@ public class DefaultChunkQueryBuilderTest {
 
     @Test
     @FixFor("DBZ-2020")
-    public void testBuildProjectionExpandsColumnsFromTable() {
+    public void testBuildProjectionKeepsSelectStarWhenNoGeneratedColumns() {
         final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
@@ -497,7 +497,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1").create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -95,11 +95,12 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val1)
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -116,11 +117,11 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -140,11 +141,11 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -165,11 +166,11 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -190,11 +191,12 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo(
+                        "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -214,7 +216,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -229,7 +231,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -244,7 +246,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -260,7 +262,7 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -327,14 +329,14 @@ public class DefaultChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -349,7 +351,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(new Object[]{ null, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NOT NULL) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -379,14 +381,14 @@ public class DefaultChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? OR \"pk2\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -401,7 +403,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(new Object[]{ null, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND 1 = 0) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -439,13 +441,13 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
 
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -477,5 +479,72 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(pk1).addColumn(pk2).addColumn(val1).addColumn(val2).addColumn(val3)
                 .setPrimaryKeyNames("pk1", "pk2").create();
         return table;
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExpandsColumnsFromTable() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExcludesGeneratedColumns() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExcludesGeneratedColumnsAndAppliesIncludeList() {
+        final RelationalDatabaseConnectorConfig cfg = buildConfig(Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, ".*\\.(pk1|val1|gen1)$")
+                .build());
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                cfg, new JdbcConnection(cfg.getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        // gen1 is include-listed but must still be dropped because it is generated; val2 is not include-listed.
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -547,4 +547,42 @@ public class DefaultChunkQueryBuilderTest {
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
                 .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionKeepsAutoIncrementedGeneratedColumnsAsStar() {
+        // MySQL/MariaDB set both autoIncremented and generated for AUTO_INCREMENT; that alone must
+        // not force an explicit projection (keeps the SELECT * race-safe path).
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).autoIncremented(true).generated(true).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionKeepsAutoIncrementWhenExcludingTrueGeneratedColumns() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).autoIncremented(true).generated(true).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -632,4 +632,42 @@ public class DefaultChunkQueryBuilderTest {
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
                 .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionKeepsAutoIncrementedGeneratedColumnsAsStar() {
+        // MySQL/MariaDB set both autoIncremented and generated for AUTO_INCREMENT; that alone must
+        // not force an explicit projection (keeps the SELECT * race-safe path).
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).autoIncremented(true).generated(true).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionKeepsAutoIncrementWhenExcludingTrueGeneratedColumns() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).autoIncremented(true).generated(true).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -107,11 +107,11 @@ public class DefaultChunkQueryBuilderTest {
         final List<Column> pkColumns = List.of(pk1);
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -135,11 +135,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -166,11 +166,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         // Surrogate key: only the surrogate column (pk2) is bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1));
@@ -199,11 +199,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Base builder uses a triangular expansion of the boundary params
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk1, 1), qp(pk2, 5), qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -232,11 +232,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Base builder uses a triangular expansion of the boundary params
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk1, 1), qp(pk2, 5), qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -261,7 +261,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -276,7 +276,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -291,7 +291,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -307,7 +307,7 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -380,14 +380,14 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKeyWithNulls = new Object[]{ null, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -402,7 +402,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(maximumKeyWithNulls);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NOT NULL) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -448,14 +448,14 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKeyWithNulls = new Object[]{ null, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? OR \"pk2\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -470,7 +470,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(maximumKeyWithNulls);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND 1 = 0) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -521,13 +521,13 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
 
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
         // Params follow the message-key column order (pk2, pk1, pk3), triangularly expanded per bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1), qp(pk2, 1), qp(pk1, 5), qp(pk2, 1), qp(pk1, 5), qp(pk3, 3));
@@ -564,5 +564,72 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(pk1).addColumn(pk2).addColumn(val1).addColumn(val2).addColumn(val3)
                 .setPrimaryKeyNames("pk1", "pk2").create();
         return table;
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExpandsColumnsFromTable() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExcludesGeneratedColumns() {
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void testBuildProjectionExcludesGeneratedColumnsAndAppliesIncludeList() {
+        final RelationalDatabaseConnectorConfig cfg = buildConfig(Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, ".*\\.(pk1|val1|gen1)$")
+                .build());
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
+                cfg, new JdbcConnection(cfg.getJdbcConfig(), c -> null, "\"", "\""));
+        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").generated(true).create();
+        final Column val2 = Column.editor().name("val2").create();
+        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .addColumn(val2)
+                .setPrimaryKeyNames("pk1").create();
+
+        // gen1 is include-listed but must still be dropped because it is generated; val2 is not include-listed.
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -587,7 +587,9 @@ public class DefaultChunkQueryBuilderTest {
 
     @Test
     @FixFor("DBZ-2020")
-    public void testBuildProjectionExcludesGeneratedColumns() {
+    public void testBuildProjectionKeepsGeneratedColumnsPresentInTableAsStar() {
+        // DBZ-2020: generated columns still present in the Table (Oracle, decoderbufs, MySQL STORED)
+        // must stay in SELECT *; only pgoutput excludes them via the side-map hook.
         final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
@@ -603,12 +605,12 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1").create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
     @FixFor("DBZ-2020")
-    public void testBuildProjectionExcludesGeneratedColumnsAndAppliesIncludeList() {
+    public void testBuildProjectionAppliesIncludeListWithoutDroppingGeneratedColumns() {
         final RelationalDatabaseConnectorConfig cfg = buildConfig(Configuration.create()
                 .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
                 .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
@@ -628,16 +630,17 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
 
-        // gen1 is include-listed but must still be dropped because it is generated; val2 is not include-listed.
+        // Only the column filter drops columns: gen1 is include-listed and kept (not dropped for being
+        // generated); val2 is not include-listed and is dropped.
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"gen1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
     @FixFor("DBZ-2020")
     public void testBuildProjectionKeepsAutoIncrementedGeneratedColumnsAsStar() {
-        // MySQL/MariaDB set both autoIncremented and generated for AUTO_INCREMENT; that alone must
-        // not force an explicit projection (keeps the SELECT * race-safe path).
+        // MySQL/MariaDB set both autoIncremented and generated for AUTO_INCREMENT; the base builder
+        // keeps SELECT * (race-safe path), same as any other non-filtered table.
         final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
@@ -650,24 +653,5 @@ public class DefaultChunkQueryBuilderTest {
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
                 .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
-    }
-
-    @Test
-    @FixFor("DBZ-2020")
-    public void testBuildProjectionKeepsAutoIncrementWhenExcludingTrueGeneratedColumns() {
-        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
-                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
-        final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
-        final Column pk1 = Column.editor().name("pk1").optional(false).autoIncremented(true).generated(true).create();
-        final Column val1 = Column.editor().name("val1").create();
-        final Column gen1 = Column.editor().name("gen1").generated(true).create();
-        final Table table = Table.editor().tableId(new TableId(null, "s1", "table1"))
-                .addColumn(pk1)
-                .addColumn(val1)
-                .addColumn(gen1)
-                .setPrimaryKeyNames("pk1").create();
-
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/DefaultChunkQueryBuilderTest.java
@@ -107,11 +107,11 @@ public class DefaultChunkQueryBuilderTest {
         final List<Column> pkColumns = List.of(pk1);
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -135,11 +135,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk1\" > ?) AND NOT (\"pk1\" > ?) AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -166,11 +166,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE (\"pk2\" > ?) AND NOT (\"pk2\" > ?) AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         // Surrogate key: only the surrogate column (pk2) is bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1));
@@ -199,11 +199,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Base builder uses a triangular expansion of the boundary params
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk1, 1), qp(pk2, 5), qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -232,11 +232,11 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Base builder uses a triangular expansion of the boundary params
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk1, 1), qp(pk2, 5), qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -261,7 +261,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -276,7 +276,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -291,7 +291,7 @@ public class DefaultChunkQueryBuilderTest {
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" DESC, \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -307,7 +307,7 @@ public class DefaultChunkQueryBuilderTest {
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildMaxPrimaryKeyQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
     }
 
     @Test
@@ -380,14 +380,14 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKeyWithNulls = new Object[]{ null, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -402,7 +402,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(maximumKeyWithNulls);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NOT NULL) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -448,14 +448,14 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKeyWithNulls = new Object[]{ null, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? OR \"pk2\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +
@@ -470,7 +470,7 @@ public class DefaultChunkQueryBuilderTest {
         context.maximumKey(maximumKeyWithNulls);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? OR \"pk1\" IS NULL)) " +
                         "OR (\"pk1\" = ? AND 1 = 0) " +
                         "OR (\"pk1\" = ? AND \"pk2\" IS NULL AND \"pk3\" > ?)) " +
@@ -521,13 +521,13 @@ public class DefaultChunkQueryBuilderTest {
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
 
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk2\" > ?) OR (\"pk2\" = ? AND \"pk1\" > ?) OR (\"pk2\" = ? AND \"pk1\" = ? AND \"pk3\" > ?)) ORDER BY \"pk2\", \"pk1\", \"pk3\" LIMIT 1024");
         // Params follow the message-key column order (pk2, pk1, pk3), triangularly expanded per bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1), qp(pk2, 1), qp(pk1, 5), qp(pk2, 1), qp(pk1, 5), qp(pk3, 3));
@@ -568,7 +568,7 @@ public class DefaultChunkQueryBuilderTest {
 
     @Test
     @FixFor("DBZ-2020")
-    public void testBuildProjectionExpandsColumnsFromTable() {
+    public void testBuildProjectionKeepsSelectStarWhenNoGeneratedColumns() {
         final ChunkQueryBuilder<TableId> chunkQueryBuilder = new DefaultChunkQueryBuilder<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""));
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
@@ -582,7 +582,7 @@ public class DefaultChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1").create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
@@ -95,11 +95,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -116,11 +116,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -140,11 +140,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -165,11 +165,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -191,11 +191,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
                 .isEqualTo(
-                        "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                        "SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -238,14 +238,14 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
@@ -94,11 +94,12 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val1)
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -115,11 +116,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
     }
 
     @Test
@@ -139,11 +140,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .setPrimaryKeyNames("pk1", "pk2").create();
         context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), List.of(), "pk2");
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1 });
         context.maximumKey(new Object[]{ 10 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
     }
 
     @Test
@@ -164,11 +165,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -189,11 +190,12 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2", "pk3").create();
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo(
+                        "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
     }
 
     @Test
@@ -236,14 +238,14 @@ public class RowValueConstructorChunkQueryBuilderTest {
                 .create();
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(new Object[]{ 1, 5, 3 });
         context.maximumKey(new Object[]{ 10, 50, 30 });
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
@@ -97,11 +97,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final List<Column> pkColumns = List.of(pk1);
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -125,11 +125,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -156,11 +156,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         // Surrogate key: only the surrogate column (pk2) is bound, one param per bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1));
@@ -189,11 +189,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Row value constructor path (all-required keys): one param per column.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -222,11 +222,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Row value constructor path (all-required keys): one param per column.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -277,14 +277,14 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
+                "SELECT * FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/RowValueConstructorChunkQueryBuilderTest.java
@@ -97,11 +97,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final List<Column> pkColumns = List.of(pk1);
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
-        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+        assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -125,11 +125,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
+                "SELECT \"pk1\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk1\" > ? AND \"pk1\" <= ? AND \"val1\"=foo ORDER BY \"pk1\" LIMIT 1024");
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1));
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, maximumKey))
@@ -156,11 +156,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1 };
         final Object[] maximumKey = new Object[]{ 10 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"pk2\" > ? AND \"pk2\" <= ? AND \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         // Surrogate key: only the surrogate column (pk2) is bound, one param per bound.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk2, 1));
@@ -189,11 +189,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Row value constructor path (all-required keys): one param per column.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -222,11 +222,11 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] chunkEndPosition = new Object[]{ 1, 5, 3 };
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo")))
-                .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                .isEqualTo("SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.of("\"val1\"=foo"))).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\", \"val2\" FROM \"s1\".\"table1\" WHERE ROW(\"pk1\", \"pk2\", \"pk3\") > ROW(?, ?, ?) AND ROW(\"pk1\", \"pk2\", \"pk3\") <= ROW(?, ?, ?) AND \"val1\"=foo ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         // Row value constructor path (all-required keys): one param per column.
         assertThat(boundaryParams(chunkQueryBuilder, pkColumns, chunkEndPosition))
                 .containsExactly(qp(pk1, 1), qp(pk2, 5), qp(pk3, 3));
@@ -277,14 +277,14 @@ public class RowValueConstructorChunkQueryBuilderTest {
         final Object[] maximumKey = new Object[]{ 10, 50, 30 };
 
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
 
         // Next chunk position and maximum key are both completely NOT NULL
         context.nextChunkPosition(chunkEndPosition);
         context.maximumKey(maximumKey);
         assertThat(chunkQueryBuilder.buildChunkQuery(context, table, Optional.empty())).isEqualTo(
                 // chunk end
-                "SELECT * FROM \"s1\".\"table1\" WHERE " +
+                "SELECT \"pk1\", \"pk2\", \"pk3\", \"val1\" FROM \"s1\".\"table1\" WHERE " +
                         "(((\"pk1\" > ? AND \"pk1\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND (\"pk2\" > ? AND \"pk2\" IS NOT NULL)) " +
                         "OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) " +

--- a/debezium-connector-common/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
@@ -71,6 +71,8 @@ public class HistoryRecordTest {
                         .optional(true)
                         .defaultValueExpression("1")
                         .comment("third comment")
+                        .generated(true)
+                        .invisible(true)
                         .create())
                 .setPrimaryKeyNames("first")
                 .setComment("table comment")
@@ -109,6 +111,14 @@ public class HistoryRecordTest {
 
         assertThat(secondColumn.get("defaultValueExpression")).isEqualTo("1");
 
+        Document thirdColumn = deserialized.tableChanges()
+                .get(0).asDocument()
+                .getDocument("table")
+                .getArray("columns")
+                .get(2).asDocument();
+        assertThat(thirdColumn.getBoolean("generated")).isTrue();
+        assertThat(thirdColumn.getBoolean("invisible")).isTrue();
+
         Document firstAttribute = deserialized.tableChanges()
                 .get(0).asDocument()
                 .getDocument("table")
@@ -128,7 +138,43 @@ public class HistoryRecordTest {
         List<Struct> columnStructs = (List<Struct>) tableStruct.get(ConnectTableChangeSerializer.COLUMNS_KEY);
         assertThat(columnStructs.get(0).get(ConnectTableChangeSerializer.COMMENT_KEY)).isEqualTo("first comment");
         assertThat(columnStructs.get(0).get(ConnectTableChangeSerializer.ENUM_VALUES)).isNull();
+        assertThat((Boolean) columnStructs.get(0).get(ConnectTableChangeSerializer.GENERATED_KEY)).isFalse();
+        assertThat((Boolean) columnStructs.get(0).get(ConnectTableChangeSerializer.INVISIBLE_KEY)).isFalse();
         assertThat(columnStructs.get(1).get(ConnectTableChangeSerializer.DEFAULT_VALUE_EXPRESSION)).isEqualTo("1");
         assertThat(columnStructs.get(1).get(ConnectTableChangeSerializer.ENUM_VALUES)).isEqualTo(Collect.arrayListOf("1", "2"));
+        assertThat((Boolean) columnStructs.get(2).get(ConnectTableChangeSerializer.GENERATED_KEY)).isTrue();
+        assertThat((Boolean) columnStructs.get(2).get(ConnectTableChangeSerializer.INVISIBLE_KEY)).isTrue();
+    }
+
+    @Test
+    public void shouldDefaultInvisibleToFalseWhenMissingFromOlderHistory() {
+        Document column = Document.create()
+                .setString("name", "col")
+                .setNumber("jdbcType", Types.INTEGER)
+                .setString("typeName", "INT")
+                .setString("typeExpression", "INT")
+                .setNumber("position", 1)
+                .setBoolean("optional", false)
+                .setBoolean("autoIncremented", false)
+                .setBoolean("generated", false)
+                .setBoolean("hasDefaultValue", false);
+
+        Document table = Document.create();
+        table.setString("defaultCharsetName", null);
+        table.setArray("columns", column);
+        table.setArray("primaryKeyColumnNames", Array.create("col"));
+        table.setArray("attributes");
+
+        Document change = Document.create();
+        change.setString("type", "CREATE");
+        change.setString("id", "\"db\".\"myschema\".\"foo\"");
+        change.setDocument("table", table);
+
+        Array tableChangesArray = Array.create();
+        tableChangesArray.add(change);
+        TableChanges deserialized = new JsonTableChangeSerializer().deserialize(tableChangesArray, true);
+        Column deserializedColumn = deserialized.iterator().next().getTable().columnWithName("col");
+        assertThat(deserializedColumn.isInvisible()).isFalse();
+        assertThat(deserializedColumn.isGenerated()).isFalse();
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotIT.java
@@ -5,17 +5,24 @@
  */
 package io.debezium.connector.oracle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -228,15 +235,49 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Oracl
         connection.execute("CREATE TABLE a (pk numeric(9,0) primary key, aa numeric(9,0))");
         connection.execute("CREATE TABLE b (pk numeric(9,0) primary key, aa numeric(9,0))");
         connection.execute("CREATE TABLE a42 (pk1 numeric(9,0), pk2 numeric(9,0), pk3 numeric(9,0), pk4 numeric(9,0), aa numeric(9,0))");
+        // cc is a virtual (generated) column; DBZ-2020 must keep it in the incremental snapshot.
+        connection.execute("CREATE TABLE gencol (pk numeric(9,0) primary key, aa numeric(9,0), cc numeric(9,0) GENERATED ALWAYS AS (aa + 1) VIRTUAL)");
         TestHelper.streamTable(connection, "a");
         TestHelper.streamTable(connection, "b");
         TestHelper.streamTable(connection, "a42");
+        TestHelper.streamTable(connection, "gencol");
     }
 
     private void dropTables() throws Exception {
         TestHelper.dropTable(connection, "a");
         TestHelper.dropTable(connection, "b");
         TestHelper.dropTable(connection, "a42");
+        TestHelper.dropTable(connection, "gencol");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void incrementalSnapshotKeepsVirtualGeneratedColumnValue() throws Exception {
+        // DBZ-2020: Oracle keeps the virtual column in the Table, so its computed value (aa + 1) must
+        // appear in the incremental snapshot rather than NULL.
+        connection.execute("INSERT INTO gencol (pk, aa) VALUES (1, 1)");
+        connection.execute("INSERT INTO gencol (pk, aa) VALUES (2, 2)");
+        connection.commit();
+
+        startConnector(x -> x.with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.GENCOL"));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal(TestHelper.getDatabaseName() + ".DEBEZIUM.GENCOL");
+
+        final String topicName = "server1.DEBEZIUM.GENCOL";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("PK"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    assertThat(after.schema().field("CC")).isNotNull();
+                    assertThat(after.getInt32("CC")).isEqualTo(after.getInt32("AA") + 1);
+                    return after.getInt32("AA");
+                },
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.source.snapshot.incremental.RowValueConstructorChunkQueryBuilder;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.spi.schema.DataCollectionId;
+
+/**
+ * PostgreSQL chunk query builder that consults {@link PostgresSchema}'s generated-column side map.
+ *
+ * <p>For pgoutput, {@link PostgresSchema#refreshFromIncrementalSnapshot} prunes generated columns from
+ * the in-memory {@link Table}. Without the side map, {@code buildProjection} would see no generated
+ * columns and fall back to {@code SELECT *}, which returns those columns from the database and fails
+ * with "Column 'X' not found in result set" (DBZ-2020).</p>
+ *
+ * @param <T> data collection id type
+ */
+public class PostgresChunkQueryBuilder<T extends DataCollectionId> extends RowValueConstructorChunkQueryBuilder<T> {
+
+    private final PostgresSchema schema;
+
+    public PostgresChunkQueryBuilder(RelationalDatabaseConnectorConfig config,
+                                     JdbcConnection jdbcConnection,
+                                     PostgresSchema schema) {
+        super(config, jdbcConnection);
+        this.schema = schema;
+    }
+
+    @Override
+    protected boolean hasAdditionalGeneratedColumns(Table table) {
+        return !schema.getGeneratedColumnsForTableId(table.id()).isEmpty();
+    }
+
+    @Override
+    protected boolean isAdditionalGeneratedColumn(Table table, String columnName) {
+        // After pruning, generated columns are absent from table.columns(), so this filter is a
+        // no-op for the stream over table.columns(). Kept for symmetry with the detection hook.
+        return schema.getGeneratedColumnsForTableId(table.id()).stream()
+                .anyMatch(name -> name.equalsIgnoreCase(columnName));
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilder.java
@@ -39,8 +39,8 @@ public class PostgresChunkQueryBuilder<T extends DataCollectionId> extends RowVa
 
     @Override
     protected boolean isAdditionalGeneratedColumn(Table table, String columnName) {
-        // After pruning, generated columns are absent from table.columns(), so this filter is a
-        // no-op for the stream over table.columns(). Kept for symmetry with the detection hook.
+        // Side-map entries can still exist for columns that are present in table.columns()
+        // (e.g. before pruning). Always consult the side map for projection filtering.
         return schema.getGeneratedColumnsForTableId(table.id()).stream()
                 .anyMatch(name -> name.equalsIgnoreCase(columnName));
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -88,6 +88,10 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.jdbcConnection = (PostgresConnection) jdbcConnection;
         this.schema = (PostgresSchema) databaseSchema;
+        // Replace the default RowValueConstructor builder with one that consults the generated-column
+        // side map, so buildProjection still expands when refreshFromIncrementalSnapshot has pruned
+        // generated columns from the Table (DBZ-2020 / pgoutput).
+        this.chunkQueryBuilder = new PostgresChunkQueryBuilder<>(config, jdbcConnection, this.schema);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -50,6 +50,7 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     private final static Logger LOGGER = LoggerFactory.getLogger(PostgresSchema.class);
 
     private final Map<TableId, List<String>> tableIdToToastableColumns;
+    private final Map<TableId, List<String>> tableIdToGeneratedColumns;
     private final Map<Integer, TableId> relationIdToTableId;
     private final boolean readToastableColumns;
     private final PostgresConnectorConfig connectorConfig;
@@ -69,6 +70,7 @@ public class PostgresSchema extends RelationalDatabaseSchema {
 
         this.connectorConfig = cdcSourceTaskContext.getConfig();
         this.tableIdToToastableColumns = new HashMap<>();
+        this.tableIdToGeneratedColumns = new HashMap<>();
         this.relationIdToTableId = new HashMap<>();
         this.readToastableColumns = connectorConfig.skipRefreshSchemaOnMissingToastableData();
     }
@@ -140,7 +142,11 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         var updatedTable = temp.forTable(tableId);
         // The Postgres JDBC driver does not surface IS_GENERATEDCOLUMN, so populate it here before
         // any consumer (including the removeGeneratedColumns branch below) inspects isGenerated().
-        updatedTable = applyGeneratedColumnFlags(connection, updatedTable);
+        // Also refresh the side map used by incremental-snapshot projection: refreshFromIncrementalSnapshot
+        // may prune generated columns from the Table, but buildProjection still needs to know they exist.
+        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
+        tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
+        updatedTable = applyGeneratedColumnFlags(updatedTable, generatedColumnNames);
         if (removeGeneratedColumns) {
             var editor = updatedTable.edit();
             final var notGeneratedColumns = updatedTable.filterColumns(x -> !x.isGenerated());
@@ -257,13 +263,19 @@ public class PostgresSchema extends RelationalDatabaseSchema {
      * <p>{@code attgenerated} is a single character: {@code ''} for regular columns, {@code 's'} for
      * {@code STORED} generated columns (PostgreSQL 12+) and {@code 'v'} for {@code VIRTUAL} generated
      * columns (PostgreSQL 18+). Any non-empty value is treated as generated.</p>
+     *
+     * <p>Also stores the names in {@link #tableIdToGeneratedColumns} so incremental-snapshot projection
+     * can still detect generated columns after {@link #refreshFromIncrementalSnapshot} has pruned them
+     * from the Table for pgoutput.</p>
      */
     private void refreshGeneratedColumnsMap(PostgresConnection connection, TableId tableId) {
         final Table current = tables().forTable(tableId);
         if (current == null) {
             return;
         }
-        final Table updated = applyGeneratedColumnFlags(connection, current);
+        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
+        tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
+        final Table updated = applyGeneratedColumnFlags(current, generatedColumnNames);
         if (updated != current) {
             tables().overwriteTable(updated);
         }
@@ -271,11 +283,10 @@ public class PostgresSchema extends RelationalDatabaseSchema {
 
     /**
      * Returns a {@link Table} whose columns carry the correct {@link Column#isGenerated()} value based
-     * on a {@code pg_attribute.attgenerated} lookup. Returns the input unchanged when no generated
-     * columns are present, so callers can cheaply detect the common case.
+     * on the provided generated-column names. Returns the input unchanged when no generated columns
+     * are present, so callers can cheaply detect the common case.
      */
-    private Table applyGeneratedColumnFlags(PostgresConnection connection, Table table) {
-        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, table.id());
+    private Table applyGeneratedColumnFlags(Table table, List<String> generatedColumnNames) {
         if (generatedColumnNames.isEmpty()) {
             return table;
         }
@@ -338,6 +349,14 @@ public class PostgresSchema extends RelationalDatabaseSchema {
 
     public List<String> getToastableColumnsForTableId(TableId tableId) {
         return tableIdToToastableColumns.getOrDefault(tableId, Collections.emptyList());
+    }
+
+    /**
+     * Generated column names for {@code tableId}, including those that may have been pruned from the
+     * in-memory {@link Table} by {@link #refreshFromIncrementalSnapshot} for pgoutput.
+     */
+    public List<String> getGeneratedColumnsForTableId(TableId tableId) {
+        return tableIdToGeneratedColumns.getOrDefault(tableId, Collections.emptyList());
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -25,9 +25,11 @@ import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
 import io.debezium.connector.postgresql.connection.ReplicaIdentityInfo;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
@@ -89,6 +91,11 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     protected PostgresSchema refresh(PostgresConnection connection, boolean printReplicaIdentityInfo) throws SQLException {
         // read all the information from the DB
         connection.readSchema(tables(), null, null, getTableFilter(), null, true);
+        // The Postgres JDBC driver does not expose the IS_GENERATEDCOLUMN metadata slot that
+        // JdbcConnection.readSchema() relies on, so Column.isGenerated() is left false after the
+        // initial read. Populate it from pg_attribute.attgenerated so incremental snapshot and any
+        // other consumer that relies on isGenerated() can behave correctly.
+        tableIds().forEach(tableId -> refreshGeneratedColumnsMap(connection, tableId));
         if (printReplicaIdentityInfo) {
             // print out all the replica identity info
             tableIds().forEach(tableId -> printReplicaIdentityInfo(connection, tableId));
@@ -131,6 +138,9 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         }
 
         var updatedTable = temp.forTable(tableId);
+        // The Postgres JDBC driver does not surface IS_GENERATEDCOLUMN, so populate it here before
+        // any consumer (including the removeGeneratedColumns branch below) inspects isGenerated().
+        updatedTable = applyGeneratedColumnFlags(connection, updatedTable);
         if (removeGeneratedColumns) {
             var editor = updatedTable.edit();
             final var notGeneratedColumns = updatedTable.filterColumns(x -> !x.isGenerated());
@@ -236,6 +246,86 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         }
 
         tableIdToToastableColumns.put(tableId, Collections.unmodifiableList(toastableColumns));
+    }
+
+    /**
+     * Reads the set of generated columns for {@code tableId} from {@code pg_attribute.attgenerated} and
+     * updates the in-memory {@link Table} so that {@link Column#isGenerated()} reflects the database state.
+     * The Postgres JDBC driver does not populate {@code IS_GENERATEDCOLUMN}, which is why we do this
+     * server-side.
+     *
+     * <p>{@code attgenerated} is a single character: {@code ''} for regular columns, {@code 's'} for
+     * {@code STORED} generated columns (PostgreSQL 12+) and {@code 'v'} for {@code VIRTUAL} generated
+     * columns (PostgreSQL 18+). Any non-empty value is treated as generated.</p>
+     */
+    private void refreshGeneratedColumnsMap(PostgresConnection connection, TableId tableId) {
+        final Table current = tables().forTable(tableId);
+        if (current == null) {
+            return;
+        }
+        final Table updated = applyGeneratedColumnFlags(connection, current);
+        if (updated != current) {
+            tables().overwriteTable(updated);
+        }
+    }
+
+    /**
+     * Returns a {@link Table} whose columns carry the correct {@link Column#isGenerated()} value based
+     * on a {@code pg_attribute.attgenerated} lookup. Returns the input unchanged when no generated
+     * columns are present, so callers can cheaply detect the common case.
+     */
+    private Table applyGeneratedColumnFlags(PostgresConnection connection, Table table) {
+        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, table.id());
+        if (generatedColumnNames.isEmpty()) {
+            return table;
+        }
+        final TableEditor editor = table.edit();
+        for (String columnName : generatedColumnNames) {
+            final Column existing = table.columnWithName(columnName);
+            if (existing == null) {
+                // Column was filtered out (e.g. by column.exclude.list) or dropped between reads.
+                continue;
+            }
+            if (existing.isGenerated()) {
+                continue;
+            }
+            editor.updateColumn(existing.edit().generated(true).create());
+        }
+        return editor.create();
+    }
+
+    private List<String> readGeneratedColumnNames(PostgresConnection connection, TableId tableId) {
+        // See applyGeneratedColumnFlags for why attgenerated <> '' captures both STORED (PG12+) and
+        // VIRTUAL (PG18+) generated columns.
+        final String statement = "select att.attname" +
+                " from pg_attribute att" +
+                " join pg_class tbl on tbl.oid = att.attrelid" +
+                " join pg_namespace ns on tbl.relnamespace = ns.oid" +
+                " where tbl.relname = ?" +
+                " and ns.nspname = ?" +
+                " and att.attnum > 0" +
+                " and att.attgenerated <> ''" +
+                " and not att.attisdropped;";
+        final String relName = tableId.table();
+        final String schema = tableId.schema() != null && tableId.schema().length() > 0 ? tableId.schema() : PUBLIC_SCHEMA_NAME;
+        final List<String> generatedColumns = new ArrayList<>();
+        try {
+            connection.prepareQuery(statement, stmt -> {
+                stmt.setString(1, relName);
+                stmt.setString(2, schema);
+            }, rs -> {
+                while (rs.next()) {
+                    generatedColumns.add(rs.getString(1));
+                }
+            });
+            if (!connection.connection().getAutoCommit()) {
+                connection.connection().commit();
+            }
+        }
+        catch (SQLException e) {
+            throw new ConnectException("Unable to read generated column metadata for " + tableId, e);
+        }
+        return generatedColumns;
     }
 
     protected static TableId parse(String table) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -140,19 +140,19 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         }
 
         var updatedTable = temp.forTable(tableId);
-        // The Postgres JDBC driver does not surface IS_GENERATEDCOLUMN, so populate it here before
-        // any consumer (including the removeGeneratedColumns branch below) inspects isGenerated().
-        // Also refresh the side map used by incremental-snapshot projection: refreshFromIncrementalSnapshot
-        // may prune generated columns from the Table, but buildProjection still needs to know they exist.
-        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
-        tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
-        updatedTable = applyGeneratedColumnFlags(updatedTable, generatedColumnNames);
-        if (removeGeneratedColumns) {
-            var editor = updatedTable.edit();
-            final var notGeneratedColumns = updatedTable.filterColumns(x -> !x.isGenerated());
-            LOGGER.debug("Removing generated columns, the new column list is '{}'", notGeneratedColumns);
-            editor.setColumns(notGeneratedColumns);
-            updatedTable = editor.create();
+        // DBZ-2020: only pgoutput prunes generated columns and needs them tracked; other decoders keep
+        // the column (and its value) in the Table, so leave them untouched here.
+        if (tracksGeneratedColumns()) {
+            final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
+            tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
+            updatedTable = applyGeneratedColumnFlags(updatedTable, generatedColumnNames);
+            if (removeGeneratedColumns) {
+                var editor = updatedTable.edit();
+                final var notGeneratedColumns = updatedTable.filterColumns(x -> !x.isGenerated());
+                LOGGER.debug("Removing generated columns, the new column list is '{}'", notGeneratedColumns);
+                editor.setColumns(notGeneratedColumns);
+                updatedTable = editor.create();
+            }
         }
 
         // overwrite (add or update) or views of the tables
@@ -255,20 +255,14 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     }
 
     /**
-     * Reads the set of generated columns for {@code tableId} from {@code pg_attribute.attgenerated} and
-     * updates the in-memory {@link Table} so that {@link Column#isGenerated()} reflects the database state.
-     * The Postgres JDBC driver does not populate {@code IS_GENERATEDCOLUMN}, which is why we do this
-     * server-side.
-     *
-     * <p>{@code attgenerated} is a single character: {@code ''} for regular columns, {@code 's'} for
-     * {@code STORED} generated columns (PostgreSQL 12+) and {@code 'v'} for {@code VIRTUAL} generated
-     * columns (PostgreSQL 18+). Any non-empty value is treated as generated.</p>
-     *
-     * <p>Also stores the names in {@link #tableIdToGeneratedColumns} so incremental-snapshot projection
-     * can still detect generated columns after {@link #refreshFromIncrementalSnapshot} has pruned them
-     * from the Table for pgoutput.</p>
+     * Populates {@link Column#isGenerated()} from {@code pg_attribute.attgenerated} (the Postgres JDBC
+     * driver does not surface {@code IS_GENERATEDCOLUMN}) and records the names in
+     * {@link #tableIdToGeneratedColumns}. Runs for pgoutput only; see {@link #tracksGeneratedColumns()}.
      */
     private void refreshGeneratedColumnsMap(PostgresConnection connection, TableId tableId) {
+        if (!tracksGeneratedColumns()) {
+            return;
+        }
         final Table current = tables().forTable(tableId);
         if (current == null) {
             return;
@@ -352,11 +346,19 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     }
 
     /**
-     * Generated column names for {@code tableId}, including those that may have been pruned from the
-     * in-memory {@link Table} by {@link #refreshFromIncrementalSnapshot} for pgoutput.
+     * Generated column names for {@code tableId}, including any pruned from the {@link Table} for
+     * pgoutput. Empty for other decoders; see {@link #tracksGeneratedColumns()}.
      */
     public List<String> getGeneratedColumnsForTableId(TableId tableId) {
         return tableIdToGeneratedColumns.getOrDefault(tableId, Collections.emptyList());
+    }
+
+    /**
+     * Only pgoutput prunes generated columns from the {@link Table}, so only pgoutput needs them tracked
+     * for the incremental-snapshot projection; other decoders keep the column and its value (DBZ-2020).
+     */
+    private boolean tracksGeneratedColumns() {
+        return connectorConfig.plugin() == LogicalDecoder.PGOUTPUT;
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -143,12 +144,16 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         // DBZ-2020: only pgoutput prunes generated columns and needs them tracked; other decoders keep
         // the column (and its value) in the Table, so leave them untouched here.
         if (tracksGeneratedColumns()) {
-            final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
+            final List<String> generatedColumnNames = trackedGeneratedColumnNames(updatedTable, connection, tableId);
             tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
             updatedTable = applyGeneratedColumnFlags(updatedTable, generatedColumnNames);
             if (removeGeneratedColumns) {
+                // DBZ-2020: never prune a primary key column, generated or not; removing it here would
+                // leave a dangling PK reference and TableEditorImpl would reject the table.
+                final List<String> primaryKeyColumnNames = updatedTable.primaryKeyColumnNames();
                 var editor = updatedTable.edit();
-                final var notGeneratedColumns = updatedTable.filterColumns(x -> !x.isGenerated());
+                final var notGeneratedColumns = updatedTable.filterColumns(
+                        x -> !x.isGenerated() || primaryKeyColumnNames.contains(x.name()));
                 LOGGER.debug("Removing generated columns, the new column list is '{}'", notGeneratedColumns);
                 editor.setColumns(notGeneratedColumns);
                 updatedTable = editor.create();
@@ -267,12 +272,30 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         if (current == null) {
             return;
         }
-        final List<String> generatedColumnNames = readGeneratedColumnNames(connection, tableId);
+        final List<String> generatedColumnNames = trackedGeneratedColumnNames(current, connection, tableId);
         tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
         final Table updated = applyGeneratedColumnFlags(current, generatedColumnNames);
         if (updated != current) {
             tables().overwriteTable(updated);
         }
+    }
+
+    /**
+     * Returns the generated-column names of {@code table} to track in {@link #tableIdToGeneratedColumns}
+     * and prune from the incremental snapshot chunk projection.
+     *
+     * <p>DBZ-2020: a generated column that is also the primary key is excluded, so it stays in both the
+     * {@link Table} and the chunk projection instead of being pruned as generated.</p>
+     */
+    private List<String> trackedGeneratedColumnNames(Table table, PostgresConnection connection, TableId tableId) {
+        final List<String> allGeneratedColumnNames = readGeneratedColumnNames(connection, tableId);
+        final List<String> primaryKeyColumnNames = table.primaryKeyColumnNames();
+        if (primaryKeyColumnNames.isEmpty()) {
+            return allGeneratedColumnNames;
+        }
+        return allGeneratedColumnNames.stream()
+                .filter(name -> !primaryKeyColumnNames.contains(name))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -8,10 +8,13 @@ package io.debezium.connector.postgresql;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
@@ -35,6 +38,7 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
 import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.util.Strings;
 
 /**
  * Component that records the schema information for the {@link PostgresConnector}. The schema information contains
@@ -94,11 +98,9 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     protected PostgresSchema refresh(PostgresConnection connection, boolean printReplicaIdentityInfo) throws SQLException {
         // read all the information from the DB
         connection.readSchema(tables(), null, null, getTableFilter(), null, true);
-        // The Postgres JDBC driver does not expose the IS_GENERATEDCOLUMN metadata slot that
-        // JdbcConnection.readSchema() relies on, so Column.isGenerated() is left false after the
-        // initial read. Populate it from pg_attribute.attgenerated so incremental snapshot and any
-        // other consumer that relies on isGenerated() can behave correctly.
-        tableIds().forEach(tableId -> refreshGeneratedColumnsMap(connection, tableId));
+        // The Postgres JDBC driver does not reliably populate IS_GENERATEDCOLUMN metadata.
+        // Populate generated-column metadata from pg_attribute.attgenerated.
+        refreshGeneratedColumnsMap(connection);
         if (printReplicaIdentityInfo) {
             // print out all the replica identity info
             tableIds().forEach(tableId -> printReplicaIdentityInfo(connection, tableId));
@@ -144,9 +146,10 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         // DBZ-2020: only pgoutput prunes generated columns and needs them tracked; other decoders keep
         // the column (and its value) in the Table, so leave them untouched here.
         if (tracksGeneratedColumns()) {
-            final List<String> generatedColumnNames = trackedGeneratedColumnNames(updatedTable, connection, tableId);
-            tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
-            updatedTable = applyGeneratedColumnFlags(updatedTable, generatedColumnNames);
+            final List<String> allGeneratedColumnNames = readGeneratedColumnNames(connection, tableId);
+            final List<String> trackedGeneratedColumnNames = trackedGeneratedColumnNames(updatedTable, allGeneratedColumnNames);
+            tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(trackedGeneratedColumnNames));
+            updatedTable = applyGeneratedColumnFlags(updatedTable, allGeneratedColumnNames);
             if (removeGeneratedColumns) {
                 // DBZ-2020: never prune a primary key column, generated or not; removing it here would
                 // leave a dangling PK reference and TableEditorImpl would reject the table.
@@ -226,37 +229,21 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         // I Would prefer to use data provided by PgDatabaseMetaData, but the PG JDBC driver does not expose storage type
         // information. Thus, we need to make a separate query. If we are refreshing schemas rarely, this is not a big
         // deal.
-        List<String> toastableColumns = new ArrayList<>();
-        String relName = tableId.table();
-        String schema = tableId.schema() != null && tableId.schema().length() > 0 ? tableId.schema() : "public";
-        String statement = "select att.attname" +
-                " from pg_attribute att " +
-                " join pg_class tbl on tbl.oid = att.attrelid" +
-                " join pg_namespace ns on tbl.relnamespace = ns.oid" +
-                " where tbl.relname = ?" +
-                " and ns.nspname = ?" +
-                " and att.attnum > 0" +
-                " and att.attstorage in ('x', 'e', 'm')" +
-                " and not att.attisdropped;";
-
-        try {
-            connection.prepareQuery(statement, stmt -> {
-                stmt.setString(1, relName);
-                stmt.setString(2, schema);
-            }, rs -> {
-                while (rs.next()) {
-                    toastableColumns.add(rs.getString(1));
-                }
-            });
-            if (!connection.connection().getAutoCommit()) {
-                connection.connection().commit();
-            }
-        }
-        catch (SQLException e) {
-            throw new ConnectException("Unable to refresh toastable columns mapping", e);
-        }
-
+        final List<String> toastableColumns = readColumnNames(connection, tableId, "att.attstorage in ('x', 'e', 'm')",
+                "Unable to refresh toastable columns mapping");
         tableIdToToastableColumns.put(tableId, Collections.unmodifiableList(toastableColumns));
+    }
+
+    /**
+     * Refreshes generated-column metadata for all currently captured tables with one metadata query.
+     */
+    private void refreshGeneratedColumnsMap(PostgresConnection connection) {
+        if (!tracksGeneratedColumns()) {
+            return;
+        }
+        final Set<TableId> tableIds = tableIds();
+        final Map<TableId, List<String>> allGeneratedColumnsByTable = readGeneratedColumnNames(connection, tableIds);
+        tableIds.forEach(tableId -> refreshGeneratedColumnsMap(tableId, allGeneratedColumnsByTable.getOrDefault(tableId, List.of())));
     }
 
     /**
@@ -268,13 +255,17 @@ public class PostgresSchema extends RelationalDatabaseSchema {
         if (!tracksGeneratedColumns()) {
             return;
         }
+        refreshGeneratedColumnsMap(tableId, readGeneratedColumnNames(connection, tableId));
+    }
+
+    private void refreshGeneratedColumnsMap(TableId tableId, List<String> allGeneratedColumnNames) {
         final Table current = tables().forTable(tableId);
         if (current == null) {
             return;
         }
-        final List<String> generatedColumnNames = trackedGeneratedColumnNames(current, connection, tableId);
-        tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNames));
-        final Table updated = applyGeneratedColumnFlags(current, generatedColumnNames);
+        final List<String> generatedColumnNamesForProjection = trackedGeneratedColumnNames(current, allGeneratedColumnNames);
+        tableIdToGeneratedColumns.put(tableId, Collections.unmodifiableList(generatedColumnNamesForProjection));
+        final Table updated = applyGeneratedColumnFlags(current, allGeneratedColumnNames);
         if (updated != current) {
             tables().overwriteTable(updated);
         }
@@ -287,15 +278,14 @@ public class PostgresSchema extends RelationalDatabaseSchema {
      * <p>DBZ-2020: a generated column that is also the primary key is excluded, so it stays in both the
      * {@link Table} and the chunk projection instead of being pruned as generated.</p>
      */
-    private List<String> trackedGeneratedColumnNames(Table table, PostgresConnection connection, TableId tableId) {
-        final List<String> allGeneratedColumnNames = readGeneratedColumnNames(connection, tableId);
+    private List<String> trackedGeneratedColumnNames(Table table, List<String> allGeneratedColumnNames) {
         final List<String> primaryKeyColumnNames = table.primaryKeyColumnNames();
         if (primaryKeyColumnNames.isEmpty()) {
             return allGeneratedColumnNames;
         }
         return allGeneratedColumnNames.stream()
                 .filter(name -> !primaryKeyColumnNames.contains(name))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -323,8 +313,58 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     }
 
     private List<String> readGeneratedColumnNames(PostgresConnection connection, TableId tableId) {
+        return readColumnNames(connection, tableId, "att.attgenerated <> ''",
+                "Unable to read generated column metadata for " + tableId);
+    }
+
+    private Map<TableId, List<String>> readGeneratedColumnNames(PostgresConnection connection, Collection<TableId> tableIds) {
+        if (tableIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
         // See applyGeneratedColumnFlags for why attgenerated <> '' captures both STORED (PG12+) and
         // VIRTUAL (PG18+) generated columns.
+        final Set<TableId> capturedLookupKeys = tableIds.stream()
+                .map(tableId -> new TableId(null, schemaName(tableId), tableId.table()))
+                .collect(Collectors.toSet());
+        final String tablePredicates = String.join(" OR ", Collections.nCopies(capturedLookupKeys.size(), "(ns.nspname = ? and tbl.relname = ?)"));
+        final String statement = "select ns.nspname, tbl.relname, att.attname" +
+                " from pg_attribute att" +
+                " join pg_class tbl on tbl.oid = att.attrelid" +
+                " join pg_namespace ns on tbl.relnamespace = ns.oid" +
+                " where (" + tablePredicates + ")" +
+                " and att.attnum > 0" +
+                " and att.attgenerated <> ''" +
+                " and not att.attisdropped;";
+
+        final Map<TableId, TableId> capturedTablesByName = new HashMap<>();
+        for (TableId tableId : tableIds) {
+            capturedTablesByName.put(new TableId(null, schemaName(tableId), tableId.table()), tableId);
+        }
+
+        final Map<TableId, List<String>> generatedColumnsByTable = new LinkedHashMap<>();
+        runColumnMetadataQuery(connection, statement, stmt -> {
+            int index = 1;
+            for (TableId lookupTableId : capturedLookupKeys) {
+                stmt.setString(index++, lookupTableId.schema());
+                stmt.setString(index++, lookupTableId.table());
+            }
+        }, rs -> {
+            while (rs.next()) {
+                final String schema = rs.getString(1);
+                final String tableName = rs.getString(2);
+                final String columnName = rs.getString(3);
+                final TableId lookupKey = new TableId(null, schema, tableName);
+                final TableId capturedTableId = capturedTablesByName.get(lookupKey);
+                if (capturedTableId != null) {
+                    generatedColumnsByTable.computeIfAbsent(capturedTableId, ignored -> new ArrayList<>()).add(columnName);
+                }
+            }
+        }, "Unable to read generated column metadata");
+        return generatedColumnsByTable;
+    }
+
+    private List<String> readColumnNames(PostgresConnection connection, TableId tableId, String predicate, String errorContext) {
         final String statement = "select att.attname" +
                 " from pg_attribute att" +
                 " join pg_class tbl on tbl.oid = att.attrelid" +
@@ -332,28 +372,37 @@ public class PostgresSchema extends RelationalDatabaseSchema {
                 " where tbl.relname = ?" +
                 " and ns.nspname = ?" +
                 " and att.attnum > 0" +
-                " and att.attgenerated <> ''" +
+                " and " + predicate +
                 " and not att.attisdropped;";
-        final String relName = tableId.table();
-        final String schema = tableId.schema() != null && tableId.schema().length() > 0 ? tableId.schema() : PUBLIC_SCHEMA_NAME;
-        final List<String> generatedColumns = new ArrayList<>();
+
+        final List<String> columnNames = new ArrayList<>();
+        runColumnMetadataQuery(connection, statement, stmt -> {
+            stmt.setString(1, tableId.table());
+            stmt.setString(2, schemaName(tableId));
+        }, rs -> {
+            while (rs.next()) {
+                columnNames.add(rs.getString(1));
+            }
+        }, errorContext);
+        return columnNames;
+    }
+
+    private void runColumnMetadataQuery(PostgresConnection connection, String statement,
+                                        JdbcConnection.StatementPreparer statementPreparer,
+                                        JdbcConnection.ResultSetConsumer consumer, String errorContext) {
         try {
-            connection.prepareQuery(statement, stmt -> {
-                stmt.setString(1, relName);
-                stmt.setString(2, schema);
-            }, rs -> {
-                while (rs.next()) {
-                    generatedColumns.add(rs.getString(1));
-                }
-            });
+            connection.prepareQuery(statement, statementPreparer, consumer);
             if (!connection.connection().getAutoCommit()) {
                 connection.connection().commit();
             }
         }
         catch (SQLException e) {
-            throw new ConnectException("Unable to read generated column metadata for " + tableId, e);
+            throw new ConnectException(errorContext, e);
         }
-        return generatedColumns;
+    }
+
+    private String schemaName(TableId tableId) {
+        return Strings.isNullOrEmpty(tableId.schema()) ? PUBLIC_SCHEMA_NAME : tableId.schema();
     }
 
     protected static TableId parse(String table) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -49,6 +49,10 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.jdbcConnection = (PostgresConnection) jdbcConnection;
         this.schema = (PostgresSchema) databaseSchema;
+        // Replace the default RowValueConstructor builder with one that consults the generated-column
+        // side map, so buildProjection still expands when refreshFromIncrementalSnapshot has pruned
+        // generated columns from the Table (DBZ-2020 / pgoutput).
+        this.chunkQueryBuilder = new PostgresChunkQueryBuilder<>(config, jdbcConnection, this.schema);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -546,6 +546,39 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     }
 
     @Test
+    @FixFor("DBZ-2020")
+    public void incrementalSnapshotSkipsGeneratedColumnWithoutColumnExcludeList() throws Exception {
+        // Regression test for DBZ-2020: without any column.exclude.list workaround, the incremental
+        // snapshot chunk query must skip STORED generated columns; otherwise PostgreSQL rejects the
+        // implicit assignment when Debezium tries to select every column.
+        final String setup = "CREATE TABLE s1.gencol_isnap (pk int PRIMARY KEY, aa integer,"
+                + " gencol varchar(10) GENERATED ALWAYS AS ('aa') STORED, bb varchar(2));";
+        TestHelper.execute(setup);
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("INSERT INTO s1.gencol_isnap (pk, aa, bb) VALUES (1, 1, 'a')");
+            connection.execute("INSERT INTO s1.gencol_isnap (pk, aa, bb) VALUES (2, 2, 'b')");
+        }
+
+        startConnector(x -> x
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.gencol_isnap")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue()));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal("s1.gencol_isnap");
+
+        final String topicName = "test_server.s1.gencol_isnap";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("pk"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32("aa"),
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
+    }
+
+    @Test
     @FixFor("DBZ-1329")
     public void snapshotNewTableWithoutTableIncludeList() throws Exception {
         // Testing.Print.enable();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -601,6 +601,39 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     }
 
     @Test
+    @FixFor("DBZ-2020")
+    public void incrementalSnapshotSkipsGeneratedColumnWithoutColumnExcludeList() throws Exception {
+        // Regression test for DBZ-2020: without any column.exclude.list workaround, the incremental
+        // snapshot chunk query must skip STORED generated columns; otherwise PostgreSQL rejects the
+        // implicit assignment when Debezium tries to select every column.
+        final String setup = "CREATE TABLE s1.gencol_isnap (pk int PRIMARY KEY, aa integer,"
+                + " gencol varchar(10) GENERATED ALWAYS AS ('aa') STORED, bb varchar(2));";
+        TestHelper.execute(setup);
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("INSERT INTO s1.gencol_isnap (pk, aa, bb) VALUES (1, 1, 'a')");
+            connection.execute("INSERT INTO s1.gencol_isnap (pk, aa, bb) VALUES (2, 2, 'b')");
+        }
+
+        startConnector(x -> x
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.gencol_isnap")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue()));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal("s1.gencol_isnap");
+
+        final String topicName = "test_server.s1.gencol_isnap";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("pk"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32("aa"),
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
+    }
+
+    @Test
     @FixFor("DBZ-1329")
     public void snapshotNewTableWithoutTableIncludeList() throws Exception {
         // Testing.Print.enable();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -720,11 +720,12 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     @FixFor("DBZ-2020")
     @SkipWhenDecoderPluginNameIsNot(value = DecoderPluginName.PGOUTPUT, reason = "Only pgoutput prunes generated columns from the in-memory Table")
     public void incrementalSnapshotWithGeneratedPrimaryKeyColumn() throws Exception {
-        // DBZ-2020 edge case: Postgres allows a STORED generated column to be the primary key.
-        // If it is pruned from the in-memory Table like any other generated column, the incremental
-        // snapshot's chunk-boundary logic (which reads primary key columns from the Table) may break.
-        // This test records the actual observed behavior for review; it is not asserting the "correct"
-        // outcome, since that has not been discussed on Zulip.
+        // DBZ-2020 follow-up: Postgres allows a STORED generated column to also be the primary key.
+        // Pruning it like any other generated column removes it from the in-memory Table while its
+        // primary key reference remains, which TableEditorImpl rejects as an invalid table definition,
+        // silently failing the incremental snapshot. Such columns must stay in both the Table and the
+        // chunk projection, with their computed value present, the same way non-pgoutput decoders
+        // already treat them.
         final String setup = "CREATE TABLE s1.gencol_pk (id int NOT NULL,"
                 + " pk int GENERATED ALWAYS AS (id) STORED, bb varchar(2), PRIMARY KEY(pk));";
         TestHelper.execute(setup);
@@ -748,6 +749,9 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 k -> k.getInt32("pk"),
                 record -> {
                     final Struct after = ((Struct) record.value()).getStruct("after");
+                    // the generated PK column must be kept, with its computed value equal to "id".
+                    assertThat(after.schema().field("pk")).isNotNull();
+                    assertThat(after.getInt32("pk")).isEqualTo(after.getInt32("id"));
                     return after.getInt32("id");
                 },
                 topicName,

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIs;
 import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
 import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot.DecoderPluginName;
 import io.debezium.converters.CloudEventsConverterTest;
@@ -632,6 +633,122 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                     final Struct after = ((Struct) record.value()).getStruct("after");
                     assertThat(after.schema().field("gencol")).isNull();
                     return after.getInt32("aa");
+                },
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    @SkipWhenDecoderPluginNameIs(value = SkipWhenDecoderPluginNameIs.DecoderPluginName.PGOUTPUT, reason = "decoderbufs does not prune generated columns; the computed value must stay in the incremental snapshot")
+    public void incrementalSnapshotKeepsGeneratedColumnValueForDecoderbufs() throws Exception {
+        // DBZ-2020: decoderbufs keeps the generated column in the Table, so its computed value must
+        // appear in the incremental snapshot rather than NULL.
+        final String setup = "CREATE TABLE s1.gencol_isnap_db (pk int PRIMARY KEY, aa integer,"
+                + " gencol varchar(10) GENERATED ALWAYS AS ('aa') STORED, bb varchar(2));";
+        TestHelper.execute(setup);
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("INSERT INTO s1.gencol_isnap_db (pk, aa, bb) VALUES (1, 1, 'a')");
+            connection.execute("INSERT INTO s1.gencol_isnap_db (pk, aa, bb) VALUES (2, 2, 'b')");
+        }
+
+        startConnector(x -> x
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.gencol_isnap_db")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue()));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal("s1.gencol_isnap_db");
+
+        final String topicName = "test_server.s1.gencol_isnap_db";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("pk"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    assertThat(after.schema().field("gencol")).isNotNull();
+                    assertThat(after.getString("gencol")).isEqualTo("aa");
+                    return after.getInt32("aa");
+                },
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    @SkipWhenDecoderPluginNameIsNot(value = DecoderPluginName.PGOUTPUT, reason = "Only pgoutput prunes generated columns from the in-memory Table")
+    public void incrementalSnapshotSkipsMultipleGeneratedColumns() throws Exception {
+        // DBZ-2020: the side map is a List<String>; make sure every generated column is excluded from
+        // the chunk projection, not just the first one found.
+        final String setup = "CREATE TABLE s1.gencol_multi (pk int PRIMARY KEY, aa integer,"
+                + " gencol1 varchar(10) GENERATED ALWAYS AS ('aa') STORED,"
+                + " gencol2 varchar(10) GENERATED ALWAYS AS ('bb') STORED, bb varchar(2));";
+        TestHelper.execute(setup);
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("INSERT INTO s1.gencol_multi (pk, aa, bb) VALUES (1, 1, 'a')");
+            connection.execute("INSERT INTO s1.gencol_multi (pk, aa, bb) VALUES (2, 2, 'b')");
+        }
+
+        startConnector(x -> x
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.gencol_multi")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue()));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal("s1.gencol_multi");
+
+        final String topicName = "test_server.s1.gencol_multi";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("pk"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    assertThat(after.schema().field("gencol1")).isNull();
+                    assertThat(after.schema().field("gencol2")).isNull();
+                    return after.getInt32("aa");
+                },
+                topicName,
+                null);
+        assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    @SkipWhenDecoderPluginNameIsNot(value = DecoderPluginName.PGOUTPUT, reason = "Only pgoutput prunes generated columns from the in-memory Table")
+    public void incrementalSnapshotWithGeneratedPrimaryKeyColumn() throws Exception {
+        // DBZ-2020 edge case: Postgres allows a STORED generated column to be the primary key.
+        // If it is pruned from the in-memory Table like any other generated column, the incremental
+        // snapshot's chunk-boundary logic (which reads primary key columns from the Table) may break.
+        // This test records the actual observed behavior for review; it is not asserting the "correct"
+        // outcome, since that has not been discussed on Zulip.
+        final String setup = "CREATE TABLE s1.gencol_pk (id int NOT NULL,"
+                + " pk int GENERATED ALWAYS AS (id) STORED, bb varchar(2), PRIMARY KEY(pk));";
+        TestHelper.execute(setup);
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("INSERT INTO s1.gencol_pk (id, bb) VALUES (1, 'a')");
+            connection.execute("INSERT INTO s1.gencol_pk (id, bb) VALUES (2, 'b')");
+        }
+
+        startConnector(x -> x
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.gencol_pk")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue()));
+        waitForConnectorToStart();
+
+        sendAdHocSnapshotSignal("s1.gencol_pk");
+
+        final String topicName = "test_server.s1.gencol_pk";
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                2,
+                x -> true,
+                k -> k.getInt32("pk"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    return after.getInt32("id");
                 },
                 topicName,
                 null);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -602,10 +602,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
 
     @Test
     @FixFor("DBZ-2020")
+    @SkipWhenDecoderPluginNameIsNot(value = DecoderPluginName.PGOUTPUT, reason = "Only pgoutput prunes generated columns from the in-memory Table")
     public void incrementalSnapshotSkipsGeneratedColumnWithoutColumnExcludeList() throws Exception {
-        // Regression test for DBZ-2020: without any column.exclude.list workaround, the incremental
-        // snapshot chunk query must skip STORED generated columns; otherwise PostgreSQL rejects the
-        // implicit assignment when Debezium tries to select every column.
+        // Regression for DBZ-2020: without column.exclude.list, pgoutput incremental snapshot must
+        // omit STORED generated columns from the chunk SELECT. Otherwise SELECT * returns them while
+        // the pruned Table does not, and ColumnUtils fails with "Column 'X' not found in result set".
         final String setup = "CREATE TABLE s1.gencol_isnap (pk int PRIMARY KEY, aa integer,"
                 + " gencol varchar(10) GENERATED ALWAYS AS ('aa') STORED, bb varchar(2));";
         TestHelper.execute(setup);
@@ -627,7 +628,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 2,
                 x -> true,
                 k -> k.getInt32("pk"),
-                record -> ((Struct) record.value()).getStruct("after").getInt32("aa"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    assertThat(after.schema().field("gencol")).isNull();
+                    return after.getInt32("aa");
+                },
                 topicName,
                 null);
         assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -547,10 +547,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
 
     @Test
     @FixFor("DBZ-2020")
+    @SkipWhenDecoderPluginNameIsNot(value = DecoderPluginName.PGOUTPUT, reason = "Only pgoutput prunes generated columns from the in-memory Table")
     public void incrementalSnapshotSkipsGeneratedColumnWithoutColumnExcludeList() throws Exception {
-        // Regression test for DBZ-2020: without any column.exclude.list workaround, the incremental
-        // snapshot chunk query must skip STORED generated columns; otherwise PostgreSQL rejects the
-        // implicit assignment when Debezium tries to select every column.
+        // Regression for DBZ-2020: without column.exclude.list, pgoutput incremental snapshot must
+        // omit STORED generated columns from the chunk SELECT. Otherwise SELECT * returns them while
+        // the pruned Table does not, and ColumnUtils fails with "Column 'X' not found in result set".
         final String setup = "CREATE TABLE s1.gencol_isnap (pk int PRIMARY KEY, aa integer,"
                 + " gencol varchar(10) GENERATED ALWAYS AS ('aa') STORED, bb varchar(2));";
         TestHelper.execute(setup);
@@ -572,7 +573,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 2,
                 x -> true,
                 k -> k.getInt32("pk"),
-                record -> ((Struct) record.value()).getStruct("after").getInt32("aa"),
+                record -> {
+                    final Struct after = ((Struct) record.value()).getStruct("after");
+                    assertThat(after.schema().field("gencol")).isNull();
+                    return after.getInt32("aa");
+                },
                 topicName,
                 null);
         assertThat(dbChanges).containsExactly(entry(1, 1), entry(2, 2));

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilderTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilderTest.java
@@ -142,4 +142,26 @@ public class PostgresChunkQueryBuilderTest {
         assertThat(chunkQueryBuilder.buildChunkQuery(new SignalBasedIncrementalSnapshotContext<>(), table, Optional.empty()))
                 .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
     }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void shouldExcludeAllSideMapGeneratedColumnsWhenMultiplePresent() {
+        // The side map is a List<String>; make sure every entry is excluded from the projection, not
+        // just the first one found.
+        final TableId tableId = new TableId(null, "s1", "table1");
+        when(schema.getGeneratedColumnsForTableId(tableId)).thenReturn(List.of("gen1", "gen2"));
+
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new PostgresChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""), schema);
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Table prunedTable = Table.editor().tableId(tableId)
+                .addColumn(pk1)
+                .addColumn(val1)
+                .setPrimaryKeyNames("pk1")
+                .create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(new SignalBasedIncrementalSnapshotContext<>(), prunedTable, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilderTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkQueryBuilderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.source.snapshot.incremental.ChunkQueryBuilder;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnFilterMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+/**
+ * Unit tests for {@link PostgresChunkQueryBuilder} side-map interaction (DBZ-2020).
+ */
+public class PostgresChunkQueryBuilderTest {
+
+    @Mock
+    private PostgresSchema schema;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private RelationalDatabaseConnectorConfig config() {
+        return new RelationalDatabaseConnectorConfig(
+                Configuration.create()
+                        .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                        .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                        .build(),
+                null, null, 0, ColumnFilterMode.SCHEMA, true) {
+            @Override
+            protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+                return null;
+            }
+
+            @Override
+            public String getContextName() {
+                return null;
+            }
+
+            @Override
+            public String getConnectorName() {
+                return null;
+            }
+
+            @Override
+            public EnumeratedValue getSnapshotMode() {
+                return null;
+            }
+
+            @Override
+            public Optional<EnumeratedValue> getSnapshotLockingMode() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void shouldKeepSelectStarWhenSideMapIsEmpty() {
+        final TableId tableId = new TableId(null, "s1", "table1");
+        when(schema.getGeneratedColumnsForTableId(tableId)).thenReturn(Collections.emptyList());
+
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new PostgresChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""), schema);
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Table table = Table.editor().tableId(tableId)
+                .addColumn(pk1)
+                .addColumn(val1)
+                .setPrimaryKeyNames("pk1")
+                .create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(new SignalBasedIncrementalSnapshotContext<>(), table, Optional.empty()))
+                .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void shouldExpandProjectionWhenSideMapHasGeneratedColumnsAfterPrune() {
+        // Simulates pgoutput refreshFromIncrementalSnapshot: Table no longer lists gen1, but the
+        // side map still knows about it so buildProjection must expand instead of SELECT *.
+        final TableId tableId = new TableId(null, "s1", "table1");
+        when(schema.getGeneratedColumnsForTableId(tableId)).thenReturn(List.of("gen1"));
+
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new PostgresChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""), schema);
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Table prunedTable = Table.editor().tableId(tableId)
+                .addColumn(pk1)
+                .addColumn(val1)
+                .setPrimaryKeyNames("pk1")
+                .create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(new SignalBasedIncrementalSnapshotContext<>(), prunedTable, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+
+    @Test
+    @FixFor("DBZ-2020")
+    public void shouldOmitSideMapGeneratedColumnStillPresentOnTable() {
+        // Side map is the source of truth: even if the in-memory column is not marked generated,
+        // a name present in the side map must be dropped from the explicit projection.
+        final TableId tableId = new TableId(null, "s1", "table1");
+        when(schema.getGeneratedColumnsForTableId(tableId)).thenReturn(List.of("gen1"));
+
+        final ChunkQueryBuilder<TableId> chunkQueryBuilder = new PostgresChunkQueryBuilder<>(
+                config(), new JdbcConnection(config().getJdbcConfig(), c -> null, "\"", "\""), schema);
+        final Column pk1 = Column.editor().name("pk1").optional(false).create();
+        final Column val1 = Column.editor().name("val1").create();
+        final Column gen1 = Column.editor().name("gen1").create();
+        final Table table = Table.editor().tableId(tableId)
+                .addColumn(pk1)
+                .addColumn(val1)
+                .addColumn(gen1)
+                .setPrimaryKeyNames("pk1")
+                .create();
+
+        assertThat(chunkQueryBuilder.buildChunkQuery(new SignalBasedIncrementalSnapshotContext<>(), table, Optional.empty()))
+                .isEqualTo("SELECT \"pk1\", \"val1\" FROM \"s1\".\"table1\" ORDER BY \"pk1\" LIMIT 1024");
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -331,6 +331,36 @@ public class PostgresSchemaIT {
     }
 
     @Test
+    @FixFor("DBZ-2020")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 12, reason = "Generated columns are supported from Postgres 12+")
+    void shouldKeepGeneratedPrimaryKeyMarkedAsGeneratedForPgoutput() throws Exception {
+        String statements = "CREATE SCHEMA IF NOT EXISTS public;" +
+                "DROP TABLE IF EXISTS generated_pk_table;" +
+                "CREATE TABLE generated_pk_table (" +
+                "id int not null, " +
+                "pk int GENERATED ALWAYS AS (id) STORED PRIMARY KEY, " +
+                "payload text);";
+        TestHelper.execute(statements);
+
+        PostgresConnectorConfig config = new PostgresConnectorConfig(
+                TestHelper.defaultConfig()
+                        .with(PostgresConnectorConfig.PLUGIN_NAME, PostgresConnectorConfig.LogicalDecoder.PGOUTPUT.getValue())
+                        .build());
+        schema = TestHelper.getSchema(config);
+        final TableId tableId = TableId.parse("public.generated_pk_table", false);
+
+        try (PostgresConnection connection = TestHelper.createWithTypeRegistry()) {
+            schema.refresh(connection, false);
+
+            final Table table = schema.tableFor(tableId);
+            assertThat(table).isNotNull();
+            assertThat(table.columnWithName("pk")).isNotNull();
+            assertThat(table.columnWithName("pk").isGenerated()).isTrue();
+            assertThat(schema.getGeneratedColumnsForTableId(tableId)).doesNotContain("pk");
+        }
+    }
+
+    @Test
     void shouldProperlyGetDefaultColumnValues() throws Exception {
         String ddl = "DROP TABLE IF EXISTS default_column_test; CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE TABLE default_column_test (" +
                 "pk SERIAL, " +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -274,6 +274,13 @@ The {prodname} connector for PostgreSQL does not support schema changes while an
 If a schema change is performed _before_ the incremental snapshot start but _after_ sending the signal then passthrough config option `database.autosave` is set to `conservative` to correctly process the schema change.
 ====
 
+[NOTE]
+====
+When a captured table has `GENERATED` columns, the connector detects them at schema discovery time from `pg_attribute.attgenerated` and omits them from the chunk `SELECT` used during an incremental snapshot.
+Values for those columns are not present in the resulting snapshot events; recompute them on the consumer side if needed.
+Tables without any generated columns are unaffected; all known columns are selected explicitly.
+====
+
 // Type: procedure
 [id="postgresql-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -278,7 +278,7 @@ If a schema change is performed _before_ the incremental snapshot start but _aft
 ====
 When a captured table has `GENERATED` columns, the connector detects them at schema discovery time from `pg_attribute.attgenerated` and omits them from the chunk `SELECT` used during an incremental snapshot.
 Values for those columns are not present in the resulting snapshot events; recompute them on the consumer side if needed.
-Tables without any generated columns are unaffected; all known columns are selected explicitly.
+Tables without any generated columns continue to use `SELECT *` and are unaffected.
 ====
 
 // Type: procedure

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -276,8 +276,11 @@ If a schema change is performed _before_ the incremental snapshot start but _aft
 
 [NOTE]
 ====
-When a captured table has `GENERATED` columns, the connector detects them at schema discovery time from `pg_attribute.attgenerated` and omits them from the chunk `SELECT` used during an incremental snapshot.
+When you use the `pgoutput` logical decoding plug-in and a captured table has `GENERATED` columns, the connector detects them at schema discovery time from `pg_attribute.attgenerated` and omits them from the chunk `SELECT` that it uses during an incremental snapshot.
 Values for those columns are not present in the resulting snapshot events; recompute them on the consumer side if needed.
+A `GENERATED` column that is also part of the primary key is retained, along with its computed value.
+
+Other decoding plug-ins, such as `decoderbufs`, retain `GENERATED` columns and emit their computed values.
 Tables without any generated columns continue to use `SELECT *` and are unaffected.
 ====
 


### PR DESCRIPTION
Fixes debezium/dbz#2020

## Summary

Incremental snapshot fails with `Column 'X' not found in result set` when a PostgreSQL table has `GENERATED` columns and no `column.exclude.list` is configured.

**Root cause:** The Postgres JDBC driver does not populate `IS_GENERATEDCOLUMN`, so `Column.isGenerated()` stays false. For pgoutput, `refreshFromIncrementalSnapshot()` then prunes generated columns from the in-memory `Table`, while the chunk query still used `SELECT *`, so the JDBC result set contained columns the pruned table no longer knew about.

**Fix:**
- Populate `Column.isGenerated()` on Postgres at schema discovery via `pg_attribute.attgenerated` (STORED on PG12+, VIRTUAL on PG18+)
- Keep a Postgres-side map of generated column names (`PostgresSchema.tableIdToGeneratedColumns`) so projection still knows about them after the in-memory `Table` is pruned
- `PostgresChunkQueryBuilder` uses that map through `hasAdditionalGeneratedColumns` / `isAdditionalGeneratedColumn` hooks
- `AbstractChunkQueryBuilder.buildProjection()` keeps the two-branch behavior agreed on Zulip: `SELECT *` when nothing is filtered or generated (avoids widening the schemaChanges race from DBZ-6000 / DBZ-7532); explicit column list only when column filters or generated columns apply
- Treat MySQL/MariaDB `AUTO_INCREMENT` carefully: those connectors set both `autoIncremented` and `generated`, so projection only omits generated columns that are not auto-incremented
- Add `Column.isInvisible()` / `ColumnEditor.invisible()` to the relational model + schema-history SerDe (optional, default false; no consumer yet, Oracle follow-up)
- Postgres IT regression + unit tests for both projection paths and the AUTO_INCREMENT guard

Leaving `refreshFromIncrementalSnapshot()` pruning as-is for this PR. Broader cleanup (stop pruning / filter at schema-build) is a follow-up.

Supersedes #7532 (will close once this lands).

Related Zulip: https://debezium.zulipchat.com/#narrow/channel/302533-dev/topic/DBZ-2020.3A.20generated.20columns.20in.20incremental.20snapshot

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`