### PR TITLE
debezium/dbz#2172 Fix INTEGER UNSIGNED synonym mapping to int32 instead of int64

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -162,6 +162,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
             return SchemaBuilder.int32();
         }
         if (matches(typeName, "INT UNSIGNED") || matches(typeName, "INT UNSIGNED ZEROFILL")
+                || matches(typeName, "INTEGER UNSIGNED") || matches(typeName, "INTEGER UNSIGNED ZEROFILL")
                 || matches(typeName, "INT4 UNSIGNED") || matches(typeName, "INT4 UNSIGNED ZEROFILL")) {
             // In order to capture unsigned INT 32-bit data source, INT64 will be required to safely capture all valid values
             // Source: https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.Type.html
@@ -241,6 +242,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
             return (data) -> convertUnsignedMediumint(column, fieldDefn, data);
         }
         if (matches(typeName, "INT UNSIGNED") || matches(typeName, "INT UNSIGNED ZEROFILL")
+                || matches(typeName, "INTEGER UNSIGNED") || matches(typeName, "INTEGER UNSIGNED ZEROFILL")
                 || matches(typeName, "INT4 UNSIGNED") || matches(typeName, "INT4 UNSIGNED ZEROFILL")) {
             // Convert INT UNSIGNED internally from SIGNED to UNSIGNED based on the boundary settings
             return (data) -> convertUnsignedInt(column, fieldDefn, data);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
@@ -3199,8 +3199,8 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         assertThat(getColumnSchema(table, "medium_un_c").defaultValue()).isEqualTo(9);
         assertThat(getColumnSchema(table, "medium_un_z_c").defaultValue()).isEqualTo(10);
         assertThat(getColumnSchema(table, "int_c").defaultValue()).isEqualTo(11);
-        assertThat(getColumnSchema(table, "int_un_c").defaultValue()).isEqualTo(12);
-        assertThat(getColumnSchema(table, "int_un_z_c").defaultValue()).isEqualTo(13);
+        assertThat(getColumnSchema(table, "int_un_c").defaultValue()).isEqualTo(12L);
+        assertThat(getColumnSchema(table, "int_un_z_c").defaultValue()).isEqualTo(13L);
         assertThat(getColumnSchema(table, "int11_c").defaultValue()).isEqualTo(14);
         assertThat(getColumnSchema(table, "big_c").defaultValue()).isEqualTo(15L);
         assertThat(getColumnSchema(table, "big_un_c").defaultValue()).isEqualTo(new BigDecimal(16));

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogUnsignedIntegerIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogUnsignedIntegerIT.java
@@ -79,7 +79,7 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
         int numCreateDatabase = 1;
-        int numCreateTables = 7;
+        int numCreateTables = 8;
         int numDataRecords = numCreateTables * 3; // Total data records
         SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords);
         stopConnector();
@@ -92,6 +92,8 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_mediumint_unsigned")).size())
                 .isEqualTo(3);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_int_unsigned")).size())
+                .isEqualTo(3);
+        assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_integer_unsigned")).size())
                 .isEqualTo(3);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_bigint_unsigned")).size())
                 .isEqualTo(3);
@@ -111,6 +113,9 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
             Struct value = (Struct) record.value();
             if (record.topic().endsWith("dbz_228_int_unsigned")) {
                 assertIntUnsigned(value);
+            }
+            else if (record.topic().endsWith("dbz_integer_unsigned")) {
+                assertIntegerUnsignedSynonym(value);
             }
             else if (record.topic().endsWith("dbz_228_tinyint_unsigned")) {
                 assertTinyintUnsigned(value);
@@ -147,7 +152,7 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
         int numCreateDatabase = 1;
-        int numCreateTables = 7;
+        int numCreateTables = 8;
         int numDataRecords = numCreateTables * 3; // Total data records
         SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords);
         stopConnector();
@@ -181,7 +186,7 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
-        int numTables = 7;
+        int numTables = 8;
         int numDataRecords = numTables * 3;
         int numDdlRecords = numTables * 2 + 3; // for each table (1 drop + 1 create) + for each db (1 create + 1 drop + 1 use)
         int numSetVariables = 1;
@@ -196,6 +201,8 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_mediumint_unsigned")).size())
                 .isEqualTo(3);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_int_unsigned")).size())
+                .isEqualTo(3);
+        assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_integer_unsigned")).size())
                 .isEqualTo(3);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_228_bigint_unsigned")).size())
                 .isEqualTo(3);
