### PR TITLE
Dbz 9913 Remove hard line breaks from MongoDB documentation

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
@@ -260,13 +260,13 @@ Specify a custom `CollectionNameStrategy` implementation.
 |[[mongodb-sink-property-field-include-list]]<<mongodb-sink-property-field-include-list, `+field.include.list+`>>
 |_empty string_
 |An optional, comma-separated list of field names that match the fully-qualified names of fields to include from the change event value.
-Fully-qualified names for fields are of the form `_fieldName_` or `_topicName_:__fieldName__`. +
+Fully-qualified names for fields are of the form `_fieldName_` or `_topicName_:__fieldName__`.
 If you include this property in the configuration, do not set the `field.exclude.list` property.
 
 |[[mongodb-sink-property-field-exclude-list]]<<mongodb-sink-property-field-exclude-list, `+field.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of field names that match the fully-qualified names of fields to exclude from the change event value.
-Fully-qualified names for fields are of the form `_fieldName_` or `_topicName_:__fieldName__`. +
+Fully-qualified names for fields are of the form `_fieldName_` or `_topicName_:__fieldName__`.
 
 If you include this property in the configuration, do not set the `field.include.list` property.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb-sink.adoc
@@ -261,6 +261,7 @@ Specify a custom `CollectionNameStrategy` implementation.
 |_empty string_
 |An optional, comma-separated list of field names that match the fully-qualified names of fields to include from the change event value.
 Fully-qualified names for fields are of the form `_fieldName_` or `_topicName_:__fieldName__`.
+
 If you include this property in the configuration, do not set the `field.exclude.list` property.
 
 |[[mongodb-sink-property-field-exclude-list]]<<mongodb-sink-property-field-exclude-list, `+field.exclude.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -684,11 +684,12 @@ Every change event that captures a change to the `customers` collection has the 
 
 |2
 |`fulfillment.inventory.customers.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example:
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. 
+In the preceding example, the `name` field includes the following values:
 
-* `fulfillment` is the name of the connector that generated this event.
-* `inventory` is the database that contains the collection that was changed.
-* `customers` is the collection that contains the document that was updated.
+`fulfillment`:: The name of the connector that generated the event.
+`inventory`:: The database that contains the collection that the operation changed.
+`customers`:: The collection that contains the document that the operation updated.
 
 |3
 |`optional`
@@ -1604,6 +1605,7 @@ The property is subject to removal in a future release if the default behavior c
 |[[mongodb-property-mongodb-connection-string]]<<mongodb-property-mongodb-connection-string, `+mongodb.connection.string+`>>
 |No default
 |Specifies a https://www.mongodb.com/docs/manual/reference/connection-string/[connection string] that the connector uses to connect to a MongoDB replica set.
+
 This property replaces the `mongodb.hosts` property that was available in previous versions of the MongoDB connector.
 
 |[[mongodb-property-topic-prefix]]<<mongodb-property-topic-prefix, `+topic.prefix+`>>
@@ -1611,6 +1613,7 @@ This property replaces the `mongodb.hosts` property that was available in previo
 |A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors.
 Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
 Use only alphanumeric characters, hyphens, dots and underscores to form the name.
+
 The logical name should be unique across all other connectors, because the name is used as the prefix in naming the Kafka topics that receive records from this connector.
 
 [WARNING]
@@ -1664,15 +1667,16 @@ Database and collection includes/excludes are evaluated as comma-separated list 
 |[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `+database.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions or literals that match database names to be monitored.
+
 By default, all databases are monitored.
 When `database.include.list` is set, the connector monitors only the databases that the property specifies.
 Other databases are excluded from monitoring.
 
-To match the name of a database, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property
+To match the name of a database, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property:
 
-- applies the regular expression that you specify as an _anchored_ regular expression.
+- Applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the database
+- Compares the literals that you specify with the entire name string of the database.
 
 
 If you include this property in the configuration, do not also set the `database.exclude.list` property.
