### PR TITLE
debezium/dbz#2173 Fix chunked snapshot failure on tables whose names require quoting

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -1100,8 +1100,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
     protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
         // todo: snapshot select overrides?
+        // Use the quoted, fully-qualified identifier (as the rest of the snapshot SQL does) so that
+        // schema/table names requiring quoting - special characters, reserved words, etc. - remain valid.
         return jdbcConnection.queryAndMap(
-                "SELECT COUNT(1) FROM %s".formatted(jdbcConnection.getQualifiedTableName(tableId)),
+                "SELECT COUNT(1) FROM %s".formatted(jdbcConnection.quotedTableIdString(tableId)),
                 rs -> rs.next() ? rs.getLong(1) : 0L);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -242,6 +242,14 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     }
 
     @Override
+    protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
+        // Oracle TableIds carry a CDB/PDB catalog that cannot appear in a qualified name; strip it
+        // before quoting (as getSnapshotSelect does), otherwise the shared implementation would emit
+        // an invalid "catalog"."schema"."table".
+        return jdbcConnection.getRowCount(new TableId(null, tableId.schema(), tableId.table()));
+    }
+
+    @Override
     protected List<Pattern> getSignalDataCollectionPattern(String signalingDataCollection) {
         // Oracle expects this value to be supplied using "<database>.<schema>.<table>"; however the
         // TableIdMapper used by the connector uses only "<schema>.<table>". This primarily targets

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkedSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresChunkedSnapshotIT.java
@@ -5,16 +5,23 @@
  */
 package io.debezium.connector.postgresql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.AbstractChunkedSnapshotTest;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 /**
  * PostgreSQL-specific chunked table snapshot integration tests.
@@ -46,6 +53,47 @@ public class PostgresChunkedSnapshotIT extends AbstractChunkedSnapshotTest<Postg
             connection.close();
         }
         super.afterEach();
+    }
+
+    @Test
+    @FixFor("dbz#2173")
+    public void shouldSnapshotChunkedTableWhoseNameRequiresQuoting() throws Exception {
+        final int ROW_COUNT = 1_000;
+
+        // A primary-keyed table whose fully-qualified name requires quoting. Unquoted, the chunked
+        // snapshot row-count query would be `SELECT COUNT(1) FROM public.table_with_pk.1#2/3`, which
+        // Postgres rejects with "syntax error at or near .1".
+        final String qualifiedTableName = "public.\"table_with_pk.1#2/3\"";
+
+        connection.execute("CREATE TABLE %s (id numeric(9,0) primary key, data varchar(50))".formatted(qualifiedTableName));
+        try (PreparedStatement st = connection.connection().prepareStatement("INSERT INTO " + qualifiedTableName + " VALUES (?,?)")) {
+            for (int i = 0; i < ROW_COUNT; i++) {
+                st.setInt(1, i);
+                st.setString(2, String.valueOf(i));
+                st.addBatch();
+            }
+            st.executeBatch();
+        }
+        connection.commit();
+
+        final Configuration config = getConfig()
+                .with(CommonConnectorConfig.SNAPSHOT_MAX_THREADS, 2)
+                .with(CommonConnectorConfig.SNAPSHOT_MAX_THREADS_MULTIPLIER, 2)
+                .with(RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST, "public")
+                .with(CommonConnectorConfig.MAX_BATCH_SIZE, ROW_COUNT)
+                .with(CommonConnectorConfig.MAX_QUEUE_SIZE, ROW_COUNT + 1)
+                .build();
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted();
+
+        final SourceRecords allRecords = consumeRecordsByTopic(ROW_COUNT);
+        assertThat(allRecords.allRecordsInOrder()).hasSize(ROW_COUNT);
+
+        // Confirm the chunked (not legacy) algorithm actually ran, i.e. the previously-failing path.
+        assertCreatedChunkSnapshotWorker(2);
     }
 
     @Override


### PR DESCRIPTION
# What

Debezium's chunked/parallel snapshot algorithm (used when `snapshot.max.threads > 1` and `legacy.snapshot.max.threads` is not enabled) computes a per-table row count in `RelationalSnapshotChangeEventSource.rowCountForTableChunked`:

```java
"SELECT COUNT(1) FROM %s".formatted(jdbcConnection.getQualifiedTableName(tableId))
```

`JdbcConnection.getQualifiedTableName()` returns `schema + "." + table` **without quoting**. For any schema/table name that requires quoting (special characters, dots, `#`, `/`, leading digit, uppercase, reserved words) this generates invalid SQL and crashes the snapshot. For example a Postgres table `table_with_pk.1#2/3` yields:

```
SELECT COUNT(1) FROM public.table_with_pk.1#2/3
```

which PostgreSQL rejects with `ERROR: syntax error at or near ".1"`.

This changes the call site to `quotedTableIdString(tableId)`, which is the same method each connector already uses to qualify tables in its snapshot `SELECT`, so the row-count query is quoted consistently per dialect:

- **Postgres / SQL Server** – double-quoted (`"schema"."table"` / `"db"."schema"."table"`); SQL Server's snapshot select literally uses `jdbcConnection.quotedTableIdString(...)`.
- **MySQL / MariaDB** – backtick-quoted (`` `db`.`table` ``) via the binlog `quotedTableIdString` override.
- **Oracle** – `TableId` carries a CDB/PDB catalog that cannot appear in a qualified name, so `OracleSnapshotChangeEventSource` overrides `rowCountForTableChunked` to strip the catalog before quoting, mirroring what its `getSnapshotSelect` already does. Without this it would emit an invalid `"catalog"."schema"."table"`.

`getQualifiedTableName()` itself is intentionally left unchanged, because it is also used as an identifier / map key (not SQL) by `ReselectColumnsPostProcessor`.

# Why

Fixes https://github.com/debezium/dbz/issues/2173

This is a regression from the new chunked snapshot; the non-chunked path already quoted identifiers correctly, so these tables snapshotted fine before. Only `rowCountForTableChunked` used the unquoted form; the other chunked-path queries (chunk boundaries, chunk data selects) already quote via `quotedTableIdString` / `quoteIdentifier`.

# Test

## Integration test

Added `PostgresChunkedSnapshotIT#shouldSnapshotChunkedTableWhoseNameRequiresQuoting`, which creates a primary-keyed table named `public."table_with_pk.1#2/3"`, runs a chunked snapshot with `snapshot.max.threads=2`, and asserts all rows are captured and the chunked worker pool was used. Without the fix this fails during snapshot with `ERROR: syntax error at or near ".1"`.

```bash
mvn test -pl debezium-connector-postgres -Dit.test=PostgresChunkedSnapshotIT#shouldSnapshotChunkedTableWhoseNameRequiresQuoting -Dcheckstyle.skip=true -Dformat.skip=true -Denforcer.skip=true -Drevapi.skip=true
```

The existing `OracleChunkedSnapshotIT` covers the Oracle override (the shared change alone would have regressed it by emitting a 3-part catalog-qualified name).

## Test in real env

Reproduced the original crash in our system (a PostgreSQL data migration with `snapshot.max.threads=2` capturing tables with special-character names). With this fix in place the snapshot completes successfully.
