### PR TITLE
debezium/dbz#978 Add opt-in binlog-metadata-based schema mode for MySQL and MariaDB

### DIFF
--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -17,14 +17,14 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-ci-binlog-metadata' ]
+        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-ci,mariadb-feature-binlog-metadata' ]
         version-mariadb-server: [ "11.4.3", "11.7" ]
         exclude:
           - profile: "mariadb-ci-gtids"
             version-mariadb-server: "11.7"
           - profile: "mariadb-ci-ssl"
             version-mariadb-server: "11.7"
-          - profile: "mariadb-ci-binlog-metadata"
+          - profile: "mariadb-ci,mariadb-feature-binlog-metadata"
             version-mariadb-server: "11.7"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -17,12 +17,14 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl' ]
+        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-ci-binlog-metadata' ]
         version-mariadb-server: [ "11.4.3", "11.7" ]
         exclude:
           - profile: "mariadb-ci-gtids"
             version-mariadb-server: "11.7"
           - profile: "mariadb-ci-ssl"
+            version-mariadb-server: "11.7"
+          - profile: "mariadb-ci-binlog-metadata"
             version-mariadb-server: "11.7"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-innodb-binlog', 'mariadb-ci-binlog-metadata' ]
+        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-innodb-binlog', 'mariadb-ci,mariadb-feature-binlog-metadata' ]
         version-mariadb-server: [ "11.4", "11.8", "12.3" ]
         exclude:
           - profile: "mariadb-ci-gtids"
@@ -32,9 +32,9 @@ jobs:
             version-mariadb-server: "11.4"
           - profile: "mariadb-innodb-binlog"
             version-mariadb-server: "11.8"
-          - profile: "mariadb-ci-binlog-metadata"
+          - profile: "mariadb-ci,mariadb-feature-binlog-metadata"
             version-mariadb-server: "11.8"
-          - profile: "mariadb-ci-binlog-metadata"
+          - profile: "mariadb-ci,mariadb-feature-binlog-metadata"
             version-mariadb-server: "12.3"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-innodb-binlog' ]
+        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-innodb-binlog', 'mariadb-ci-binlog-metadata' ]
         version-mariadb-server: [ "11.4", "11.8", "12.3" ]
         exclude:
           - profile: "mariadb-ci-gtids"
@@ -32,6 +32,10 @@ jobs:
             version-mariadb-server: "11.4"
           - profile: "mariadb-innodb-binlog"
             version-mariadb-server: "11.8"
+          - profile: "mariadb-ci-binlog-metadata"
+            version-mariadb-server: "11.8"
+          - profile: "mariadb-ci-binlog-metadata"
+            version-mariadb-server: "12.3"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/connector-mysql-workflow.yml
+++ b/.github/workflows/connector-mysql-workflow.yml
@@ -17,9 +17,9 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ "mysql-ci", "mysql-ci-gtids", "mysql-ci-percona", "mysql-ci-ssl" ]
+        profile: [ "mysql-ci", "mysql-ci-gtids", "mysql-ci-percona", "mysql-ci-ssl", "mysql-ci-binlog-metadata" ]
         version-mysql-server: [ "8.0", "8.4", "9.7" ]
-        # Always exclude mysql-ci-gtids and mysql-ci-ssl profiles for all versions except most recent
+        # Always exclude mysql-ci-gtids, mysql-ci-ssl and mysql-ci-binlog-metadata profiles for all versions except most recent
         exclude:
           - profile: "mysql-ci-gtids"
             version-mysql-server: "8.0"
@@ -28,6 +28,10 @@ jobs:
           - profile: "mysql-ci-ssl"
             version-mysql-server: "8.0"
           - profile: "mysql-ci-ssl"