@@ -1682,11 +1686,11 @@ If you include this property in the configuration, do not also set the `database
 |An optional comma-separated list of regular expressions or literals that match database names to be excluded from monitoring.
 When `database.exclude.list` is set, the connector monitors every database except the ones that the property specifies.
 
-To match the name of a database, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property
+To match the name of a database, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property:
 
-- applies the regular expression that you specify as an _anchored_ regular expression.
+- Applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the database
+- Compares the literals that you specify with the entire name string of the database.
 
 If you include this property in the configuration, do not set the `database.include.list` property.
 
@@ -1698,11 +1702,11 @@ When `collection.include.list` is set, the connector monitors only the collectio
 Other collections are excluded from monitoring.
 Collection identifiers are of the form _databaseName_._collectionName_.
 
-To match the name of a namespace, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property
+To match the name of a namespace, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property:
 
-- applies the regular expression that you specify as an _anchored_ regular expression.
+- Applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the namespace; it does not match substrings in the name.
-- compares the literals that you specify with the entire name string of the namespace
+- Compares the literals that you specify with the entire name string of the namespace.
 
 
 If you include this property in the configuration, do not also set the `collection.exclude.list` property.
@@ -1713,11 +1717,11 @@ If you include this property in the configuration, do not also set the `collecti
 When `collection.exclude.list` is set, the connector monitors every collection except the ones that the property specifies.
 Collection identifiers are of the form _databaseName_._collectionName_.
 
-To match the name of a namespace, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property
+To match the name of a namespace, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property:
 
-- applies the regular expression that you specify as an _anchored_ regular expression.
+- Applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the namespace; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the namespace
+- Compares the literals that you specify with the entire name string of the namespace.
 
 If you include this property in the configuration, do not set the `collection.include.list` property.
 