@@ -216,6 +223,9 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
             Struct value = (Struct) record.value();
             if (record.topic().endsWith("dbz_228_int_unsigned")) {
                 assertIntUnsigned(value);
+            }
+            else if (record.topic().endsWith("dbz_integer_unsigned")) {
+                assertIntegerUnsignedSynonym(value);
             }
             else if (record.topic().endsWith("dbz_228_tinyint_unsigned")) {
                 assertTinyintUnsigned(value);
@@ -374,6 +384,35 @@ public abstract class BinlogUnsignedIntegerIT<C extends SourceConnector> extends
                 assertThat(after.getInt64("c4")).isEqualTo(0L);
                 assertThat(after.getInt64("c5")).isEqualTo(0L);
                 assertThat(after.getInt32("c6")).isEqualTo(-2147483648);
+        }
+    }
+
+    private void assertIntegerUnsignedSynonym(Struct value) {
+        Struct after = value.getStruct(Envelope.FieldName.AFTER);
+        Integer i = after.getInt32("id");
+        assertThat(i).isNotNull();
+        // The INTEGER UNSIGNED synonym must behave identically to INT UNSIGNED: INT64 schema for unsigned columns
+        assertThat(after.schema().field("c1").schema()).isEqualTo(Schema.INT64_SCHEMA);
+        assertThat(after.schema().field("c2").schema()).isEqualTo(Schema.INT64_SCHEMA);
+
+        // Signed INTEGER remains INT32
+        assertThat(after.schema().field("c3").schema()).isEqualTo(Schema.INT32_SCHEMA);
+
+        switch (i) {
+            case 1:
+                assertThat(after.getInt64("c1")).isEqualTo(4294967295L);
+                assertThat(after.getInt64("c2")).isEqualTo(4294967295L);
+                assertThat(after.getInt32("c3")).isEqualTo(2147483647);
+                break;
+            case 2:
+                assertThat(after.getInt64("c1")).isEqualTo(3294967295L);
+                assertThat(after.getInt64("c2")).isEqualTo(3294967295L);
+                assertThat(after.getInt32("c3")).isEqualTo(-1147483647);
+                break;
+            case 3:
+                assertThat(after.getInt64("c1")).isEqualTo(0L);
+                assertThat(after.getInt64("c2")).isEqualTo(0L);
+                assertThat(after.getInt32("c3")).isEqualTo(-2147483648);
         }
     }
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
@@ -207,6 +207,38 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
     }
 
     @Test
+    public void testIntegerUnsignedSynonymMatchesIntUnsigned() {
+        String sql = "CREATE TABLE INTEGER_UNSIGNED_TABLE (A INT UNSIGNED NOT NULL, B INTEGER UNSIGNED NOT NULL);";
+
+        final BinlogValueConverters converters = getValueConverters(
+                JdbcValueConverters.DecimalMode.PRECISE,
+                TemporalPrecisionMode.CONNECT,
+                JdbcValueConverters.BigIntUnsignedMode.LONG,
+                BinaryHandlingMode.BYTES,
+                x -> x,
+                EventConvertingFailureHandlingMode.WARN);
+
+        DdlParser parser = getDdlParser();
+        Tables tables = new Tables();
+        parser.parse(sql, tables);
+        Table table = tables.forTable(new TableId(null, null, "INTEGER_UNSIGNED_TABLE"));
+
+        // "INT UNSIGNED" and its "INTEGER UNSIGNED" synonym must produce identical schemas/conversions,
+        // otherwise streaming (DDL-parsed) and snapshot (JDBC metadata, always normalized to "INT") diverge.
+        Column colA = table.columnWithName("A");
+        Column colB = table.columnWithName("B");
+
+        Field fieldA = new Field(colA.name(), -1, converters.schemaBuilder(colA).build());
+        Field fieldB = new Field(colB.name(), -1, converters.schemaBuilder(colB).build());
+
+        assertEquals(fieldA.schema(), fieldB.schema());
+        assertEquals(org.apache.kafka.connect.data.Schema.Type.INT64, fieldB.schema().type());
+
+        long valueAboveIntMax = 4294967295L;
+        assertEquals(valueAboveIntMax, converters.converter(colB, fieldB).convert(valueAboveIntMax));
+    }
+
+    @Test
     @FixFor("DBZ-5996")
     public void testZonedDateTimeWithMicrosecondPrecision() {
         String zonedDateTimeTable = "ZONED_DATE_TIME_TABLE";

--- a/debezium-connector-binlog/src/test/resources/ddl/unsigned_integer_test.sql
+++ b/debezium-connector-binlog/src/test/resources/ddl/unsigned_integer_test.sql
@@ -61,6 +61,18 @@ INSERT INTO dbz_228_int_unsigned VALUES (default, 3294967295, 3294967295, -11474
 INSERT INTO dbz_228_int_unsigned VALUES (default, 0, 0, -2147483648, 0, 0, -2147483648);
 
 
+-- Handle the INTEGER UNSIGNED synonym identically to INT UNSIGNED
+CREATE TABLE dbz_integer_unsigned (
+  id int auto_increment NOT NULL,
+  c1 INTEGER(11) UNSIGNED ZEROFILL NOT NULL,
+  c2 INTEGER(11) UNSIGNED NOT NULL,
+  c3 INTEGER(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO dbz_integer_unsigned VALUES (default, 4294967295, 4294967295, 2147483647);
+INSERT INTO dbz_integer_unsigned VALUES (default, 3294967295, 3294967295, -1147483647);
+INSERT INTO dbz_integer_unsigned VALUES (default, 0, 0, -2147483648);
+
 -- DBZ-228 handle unsigned BIGINT UNSIGNED
 CREATE TABLE dbz_228_bigint_unsigned (
   id int auto_increment NOT NULL,


### PR DESCRIPTION
MySQL DDL parsing preserves the literal INTEGER token text, but JDBC metadata (used during snapshot) always normalizes it to INT. Since BinlogValueConverters only matched "INT UNSIGNED" and not the "INTEGER UNSIGNED" synonym, streaming produces an int32 schema while snapshot produces int64 for the same column, causing a ClassCastException when the two paths mixed.

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2172

## Description
<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