+            version-mysql-server: "8.4"
+          - profile: "mysql-ci-binlog-metadata"
+            version-mysql-server: "8.0"
+          - profile: "mysql-ci-binlog-metadata"
             version-mysql-server: "8.4"
     name: MySQL ${{ matrix.version-mysql-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/connector-mysql-workflow.yml
+++ b/.github/workflows/connector-mysql-workflow.yml
@@ -17,9 +17,9 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ "mysql-ci", "mysql-ci-gtids", "mysql-ci-percona", "mysql-ci-ssl", "mysql-ci-binlog-metadata" ]
+        profile: [ "mysql-ci", "mysql-ci-gtids", "mysql-ci-percona", "mysql-ci-ssl", "mysql-ci,mysql-feature-binlog-metadata" ]
         version-mysql-server: [ "8.0", "8.4", "9.7" ]
-        # Always exclude mysql-ci-gtids, mysql-ci-ssl and mysql-ci-binlog-metadata profiles for all versions except most recent
+        # Always exclude the mysql-ci-gtids, mysql-ci-ssl and binlog-metadata builds for all versions except most recent
         exclude:
           - profile: "mysql-ci-gtids"
             version-mysql-server: "8.0"
@@ -29,9 +29,9 @@ jobs:
             version-mysql-server: "8.0"
           - profile: "mysql-ci-ssl"
             version-mysql-server: "8.4"
-          - profile: "mysql-ci-binlog-metadata"
+          - profile: "mysql-ci,mysql-feature-binlog-metadata"
             version-mysql-server: "8.0"
-          - profile: "mysql-ci-binlog-metadata"
+          - profile: "mysql-ci,mysql-feature-binlog-metadata"
             version-mysql-server: "8.4"
     name: MySQL ${{ matrix.version-mysql-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -28,6 +28,9 @@ import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
+import io.debezium.relational.history.MemorySchemaHistory;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.util.Collect;
 
@@ -454,6 +457,21 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "transaction in progress is going to be committed or rolled back. Use 0 to disable look-ahead "
                     + "buffering. Defaults to " + DEFAULT_BINLOG_BUFFER_SIZE + " (i.e. buffering is disabled.");
 
+    public static final Field BINLOG_METADATA_BASED_SCHEMA = Field.create("binlog.metadata.based.schema")
+            .withDisplayName("Reconstruct streaming schema from binlog metadata")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(false)
+            .withValidation(Field::isBoolean)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withDescription("When 'true', the streaming table schema is reconstructed on the fly from the "
+                    + "column metadata carried by binlog TABLE_MAP events instead of from a persisted schema "
+                    + "history topic. This is an opt-in mode that requires the source server to run with "
+                    + "'binlog_row_metadata=FULL' so that column names, types, charsets, enum/set values and the "
+                    + "primary key are present in every TABLE_MAP event. When enabled, no external schema history "
+                    + "topic is created or required. Defaults to 'false'.");
+
     public static final Field TOPIC_NAMING_STRATEGY = Field.create("topic.naming.strategy")
             .withDisplayName("Topic naming strategy class")
             .withType(ConfigDef.Type.CLASS)
@@ -647,7 +665,8 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             .group(Field.Group.CONNECTION_ADVANCED_SSL, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD)
             .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE, GTID_SOURCE_INCLUDES,
                     GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS)
-            .group(Field.Group.CONNECTOR_ADVANCED, ROW_COUNT_FOR_STREAMING_RESULT_SETS, BUFFER_SIZE_FOR_BINLOG_READER, INCLUDE_SQL_QUERY, IGNORE_GTID_ON_RECOVERY)
+            .group(Field.Group.CONNECTOR_ADVANCED, ROW_COUNT_FOR_STREAMING_RESULT_SETS, BUFFER_SIZE_FOR_BINLOG_READER, INCLUDE_SQL_QUERY, IGNORE_GTID_ON_RECOVERY,
+                    BINLOG_METADATA_BASED_SCHEMA)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .group(Field.Group.FILTERS, TABLES_IGNORE_BUILTIN, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST)
@@ -798,6 +817,29 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
      */
     public boolean isSqlQueryIncluded() {
         return config.getBoolean(INCLUDE_SQL_QUERY);
+    }
+
+    /**
+     * @return whether the streaming table schema should be reconstructed from binlog TABLE_MAP metadata
+     *         (opt-in, requires {@code binlog_row_metadata=FULL}) instead of from a persisted schema history topic.
+     */
+    public boolean isBinlogMetadataBasedSchema() {
+        return config.getBoolean(BINLOG_METADATA_BASED_SCHEMA);
+    }
+
+    @Override
+    public SchemaHistory getSchemaHistory() {
+        if (!isBinlogMetadataBasedSchema()) {
+            return super.getSchemaHistory();
+        }
+        // In binlog-metadata-based schema mode the streaming schema is reconstructed from TABLE_MAP events,
+        // so no persistent schema history is used. An in-memory history satisfies the historized base class
+        // lifecycle without creating or requiring an external history topic (and without requiring any
+        // schema.history.internal.* connection settings).
+        final SchemaHistory schemaHistory = new MemorySchemaHistory();
+        schemaHistory.configure(Configuration.empty(), getHistoryRecordComparator(),
+                SchemaHistoryListener.NOOP, useCatalogBeforeSchema());
+        return schemaHistory;
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -21,6 +21,7 @@ import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
 import io.debezium.connector.binlog.gtid.GtidSet;
 import io.debezium.connector.binlog.gtid.GtidSetFactory;
+import io.debezium.connector.binlog.history.BinlogMetadataSchemaHistory;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.ColumnFilterMode;
@@ -28,7 +29,6 @@ import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
-import io.debezium.relational.history.MemorySchemaHistory;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -833,10 +833,10 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             return super.getSchemaHistory();
         }
         // In binlog-metadata-based schema mode the streaming schema is reconstructed from TABLE_MAP events,
-        // so no persistent schema history is used. An in-memory history satisfies the historized base class
-        // lifecycle without creating or requiring an external history topic (and without requiring any
-        // schema.history.internal.* connection settings).
-        final SchemaHistory schemaHistory = new MemorySchemaHistory();
+        // so no persistent schema history is used. The no-op history satisfies the historized lifecycle
+        // (the snapshot phase runs unchanged) without creating or requiring an external history topic, and
+        // without requiring any schema.history.internal.* connection settings.
+        final SchemaHistory schemaHistory = new BinlogMetadataSchemaHistory();
         schemaHistory.configure(Configuration.empty(), getHistoryRecordComparator(),
                 SchemaHistoryListener.NOOP, useCatalogBeforeSchema());
         return schemaHistory;

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -7,9 +7,12 @@ package io.debezium.connector.binlog;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -18,8 +21,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.metadata.BinlogMetadataTableBuilder;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.relational.CustomConverterRegistry;
@@ -65,8 +70,8 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     private final Map<Long, TableId> tableIdsByTableNumber = new ConcurrentHashMap<>();
     private final Map<Long, TableId> excludeTableIdsByTableNumber = new ConcurrentHashMap<>();
     private final BinlogConnectorConfig connectorConfig;
-    private final BinlogMetadataTableBuilder metadataTableBuilder = new BinlogMetadataTableBuilder();
-    private final Set<TableId> tablesRegisteredFromBinlogMetadata = ConcurrentHashMap.newKeySet();
+    private final BinlogMetadataTableBuilder metadataTableBuilder;
+    private final Map<TableId, TableMapMetadataSnapshot> tablesRegisteredFromBinlogMetadata = new ConcurrentHashMap<>();
 
     /**
      * Creates a binlog-connector based relational schema based on the supplied configuration. The DDL
@@ -105,19 +110,13 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         this.ddlParser = createDdlParser(connectorConfig, valueConverter);
         this.connectorConfig = connectorConfig;
         this.filters = connectorConfig.getTableFilters();
+        this.metadataTableBuilder = new BinlogMetadataTableBuilder(
+                () -> connectorConfig.getServiceRegistry().tryGetService(BinlogCharsetRegistry.class));
     }
 
     @Override
     protected DdlParser getDdlParser() {
         return ddlParser;
-    }
-
-    @Override
-    public boolean isHistorized() {
-        // In binlog-metadata-based schema mode the schema is rebuilt from the log itself (TABLE_MAP events),
-        // so the connector behaves like a non-historized connector (e.g. PostgreSQL): no schema snapshot,
-        // no history recovery and no persisted schema history topic.
-        return !connectorConfig.isBinlogMetadataBasedSchema();
     }
 
     @Override
@@ -234,16 +233,93 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         // A TABLE_MAP event precedes the row events for its table within every transaction, so it is seen
         // very frequently. Rebuilding the table and its Kafka Connect schema on every event would be
         // wasteful (the PostgreSQL connector rebuilds unconditionally, but its pgoutput relation messages
-        // are rare, whereas TABLE_MAP is per-transaction). Instead, each table is populated once and only
-        // rebuilt after a DDL statement for it has been parsed from the binlog, which marks it dirty by
-        // removing it from this registry (see the invalidation in parseDdl).
-        if (tablesRegisteredFromBinlogMetadata.contains(tableId) && schemaFor(tableId) != null) {
+        // are rare, whereas TABLE_MAP is per-transaction). Instead, each table is populated once and
+        // rebuilt when either:
+        // - a DDL statement for it has been parsed from the binlog, which marks it dirty by removing it
+        // from this registry (see the invalidation in parseDdl); or
+        // - the TABLE_MAP metadata no longer structurally matches what was registered, which catches
+        // schema drift that never appears as a binlog DDL statement (for example an ALTER executed
+        // with sql_log_bin=OFF); the comparison is a cheap field-by-field check without allocations.
+        final TableMapMetadataSnapshot registered = tablesRegisteredFromBinlogMetadata.get(tableId);
+        if (registered != null && registered.matches(metadata) && schemaFor(tableId) != null) {
             return true;
         }
         final Table table = metadataTableBuilder.build(tableId, metadata);
         refresh(table);
-        tablesRegisteredFromBinlogMetadata.add(tableId);
+        tablesRegisteredFromBinlogMetadata.put(tableId, TableMapMetadataSnapshot.of(metadata));
         return true;
+    }
+
+    /**
+     * Snapshot of the {@code TABLE_MAP} fields the {@link BinlogMetadataTableBuilder} consumes, used to
+     * detect whether a newly received event still structurally matches the registered schema.
+     */
+    private static final class TableMapMetadataSnapshot {
+
+        private final byte[] columnTypes;
+        private final int[] columnMetadata;
+        private final BitSet columnNullability;
+        private final List<String> columnNames;
+        private final BitSet signedness;
+        private final List<Integer> columnCharsets;
+        private final Integer defaultCharsetCollation;
+        private final Map<Integer, Integer> defaultCharsetOverrides;
+        private final List<String[]> enumStrValues;
+        private final List<String[]> setStrValues;
+        private final List<Integer> simplePrimaryKeys;
+
+        private TableMapMetadataSnapshot(TableMapEventData data, TableMapEventMetadata meta) {
+            this.columnTypes = data.getColumnTypes() != null ? data.getColumnTypes().clone() : null;
+            this.columnMetadata = data.getColumnMetadata() != null ? data.getColumnMetadata().clone() : null;
+            this.columnNullability = data.getColumnNullability() != null ? (BitSet) data.getColumnNullability().clone() : null;
+            this.columnNames = meta.getColumnNames();
+            this.signedness = meta.getSignedness() != null ? (BitSet) meta.getSignedness().clone() : null;
+            this.columnCharsets = meta.getColumnCharsets();
+            final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
+            this.defaultCharsetCollation = defaultCharset != null ? defaultCharset.getDefaultCharsetCollation() : null;
+            this.defaultCharsetOverrides = defaultCharset != null ? defaultCharset.getCharsetCollations() : null;
+            this.enumStrValues = meta.getEnumStrValues();
+            this.setStrValues = meta.getSetStrValues();
+            this.simplePrimaryKeys = meta.getSimplePrimaryKeys();
+        }
+
+        static TableMapMetadataSnapshot of(TableMapEventData data) {
+            return new TableMapMetadataSnapshot(data, data.getEventMetadata());
+        }
+
+        boolean matches(TableMapEventData data) {
+            final TableMapEventMetadata meta = data.getEventMetadata();
+            if (meta == null) {
+                return false;
+            }
+            final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
+            return Arrays.equals(columnTypes, data.getColumnTypes())
+                    && Arrays.equals(columnMetadata, data.getColumnMetadata())
+                    && Objects.equals(columnNullability, data.getColumnNullability())
+                    && Objects.equals(columnNames, meta.getColumnNames())
+                    && Objects.equals(signedness, meta.getSignedness())
+                    && Objects.equals(columnCharsets, meta.getColumnCharsets())
+                    && Objects.equals(defaultCharsetCollation, defaultCharset != null ? defaultCharset.getDefaultCharsetCollation() : null)
+                    && Objects.equals(defaultCharsetOverrides, defaultCharset != null ? defaultCharset.getCharsetCollations() : null)
+                    && stringArrayListsEqual(enumStrValues, meta.getEnumStrValues())
+                    && stringArrayListsEqual(setStrValues, meta.getSetStrValues())
+                    && Objects.equals(simplePrimaryKeys, meta.getSimplePrimaryKeys());
+        }
+
+        private static boolean stringArrayListsEqual(List<String[]> left, List<String[]> right) {
+            if (left == null || right == null) {
+                return left == right;
+            }
+            if (left.size() != right.size()) {
+                return false;
+            }
+            for (int i = 0; i < left.size(); i++) {
+                if (!Arrays.equals(left.get(i), right.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     /**
@@ -320,25 +396,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
      */
     public List<SchemaChangeEvent> parseSnapshotDdl(P partition, String ddlStatements, String databaseName, O offset, Instant sourceTime) {
         LOGGER.debug("Processing snapshot DDL '{}' for database '{}'", ddlStatements, databaseName);
-        final List<SchemaChangeEvent> schemaChangeEvents = parseDdl(partition, ddlStatements, databaseName, offset, sourceTime, true);
-        if (connectorConfig.isBinlogMetadataBasedSchema()) {
-            // In binlog-metadata-based schema mode the connector is non-historized, so the Kafka TableSchema
-            // is not built via the historized applySchemaChange() dispatch path. Build and register it here for
-            // the tables discovered during the snapshot, mirroring how non-historized connectors (e.g.
-            // PostgreSQL) refresh their schema during the snapshot. During streaming the schema is (re)built
-            // from TABLE_MAP events instead.
-            for (SchemaChangeEvent event : schemaChangeEvents) {
-                if (event.getType() == SchemaChangeEvent.SchemaChangeEventType.CREATE
-                        || event.getType() == SchemaChangeEvent.SchemaChangeEventType.ALTER) {
-                    event.getTableChanges().forEach(change -> {
-                        if (change.getTable() != null) {
-                            buildAndRegisterSchema(change.getTable());
-                        }
-                    });
-                }
-            }
-        }
-        return schemaChangeEvents;
+        return parseDdl(partition, ddlStatements, databaseName, offset, sourceTime, true);
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -7,7 +7,6 @@ package io.debezium.connector.binlog;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
-import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.binlog.metadata.BinlogMetadataTableBuilder;
@@ -68,7 +66,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     private final Map<Long, TableId> excludeTableIdsByTableNumber = new ConcurrentHashMap<>();
     private final BinlogConnectorConfig connectorConfig;
     private final BinlogMetadataTableBuilder metadataTableBuilder = new BinlogMetadataTableBuilder();
-    private final Map<TableId, String> lastMetadataSignatureByTable = new ConcurrentHashMap<>();
+    private final Set<TableId> tablesRegisteredFromBinlogMetadata = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates a binlog-connector based relational schema based on the supplied configuration. The DDL
@@ -236,55 +234,46 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         // A TABLE_MAP event precedes the row events for its table within every transaction, so it is seen
         // very frequently. Rebuilding the table and its Kafka Connect schema on every event would be
         // wasteful (the PostgreSQL connector rebuilds unconditionally, but its pgoutput relation messages
-        // are rare, whereas TABLE_MAP is per-transaction). Skip the rebuild when the metadata is unchanged
-        // from what was last registered for this table. The signature is a deterministic serialization of
-        // every field the builder reads (not a hash), so an unnoticed change cannot leave a stale schema;
-        // in the worst case a signature bug only causes an unnecessary rebuild.
-        final String signature = metadataSignature(metadata);
-        if (signature.equals(lastMetadataSignatureByTable.get(tableId)) && schemaFor(tableId) != null) {
+        // are rare, whereas TABLE_MAP is per-transaction). Instead, each table is populated once and only
+        // rebuilt after a DDL statement for it has been parsed from the binlog, which marks it dirty by
+        // removing it from this registry (see the invalidation in parseDdl).
+        if (tablesRegisteredFromBinlogMetadata.contains(tableId) && schemaFor(tableId) != null) {
             return true;
         }
         final Table table = metadataTableBuilder.build(tableId, metadata);
         refresh(table);
-        lastMetadataSignatureByTable.put(tableId, signature);
+        tablesRegisteredFromBinlogMetadata.add(tableId);
         return true;
     }
 
     /**
-     * Build a deterministic signature of every {@code TABLE_MAP} field the {@link BinlogMetadataTableBuilder}
-     * uses to reconstruct a table, so that an unchanged schema can be detected without rebuilding.
+     * Mark tables affected by parsed DDL statements as dirty so that the next {@code TABLE_MAP} event
+     * rebuilds their schema from the binlog metadata. Statements that cannot be attributed to a specific
+     * table (for example database-wide statements) conservatively clear the whole registry; the only cost
+     * of over-invalidation is a single rebuild per table on its next TABLE_MAP event.
      */
-    private static String metadataSignature(TableMapEventData data) {
-        final TableMapEventMetadata meta = data.getEventMetadata();
-        final StringBuilder sb = new StringBuilder();
-        sb.append(Arrays.toString(data.getColumnTypes()));
-        sb.append('|').append(Arrays.toString(data.getColumnMetadata()));
-        sb.append('|').append(data.getColumnNullability());
-        if (meta != null) {
-            sb.append('|').append(meta.getColumnNames());
-            sb.append('|').append(meta.getSignedness());
-            sb.append('|').append(stringArrayListsToString(meta.getEnumStrValues()));
-            sb.append('|').append(stringArrayListsToString(meta.getSetStrValues()));
-            sb.append('|').append(meta.getColumnCharsets());
-            final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
-            if (defaultCharset != null) {
-                sb.append('|').append(defaultCharset.getDefaultCharsetCollation())
-                        .append(defaultCharset.getCharsetCollations());
+    private void invalidateBinlogMetadataRegistrations(DdlChanges ddlChanges) {
+        if (tablesRegisteredFromBinlogMetadata.isEmpty() || ddlChanges.isEmpty()) {
+            return;
+        }
+        ddlChanges.getEventsByDatabase((String dbName, List<DdlParserListener.Event> events) -> events.forEach(event -> {
+            if (event instanceof DdlParserListener.SetVariableEvent) {
+                // Variable assignments do not change any table structure.
+                return;
             }
-            sb.append('|').append(meta.getSimplePrimaryKeys());
-        }
-        return sb.toString();
-    }
-
-    private static String stringArrayListsToString(List<String[]> lists) {
-        if (lists == null) {
-            return "null";
-        }
-        final StringBuilder sb = new StringBuilder();
-        for (String[] values : lists) {
-            sb.append(Arrays.toString(values));
-        }
-        return sb.toString();
+            final TableId tableId = getTableId(event);
+            if (tableId == null) {
+                tablesRegisteredFromBinlogMetadata.clear();
+                return;
+            }
+            tablesRegisteredFromBinlogMetadata.remove(tableId);
+            if (event instanceof DdlParserListener.TableAlteredEvent) {
+                final TableId previousTableId = ((DdlParserListener.TableAlteredEvent) event).previousTableId();
+                if (previousTableId != null) {
+                    tablesRegisteredFromBinlogMetadata.remove(previousTableId);
+                }
+            }
+        }));
     }
 
     /**
@@ -422,10 +411,19 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         catch (ParsingException | MultipleParsingExceptions e) {
             if (skipUnparseableDdlStatements()) {
                 LOGGER.warn("Ignoring unparseable DDL statement '{}'", ddlStatements, e);
+                if (connectorConfig.isBinlogMetadataBasedSchema()) {
+                    // The affected tables are unknown, so conservatively mark everything dirty; each table is
+                    // rebuilt from its next TABLE_MAP event.
+                    tablesRegisteredFromBinlogMetadata.clear();
+                }
             }
             else {
                 throw e;
             }
+        }
+
+        if (connectorConfig.isBinlogMetadataBasedSchema()) {
+            invalidateBinlogMetadataRegistrations(ddlChanges);
         }
 
         // No need to send schema events or store DDL if no table has changed

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -17,7 +17,10 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.binlog.metadata.BinlogMetadataTableBuilder;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.DefaultValueConverter;
@@ -62,6 +65,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     private final Map<Long, TableId> tableIdsByTableNumber = new ConcurrentHashMap<>();
     private final Map<Long, TableId> excludeTableIdsByTableNumber = new ConcurrentHashMap<>();
     private final BinlogConnectorConfig connectorConfig;
+    private final BinlogMetadataTableBuilder metadataTableBuilder = new BinlogMetadataTableBuilder();
 
     /**
      * Creates a binlog-connector based relational schema based on the supplied configuration. The DDL
@@ -105,6 +109,14 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     @Override
     protected DdlParser getDdlParser() {
         return ddlParser;
+    }
+
+    @Override
+    public boolean isHistorized() {
+        // In binlog-metadata-based schema mode the schema is rebuilt from the log itself (TABLE_MAP events),
+        // so the connector behaves like a non-historized connector (e.g. PostgreSQL): no schema snapshot,
+        // no history recovery and no persisted schema history topic.
+        return !connectorConfig.isBinlogMetadataBasedSchema();
     }
 
     @Override
@@ -202,6 +214,28 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     }
 
     /**
+     * Reconstruct and register a table definition from the FULL metadata carried by a binlog
+     * {@code TABLE_MAP} event. This is used by the opt-in binlog-metadata-based schema mode
+     * (see {@link BinlogConnectorConfig#BINLOG_METADATA_BASED_SCHEMA}) where the
+     * streaming schema is derived from the log itself rather than from a persisted schema history
+     * topic, analogous to how the PostgreSQL connector rebuilds schema from pgoutput relation
+     * messages.
+     *
+     * @param metadata the {@code TABLE_MAP} event data, which must include FULL column metadata; never null
+     * @return true if the table is captured and was (re)registered; false if excluded by the filters
+     * @throws IllegalStateException if the event lacks FULL metadata (i.e. {@code binlog_row_metadata} is not FULL)
+     */
+    public boolean registerTableFromBinlogMetadata(TableMapEventData metadata) {
+        final TableId tableId = new TableId(metadata.getDatabase(), null, metadata.getTable());
+        if (!filters.dataCollectionFilter().isIncluded(tableId)) {
+            return false;
+        }
+        final Table table = metadataTableBuilder.build(tableId, metadata);
+        refresh(table);
+        return true;
+    }
+
+    /**
      * Return the table id associated with connector-specific table number.
      *
      * @param tableNumber the table number from binlog
@@ -245,7 +279,25 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
      */
     public List<SchemaChangeEvent> parseSnapshotDdl(P partition, String ddlStatements, String databaseName, O offset, Instant sourceTime) {
         LOGGER.debug("Processing snapshot DDL '{}' for database '{}'", ddlStatements, databaseName);
-        return parseDdl(partition, ddlStatements, databaseName, offset, sourceTime, true);
+        final List<SchemaChangeEvent> schemaChangeEvents = parseDdl(partition, ddlStatements, databaseName, offset, sourceTime, true);
+        if (connectorConfig.isBinlogMetadataBasedSchema()) {
+            // In binlog-metadata-based schema mode the connector is non-historized, so the Kafka TableSchema
+            // is not built via the historized applySchemaChange() dispatch path. Build and register it here for
+            // the tables discovered during the snapshot, mirroring how non-historized connectors (e.g.
+            // PostgreSQL) refresh their schema during the snapshot. During streaming the schema is (re)built
+            // from TABLE_MAP events instead.
+            for (SchemaChangeEvent event : schemaChangeEvents) {
+                if (event.getType() == SchemaChangeEvent.SchemaChangeEventType.CREATE
+                        || event.getType() == SchemaChangeEvent.SchemaChangeEventType.ALTER) {
+                    event.getTableChanges().forEach(change -> {
+                        if (change.getTable() != null) {
+                            buildAndRegisterSchema(change.getTable());
+                        }
+                    });
+                }
+            }
+        }
+        return schemaChangeEvents;
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -266,6 +266,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         private final Map<Integer, Integer> defaultCharsetOverrides;
         private final List<String[]> enumStrValues;
         private final List<String[]> setStrValues;
+        private final List<Integer> geometryTypes;
         private final List<Integer> simplePrimaryKeys;
 
         private TableMapMetadataSnapshot(TableMapEventData data, TableMapEventMetadata meta) {
@@ -280,6 +281,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
             this.defaultCharsetOverrides = defaultCharset != null ? defaultCharset.getCharsetCollations() : null;
             this.enumStrValues = meta.getEnumStrValues();
             this.setStrValues = meta.getSetStrValues();
+            this.geometryTypes = meta.getGeometryTypes();
             this.simplePrimaryKeys = meta.getSimplePrimaryKeys();
         }
 
@@ -303,6 +305,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
                     && Objects.equals(defaultCharsetOverrides, defaultCharset != null ? defaultCharset.getCharsetCollations() : null)
                     && stringArrayListsEqual(enumStrValues, meta.getEnumStrValues())
                     && stringArrayListsEqual(setStrValues, meta.getSetStrValues())
+                    && Objects.equals(geometryTypes, meta.getGeometryTypes())
                     && Objects.equals(simplePrimaryKeys, meta.getSimplePrimaryKeys());
         }
 

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -363,8 +363,8 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
                 return;
             }
             tablesRegisteredFromBinlogMetadata.remove(tableId);
-            if (event instanceof DdlParserListener.TableAlteredEvent) {
-                final TableId previousTableId = ((DdlParserListener.TableAlteredEvent) event).previousTableId();
+            if (event instanceof DdlParserListener.TableAlteredEvent alteredEvent) {
+                final TableId previousTableId = alteredEvent.previousTableId();
                 if (previousTableId != null) {
                     tablesRegisteredFromBinlogMetadata.remove(previousTableId);
                 }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -7,6 +7,7 @@ package io.debezium.connector.binlog;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.binlog.metadata.BinlogMetadataTableBuilder;
@@ -66,6 +68,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     private final Map<Long, TableId> excludeTableIdsByTableNumber = new ConcurrentHashMap<>();
     private final BinlogConnectorConfig connectorConfig;
     private final BinlogMetadataTableBuilder metadataTableBuilder = new BinlogMetadataTableBuilder();
+    private final Map<TableId, String> lastMetadataSignatureByTable = new ConcurrentHashMap<>();
 
     /**
      * Creates a binlog-connector based relational schema based on the supplied configuration. The DDL
@@ -230,9 +233,58 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         if (!filters.dataCollectionFilter().isIncluded(tableId)) {
             return false;
         }
+        // A TABLE_MAP event precedes the row events for its table within every transaction, so it is seen
+        // very frequently. Rebuilding the table and its Kafka Connect schema on every event would be
+        // wasteful (the PostgreSQL connector rebuilds unconditionally, but its pgoutput relation messages
+        // are rare, whereas TABLE_MAP is per-transaction). Skip the rebuild when the metadata is unchanged
+        // from what was last registered for this table. The signature is a deterministic serialization of
+        // every field the builder reads (not a hash), so an unnoticed change cannot leave a stale schema;
+        // in the worst case a signature bug only causes an unnecessary rebuild.
+        final String signature = metadataSignature(metadata);
+        if (signature.equals(lastMetadataSignatureByTable.get(tableId)) && schemaFor(tableId) != null) {
+            return true;
+        }
         final Table table = metadataTableBuilder.build(tableId, metadata);
         refresh(table);
+        lastMetadataSignatureByTable.put(tableId, signature);
         return true;
+    }
+
+    /**
+     * Build a deterministic signature of every {@code TABLE_MAP} field the {@link BinlogMetadataTableBuilder}
+     * uses to reconstruct a table, so that an unchanged schema can be detected without rebuilding.
+     */
+    private static String metadataSignature(TableMapEventData data) {
+        final TableMapEventMetadata meta = data.getEventMetadata();
+        final StringBuilder sb = new StringBuilder();
+        sb.append(Arrays.toString(data.getColumnTypes()));
+        sb.append('|').append(Arrays.toString(data.getColumnMetadata()));
+        sb.append('|').append(data.getColumnNullability());
+        if (meta != null) {
+            sb.append('|').append(meta.getColumnNames());
+            sb.append('|').append(meta.getSignedness());
+            sb.append('|').append(stringArrayListsToString(meta.getEnumStrValues()));
+            sb.append('|').append(stringArrayListsToString(meta.getSetStrValues()));
+            sb.append('|').append(meta.getColumnCharsets());
+            final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
+            if (defaultCharset != null) {
+                sb.append('|').append(defaultCharset.getDefaultCharsetCollation())
+                        .append(defaultCharset.getCharsetCollations());
+            }
+            sb.append('|').append(meta.getSimplePrimaryKeys());
+        }
+        return sb.toString();
+    }
+
+    private static String stringArrayListsToString(List<String[]> lists) {
+        if (lists == null) {
+            return "null";
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (String[] values : lists) {
+            sb.append(Arrays.toString(values));
+        }
+        return sb.toString();
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -264,10 +264,15 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         private final List<Integer> columnCharsets;
         private final Integer defaultCharsetCollation;
         private final Map<Integer, Integer> defaultCharsetOverrides;
+        private final List<Integer> enumAndSetColumnCharsets;
+        private final Integer enumAndSetDefaultCharsetCollation;
+        private final Map<Integer, Integer> enumAndSetDefaultCharsetOverrides;
         private final List<String[]> enumStrValues;
         private final List<String[]> setStrValues;
         private final List<Integer> geometryTypes;
+        private final List<Integer> vectorDimensionality;
         private final List<Integer> simplePrimaryKeys;
+        private final Map<Integer, Integer> primaryKeysWithPrefix;
 
         private TableMapMetadataSnapshot(TableMapEventData data, TableMapEventMetadata meta) {
             this.columnTypes = data.getColumnTypes() != null ? data.getColumnTypes().clone() : null;
@@ -279,10 +284,16 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
             final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
             this.defaultCharsetCollation = defaultCharset != null ? defaultCharset.getDefaultCharsetCollation() : null;
             this.defaultCharsetOverrides = defaultCharset != null ? defaultCharset.getCharsetCollations() : null;
+            final TableMapEventMetadata.DefaultCharset enumAndSetDefaultCharset = meta.getEnumAndSetDefaultCharset();
+            this.enumAndSetColumnCharsets = meta.getEnumAndSetColumnCharsets();
+            this.enumAndSetDefaultCharsetCollation = enumAndSetDefaultCharset != null ? enumAndSetDefaultCharset.getDefaultCharsetCollation() : null;
+            this.enumAndSetDefaultCharsetOverrides = enumAndSetDefaultCharset != null ? enumAndSetDefaultCharset.getCharsetCollations() : null;
             this.enumStrValues = meta.getEnumStrValues();
             this.setStrValues = meta.getSetStrValues();
             this.geometryTypes = meta.getGeometryTypes();
+            this.vectorDimensionality = meta.getVectorDimensionality();
             this.simplePrimaryKeys = meta.getSimplePrimaryKeys();
+            this.primaryKeysWithPrefix = meta.getPrimaryKeysWithPrefix();
         }
 
         static TableMapMetadataSnapshot of(TableMapEventData data) {
@@ -295,6 +306,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
                 return false;
             }
             final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
+            final TableMapEventMetadata.DefaultCharset enumAndSetDefaultCharset = meta.getEnumAndSetDefaultCharset();
             return Arrays.equals(columnTypes, data.getColumnTypes())
                     && Arrays.equals(columnMetadata, data.getColumnMetadata())
                     && Objects.equals(columnNullability, data.getColumnNullability())
@@ -303,10 +315,15 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
                     && Objects.equals(columnCharsets, meta.getColumnCharsets())
                     && Objects.equals(defaultCharsetCollation, defaultCharset != null ? defaultCharset.getDefaultCharsetCollation() : null)
                     && Objects.equals(defaultCharsetOverrides, defaultCharset != null ? defaultCharset.getCharsetCollations() : null)
+                    && Objects.equals(enumAndSetColumnCharsets, meta.getEnumAndSetColumnCharsets())
+                    && Objects.equals(enumAndSetDefaultCharsetCollation, enumAndSetDefaultCharset != null ? enumAndSetDefaultCharset.getDefaultCharsetCollation() : null)
+                    && Objects.equals(enumAndSetDefaultCharsetOverrides, enumAndSetDefaultCharset != null ? enumAndSetDefaultCharset.getCharsetCollations() : null)
                     && stringArrayListsEqual(enumStrValues, meta.getEnumStrValues())
                     && stringArrayListsEqual(setStrValues, meta.getSetStrValues())
                     && Objects.equals(geometryTypes, meta.getGeometryTypes())
-                    && Objects.equals(simplePrimaryKeys, meta.getSimplePrimaryKeys());
+                    && Objects.equals(vectorDimensionality, meta.getVectorDimensionality())
+                    && Objects.equals(simplePrimaryKeys, meta.getSimplePrimaryKeys())
+                    && Objects.equals(primaryKeysWithPrefix, meta.getPrimaryKeysWithPrefix());
         }
 
         private static boolean stringArrayListsEqual(List<String[]> left, List<String[]> right) {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
@@ -51,7 +51,6 @@ import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
-import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.SnapshotTablesRowCountOrder;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.RelationalTableFilters;
@@ -113,35 +112,6 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         this.databaseSchema = schema;
         this.lastEventProcessor = lastEventProcessor;
         this.preSnapshotAction = preSnapshotAction;
-    }
-
-    @Override
-    public SnapshotResult<O> execute(ChangeEventSourceContext context, P partition, O previousOffset, SnapshottingTask snapshottingTask)
-            throws InterruptedException {
-        // In binlog-metadata-based schema mode the connector is non-historized, so a snapshot mode that does
-        // not snapshot data (for example 'no_data' or 'schema_only') skips the snapshot entirely, including the
-        // step that records the current binlog position. Without a start offset a fresh connector would stream
-        // from the earliest available binlog. Seed the current binlog position/GTID here so that streaming
-        // begins from the current point, matching the behavior of a historized 'no_data' snapshot. This is only
-        // done for a fresh connector (no previous offset); on restart the persisted offset is used unchanged.
-        if (connectorConfig.isBinlogMetadataBasedSchema() && previousOffset == null && snapshottingTask.shouldSkipSnapshot()) {
-            final O offsetContext = getInitialOffsetContext(connectorConfig);
-            try {
-                setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(offsetContext, connection, snapshotterService);
-            }
-            catch (InterruptedException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new DebeziumException("Failed to determine the current binlog position for the "
-                        + "binlog-metadata-based schema mode while skipping the snapshot", e);
-            }
-            LOGGER.info("Binlog-metadata-based schema mode: snapshot skipped for a fresh connector; seeded the "
-                    + "current binlog position so that streaming starts from the current point instead of the earliest binlog");
-            notificationService.initialSnapshotNotificationService().notifySkipped(partition, offsetContext);
-            return SnapshotResult.skipped(offsetContext);
-        }
-        return super.execute(context, partition, previousOffset, snapshottingTask);
     }
 
     @Override
@@ -396,19 +366,6 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         finally {
             if (executorService != null) {
                 executorService.shutdownNow();
-            }
-        }
-
-        if (connectorConfig.isBinlogMetadataBasedSchema()) {
-            // In binlog-metadata-based schema mode the connector is non-historized, so snapshotSchema() is
-            // false and the "persist schema history" step (which normally copies the captured table
-            // definitions into the snapshot context) is skipped. Make those definitions available to the
-            // data snapshot here, mirroring how non-historized connectors expose schema during the snapshot.
-            for (TableId tableId : databaseSchema.tableIds()) {
-                final Table table = databaseSchema.tableFor(tableId);
-                if (table != null) {
-                    snapshotContext.tables.overwriteTable(table);
-                }
             }
         }
     }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
@@ -51,6 +51,7 @@ import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.SnapshotTablesRowCountOrder;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.RelationalTableFilters;
@@ -112,6 +113,35 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         this.databaseSchema = schema;
         this.lastEventProcessor = lastEventProcessor;
         this.preSnapshotAction = preSnapshotAction;
+    }
+
+    @Override
+    public SnapshotResult<O> execute(ChangeEventSourceContext context, P partition, O previousOffset, SnapshottingTask snapshottingTask)
+            throws InterruptedException {
+        // In binlog-metadata-based schema mode the connector is non-historized, so a snapshot mode that does
+        // not snapshot data (for example 'no_data' or 'schema_only') skips the snapshot entirely, including the
+        // step that records the current binlog position. Without a start offset a fresh connector would stream
+        // from the earliest available binlog. Seed the current binlog position/GTID here so that streaming
+        // begins from the current point, matching the behavior of a historized 'no_data' snapshot. This is only
+        // done for a fresh connector (no previous offset); on restart the persisted offset is used unchanged.
+        if (connectorConfig.isBinlogMetadataBasedSchema() && previousOffset == null && snapshottingTask.shouldSkipSnapshot()) {
+            final O offsetContext = getInitialOffsetContext(connectorConfig);
+            try {
+                setOffsetContextBinlogPositionAndGtidDetailsForSnapshot(offsetContext, connection, snapshotterService);
+            }
+            catch (InterruptedException e) {
+                throw e;
+            }
+            catch (Exception e) {
+                throw new DebeziumException("Failed to determine the current binlog position for the "
+                        + "binlog-metadata-based schema mode while skipping the snapshot", e);
+            }
+            LOGGER.info("Binlog-metadata-based schema mode: snapshot skipped for a fresh connector; seeded the "
+                    + "current binlog position so that streaming starts from the current point instead of the earliest binlog");
+            notificationService.initialSnapshotNotificationService().notifySkipped(partition, offsetContext);
+            return SnapshotResult.skipped(offsetContext);
+        }
+        return super.execute(context, partition, previousOffset, snapshottingTask);
     }
 
     @Override
@@ -366,6 +396,19 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         finally {
             if (executorService != null) {
                 executorService.shutdownNow();
+            }
+        }
+
+        if (connectorConfig.isBinlogMetadataBasedSchema()) {
+            // In binlog-metadata-based schema mode the connector is non-historized, so snapshotSchema() is
+            // false and the "persist schema history" step (which normally copies the captured table
+            // definitions into the snapshot context) is skipped. Make those definitions available to the
+            // data snapshot here, mirroring how non-historized connectors expose schema during the snapshot.
+            for (TableId tableId : databaseSchema.tableIds()) {
+                final Table table = databaseSchema.tableFor(tableId);
+                if (table != null) {
+                    snapshotContext.tables.overwriteTable(table);
+                }
             }
         }
     }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSourceTask.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSourceTask.java
@@ -58,8 +58,9 @@ public abstract class BinlogSourceTask<P extends Partition, O extends OffsetCont
      *
      * @param snapshotter the snapshotter, should ont be null
      * @param connection the database connection, should not be null
+     * @param connectorConfig the connector configuration, should not be null
      */
-    protected void validateBinlogConfiguration(Snapshotter snapshotter, BinlogConnectorConnection connection) {
+    protected void validateBinlogConfiguration(Snapshotter snapshotter, BinlogConnectorConnection connection, BinlogConnectorConfig connectorConfig) {
         if (snapshotter.shouldStream()) {
             // Check whether the row-level binlog is enabled ...
             if (!connection.isBinlogFormatRow()) {
@@ -71,6 +72,13 @@ public abstract class BinlogSourceTask<P extends Partition, O extends OffsetCont
                 throw new DebeziumException("The database server is not configured to use a FULL binlog_row_image, which is "
                         + "required for this connector to work properly. Change the database configuration to use a "
                         + "binlog_row_image=FULL and restart the connector.");
+            }
+            if (connectorConfig.isBinlogMetadataBasedSchema() && !connection.isBinlogRowMetadataFull()) {
+                throw new DebeziumException("The '" + BinlogConnectorConfig.BINLOG_METADATA_BASED_SCHEMA.name()
+                        + "' mode is enabled but the database server is not configured to use a FULL binlog_row_metadata, "
+                        + "which is required for this mode so that TABLE_MAP events carry the column names, types and keys "
+                        + "needed to reconstruct the schema. Change the database configuration to use "
+                        + "binlog_row_metadata=FULL and restart the connector, or disable the mode.");
             }
         }
     }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -969,6 +969,14 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         String databaseName = metadata.getDatabase();
         String tableName = metadata.getTable();
         TableId tableId = new TableId(databaseName, null, tableName);
+        if (connectorConfig.isBinlogMetadataBasedSchema()) {
+            // Opt-in mode: reconstruct the table schema directly from the FULL metadata carried by this
+            // TABLE_MAP event instead of relying on a persisted schema history topic. Because a TABLE_MAP
+            // event precedes the row events for its table within every transaction (and is re-read from the
+            // transaction BEGIN when a restart resumes mid-transaction), the schema is always refreshed
+            // before the resumed row events are decoded.
+            schema.registerTableFromBinlogMetadata(metadata);
+        }
         if (schema.assignTableNumber(tableNumber, tableId)) {
             LOGGER.debug("Received update table metadata event: {}", event);
         }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -987,6 +987,14 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         String databaseName = metadata.getDatabase();
         String tableName = metadata.getTable();
         TableId tableId = new TableId(databaseName, null, tableName);
+        if (connectorConfig.isBinlogMetadataBasedSchema()) {
+            // Opt-in mode: reconstruct the table schema directly from the FULL metadata carried by this
+            // TABLE_MAP event instead of relying on a persisted schema history topic. Because a TABLE_MAP
+            // event precedes the row events for its table within every transaction (and is re-read from the
+            // transaction BEGIN when a restart resumes mid-transaction), the schema is always refreshed
+            // before the resumed row events are decoded.
+            schema.registerTableFromBinlogMetadata(metadata);
+        }
         if (schema.assignTableNumber(tableNumber, tableId)) {
             LOGGER.debug("Received update table metadata event: {}", event);
         }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogMetadataSchemaHistory.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogMetadataSchemaHistory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.history;
+
+import java.util.function.Consumer;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.relational.history.AbstractSchemaHistory;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.SchemaHistory;
+
+/**
+ * A no-op {@link SchemaHistory} used by the binlog-metadata-based schema mode (debezium/dbz#978). In
+ * this mode the streaming table schema is reconstructed from the FULL metadata carried by binlog
+ * {@code TABLE_MAP} events, so no persistent schema history storage is needed: records are discarded and
+ * recovery is a no-op, while the snapshot phase runs exactly as with a persistent history. The storage
+ * always reports itself as present so that connector startup never attempts to create or recover it.
+ */
+@ThreadSafe
+public final class BinlogMetadataSchemaHistory extends AbstractSchemaHistory {
+
+    @Override
+    protected void storeRecord(HistoryRecord record) {
+        // The schema is rebuilt from the binlog TABLE_MAP metadata; nothing needs to be persisted.
+    }
+
+    @Override
+    protected void recoverRecords(Consumer<HistoryRecord> records) {
+        // Nothing was persisted, so there is nothing to recover; the schema is rebuilt from the binlog.
+    }
+
+    @Override
+    public boolean storageExists() {
+        return true;
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "binlog-metadata-based (no persistent schema history)";
+    }
+}

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
@@ -319,6 +319,32 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
     }
 
     /**
+     * Determines whether the binlog carries FULL table metadata, i.e. {@code binlog_row_metadata='FULL'}.
+     * When enabled, every {@code TABLE_MAP} event includes column names, types, charsets, enum/set values
+     * and the primary key, which is required by the binlog-metadata-based schema mode.
+     *
+     * @return {@code true} if {@code binlog_row_metadata} is set to {@code FULL}, {@code false} otherwise
+     *         (including on servers that do not expose the variable, e.g. MySQL 5.7, where it defaults to MINIMAL)
+     */
+    public boolean isBinlogRowMetadataFull() {
+        try {
+            final String rowMetadata = queryAndMap("SHOW GLOBAL VARIABLES LIKE 'binlog_row_metadata'", rs -> {
+                if (rs.next()) {
+                    return rs.getString(2);
+                }
+                // The variable was introduced in MySQL 8.0 with a default of 'MINIMAL'.
+                // On servers that do not expose it (e.g. MySQL 5.7) FULL metadata is not available.
+                return "MINIMAL";
+            });
+            LOGGER.debug("binlog_row_metadata={}", rowMetadata);
+            return "FULL".equalsIgnoreCase(rowMetadata);
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to the database and looking at BINLOG_ROW_METADATA mode: ", e);
+        }
+    }
+
+    /**
      * Determine whether the database server has the row-level binlog enabled.
      *
      * @return {@code true} if the server's {@code binlog_format} is set to {@code ROW}, {@code false} otherwise

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -79,6 +79,7 @@ public class BinlogMetadataTableBuilder {
     private static final int TYPE_TIMESTAMP_V2 = 17;
     private static final int TYPE_DATETIME_V2 = 18;
     private static final int TYPE_TIME_V2 = 19;
+    private static final int TYPE_VECTOR = 242;
     private static final int TYPE_JSON = 245;
     private static final int TYPE_NEWDECIMAL = 246;
     private static final int TYPE_ENUM = 247;
@@ -165,6 +166,7 @@ public class BinlogMetadataTableBuilder {
                 case TYPE_TIMESTAMP, TYPE_TIMESTAMP_V2 -> column.type("TIMESTAMP").jdbcType(Types.TIMESTAMP_WITH_TIMEZONE).length(columnMeta[i]);
                 case TYPE_JSON -> column.type("JSON").jdbcType(Types.OTHER);
                 case TYPE_GEOMETRY -> column.type("GEOMETRY").jdbcType(Types.OTHER);
+                case TYPE_VECTOR -> column.type("VECTOR").jdbcType(Types.OTHER);
                 case TYPE_VARCHAR, TYPE_VAR_STRING -> charType(column, binary ? "VARBINARY" : "VARCHAR",
                         binary ? Types.VARBINARY : Types.VARCHAR, byteToCharLength(columnMeta[i], collation), binary ? null : collation);
                 case TYPE_TINY_BLOB, TYPE_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB -> blobType(column, code, columnMeta[i], binary, collation);

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -36,6 +36,16 @@ import io.debezium.relational.TableId;
  * <p>
  * Attributes that the binlog metadata does not carry (column defaults, generated-column flag,
  * comments) are intentionally not populated; those are documented limitations of this mode.
+ * <p>
+ * The authoritative list of what the server writes is {@code Table_map_log_event::init_metadata_fields()}
+ * in MySQL {@code sql/log_event.cc}: {@code MINIMAL} metadata consists of SIGNEDNESS,
+ * DEFAULT_CHARSET/COLUMN_CHARSET (string columns) and GEOMETRY_TYPE, and {@code FULL} adds COLUMN_NAME,
+ * ENUM_AND_SET_DEFAULT_CHARSET/ENUM_AND_SET_COLUMN_CHARSET, SET_STR_VALUE, ENUM_STR_VALUE, either
+ * SIMPLE_PRIMARY_KEY or PRIMARY_KEY_WITH_PREFIX, COLUMN_VISIBILITY and, on MySQL 9, VECTOR_DIMENSIONALITY.
+ * No field carries the integer display width, column DEFAULT values, the FLOAT(M,D) precision, or column
+ * comments, which is the source-level basis for the documented differences from the schema history mode.
+ * COLUMN_VISIBILITY is intentionally not consumed: invisible columns are present in every row event and
+ * the DDL-based path keeps them as ordinary columns as well.
  */
 public class BinlogMetadataTableBuilder {
 
@@ -119,10 +129,11 @@ public class BinlogMetadataTableBuilder {
         final List<String[]> enumValues = meta.getEnumStrValues();
         final List<String[]> setValues = meta.getSetStrValues();
         final List<Integer> geometryTypes = meta.getGeometryTypes();
+        final List<Integer> vectorDimensions = meta.getVectorDimensionality();
         final List<Integer> simplePk = meta.getSimplePrimaryKeys();
 
         final int columnCount = types.length;
-        final int[] collationPerColumn = resolveColumnCollations(types, meta);
+        final int[] collationPerColumn = resolveColumnCollations(types, columnMeta, meta);
 
         final TableEditor table = Table.editor().tableId(tableId);
 
@@ -130,6 +141,7 @@ public class BinlogMetadataTableBuilder {
         int enumIndex = 0;
         int setIndex = 0;
         int geometryIndex = 0;
+        int vectorIndex = 0;
         for (int i = 0; i < columnCount; i++) {
             final int code = types[i] & 0xFF;
             final ColumnEditor column = Column.editor()
@@ -168,7 +180,7 @@ public class BinlogMetadataTableBuilder {
                 case TYPE_TIMESTAMP, TYPE_TIMESTAMP_V2 -> column.type("TIMESTAMP").jdbcType(Types.TIMESTAMP_WITH_TIMEZONE).length(columnMeta[i]);
                 case TYPE_JSON -> column.type("JSON").jdbcType(Types.OTHER);
                 case TYPE_GEOMETRY -> column.type(geometryTypeName(geometryTypes, geometryIndex++)).jdbcType(Types.OTHER);
-                case TYPE_VECTOR -> column.type("VECTOR").jdbcType(Types.OTHER);
+                case TYPE_VECTOR -> vectorType(column, vectorDimensions, vectorIndex++);
                 case TYPE_VARCHAR, TYPE_VAR_STRING -> charType(column, binary ? "VARBINARY" : "VARCHAR",
                         binary ? Types.VARBINARY : Types.VARCHAR, byteToCharLength(columnMeta[i], collation), binary ? null : collation);
                 case TYPE_TINY_BLOB, TYPE_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB -> blobType(column, code, columnMeta[i], binary, collation);
@@ -205,6 +217,21 @@ public class BinlogMetadataTableBuilder {
                 pkNames.add(names.get(idx));
             }
             table.setPrimaryKeyNames(pkNames);
+        }
+        else {
+            // When any key part uses a prefix, e.g. PRIMARY KEY (`code`(5)), the server writes
+            // PRIMARY_KEY_WITH_PREFIX instead of SIMPLE_PRIMARY_KEY (either/or; see
+            // Table_map_log_event::init_primary_key_field() in MySQL sql/log_event.cc). The map keeps
+            // the key part order and the prefix length is irrelevant here: the relational model tracks
+            // key column names only, exactly like the DDL parser does for a prefixed key.
+            final Map<Integer, Integer> prefixPk = meta.getPrimaryKeysWithPrefix();
+            if (prefixPk != null && !prefixPk.isEmpty()) {
+                final List<String> pkNames = new ArrayList<>(prefixPk.size());
+                for (Integer idx : prefixPk.keySet()) {
+                    pkNames.add(names.get(idx));
+                }
+                table.setPrimaryKeyNames(pkNames);
+            }
         }
 
         return table.create();
@@ -285,6 +312,17 @@ public class BinlogMetadataTableBuilder {
     }
 
     /**
+     * The {@code VECTOR_DIMENSIONALITY} metadata field (MySQL 9) carries the dimensionality of every
+     * vector column, which the DDL parser stores as the column length.
+     */
+    private static void vectorType(ColumnEditor column, List<Integer> vectorDimensions, int vectorIndex) {
+        column.type("VECTOR").jdbcType(Types.OTHER);
+        if (vectorDimensions != null && vectorIndex < vectorDimensions.size()) {
+            column.length(vectorDimensions.get(vectorIndex));
+        }
+    }
+
+    /**
      * Resolve the concrete spatial type name from the {@code GEOMETRY_TYPE} metadata field, which carries
      * the real type of every geometry column ({@code Field::geometry_type} codes).
      */
@@ -340,45 +378,70 @@ public class BinlogMetadataTableBuilder {
         };
     }
 
+    /**
+     * Whether the column takes part in the DEFAULT_CHARSET/COLUMN_CHARSET numbering. Mirrors
+     * {@code is_character_type()} in MySQL {@code sql/log_event.cc}: STRING, VAR_STRING, VARCHAR and the
+     * BLOB family only. ENUM and SET columns are excluded even though they are transported as STRING,
+     * because the server tests the field's real type; they are numbered separately and take their
+     * charset from the ENUM_AND_SET_* fields instead.
+     */
     private static boolean isCharacterType(int code) {
         return switch (code) {
-            case TYPE_VARCHAR, TYPE_VAR_STRING, TYPE_STRING, TYPE_ENUM, TYPE_SET,
+            case TYPE_VARCHAR, TYPE_VAR_STRING, TYPE_STRING,
                     TYPE_TINY_BLOB, TYPE_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB ->
                 true;
             default -> false;
         };
     }
 
+    private static boolean isEnumOrSetColumn(int code, int meta) {
+        if (code == TYPE_ENUM || code == TYPE_SET) {
+            return true;
+        }
+        if (code == TYPE_STRING) {
+            final int realType = unpackStringRealType(meta);
+            return realType == TYPE_ENUM || realType == TYPE_SET;
+        }
+        return false;
+    }
+
     /**
-     * Resolve the collation id per column. MySQL encodes charset either as an explicit per-character-column
-     * list ({@code COLUMN_CHARSET}) or as a default plus sparse overrides ({@code DEFAULT_CHARSET}), both
-     * indexed over character-type columns only.
+     * Resolve the collation id per column. MySQL encodes charset either as an explicit per-column list
+     * ({@code COLUMN_CHARSET}) or as a default plus sparse overrides ({@code DEFAULT_CHARSET}). Both are
+     * indexed over character-type columns only, and ENUM/SET columns have their own pair of fields
+     * ({@code ENUM_AND_SET_COLUMN_CHARSET}/{@code ENUM_AND_SET_DEFAULT_CHARSET}) with an independent
+     * numbering (see {@code Table_map_log_event::init_charset_field()} in MySQL {@code sql/log_event.cc}).
      */
-    private int[] resolveColumnCollations(byte[] types, TableMapEventMetadata meta) {
+    private int[] resolveColumnCollations(byte[] types, int[] columnMeta, TableMapEventMetadata meta) {
         final int[] result = new int[types.length];
-        final List<Integer> explicit = meta.getColumnCharsets();
-        final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
         int charIndex = 0;
+        int enumSetIndex = 0;
         for (int i = 0; i < types.length; i++) {
-            if (!isCharacterType(types[i] & 0xFF)) {
-                result[i] = -1;
-                continue;
+            final int code = types[i] & 0xFF;
+            if (isEnumOrSetColumn(code, columnMeta[i])) {
+                result[i] = resolveCollation(meta.getEnumAndSetColumnCharsets(), meta.getEnumAndSetDefaultCharset(), enumSetIndex++);
             }
-            if (explicit != null && charIndex < explicit.size()) {
-                result[i] = explicit.get(charIndex);
-            }
-            else if (defaultCharset != null) {
-                final Map<Integer, Integer> overrides = defaultCharset.getCharsetCollations();
-                result[i] = overrides != null && overrides.containsKey(charIndex)
-                        ? overrides.get(charIndex)
-                        : defaultCharset.getDefaultCharsetCollation();
+            else if (isCharacterType(code)) {
+                result[i] = resolveCollation(meta.getColumnCharsets(), meta.getDefaultCharset(), charIndex++);
             }
             else {
                 result[i] = -1;
             }
-            charIndex++;
         }
         return result;
+    }
+
+    private static int resolveCollation(List<Integer> explicit, TableMapEventMetadata.DefaultCharset defaultCharset, int index) {
+        if (explicit != null && index < explicit.size()) {
+            return explicit.get(index);
+        }
+        if (defaultCharset != null) {
+            final Map<Integer, Integer> overrides = defaultCharset.getCharsetCollations();
+            return overrides != null && overrides.containsKey(index)
+                    ? overrides.get(index)
+                    : defaultCharset.getDefaultCharsetCollation();
+        }
+        return -1;
     }
 
     /** Convert a byte length to a character length using the collation's maximum bytes-per-character. */

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -338,7 +338,7 @@ public class BinlogMetadataTableBuilder {
     }
 
     // Minimal collation -> max-bytes-per-char / charset-name catalog for the common collations.
-    // TODO(dbz#978): source this from the connector's full charset registry rather than a static subset.
+    // TODO (debezium/dbz#978): source this from the connector's full charset registry rather than a static subset.
     private static int maxBytesPerChar(int collation) {
         return switch (collation) {
             case 45, 46, 224, 255 -> 4; // utf8mb4_*

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -272,6 +272,9 @@ public class BinlogMetadataTableBuilder {
             expr.append(')');
             column.type(typeName, expr.toString());
             column.enumValues(List.of(values));
+            // Mirror the DDL parser convention (see ColumnDefinitionParserListener): ENUM columns get
+            // length 1 and SET columns "number of options + number of commas".
+            column.length("ENUM".equals(typeName) ? 1 : Math.max(0, values.length * 2 - 1));
         }
         else {
             column.type(typeName);

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.metadata;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+
+/**
+ * Builds a Debezium {@link Table} from the {@code TABLE_MAP} event metadata that MySQL writes into
+ * the binlog when {@code binlog_row_metadata=FULL}. This is the basis for the schema-history-free
+ * streaming mode (debezium/dbz#978): the streaming schema is reconstructed from the binlog itself,
+ * analogous to how the PostgreSQL connector uses pgoutput relation messages.
+ * <p>
+ * The mapping mirrors what the DDL-based path ({@code MySqlAntlrDdlParser}) produces so that the
+ * downstream value converters behave identically: JDBC types follow the same {@code DataTypeEntry}
+ * registrations (e.g. TINYINT/SMALLINT &rarr; {@link Types#SMALLINT}, DATETIME &rarr;
+ * {@link Types#TIMESTAMP}, TIMESTAMP &rarr; {@link Types#TIMESTAMP_WITH_TIMEZONE}, ENUM/SET &rarr;
+ * {@link Types#CHAR}, JSON/GEOMETRY &rarr; {@link Types#OTHER}).
+ * <p>
+ * Attributes that the binlog metadata does not carry (column defaults, generated-column flag,
+ * comments) are intentionally not populated; those are documented limitations of this mode.
+ */
+public class BinlogMetadataTableBuilder {
+
+    // MySQL binlog column type codes (com.github.shyiko...deserialization.ColumnType getCode()).
+    private static final int TYPE_DECIMAL = 0;
+    private static final int TYPE_TINY = 1;
+    private static final int TYPE_SHORT = 2;
+    private static final int TYPE_LONG = 3;
+    private static final int TYPE_FLOAT = 4;
+    private static final int TYPE_DOUBLE = 5;
+    private static final int TYPE_TIMESTAMP = 7;
+    private static final int TYPE_LONGLONG = 8;
+    private static final int TYPE_INT24 = 9;
+    private static final int TYPE_DATE = 10;
+    private static final int TYPE_TIME = 11;
+    private static final int TYPE_DATETIME = 12;
+    private static final int TYPE_YEAR = 13;
+    private static final int TYPE_NEWDATE = 14;
+    private static final int TYPE_VARCHAR = 15;
+    private static final int TYPE_BIT = 16;
+    private static final int TYPE_TIMESTAMP_V2 = 17;
+    private static final int TYPE_DATETIME_V2 = 18;
+    private static final int TYPE_TIME_V2 = 19;
+    private static final int TYPE_JSON = 245;
+    private static final int TYPE_NEWDECIMAL = 246;
+    private static final int TYPE_ENUM = 247;
+    private static final int TYPE_SET = 248;
+    private static final int TYPE_TINY_BLOB = 249;
+    private static final int TYPE_MEDIUM_BLOB = 250;
+    private static final int TYPE_LONG_BLOB = 251;
+    private static final int TYPE_BLOB = 252;
+    private static final int TYPE_VAR_STRING = 253;
+    private static final int TYPE_STRING = 254;
+    private static final int TYPE_GEOMETRY = 255;
+
+    private static final int BINARY_COLLATION_ID = 63;
+
+    /**
+     * Build a {@link Table} for the given identifier from a {@code TABLE_MAP} event that carries FULL
+     * row metadata.
+     *
+     * @param tableId the fully-qualified table identifier; never null
+     * @param data the table-map event data; its {@link TableMapEventData#getEventMetadata()} must be
+     *            present (i.e. {@code binlog_row_metadata=FULL})
+     * @return the reconstructed table
+     * @throws IllegalStateException if the FULL metadata (column names) is not present
+     */
+    public Table build(TableId tableId, TableMapEventData data) {
+        final TableMapEventMetadata meta = data.getEventMetadata();
+        if (meta == null || meta.getColumnNames() == null || meta.getColumnNames().isEmpty()) {
+            throw new IllegalStateException(
+                    "TABLE_MAP for '" + tableId + "' has no column metadata; binlog_row_metadata=FULL is required for the binlog-metadata schema mode");
+        }
+
+        final byte[] types = data.getColumnTypes();
+        final int[] columnMeta = data.getColumnMetadata();
+        final BitSet nullability = data.getColumnNullability();
+        final List<String> names = meta.getColumnNames();
+        final BitSet signedness = meta.getSignedness();
+        final List<String[]> enumValues = meta.getEnumStrValues();
+        final List<String[]> setValues = meta.getSetStrValues();
+        final List<Integer> simplePk = meta.getSimplePrimaryKeys();
+
+        final int columnCount = types.length;
+        final int[] collationPerColumn = resolveColumnCollations(types, meta);
+
+        final TableEditor table = Table.editor().tableId(tableId);
+
+        int numericIndex = 0;
+        int enumIndex = 0;
+        int setIndex = 0;
+        for (int i = 0; i < columnCount; i++) {
+            final int code = types[i] & 0xFF;
+            final ColumnEditor column = Column.editor()
+                    .name(names.get(i))
+                    .position(i + 1)
+                    .optional(nullability != null && nullability.get(i));
+
+            final boolean isNumeric = isNumericType(code);
+            final boolean unsigned = isNumeric && signedness != null && signedness.get(numericIndex);
+            if (isNumeric) {
+                numericIndex++;
+            }
+
+            final int collation = collationPerColumn[i];
+            final boolean binary = collation == BINARY_COLLATION_ID;
+
+            switch (code) {
+                case TYPE_TINY -> intType(column, "TINYINT", Types.SMALLINT, unsigned);
+                case TYPE_SHORT -> intType(column, "SMALLINT", Types.SMALLINT, unsigned);
+                case TYPE_INT24 -> intType(column, "MEDIUMINT", Types.INTEGER, unsigned);
+                case TYPE_LONG -> intType(column, "INT", Types.INTEGER, unsigned);
+                case TYPE_LONGLONG -> intType(column, "BIGINT", Types.BIGINT, unsigned);
+                case TYPE_FLOAT -> intType(column, "FLOAT", Types.FLOAT, unsigned);
+                case TYPE_DOUBLE -> intType(column, "DOUBLE", Types.DOUBLE, unsigned);
+                case TYPE_YEAR -> column.type("YEAR").jdbcType(Types.INTEGER);
+                case TYPE_DECIMAL, TYPE_NEWDECIMAL -> {
+                    column.type(unsigned ? "DECIMAL UNSIGNED" : "DECIMAL").jdbcType(Types.DECIMAL);
+                    column.length(columnMeta[i] & 0xFF);
+                    column.scale((columnMeta[i] >> 8) & 0xFF);
+                }
+                case TYPE_BIT -> column.type("BIT").jdbcType(Types.BIT).length(columnMeta[i]);
+                case TYPE_DATE, TYPE_NEWDATE -> column.type("DATE").jdbcType(Types.DATE);
+                case TYPE_TIME, TYPE_TIME_V2 -> column.type("TIME").jdbcType(Types.TIME).length(columnMeta[i]);
+                case TYPE_DATETIME, TYPE_DATETIME_V2 -> column.type("DATETIME").jdbcType(Types.TIMESTAMP).length(columnMeta[i]);
+                case TYPE_TIMESTAMP, TYPE_TIMESTAMP_V2 -> column.type("TIMESTAMP").jdbcType(Types.TIMESTAMP_WITH_TIMEZONE).length(columnMeta[i]);
+                case TYPE_JSON -> column.type("JSON").jdbcType(Types.OTHER);
+                case TYPE_GEOMETRY -> column.type("GEOMETRY").jdbcType(Types.OTHER);
+                case TYPE_VARCHAR, TYPE_VAR_STRING -> charType(column, binary ? "VARBINARY" : "VARCHAR",
+                        binary ? Types.VARBINARY : Types.VARCHAR, byteToCharLength(columnMeta[i], collation), binary ? null : collation);
+                case TYPE_TINY_BLOB, TYPE_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB -> blobType(column, code, columnMeta[i], binary, collation);
+                case TYPE_STRING -> stringType(column, columnMeta[i], binary, collation,
+                        enumValues, setValues, enumIndex, setIndex);
+                case TYPE_ENUM -> enumOrSet(column, "ENUM", enumValues, enumIndex, collation);
+                case TYPE_SET -> enumOrSet(column, "SET", setValues, setIndex, collation);
+                default -> column.type("UNKNOWN").jdbcType(Types.OTHER);
+            }
+
+            // STRING code may resolve to ENUM/SET internally; advance those indices there.
+            if (code == TYPE_STRING) {
+                final int realType = unpackStringRealType(columnMeta[i]);
+                if (realType == TYPE_ENUM) {
+                    enumIndex++;
+                }
+                else if (realType == TYPE_SET) {
+                    setIndex++;
+                }
+            }
+            else if (code == TYPE_ENUM) {
+                enumIndex++;
+            }
+            else if (code == TYPE_SET) {
+                setIndex++;
+            }
+
+            table.addColumn(column.create());
+        }
+
+        if (simplePk != null && !simplePk.isEmpty()) {
+            final List<String> pkNames = new ArrayList<>(simplePk.size());
+            for (Integer idx : simplePk) {
+                pkNames.add(names.get(idx));
+            }
+            table.setPrimaryKeyNames(pkNames);
+        }
+
+        return table.create();
+    }
+
+    private void intType(ColumnEditor column, String baseName, int jdbcType, boolean unsigned) {
+        column.type(unsigned ? baseName + " UNSIGNED" : baseName).jdbcType(jdbcType);
+    }
+
+    private void charType(ColumnEditor column, String typeName, int jdbcType, int length, Integer collation) {
+        column.type(typeName).jdbcType(jdbcType).length(length);
+        if (collation != null) {
+            column.charsetName(collationName(collation));
+        }
+    }
+
+    private void blobType(ColumnEditor column, int code, int meta, boolean binary, int collation) {
+        // BLOB family: meta = number of length bytes (1=TINY, 2=normal, 3=MEDIUM, 4=LONG).
+        final String prefix = switch (code) {
+            case TYPE_TINY_BLOB -> "TINY";
+            case TYPE_MEDIUM_BLOB -> "MEDIUM";
+            case TYPE_LONG_BLOB -> "LONG";
+            default -> "";
+        };
+        if (binary) {
+            column.type(prefix + "BLOB").jdbcType(Types.BLOB);
+        }
+        else {
+            column.type(prefix + "TEXT").jdbcType(Types.VARCHAR).charsetName(collationName(collation));
+        }
+    }
+
+    private void stringType(ColumnEditor column, int meta, boolean binary, int collation,
+                            List<String[]> enumValues, List<String[]> setValues, int enumIdx, int setIdx) {
+        final int realType = unpackStringRealType(meta);
+        if (realType == TYPE_ENUM) {
+            enumOrSet(column, "ENUM", enumValues, enumIdx, collation);
+            return;
+        }
+        if (realType == TYPE_SET) {
+            enumOrSet(column, "SET", setValues, setIdx, collation);
+            return;
+        }
+        // Plain CHAR / BINARY.
+        final int byteLength = unpackStringLength(meta);
+        if (binary) {
+            column.type("BINARY").jdbcType(Types.BINARY).length(byteLength);
+        }
+        else {
+            column.type("CHAR").jdbcType(Types.CHAR).length(byteToCharLength(byteLength, collation)).charsetName(collationName(collation));
+        }
+    }
+
+    private void enumOrSet(ColumnEditor column, String typeName, List<String[]> valueLists, int index, int collation) {
+        column.jdbcType(Types.CHAR);
+        if (valueLists != null && index < valueLists.size()) {
+            final String[] values = valueLists.get(index);
+            final StringBuilder expr = new StringBuilder(typeName).append('(');
+            for (int i = 0; i < values.length; i++) {
+                if (i > 0) {
+                    expr.append(',');
+                }
+                expr.append('\'').append(values[i]).append('\'');
+            }
+            expr.append(')');
+            column.type(typeName, expr.toString());
+            column.enumValues(List.of(values));
+        }
+        else {
+            column.type(typeName);
+        }
+        if (collation != BINARY_COLLATION_ID) {
+            column.charsetName(collationName(collation));
+        }
+    }
+
+    /**
+     * Unpack the real type packed into a {@code MYSQL_TYPE_STRING} metadata value (CHAR longer than
+     * 255 bytes, ENUM, or SET are all transported as STRING). Canonical MySQL algorithm.
+     */
+    private static int unpackStringRealType(int meta) {
+        if (meta < 256) {
+            return TYPE_STRING;
+        }
+        final int byte0 = meta >> 8;
+        if ((byte0 & 0x30) != 0x30) {
+            return byte0 | 0x30;
+        }
+        return byte0;
+    }
+
+    private static int unpackStringLength(int meta) {
+        if (meta < 256) {
+            return meta;
+        }
+        final int byte0 = meta >> 8;
+        final int byte1 = meta & 0xFF;
+        if ((byte0 & 0x30) != 0x30) {
+            return byte1 | (((byte0 & 0x30) ^ 0x30) << 4);
+        }
+        return byte1;
+    }
+
+    private static boolean isNumericType(int code) {
+        return switch (code) {
+            case TYPE_TINY, TYPE_SHORT, TYPE_INT24, TYPE_LONG, TYPE_LONGLONG,
+                    TYPE_FLOAT, TYPE_DOUBLE, TYPE_YEAR, TYPE_DECIMAL, TYPE_NEWDECIMAL ->
+                true;
+            default -> false;
+        };
+    }
+
+    private static boolean isCharacterType(int code) {
+        return switch (code) {
+            case TYPE_VARCHAR, TYPE_VAR_STRING, TYPE_STRING, TYPE_ENUM, TYPE_SET,
+                    TYPE_TINY_BLOB, TYPE_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB ->
+                true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Resolve the collation id per column. MySQL encodes charset either as an explicit per-character-column
+     * list ({@code COLUMN_CHARSET}) or as a default plus sparse overrides ({@code DEFAULT_CHARSET}), both
+     * indexed over character-type columns only.
+     */
+    private int[] resolveColumnCollations(byte[] types, TableMapEventMetadata meta) {
+        final int[] result = new int[types.length];
+        final List<Integer> explicit = meta.getColumnCharsets();
+        final TableMapEventMetadata.DefaultCharset defaultCharset = meta.getDefaultCharset();
+        int charIndex = 0;
+        for (int i = 0; i < types.length; i++) {
+            if (!isCharacterType(types[i] & 0xFF)) {
+                result[i] = -1;
+                continue;
+            }
+            if (explicit != null && charIndex < explicit.size()) {
+                result[i] = explicit.get(charIndex);
+            }
+            else if (defaultCharset != null) {
+                final Map<Integer, Integer> overrides = defaultCharset.getCharsetCollations();
+                result[i] = overrides != null && overrides.containsKey(charIndex)
+                        ? overrides.get(charIndex)
+                        : defaultCharset.getDefaultCharsetCollation();
+            }
+            else {
+                result[i] = -1;
+            }
+            charIndex++;
+        }
+        return result;
+    }
+
+    /** Convert a byte length to a character length using the collation's maximum bytes-per-character. */
+    private static int byteToCharLength(int byteLength, int collation) {
+        final int maxBytes = maxBytesPerChar(collation);
+        return maxBytes <= 1 ? byteLength : byteLength / maxBytes;
+    }
+
+    // Minimal collation -> max-bytes-per-char / charset-name catalog for the common collations.
+    // TODO(dbz#978): source this from the connector's full charset registry rather than a static subset.
+    private static int maxBytesPerChar(int collation) {
+        return switch (collation) {
+            case 45, 46, 224, 255 -> 4; // utf8mb4_*
+            case 33, 83, 192 -> 3; // utf8mb3_*
+            default -> 1; // latin1/ascii/binary/etc.
+        };
+    }
+
+    private static String collationName(int collation) {
+        return switch (collation) {
+            case 45, 46, 224, 255 -> "utf8mb4";
+            case 33, 83, 192 -> "utf8mb3";
+            case 63 -> "binary";
+            case 8 -> "latin1";
+            default -> null;
+        };
+    }
+}

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -10,10 +10,12 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 
+import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.Table;
@@ -36,6 +38,26 @@ import io.debezium.relational.TableId;
  * comments) are intentionally not populated; those are documented limitations of this mode.
  */
 public class BinlogMetadataTableBuilder {
+
+    private final Supplier<BinlogCharsetRegistry> charsetRegistrySupplier;
+    private BinlogCharsetRegistry charsetRegistry;
+    private boolean charsetRegistryResolved;
+
+    /**
+     * Creates a builder without a charset registry; collation ids are resolved from a minimal static
+     * catalog only. Intended for tests.
+     */
+    public BinlogMetadataTableBuilder() {
+        this(null);
+    }
+
+    /**
+     * @param charsetRegistrySupplier lazily supplies the connector's charset registry used to resolve
+     *            collation ids to character set names; may be null
+     */
+    public BinlogMetadataTableBuilder(Supplier<BinlogCharsetRegistry> charsetRegistrySupplier) {
+        this.charsetRegistrySupplier = charsetRegistrySupplier;
+    }
 
     // MySQL binlog column type codes (com.github.shyiko...deserialization.ColumnType getCode()).
     private static final int TYPE_DECIMAL = 0;
@@ -135,7 +157,8 @@ public class BinlogMetadataTableBuilder {
                     column.length(columnMeta[i] & 0xFF);
                     column.scale((columnMeta[i] >> 8) & 0xFF);
                 }
-                case TYPE_BIT -> column.type("BIT").jdbcType(Types.BIT).length(columnMeta[i]);
+                // BIT metadata is encoded as (bytes << 8) | remaining_bits, so BIT(8) arrives as 0x0100.
+                case TYPE_BIT -> column.type("BIT").jdbcType(Types.BIT).length(((columnMeta[i] >> 8) * 8) + (columnMeta[i] & 0xFF));
                 case TYPE_DATE, TYPE_NEWDATE -> column.type("DATE").jdbcType(Types.DATE);
                 case TYPE_TIME, TYPE_TIME_V2 -> column.type("TIME").jdbcType(Types.TIME).length(columnMeta[i]);
                 case TYPE_DATETIME, TYPE_DATETIME_V2 -> column.type("DATETIME").jdbcType(Types.TIMESTAMP).length(columnMeta[i]);
@@ -332,22 +355,40 @@ public class BinlogMetadataTableBuilder {
     }
 
     /** Convert a byte length to a character length using the collation's maximum bytes-per-character. */
-    private static int byteToCharLength(int byteLength, int collation) {
+    private int byteToCharLength(int byteLength, int collation) {
         final int maxBytes = maxBytesPerChar(collation);
         return maxBytes <= 1 ? byteLength : byteLength / maxBytes;
     }
 
-    // Minimal collation -> max-bytes-per-char / charset-name catalog for the common collations.
-    // TODO (debezium/dbz#978): source this from the connector's full charset registry rather than a static subset.
-    private static int maxBytesPerChar(int collation) {
-        return switch (collation) {
-            case 45, 46, 224, 255 -> 4; // utf8mb4_*
-            case 33, 83, 192 -> 3; // utf8mb3_*
-            default -> 1; // latin1/ascii/binary/etc.
+    /**
+     * Maximum bytes-per-character of the character set behind the given collation, used to convert the
+     * byte length carried by the binlog metadata into the character length of the column.
+     */
+    private int maxBytesPerChar(int collation) {
+        final String charsetName = collationName(collation);
+        if (charsetName == null) {
+            return 1;
+        }
+        return switch (charsetName) {
+            case "utf8mb4", "utf16", "utf16le", "utf32", "gb18030" -> 4;
+            case "utf8", "utf8mb3", "eucjpms", "ujis" -> 3;
+            case "ucs2", "gbk", "sjis", "big5", "euckr", "cp932", "gb2312" -> 2;
+            default -> 1;
         };
     }
 
-    private static String collationName(int collation) {
+    /**
+     * Resolve the character set name for a collation id, preferring the connector's charset registry and
+     * falling back to a minimal static catalog when no registry is available (for example in unit tests).
+     */
+    private String collationName(int collation) {
+        final BinlogCharsetRegistry registry = charsetRegistry();
+        if (registry != null) {
+            final String name = registry.getCharsetNameForCollationIndex(collation);
+            if (name != null) {
+                return name;
+            }
+        }
         return switch (collation) {
             case 45, 46, 224, 255 -> "utf8mb4";
             case 33, 83, 192 -> "utf8mb3";
@@ -355,5 +396,13 @@ public class BinlogMetadataTableBuilder {
             case 8 -> "latin1";
             default -> null;
         };
+    }
+
+    private BinlogCharsetRegistry charsetRegistry() {
+        if (!charsetRegistryResolved) {
+            charsetRegistryResolved = true;
+            charsetRegistry = charsetRegistrySupplier != null ? charsetRegistrySupplier.get() : null;
+        }
+        return charsetRegistry;
     }
 }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -118,6 +118,7 @@ public class BinlogMetadataTableBuilder {
         final BitSet signedness = meta.getSignedness();
         final List<String[]> enumValues = meta.getEnumStrValues();
         final List<String[]> setValues = meta.getSetStrValues();
+        final List<Integer> geometryTypes = meta.getGeometryTypes();
         final List<Integer> simplePk = meta.getSimplePrimaryKeys();
 
         final int columnCount = types.length;
@@ -128,6 +129,7 @@ public class BinlogMetadataTableBuilder {
         int numericIndex = 0;
         int enumIndex = 0;
         int setIndex = 0;
+        int geometryIndex = 0;
         for (int i = 0; i < columnCount; i++) {
             final int code = types[i] & 0xFF;
             final ColumnEditor column = Column.editor()
@@ -165,7 +167,7 @@ public class BinlogMetadataTableBuilder {
                 case TYPE_DATETIME, TYPE_DATETIME_V2 -> column.type("DATETIME").jdbcType(Types.TIMESTAMP).length(columnMeta[i]);
                 case TYPE_TIMESTAMP, TYPE_TIMESTAMP_V2 -> column.type("TIMESTAMP").jdbcType(Types.TIMESTAMP_WITH_TIMEZONE).length(columnMeta[i]);
                 case TYPE_JSON -> column.type("JSON").jdbcType(Types.OTHER);
-                case TYPE_GEOMETRY -> column.type("GEOMETRY").jdbcType(Types.OTHER);
+                case TYPE_GEOMETRY -> column.type(geometryTypeName(geometryTypes, geometryIndex++)).jdbcType(Types.OTHER);
                 case TYPE_VECTOR -> column.type("VECTOR").jdbcType(Types.OTHER);
                 case TYPE_VARCHAR, TYPE_VAR_STRING -> charType(column, binary ? "VARBINARY" : "VARCHAR",
                         binary ? Types.VARBINARY : Types.VARCHAR, byteToCharLength(columnMeta[i], collation), binary ? null : collation);
@@ -277,6 +279,26 @@ public class BinlogMetadataTableBuilder {
         if (collation != BINARY_COLLATION_ID) {
             column.charsetName(collationName(collation));
         }
+    }
+
+    /**
+     * Resolve the concrete spatial type name from the {@code GEOMETRY_TYPE} metadata field, which carries
+     * the real type of every geometry column ({@code Field::geometry_type} codes).
+     */
+    private static String geometryTypeName(List<Integer> geometryTypes, int geometryIndex) {
+        if (geometryTypes == null || geometryIndex >= geometryTypes.size()) {
+            return "GEOMETRY";
+        }
+        return switch (geometryTypes.get(geometryIndex)) {
+            case 1 -> "POINT";
+            case 2 -> "LINESTRING";
+            case 3 -> "POLYGON";
+            case 4 -> "MULTIPOINT";
+            case 5 -> "MULTILINESTRING";
+            case 6 -> "MULTIPOLYGON";
+            case 7 -> "GEOMETRYCOLLECTION";
+            default -> "GEOMETRY";
+        };
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -159,14 +159,15 @@ public class BinlogMetadataTableBuilder {
             final boolean binary = collation == BINARY_COLLATION_ID;
 
             switch (code) {
-                case TYPE_TINY -> intType(column, "TINYINT", Types.SMALLINT, unsigned);
-                case TYPE_SHORT -> intType(column, "SMALLINT", Types.SMALLINT, unsigned);
-                case TYPE_INT24 -> intType(column, "MEDIUMINT", Types.INTEGER, unsigned);
-                case TYPE_LONG -> intType(column, "INT", Types.INTEGER, unsigned);
-                case TYPE_LONGLONG -> intType(column, "BIGINT", Types.BIGINT, unsigned);
-                case TYPE_FLOAT -> intType(column, "FLOAT", Types.FLOAT, unsigned);
-                case TYPE_DOUBLE -> intType(column, "DOUBLE", Types.DOUBLE, unsigned);
+                case TYPE_TINY -> numericType(column, "TINYINT", Types.SMALLINT, unsigned);
+                case TYPE_SHORT -> numericType(column, "SMALLINT", Types.SMALLINT, unsigned);
+                case TYPE_INT24 -> numericType(column, "MEDIUMINT", Types.INTEGER, unsigned);
+                case TYPE_LONG -> numericType(column, "INT", Types.INTEGER, unsigned);
+                case TYPE_LONGLONG -> numericType(column, "BIGINT", Types.BIGINT, unsigned);
+                case TYPE_FLOAT -> numericType(column, "FLOAT", Types.FLOAT, unsigned);
+                case TYPE_DOUBLE -> numericType(column, "DOUBLE", Types.DOUBLE, unsigned);
                 case TYPE_YEAR -> column.type("YEAR").jdbcType(Types.INTEGER);
+                // DECIMAL metadata is encoded as (scale << 8) | precision.
                 case TYPE_DECIMAL, TYPE_NEWDECIMAL -> {
                     column.type(unsigned ? "DECIMAL UNSIGNED" : "DECIMAL").jdbcType(Types.DECIMAL);
                     column.length(columnMeta[i] & 0xFF);
@@ -237,7 +238,7 @@ public class BinlogMetadataTableBuilder {
         return table.create();
     }
 
-    private void intType(ColumnEditor column, String baseName, int jdbcType, boolean unsigned) {
+    private void numericType(ColumnEditor column, String baseName, int jdbcType, boolean unsigned) {
         column.type(unsigned ? baseName + " UNSIGNED" : baseName).jdbcType(jdbcType);
     }
 

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -30,9 +30,9 @@ import io.debezium.relational.TableId;
  * <p>
  * The mapping mirrors what the DDL-based path ({@code MySqlAntlrDdlParser}) produces so that the
  * downstream value converters behave identically: JDBC types follow the same {@code DataTypeEntry}
- * registrations (e.g. TINYINT/SMALLINT &rarr; {@link Types#SMALLINT}, DATETIME &rarr;
- * {@link Types#TIMESTAMP}, TIMESTAMP &rarr; {@link Types#TIMESTAMP_WITH_TIMEZONE}, ENUM/SET &rarr;
- * {@link Types#CHAR}, JSON/GEOMETRY &rarr; {@link Types#OTHER}).
+ * registrations (e.g. TINYINT &rarr; {@link Types#TINYINT}, SMALLINT &rarr; {@link Types#SMALLINT},
+ * DATETIME &rarr; {@link Types#TIMESTAMP}, TIMESTAMP &rarr; {@link Types#TIMESTAMP_WITH_TIMEZONE},
+ * ENUM/SET &rarr; {@link Types#CHAR}, JSON/GEOMETRY &rarr; {@link Types#OTHER}).
  * <p>
  * Attributes that the binlog metadata does not carry (column defaults, generated-column flag,
  * comments) are intentionally not populated; those are documented limitations of this mode.

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilder.java
@@ -159,7 +159,7 @@ public class BinlogMetadataTableBuilder {
             final boolean binary = collation == BINARY_COLLATION_ID;
 
             switch (code) {
-                case TYPE_TINY -> numericType(column, "TINYINT", Types.SMALLINT, unsigned);
+                case TYPE_TINY -> numericType(column, "TINYINT", Types.TINYINT, unsigned);
                 case TYPE_SHORT -> numericType(column, "SMALLINT", Types.SMALLINT, unsigned);
                 case TYPE_INT24 -> numericType(column, "MEDIUMINT", Types.INTEGER, unsigned);
                 case TYPE_LONG -> numericType(column, "INT", Types.INTEGER, unsigned);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMode;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -66,6 +67,7 @@ public abstract class BinlogConvertingFailureIT<C extends SourceConnector> exten
 
     @Test
     @FixFor("DBZ-7143")
+    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
     public void shouldRecoverToSyncSchemaWhenFailedValueConvertByDdlWithSqlLogBinIsOff() throws Exception {
         // Use the DB configuration to define the connector's configuration to use the "replica"
         // which may be the same as the "primary" ...
@@ -187,6 +189,7 @@ public abstract class BinlogConvertingFailureIT<C extends SourceConnector> exten
 
     @Test
     @FixFor("DBZ-7143")
+    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
     public void shouldFailedConvertedValueIsNullWithSkipMode() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
@@ -67,7 +67,9 @@ public abstract class BinlogConvertingFailureIT<C extends SourceConnector> exten
 
     @Test
     @FixFor("DBZ-7143")
-    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
+    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts the conversion failures that the stale schema "
+            + "history produces; the binlog metadata mode detects the drift structurally at the next TABLE_MAP event and self-heals, so the "
+            + "asserted failures do not occur")
     public void shouldRecoverToSyncSchemaWhenFailedValueConvertByDdlWithSqlLogBinIsOff() throws Exception {
         // Use the DB configuration to define the connector's configuration to use the "replica"
         // which may be the same as the "primary" ...
@@ -189,7 +191,9 @@ public abstract class BinlogConvertingFailureIT<C extends SourceConnector> exten
 
     @Test
     @FixFor("DBZ-7143")
-    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
+    @SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts the conversion failures that the stale schema "
+            + "history produces; the binlog metadata mode detects the drift structurally at the next TABLE_MAP event and self-heals, so the "
+            + "asserted failures do not occur")
     public void shouldFailedConvertedValueIsNullWithSkipMode() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
@@ -338,7 +338,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void schemaHistorySaveDefaultValuesTest() throws InterruptedException, SQLException {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -504,7 +506,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void tinyIntBooleanTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -535,7 +539,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
     @Test
     @FixFor("DBZ-1689")
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void intBooleanTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -816,7 +822,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
     @Test
     @FixFor("DBZ-771")
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void columnTypeAndDefaultValueChange() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -899,7 +907,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @FixFor({ "DBZ-2267", "DBZ-6029" })
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void alterDateAndTimeTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -980,7 +990,9 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @FixFor("DBZ-5241")
-    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column DEFAULT values exist only in the table definition; none of the TABLE_MAP optional metadata "
+            + "fields carries them, so schemas reconstructed from the binlog declare no field defaults. Row values are unaffected, because "
+            + "binlog_row_image=FULL writes the materialized values")
     public void shouldConvertDefaultWithCharacterSetIntroducer() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.jdbc.BinlogValueConverters;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -337,6 +338,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void schemaHistorySaveDefaultValuesTest() throws InterruptedException, SQLException {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -502,6 +504,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void tinyIntBooleanTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -532,6 +535,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
     @Test
     @FixFor("DBZ-1689")
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void intBooleanTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -812,6 +816,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
     @Test
     @FixFor("DBZ-771")
     @SkipWhenKafkaVersion(check = EqualityCheck.EQUAL, value = KafkaVersion.KAFKA_1XX, description = "Not compatible with Kafka 1.x")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void columnTypeAndDefaultValueChange() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -894,6 +899,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @FixFor({ "DBZ-2267", "DBZ-6029" })
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void alterDateAndTimeTest() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
@@ -974,6 +980,7 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
 
     @Test
     @FixFor("DBZ-5241")
+    @SkipWhenSchemaHistoryDisabled(reason = "Column default values are not carried by the binlog TABLE_MAP metadata")
     public void shouldConvertDefaultWithCharacterSetIntroducer() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogEnumColumnIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogEnumColumnIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.data.Envelope.FieldName;
@@ -95,6 +96,7 @@ public abstract class BinlogEnumColumnIT<C extends SourceConnector> extends Abst
 
     @Test
     @FixFor("DBZ-1636")
+    @SkipWhenSchemaHistoryDisabled(reason = "Asserts the propagated source column type, whose display form is not carried by the binlog TABLE_MAP metadata")
     public void shouldPropagateColumnSourceType() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogEnumColumnIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogEnumColumnIT.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.data.Envelope.FieldName;
@@ -96,7 +95,6 @@ public abstract class BinlogEnumColumnIT<C extends SourceConnector> extends Abst
 
     @Test
     @FixFor("DBZ-1636")
-    @SkipWhenSchemaHistoryDisabled(reason = "Asserts the propagated source column type, whose display form is not carried by the binlog TABLE_MAP metadata")
     public void shouldPropagateColumnSourceType() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogFloatIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogFloatIT.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -61,6 +62,7 @@ public abstract class BinlogFloatIT<C extends SourceConnector> extends AbstractB
 
     @Test
     @FixFor("DBZ-3865")
+    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the FLOAT(M,D) precision")
     public void shouldHandleFloatAsFloatAndDouble() throws SQLException, InterruptedException {
         String includeTables = String.join(",",
                 Collect.arrayListOf(DATABASE.qualifiedTableName(TABLE_NAME), DATABASE.qualifiedTableName("DBZ3865_2")));

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogFloatIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogFloatIT.java
@@ -62,7 +62,9 @@ public abstract class BinlogFloatIT<C extends SourceConnector> extends AbstractB
 
     @Test
     @FixFor("DBZ-3865")
-    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the FLOAT(M,D) precision")
+    @SkipWhenSchemaHistoryDisabled(reason = "A FLOAT(M,D) column (a syntax deprecated in MySQL 8.0.17) is promoted to FLOAT64 based on the "
+            + "precision declared in the DDL; the binlog TABLE_MAP metadata carries only the 4-byte or 8-byte storage size, so the "
+            + "reconstructed column stays FLOAT32")
     public void shouldHandleFloatAsFloatAndDouble() throws SQLException, InterruptedException {
         String includeTables = String.join(",",
                 Collect.arrayListOf(DATABASE.qualifiedTableName(TABLE_NAME), DATABASE.qualifiedTableName("DBZ3865_2")));

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogGeometryIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogGeometryIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.data.Envelope;
@@ -69,6 +70,7 @@ public abstract class BinlogGeometryIT<C extends SourceConnector> extends Abstra
     }
 
     @Test
+    @SkipWhenSchemaHistoryDisabled(reason = "The spatial subtype (e.g. POINT) is not carried by the binlog TABLE_MAP metadata, so all spatial columns surface as GEOMETRY")
     void shouldConsumeAllEventsFromDatabaseUsingStreaming() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogGeometryIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogGeometryIT.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.data.Envelope;
@@ -70,7 +69,6 @@ public abstract class BinlogGeometryIT<C extends SourceConnector> extends Abstra
     }
 
     @Test
-    @SkipWhenSchemaHistoryDisabled(reason = "The spatial subtype (e.g. POINT) is not carried by the binlog TABLE_MAP metadata, so all spatial columns surface as GEOMETRY")
     void shouldConsumeAllEventsFromDatabaseUsingStreaming() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogJdbcSinkDataTypeConverterIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogJdbcSinkDataTypeConverterIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.converters.JdbcSinkDataTypesConverter;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -32,6 +33,7 @@ import io.debezium.jdbc.JdbcConnection;
  *
  * @author Chris Cranford
  */
+@SkipWhenSchemaHistoryDisabled(reason = "Asserts mappings that rely on integer display width, FLOAT precision and nationalized character source types, none of which are carried by the binlog TABLE_MAP metadata")
 public abstract class BinlogJdbcSinkDataTypeConverterIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-jdbc-sink.text").toAbsolutePath();

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogJdbcSinkDataTypeConverterIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogJdbcSinkDataTypeConverterIT.java
@@ -33,7 +33,9 @@ import io.debezium.jdbc.JdbcConnection;
  *
  * @author Chris Cranford
  */
-@SkipWhenSchemaHistoryDisabled(reason = "Asserts mappings that rely on integer display width, FLOAT precision and nationalized character source types, none of which are carried by the binlog TABLE_MAP metadata")
+@SkipWhenSchemaHistoryDisabled(reason = "Asserts streaming-phase propagated source types that exist only as DDL text: BOOLEAN, REAL, NCHAR and "
+        + "NVARCHAR are aliases that the server normalizes to TINYINT(1), DOUBLE and CHAR/VARCHAR, and the binlog carries only the normalized "
+        + "storage types, without the display width that is deprecated since MySQL 8.0.17")
 public abstract class BinlogJdbcSinkDataTypeConverterIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-jdbc-sink.text").toAbsolutePath();

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -243,6 +243,48 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
+    public void shouldResolveMixedCharsetsWhenEnumPrecedesStringColumns() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // These values round-trip only when each column is decoded with its own charset: the 'é' in
+        // the latin1 column is the single byte 0xE9, which is not valid UTF-8. An ENUM column in
+        // front of the string columns must not shift the per-column charset numbering.
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO charset_mix (status, name_latin1, note_utf8) VALUES ('DONE', 'café', 'メモ')");
+
+        final List<SourceRecord> records = consumeTable("charset_mix", 1);
+        assertThat(records).hasSize(1);
+        final Struct after = afterOf(records.get(0));
+        assertThat(after.getString("status")).isEqualTo("DONE");
+        assertThat(after.getString("name_latin1")).isEqualTo("café");
+        assertThat(after.getString("note_utf8")).isEqualTo("メモ");
+
+        stopConnector();
+    }
+
+    @Test
+    public void shouldReconstructPrimaryKeyDefinedWithColumnPrefix() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        executeStatements(DATABASE.getDatabaseName(), "INSERT INTO prefix_pk (code, qty) VALUES ('ABCDEFGH', 7)");
+
+        final List<SourceRecord> records = consumeTable("prefix_pk", 1);
+        assertThat(records).hasSize(1);
+        final SourceRecord record = records.get(0);
+        // A prefixed key is written as PRIMARY_KEY_WITH_PREFIX metadata and must still yield a keyed
+        // record with the full column value.
+        assertThat(record.key()).isNotNull();
+        assertThat(((Struct) record.key()).getString("code")).isEqualTo("ABCDEFGH");
+        assertThat(afterOf(record).getInt32("qty")).isEqualTo(7);
+
+        stopConnector();
+    }
+
+    @Test
     public void shouldStreamFromRewoundOffsetAcrossDdlChange() throws Exception {
         final Configuration config = metadataModeConfig().build();
         start(getConnectorClass(), config);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -146,8 +146,8 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
         assertThat(before).hasSize(1);
         assertThat(afterOf(before.get(0)).schema().field("priority")).isNull();
 
-        // Schema change mid-stream: the next TABLE_MAP carries the new column, so the cached schema must be
-        // rebuilt (the metadata signature changes) rather than reused.
+        // Schema change mid-stream: the parsed DDL marks the table dirty, so the next TABLE_MAP (which
+        // carries the new column) must rebuild the schema rather than reuse the registered one.
         executeStatements(DATABASE.getDatabaseName(), "ALTER TABLE orders ADD COLUMN priority INT");
         executeStatements(DATABASE.getDatabaseName(),
                 "INSERT INTO orders (quantity, status, price, code, note, created_at, priority) "

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -243,6 +243,59 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
+    public void shouldStreamFromRewoundOffsetAcrossDdlChange() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // First change: consume it so that the committed offset lands right after this event. This
+        // offset is the rewind point, taken while the table still has its original schema.
+        insertMarkerOrder("RW01");
+        assertThat(consumeOrders(1)).hasSize(1);
+        stopConnector();
+        // The inherited Testing.Files interface shadows java.nio.file.Files, hence the qualified name.
+        final byte[] rewindPoint = java.nio.file.Files.readAllBytes(OFFSET_STORE_PATH);
+
+        // While the connector keeps running past the rewind point, the table goes through
+        // DML -> DDL -> DML, so the offset ends up beyond a schema change.
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+        insertMarkerOrder("RW02");
+        executeStatements(DATABASE.getDatabaseName(), "ALTER TABLE orders ADD COLUMN rewound INT");
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO orders (quantity, status, price, code, note, created_at, rewound) "
+                        + "VALUES (1, 'NEW', 1.000, 'RW03', 'post-ddl', NOW(3), 42)");
+        assertThat(consumeOrders(2)).hasSize(2);
+        stopConnector();
+
+        // Rewind the offset behind the DDL statement. Because this mode keeps no persistent state other
+        // than the offset, this is equivalent to an operator seeding a binlog position (or GTID set) for
+        // a fresh connector, and it must work even though the current database schema no longer matches
+        // the schema at the rewind point. A schema-history connector cannot do this without a history
+        // topic that covers the target position.
+        java.nio.file.Files.write(OFFSET_STORE_PATH, rewindPoint);
+
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        final List<SourceRecord> replayed = consumeOrders(2);
+        assertThat(replayed).hasSize(2);
+
+        // The replayed pre-DDL row must decode with the point-in-time schema carried by its TABLE_MAP
+        // event, not with the current schema of the table.
+        final Struct preDdl = afterOf(replayed.get(0));
+        assertThat(preDdl.getString("code")).isEqualTo("RW02");
+        assertThat(preDdl.schema().field("rewound")).as("pre-DDL row decoded with point-in-time schema").isNull();
+
+        // The replayed post-DDL row must decode with the new schema.
+        final Struct postDdl = afterOf(replayed.get(1));
+        assertThat(postDdl.getString("code")).isEqualTo("RW03");
+        assertThat(postDdl.getInt32("rewound")).isEqualTo(42);
+
+        stopConnector();
+    }
+
+    @Test
     public void shouldFailFastWhenBinlogRowMetadataIsNotFull() throws Exception {
         setBinlogRowMetadata("MINIMAL");
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -285,6 +285,33 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
+    public void shouldCarryMaterializedDefaultValuesWithoutDeclaringSchemaDefaults() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // The status column is declared NOT NULL DEFAULT 'NEW' and omitted here, so the server
+        // materializes the default into the written row.
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO orders (quantity, price, code, note, created_at) VALUES (1, 1.000, 'DF01', 'default', NOW(3))");
+
+        final List<SourceRecord> records = consumeOrders(1);
+        assertThat(records).hasSize(1);
+        final Struct after = afterOf(records.get(0));
+
+        // Row values are complete: the change event carries the materialized default value.
+        assertThat(after.getString("status")).isEqualTo("NEW");
+
+        // The reconstructed schema declares no field default, because column DEFAULT values are not
+        // part of the TABLE_MAP metadata. This pins the documented boundary of the mode: the column
+        // stays a required field without a default, while the row data is unaffected.
+        assertThat(after.schema().field("status").schema().defaultValue()).isNull();
+        assertThat(after.schema().field("status").schema().isOptional()).isFalse();
+
+        stopConnector();
+    }
+
+    @Test
     public void shouldStreamFromRewoundOffsetAcrossDdlChange() throws Exception {
         final Configuration config = metadataModeConfig().build();
         start(getConnectorClass(), config);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
+import io.debezium.connector.binlog.util.BinlogTestConnection;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.data.Envelope;
+import io.debezium.util.Testing;
+
+/**
+ * Integration tests for the opt-in binlog-metadata-based schema mode (see
+ * {@link BinlogConnectorConfig#BINLOG_METADATA_BASED_SCHEMA}), which reconstructs the streaming table
+ * schema from the FULL metadata carried by binlog {@code TABLE_MAP} events instead of from a persisted
+ * schema history topic (debezium/dbz#978).
+ * <p>
+ * The mode relies only on the self-describing binlog, so it works for any binlog-based connector whose
+ * server can emit {@code binlog_row_metadata=FULL} (MySQL 8.0+, MariaDB 10.5+). The central test,
+ * {@link #shouldResumeMidMultiRowInsertWithReconstructedSchema()}, covers the key scenario: a connector
+ * restart in the middle of a multi-row INSERT must resume without losing rows and must decode the
+ * resumed rows with the schema rebuilt from the re-read {@code TABLE_MAP} event.
+ */
+public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
+
+    private static final Path SCHEMA_HISTORY_PATH = Testing.Files
+            .createTestingPath("file-schema-history-binlog-metadata.txt").toAbsolutePath();
+
+    protected final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase("binlogmeta", "binlog_metadata_schema")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private String originalRowMetadata;
+
+    @BeforeEach
+    void beforeEach() throws SQLException {
+        stopConnector();
+        originalRowMetadata = currentBinlogRowMetadata();
+        setBinlogRowMetadata("FULL");
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    void afterEach() throws SQLException {
+        try {
+            stopConnector();
+        }
+        finally {
+            if (originalRowMetadata != null) {
+                setBinlogRowMetadata(originalRowMetadata);
+            }
+            Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    public void shouldReconstructSchemaFromBinlogMetadataWithoutHistoryTopic() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        insertOrders(5);
+        final List<SourceRecord> orders = consumeOrders(5);
+        assertThat(orders).hasSize(5);
+
+        for (SourceRecord record : orders) {
+            assertOrderSchema(afterOf(record));
+        }
+        // Spot-check a couple of reconstructed values.
+        final Struct first = afterOf(orders.get(0));
+        assertThat(first.getString("status")).isEqualTo("NEW");
+        assertThat(first.get("code")).isNotNull();
+
+        // The mode must not create or depend on a persisted schema history topic/file.
+        assertThat(SCHEMA_HISTORY_PATH.toFile().exists()).isFalse();
+
+        stopConnector();
+    }
+
+    @Test
+    public void shouldReconstructAllDataTypesFromBinlogMetadata() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        insertAllTypesRow();
+
+        final List<SourceRecord> records = consumeTable("all_types", 1);
+        assertThat(records).hasSize(1);
+        final SourceRecord record = records.get(0);
+        // A successful decode of a fully-populated row proves every column type code was mapped to a
+        // schema the value converters accept.
+        assertThat(operationOf(record)).isEqualTo("c");
+        final Struct after = afterOf(record);
+
+        // Every column must be present in the schema reconstructed from the TABLE_MAP metadata.
+        for (String column : ALL_TYPES_COLUMNS) {
+            assertThat(after.schema().field(column)).as("column '%s' reconstructed", column).isNotNull();
+        }
+
+        // Spot-check values whose representation is identical on MySQL and MariaDB.
+        assertThat(after.getInt32("id")).isEqualTo(1);
+        assertThat(after.getInt32("c_int")).isEqualTo(42);
+        assertThat(after.getInt64("c_bigint")).isEqualTo(9_000_000_000L);
+        assertThat(after.getString("c_char")).isEqualTo("ABCD");
+        assertThat(after.getString("c_varchar")).isEqualTo("hello");
+        assertThat(after.getString("c_enum")).isEqualTo("OK");
+        assertThat(after.getString("c_set")).isEqualTo("a,c");
+
+        stopConnector();
+    }
+
+    @Test
+    public void shouldSnapshotExistingDataThenStreamWithReconstructedSchema() throws Exception {
+        // Rows that exist before the connector starts must be captured by the initial snapshot.
+        insertOrders(4);
+
+        final Configuration config = metadataModeConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with("snapshot.locking.mode", "none")
+                .build();
+        start(getConnectorClass(), config);
+
+        // Snapshot read events (op=r) for the pre-existing rows, decoded with the reconstructed schema.
+        final List<SourceRecord> snapshot = consumeOrders(4);
+        assertThat(snapshot).hasSize(4);
+        for (SourceRecord record : snapshot) {
+            assertThat(operationOf(record)).isEqualTo("r");
+            assertOrderSchema(afterOf(record));
+        }
+
+        // Handoff to streaming: a subsequent change is captured as a create event with the same schema.
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+        insertOrders(1);
+        final List<SourceRecord> streamed = consumeOrders(1);
+        assertThat(streamed).hasSize(1);
+        assertThat(operationOf(streamed.get(0))).isEqualTo("c");
+        assertOrderSchema(afterOf(streamed.get(0)));
+
+        stopConnector();
+    }
+
+    @Test
+    public void shouldResumeMidMultiRowInsertWithReconstructedSchema() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // A single multi-row INSERT is emitted as one WRITE_ROWS event preceded by one TABLE_MAP event.
+        final int total = 20;
+        insertOrders(total);
+
+        final Set<Integer> seenIds = new HashSet<>();
+
+        // Consume a prefix of the rows, verify each is decoded with the reconstructed schema, then
+        // force a restart. The committed offset lands in the middle of the multi-row WRITE_ROWS event.
+        final SourceRecords beforeRestart = consumeRecordsByTopic(8);
+        final List<SourceRecord> beforeOrders = beforeRestart.recordsForTopic(DATABASE.topicForTable("orders"));
+        assertThat(beforeOrders).isNotEmpty();
+        for (SourceRecord record : beforeOrders) {
+            assertOrderSchema(afterOf(record));
+            seenIds.add(afterOf(record).getInt32("id"));
+        }
+        stopConnector();
+
+        // Restart: the connector resumes from the mid-event offset. handleTransactionBegin re-reads from
+        // the transaction BEGIN, re-reads the TABLE_MAP (rebuilding the schema), skips the already-emitted
+        // rows and emits the remainder.
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (seenIds.size() < total && System.currentTimeMillis() < deadline) {
+            final SourceRecords more = consumeRecordsByTopic(total);
+            final List<SourceRecord> orders = more.recordsForTopic(DATABASE.topicForTable("orders"));
+            if (orders == null) {
+                continue;
+            }
+            for (SourceRecord record : orders) {
+                // The key assertion: resumed rows still decode with the full schema reconstructed from
+                // the re-read TABLE_MAP event.
+                assertOrderSchema(afterOf(record));
+                seenIds.add(afterOf(record).getInt32("id"));
+            }
+        }
+
+        // No rows may be lost across the mid-event restart (at-least-once duplicates are tolerated).
+        assertThat(seenIds).hasSize(total);
+        assertThat(SCHEMA_HISTORY_PATH.toFile().exists()).isFalse();
+
+        stopConnector();
+    }
+
+    @Test
+    public void shouldFailFastWhenBinlogRowMetadataIsNotFull() throws Exception {
+        setBinlogRowMetadata("MINIMAL");
+
+        final Configuration config = metadataModeConfig().build();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        start(getConnectorClass(), config, (success, message, throwable) -> {
+            if (!success) {
+                error.set(throwable);
+            }
+        });
+
+        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (error.get() == null && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100);
+        }
+
+        assertThat(error.get())
+                .as("connector should fail fast when binlog_row_metadata is not FULL")
+                .isNotNull();
+        assertThat(error.get().getMessage()).contains("binlog_row_metadata");
+    }
+
+    @Test
+    public void shouldStreamFromCurrentPositionWhenSnapshotIsSkipped() throws Exception {
+        // Rows that already exist before the connector starts. With a no_data snapshot in this
+        // (non-historized) mode the snapshot is skipped, so the connector must seed the current binlog
+        // position and must NOT replay these pre-existing rows.
+        insertOrders(3);
+
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // A change made after streaming has started must be captured.
+        insertMarkerOrder("MK00");
+
+        // It must be the FIRST record we see: if streaming had begun from the earliest binlog, the
+        // pre-existing rows would have been emitted first.
+        final List<SourceRecord> orders = consumeOrders(1);
+        assertThat(orders).hasSize(1);
+        final Struct after = afterOf(orders.get(0));
+        assertThat(operationOf(orders.get(0))).isEqualTo("c");
+        assertThat(after.getString("code")).isEqualTo("MK00");
+        assertOrderSchema(after);
+
+        stopConnector();
+    }
+
+    protected Configuration.Builder metadataModeConfig() {
+        return DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(BinlogConnectorConfig.BINLOG_METADATA_BASED_SCHEMA, true);
+    }
+
+    private static final List<String> ALL_TYPES_COLUMNS = List.of(
+            "id", "c_tinyint", "c_tinyint_u", "c_bool", "c_smallint", "c_smallint_u", "c_mediumint",
+            "c_mediumint_u", "c_int", "c_int_u", "c_bigint", "c_bigint_u", "c_decimal", "c_float", "c_double",
+            "c_bit", "c_date", "c_datetime", "c_timestamp", "c_time", "c_year", "c_char", "c_varchar",
+            "c_binary", "c_varbinary", "c_tinytext", "c_text", "c_mediumtext", "c_longtext", "c_tinyblob",
+            "c_blob", "c_mediumblob", "c_longblob", "c_enum", "c_set", "c_json");
+
+    private List<SourceRecord> consumeOrders(int expected) throws InterruptedException {
+        return consumeTable("orders", expected);
+    }
+
+    /**
+     * Consume change records for the given table until {@code expected} of them have been collected or a
+     * timeout elapses. This tolerates the streaming latency of a freshly started connector.
+     */
+    protected List<SourceRecord> consumeTable(String table, int expected) throws InterruptedException {
+        final List<SourceRecord> collected = new ArrayList<>();
+        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (collected.size() < expected && System.currentTimeMillis() < deadline) {
+            final SourceRecords records = consumeRecordsByTopic(expected - collected.size());
+            final List<SourceRecord> forTable = records.recordsForTopic(DATABASE.topicForTable(table));
+            if (forTable != null) {
+                collected.addAll(forTable);
+            }
+        }
+        return collected;
+    }
+
+    private void insertOrders(int count) throws SQLException {
+        final StringBuilder sql = new StringBuilder(
+                "INSERT INTO orders (quantity, status, price, code, note, created_at) VALUES ");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                sql.append(',');
+            }
+            sql.append(String.format("(%d,'NEW',%d.500,'C%03d','note-%d',NOW(3))", 100 + i, 10 + i, i, i));
+        }
+        executeStatements(DATABASE.getDatabaseName(), sql.toString());
+    }
+
+    private void insertAllTypesRow() throws SQLException {
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO all_types (c_tinyint, c_tinyint_u, c_bool, c_smallint, c_smallint_u, c_mediumint, "
+                        + "c_mediumint_u, c_int, c_int_u, c_bigint, c_bigint_u, c_decimal, c_float, c_double, c_bit, "
+                        + "c_date, c_datetime, c_timestamp, c_time, c_year, c_char, c_varchar, c_binary, c_varbinary, "
+                        + "c_tinytext, c_text, c_mediumtext, c_longtext, c_tinyblob, c_blob, c_mediumblob, c_longblob, "
+                        + "c_enum, c_set, c_json) VALUES ("
+                        + "-5, 200, 1, -30000, 60000, -8000000, 16000000, 42, 4000000000, 9000000000, "
+                        + "18000000000000000000, 12345.678, 3.14, 2.718281828, b'10101', '2026-07-03', "
+                        + "'2026-07-03 12:34:56.789', '2026-07-03 12:34:56.123456', '12:34:56.789', 2026, 'ABCD', "
+                        + "'hello', 0x0102030405060708, 0xAABBCC, 'tiny', 'text', 'medium', 'long', 0x01, 0x02, 0x03, "
+                        + "0x04, 'OK', 'a,c', JSON_OBJECT('k', 'v'))");
+    }
+
+    private void insertMarkerOrder(String code) throws SQLException {
+        executeStatements(DATABASE.getDatabaseName(), String.format(
+                "INSERT INTO orders (quantity, status, price, code, note, created_at) "
+                        + "VALUES (1, 'NEW', 1.000, '%s', 'marker', NOW(3))",
+                code));
+    }
+
+    protected static Struct afterOf(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+    }
+
+    protected static String operationOf(SourceRecord record) {
+        return ((Struct) record.value()).getString(Envelope.FieldName.OPERATION);
+    }
+
+    private static void assertOrderSchema(Struct after) {
+        final Schema schema = after.schema();
+        assertThat(schema.field("id")).isNotNull();
+        assertThat(schema.field("quantity")).isNotNull();
+        assertThat(schema.field("status")).isNotNull();
+        assertThat(schema.field("price")).isNotNull();
+        assertThat(schema.field("code")).isNotNull();
+        assertThat(schema.field("note")).isNotNull();
+        assertThat(schema.field("created_at")).isNotNull();
+        // Types reconstructed from TABLE_MAP metadata.
+        assertThat(schema.field("id").schema().type()).isEqualTo(Schema.Type.INT32);
+        assertThat(schema.field("code").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(schema.field("quantity").schema().type()).isEqualTo(Schema.Type.INT64);
+    }
+
+    private String currentBinlogRowMetadata() throws SQLException {
+        try (BinlogTestConnection db = getTestDatabaseConnection("mysql")) {
+            return db.queryAndMap("SHOW GLOBAL VARIABLES LIKE 'binlog_row_metadata'",
+                    rs -> rs.next() ? rs.getString(2) : null);
+        }
+    }
+
+    private void setBinlogRowMetadata(String value) throws SQLException {
+        try (BinlogTestConnection db = getTestDatabaseConnection("mysql")) {
+            db.execute("SET GLOBAL binlog_row_metadata = '" + value + "'");
+        }
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -135,6 +135,34 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
+    public void shouldRefreshSchemaWhenTableIsAltered() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // First write: schema before the change (no 'priority' column).
+        insertOrders(1);
+        final List<SourceRecord> before = consumeOrders(1);
+        assertThat(before).hasSize(1);
+        assertThat(afterOf(before.get(0)).schema().field("priority")).isNull();
+
+        // Schema change mid-stream: the next TABLE_MAP carries the new column, so the cached schema must be
+        // rebuilt (the metadata signature changes) rather than reused.
+        executeStatements(DATABASE.getDatabaseName(), "ALTER TABLE orders ADD COLUMN priority INT");
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO orders (quantity, status, price, code, note, created_at, priority) "
+                        + "VALUES (1, 'NEW', 1.000, 'ALT0', 'altered', NOW(3), 7)");
+
+        final List<SourceRecord> after = consumeOrders(1);
+        assertThat(after).hasSize(1);
+        final Struct struct = afterOf(after.get(0));
+        assertThat(struct.schema().field("priority")).as("schema rebuilt after ALTER").isNotNull();
+        assertThat(struct.getInt32("priority")).isEqualTo(7);
+
+        stopConnector();
+    }
+
+    @Test
     public void shouldSnapshotExistingDataThenStreamWithReconstructedSchema() throws Exception {
         // Rows that exist before the connector starts must be captured by the initial snapshot.
         insertOrders(4);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -169,7 +169,6 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
 
         final Configuration config = metadataModeConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with("snapshot.locking.mode", "none")
                 .build();
         start(getConnectorClass(), config);
 
@@ -267,10 +266,10 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
-    public void shouldStreamFromCurrentPositionWhenSnapshotIsSkipped() throws Exception {
-        // Rows that already exist before the connector starts. With a no_data snapshot in this
-        // (non-historized) mode the snapshot is skipped, so the connector must seed the current binlog
-        // position and must NOT replay these pre-existing rows.
+    public void shouldStreamFromCurrentPositionWithNoDataSnapshot() throws Exception {
+        // Rows that already exist before the connector starts. With a no_data snapshot the connector must
+        // record the current binlog position (exactly as with a persistent schema history) and must NOT
+        // replay these pre-existing rows.
         insertOrders(3);
 
         final Configuration config = metadataModeConfig().build();
@@ -295,6 +294,9 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     protected Configuration.Builder metadataModeConfig() {
         return DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                // Schema change events are emitted exactly as with a persistent schema history; disabled
+                // here so that the tests can consume data change records by plain counts.
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                 .with(BinlogConnectorConfig.BINLOG_METADATA_BASED_SCHEMA, true);
     }
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetadataBasedSchemaIT.java
@@ -285,6 +285,55 @@ public abstract class BinlogMetadataBasedSchemaIT<C extends SourceConnector> ext
     }
 
     @Test
+    public void shouldEmitSchemaChangeEventForTableNotYetRegisteredAfterRestart() throws Exception {
+        final Configuration config = metadataModeConfig()
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // Commit an offset past the initial schema snapshot, so that the restart below skips the
+        // snapshot and streaming starts with an empty in-memory model.
+        insertMarkerOrder("RS01");
+        assertThat(consumeOrders(1)).hasSize(1);
+        stopConnector();
+
+        // While the connector is stopped, alter a table that will have produced no row event after
+        // the restart: the DDL statement is then read before any TABLE_MAP event has registered the
+        // table. It must neither kill the task nor be dropped from the schema change topic.
+        executeStatements(DATABASE.getDatabaseName(), "ALTER TABLE all_types ADD COLUMN extra_after_restart INT");
+
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // The schema change event carries the DDL statement; the table structure at that point is
+        // unknown (it only arrives with the next TABLE_MAP event), so tableChanges stays empty.
+        SourceRecord schemaChange = null;
+        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (schemaChange == null && System.currentTimeMillis() < deadline) {
+            final List<SourceRecord> changes = consumeRecordsByTopic(1).recordsForTopic(DATABASE.getServerName());
+            if (changes != null && !changes.isEmpty()) {
+                schemaChange = changes.get(0);
+            }
+        }
+        assertThat(schemaChange).as("schema change event emitted for a not-yet-registered table").isNotNull();
+        final Struct changeValue = (Struct) schemaChange.value();
+        assertThat(changeValue.getString("ddl")).contains("extra_after_restart");
+        assertThat(changeValue.getArray("tableChanges")).isEmpty();
+
+        // The next TABLE_MAP event carries the post-DDL schema, so the row must decode with the new
+        // column present.
+        insertAllTypesRow();
+        final List<SourceRecord> records = consumeTable("all_types", 1);
+        assertThat(records).hasSize(1);
+        final Struct after = afterOf(records.get(0));
+        assertThat(after.schema().field("extra_after_restart")).as("column added while stopped").isNotNull();
+        assertThat(after.getInt32("c_int")).isEqualTo(42);
+
+        stopConnector();
+    }
+
+    @Test
     public void shouldCarryMaterializedDefaultValuesWithoutDeclaringSchemaDefaults() throws Exception {
         final Configuration config = metadataModeConfig().build();
         start(getConnectorClass(), config);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -33,6 +34,7 @@ import io.debezium.junit.SkipWhenDatabaseVersion;
  * @author Inki Hwang
  */
 @SkipWhenDatabaseVersion(check = LESS_THAN, major = 5, minor = 6, reason = "DDL uses fractional second data types, not supported until MySQL 5.6")
+@SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
 public abstract class BinlogSchemaValidateIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final Path DB_HISTORY_PATH = Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSchemaValidateIT.java
@@ -34,7 +34,9 @@ import io.debezium.junit.SkipWhenDatabaseVersion;
  * @author Inki Hwang
  */
 @SkipWhenDatabaseVersion(check = LESS_THAN, major = 5, minor = 6, reason = "DDL uses fractional second data types, not supported until MySQL 5.6")
-@SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts stale-schema behavior specific to the schema history mode; with binlog metadata the schema self-heals at the next TABLE_MAP event")
+@SkipWhenSchemaHistoryDisabled(reason = "Provokes schema drift with sql_log_bin=OFF and asserts that the connector fails on the drifted rows "
+        + "and is then repaired with the recovery snapshot mode (DBZ-7093). With the binlog metadata mode the schema self-heals at the next "
+        + "TABLE_MAP event, so the expected failure never happens and there is no history to recover")
 public abstract class BinlogSchemaValidateIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final Path DB_HISTORY_PATH = Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTypeInSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTypeInSchemaIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.doc.FixFor;
@@ -30,6 +31,7 @@ import io.debezium.doc.FixFor;
  *
  * @author Gunnar Morling
  */
+@SkipWhenSchemaHistoryDisabled(reason = "Asserts propagated source column types including display width and precision, which are not carried by the binlog TABLE_MAP metadata")
 public abstract class BinlogSourceTypeInSchemaIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final String TYPE_NAME_PARAMETER_KEY = "__debezium.source.column.type";

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTypeInSchemaIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTypeInSchemaIT.java
@@ -31,7 +31,9 @@ import io.debezium.doc.FixFor;
  *
  * @author Gunnar Morling
  */
-@SkipWhenSchemaHistoryDisabled(reason = "Asserts propagated source column types including display width and precision, which are not carried by the binlog TABLE_MAP metadata")
+@SkipWhenSchemaHistoryDisabled(reason = "Asserts propagated source types that include the FLOAT(M,D) precision and the NUMERIC alias, both of "
+        + "which exist only in the DDL text; the binlog TABLE_MAP metadata carries the storage type instead (the FLOAT pack length and the "
+        + "DECIMAL base type), so the propagated strings differ")
 public abstract class BinlogSourceTypeInSchemaIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
 
     private static final String TYPE_NAME_PARAMETER_KEY = "__debezium.source.column.type";

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
@@ -39,6 +39,7 @@ import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMo
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.junit.SkipWhenDatabaseIs;
 import io.debezium.connector.binlog.junit.SkipWhenDatabaseIs.Type;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -513,6 +514,7 @@ public abstract class BinlogStreamingSourceIT<C extends SourceConnector> extends
     }
 
     @Test
+    @SkipWhenSchemaHistoryDisabled(reason = "The schema is reconstructed from TABLE_MAP events, so the provoked schema inconsistency cannot occur")
     void shouldFailOnSchemaInconsistency() throws Exception {
         assertThrows(ConnectException.class, () -> {
             inconsistentSchema(null);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStreamingSourceIT.java
@@ -514,7 +514,9 @@ public abstract class BinlogStreamingSourceIT<C extends SourceConnector> extends
     }
 
     @Test
-    @SkipWhenSchemaHistoryDisabled(reason = "The schema is reconstructed from TABLE_MAP events, so the provoked schema inconsistency cannot occur")
+    @SkipWhenSchemaHistoryDisabled(reason = "Expects the connector to fail when the row layout no longer matches the recovered schema; the binlog "
+            + "metadata mode rebuilds the schema from the TABLE_MAP event that precedes every row event, so the provoked inconsistency cannot "
+            + "occur")
     void shouldFailOnSchemaInconsistency() throws Exception {
         assertThrows(ConnectException.class, () -> {
             inconsistentSchema(null);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.binlog.converters.TinyIntOneToBooleanConverter;
+import io.debezium.connector.binlog.junit.SkipWhenSchemaHistoryDisabled;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.doc.FixFor;
@@ -90,6 +91,7 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
 
     @Test
     @FixFor("DBZ-1800")
+    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the integer display width, so TINYINT(1) cannot be mapped to BOOLEAN")
     public void shouldHandleTinyIntOneAsBoolean() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()
@@ -145,6 +147,7 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
 
     @Test
     @FixFor("DBZ-2085")
+    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the integer display width, so TINYINT(1) cannot be mapped to BOOLEAN")
     public void shouldDefaultValueForTinyIntOneAsBoolean() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
@@ -130,6 +130,7 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
                 .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("DBZ1773"))
                 .with(BinlogConnectorConfig.CUSTOM_CONVERTERS, "boolean")
                 .with("boolean.type", TinyIntOneToBooleanConverter.class.getName())
+                .with("boolean.length.checker", "false")
                 .with("boolean.selector", ".*DBZ1773.b")
                 .build();
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
@@ -91,7 +91,11 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
 
     @Test
     @FixFor("DBZ-1800")
-    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the integer display width, so TINYINT(1) cannot be mapped to BOOLEAN")
+    @SkipWhenSchemaHistoryDisabled(reason = "TinyIntOneToBooleanConverter detects boolean columns through the TINYINT(1) display width, which "
+            + "exists only in the table definition: integer TABLE_MAP metadata is empty, and MySQL deprecated integer display widths in "
+            + "8.0.17, retaining only TINYINT(1) as a boolean marker. The converter still works with length.checker=false and an explicit "
+            + "selector, the setup already recommended for MySQL 8, where even SHOW CREATE TABLE drops the width of TINYINT(1) UNSIGNED "
+            + "(DBZ-5343)")
     public void shouldHandleTinyIntOneAsBoolean() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()
@@ -147,7 +151,11 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
 
     @Test
     @FixFor("DBZ-2085")
-    @SkipWhenSchemaHistoryDisabled(reason = "The binlog TABLE_MAP metadata does not carry the integer display width, so TINYINT(1) cannot be mapped to BOOLEAN")
+    @SkipWhenSchemaHistoryDisabled(reason = "TinyIntOneToBooleanConverter detects boolean columns through the TINYINT(1) display width, which "
+            + "exists only in the table definition: integer TABLE_MAP metadata is empty, and MySQL deprecated integer display widths in "
+            + "8.0.17, retaining only TINYINT(1) as a boolean marker. The converter still works with length.checker=false and an explicit "
+            + "selector, the setup already recommended for MySQL 8, where even SHOW CREATE TABLE drops the width of TINYINT(1) UNSIGNED "
+            + "(DBZ-5343)")
     public void shouldDefaultValueForTinyIntOneAsBoolean() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/junit/SkipTestWhenSchemaHistoryDisabledExtension.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/junit/SkipTestWhenSchemaHistoryDisabledExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.junit;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.junit.AnnotationBasedExtension;
+
+/**
+ * JUnit 5 extension that skips a test annotated with {@link SkipWhenSchemaHistoryDisabled} when the
+ * testsuite runs with the binlog-metadata-based schema mode enabled, in which no schema history is used.
+ */
+public class SkipTestWhenSchemaHistoryDisabledExtension extends AnnotationBasedExtension implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        SkipWhenSchemaHistoryDisabled annotation = hasAnnotation(context, SkipWhenSchemaHistoryDisabled.class);
+        if (annotation != null && UniqueDatabase.isBinlogMetadataBasedSchemaTestsuite()) {
+            String reasonForSkipping = "Test depends on the schema history, but the testsuite runs with the "
+                    + "binlog-metadata-based schema mode" + System.lineSeparator() + annotation.reason();
+            return ConditionEvaluationResult.disabled(reasonForSkipping);
+        }
+        return ConditionEvaluationResult.enabled("Schema history is in use");
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/junit/SkipWhenSchemaHistoryDisabled.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/junit/SkipWhenSchemaHistoryDisabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Marker annotation for tests that inherently depend on the schema history (its storage, recovery, or the
+ * schema change events emitted during a schema snapshot). Such tests are skipped when the testsuite runs
+ * with the binlog-metadata-based schema mode enabled (see
+ * {@link io.debezium.connector.binlog.util.UniqueDatabase#BINLOG_METADATA_BASED_SCHEMA_PROPERTY}), where no
+ * schema history is used.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@ExtendWith(SkipTestWhenSchemaHistoryDisabledExtension.class)
+public @interface SkipWhenSchemaHistoryDisabled {
+
+    /**
+     * Returns the reason why the test depends on the schema history.
+     */
+    String reason() default "";
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -190,6 +190,27 @@ class BinlogMetadataTableBuilderTest {
     }
 
     @Test
+    void shouldResolveSpatialSubtypesFromGeometryTypeMetadata() {
+        // GEOMETRY_TYPE metadata carries the real spatial type of every geometry column.
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of("g_point", "g_geom", "g_poly"));
+        meta.setGeometryTypes(List.of(1, 0, 3));
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("spatial");
+        data.setColumnTypes(new byte[]{ (byte) 255, (byte) 255, (byte) 255 });
+        data.setColumnMetadata(new int[]{ 4, 4, 4 });
+        data.setColumnNullability(new BitSet());
+        data.setEventMetadata(meta);
+
+        final Table table = builder.build(TableId.parse("test.spatial"), data);
+        assertThat(table.columnWithName("g_point").typeName()).isEqualTo("POINT");
+        assertThat(table.columnWithName("g_geom").typeName()).isEqualTo("GEOMETRY");
+        assertThat(table.columnWithName("g_poly").typeName()).isEqualTo("POLYGON");
+    }
+
+    @Test
     void shouldFailWhenMetadataMissing() {
         final TableMapEventData data = new TableMapEventData();
         data.setDatabase("test");

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Types;
 import java.util.BitSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -178,6 +179,8 @@ class BinlogMetadataTableBuilderTest {
     void shouldMapVectorColumn() {
         final TableMapEventMetadata meta = new TableMapEventMetadata();
         meta.setColumnNames(List.of("v"));
+        // VECTOR_DIMENSIONALITY carries the dimensionality of every vector column.
+        meta.setVectorDimensionality(List.of(1536));
 
         final TableMapEventData data = new TableMapEventData();
         data.setDatabase("test");
@@ -190,6 +193,71 @@ class BinlogMetadataTableBuilderTest {
         final Table table = builder.build(TableId.parse("test.vec"), data);
         assertThat(table.columnWithName("v").typeName()).isEqualTo("VECTOR");
         assertThat(table.columnWithName("v").jdbcType()).isEqualTo(Types.OTHER);
+        assertThat(table.columnWithName("v").length()).isEqualTo(1536);
+    }
+
+    @Test
+    void shouldResolveEnumAndSetCharsetsFromDedicatedFields() {
+        // ENUM and SET columns are excluded from the DEFAULT_CHARSET/COLUMN_CHARSET numbering (the
+        // server tests the real type; see is_character_type() in MySQL sql/log_event.cc) and take
+        // their charset from the ENUM_AND_SET_* fields. An ENUM in front of the string columns must
+        // therefore not shift the explicit per-column charset list.
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of("status", "name_latin1", "note_utf8"));
+        meta.setEnumStrValues(List.<String[]> of(new String[]{ "A", "B" }));
+        // COLUMN_CHARSET indexed over the string columns only: latin1(8), utf8mb4(255).
+        meta.setColumnCharsets(List.of(8, 255));
+        final DefaultCharset enumAndSetCharset = new DefaultCharset();
+        enumAndSetCharset.setDefaultCharsetCollation(255);
+        meta.setEnumAndSetDefaultCharset(enumAndSetCharset);
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("charset_mix");
+        // status is transported as STRING(254) with the ENUM real type packed into the metadata.
+        data.setColumnTypes(new byte[]{ (byte) 254, 15, 15 });
+        data.setColumnMetadata(new int[]{ (247 << 8) | 1, 100, 200 });
+        data.setColumnNullability(new BitSet());
+        data.setEventMetadata(meta);
+
+        final Table table = builder.build(TableId.parse("test.charset_mix"), data);
+
+        final Column status = table.columnWithName("status");
+        assertThat(status.typeName()).isEqualTo("ENUM");
+        assertThat(status.charsetName()).isEqualTo("utf8mb4");
+
+        final Column nameLatin1 = table.columnWithName("name_latin1");
+        assertThat(nameLatin1.charsetName()).isEqualTo("latin1");
+        assertThat(nameLatin1.length()).isEqualTo(100);
+
+        final Column noteUtf8 = table.columnWithName("note_utf8");
+        assertThat(noteUtf8.charsetName()).isEqualTo("utf8mb4");
+        assertThat(noteUtf8.length()).isEqualTo(50); // 200 bytes / 4 (utf8mb4)
+    }
+
+    @Test
+    void shouldReconstructPrefixedPrimaryKey() {
+        // When any key part uses a prefix, the server writes PRIMARY_KEY_WITH_PREFIX instead of
+        // SIMPLE_PRIMARY_KEY (see Table_map_log_event::init_primary_key_field() in sql/log_event.cc).
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of("code", "qty"));
+        final Map<Integer, Integer> prefixPk = new LinkedHashMap<>();
+        prefixPk.put(0, 5);
+        meta.setPrimaryKeysWithPrefix(prefixPk);
+        final DefaultCharset defaultCharset = new DefaultCharset();
+        defaultCharset.setDefaultCharsetCollation(255);
+        meta.setDefaultCharset(defaultCharset);
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("prefix_pk");
+        data.setColumnTypes(new byte[]{ 15, 3 });
+        data.setColumnMetadata(new int[]{ 256, 0 });
+        data.setColumnNullability(new BitSet());
+        data.setEventMetadata(meta);
+
+        final Table table = builder.build(TableId.parse("test.prefix_pk"), data);
+        assertThat(table.primaryKeyColumnNames()).containsExactly("code");
     }
 
     @Test

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -127,10 +127,13 @@ class BinlogMetadataTableBuilderTest {
         assertThat(status.typeName()).isEqualTo("ENUM");
         assertThat(status.jdbcType()).isEqualTo(Types.CHAR);
         assertThat(status.enumValues()).containsExactly("NEW", "OK", "ERR");
+        // The DDL parser assigns ENUM columns length 1 and SET columns options + commas.
+        assertThat(status.length()).isEqualTo(1);
 
         final Column tags = table.columnWithName("tags");
         assertThat(tags.typeName()).isEqualTo("SET");
         assertThat(tags.enumValues()).containsExactly("a", "b", "c");
+        assertThat(tags.length()).isEqualTo(5);
 
         final Column flags = table.columnWithName("flags");
         assertThat(flags.typeName()).isEqualTo("BIT");

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -172,6 +172,24 @@ class BinlogMetadataTableBuilderTest {
     }
 
     @Test
+    void shouldMapVectorColumn() {
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of("v"));
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("vec");
+        data.setColumnTypes(new byte[]{ (byte) 242 });
+        data.setColumnMetadata(new int[]{ 4 });
+        data.setColumnNullability(new BitSet());
+        data.setEventMetadata(meta);
+
+        final Table table = builder.build(TableId.parse("test.vec"), data);
+        assertThat(table.columnWithName("v").typeName()).isEqualTo("VECTOR");
+        assertThat(table.columnWithName("v").jdbcType()).isEqualTo(Types.OTHER);
+    }
+
+    @Test
     void shouldFailWhenMetadataMissing() {
         final TableMapEventData data = new TableMapEventData();
         data.setDatabase("test");

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Types;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata.DefaultCharset;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+/**
+ * Unit test for {@link BinlogMetadataTableBuilder}, seeded with the exact FULL {@code TABLE_MAP}
+ * metadata values captured from a real MySQL/Percona 8.0.35 server (see
+ * {@code .experiment/dbz978/tablemap-groundtruth.md}). Asserts the reconstructed {@link Table}
+ * matches the source {@code types_demo} DDL.
+ */
+class BinlogMetadataTableBuilderTest {
+
+    private final BinlogMetadataTableBuilder builder = new BinlogMetadataTableBuilder();
+
+    /**
+     * Builds a TABLE_MAP event equivalent to:
+     *
+     * <pre>
+     * CREATE TABLE types_demo (
+     *   id INT NOT NULL, big_u BIGINT UNSIGNED, small_s SMALLINT, is_active TINYINT(1),
+     *   price DECIMAL(12,3), ratio DOUBLE, name VARCHAR(64) utf8mb4, code CHAR(4) NOT NULL,
+     *   raw_b BINARY(8), descr TEXT, blob_c BLOB, status ENUM('NEW','OK','ERR'),
+     *   tags SET('a','b','c'), flags BIT(5), created_at DATETIME(3), ts TIMESTAMP(6),
+     *   d DATE, doc JSON, PRIMARY KEY (id, code));
+     * </pre>
+     */
+    private TableMapEventData typesDemoTableMap() {
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of(
+                "id", "big_u", "small_s", "is_active", "price", "ratio", "name", "code",
+                "raw_b", "descr", "blob_c", "status", "tags", "flags", "created_at", "ts", "d", "doc"));
+        // signedness is indexed over numeric columns only: id,big_u,small_s,is_active,price,ratio -> bit 1 (big_u) unsigned
+        final BitSet signedness = new BitSet();
+        signedness.set(1);
+        meta.setSignedness(signedness);
+        // default charset utf8mb4 (255), with binary (63) overrides for the character-column indices of raw_b (2) and blob_c (4)
+        final DefaultCharset defaultCharset = new DefaultCharset();
+        defaultCharset.setDefaultCharsetCollation(255);
+        defaultCharset.setCharsetCollations(Map.of(2, 63, 4, 63));
+        meta.setDefaultCharset(defaultCharset);
+        meta.setEnumStrValues(List.<String[]> of(new String[]{ "NEW", "OK", "ERR" }));
+        meta.setSetStrValues(List.<String[]> of(new String[]{ "a", "b", "c" }));
+        meta.setSimplePrimaryKeys(List.of(0, 7));
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("types_demo");
+        data.setColumnTypes(new byte[]{
+                3, 8, 2, 1, (byte) 246, 5, 15, (byte) 254, (byte) 254, (byte) 252,
+                (byte) 252, (byte) 254, (byte) 254, 16, 18, 17, 10, (byte) 245 });
+        data.setColumnMetadata(new int[]{
+                0, 0, 0, 0, 780, 8, 256, 65040, 65032, 2, 2, 63233, 63489, 5, 3, 6, 0, 4 });
+        // nullable = all except id(0) and code(7)
+        final BitSet nullability = new BitSet();
+        for (int i = 0; i < 18; i++) {
+            if (i != 0 && i != 7) {
+                nullability.set(i);
+            }
+        }
+        data.setColumnNullability(nullability);
+        data.setEventMetadata(meta);
+        return data;
+    }
+
+    @Test
+    void shouldReconstructTableFromFullMetadata() {
+        final Table table = builder.build(TableId.parse("test.types_demo"), typesDemoTableMap());
+
+        assertThat(table.columns()).hasSize(18);
+        assertThat(table.primaryKeyColumnNames()).containsExactly("id", "code");
+
+        assertColumn(table, "id", "INT", Types.INTEGER, false);
+        assertColumn(table, "big_u", "BIGINT UNSIGNED", Types.BIGINT, true);
+        assertColumn(table, "small_s", "SMALLINT", Types.SMALLINT, true);
+        assertColumn(table, "is_active", "TINYINT", Types.SMALLINT, true);
+
+        final Column price = table.columnWithName("price");
+        assertThat(price.typeName()).isEqualTo("DECIMAL");
+        assertThat(price.jdbcType()).isEqualTo(Types.DECIMAL);
+        assertThat(price.length()).isEqualTo(12);
+        assertThat(price.scale()).contains(3);
+
+        assertColumn(table, "ratio", "DOUBLE", Types.DOUBLE, true);
+
+        final Column name = table.columnWithName("name");
+        assertThat(name.typeName()).isEqualTo("VARCHAR");
+        assertThat(name.jdbcType()).isEqualTo(Types.VARCHAR);
+        assertThat(name.length()).isEqualTo(64); // 256 bytes / 4 (utf8mb4)
+        assertThat(name.charsetName()).isEqualTo("utf8mb4");
+
+        final Column code = table.columnWithName("code");
+        assertThat(code.typeName()).isEqualTo("CHAR");
+        assertThat(code.jdbcType()).isEqualTo(Types.CHAR);
+        assertThat(code.length()).isEqualTo(4);
+        assertThat(code.isOptional()).isFalse();
+
+        final Column rawB = table.columnWithName("raw_b");
+        assertThat(rawB.typeName()).isEqualTo("BINARY");
+        assertThat(rawB.jdbcType()).isEqualTo(Types.BINARY);
+        assertThat(rawB.length()).isEqualTo(8);
+
+        assertColumn(table, "descr", "TEXT", Types.VARCHAR, true);
+        assertColumn(table, "blob_c", "BLOB", Types.BLOB, true);
+
+        final Column status = table.columnWithName("status");
+        assertThat(status.typeName()).isEqualTo("ENUM");
+        assertThat(status.jdbcType()).isEqualTo(Types.CHAR);
+        assertThat(status.enumValues()).containsExactly("NEW", "OK", "ERR");
+
+        final Column tags = table.columnWithName("tags");
+        assertThat(tags.typeName()).isEqualTo("SET");
+        assertThat(tags.enumValues()).containsExactly("a", "b", "c");
+
+        final Column flags = table.columnWithName("flags");
+        assertThat(flags.typeName()).isEqualTo("BIT");
+        assertThat(flags.jdbcType()).isEqualTo(Types.BIT);
+        assertThat(flags.length()).isEqualTo(5);
+
+        final Column createdAt = table.columnWithName("created_at");
+        assertThat(createdAt.typeName()).isEqualTo("DATETIME");
+        assertThat(createdAt.jdbcType()).isEqualTo(Types.TIMESTAMP);
+        assertThat(createdAt.length()).isEqualTo(3);
+
+        final Column ts = table.columnWithName("ts");
+        assertThat(ts.typeName()).isEqualTo("TIMESTAMP");
+        assertThat(ts.jdbcType()).isEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
+        assertThat(ts.length()).isEqualTo(6);
+
+        assertColumn(table, "d", "DATE", Types.DATE, true);
+        assertColumn(table, "doc", "JSON", Types.OTHER, true);
+    }
+
+    @Test
+    void shouldFailWhenMetadataMissing() {
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("no_meta");
+        data.setColumnTypes(new byte[]{ 3 });
+        data.setColumnMetadata(new int[]{ 0 });
+        data.setColumnNullability(new BitSet());
+        // no event metadata (MINIMAL) -> must fail fast
+        assertThatThrownBy(() -> builder.build(TableId.parse("test.no_meta"), data))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("binlog_row_metadata=FULL");
+    }
+
+    private void assertColumn(Table table, String name, String typeName, int jdbcType, boolean optional) {
+        final Column c = table.columnWithName(name);
+        assertThat(c).as("column %s exists", name).isNotNull();
+        assertThat(c.typeName()).as("%s typeName", name).isEqualTo(typeName);
+        assertThat(c.jdbcType()).as("%s jdbcType", name).isEqualTo(jdbcType);
+        assertThat(c.isOptional()).as("%s optional", name).isEqualTo(optional);
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -152,6 +152,26 @@ class BinlogMetadataTableBuilderTest {
     }
 
     @Test
+    void shouldDecodeBitLengthFromPackedMetadata() {
+        // BIT metadata is (bytes << 8) | remaining_bits: BIT(2)=2, BIT(8)=0x0100, BIT(64)=0x0800.
+        final TableMapEventMetadata meta = new TableMapEventMetadata();
+        meta.setColumnNames(List.of("b2", "b8", "b64"));
+
+        final TableMapEventData data = new TableMapEventData();
+        data.setDatabase("test");
+        data.setTable("bits");
+        data.setColumnTypes(new byte[]{ 16, 16, 16 });
+        data.setColumnMetadata(new int[]{ 2, 256, 2048 });
+        data.setColumnNullability(new BitSet());
+        data.setEventMetadata(meta);
+
+        final Table table = builder.build(TableId.parse("test.bits"), data);
+        assertThat(table.columnWithName("b2").length()).isEqualTo(2);
+        assertThat(table.columnWithName("b8").length()).isEqualTo(8);
+        assertThat(table.columnWithName("b64").length()).isEqualTo(64);
+    }
+
+    @Test
     void shouldFailWhenMetadataMissing() {
         final TableMapEventData data = new TableMapEventData();
         data.setDatabase("test");

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/metadata/BinlogMetadataTableBuilderTest.java
@@ -94,7 +94,7 @@ class BinlogMetadataTableBuilderTest {
         assertColumn(table, "id", "INT", Types.INTEGER, false);
         assertColumn(table, "big_u", "BIGINT UNSIGNED", Types.BIGINT, true);
         assertColumn(table, "small_s", "SMALLINT", Types.SMALLINT, true);
-        assertColumn(table, "is_active", "TINYINT", Types.SMALLINT, true);
+        assertColumn(table, "is_active", "TINYINT", Types.TINYINT, true);
 
         final Column price = table.columnWithName("price");
         assertThat(price.typeName()).isEqualTo("DECIMAL");

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/UniqueDatabase.java
@@ -47,6 +47,14 @@ import io.debezium.storage.file.history.FileSchemaHistory;
  */
 public abstract class UniqueDatabase {
 
+    /**
+     * System property that, when set to {@code true}, runs the testsuite with the binlog-metadata-based
+     * schema mode ({@link BinlogConnectorConfig#BINLOG_METADATA_BASED_SCHEMA}) enabled for every connector
+     * configuration built through this class, so the whole suite can be executed either with or without a
+     * schema history.
+     */
+    public static final String BINLOG_METADATA_BASED_SCHEMA_PROPERTY = "use.binlog.metadata.based.schema";
+
     private static final String DEFAULT_DATABASE = "mysql";
     private static final String[] CREATE_DATABASE_DDL = new String[]{
             "CREATE DATABASE `$DBNAME$`;",
@@ -140,6 +148,25 @@ public abstract class UniqueDatabase {
     }
 
     /**
+     * @return true when the testsuite runs with the binlog-metadata-based schema mode enabled
+     *         (see {@link #BINLOG_METADATA_BASED_SCHEMA_PROPERTY})
+     */
+    public static boolean isBinlogMetadataBasedSchemaTestsuite() {
+        return Boolean.getBoolean(BINLOG_METADATA_BASED_SCHEMA_PROPERTY);
+    }
+
+    /**
+     * The binlog-metadata-based schema mode requires {@code binlog_row_metadata=FULL}. The variable is
+     * dynamic, so enable it before the test tables are created; their {@code TABLE_MAP} events then always
+     * carry the FULL metadata.
+     */
+    private static void ensureFullBinlogRowMetadata(JdbcConnection connection) throws Exception {
+        if (isBinlogMetadataBasedSchemaTestsuite()) {
+            connection.execute("SET GLOBAL binlog_row_metadata = 'FULL'");
+        }
+    }
+
+    /**
      * Creates the database and populates it with initialization SQL script. To use multiline
      * statements for stored procedures definition use delimiter $$ to delimit statements in the procedure.
      * See fnDbz162 procedure in reqression_test.sql for example of usage.
@@ -161,6 +188,7 @@ public abstract class UniqueDatabase {
         assertNotNull(ddlTestFile, "Cannot locate " + ddlFile);
         try {
             try (JdbcConnection connection = forTestDatabase(DEFAULT_DATABASE, urlProperties)) {
+                ensureFullBinlogRowMetadata(connection);
                 final List<String> statements = readFileContents(ddlTestFile.toURI(), (data) -> Arrays.stream(
                         Stream.concat(
                                 Arrays.stream(charset != null ? CREATE_DATABASE_WITH_CHARSET_DDL : CREATE_DATABASE_DDL),
@@ -185,6 +213,7 @@ public abstract class UniqueDatabase {
 
     public void create(Map<String, Object> urlProperties) {
         try (JdbcConnection connection = forTestDatabase(DEFAULT_DATABASE, urlProperties)) {
+            ensureFullBinlogRowMetadata(connection);
             String[] ddl = charset != null ? CREATE_DATABASE_WITH_CHARSET_DDL : CREATE_DATABASE_DDL;
 
             String[] statements = Arrays.stream(ddl)
@@ -213,6 +242,7 @@ public abstract class UniqueDatabase {
         final URL ddlTestFile = UniqueDatabase.class.getClassLoader().getResource(ddlFile);
         assertNotNull(ddlTestFile, "Cannot locate " + ddlFile);
         try (JdbcConnection connection = forTestDatabase(DEFAULT_DATABASE, urlProperties)) {
+            ensureFullBinlogRowMetadata(connection);
             final List<String> statements = readFileContents(ddlTestFile.toURI(), (data) -> Arrays.stream(
                     Stream.concat(
                             Arrays.stream(new String[]{ "USE `$DBNAME$`;" }),
@@ -316,12 +346,19 @@ public abstract class UniqueDatabase {
      * database not filtered by default
      */
     public Configuration.Builder defaultConfigWithoutDatabaseFilter() {
-        return defaultJdbcConfigBuilder()
+        final Builder builder = defaultJdbcConfigBuilder()
                 .with(BinlogConnectorConfig.SERVER_ID, 18765)
                 .with(BinlogConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(BinlogConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
                 .with(BinlogConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER, 10_000)
                 .with(CommonConnectorConfig.TOPIC_PREFIX, getServerName());
+        if (isBinlogMetadataBasedSchemaTestsuite()) {
+            // Run the testsuite with the schema reconstructed from the binlog TABLE_MAP metadata instead
+            // of from the schema history, so that the suite verifies both modes are compatible. The schema
+            // history configured above is ignored by the connector in this mode.
+            builder.with(BinlogConnectorConfig.BINLOG_METADATA_BASED_SCHEMA, true);
+        }
+        return builder;
     }
 
     /**

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -956,6 +956,85 @@
             </build>
         </profile>
 
+        <!-- Runs the same testsuite as mariadb-ci, but with the binlog-metadata-based schema mode enabled,
+             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <profile>
+            <id>mariadb-ci-binlog-metadata</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <docker.dbs>debezium/mariadb-server-test-database</docker.dbs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.debezium</groupId>
+                                <artifactId>debezium-assembly-descriptors</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
+                                    <descriptorRefs>
+                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
+                                    </descriptorRefs>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${version.failsafe.plugin}</version>
+                        <configuration>
+                            <skipTests>${skipITs}</skipTests>
+                            <enableAssertions>true</enableAssertions>
+                            <systemPropertyVariables>
+                                <!-- Make these available to the tests via system properties -->
+                                <database.hostname>${docker.host.address}</database.hostname>
+                                <database.user>${mariadb.user}</database.user>
+                                <database.password>${mariadb.password}</database.password>
+                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
+                                <database.replica.user>${mariadb.replica.user}</database.replica.user>
+                                <database.replica.password>${mariadb.replica.password}</database.replica.password>
+                                <database.port>${mariadb.port}</database.port>
+                                <database.replica.port>${mariadb.port}</database.replica.port>
+                                <database.ssl.mode>disable</database.ssl.mode>
+                                <!-- Specifies which driver to use for the tests -->
+                                <skipLongRunningTests>false</skipLongRunningTests>
+                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
+                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
+                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mariadb-binlog-metadata</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Runs tests only with GTID setup -->
         <profile>
             <id>mariadb-ci-gtids</id>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -214,6 +214,10 @@
         <docker.skip>false</docker.skip>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/Pacific/Samoa /etc/localtime</docker.initimage>
 
+        <!-- Toggled to true by the mariadb-feature-binlog-metadata profile to run the testsuite with the
+             binlog-metadata-based schema mode, i.e. without a schema history (debezium/dbz#978) -->
+        <use.binlog.metadata.based.schema>false</use.binlog.metadata.based.schema>
+
         <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
@@ -529,6 +533,7 @@
                         <!-- Specifies which driver to use for the tests -->
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                         <database.ssl.mode>disable</database.ssl.mode>
+                        <use.binlog.metadata.based.schema>${use.binlog.metadata.based.schema}</use.binlog.metadata.based.schema>
                     </systemPropertyVariables>
                     <argLine>-javaagent:"${settings.localRepository}/@{opentelemetry.agent.for.testing.artifact.relative.path}" -Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=off</argLine>
                     <runOrder>${runOrder}</runOrder>
@@ -956,83 +961,17 @@
             </build>
         </profile>
 
-        <!-- Runs the same testsuite as mariadb-ci, but with the binlog-metadata-based schema mode enabled,
-             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <!-- Feature toggle meant to be combined with a mariadb-ci* profile: enables the binlog-metadata-based
+             schema mode so the same testsuite runs without a schema history (debezium/dbz#978),
+             e.g. -P mariadb-ci,mariadb-feature-binlog-metadata -->
         <profile>
-            <id>mariadb-ci-binlog-metadata</id>
+            <id>mariadb-feature-binlog-metadata</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <docker.dbs>debezium/mariadb-server-test-database</docker.dbs>
+                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.debezium</groupId>
-                                <artifactId>debezium-assembly-descriptors</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <finalName>${project.artifactId}-${project.version}</finalName>
-                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
-                                    <descriptorRefs>
-                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
-                                    </descriptorRefs>
-                                    <tarLongFileMode>posix</tarLongFileMode>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                        <configuration>
-                            <skipTests>${skipITs}</skipTests>
-                            <enableAssertions>true</enableAssertions>
-                            <systemPropertyVariables>
-                                <!-- Make these available to the tests via system properties -->
-                                <database.hostname>${docker.host.address}</database.hostname>
-                                <database.user>${mariadb.user}</database.user>
-                                <database.password>${mariadb.password}</database.password>
-                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
-                                <database.replica.user>${mariadb.replica.user}</database.replica.user>
-                                <database.replica.password>${mariadb.replica.password}</database.replica.password>
-                                <database.port>${mariadb.port}</database.port>
-                                <database.replica.port>${mariadb.port}</database.replica.port>
-                                <database.ssl.mode>disable</database.ssl.mode>
-                                <!-- Specifies which driver to use for the tests -->
-                                <skipLongRunningTests>false</skipLongRunningTests>
-                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
-                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
-                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
-                            </systemPropertyVariables>
-                            <runOrder>${runOrder}</runOrder>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test-mariadb-binlog-metadata</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <!-- Runs tests only with GTID setup -->

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -216,6 +216,10 @@
         <docker.skip>false</docker.skip>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/Pacific/Samoa /etc/localtime</docker.initimage>
 
+        <!-- Toggled to true by the mariadb-feature-binlog-metadata profile to run the testsuite with the
+             binlog-metadata-based schema mode, i.e. without a schema history (debezium/dbz#978) -->
+        <use.binlog.metadata.based.schema>false</use.binlog.metadata.based.schema>
+
         <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
@@ -585,6 +589,7 @@
                         <!-- Specifies which driver to use for the tests -->
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                         <database.ssl.mode>disable</database.ssl.mode>
+                        <use.binlog.metadata.based.schema>${use.binlog.metadata.based.schema}</use.binlog.metadata.based.schema>
                     </systemPropertyVariables>
                     <argLine>-javaagent:"${settings.localRepository}/@{opentelemetry.agent.for.testing.artifact.relative.path}" -Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=off</argLine>
                     <runOrder>${runOrder}</runOrder>
@@ -1045,83 +1050,17 @@
             </build>
         </profile>
 
-        <!-- Runs the same testsuite as mariadb-ci, but with the binlog-metadata-based schema mode enabled,
-             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <!-- Feature toggle meant to be combined with a mariadb-ci* profile: enables the binlog-metadata-based
+             schema mode so the same testsuite runs without a schema history (debezium/dbz#978),
+             e.g. -P mariadb-ci,mariadb-feature-binlog-metadata -->
         <profile>
-            <id>mariadb-ci-binlog-metadata</id>
+            <id>mariadb-feature-binlog-metadata</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <docker.dbs>debezium/mariadb-server-test-database</docker.dbs>
+                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.debezium</groupId>
-                                <artifactId>debezium-assembly-descriptors</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <finalName>${project.artifactId}-${project.version}</finalName>
-                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
-                                    <descriptorRefs>
-                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
-                                    </descriptorRefs>
-                                    <tarLongFileMode>posix</tarLongFileMode>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                        <configuration>
-                            <skipTests>${skipITs}</skipTests>
-                            <enableAssertions>true</enableAssertions>
-                            <systemPropertyVariables>
-                                <!-- Make these available to the tests via system properties -->
-                                <database.hostname>${docker.host.address}</database.hostname>
-                                <database.user>${mariadb.user}</database.user>
-                                <database.password>${mariadb.password}</database.password>
-                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
-                                <database.replica.user>${mariadb.replica.user}</database.replica.user>
-                                <database.replica.password>${mariadb.replica.password}</database.replica.password>
-                                <database.port>${mariadb.port}</database.port>
-                                <database.replica.port>${mariadb.port}</database.replica.port>
-                                <database.ssl.mode>disable</database.ssl.mode>
-                                <!-- Specifies which driver to use for the tests -->
-                                <skipLongRunningTests>false</skipLongRunningTests>
-                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
-                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
-                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
-                            </systemPropertyVariables>
-                            <runOrder>${runOrder}</runOrder>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test-mariadb-binlog-metadata</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <!-- Runs tests only with GTID setup -->

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -1045,6 +1045,85 @@
             </build>
         </profile>
 
+        <!-- Runs the same testsuite as mariadb-ci, but with the binlog-metadata-based schema mode enabled,
+             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <profile>
+            <id>mariadb-ci-binlog-metadata</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <docker.dbs>debezium/mariadb-server-test-database</docker.dbs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.debezium</groupId>
+                                <artifactId>debezium-assembly-descriptors</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
+                                    <descriptorRefs>
+                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
+                                    </descriptorRefs>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${version.failsafe.plugin}</version>
+                        <configuration>
+                            <skipTests>${skipITs}</skipTests>
+                            <enableAssertions>true</enableAssertions>
+                            <systemPropertyVariables>
+                                <!-- Make these available to the tests via system properties -->
+                                <database.hostname>${docker.host.address}</database.hostname>
+                                <database.user>${mariadb.user}</database.user>
+                                <database.password>${mariadb.password}</database.password>
+                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
+                                <database.replica.user>${mariadb.replica.user}</database.replica.user>
+                                <database.replica.password>${mariadb.replica.password}</database.replica.password>
+                                <database.port>${mariadb.port}</database.port>
+                                <database.replica.port>${mariadb.port}</database.replica.port>
+                                <database.ssl.mode>disable</database.ssl.mode>
+                                <!-- Specifies which driver to use for the tests -->
+                                <skipLongRunningTests>false</skipLongRunningTests>
+                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
+                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
+                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mariadb-binlog-metadata</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Runs tests only with GTID setup -->
         <profile>
             <id>mariadb-ci-gtids</id>

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
@@ -146,7 +146,7 @@ public class MariaDbConnectorTask extends BinlogSourceTask<MariaDbPartition, Mar
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);
         final Snapshotter snapshotter = snapshotterService.getSnapshotter();
 
-        validateBinlogConfiguration(snapshotter, connection);
+        validateBinlogConfiguration(snapshotter, connection, connectorConfig);
 
         // If the binlog position is not available, it is necessary to re-execute the snapshot
         if (validateSnapshotFeasibility(snapshotter, previousOffsets.getTheOnlyOffset(), connection)) {

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
@@ -40,12 +40,14 @@ public class MariaDbDatabaseSchema extends BinlogDatabaseSchema<MariaDbPartition
 
     @Override
     protected DdlParser createDdlParser(BinlogConnectorConfig connectorConfig, MariaDbValueConverters valueConverter) {
-        return new MariaDbAntlrDdlParser(
+        MariaDbAntlrDdlParser parser = new MariaDbAntlrDdlParser(
                 true,
                 false,
                 connectorConfig.isSchemaChangesHistoryEnabled(),
                 getTableFilter(),
                 connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+        parser.setEmitChangesForMissingAlteredTables(connectorConfig.isBinlogMetadataBasedSchema());
+        return parser;
     }
 
 }

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/listener/AlterTableParserListener.java
@@ -13,8 +13,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.ParseTreeListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.mariadb.antlr.MariaDbAntlrDdlParser;
 import io.debezium.ddl.parser.mariadb.generated.MariaDBParser;
@@ -32,8 +30,6 @@ public class AlterTableParserListener extends TableCommonParserListener {
 
     private static final int STARTING_INDEX = 1;
 
-    private final static Logger LOG = LoggerFactory.getLogger(AlterTableParserListener.class);
-
     private ColumnEditor defaultValueColumnEditor;
     private DefaultValueParserListener defaultValueListener;
 
@@ -47,18 +43,7 @@ public class AlterTableParserListener extends TableCommonParserListener {
     @Override
     public void enterAlterTable(MariaDBParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableName().fullId());
-        if (parser.databaseTables().forTable(tableId) == null) {
-            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
-                // The table is captured but not yet part of the in-memory model, e.g. when the schema
-                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
-                // the table since the restart. Signal the event without applying the statement, so
-                // that the schema change is still emitted; the schema itself is restored by the next
-                // TABLE_MAP event.
-                parser.signalAlterTable(tableId, null, ctx);
-            }
-            else {
-                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
-            }
+        if (parser.handleAlterTableIfTableIsMissing(tableId, ctx, parser.getTableFilter())) {
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/listener/AlterTableParserListener.java
@@ -48,7 +48,17 @@ public class AlterTableParserListener extends TableCommonParserListener {
     public void enterAlterTable(MariaDBParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableName().fullId());
         if (parser.databaseTables().forTable(tableId) == null) {
-            LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
+                // The table is captured but not yet part of the in-memory model, e.g. when the schema
+                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
+                // the table since the restart. Signal the event without applying the statement, so
+                // that the schema change is still emitted; the schema itself is restored by the next
+                // TABLE_MAP event.
+                parser.signalAlterTable(tableId, null, ctx);
+            }
+            else {
+                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            }
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbBinlogMetadataSchemaIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbBinlogMetadataSchemaIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import io.debezium.connector.binlog.BinlogMetadataBasedSchemaIT;
+
+/**
+ * MariaDB integration test for the binlog-metadata-based schema mode (debezium/dbz#978). MariaDB 10.5+
+ * exposes {@code binlog_row_metadata} and emits the same FULL {@code TABLE_MAP} metadata as MySQL 8.0+,
+ * so the shared logic applies unchanged.
+ */
+public class MariaDbBinlogMetadataSchemaIT extends BinlogMetadataBasedSchemaIT<MariaDbConnector> implements MariaDbCommon {
+
+}

--- a/debezium-connector-mariadb/src/test/resources/ddl/binlog_metadata_schema.sql
+++ b/debezium-connector-mariadb/src/test/resources/ddl/binlog_metadata_schema.sql
@@ -1,0 +1,55 @@
+-- Table used by BinlogMetadataBasedSchemaIT (MySQL and MariaDB) to verify that the streaming schema
+-- can be reconstructed purely from binlog TABLE_MAP metadata (binlog_row_metadata=FULL), without
+-- relying on a persisted schema history topic. Rows are inserted at runtime by the test.
+CREATE TABLE orders (
+  id INT NOT NULL AUTO_INCREMENT,
+  quantity BIGINT UNSIGNED,
+  status ENUM('NEW','SHIPPED','CANCELLED') NOT NULL DEFAULT 'NEW',
+  price DECIMAL(12,3),
+  code CHAR(4) NOT NULL,
+  note VARCHAR(64),
+  created_at DATETIME(3),
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;
+
+-- Broad data-type coverage: every column type must be reconstructed from TABLE_MAP metadata and the
+-- row must decode without error. Types available on both MySQL 8.0+ and MariaDB 10.5+.
+CREATE TABLE all_types (
+  id            INT NOT NULL AUTO_INCREMENT,
+  c_tinyint     TINYINT,
+  c_tinyint_u   TINYINT UNSIGNED,
+  c_bool        TINYINT(1),
+  c_smallint    SMALLINT,
+  c_smallint_u  SMALLINT UNSIGNED,
+  c_mediumint   MEDIUMINT,
+  c_mediumint_u MEDIUMINT UNSIGNED,
+  c_int         INT,
+  c_int_u       INT UNSIGNED,
+  c_bigint      BIGINT,
+  c_bigint_u    BIGINT UNSIGNED,
+  c_decimal     DECIMAL(12,3),
+  c_float       FLOAT,
+  c_double      DOUBLE,
+  c_bit         BIT(5),
+  c_date        DATE,
+  c_datetime    DATETIME(3),
+  c_timestamp   TIMESTAMP(6) NULL,
+  c_time        TIME(3),
+  c_year        YEAR,
+  c_char        CHAR(4),
+  c_varchar     VARCHAR(64),
+  c_binary      BINARY(8),
+  c_varbinary   VARBINARY(32),
+  c_tinytext    TINYTEXT,
+  c_text        TEXT,
+  c_mediumtext  MEDIUMTEXT,
+  c_longtext    LONGTEXT,
+  c_tinyblob    TINYBLOB,
+  c_blob        BLOB,
+  c_mediumblob  MEDIUMBLOB,
+  c_longblob    LONGBLOB,
+  c_enum        ENUM('NEW','OK','ERR') NOT NULL DEFAULT 'NEW',
+  c_set         SET('a','b','c'),
+  c_json        JSON,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;

--- a/debezium-connector-mariadb/src/test/resources/ddl/binlog_metadata_schema.sql
+++ b/debezium-connector-mariadb/src/test/resources/ddl/binlog_metadata_schema.sql
@@ -53,3 +53,22 @@ CREATE TABLE all_types (
   c_json        JSON,
   PRIMARY KEY (id)
 ) DEFAULT CHARSET=utf8mb4;
+
+-- Mixed-charset table with the ENUM in front of the string columns: the ENUM takes its charset from
+-- the ENUM_AND_SET_* metadata fields and must not shift the per-column charset numbering of the
+-- string columns that follow it.
+CREATE TABLE charset_mix (
+  id INT NOT NULL AUTO_INCREMENT,
+  status ENUM('NEW','DONE') NOT NULL,
+  name_latin1 VARCHAR(80) CHARACTER SET latin1,
+  note_utf8 VARCHAR(40) CHARACTER SET utf8mb4,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;
+
+-- The primary key uses a column prefix, so the server writes PRIMARY_KEY_WITH_PREFIX instead of
+-- SIMPLE_PRIMARY_KEY into the TABLE_MAP metadata.
+CREATE TABLE prefix_pk (
+  code VARCHAR(64) NOT NULL,
+  qty INT,
+  PRIMARY KEY (code(5))
+) DEFAULT CHARSET=utf8mb4;

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -1104,6 +1104,87 @@
             </build>
         </profile>
 
+        <!-- Runs the same testsuite as mysql-ci, but with the binlog-metadata-based schema mode enabled,
+             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <profile>
+            <id>mysql-ci-binlog-metadata</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <docker.dbs>debezium/mysql-server-test-database</docker.dbs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.debezium</groupId>
+                                <artifactId>debezium-assembly-descriptors</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
+                                    <descriptorRefs>
+                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
+                                    </descriptorRefs>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${version.failsafe.plugin}</version>
+                        <configuration>
+                            <skipTests>${skipITs}</skipTests>
+                            <enableAssertions>true</enableAssertions>
+                            <systemPropertyVariables>
+                                <!-- Make these available to the tests via system properties -->
+                                <database.hostname>${docker.host.address}</database.hostname>
+                                <database.user>${mysql.user}</database.user>
+                                <database.password>${mysql.password}</database.password>
+                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
+                                <database.replica.user>${mysql.replica.user}</database.replica.user>
+                                <database.replica.password>${mysql.replica.password}</database.replica.password>
+                                <database.port>${mysql.port}</database.port>
+                                <database.replica.port>${mysql.port}</database.replica.port>
+                                <database.ssl.mode>disabled</database.ssl.mode>
+                                <!-- Specifies which driver to use for the tests -->
+                                <database.protocol>${mysql.database.protocol}</database.protocol>
+                                <database.jdbc.driver>${mysql.database.jdbc.driver}</database.jdbc.driver>
+                                <skipLongRunningTests>false</skipLongRunningTests>
+                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
+                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
+                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mysql-binlog-metadata</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Runs tests only with GTID setup -->
         <profile>
             <id>mysql-ci-gtids</id>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -246,6 +246,10 @@
         <docker.platform>linux/amd64</docker.platform>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/US/Samoa /etc/localtime</docker.initimage>
 
+        <!-- Toggled to true by the mysql-feature-binlog-metadata profile to run the testsuite with the
+             binlog-metadata-based schema mode, i.e. without a schema history (debezium/dbz#978) -->
+        <use.binlog.metadata.based.schema>false</use.binlog.metadata.based.schema>
+
         <mockito.argLine>-javaagent:${org.mockito:mockito-core:jar}</mockito.argLine>
     </properties>
     <build>
@@ -613,6 +617,7 @@
                         <database.jdbc.driver>${mysql.database.jdbc.driver}</database.jdbc.driver>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                         <database.ssl.mode>disabled</database.ssl.mode>
+                        <use.binlog.metadata.based.schema>${use.binlog.metadata.based.schema}</use.binlog.metadata.based.schema>
                     </systemPropertyVariables>
                     <argLine>-javaagent:"${settings.localRepository}/@{opentelemetry.agent.for.testing.artifact.relative.path}" -Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=off</argLine>
                     <runOrder>${runOrder}</runOrder>
@@ -1104,85 +1109,17 @@
             </build>
         </profile>
 
-        <!-- Runs the same testsuite as mysql-ci, but with the binlog-metadata-based schema mode enabled,
-             so the suite is executed without a schema history (debezium/dbz#978) -->
+        <!-- Feature toggle meant to be combined with a mysql-ci* profile: enables the binlog-metadata-based
+             schema mode so the same testsuite runs without a schema history (debezium/dbz#978),
+             e.g. -P mysql-ci,mysql-feature-binlog-metadata -->
         <profile>
-            <id>mysql-ci-binlog-metadata</id>
+            <id>mysql-feature-binlog-metadata</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <docker.dbs>debezium/mysql-server-test-database</docker.dbs>
+                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.debezium</groupId>
-                                <artifactId>debezium-assembly-descriptors</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <finalName>${project.artifactId}-${project.version}</finalName>
-                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
-                                    <descriptorRefs>
-                                        <descriptorRef>${assembly.descriptor}</descriptorRef>
-                                    </descriptorRefs>
-                                    <tarLongFileMode>posix</tarLongFileMode>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                        <configuration>
-                            <skipTests>${skipITs}</skipTests>
-                            <enableAssertions>true</enableAssertions>
-                            <systemPropertyVariables>
-                                <!-- Make these available to the tests via system properties -->
-                                <database.hostname>${docker.host.address}</database.hostname>
-                                <database.user>${mysql.user}</database.user>
-                                <database.password>${mysql.password}</database.password>
-                                <database.replica.hostname>${docker.host.address}</database.replica.hostname>
-                                <database.replica.user>${mysql.replica.user}</database.replica.user>
-                                <database.replica.password>${mysql.replica.password}</database.replica.password>
-                                <database.port>${mysql.port}</database.port>
-                                <database.replica.port>${mysql.port}</database.replica.port>
-                                <database.ssl.mode>disabled</database.ssl.mode>
-                                <!-- Specifies which driver to use for the tests -->
-                                <database.protocol>${mysql.database.protocol}</database.protocol>
-                                <database.jdbc.driver>${mysql.database.jdbc.driver}</database.jdbc.driver>
-                                <skipLongRunningTests>false</skipLongRunningTests>
-                                <isAssemblyProfileActive>true</isAssemblyProfileActive>
-                                <!-- Reconstruct the streaming schema from the binlog instead of the schema history -->
-                                <use.binlog.metadata.based.schema>true</use.binlog.metadata.based.schema>
-                            </systemPropertyVariables>
-                            <runOrder>${runOrder}</runOrder>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test-mysql-binlog-metadata</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <!-- Runs tests only with GTID setup -->

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -137,7 +137,7 @@ public class MySqlConnectorTask extends BinlogSourceTask<MySqlPartition, MySqlOf
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);
         final Snapshotter snapshotter = snapshotterService.getSnapshotter();
 
-        validateBinlogConfiguration(snapshotter, connection);
+        validateBinlogConfiguration(snapshotter, connection, connectorConfig);
 
         // If the binlog position is not available it is necessary to re-execute snapshot
         if (validateSnapshotFeasibility(snapshotter, previousOffsets.getTheOnlyOffset(), connection)) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -65,21 +65,25 @@ public class MySqlDatabaseSchema extends BinlogDatabaseSchema<MySqlPartition, My
     }
 
     private DdlParser createOracleParser(BinlogConnectorConfig connectorConfig) {
-        return new MySqlAntlrDdlParser(
+        MySqlAntlrDdlParser parser = new MySqlAntlrDdlParser(
                 true,
                 false,
                 connectorConfig.isSchemaCommentsHistoryEnabled(),
                 getTableFilter(),
                 connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+        parser.setEmitChangesForMissingAlteredTables(connectorConfig.isBinlogMetadataBasedSchema());
+        return parser;
     }
 
     private DdlParser createLegacyPtParser(BinlogConnectorConfig connectorConfig) {
-        return new io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser(
+        io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser parser = new io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser(
                 true,
                 false,
                 connectorConfig.isSchemaCommentsHistoryEnabled(),
                 getTableFilter(),
                 connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+        parser.setEmitChangesForMissingAlteredTables(connectorConfig.isBinlogMetadataBasedSchema());
+        return parser;
     }
 
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
@@ -51,7 +51,17 @@ public class AlterTableParserListener extends TableCommonParserListener {
     public void enterAlterTable(MySqlParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableRef());
         if (parser.databaseTables().forTable(tableId) == null) {
-            LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
+                // The table is captured but not yet part of the in-memory model, e.g. when the schema
+                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
+                // the table since the restart. Signal the event without applying the statement, so
+                // that the schema change is still emitted; the schema itself is restored by the next
+                // TABLE_MAP event.
+                parser.signalAlterTable(tableId, null, ctx);
+            }
+            else {
+                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            }
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.ParseTreeListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser;
@@ -32,8 +30,6 @@ public class AlterTableParserListener extends TableCommonParserListener {
 
     private static final int STARTING_INDEX = 1;
 
-    private final static Logger LOG = LoggerFactory.getLogger(AlterTableParserListener.class);
-
     private ColumnEditor defaultValueColumnEditor;
     private DefaultValueParserListener defaultValueListener;
 
@@ -50,18 +46,7 @@ public class AlterTableParserListener extends TableCommonParserListener {
     @Override
     public void enterAlterTable(MySqlParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableRef());
-        if (parser.databaseTables().forTable(tableId) == null) {
-            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
-                // The table is captured but not yet part of the in-memory model, e.g. when the schema
-                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
-                // the table since the restart. Signal the event without applying the statement, so
-                // that the schema change is still emitted; the schema itself is restored by the next
-                // TABLE_MAP event.
-                parser.signalAlterTable(tableId, null, ctx);
-            }
-            else {
-                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
-            }
+        if (parser.handleAlterTableIfTableIsMissing(tableId, ctx, parser.getTableFilter())) {
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/legacy/AlterTableParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/legacy/AlterTableParserListener.java
@@ -14,8 +14,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.ParseTreeListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser;
 import io.debezium.ddl.parser.mysql.legacy.MySqlParser;
@@ -33,8 +31,6 @@ public class AlterTableParserListener extends TableCommonParserListener {
 
     private static final int STARTING_INDEX = 1;
 
-    private final static Logger LOG = LoggerFactory.getLogger(AlterTableParserListener.class);
-
     private ColumnEditor defaultValueColumnEditor;
     private DefaultValueParserListener defaultValueListener;
 
@@ -48,18 +44,7 @@ public class AlterTableParserListener extends TableCommonParserListener {
     @Override
     public void enterAlterTable(MySqlParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableName().fullId());
-        if (parser.databaseTables().forTable(tableId) == null) {
-            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
-                // The table is captured but not yet part of the in-memory model, e.g. when the schema
-                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
-                // the table since the restart. Signal the event without applying the statement, so
-                // that the schema change is still emitted; the schema itself is restored by the next
-                // TABLE_MAP event.
-                parser.signalAlterTable(tableId, null, ctx);
-            }
-            else {
-                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
-            }
+        if (parser.handleAlterTableIfTableIsMissing(tableId, ctx, parser.getTableFilter())) {
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/legacy/AlterTableParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/legacy/AlterTableParserListener.java
@@ -49,7 +49,17 @@ public class AlterTableParserListener extends TableCommonParserListener {
     public void enterAlterTable(MySqlParser.AlterTableContext ctx) {
         final TableId tableId = parser.parseQualifiedTableId(ctx.tableName().fullId());
         if (parser.databaseTables().forTable(tableId) == null) {
-            LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            if (parser.isEmitChangesForMissingAlteredTables() && parser.getTableFilter() != null && parser.getTableFilter().isIncluded(tableId)) {
+                // The table is captured but not yet part of the in-memory model, e.g. when the schema
+                // is reconstructed from binlog TABLE_MAP metadata and no row event has been seen for
+                // the table since the restart. Signal the event without applying the statement, so
+                // that the schema change is still emitted; the schema itself is restored by the next
+                // TABLE_MAP event.
+                parser.signalAlterTable(tableId, null, ctx);
+            }
+            else {
+                LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            }
             return;
         }
         tableEditor = parser.databaseTables().editTable(tableId);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinlogMetadataSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinlogMetadataSchemaIT.java
@@ -39,8 +39,10 @@ public class MySqlBinlogMetadataSchemaIT extends BinlogMetadataBasedSchemaIT<MyS
         final Struct after = afterOf(records.get(0));
         assertThat(after.schema().field("c_point")).as("c_point reconstructed").isNotNull();
         assertThat(after.schema().field("c_geometry")).as("c_geometry reconstructed").isNotNull();
-        // Spatial values decode to a Debezium geometry struct (io.debezium.data.geometry.Geometry).
-        assertThat(after.getStruct("c_point")).isNotNull();
+        // The GEOMETRY_TYPE metadata carries the spatial subtype, so a POINT column surfaces with the
+        // Point logical type including its x/y fields; plain GEOMETRY surfaces as a geometry struct.
+        assertThat(after.getStruct("c_point").getFloat64("x")).isEqualTo(1.0);
+        assertThat(after.getStruct("c_point").getFloat64("y")).isEqualTo(1.0);
         assertThat(after.getStruct("c_geometry")).isNotNull();
 
         stopConnector();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinlogMetadataSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinlogMetadataSchemaIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogMetadataBasedSchemaIT;
+
+/**
+ * MySQL integration test for the binlog-metadata-based schema mode (debezium/dbz#978). Adds coverage for
+ * MySQL spatial types, which are not available in the same form on MariaDB.
+ */
+public class MySqlBinlogMetadataSchemaIT extends BinlogMetadataBasedSchemaIT<MySqlConnector> implements MySqlCommon {
+
+    @Test
+    public void shouldReconstructSpatialTypesFromBinlogMetadata() throws Exception {
+        final Configuration config = metadataModeConfig().build();
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        executeStatements(DATABASE.getDatabaseName(),
+                "INSERT INTO spatial_types (c_point, c_geometry) VALUES ("
+                        + "ST_GeomFromText('POINT(1 1)'), ST_GeomFromText('POINT(8.25 3.22)', 4326))");
+
+        final List<SourceRecord> records = consumeTable("spatial_types", 1);
+        assertThat(records).hasSize(1);
+        assertThat(operationOf(records.get(0))).isEqualTo("c");
+
+        final Struct after = afterOf(records.get(0));
+        assertThat(after.schema().field("c_point")).as("c_point reconstructed").isNotNull();
+        assertThat(after.schema().field("c_geometry")).as("c_geometry reconstructed").isNotNull();
+        // Spatial values decode to a Debezium geometry struct (io.debezium.data.geometry.Geometry).
+        assertThat(after.getStruct("c_point")).isNotNull();
+        assertThat(after.getStruct("c_geometry")).isNotNull();
+
+        stopConnector();
+    }
+}

--- a/debezium-connector-mysql/src/test/resources/ddl/binlog_metadata_schema.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/binlog_metadata_schema.sql
@@ -54,6 +54,25 @@ CREATE TABLE all_types (
   PRIMARY KEY (id)
 ) DEFAULT CHARSET=utf8mb4;
 
+-- Mixed-charset table with the ENUM in front of the string columns: the ENUM takes its charset from
+-- the ENUM_AND_SET_* metadata fields and must not shift the per-column charset numbering of the
+-- string columns that follow it.
+CREATE TABLE charset_mix (
+  id INT NOT NULL AUTO_INCREMENT,
+  status ENUM('NEW','DONE') NOT NULL,
+  name_latin1 VARCHAR(80) CHARACTER SET latin1,
+  note_utf8 VARCHAR(40) CHARACTER SET utf8mb4,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;
+
+-- The primary key uses a column prefix, so the server writes PRIMARY_KEY_WITH_PREFIX instead of
+-- SIMPLE_PRIMARY_KEY into the TABLE_MAP metadata.
+CREATE TABLE prefix_pk (
+  code VARCHAR(64) NOT NULL,
+  qty INT,
+  PRIMARY KEY (code(5))
+) DEFAULT CHARSET=utf8mb4;
+
 -- Spatial types (MySQL only). In the binlog these all share the GEOMETRY type code; the value is WKB
 -- and decodes to a Debezium geometry struct.
 CREATE TABLE spatial_types (

--- a/debezium-connector-mysql/src/test/resources/ddl/binlog_metadata_schema.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/binlog_metadata_schema.sql
@@ -1,0 +1,64 @@
+-- Table used by BinlogMetadataBasedSchemaIT (MySQL and MariaDB) to verify that the streaming schema
+-- can be reconstructed purely from binlog TABLE_MAP metadata (binlog_row_metadata=FULL), without
+-- relying on a persisted schema history topic. Rows are inserted at runtime by the test.
+CREATE TABLE orders (
+  id INT NOT NULL AUTO_INCREMENT,
+  quantity BIGINT UNSIGNED,
+  status ENUM('NEW','SHIPPED','CANCELLED') NOT NULL DEFAULT 'NEW',
+  price DECIMAL(12,3),
+  code CHAR(4) NOT NULL,
+  note VARCHAR(64),
+  created_at DATETIME(3),
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;
+
+-- Broad data-type coverage: every column type must be reconstructed from TABLE_MAP metadata and the
+-- row must decode without error. Types available on both MySQL 8.0+ and MariaDB 10.5+.
+CREATE TABLE all_types (
+  id            INT NOT NULL AUTO_INCREMENT,
+  c_tinyint     TINYINT,
+  c_tinyint_u   TINYINT UNSIGNED,
+  c_bool        TINYINT(1),
+  c_smallint    SMALLINT,
+  c_smallint_u  SMALLINT UNSIGNED,
+  c_mediumint   MEDIUMINT,
+  c_mediumint_u MEDIUMINT UNSIGNED,
+  c_int         INT,
+  c_int_u       INT UNSIGNED,
+  c_bigint      BIGINT,
+  c_bigint_u    BIGINT UNSIGNED,
+  c_decimal     DECIMAL(12,3),
+  c_float       FLOAT,
+  c_double      DOUBLE,
+  c_bit         BIT(5),
+  c_date        DATE,
+  c_datetime    DATETIME(3),
+  c_timestamp   TIMESTAMP(6) NULL,
+  c_time        TIME(3),
+  c_year        YEAR,
+  c_char        CHAR(4),
+  c_varchar     VARCHAR(64),
+  c_binary      BINARY(8),
+  c_varbinary   VARBINARY(32),
+  c_tinytext    TINYTEXT,
+  c_text        TEXT,
+  c_mediumtext  MEDIUMTEXT,
+  c_longtext    LONGTEXT,
+  c_tinyblob    TINYBLOB,
+  c_blob        BLOB,
+  c_mediumblob  MEDIUMBLOB,
+  c_longblob    LONGBLOB,
+  c_enum        ENUM('NEW','OK','ERR') NOT NULL DEFAULT 'NEW',
+  c_set         SET('a','b','c'),
+  c_json        JSON,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;
+
+-- Spatial types (MySQL only). In the binlog these all share the GEOMETRY type code; the value is WKB
+-- and decodes to a Debezium geometry struct.
+CREATE TABLE spatial_types (
+  id         INT NOT NULL AUTO_INCREMENT,
+  c_point    POINT,
+  c_geometry GEOMETRY,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4;

--- a/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
+++ b/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
@@ -70,10 +70,6 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
         this.emitChangesForMissingAlteredTables = emitChangesForMissingAlteredTables;
     }
 
-    public boolean isEmitChangesForMissingAlteredTables() {
-        return emitChangesForMissingAlteredTables;
-    }
-
     @Override
     public DdlChanges parse(String ddlContent, Tables databaseTables) {
         this.databaseTables = databaseTables;
@@ -257,6 +253,34 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
      */
     public void signalAlterTable(TableId id, TableId previousId, ParserRuleContext ctx) {
         signalAlterTable(id, previousId, getText(ctx));
+    }
+
+    /**
+     * Handle an alter table statement if the table is missing from the in-memory model.
+     * <p>
+     * In binlog-metadata-based schema mode, a captured table enters the model only after its first
+     * {@code TABLE_MAP} event. If an alter statement is read before that event, signal the schema
+     * change without applying it to the model. The next {@code TABLE_MAP} event restores the table
+     * structure. In other modes, or for a table that is not captured, ignore the statement as usual.
+     *
+     * @param id          the table identifier; may not be null
+     * @param ctx         the start of the statement; may not be null
+     * @param tableFilter the table capture filter; may be null
+     * @return {@code true} if the table is missing and the caller should stop processing the statement,
+     *         or {@code false} if the table exists and the caller should process it normally
+     */
+    public boolean handleAlterTableIfTableIsMissing(TableId id, ParserRuleContext ctx, Tables.TableFilter tableFilter) {
+        if (databaseTables.forTable(id) != null) {
+            return false;
+        }
+
+        if (emitChangesForMissingAlteredTables && tableFilter != null && tableFilter.isIncluded(id)) {
+            signalAlterTable(id, null, ctx);
+        }
+        else {
+            logger.debug("Ignoring ALTER TABLE statement for non-captured table {}", id);
+        }
+        return true;
     }
 
     @Override

--- a/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
+++ b/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
@@ -50,11 +50,28 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
      */
     private AntlrDdlParserListener antlrDdlParserListener;
 
+    /**
+     * Whether an ALTER TABLE statement for a table that is included in the capture filter but not
+     * present in the in-memory model emits a change event without being applied. Used by the
+     * binlog-metadata-based schema mode, where a table only enters the model with its first
+     * {@code TABLE_MAP} event, so a statement read before that must still reach the schema change
+     * topic. Disabled by default: with a schema history, a missing table means it is not captured.
+     */
+    private boolean emitChangesForMissingAlteredTables = false;
+
     protected Tables databaseTables;
 
     public AntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments) {
         super(includeViews, includeComments);
         this.throwErrorsFromTreeWalk = throwErrorsFromTreeWalk;
+    }
+
+    public void setEmitChangesForMissingAlteredTables(boolean emitChangesForMissingAlteredTables) {
+        this.emitChangesForMissingAlteredTables = emitChangesForMissingAlteredTables;
+    }
+
+    public boolean isEmitChangesForMissingAlteredTables() {
+        return emitChangesForMissingAlteredTables;
     }
 
     @Override

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -531,6 +531,21 @@ Because the schema is read from each `TABLE_MAP` event, the connector correctly 
 +
 This mode works with any `snapshot.mode`.
 For modes that do not snapshot data (for example `no_data`), a fresh connector records the current binlog position before it begins streaming, so it captures only changes that occur from that point forward, rather than replaying the earliest available binlog.
++
+*Differences from the schema history mode.*
+Change event values, keys, and restart behavior are identical in both modes; every row event carries the complete row (`binlog_row_image=FULL`) and the `TABLE_MAP` metadata carries everything that is needed to decode it.
+However, some schema attributes exist only in DDL statements and are not written to the binlog, so columns reconstructed from the binlog metadata differ from DDL-parsed columns in the following ways:
+
+* Integer display width is not available, so `TINYINT(1)` cannot be distinguished from `TINYINT`.
+The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
+* Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
+Row values are unaffected, because every change event carries the actual column values.
+* `FLOAT(M,D)` columns (deprecated in MySQL 8.0.17) map to `FLOAT32` instead of `FLOAT64`, and nationalized character columns surface as plain `CHAR`/`VARCHAR`.
+* Source column types propagated with `column.propagate.source.type` reflect the reconstructed types, without display width or precision, and column comments are not available.
+
+In exchange, this mode requires no schema history topic or settings, restarts without a history recovery phase, and recovers from schema changes that are never written to the binlog (for example an `ALTER TABLE` executed with `sql_log_bin=OFF`) by rebuilding the schema from the next `TABLE_MAP` event, whereas the schema history mode keeps using the stale schema in that situation.
+The connector offset can also be seeded or rewound to any position that the binlog still retains, even across past DDL statements, because every `TABLE_MAP` event carries the schema that was in effect at that point.
+With a schema history, the same operation requires a history topic that covers the target position; the `recovery` snapshot mode cannot substitute for one, because it rebuilds the history from the current schema and therefore cannot decode rows that were written before a schema change.
 
 [id="{context}-property-signal-data-collection"]
 xref:{context}-property-signal-data-collection[`signal.data.collection`]::

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -540,6 +540,8 @@ However, some schema attributes exist only in DDL statements and are not written
 The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
 * Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
 Row values are unaffected, because every change event carries the actual column values.
+As a consequence, a `NOT NULL` column with a `DEFAULT` value surfaces as a required field without a default: when such a column is added to a captured table, the Avro converter registers a schema that a schema registry rejects under the `BACKWARD` subject compatibility, and sink connectors that create or evolve tables do not receive the column default.
+Relaxing the subject compatibility, for example to `NONE`, avoids the rejection; adding the column as nullable avoids it as well.
 * `FLOAT(M,D)` columns (deprecated in MySQL 8.0.17) map to `FLOAT32` instead of `FLOAT64`, and nationalized character columns surface as plain `CHAR`/`VARCHAR`.
 * Source column types propagated with `column.propagate.source.type` reflect the reconstructed types, without display width or precision, and column comments are not available.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -544,6 +544,7 @@ As a consequence, a `NOT NULL` column with a `DEFAULT` value surfaces as a requi
 Relaxing the subject compatibility, for example to `NONE`, avoids the rejection; adding the column as nullable avoids it as well.
 * `FLOAT(M,D)` columns (deprecated in MySQL 8.0.17) map to `FLOAT32` instead of `FLOAT64`, and nationalized character columns surface as plain `CHAR`/`VARCHAR`.
 * Source column types propagated with `column.propagate.source.type` reflect the reconstructed types, without display width or precision, and column comments are not available.
+* After a restart, a schema change event for a table whose structure has not been observed yet carries the DDL statement without the `tableChanges` structure; the table structure is restored by the next `TABLE_MAP` event.
 
 In exchange, this mode requires no schema history topic or settings, restarts without a history recovery phase, and recovers from schema changes that are never written to the binlog (for example an `ALTER TABLE` executed with `sql_log_bin=OFF`) by rebuilding the schema from the next `TABLE_MAP` event, whereas the schema history mode keeps using the stale schema in that situation.
 The connector offset can also be seeded or rewound to any position that the binlog still retains, even across past DDL statements, because every `TABLE_MAP` event carries the schema that was in effect at that point.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -514,6 +514,24 @@ Specifies whether a connector writes watermarks to the signal data collection to
 Set the value to `true` to enable a connector that has a read-only connection to the database to use an incremental snapshot watermarking strategy that does not require writing to the signal data collection.
 endif::community[]
 
+[id="{context}-property-binlog-metadata-based-schema"]
+xref:{context}-property-binlog-metadata-based-schema[`binlog.metadata.based.schema`]::
+
+Default value::: `false`
+
+Description:::
+Specifies whether the connector reconstructs the streaming table schema from the metadata that binlog `TABLE_MAP` events carry, instead of from a persisted schema history topic.
++
+When set to `true`, the connector rebuilds each table's schema (column names, types, character sets, `ENUM`/`SET` values, and the primary key) from the binlog itself, and it does not create or depend on a schema history topic.
+In this mode you do not need to provide any `schema.history.internal.*` settings; the connector uses an in-memory schema history automatically, so no schema history storage or connection settings are required.
+This is an opt-in mode that requires the source server to run with `binlog_row_metadata=FULL`, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later.
+If the variable is not set to `FULL`, the connector fails fast at startup.
++
+Because the schema is read from each `TABLE_MAP` event, the connector correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE` operation.
++
+This mode works with any `snapshot.mode`.
+For modes that do not snapshot data (for example `no_data`), a fresh connector records the current binlog position before it begins streaming, so it captures only changes that occur from that point forward, rather than replaying the earliest available binlog.
+
 [id="{context}-property-signal-data-collection"]
 xref:{context}-property-signal-data-collection[`signal.data.collection`]::
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -520,35 +520,20 @@ xref:{context}-property-binlog-metadata-based-schema[`binlog.metadata.based.sche
 Default value::: `false`
 
 Description:::
-Specifies whether the connector reconstructs the streaming table schema from the metadata that binlog `TABLE_MAP` events carry, instead of from a persisted schema history topic.
+Specifies whether the connector reconstructs the table schema from the metadata that the server writes into the binlog when it runs with `binlog_row_metadata=FULL` (the `TABLE_MAP` events), instead of from a persisted schema history topic.
 +
 When set to `true`, the connector rebuilds each table's schema (column names, types, character sets, `ENUM`/`SET` values, and the primary key) from the binlog itself, and it does not create or depend on a schema history topic.
 In this mode you do not need to provide any `schema.history.internal.*` settings; the connector uses an in-memory schema history automatically, so no schema history storage or connection settings are required.
 This is an opt-in mode that requires the source server to run with `binlog_row_metadata=FULL`, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later.
 If the variable is not set to `FULL`, the connector fails fast at startup.
 +
-Because the schema is read from each `TABLE_MAP` event, the connector correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE` operation.
+Because the schema is read from the binlog itself, the connector correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE` operation.
 +
 This mode works with any `snapshot.mode`.
 For modes that do not snapshot data (for example `no_data`), a fresh connector records the current binlog position before it begins streaming, so it captures only changes that occur from that point forward, rather than replaying the earliest available binlog.
 +
-*Differences from the schema history mode.*
-Change event values, keys, and restart behavior are identical in both modes; every row event carries the complete row (`binlog_row_image=FULL`) and the `TABLE_MAP` metadata carries everything that is needed to decode it.
-However, some schema attributes exist only in DDL statements and are not written to the binlog, so columns reconstructed from the binlog metadata differ from DDL-parsed columns in the following ways:
-
-* Integer display width is not available, so `TINYINT(1)` cannot be distinguished from `TINYINT`.
-The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
-* Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
-Row values are unaffected, because every change event carries the actual column values.
-As a consequence, a `NOT NULL` column with a `DEFAULT` value surfaces as a required field without a default: when such a column is added to a captured table, the Avro converter registers a schema that a schema registry rejects under the `BACKWARD` subject compatibility, and sink connectors that create or evolve tables do not receive the column default.
-Relaxing the subject compatibility, for example to `NONE`, avoids the rejection; adding the column as nullable avoids it as well.
-* `FLOAT(M,D)` columns (deprecated in MySQL 8.0.17) map to `FLOAT32` instead of `FLOAT64`, and nationalized character columns surface as plain `CHAR`/`VARCHAR`.
-* Source column types propagated with `column.propagate.source.type` reflect the reconstructed types, without display width or precision, and column comments are not available.
-* After a restart, a schema change event for a table whose structure has not been observed yet carries the DDL statement without the `tableChanges` structure; the table structure is restored by the next `TABLE_MAP` event.
-
-In exchange, this mode requires no schema history topic or settings, restarts without a history recovery phase, and recovers from schema changes that are never written to the binlog (for example an `ALTER TABLE` executed with `sql_log_bin=OFF`) by rebuilding the schema from the next `TABLE_MAP` event, whereas the schema history mode keeps using the stale schema in that situation.
-The connector offset can also be seeded or rewound to any position that the binlog still retains, even across past DDL statements, because every `TABLE_MAP` event carries the schema that was in effect at that point.
-With a schema history, the same operation requires a history topic that covers the target position; the `recovery` snapshot mode cannot substitute for one, because it rebuilds the history from the current schema and therefore cannot decode rows that were written before a schema change.
+The two modes are not fully equivalent: schema attributes that exist only in DDL statements (for example, column default values and the integer display width) are not part of the reconstructed schema.
+For the advantages and limitations of each mode, see xref:{context}-comparison-schema-history-binlog-metadata[the comparison between the schema history and the binlog metadata mode].
 
 [id="{context}-property-signal-data-collection"]
 xref:{context}-property-signal-data-collection[`signal.data.collection`]::

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -136,22 +136,33 @@ If consumers do not need the records the connector generates for helper tables, 
 [id="{context}-comparison-schema-history-binlog-metadata"]
 ==== Comparison between the schema history and the binlog metadata mode
 
-The two modes produce identical change events for the same row changes.
-Every change that the connector reads from the binlog carries the complete row together with the schema information that is needed to decode it, so change event values and keys, snapshots, and restart behavior do not differ between the modes.
-The modes are not fully equivalent, however: they differ in where the table schema comes from, and in the schema attributes that are available from that source.
+For schema attributes that are available from both sources, the two modes produce the same row values and keys.
+However, the modes differ in where the connector obtains the table schema, which schema attributes are available, and how the connector can recover or start from an earlier binlog position.
+
+.Advantages of the schema history mode
+* The mode works without requiring the source server to support or enable `binlog_row_metadata=FULL`.
+* The DDL statements in the schema history preserve schema attributes that are not present in binlog row metadata, including integer display widths, column default values, and column comments.
+* Before the connector resumes streaming, it reconstructs the complete table structures that existed at the starting binlog position.
+As a result, a schema change event that occurs before the next row event for a table can include the corresponding `tableChanges` structure.
+
+.Limitations of the schema history mode
+* The connector requires a schema history topic and the corresponding `schema.history.internal.*` configuration, and it must recover the history before it resumes streaming.
+* The history must contain the DDL statements that are required to reconstruct the schema at the connector's starting binlog position.
+If a connector offset is manually seeded or rewound to a position that predates the available history, the connector cannot safely decode rows across intervening schema changes.
+The xref:{context}-connector-snapshot-mode-options[`recovery` snapshot mode] rebuilds the history from the current table structures and cannot restore the schema that existed at an earlier binlog position.
+* A schema change that is not written to the binlog, for example, an `ALTER TABLE` statement that runs with `sql_log_bin=OFF`, is not added to the schema history and can leave the connector's in-memory schema out of date.
 
 .Advantages of the binlog metadata mode
 * The connector requires no schema history topic and no `schema.history.internal.*` settings; there is no history storage to provision, monitor, or recover.
 * The connector restarts without a history recovery phase.
-* Schema changes that are never written to the binlog (for example, an `ALTER TABLE` executed with `sql_log_bin=OFF`) heal themselves as soon as the connector reads the next change for the table, whereas the schema history mode keeps using the stale schema.
+* Schema changes that are never written to the binlog, for example, an `ALTER TABLE` statement that runs with `sql_log_bin=OFF`, heal themselves as soon as the connector reads the next change for the table.
 * The connector offset can be seeded or rewound to any position that the binlog still retains, even across past DDL statements, because the binlog carries the schema that was in effect at every position.
-With a schema history, pointing a new connector at an earlier binlog position stops the connector when a schema change lies between that position and the current table structure, because the schema history topic does not describe the schema at that position and decoding the older rows with the current schema fails.
-The xref:{context}-connector-snapshot-mode-options[`recovery` snapshot mode] cannot repair this, because it rebuilds the history from the current schema; the binlog metadata mode does not have this restriction.
 
 .Limitations of the binlog metadata mode
-The schema information that the server writes into the binlog with `binlog_row_metadata=FULL` does not include every schema attribute that the schema history mode records.
-The following attributes are not available in the binlog metadata mode, so the behaviors that depend on them work differently:
+The binlog metadata mode has the following limitations:
 
+* The source server must support `binlog_row_metadata` and run with `binlog_row_metadata=FULL`.
+The connector fails at startup if full row metadata is not enabled.
 * Integer display width is not available, so `TINYINT(1)` cannot be distinguished from `TINYINT`.
 The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
 * Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
@@ -163,8 +174,8 @@ Relaxing the subject compatibility, for example to `NONE`, avoids the rejection;
 * After a restart, a schema change event for a table whose structure has not been observed yet carries the DDL statement without the `tableChanges` structure; the table structure is restored as soon as the connector reads the next change for the table.
 
 .Choosing a mode
-Use the schema history mode when consumers depend on the schema attributes above -- for example, `TINYINT(1)`-to-`BOOLEAN` conversion without an explicit selector, field default values in registered Avro schemas under the `BACKWARD` subject compatibility, or fully populated `tableChanges` structures in schema change events.
-Use the binlog metadata mode to remove the schema history topic and its operational handling when those attributes are not required; the row data that the connector emits is the same in both modes.
+Use the schema history mode if the source server cannot provide full binlog row metadata, or if consumers depend on attributes such as integer display widths, column default values, column comments, or fully populated `tableChanges` structures in schema change events.
+Use the binlog metadata mode when the source server provides full row metadata and those attributes are not required, especially if you want to remove schema history storage and recovery or start from any position that the binlog still retains.
 
 end::schema-history[]
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -119,13 +119,10 @@ Optionally, the connector can also xref:{context}-schema-change-topic[emit schem
 
 [NOTE]
 ====
-When the source server runs with `binlog_row_metadata=FULL`, every `TABLE_MAP` event in the binlog carries the full column metadata (column names, types, character sets, `ENUM`/`SET` values, and the primary key).
-In this configuration, you can set `binlog.metadata.based.schema` to `true` to have the connector reconstruct the streaming table schema directly from the binlog, similar to how the {prodname} PostgreSQL connector rebuilds schema from replication messages.
-When you enable this option, the connector does not create or depend on a schema history topic, which removes the operational overhead of managing that topic.
-In this mode you do not need to provide any `schema.history.internal.*` settings; the connector installs an in-memory schema history automatically, so no schema history storage or connection settings (such as `schema.history.internal.kafka.bootstrap.servers`) are required.
-Because the connector reads the point-in-time schema from each `TABLE_MAP` event, it also correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE`.
-This is an opt-in mode that requires FULL binlog row metadata, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later; the connector fails fast at startup if `binlog_row_metadata` is not set to `FULL`.
-Change event values and keys are identical in both modes, but schema attributes that exist only in DDL statements (column default values, integer display width, column comments) are not part of the reconstructed schema; see the `binlog.metadata.based.schema` property description for the complete list of differences.
+When the source server runs with `binlog_row_metadata=FULL` (available on MySQL 8.0 and later and on MariaDB 10.5 and later), the server writes the full column metadata (column names, types, character sets, `ENUM`/`SET` values, and the primary key) into the binlog.
+In this configuration, you can set `binlog.metadata.based.schema` to `true` to have the connector reconstruct the table schema directly from the binlog instead of creating and using a schema history topic.
+This is an opt-in mode; the connector fails fast at startup if `binlog_row_metadata` is not set to `FULL`.
+For the trade-offs between the two modes, see xref:{context}-comparison-schema-history-binlog-metadata[the comparison below].
 ====
 
 When the {connector-name} connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
@@ -135,6 +132,39 @@ If consumers do not need the records the connector generates for helper tables, 
 .Additional resources
 
 * xref:{context}-topic-names[Default names for topics] that receive {prodname} event records.
+
+[id="{context}-comparison-schema-history-binlog-metadata"]
+==== Comparison between the schema history and the binlog metadata mode
+
+The two modes produce identical change events for the same row changes.
+Every change that the connector reads from the binlog carries the complete row together with the schema information that is needed to decode it, so change event values and keys, snapshots, and restart behavior do not differ between the modes.
+The modes are not fully equivalent, however: they differ in where the table schema comes from, and in the schema attributes that are available from that source.
+
+.Advantages of the binlog metadata mode
+* The connector requires no schema history topic and no `schema.history.internal.*` settings; there is no history storage to provision, monitor, or recover.
+* The connector restarts without a history recovery phase.
+* Schema changes that are never written to the binlog (for example, an `ALTER TABLE` executed with `sql_log_bin=OFF`) heal themselves as soon as the connector reads the next change for the table, whereas the schema history mode keeps using the stale schema.
+* The connector offset can be seeded or rewound to any position that the binlog still retains, even across past DDL statements, because the binlog carries the schema that was in effect at every position.
+With a schema history, pointing a new connector at an earlier binlog position stops the connector when a schema change lies between that position and the current table structure, because the schema history topic does not describe the schema at that position and decoding the older rows with the current schema fails.
+The xref:{context}-connector-snapshot-mode-options[`recovery` snapshot mode] cannot repair this, because it rebuilds the history from the current schema; the binlog metadata mode does not have this restriction.
+
+.Limitations of the binlog metadata mode
+The schema information that the server writes into the binlog with `binlog_row_metadata=FULL` does not include every schema attribute that the schema history mode records.
+The following attributes are not available in the binlog metadata mode, so the behaviors that depend on them work differently:
+
+* Integer display width is not available, so `TINYINT(1)` cannot be distinguished from `TINYINT`.
+The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
+* Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
+Row values are unaffected, because every change event carries the actual column values.
+As a consequence, a `NOT NULL` column with a `DEFAULT` value surfaces as a required field without a default: when such a column is added to a captured table, the Avro converter registers a schema that a schema registry rejects under the `BACKWARD` subject compatibility, and sink connectors that create or evolve tables do not receive the column default.
+Relaxing the subject compatibility, for example to `NONE`, avoids the rejection; adding the column as nullable avoids it as well.
+* `FLOAT(M,D)` columns (deprecated in MySQL 8.0.17) map to `FLOAT32` instead of `FLOAT64`, and nationalized character columns surface as plain `CHAR`/`VARCHAR`.
+* Source column types propagated with `column.propagate.source.type` reflect the reconstructed types, without display width or precision, and column comments are not available.
+* After a restart, a schema change event for a table whose structure has not been observed yet carries the DDL statement without the `tableChanges` structure; the table structure is restored as soon as the connector reads the next change for the table.
+
+.Choosing a mode
+Use the schema history mode when consumers depend on the schema attributes above -- for example, `TINYINT(1)`-to-`BOOLEAN` conversion without an explicit selector, field default values in registered Avro schemas under the `BACKWARD` subject compatibility, or fully populated `tableChanges` structures in schema change events.
+Use the binlog metadata mode to remove the schema history topic and its operational handling when those attributes are not required; the row data that the connector emits is the same in both modes.
 
 end::schema-history[]
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -125,6 +125,7 @@ When you enable this option, the connector does not create or depend on a schema
 In this mode you do not need to provide any `schema.history.internal.*` settings; the connector installs an in-memory schema history automatically, so no schema history storage or connection settings (such as `schema.history.internal.kafka.bootstrap.servers`) are required.
 Because the connector reads the point-in-time schema from each `TABLE_MAP` event, it also correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE`.
 This is an opt-in mode that requires FULL binlog row metadata, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later; the connector fails fast at startup if `binlog_row_metadata` is not set to `FULL`.
+Change event values and keys are identical in both modes, but schema attributes that exist only in DDL statements (column default values, integer display width, column comments) are not part of the reconstructed schema; see the `binlog.metadata.based.schema` property description for the complete list of differences.
 ====
 
 When the {connector-name} connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -117,6 +117,16 @@ The connector rebuilds the table structures that existed at this point in time b
 This database schema history topic is for internal connector use only.
 Optionally, the connector can also xref:{context}-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
+[NOTE]
+====
+When the source server runs with `binlog_row_metadata=FULL`, every `TABLE_MAP` event in the binlog carries the full column metadata (column names, types, character sets, `ENUM`/`SET` values, and the primary key).
+In this configuration, you can set `binlog.metadata.based.schema` to `true` to have the connector reconstruct the streaming table schema directly from the binlog, similar to how the {prodname} PostgreSQL connector rebuilds schema from replication messages.
+When you enable this option, the connector does not create or depend on a schema history topic, which removes the operational overhead of managing that topic.
+In this mode you do not need to provide any `schema.history.internal.*` settings; the connector installs an in-memory schema history automatically, so no schema history storage or connection settings (such as `schema.history.internal.kafka.bootstrap.servers`) are required.
+Because the connector reads the point-in-time schema from each `TABLE_MAP` event, it also correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE`.
+This is an opt-in mode that requires FULL binlog row metadata, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later; the connector fails fast at startup if `binlog_row_metadata` is not set to `FULL`.
+====
+
 When the {connector-name} connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
 You must configure the connector to capture changes that occur in these helper tables.
 If consumers do not need the records the connector generates for helper tables, configure a {link-prefix}:{link-filtering}#message-filtering[single message transform (SMT)] to remove these records from the messages that the connector emits.
@@ -2652,6 +2662,11 @@ endif::MARIADB[]
 
 |`binlog_row_image`
 |The `binlog_row_image` must be set to `FULL` or `full`.
+
+|`binlog_row_metadata`
+|Optional.
+Required to be set to `FULL` only when you enable the `binlog.metadata.based.schema` option, so that the connector can reconstruct the table schema directly from `TABLE_MAP` events in the binlog.
+For all other configurations, this variable can retain its default value.
 
 |`binlog_expire_logs_seconds`
 |The `binlog_expire_logs_seconds` corresponds to deprecated system variable `expire_logs_days`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -164,7 +164,8 @@ The binlog metadata mode has the following limitations:
 * The source server must support `binlog_row_metadata` and run with `binlog_row_metadata=FULL`.
 The connector fails at startup if full row metadata is not enabled.
 * Integer display width is not available, so `TINYINT(1)` cannot be distinguished from `TINYINT`.
-The default mapping (`INT16`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length; set its `length.checker` option to `false` to convert all `TINYINT` columns instead.
+The default mapping (`INT8`) is identical in both modes, but the optional `TinyIntOneToBooleanConverter` relies on the column length.
+To use the converter in binlog metadata mode, set its `length.checker` option to `false` and configure an explicit selector for the columns to convert.
 * Column default values are not part of the reconstructed schema, so the Kafka field schemas do not declare them.
 Row values are unaffected, because every change event carries the actual column values.
 As a consequence, a `NOT NULL` column with a `DEFAULT` value surfaces as a required field without a default: when such a column is added to a captured table, the Avro converter registers a schema that a schema registry rejects under the `BACKWARD` subject compatibility, and sink connectors that create or evolve tables do not receive the column default.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -117,6 +117,16 @@ The connector rebuilds the table structures that existed at this point in time b
 This database schema history topic is for internal connector use only.
 Optionally, the connector can also xref:{context}-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
+[NOTE]
+====
+When the source server runs with `binlog_row_metadata=FULL`, every `TABLE_MAP` event in the binlog carries the full column metadata (column names, types, character sets, `ENUM`/`SET` values, and the primary key).
+In this configuration, you can set `binlog.metadata.based.schema` to `true` to have the connector reconstruct the streaming table schema directly from the binlog, similar to how the {prodname} PostgreSQL connector rebuilds schema from replication messages.
+When you enable this option, the connector does not create or depend on a schema history topic, which removes the operational overhead of managing that topic.
+In this mode you do not need to provide any `schema.history.internal.*` settings; the connector installs an in-memory schema history automatically, so no schema history storage or connection settings (such as `schema.history.internal.kafka.bootstrap.servers`) are required.
+Because the connector reads the point-in-time schema from each `TABLE_MAP` event, it also correctly resumes streaming after a restart that occurs in the middle of a multi-row `INSERT` or `UPDATE`.
+This is an opt-in mode that requires FULL binlog row metadata, which is available on MySQL 8.0 and later and on MariaDB 10.5 and later; the connector fails fast at startup if `binlog_row_metadata` is not set to `FULL`.
+====
+
 When the {connector-name} connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
 You must configure the connector to capture changes that occur in these helper tables.
 If consumers do not need the records the connector generates for helper tables, configure a {link-prefix}:{link-filtering}#message-filtering[single message transform (SMT)] to remove these records from the messages that the connector emits.
@@ -2569,6 +2579,11 @@ tag::binlog-config-props[]
 
 |`binlog_row_image`
 |The `binlog_row_image` must be set to `FULL` or `full`.
+
+|`binlog_row_metadata`
+|Optional.
+Required to be set to `FULL` only when you enable the `binlog.metadata.based.schema` option, so that the connector can reconstruct the table schema directly from `TABLE_MAP` events in the binlog.
+For all other configurations, this variable can retain its default value.
 
 |`binlog_expire_logs_seconds`
 |The `binlog_expire_logs_seconds` corresponds to deprecated system variable `expire_logs_days`.


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/978
This is an opt-in mode that lets the MySQL and MariaDB connectors reconstruct the streaming table schema directly from the metadata carried by binlog `TABLE_MAP` events, instead of relying on a persisted database schema history topic.

## Motivation
When a server runs with `binlog_row_metadata=FULL` (MySQL 8.0+, MariaDB 10.5+), every `TABLE_MAP` event carries the full column metadata (names, types, character sets, `ENUM`/`SET` values, primary key) — the same self-describing information the PostgreSQL connector gets from pgoutput relation messages. In that case the connector can rebuild schema from the log itself and no longer needs a schema history topic, removing the bootstrap/recovery/operational overhead of managing that topic.

## What this adds
A new opt-in property, `binlog.metadata.based.schema` (default `false`). When set to `true`:
- The streaming table schema is reconstructed from the FULL `TABLE_MAP` metadata via a new `BinlogMetadataTableBuilder`.
- The connector behaves as a non-historized connector (like PostgreSQL): no schema history topic is created or required (an in-memory history satisfies the historized base lifecycle).
- It fails fast at startup if `binlog_row_metadata` is not `FULL`.
- For snapshot modes that do not snapshot data (for example `no_data`), the current binlog position is recorded before streaming, so a fresh connector starts from the current point rather than the earliest binlog.
- It correctly resumes after a restart in the middle of a multi-row `INSERT`/`UPDATE`: the schema is rebuilt from the re-read `TABLE_MAP` event before the resumed rows are decoded.

The change lives in the shared `debezium-connector-binlog` module, so it applies to both the MySQL and MariaDB connectors with no connector-specific production code. The mode is disabled by default.

## Testing
- Unit test for the type mapping (`BinlogMetadataTableBuilderTest`), seeded with real-server ground-truth `TABLE_MAP` values.
- Integration tests (`BinlogMetadataBasedSchemaIT`, run for both MySQL and MariaDB): schema reconstruction without a history topic; initial snapshot → streaming handoff; **mid-multi-row-INSERT restart resume**; fail-fast on non-FULL; `no_data` starting from the current position.
- Manually verified end-to-end against MySQL 8.0 and MariaDB 11.4 with Kafka and Confluent Schema Registry (Avro): all-types reconstruction, DDL evolution via `TABLE_MAP`, GTID stop/resume, and confirmed that no schema history topic is created.