@@ -1810,11 +1814,12 @@ Fully-qualified names for fields are of the form _databaseName_._collectionName_
 
 |[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
-|Controls whether a _delete_ event is followed by a tombstone event.
+|Specifies whether a _delete_ event is followed by a tombstone event.
+Set one of the following options:
 
-`true` - a delete operation is represented by a _delete_ event and a subsequent tombstone event. 
+`true`:: A delete operation is represented by a _delete_ event and a subsequent tombstone event. 
 
-`false` - only a _delete_ event is emitted.
+`false`:: After a delete operation, the connector emits only a _delete_ event.
 
 After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row in case {link-kafka-docs}/#compaction[log compaction] is enabled for the topic.
 
@@ -1828,11 +1833,14 @@ After a source record is deleted, emitting a tombstone event (the default behavi
 
 |[[mongodb-property-field-name-adjustment-mode]]<<mongodb-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
 |none
-|Specifies how field names should be adjusted for compatibility with the message converter used by the connector. Possible settings: 
+|Specifies how the connector adjusts field names for compatibility with the message converter used by the connector. 
+Set one of the following options: 
 
-* `none` does not apply any adjustment.
-* `avro` replaces the characters that cannot be used in the Avro type name with underscore.
-* `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java.
+`none`:: The connector does not adjust field names.
+`avro`:: The connector replaces characters that cannot are not valid in Avro type names with underscores.
+`avro_unicode`:: The connector replaces underscores and characters that are not valid in Avro type names with the equivalent unicode, such as _uxxxx. 
++
+Note: The underscore character ('`_`') represents an escape sequence similar to a backslash in Java.
 
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
@@ -1892,6 +1900,7 @@ Always set the value of `max.queue.size` to be larger than the value of xref:{co
 |A long integer value that specifies the maximum volume of the blocking queue in bytes.
 By default, volume limits are not specified for the blocking queue.
 To specify the number of bytes that the queue can consume, set this property to a positive long value.
+
 If xref:mongodb-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
@@ -1926,16 +1935,16 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 ifdef::community[]
 |[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `+source.struct.version+`>>
 |v2
-|Schema version for the `source` block in CDC events. {prodname} 0.10 introduced a few breaking
-changes to the structure of the `source` block in order to unify the exposed structure across
-all the connectors.
-By setting this option to `v1` the structure used in earlier versions can be produced.
+|Schema version for the `source` block in CDC events. 
+{prodname} 0.10 introduced a few breaking changes to the structure of the `source` block in order to unify the exposed structure across all the connectors.
+Set this option to `v1` if you want the connector to produce events that use the source block structure from earlier versions.
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
 |[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
-|Controls how frequently heartbeat messages are sent.
+|Specifies how frequently the connector sends heartbeat messages.
+
 This property contains an interval in milliseconds that defines how frequently the connector sends messages into a heartbeat topic.
 This can be used to monitor whether the connector is still receiving change events from the database.
 You also should leverage heartbeat messages in cases where only records in non-captured collections are changed for a longer period of time.
@@ -1943,8 +1952,7 @@ In such situation the connector would proceed to read the oplog/change stream fr
 which in turn means that no offset updates are committed to Kafka.
 This will cause the oplog files to be rotated out but connector will not notice it so on restart some events are no longer available which leads to the need of re-execution of the initial snapshot.
 
-Set this parameter to `0` to not send heartbeat messages at all.
-Disabled by default.
+The default setting (`0`) prevents the connector from sending heartbeat messages.
 
 |[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `+skipped.operations+`>>
 |`t`
@@ -1967,12 +1975,12 @@ For each collection that you specify, also specify another configuration propert
 
 |[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |No default
-|An interval in milliseconds that the connector should wait before taking a snapshot after starting up;
-Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+|Specifies an interval, in milliseconds, that the connector waits after starting before it takes a snapshot.
+Use this setting to avoid snapshot interruptions when starting multiple connectors in a cluster, which can cause re-balancing of connectors.
 
 |[[mongodb-property-streaming-delay-ms]]<<mongodb-property-streaming-delay-ms, `+streaming.delay.ms+`>>
 |0
-|Specifies the time, in milliseconds, that the connector delays the start of the streaming process after it completes a snapshot.
+|Specifies an interval, in milliseconds, that the connector delays the start of the streaming process after it completes a snapshot.
 Setting a delay interval helps to prevent the connector from restarting snapshots in the event that a failure occurs immediately after the snapshot completes, but before the streaming process begins.
 Set a delay value that is higher than the value of the {link-kafka-docs}/#connectconfigs_offset.flush.interval.ms[`offset.flush.interval.ms`] property that is set for the Kafka Connect worker.
 
@@ -1980,13 +1988,15 @@ Set a delay value that is higher than the value of the {link-kafka-docs}/#connec
 |`0`
 |Specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot.
 The connector will read the collection contents in multiple batches of this size.
-Defaults to 0, which indicates that the server chooses an appropriate fetch size.
+
+The default setting (`0`) specifies that the server sets the fetch size.
 
 |[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All collections specified in `collection.include.list`
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>_._<collectionName>_`) of the schemas that you want to include in a snapshot.
 The specified items must be named in the connectors's xref:mongodb-property-collection-include-list[`collection.include.list`] property.
 This property takes effect only if the connector's xref:mongodb-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`.
+
 This property does not affect the behavior of incremental snapshots.
 
 To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
@@ -2064,6 +2074,7 @@ ifdef::community[]
 |[[mongodb-property-snapshot-mode-configuration-based-snapshot-on-data-error]]<<mongodb-property-configuration-based-snapshot-on-data-error, `+snapshot.mode.configuration.based.snapshot.on.data.error+`>>
 |false
 |If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log.
+
 Set the value to `true` to instruct the connector to perform a new snapshot.
 endif::community[]
 
@@ -2192,6 +2203,7 @@ Adjust the chunk size to a value that provides the best performance in your envi
 |[[mongodb-property-incremental-snapshot-watermarking-strategy]]<<mongodb-property-incremental-snapshot-watermarking-strategy, `+incremental.snapshot.watermarking.strategy+`>>
 |`insert_insert`
 |Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes.
+
 You can specify one of the following options:
 
 `insert_insert`:: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -236,11 +236,11 @@ During this offset consolidation procedure, the connector completes the followin
 3. Shard-specific offsets that were recorded by connector versions 2.5.x and earlier are used as-is, if both of the following conditions apply:
 
 * The offsets exist for all current database shards.
-* xref:mongodb-property-allow-offset-invalidation[Offset invalidation] is enabled. +
+* xref:mongodb-property-allow-offset-invalidation[Offset invalidation] is enabled.
 If offset invalidation is disabled, the connector fails to start.
 
 
-4. After the connector processes existing offsets in the preceding steps, it resumes streaming changes, and then commits offsets for new events that it captures. +
+4. After the connector processes existing offsets in the preceding steps, it resumes streaming changes, and then commits offsets for new events that it captures.
 If the offset consolidation procedure does not detect any existing offsets, the connector xref:mongodb-performing-a-snapshot[performs an initial snapshot].
 
 
@@ -684,10 +684,10 @@ Every change event that captures a change to the `customers` collection has the 
 
 |2
 |`fulfillment.inventory.customers.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: +
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example:
 
-* `fulfillment` is the name of the connector that generated this event. +
-* `inventory` is the database that contains the collection that was changed. +
+* `fulfillment` is the name of the connector that generated this event.
+* `inventory` is the database that contains the collection that was changed.
 * `customers` is the collection that contains the document that was updated.
 
 |3
@@ -900,8 +900,8 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
- +
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
+
 `io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field.
 
 |3
@@ -914,8 +914,8 @@ a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structu
 
 |5
 |`payload`
-|The value's actual data. This is the information that the change event is providing. +
- +
+a|The value's actual data. This is the information that the change event is providing.
+
 It may appear that the JSON representations of the events are much larger than the documents they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
@@ -953,8 +953,8 @@ a|Mandatory string that describes the type of operation that caused the connecto
 |9
 |`ts_ms`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task.  +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task. 
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |10
@@ -1038,8 +1038,8 @@ a|Mandatory string that describes the type of operation that caused the connecto
 |2
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task.  +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task. 
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |3
@@ -1050,8 +1050,8 @@ An _update_ event value does not contain a `before` field if the capture mode is
 
 |4
 |`after`
-|Contains the JSON string representation of the actual MongoDB document.
- +
+a|Contains the JSON string representation of the actual MongoDB document.
+
 An _update_ event value does not contain an `after` field if the capture mode is not set to `change_streams_update_full`
 
 |5
@@ -1126,8 +1126,8 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 |2
 |`ts_ms`, `ts_us`. `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
-The time is based on the system clock in the JVM running the Kafka Connect task.  +
- +
+The time is based on the system clock in the JVM running the Kafka Connect task. 
+
 In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |3
@@ -1265,7 +1265,7 @@ You can use either of the following methods to deploy a {prodname} MongoDB conne
 * xref:openshift-streams-mongodb-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-mongodb-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+* xref:deploying-debezium-mongodb-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 This Containerfile deployment method is deprecated.
 The instructions for this method are scheduled for removal in future versions of the documentation.
 
@@ -1381,7 +1381,7 @@ docker push _<myregistry.io>_/debezium-container-for-mongodb:latest
 
 .. Create a new {prodname} MongoDB `KafkaConnect` custom resource (CR).
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -1430,7 +1430,7 @@ Optionally, you can set properties that filter out collections that are not need
 +
 The following example configures a {prodname} connector that connects to a MongoDB replica set `rs0` at port `27017` on `192.168.99.100`,
 and captures changes that occur in the `inventory` collection.
-`inventory-connector-{context}` is the logical name of the replica set. +
+`inventory-connector-{context}` is the logical name of the replica set.
 +
 =====================================================================
 .MongoDB `inventory-connector.yaml`
@@ -1604,15 +1604,15 @@ The property is subject to removal in a future release if the default behavior c
 |[[mongodb-property-mongodb-connection-string]]<<mongodb-property-mongodb-connection-string, `+mongodb.connection.string+`>>
 |No default
 |Specifies a https://www.mongodb.com/docs/manual/reference/connection-string/[connection string] that the connector uses to connect to a MongoDB replica set.
-This property replaces the `mongodb.hosts` property that was available in previous versions of the MongoDB connector. +
+This property replaces the `mongodb.hosts` property that was available in previous versions of the MongoDB connector.
 
 |[[mongodb-property-topic-prefix]]<<mongodb-property-topic-prefix, `+topic.prefix+`>>
 |No default
 |A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors.
 Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
 Use only alphanumeric characters, hyphens, dots and underscores to form the name.
-The logical name should be unique across all other connectors, because the name is used as the prefix in naming the Kafka topics that receive records from this connector. +
- +
+The logical name should be unique across all other connectors, because the name is used as the prefix in naming the Kafka topics that receive records from this connector.
+
 [WARNING]
 ====
 Do not change the value of this property.
@@ -1664,7 +1664,7 @@ Database and collection includes/excludes are evaluated as comma-separated list 
 |[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `+database.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions or literals that match database names to be monitored.
-By default, all databases are monitored. +
+By default, all databases are monitored.
 When `database.include.list` is set, the connector monitors only the databases that the property specifies.
 Other databases are excluded from monitoring.
 
@@ -1672,7 +1672,7 @@ To match the name of a database, {prodname} performs one of the following action
 
 - applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the database +
+- compares the literals that you specify with the entire name string of the database
 
 
 If you include this property in the configuration, do not also set the `database.exclude.list` property.
@@ -1686,7 +1686,7 @@ To match the name of a database, {prodname} performs one of the following action
 
 - applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the database; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the database +
+- compares the literals that you specify with the entire name string of the database
 
 If you include this property in the configuration, do not set the `database.include.list` property.
 
@@ -1702,7 +1702,7 @@ To match the name of a namespace, {prodname} performs one of the following actio
 
 - applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the namespace; it does not match substrings in the name.
-- compares the literals that you specify with the entire name string of the namespace +
+- compares the literals that you specify with the entire name string of the namespace
 
 
 If you include this property in the configuration, do not also set the `collection.exclude.list` property.
@@ -1711,13 +1711,13 @@ If you include this property in the configuration, do not also set the `collecti
 |_empty string_
 |An optional comma-separated list of regular expressions or literals that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring.
 When `collection.exclude.list` is set, the connector monitors every collection except the ones that the property specifies.
-Collection identifiers are of the form _databaseName_._collectionName_. +
+Collection identifiers are of the form _databaseName_._collectionName_.
 
 To match the name of a namespace, {prodname} performs one of the following actions based on the value of xref:mongodb-property-filters-match-mode[`filters.match.mode`] property
 
 - applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the namespace; it does not match substrings that might be present in a database name.
-- compares the literals that you specify with the entire name string of the namespace +
+- compares the literals that you specify with the entire name string of the namespace
 
 If you include this property in the configuration, do not set the `collection.include.list` property.
 
@@ -1810,28 +1810,28 @@ Fully-qualified names for fields are of the form _databaseName_._collectionName_
 
 |[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
-|Controls whether a _delete_ event is followed by a tombstone event. +
- +
-`true` - a delete operation is represented by a _delete_ event and a subsequent tombstone event.  +
- +
-`false` - only a _delete_ event is emitted. +
- +
+|Controls whether a _delete_ event is followed by a tombstone event.
+
+`true` - a delete operation is represented by a _delete_ event and a subsequent tombstone event. 
+
+`false` - only a _delete_ event is emitted.
+
 After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row in case {link-kafka-docs}/#compaction[log compaction] is enabled for the topic.
 
 |[[mongodb-property-schema-name-adjustment-mode]]<<mongodb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
 |none
-|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings: 
 
-* `none` does not apply any adjustment. +
-* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
-* `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
+* `none` does not apply any adjustment.
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore.
+* `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java
 
 |[[mongodb-property-field-name-adjustment-mode]]<<mongodb-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
 |none
-|Specifies how field names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+|Specifies how field names should be adjusted for compatibility with the message converter used by the connector. Possible settings: 
 
-* `none` does not apply any adjustment. +
-* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment.
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore.
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java.
 
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
@@ -1891,7 +1891,7 @@ Always set the value of `max.queue.size` to be larger than the value of xref:{co
 |`0`
 |A long integer value that specifies the maximum volume of the blocking queue in bytes.
 By default, volume limits are not specified for the blocking queue.
-To specify the number of bytes that the queue can consume, set this property to a positive long value. +
+To specify the number of bytes that the queue can consume, set this property to a positive long value.
 If xref:mongodb-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
@@ -1926,16 +1926,16 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 ifdef::community[]
 |[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `+source.struct.version+`>>
 |v2
-|Schema version for the `source` block in CDC events. {prodname} 0.10 introduced a few breaking +
+|Schema version for the `source` block in CDC events. {prodname} 0.10 introduced a few breaking
 changes to the structure of the `source` block in order to unify the exposed structure across
-all the connectors. +
+all the connectors.
 By setting this option to `v1` the structure used in earlier versions can be produced.
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
 |[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
-|Controls how frequently heartbeat messages are sent. +
+|Controls how frequently heartbeat messages are sent.
 This property contains an interval in milliseconds that defines how frequently the connector sends messages into a heartbeat topic.
 This can be used to monitor whether the connector is still receiving change events from the database.
 You also should leverage heartbeat messages in cases where only records in non-captured collections are changed for a longer period of time.
@@ -1943,7 +1943,7 @@ In such situation the connector would proceed to read the oplog/change stream fr
 which in turn means that no offset updates are committed to Kafka.
 This will cause the oplog files to be rotated out but connector will not notice it so on restart some events are no longer available which leads to the need of re-execution of the initial snapshot.
 
-Set this parameter to `0` to not send heartbeat messages at all. +
+Set this parameter to `0` to not send heartbeat messages at all.
 Disabled by default.
 
 |[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `+skipped.operations+`>>
@@ -1967,7 +1967,7 @@ For each collection that you specify, also specify another configuration propert
 
 |[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |No default
-|An interval in milliseconds that the connector should wait before taking a snapshot after starting up; +
+|An interval in milliseconds that the connector should wait before taking a snapshot after starting up;
 Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
 
 |[[mongodb-property-streaming-delay-ms]]<<mongodb-property-streaming-delay-ms, `+streaming.delay.ms+`>>
@@ -1979,15 +1979,15 @@ Set a delay value that is higher than the value of the {link-kafka-docs}/#connec
 |[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`0`
 |Specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot.
-The connector will read the collection contents in multiple batches of this size. +
+The connector will read the collection contents in multiple batches of this size.
 Defaults to 0, which indicates that the server chooses an appropriate fetch size.
 
 |[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All collections specified in `collection.include.list`
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>_._<collectionName>_`) of the schemas that you want to include in a snapshot.
 The specified items must be named in the connectors's xref:mongodb-property-collection-include-list[`collection.include.list`] property.
