### PR TITLE
debezium/dbz#2178 Pass the last stable release version to build-debezium-multiplatform.sh script

### DIFF
--- a/jenkins-jobs/pipelines/release/build_debezium_images_pipeline.groovy
+++ b/jenkins-jobs/pipelines/release/build_debezium_images_pipeline.groovy
@@ -202,7 +202,7 @@ node('Slave') {
                                 git fetch origin $IMAGES_BRANCH:$IMAGES_BRANCH
                                 git checkout $IMAGES_BRANCH build-all-multiplatform.sh build-debezium-multiplatform.sh build-postgres-multiplatform.sh script-functions/
                                 echo '========== Building UI only for linux/amd64, arm64 not working =========='
-                                DRY_RUN=$DRY_RUN PLATFORM_CONDUCTOR_PLATFORM=linux/amd64 PLATFORM_STAGE_PLATFORM=linux/amd64 RELEASE_TAG=$tag ./build-debezium-multiplatform.sh $stream $MULTIPLATFORM_PLATFORMS
+                                DRY_RUN=$DRY_RUN LATEST_STREAM=$stableStream PLATFORM_CONDUCTOR_PLATFORM=linux/amd64 PLATFORM_STAGE_PLATFORM=linux/amd64 RELEASE_TAG=$tag ./build-debezium-multiplatform.sh $stream $MULTIPLATFORM_PLATFORMS
                                 git reset --hard
                             """
                         }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2178

## Description
This pull request makes a minor update to the Debezium image build pipeline by passing an additional environment variable to the build script. This change ensures that the `LATEST_STREAM` variable is set during the build process, which may be required for correct tagging or versioning.

- Build process update:
  * Added the `LATEST_STREAM` environment variable (set to `$stableStream`) to the invocation of `build-debezium-multiplatform.sh` in the `build_debezium_images_pipeline.groovy` pipeline script.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
