### PR TITLE
DBZ-9928 Adds entries omitted from the configuration properties table

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2315,6 +2315,31 @@ The property adds following headers:
 `__debezium.context.connectorLogicalName`:: The logical name of the {prodname} connector.
 `__debezium.context.taskId`:: The unique identifier of the connector task.
 `__debezium.context.connectorName`::  The name of the {prodname} connector.
+
+|[[mongodb-property-skip-messages-without-change]]<<mongodb-property-skip-messages-without-change, `+skip.messages.without.change+`>>
+|`false`
+|The MongoDB connector does not support skipping unchanged events.
+Although the property is inherited from the shared connector framework, the MongoDB connector ignores this property if it is set.
+
+|[[mongodb-property-statistics-metrics-enabled]]<<mongodb-property-statistics-metrics-enabled, `+statistics.metrics.enabled+`>>
+|`true`
+|Specifies whether the connector collects advanced statistical metrics for streaming metrics, such as quantiles.
+When set to `true`, the connector collects the following statistics:
+
+* Minimum value
+* Maximum value
+* Average value
+* P50 (median) percentile
+* P95 percentile
+* P99 percentile
+
+NOTE: Currently only `MilliSecondsBehindSource` metric supports collecting quantiles.
+
+The statistics are computed using a probabilistic data structure (DDSketch) that provides approximate quantile values with 1% relative accuracy.
+When set to `false`, the connector does not collect quantiles, and the quantile JMX metrics return `null` values.
+The connector continues to collect minimum, maximum, and average values.
+Disabling quantile collection reduces memory overhead slightly.
+For more information, see xref:mongodb-streaming-metrics[Streaming metrics].
 |===
 
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -2319,7 +2319,7 @@ The property adds following headers:
 |[[mongodb-property-skip-messages-without-change]]<<mongodb-property-skip-messages-without-change, `+skip.messages.without.change+`>>
 |`false`
 |The MongoDB connector does not support skipping unchanged events.
-Although the property is inherited from the shared connector framework, the MongoDB connector ignores this property if it is set.
+Although this property is inherited from the shared connector framework, the MongoDB connector ignores it.
 
 |[[mongodb-property-statistics-metrics-enabled]]<<mongodb-property-statistics-metrics-enabled, `+statistics.metrics.enabled+`>>
 |`true`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -43,7 +43,8 @@ Represents the data change workload for {prodname} to process.
 
 |[[connectors-strm-metric-numberofunchangedeventsskipped_{context}]]<<connectors-strm-metric-numberofunchangedeventsskipped_{context}, `NumberOfUnchangedEventsSkipped`>>
 |`long`
-|Number of update events skipped since the last connector start or metrics reset because no monitored columns changed. Defaults to `-1` if xref:{context}-property-skip-messages-without-change[`skip.messages.without.change`] is `false`.
+|Number of update events skipped since the last connector start or metrics reset because no monitored columns changed.
+Defaults to `-1` if xref:{context}-property-skip-messages-without-change[`skip.messages.without.change`] is `false`.
 ifndef::supports-skipping-unchanged-events[]
 May remain `0` for {connector-name} and other connectors that do not support skipping unchanged events, even if the property is set to `true`.
 endif::[]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9928](https://redhat.atlassian.net/browse/DBZ-9928)
## Description
Adds `skip.messages.without.change` and `statistics.metrics.enabled` entries that were omitted from the properties table in the MongoDB connector doc. 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