-This property takes effect only if the connector's xref:mongodb-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`. +
-This property does not affect the behavior of incremental snapshots. +
+This property takes effect only if the connector's xref:mongodb-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`.
+This property does not affect the behavior of incremental snapshots.
 
 To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the schema; it does not match substrings that might be present in a schema name.
@@ -2063,7 +2063,7 @@ endif::community[]
 ifdef::community[]
 |[[mongodb-property-snapshot-mode-configuration-based-snapshot-on-data-error]]<<mongodb-property-configuration-based-snapshot-on-data-error, `+snapshot.mode.configuration.based.snapshot.on.data.error+`>>
 |false
-|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log. +
+|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log.
 Set the value to `true` to instruct the connector to perform a new snapshot.
 endif::community[]
 
@@ -2186,12 +2186,12 @@ endif::community[]
 |The maximum number of documents that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
-Adjust the chunk size to a value that provides the best performance in your environment. +
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 
 |[[mongodb-property-incremental-snapshot-watermarking-strategy]]<<mongodb-property-incremental-snapshot-watermarking-strategy, `+incremental.snapshot.watermarking.strategy+`>>
 |`insert_insert`
-|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes. +
+|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes.
 You can specify one of the following options:
 
 `insert_insert`:: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.
@@ -2215,37 +2215,37 @@ Set this option to prevent rapid growth of the signaling data collection.
 
 |[[mongodb-property-topic-heartbeat-prefix]]<<mongodb-property-topic-heartbeat-prefix, `+topic.heartbeat.prefix+`>>
 |`__debezium-heartbeat`
-|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
- +
-_topic.heartbeat.prefix_._topic.prefix_ +
- +
-For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`. +
- +
+|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern:
+
+_topic.heartbeat.prefix_._topic.prefix_
+
+For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
+
 This property is ignored if `topic.heartbeat.name` is set.
 
 |[[mongodb-property-topic-heartbeat-name]]<<mongodb-property-topic-heartbeat-name, `+topic.heartbeat.name+`>>
 |_empty_
-|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`. +
- +
-When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics. +
- +
-For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`. +
- +
+|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`.
+
+When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
+
+For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`.
+
 If this property is empty or unset, the connector falls back to the default behavior: _topic.heartbeat.prefix_._topic.prefix_.
 
 |[[mongodb-property-topic-transaction]]<<mongodb-property-topic-transaction, `topic.transaction`>>
 |`transaction`
-|Controls the name of the topic to which the connector sends transaction metadata messages. The topic name has this pattern: +
- +
-_topic.prefix_._topic.transaction_ +
- +
+|Controls the name of the topic to which the connector sends transaction metadata messages. The topic name has this pattern:
+
+_topic.prefix_._topic.transaction_
+
 For example, if the topic prefix is `fulfillment`, the default topic name is `fulfillment.transaction`.
 
 |[[mongodb-property-custom-metric-tags]]<<mongodb-property-custom-metric-tags, `custom.metric.tags`>>
 |`No default`
 |Defines tags that customize MBean object names by adding metadata that provides contextual information.
 Specify a comma-separated list of key-value pairs.
-Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,  +
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example, 
 `k1=v1,k2=v2`
 
 The connector appends the specified tags to the base MBean object name.
@@ -2276,7 +2276,7 @@ The pattern that you specify for the `custom.sanitize.pattern` property override
 
 |[[mongodb-property-errors-max-retires]]<<mongodb-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error.
 Set one of the following options:
 
 `-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9913](https://redhat.atlassian.net/browse/DBZ-9913)

## Description
Removes hard line breaks from the MongoDB connector documentation (mongodb.adoc, mondodb-sink.adoc)
Tested in a local Antora build.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
