### PR TITLE
debezium/dbz#2135 Map PostgreSQL box, circle, line, lseg, path, polygon to first-class schemas

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/GeometryFormatTransformer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/GeometryFormatTransformer.java
@@ -12,7 +12,6 @@ import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,11 +178,12 @@ public class GeometryFormatTransformer<R extends ConnectRecord<R>> implements Tr
         }
         switch (geometryFormat) {
             case WKB -> {
-                // Convert to EWKB by adding SRID
+                // Convert to EWKB by adding SRID. Native (non-PostGIS) geometric types such as box, lseg,
+                // path and polygon are emitted with a null SRID, and EWKB has no way to represent a missing
+                // SRID, so there is nothing to add: leave the value untouched rather than failing the record.
                 if (srid == null) {
-                    String errorMessage = "Cannot convert to EWKB when SRID is null";
-                    LOGGER.error(errorMessage);
-                    throw new ConnectException(errorMessage);
+                    LOGGER.debug("Skipping WKB->EWKB conversion because the geometry carries no SRID");
+                    return value;
                 }
                 return value.put(Geometry.WKB_FIELD, geometry.asExtendedWkb().getBytes());
 

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/GeometryFormatTransformerTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/GeometryFormatTransformerTest.java
@@ -7,7 +7,6 @@ package io.debezium.transforms;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -16,7 +15,6 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
@@ -115,7 +113,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, POINT_GEO_WKB_HEX, POINT_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, POINT_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(POINT_GEO_WKB_HEX);
 
     }
 
@@ -137,7 +135,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, LINE_STRING_GEO_WKB_HEX, LINE_STRING_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, LINE_STRING_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(LINE_STRING_GEO_WKB_HEX);
     }
 
     /**
@@ -158,7 +156,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, POLYGON_GEO_WKB_HEX, POLYGON_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, POLYGON_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(POLYGON_GEO_WKB_HEX);
     }
 
     /**
@@ -179,7 +177,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, MULTI_POLYGON_GEO_WKB_HEX, MULTI_POLYGON_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, MULTI_POLYGON_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(MULTI_POLYGON_GEO_WKB_HEX);
     }
 
     /**
@@ -200,7 +198,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, POLYGON_MULTIPLE_RINGS_GEO_WKB_HEX, POLYGON_MULTIPLE_RINGS_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, POLYGON_MULTIPLE_RINGS_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(POLYGON_MULTIPLE_RINGS_GEO_WKB_HEX);
     }
 
     /**
@@ -221,7 +219,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, MULTI_LINE_STRING_GEO_WKB_HEX, MULTI_LINE_STRING_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, MULTI_LINE_STRING_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(MULTI_LINE_STRING_GEO_WKB_HEX);
     }
 
     /**
@@ -242,7 +240,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, GEOMETRY_COLLECTION_WKB_HEX, GEOMETRY_COLLECTION_EWKB_HEX);
 
-        assertFormatTransformationException(null, GEOMETRY_COLLECTION_WKB_HEX);
+        assertNullSridLeftUnchanged(GEOMETRY_COLLECTION_WKB_HEX);
     }
 
     /**
@@ -263,7 +261,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, MULTI_POINT_GEO_WKB_HEX, MULTI_POINT_GEO_EWKB_HEX);
 
-        assertFormatTransformationException(null, MULTI_POINT_GEO_WKB_HEX);
+        assertNullSridLeftUnchanged(MULTI_POINT_GEO_WKB_HEX);
     }
 
     /**
@@ -284,7 +282,7 @@ public class GeometryFormatTransformerTest {
 
         assertFormatTransformation(4326, EMPTY_GEOMETRY_WKB_HEX, EMPTY_GEOMETRY_EWKB_HEX);
 
-        assertFormatTransformationException(null, EMPTY_GEOMETRY_WKB_HEX);
+        assertNullSridLeftUnchanged(EMPTY_GEOMETRY_WKB_HEX);
     }
 
     /**
@@ -310,13 +308,14 @@ public class GeometryFormatTransformerTest {
     }
 
     /**
-     * Helper method to assert that the geometry WKB to EWKB transformation throws an exception for unsupported SRIDs.
-     * @param srid spatial reference id
-     * @param wkb  well-known-binary
+     * Helper method to assert that a WKB->EWKB transformation of a geometry with no SRID leaves the value
+     * unchanged. Native (non-PostGIS) geometric types carry a null SRID, which EWKB cannot represent, so
+     * the transform is a no-op rather than a hard failure.
+     * @param wkb well-known-binary
      */
-    private void assertFormatTransformationException(Integer srid, String wkb) {
-        applyTransformEnvelopePayloadException(srid, wkb);
-        applyTransformFlattenedPayloadException(srid, wkb);
+    private void assertNullSridLeftUnchanged(String wkb) {
+        applyTransformEnvelopePayloadUnchanged(wkb);
+        applyTransformFlattenedPayloadUnchanged(wkb);
     }
 
     /**
@@ -429,37 +428,35 @@ public class GeometryFormatTransformerTest {
     }
 
     /**
-     * Applies the geometry format transformation to a SourceRecord with flattened payload and asserts that an exception is thrown.
-     * @param srid spacial reference id
+     * Applies the geometry format transformation to a flattened payload whose geometry has no SRID and
+     * asserts the WKB is returned unchanged.
      * @param wkb well-known-binary
      */
-    private void applyTransformFlattenedPayloadException(Integer srid, String wkb) {
-        SourceRecord record = getFlattenedPayload(srid, wkb);
+    private void applyTransformFlattenedPayloadUnchanged(String wkb) {
+        final SourceRecord record = getFlattenedPayload(null, wkb);
 
-        assetException(srid, record);
+        final SourceRecord transformedRecord = geometryFormatTransformer.apply(record);
+        final Struct transformedValue = requireStruct(transformedRecord.value(), "value should be a struct");
 
+        final Struct geo = transformedValue.getStruct("geo");
+        assertThat(HexConverter.convertToHexString(geo.getBytes(Geometry.WKB_FIELD))).isEqualTo(wkb);
+        assertThat(geo.get(Geometry.SRID_FIELD)).isNull();
     }
 
     /**
-     * Applies the geometry format transformation to a SourceRecord with envelope payload and asserts that an exception is thrown.
-     * @param srid spacial reference id
+     * Applies the geometry format transformation to an envelope payload whose geometry has no SRID and
+     * asserts the WKB is returned unchanged.
      * @param wkb well-known-binary
      */
-    private void applyTransformEnvelopePayloadException(Integer srid, String wkb) {
-        SourceRecord record = getEnvelopPayload(srid, wkb);
+    private void applyTransformEnvelopePayloadUnchanged(String wkb) {
+        final SourceRecord record = getEnvelopPayload(null, wkb);
 
-        assetException(srid, record);
+        final SourceRecord transformedRecord = geometryFormatTransformer.apply(record);
+        final Struct transformedValue = requireStruct(transformedRecord.value(), "value should be a struct");
+        final Struct transformedAfter = transformedValue.getStruct(Envelope.FieldName.AFTER);
 
-    }
-
-    /**
-     * Asserts that applying the geometry format transformation to the given SourceRecord throws an exception.
-     * @param srid spacial reference id
-     * @param record the SourceRecord to transform
-     */
-    private void assetException(Integer srid, SourceRecord record) {
-        assertThatThrownBy(() -> geometryFormatTransformer.apply(record))
-                .isInstanceOf(ConnectException.class)
-                .hasMessage("Cannot convert to EWKB when SRID is null");
+        final Struct geo = transformedAfter.getStruct("geo");
+        assertThat(HexConverter.convertToHexString(geo.getBytes(Geometry.WKB_FIELD))).isEqualTo(wkb);
+        assertThat(geo.get(Geometry.SRID_FIELD)).isNull();
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/data/geometry/Circle.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/geometry/Circle.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.data.geometry;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * A semantic type for a PostgreSQL {@code circle}, defined by a center {@link Point} and a radius.
+ * <p>
+ * Unlike {@link Point}, this type does not extend {@link Geometry}: a circle has no faithful OGC
+ * Well-Known Binary representation (WKB has no curve primitive), so it carries its true center and
+ * radius losslessly instead. The lossy, target-specific approximation (for sinks without a native
+ * circle type) is left to the sink, which can dispatch on this logical name.
+ *
+ * @author Debezium Authors
+ */
+public class Circle {
+
+    public static final String LOGICAL_NAME = "io.debezium.data.geometry.Circle";
+    public static final String CENTER_FIELD = "center";
+    public static final String RADIUS_FIELD = "radius";
+
+    /**
+     * Returns a {@link SchemaBuilder} for a Circle field. You can use the resulting SchemaBuilder
+     * to set additional schema settings such as required/optional, default value, and documentation.
+     *
+     * @return the schema builder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.struct()
+                .name(LOGICAL_NAME)
+                .version(1)
+                .doc("Geometry (CIRCLE)")
+                .optional()
+                .field(CENTER_FIELD, Point.builder().build())
+                .field(RADIUS_FIELD, Schema.FLOAT64_SCHEMA);
+    }
+
+    /**
+     * Returns a {@link Schema} for a Circle field, with all other default Schema settings.
+     *
+     * @return the schema
+     * @see #builder()
+     */
+    public static Schema schema() {
+        return builder().build();
+    }
+
+    /**
+     * Creates a value for this schema using the circle's center coordinates and radius.
+     *
+     * @param circleSchema a {@link Schema} instance which represents a circle; may not be null
+     * @param centerX the X coordinate of the center point
+     * @param centerY the Y coordinate of the center point
+     * @param radius the radius of the circle
+     * @return a {@link Struct} which represents a Connect value for this schema; never null
+     */
+    public static Struct createValue(Schema circleSchema, double centerX, double centerY, double radius) {
+        Struct result = new Struct(circleSchema);
+        Schema centerSchema = circleSchema.field(CENTER_FIELD).schema();
+        result.put(CENTER_FIELD, Point.createValue(centerSchema, centerX, centerY));
+        result.put(RADIUS_FIELD, radius);
+        return result;
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/data/geometry/Geography.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/geometry/Geography.java
@@ -5,8 +5,11 @@
  */
 package io.debezium.data.geometry;
 
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 
 /**
  * A semantic type for a Geography class.
@@ -37,5 +40,24 @@ public class Geography extends Geometry {
                 .doc("Geography")
                 .field(WKB_FIELD, Schema.BYTES_SCHEMA)
                 .field(SRID_FIELD, Schema.OPTIONAL_INT32_SCHEMA);
+    }
+
+    /**
+     * Overrides the inherited {@link Geometry#createValue(Schema, byte[], Integer, Map)}: unlike
+     * {@link Geometry}, a {@link Geography} schema carries no {@code extensions} field, so any non-empty
+     * extensions would fail with an opaque {@code DataException}. Rejecting them here makes the misuse
+     * explicit; a {@code null} or empty map delegates to the plain three-argument form.
+     *
+     * @param geomSchema a {@link Schema} instance which represents a geography; may not be null
+     * @param wkb OGC Well-Known Binary representation of the geometry; may not be null
+     * @param srid the coordinate reference system identifier; may be null if unset/unknown
+     * @param extensions must be null or empty for a Geography value
+     * @return a {@link Struct} which represents a Connect value for this schema; never null
+     */
+    public static Struct createValue(Schema geomSchema, byte[] wkb, Integer srid, Map<String, String> extensions) {
+        if (extensions != null && !extensions.isEmpty()) {
+            throw new IllegalArgumentException("Geography does not support extensions");
+        }
+        return Geometry.createValue(geomSchema, wkb, srid);
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/data/geometry/Geometry.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/geometry/Geometry.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.data.geometry;
 
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -26,6 +28,20 @@ public class Geometry {
 
     public static final String WKB_FIELD = "wkb";
     public static final String SRID_FIELD = "srid";
+    public static final String EXTENSIONS_FIELD = "extensions";
+
+    /**
+     * Key of the {@link #EXTENSIONS_FIELD} entry that names the native source type a value originated
+     * from (for example {@code box}, {@code lseg}, {@code path}, {@code polygon}). Its presence lets a
+     * sink distinguish a native geometric type from a genuine PostGIS geometry.
+     */
+    public static final String EXTENSION_TYPE_KEY = "type";
+
+    /**
+     * Key of the {@link #EXTENSIONS_FIELD} entry that records whether a {@code path} is closed
+     * ({@code "true"}) or open ({@code "false"}), which WKB itself cannot express.
+     */
+    public static final String EXTENSION_CLOSED_KEY = "closed";
 
     /**
      * Returns a {@link SchemaBuilder} for a Geometry field. You can use the resulting SchemaBuilder
@@ -36,11 +52,12 @@ public class Geometry {
     public static SchemaBuilder builder() {
         return SchemaBuilder.struct()
                 .name(LOGICAL_NAME)
-                .version(1)
+                .version(2)
                 .doc("Geometry")
                 .optional()
                 .field(WKB_FIELD, Schema.BYTES_SCHEMA)
-                .field(SRID_FIELD, Schema.OPTIONAL_INT32_SCHEMA);
+                .field(SRID_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
+                .field(EXTENSIONS_FIELD, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
     }
 
     /**
@@ -65,6 +82,28 @@ public class Geometry {
         result.put(WKB_FIELD, wkb);
         if (srid != null) {
             result.put(SRID_FIELD, srid);
+        }
+        return result;
+    }
+
+    /**
+     * Create a value for this schema using WKB, SRID and a set of extensions.
+     * <p>
+     * Extensions carry information that plain WKB cannot express, for example the native PostgreSQL
+     * type a value originated from ({@code type}) or the open/closed nature of a {@code path}. The
+     * {@code extensions} field is optional; a {@code null} or empty map leaves it unset, which is how
+     * a genuine PostGIS geometry is distinguished from a native geometric type on the sink side.
+     *
+     * @param geomSchema a {@link Schema} instance which represents a geometry; may not be null
+     * @param wkb OGC Well-Known Binary representation of the geometry; may not be null
+     * @param srid the coordinate reference system identifier; may be null if unset/unknown
+     * @param extensions additional key/value metadata; may be null or empty
+     * @return a {@link Struct} which represents a Connect value for this schema; never null
+     */
+    public static Struct createValue(Schema geomSchema, byte[] wkb, Integer srid, Map<String, String> extensions) {
+        Struct result = createValue(geomSchema, wkb, srid);
+        if (extensions != null && !extensions.isEmpty()) {
+            result.put(EXTENSIONS_FIELD, extensions);
         }
         return result;
     }

--- a/debezium-connector-common/src/main/java/io/debezium/data/geometry/Line.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/geometry/Line.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.data.geometry;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * A semantic type for a PostgreSQL {@code line}, an infinite line described by the linear equation
+ * {@code Ax + By + C = 0} and stored as the coefficients {@code {a, b, c}}.
+ * <p>
+ * This type does not extend {@link Geometry}: an infinite line has no OGC Well-Known Binary
+ * representation (WKB models only finite geometries), so it carries the three coefficients
+ * losslessly instead and lets the sink dispatch on this logical name.
+ *
+ * @author Debezium Authors
+ */
+public class Line {
+
+    public static final String LOGICAL_NAME = "io.debezium.data.geometry.Line";
+    public static final String A_FIELD = "a";
+    public static final String B_FIELD = "b";
+    public static final String C_FIELD = "c";
+
+    /**
+     * Returns a {@link SchemaBuilder} for a Line field. You can use the resulting SchemaBuilder
+     * to set additional schema settings such as required/optional, default value, and documentation.
+     *
+     * @return the schema builder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.struct()
+                .name(LOGICAL_NAME)
+                .version(1)
+                .doc("Geometry (LINE)")
+                .optional()
+                .field(A_FIELD, Schema.FLOAT64_SCHEMA)
+                .field(B_FIELD, Schema.FLOAT64_SCHEMA)
+                .field(C_FIELD, Schema.FLOAT64_SCHEMA);
+    }
+
+    /**
+     * Returns a {@link Schema} for a Line field, with all other default Schema settings.
+     *
+     * @return the schema
+     * @see #builder()
+     */
+    public static Schema schema() {
+        return builder().build();
+    }
+
+    /**
+     * Creates a value for this schema using the line's coefficients.
+     *
+     * @param lineSchema a {@link Schema} instance which represents a line; may not be null
+     * @param a the {@code A} coefficient
+     * @param b the {@code B} coefficient
+     * @param c the {@code C} coefficient
+     * @return a {@link Struct} which represents a Connect value for this schema; never null
+     */
+    public static Struct createValue(Schema lineSchema, double a, double b, double c) {
+        Struct result = new Struct(lineSchema);
+        result.put(A_FIELD, a);
+        result.put(B_FIELD, b);
+        result.put(C_FIELD, c);
+        return result;
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/spatial/WkbReader.java
+++ b/debezium-connector-common/src/main/java/io/debezium/spatial/WkbReader.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spatial;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Reads the 2D coordinates back out of an OGC Well-Known Binary (WKB) byte array produced by
+ * {@link WkbWriter}. This is the complement used on the sink side to reconstruct native PostgreSQL
+ * geometric text (e.g. {@code box}, {@code lseg}, {@code path}, {@code polygon}) from the WKB carried
+ * on the wire, without requiring PostGIS.
+ * <p>
+ * It reuses {@link GeometryTraverser} to walk the geometry, so it stays in lock-step with the writer
+ * and the rest of {@code io.debezium.spatial}.
+ *
+ * @author Debezium Authors
+ */
+public final class WkbReader {
+
+    /**
+     * Reads the ordered {@code (x, y)} vertices of a WKB {@code LineString}.
+     *
+     * @param wkb the little-endian WKB byte array; must not be {@code null}
+     * @return the vertices, each a {@code double[]{x, y}}
+     */
+    public static List<double[]> readLineString(byte[] wkb) {
+        return collectCoordinates(wkb);
+    }
+
+    /**
+     * Reads the ordered {@code (x, y)} vertices of the single ring of a WKB {@code Polygon}. The
+     * geometries Debezium emits for PostgreSQL {@code box}/{@code polygon} always carry exactly one
+     * ring; a polygon with holes (multiple rings) cannot be reconstructed as a native PostgreSQL value
+     * and is rejected rather than silently flattening the inner rings into the outer one.
+     *
+     * @param wkb the little-endian WKB byte array; must not be {@code null}
+     * @return the ring vertices, each a {@code double[]{x, y}}
+     * @throws DebeziumException if the polygon carries more than one ring
+     */
+    public static List<double[]> readPolygonRing(byte[] wkb) {
+        final CoordinateCollector collector = new CoordinateCollector();
+        traverse(wkb, collector);
+        if (collector.ringCount > 1) {
+            throw new DebeziumException("Cannot reconstruct a native PostgreSQL polygon from a multi-ring "
+                    + "(polygon-with-holes) geometry; found " + collector.ringCount + " rings");
+        }
+        return collector.coordinates;
+    }
+
+    private static List<double[]> collectCoordinates(byte[] wkb) {
+        final CoordinateCollector collector = new CoordinateCollector();
+        traverse(wkb, collector);
+        return collector.coordinates;
+    }
+
+    private static void traverse(byte[] wkb, GeometryVisitor visitor) {
+        final ByteBuffer buffer = ByteBuffer.wrap(wkb);
+        buffer.order(GeometryUtil.getByteOrder(buffer.get()));
+        GeometryTraverser.traverse(buffer, visitor);
+    }
+
+    private static final class CoordinateCollector implements GeometryVisitor {
+
+        private final List<double[]> coordinates = new ArrayList<>();
+        private int ringCount;
+
+        @Override
+        public void startPolygon(int rings) {
+            ringCount = rings;
+        }
+
+        @Override
+        public void visitCoordinate(double[] ordinates) {
+            coordinates.add(new double[]{ ordinates[0], ordinates[1] });
+        }
+    }
+
+    private WkbReader() {
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/spatial/WkbWriter.java
+++ b/debezium-connector-common/src/main/java/io/debezium/spatial/WkbWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spatial;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+/**
+ * Builds OGC Well-Known Binary (WKB) byte arrays from raw {@code (x, y)} coordinates.
+ * <p>
+ * The rest of {@code io.debezium.spatial} reads or rewrites existing WKB/EWKB; this class is the
+ * complement that encodes 2D geometries from scratch, mirroring the byte layout emitted by
+ * {@code GeometryCoordinateSwapper.SwapVisitor} and {@code io.debezium.data.geometry.Point#buildWKBPoint}.
+ * All output uses little-endian byte order and carries no SRID (these are planar, unreferenced
+ * geometries), so it is strict OGC WKB.
+ *
+ * @author Debezium Authors
+ */
+public final class WkbWriter {
+
+    private static final int HEADER_SIZE = 1 + 4; // byte order + geometry type
+    private static final int COUNT_SIZE = 4; // a 4-byte element count (points or rings)
+    private static final int COORDINATE_SIZE = 8 + 8; // x + y as doubles
+
+    /**
+     * Builds a WKB {@code LineString} from the given points.
+     *
+     * @param points the ordered vertices, each a {@code double[]{x, y}}; must not be {@code null}
+     * @return the little-endian WKB byte array
+     */
+    public static byte[] buildLineString(List<double[]> points) {
+        final ByteBuffer buffer = allocate(HEADER_SIZE + COUNT_SIZE + points.size() * COORDINATE_SIZE);
+        writeHeader(buffer, GeometryConstants.LINE_STRING);
+        writePoints(buffer, points);
+        return buffer.array();
+    }
+
+    /**
+     * Builds a WKB {@code Polygon} from the given rings. Each ring should already be closed
+     * (first vertex equal to last).
+     *
+     * @param rings the rings, outer ring first; each ring a list of {@code double[]{x, y}}; must not be {@code null}
+     * @return the little-endian WKB byte array
+     */
+    public static byte[] buildPolygon(List<List<double[]>> rings) {
+        int capacity = HEADER_SIZE + COUNT_SIZE;
+        for (List<double[]> ring : rings) {
+            capacity += COUNT_SIZE + ring.size() * COORDINATE_SIZE;
+        }
+
+        final ByteBuffer buffer = allocate(capacity);
+        writeHeader(buffer, GeometryConstants.POLYGON);
+        buffer.putInt(rings.size());
+        for (List<double[]> ring : rings) {
+            writePoints(buffer, ring);
+        }
+        return buffer.array();
+    }
+
+    private static ByteBuffer allocate(int capacity) {
+        final ByteBuffer buffer = ByteBuffer.allocate(capacity);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        return buffer;
+    }
+
+    private static void writeHeader(ByteBuffer buffer, int geometryType) {
+        buffer.put(GeometryUtil.getByteOrderByte(ByteOrder.LITTLE_ENDIAN));
+        buffer.putInt(geometryType);
+    }
+
+    private static void writePoints(ByteBuffer buffer, List<double[]> points) {
+        buffer.putInt(points.size());
+        for (double[] point : points) {
+            buffer.putDouble(point[0]);
+            buffer.putDouble(point[1]);
+        }
+    }
+
+    private WkbWriter() {
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/data/geometry/CircleLineTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/geometry/CircleLineTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the {@link Circle} and {@link Line} semantic types and the {@link Geometry}
- * extensions field added for DBZ-2135.
+ * extensions field added for dbz#2135.
  *
  * @author Debezium Authors
  */

--- a/debezium-connector-common/src/test/java/io/debezium/data/geometry/CircleLineTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/geometry/CircleLineTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data.geometry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link Circle} and {@link Line} semantic types and the {@link Geometry}
+ * extensions field added for DBZ-2135.
+ *
+ * @author Debezium Authors
+ */
+class CircleLineTest {
+
+    @Test
+    void circleShouldCarryCenterPointAndRadius() {
+        final Schema schema = Circle.schema();
+        final Struct value = Circle.createValue(schema, 10.0, 4.0, 10.0);
+
+        final Struct center = value.getStruct(Circle.CENTER_FIELD);
+        assertThat(center.getFloat64(Point.X_FIELD)).isEqualTo(10.0);
+        assertThat(center.getFloat64(Point.Y_FIELD)).isEqualTo(4.0);
+        assertThat(center.getBytes(Point.WKB_FIELD)).isNotNull(); // center is a real OGC point
+        assertThat(value.getFloat64(Circle.RADIUS_FIELD)).isEqualTo(10.0);
+        assertThat(schema.name()).isEqualTo("io.debezium.data.geometry.Circle");
+    }
+
+    @Test
+    void lineShouldCarryCoefficients() {
+        final Schema schema = Line.schema();
+        final Struct value = Line.createValue(schema, -1.0, 0.0, 0.0);
+
+        assertThat(value.getFloat64(Line.A_FIELD)).isEqualTo(-1.0);
+        assertThat(value.getFloat64(Line.B_FIELD)).isEqualTo(0.0);
+        assertThat(value.getFloat64(Line.C_FIELD)).isEqualTo(0.0);
+        assertThat(schema.name()).isEqualTo("io.debezium.data.geometry.Line");
+    }
+
+    @Test
+    void geometrySchemaShouldExposeOptionalExtensions() {
+        final Schema schema = Geometry.schema();
+
+        assertThat(schema.version()).isEqualTo(2);
+        assertThat(schema.field(Geometry.EXTENSIONS_FIELD)).isNotNull();
+        assertThat(schema.field(Geometry.EXTENSIONS_FIELD).schema().isOptional()).isTrue();
+    }
+
+    @Test
+    void geometryCreateValueShouldStoreExtensionsWhenPresent() {
+        final Schema schema = Geometry.schema();
+        final byte[] wkb = new byte[]{ 0x01 };
+
+        final Struct withExtensions = Geometry.createValue(schema, wkb, null,
+                Map.of(Geometry.EXTENSION_TYPE_KEY, "box"));
+        assertThat(withExtensions.getMap(Geometry.EXTENSIONS_FIELD)).containsEntry(Geometry.EXTENSION_TYPE_KEY, "box");
+
+        final Struct withoutExtensions = Geometry.createValue(schema, wkb, null, Map.of());
+        assertThat(withoutExtensions.getMap(Geometry.EXTENSIONS_FIELD)).isNull();
+    }
+
+    @Test
+    void geographyShouldRejectExtensions() {
+        // Geography (v1) has no extensions field, so a non-empty extensions map cannot be represented.
+        final Schema schema = Geography.schema();
+        final byte[] wkb = new byte[]{ 0x01 };
+
+        assertThatThrownBy(() -> Geography.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // A null or empty map is fine and delegates to the plain three-argument form.
+        assertThat(Geography.createValue(schema, wkb, null, Map.of()).getBytes(Geometry.WKB_FIELD)).isEqualTo(wkb);
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/spatial/WkbWriterReaderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/spatial/WkbWriterReaderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spatial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Unit tests for {@link WkbWriter} and {@link WkbReader}, verifying that coordinates survive a
+ * round-trip through the WKB encoding used for PostgreSQL geometric types.
+ *
+ * @author Debezium Authors
+ */
+class WkbWriterReaderTest {
+
+    @Test
+    void shouldRoundTripLineString() {
+        final List<double[]> points = List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 0.0, 2.0 });
+
+        final byte[] wkb = WkbWriter.buildLineString(points);
+
+        // little-endian byte order marker + LINE_STRING type
+        assertThat(wkb[0]).isEqualTo((byte) 0x01);
+        assertCoordinates(WkbReader.readLineString(wkb), points);
+    }
+
+    @Test
+    void shouldRoundTripTwoPointLineStringForLseg() {
+        final List<double[]> points = List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 });
+
+        assertCoordinates(WkbReader.readLineString(WkbWriter.buildLineString(points)), points);
+    }
+
+    @Test
+    void shouldRoundTripPolygonRing() {
+        // A box '(1,1),(0,0)' becomes a closed 5-point ring
+        final List<double[]> ring = List.of(
+                new double[]{ 1.0, 1.0 },
+                new double[]{ 1.0, 0.0 },
+                new double[]{ 0.0, 0.0 },
+                new double[]{ 0.0, 1.0 },
+                new double[]{ 1.0, 1.0 });
+
+        final byte[] wkb = WkbWriter.buildPolygon(List.of(ring));
+
+        assertThat(wkb[0]).isEqualTo((byte) 0x01);
+        assertCoordinates(WkbReader.readPolygonRing(wkb), ring);
+    }
+
+    @Test
+    void shouldRejectMultiRingPolygonWhenReadingRing() {
+        // A polygon with a hole: an outer ring and an inner ring. Native PostgreSQL polygons are always
+        // single-ring, so reconstructing one from this would silently merge the inner ring into the outer.
+        final List<double[]> outer = List.of(
+                new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 3.0 }, new double[]{ 3.0, 3.0 },
+                new double[]{ 3.0, 0.0 }, new double[]{ 0.0, 0.0 });
+        final List<double[]> inner = List.of(
+                new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 2.0 }, new double[]{ 2.0, 2.0 },
+                new double[]{ 2.0, 1.0 }, new double[]{ 1.0, 1.0 });
+
+        final byte[] wkb = WkbWriter.buildPolygon(List.of(outer, inner));
+
+        assertThatThrownBy(() -> WkbReader.readPolygonRing(wkb))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("multi-ring");
+    }
+
+    private static void assertCoordinates(List<double[]> actual, List<double[]> expected) {
+        assertThat(actual).hasSameSizeAs(expected);
+        for (int i = 0; i < expected.size(); i++) {
+            assertThat(actual.get(i)).containsExactly(expected.get(i));
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/CircleType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/CircleType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.geometry.Circle;
+import io.debezium.data.geometry.Point;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Circle} values, binding
+ * them to the native PostgreSQL {@code circle} type without requiring PostGIS.
+ *
+ * @author Debezium Authors
+ */
+class CircleType extends AbstractType {
+
+    public static final CircleType INSTANCE = new CircleType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Circle.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as circle)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "circle";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+
+        final Struct circle = requireStruct(value);
+        final Struct center = circle.getStruct(Circle.CENTER_FIELD);
+        final double x = center.getFloat64(Point.X_FIELD);
+        final double y = center.getFloat64(Point.Y_FIELD);
+        final double radius = circle.getFloat64(Circle.RADIUS_FIELD);
+        return List.of(new ValueBindDescriptor(index, "<(" + x + "," + y + ")," + radius + ">"));
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/GeometryType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/GeometryType.java
@@ -5,14 +5,24 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.AbstractGeometryType;
+import io.debezium.data.geometry.Geometry;
 import io.debezium.sink.SinkConnectorConfig;
 import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.spatial.WkbReader;
 
 public class GeometryType extends AbstractGeometryType {
 
@@ -20,6 +30,14 @@ public class GeometryType extends AbstractGeometryType {
 
     protected static final String GEO_FROM_WKB_FUNCTION = "%s.ST_GeomFromWKB(?, ?)";
     private static final String TYPE_NAME = "%s.geometry";
+
+    /**
+     * The native PostgreSQL geometric types that the connector maps onto the shared {@link Geometry}
+     * schema. When a value carries one of these as its propagated source-column type, the sink binds it
+     * back to the native type with a plain {@code cast(? as <type>)}, so no PostGIS extension is
+     * required; anything else is treated as a genuine PostGIS geometry.
+     */
+    private static final Set<String> NATIVE_GEOMETRIC_TYPES = Set.of("box", "lseg", "path", "polygon");
 
     protected String postgisSchema = "public";
 
@@ -34,11 +52,100 @@ public class GeometryType extends AbstractGeometryType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        final Optional<String> nativeType = nativeGeometricType(schema);
+        if (nativeType.isPresent()) {
+            return "cast(? as " + nativeType.get() + ")";
+        }
         return String.format(GEO_FROM_WKB_FUNCTION, postgisSchema);
     }
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
+        final Optional<String> nativeType = nativeGeometricType(schema);
+        if (nativeType.isPresent()) {
+            return nativeType.get();
+        }
         return String.format(TYPE_NAME, postgisSchema);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        final Optional<String> nativeType = nativeGeometricType(schema);
+        if (nativeType.isPresent()) {
+            if (value == null) {
+                return List.of(new ValueBindDescriptor(index, null));
+            }
+            return List.of(new ValueBindDescriptor(index, reconstructNativeText(nativeType.get(), requireStruct(value))));
+        }
+        return super.bind(index, schema, value);
+    }
+
+    /**
+     * Returns the native PostgreSQL geometric type a value originated from, when the schema carries a
+     * propagated source-column type in {@link #NATIVE_GEOMETRIC_TYPES}. The decision is made purely from
+     * the schema so that the placeholder count in {@link #getQueryBinding} stays stable across a batch,
+     * independent of any individual (possibly null) value.
+     */
+    private Optional<String> nativeGeometricType(Schema schema) {
+        return getSourceColumnType(schema)
+                .map(type -> type.toLowerCase(Locale.ROOT))
+                .filter(NATIVE_GEOMETRIC_TYPES::contains);
+    }
+
+    /**
+     * Rebuilds the canonical PostgreSQL text of a native geometric value from the WKB carried on the
+     * shared {@link Geometry} struct, so it can be bound to a native column without PostGIS.
+     */
+    private String reconstructNativeText(String nativeType, Struct struct) {
+        final byte[] wkb = struct.getBytes(WKB);
+        switch (nativeType) {
+            case "box":
+                // A box is encoded as a closed 5-point rectangle ring; two opposite corners suffice.
+                final List<double[]> boxRing = WkbReader.readPolygonRing(wkb);
+                return point(boxRing.get(0)) + "," + point(boxRing.get(2));
+            case "lseg":
+                return "[" + joinPoints(WkbReader.readLineString(wkb)) + "]";
+            case "path":
+                final List<double[]> pathPoints = WkbReader.readLineString(wkb);
+                return isClosedPath(struct)
+                        ? "(" + joinPoints(pathPoints) + ")"
+                        : "[" + joinPoints(pathPoints) + "]";
+            case "polygon":
+                final List<double[]> ring = WkbReader.readPolygonRing(wkb);
+                // Drop the duplicated closing vertex that WKB requires but PostgreSQL text does not.
+                final List<double[]> vertices = isRingClosed(ring) ? ring.subList(0, ring.size() - 1) : ring;
+                return "(" + joinPoints(vertices) + ")";
+            default:
+                throw unexpectedValue(struct);
+        }
+    }
+
+    private boolean isClosedPath(Struct struct) {
+        if (struct.schema().field(Geometry.EXTENSIONS_FIELD) == null) {
+            return false;
+        }
+        final var extensions = struct.getMap(Geometry.EXTENSIONS_FIELD);
+        return extensions != null && Boolean.parseBoolean((String) extensions.get(Geometry.EXTENSION_CLOSED_KEY));
+    }
+
+    private static boolean isRingClosed(List<double[]> ring) {
+        if (ring.size() < 2) {
+            return false;
+        }
+        final double[] first = ring.get(0);
+        final double[] last = ring.get(ring.size() - 1);
+        return first[0] == last[0] && first[1] == last[1];
+    }
+
+    private static String joinPoints(List<double[]> points) {
+        final StringJoiner joiner = new StringJoiner(",");
+        for (double[] point : points) {
+            joiner.add(point(point));
+        }
+        return joiner.toString();
+    }
+
+    private static String point(double[] point) {
+        return "(" + point[0] + "," + point[1] + ")";
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/LineType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/LineType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.geometry.Line;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Line} values, binding
+ * them to the native PostgreSQL {@code line} type.
+ *
+ * @author Debezium Authors
+ */
+class LineType extends AbstractType {
+
+    public static final LineType INSTANCE = new LineType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Line.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as line)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "line";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+
+        final Struct line = requireStruct(value);
+        final double a = line.getFloat64(Line.A_FIELD);
+        final double b = line.getFloat64(Line.B_FIELD);
+        final double c = line.getFloat64(Line.C_FIELD);
+        return List.of(new ValueBindDescriptor(index, "{" + a + "," + b + "," + c + "}"));
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -136,6 +136,14 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         // Get first record for schema information
         JdbcSinkRecord firstRecord = records.get(0);
 
+        // The UNNEST path binds each column as a SQL array via Connection#createArrayOf, bypassing the
+        // per-value JdbcType#bind() the row-wise path uses. Types whose bind() reconstructs a different
+        // representation (e.g. the native geometric types, which turn a Struct into PostgreSQL text) would
+        // otherwise hand raw Structs to createArrayOf and fail, so fall back to the row-wise path for them.
+        if (hasUnnestUnsupportedField(firstRecord)) {
+            return Optional.empty();
+        }
+
         final SqlStatementBuilder builder = new SqlStatementBuilder();
 
         builder.append("INSERT INTO ");
@@ -167,6 +175,17 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         builder.append(")");
 
         return Optional.of(builder.build());
+    }
+
+    /**
+     * Whether a record carries a field the UNNEST batch path cannot bind. That path passes each column's
+     * values to {@link Connection#createArrayOf}, which only accepts scalar elements; a {@code STRUCT}
+     * field (the geometric types point/box/lseg/path/polygon and circle/line) needs the per-value
+     * {@code JdbcType#bind()} the row-wise path applies, so such records are handled row-wise instead.
+     */
+    private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
+        return record.jdbcFields().values().stream()
+                .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT);
     }
 
     @Override
@@ -270,6 +289,8 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         registerType(PointType.INSTANCE);
         registerType(GeometryType.INSTANCE);
         registerType(GeographyType.INSTANCE);
+        registerType(CircleType.INSTANCE);
+        registerType(LineType.INSTANCE);
         registerType(MoneyType.INSTANCE);
         registerType(XmlType.INSTANCE);
         registerType(LtreeType.INSTANCE);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
@@ -26,7 +26,7 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.spatial.WkbWriter;
 
 /**
- * Unit tests for the PostgreSQL sink binding of the geometric types added in DBZ-2135:
+ * Unit tests for the PostgreSQL sink binding of the geometric types added in dbz#2135:
  * {@link GeometryType} native reconstruction (box/lseg/path/polygon), and the standalone
  * {@link CircleType}/{@link LineType}.
  *
@@ -135,7 +135,7 @@ class GeometricTypesBindingTest {
         // The source emits these origin-only shapes as the NOT NULL fallback for a null geometric value
         // (PostgresValueConverter#geometryFallback). A box reconstructs from ring vertices 0 and 2, so its
         // fallback must carry a full ring; an lseg needs two points. This guards against the previous
-        // one-point fallback that threw IndexOutOfBounds / produced invalid native text (DBZ-2135).
+        // one-point fallback that threw IndexOutOfBounds / produced invalid native text (dbz#2135).
         final Schema boxSchema = geometrySchemaFor("box");
         final Struct box = Geometry.createValue(boxSchema,
                 WkbWriter.buildPolygon(List.of(List.of(

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.geometry.Circle;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Line;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.spatial.WkbWriter;
+
+/**
+ * Unit tests for the PostgreSQL sink binding of the geometric types added in DBZ-2135:
+ * {@link GeometryType} native reconstruction (box/lseg/path/polygon), and the standalone
+ * {@link CircleType}/{@link LineType}.
+ *
+ * @author Debezium Authors
+ */
+@Tag("UnitTests")
+class GeometricTypesBindingTest {
+
+    /**
+     * Builds a shared-{@link Geometry} schema whose propagated source-column type drives the native
+     * binding branch, mirroring how {@code column.propagate.source.type} surfaces the type on the sink.
+     */
+    private static Schema geometrySchemaFor(String sourceType) {
+        return new SchemaBuilder(Schema.Type.STRUCT)
+                .name(Geometry.LOGICAL_NAME)
+                .version(2)
+                .optional()
+                .parameter("__debezium.source.column.type", sourceType)
+                .field(Geometry.WKB_FIELD, Schema.BYTES_SCHEMA)
+                .field(Geometry.SRID_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
+                .field(Geometry.EXTENSIONS_FIELD, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build())
+                .build();
+    }
+
+    @Test
+    void boxShouldBindAsNativeText() {
+        final Schema schema = geometrySchemaFor("box");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 0.0 }, new double[]{ 0.0, 0.0 },
+                        new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 1.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box"));
+
+        assertThat(GeometryType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as box)");
+        assertThat(bindValue(GeometryType.INSTANCE, schema, value)).isEqualTo("(1.0,1.0),(0.0,0.0)");
+    }
+
+    @Test
+    void lsegShouldBindAsNativeText() {
+        final Schema schema = geometrySchemaFor("lseg");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildLineString(List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 })),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg"));
+
+        assertThat(GeometryType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as lseg)");
+        assertThat(bindValue(GeometryType.INSTANCE, schema, value)).isEqualTo("[(0.0,0.0),(0.0,1.0)]");
+    }
+
+    @Test
+    void closedPathShouldBindWithParentheses() {
+        final Schema schema = geometrySchemaFor("path");
+        final Map<String, String> extensions = new LinkedHashMap<>();
+        extensions.put(Geometry.EXTENSION_TYPE_KEY, "path");
+        extensions.put(Geometry.EXTENSION_CLOSED_KEY, "true");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildLineString(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 0.0, 2.0 })),
+                null, extensions);
+
+        assertThat(bindValue(GeometryType.INSTANCE, schema, value)).isEqualTo("((0.0,0.0),(0.0,1.0),(0.0,2.0))");
+    }
+
+    @Test
+    void openPathShouldBindWithBrackets() {
+        final Schema schema = geometrySchemaFor("path");
+        final Map<String, String> extensions = new LinkedHashMap<>();
+        extensions.put(Geometry.EXTENSION_TYPE_KEY, "path");
+        extensions.put(Geometry.EXTENSION_CLOSED_KEY, "false");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildLineString(List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 })),
+                null, extensions);
+
+        assertThat(bindValue(GeometryType.INSTANCE, schema, value)).isEqualTo("[(0.0,0.0),(0.0,1.0)]");
+    }
+
+    @Test
+    void polygonShouldDropClosingVertex() {
+        final Schema schema = geometrySchemaFor("polygon");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 0.0 },
+                        new double[]{ 0.0, 0.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon"));
+
+        assertThat(bindValue(GeometryType.INSTANCE, schema, value)).isEqualTo("((0.0,0.0),(0.0,1.0),(1.0,0.0))");
+    }
+
+    @Test
+    void multiRingPolygonShouldBeRejected() {
+        // A polygon with a hole cannot be reconstructed as a native single-ring PostgreSQL polygon.
+        final Schema schema = geometrySchemaFor("polygon");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildPolygon(List.of(
+                        List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 3.0 }, new double[]{ 3.0, 3.0 },
+                                new double[]{ 3.0, 0.0 }, new double[]{ 0.0, 0.0 }),
+                        List.of(new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 2.0 }, new double[]{ 2.0, 2.0 },
+                                new double[]{ 2.0, 1.0 }, new double[]{ 1.0, 1.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon"));
+
+        assertThatThrownBy(() -> GeometryType.INSTANCE.bind(1, schema, value))
+                .hasMessageContaining("multi-ring");
+    }
+
+    @Test
+    void degenerateFallbackShapesShouldReconstructWithoutCrashing() {
+        // The source emits these origin-only shapes as the NOT NULL fallback for a null geometric value
+        // (PostgresValueConverter#geometryFallback). A box reconstructs from ring vertices 0 and 2, so its
+        // fallback must carry a full ring; an lseg needs two points. This guards against the previous
+        // one-point fallback that threw IndexOutOfBounds / produced invalid native text (DBZ-2135).
+        final Schema boxSchema = geometrySchemaFor("box");
+        final Struct box = Geometry.createValue(boxSchema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0, 0 }, new double[]{ 0, 0 }, new double[]{ 0, 0 },
+                        new double[]{ 0, 0 }, new double[]{ 0, 0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box"));
+        assertThat(bindValue(GeometryType.INSTANCE, boxSchema, box)).isEqualTo("(0.0,0.0),(0.0,0.0)");
+
+        final Schema lsegSchema = geometrySchemaFor("lseg");
+        final Struct lseg = Geometry.createValue(lsegSchema,
+                WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 0, 0 })),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg"));
+        assertThat(bindValue(GeometryType.INSTANCE, lsegSchema, lseg)).isEqualTo("[(0.0,0.0),(0.0,0.0)]");
+    }
+
+    @Test
+    void genuinePostGisGeometryShouldUseWkbFunction() {
+        // No propagated native type -> falls back to the PostGIS ST_GeomFromWKB path (two placeholders)
+        final Schema schema = Geometry.schema();
+        assertThat(GeometryType.INSTANCE.getQueryBinding(null, schema, null)).isEqualTo("public.ST_GeomFromWKB(?, ?)");
+    }
+
+    @Test
+    void circleShouldBindAsNativeText() {
+        final Schema schema = Circle.schema();
+        final Struct value = Circle.createValue(schema, 10.0, 4.0, 10.0);
+
+        assertThat(CircleType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as circle)");
+        assertThat(bindValue(CircleType.INSTANCE, schema, value)).isEqualTo("<(10.0,4.0),10.0>");
+    }
+
+    @Test
+    void lineShouldBindAsNativeText() {
+        final Schema schema = Line.schema();
+        final Struct value = Line.createValue(schema, -1.0, 0.0, 0.0);
+
+        assertThat(LineType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as line)");
+        assertThat(bindValue(LineType.INSTANCE, schema, value)).isEqualTo("{-1.0,0.0,0.0}");
+    }
+
+    private static Object bindValue(JdbcType type, Schema schema, Object value) {
+        final List<ValueBindDescriptor> bindings = type.bind(1, schema, value);
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getIndex()).isEqualTo(1);
+        return bindings.get(0).getValue();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvider;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvider.PostgresInsertMode;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.geometry.Circle;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Line;
+import io.debezium.doc.FixFor;
+import io.debezium.spatial.WkbWriter;
+
+/**
+ * Round-trip tests that the six PostgreSQL geometric types added in DBZ-2135 bind to their native
+ * column types on a plain (non-PostGIS) PostgreSQL sink. The target table is pre-created with native
+ * column types, and the connector runs with source-type propagation so the sink can reconstruct the
+ * native values for box/lseg/path/polygon.
+ *
+ * @author Debezium Authors
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-postgresql")
+@ExtendWith(PostgresSinkDatabaseContextProvider.class)
+public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkGeometricTypesIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testBoxRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = geometrySchema("box");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 0.0 }, new double[]{ 0.0, 0.0 },
+                        new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 1.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box"));
+
+        assertRoundTrip(factory, insertMode, "box", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("(1,1),(0,0)"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testLsegRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = geometrySchema("lseg");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildLineString(List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 })),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg"));
+
+        assertRoundTrip(factory, insertMode, "lseg", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("[(0,0),(0,1)]"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testClosedPathRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = geometrySchema("path");
+        final Map<String, String> extensions = new LinkedHashMap<>();
+        extensions.put(Geometry.EXTENSION_TYPE_KEY, "path");
+        extensions.put(Geometry.EXTENSION_CLOSED_KEY, "true");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildLineString(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 0.0, 2.0 })),
+                null, extensions);
+
+        assertRoundTrip(factory, insertMode, "path", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("((0,0),(0,1),(0,2))"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testPolygonRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = geometrySchema("polygon");
+        final Struct value = Geometry.createValue(schema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 0.0 },
+                        new double[]{ 0.0, 0.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon"));
+
+        assertRoundTrip(factory, insertMode, "polygon", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("((0,0),(0,1),(1,0))"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testCircleRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = Circle.schema();
+        final Struct value = Circle.createValue(schema, 10.0, 4.0, 10.0);
+
+        assertRoundTrip(factory, insertMode, "circle", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("<(10,4),10>"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testLineRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = Line.schema();
+        final Struct value = Line.createValue(schema, -1.0, 0.0, 0.0);
+
+        assertRoundTrip(factory, insertMode, "line", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("{-1,0,0}"));
+    }
+
+    /**
+     * A batch of more than one record is what triggers PostgreSQL's UNNEST path (a single record
+     * short-circuits to a row-wise INSERT). Since the native geometric types reconstruct their value in
+     * {@code JdbcType#bind()}, which the UNNEST array-binding bypasses, this asserts the sink still routes
+     * box values through the row-wise path and reconstructs each of them correctly. Guards DBZ-2135.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-2135")
+    public void testBoxBatchRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = geometrySchema("box");
+        final List<String> expected = List.of("(1,1),(0,0)", "(3,3),(2,2)");
+
+        final List<Struct> values = List.of(
+                Geometry.createValue(schema,
+                        WkbWriter.buildPolygon(List.of(List.of(
+                                new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 0.0 }, new double[]{ 0.0, 0.0 },
+                                new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 1.0 }))),
+                        null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")),
+                Geometry.createValue(schema,
+                        WkbWriter.buildPolygon(List.of(List.of(
+                                new double[]{ 3.0, 3.0 }, new double[]{ 3.0, 2.0 }, new double[]{ 2.0, 2.0 },
+                                new double[]{ 2.0, 3.0 }, new double[]{ 3.0, 3.0 }))),
+                        null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")));
+
+        assertBatchRoundTrip(factory, insertMode, "box", schema, values, expected);
+    }
+
+    private void assertRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode, String columnType,
+                                 Schema fieldSchema, Object value, ResultSetConsumer assertion)
+            throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "false");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String topicName = topicName("server1", "schema", randomTableName());
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1, "data", fieldSchema, value, config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(String.format("CREATE TABLE %s (id int not null, data %s null, primary key(id))", destinationTable, columnType));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertion.accept(rs);
+            return null;
+        });
+    }
+
+    private void assertBatchRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode, String columnType,
+                                      Schema fieldSchema, List<Struct> values, List<String> expectedTexts)
+            throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.DELETE_ENABLED, "false");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String topicName = topicName("server1", "schema", randomTableName());
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+
+        final List<JdbcKafkaSinkRecord> records = new ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            records.add(factory.createRecordWithSchemaValue(topicName, (byte) (i + 1), "data", fieldSchema, values.get(i), config));
+        }
+
+        final String destinationTable = destinationTableName(records.get(0));
+        getSink().execute(String.format("CREATE TABLE %s (id int not null, data %s null, primary key(id))", destinationTable, columnType));
+
+        consume(records);
+
+        try (Statement st = getSink().getConnection().createStatement();
+                ResultSet rs = st.executeQuery("SELECT id, data FROM " + destinationTable + " ORDER BY id")) {
+            for (int i = 0; i < expectedTexts.size(); i++) {
+                assertThat(rs.next()).as("row %d present", i + 1).isTrue();
+                assertThat(rs.getInt(1)).isEqualTo(i + 1);
+                assertThat(rs.getString(2)).isEqualTo(expectedTexts.get(i));
+            }
+            assertThat(rs.next()).as("no extra rows").isFalse();
+        }
+    }
+
+    /**
+     * Builds the shared {@link Geometry} schema carrying the propagated native source-column type, which
+     * is what drives the sink's native (non-PostGIS) binding branch.
+     */
+    private static Schema geometrySchema(String sourceType) {
+        final SchemaBuilder builder = SchemaBuilder.struct()
+                .name(Geometry.LOGICAL_NAME)
+                .version(2)
+                .optional()
+                .parameter("__debezium.source.column.type", sourceType)
+                .field(Geometry.WKB_FIELD, Schema.BYTES_SCHEMA)
+                .field(Geometry.SRID_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
+                .field(Geometry.EXTENSIONS_FIELD, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
+        return builder.build();
+    }
+
+    @FunctionalInterface
+    private interface ResultSetConsumer {
+        void accept(java.sql.ResultSet rs) throws Exception;
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
@@ -37,7 +37,7 @@ import io.debezium.doc.FixFor;
 import io.debezium.spatial.WkbWriter;
 
 /**
- * Round-trip tests that the six PostgreSQL geometric types added in DBZ-2135 bind to their native
+ * Round-trip tests that the six PostgreSQL geometric types added in dbz#2135 bind to their native
  * column types on a plain (non-PostGIS) PostgreSQL sink. The target table is pre-created with native
  * column types, and the connector runs with source-type propagation so the sink can reconstruct the
  * native values for box/lseg/path/polygon.
@@ -56,7 +56,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testBoxRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = geometrySchema("box");
         final Struct value = Geometry.createValue(schema,
@@ -70,7 +70,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testLsegRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = geometrySchema("lseg");
         final Struct value = Geometry.createValue(schema,
@@ -82,7 +82,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testClosedPathRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = geometrySchema("path");
         final Map<String, String> extensions = new LinkedHashMap<>();
@@ -98,7 +98,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testPolygonRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = geometrySchema("polygon");
         final Struct value = Geometry.createValue(schema,
@@ -112,7 +112,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testCircleRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = Circle.schema();
         final Struct value = Circle.createValue(schema, 10.0, 4.0, 10.0);
@@ -122,7 +122,7 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testLineRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = Line.schema();
         final Struct value = Line.createValue(schema, -1.0, 0.0, 0.0);
@@ -134,11 +134,11 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
      * A batch of more than one record is what triggers PostgreSQL's UNNEST path (a single record
      * short-circuits to a row-wise INSERT). Since the native geometric types reconstruct their value in
      * {@code JdbcType#bind()}, which the UNNEST array-binding bypasses, this asserts the sink still routes
-     * box values through the row-wise path and reconstructs each of them correctly. Guards DBZ-2135.
+     * box values through the row-wise path and reconstructs each of them correctly. Guards dbz#2135.
      */
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
-    @FixFor("DBZ-2135")
+    @FixFor("debezium/dbz#2135")
     public void testBoxBatchRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Schema schema = geometrySchema("box");
         final List<String> expected = List.of("(1,1),(0,0)", "(3,3),(2,2)");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -1301,27 +1301,32 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     /**
      * Builds the non-null fallback a NOT NULL geometric column falls back to when a null value is
-     * received with no column default (see {@link #convertValue}). The WKB must be shaped so the sink
-     * can reconstruct a value the target native type actually accepts: a {@code box} is rebuilt from
-     * ring vertices 0 and 2 (so it needs a full ring), an {@code lseg} is a two-point segment, while a
-     * {@code path}/{@code polygon} tolerate a single point. All coordinates are the origin.
+     * received with no column default (see {@link #convertValue}). When {@code column.propagate.source.type}
+     * is unset the sink binds these through PostGIS {@code ST_GeomFromWKB}, which enforces the OGC
+     * minimum-vertex rules (a ring needs at least four points, a line string at least two) and rejects
+     * degenerate geometry. So each fallback is a small but genuinely valid shape rather than a repeated
+     * origin point: a {@code box}/{@code polygon} is a unit square/triangle ring (the box is rebuilt from
+     * ring vertices 0 and 2, which the square places on opposite corners), and an {@code lseg}/{@code path}
+     * is a two distinct-point segment.
      */
-    private static Struct geometryFallback(Schema schema, String type) {
+    // package-private for direct unit testing of the OGC minimum-vertex invariant
+    static Struct geometryFallback(Schema schema, String type) {
         final byte[] wkb;
         switch (type) {
             case "box":
                 wkb = WkbWriter.buildPolygon(List.of(List.of(
-                        new double[]{ 0, 0 }, new double[]{ 0, 0 }, new double[]{ 0, 0 },
-                        new double[]{ 0, 0 }, new double[]{ 0, 0 })));
+                        new double[]{ 0, 0 }, new double[]{ 0, 1 }, new double[]{ 1, 1 },
+                        new double[]{ 1, 0 }, new double[]{ 0, 0 })));
                 break;
             case "lseg":
-                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 0, 0 }));
+                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 1, 0 }));
                 break;
             case "polygon":
-                wkb = WkbWriter.buildPolygon(List.of(List.of(new double[]{ 0, 0 })));
+                wkb = WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0, 0 }, new double[]{ 1, 0 }, new double[]{ 0, 1 }, new double[]{ 0, 0 })));
                 break;
             default: // path
-                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }));
+                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 1, 0 }));
                 break;
         }
         return Geometry.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, type));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,9 +42,16 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.postgresql.PGStatement;
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
 import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.HStoreConverter;
 import org.postgresql.util.PGInterval;
@@ -64,8 +72,10 @@ import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.TsVector;
 import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
+import io.debezium.data.geometry.Circle;
 import io.debezium.data.geometry.Geography;
 import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Line;
 import io.debezium.data.geometry.Point;
 import io.debezium.data.vector.DoubleVector;
 import io.debezium.data.vector.FloatVector;
@@ -74,6 +84,7 @@ import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
+import io.debezium.spatial.WkbWriter;
 import io.debezium.time.Conversions;
 import io.debezium.time.Interval;
 import io.debezium.time.MicroDuration;
@@ -232,6 +243,15 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 return Uuid.builder();
             case PgOid.POINT:
                 return Point.builder();
+            case PgOid.BOX:
+            case PgOid.LSEG:
+            case PgOid.PATH:
+            case PgOid.POLYGON:
+                return Geometry.builder();
+            case PgOid.CIRCLE:
+                return Circle.builder();
+            case PgOid.LINE:
+                return Line.builder();
             case PgOid.MONEY:
                 return moneySchema();
             case PgOid.NUMERIC:
@@ -465,6 +485,18 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 return data -> convertString(column, fieldDefn, data);
             case PgOid.POINT:
                 return data -> convertPoint(column, fieldDefn, data);
+            case PgOid.BOX:
+                return data -> convertBox(column, fieldDefn, data);
+            case PgOid.LSEG:
+                return data -> convertLseg(column, fieldDefn, data);
+            case PgOid.PATH:
+                return data -> convertPath(column, fieldDefn, data);
+            case PgOid.POLYGON:
+                return data -> convertPolygon(column, fieldDefn, data);
+            case PgOid.CIRCLE:
+                return data -> convertCircle(column, fieldDefn, data);
+            case PgOid.LINE:
+                return data -> convertLine(column, fieldDefn, data);
             case PgOid.MONEY:
                 return data -> convertMoney(column, fieldDefn, data, decimalMode);
             case PgOid.NUMERIC:
@@ -1131,6 +1163,186 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 r.deliver(Point.createValue(schema, ((PgProto.Point) data).getX(), ((PgProto.Point) data).getY()));
             }
         });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code box} to a {@link Geometry} value. The two opposing corners are
+     * encoded as a coordinate-exact, closed 5-point polygon ring; the {@code box} label is preserved
+     * in the extensions so the sink can reconstruct the native value.
+     */
+    protected Object convertBox(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        return convertValue(column, fieldDefn, data, geometryFallback(schema, "box"), (r) -> {
+            PGbox box = asGeometricValue(column, data, PGbox.class, PGbox::new);
+            if (box != null) {
+                double x1 = box.point[0].x, y1 = box.point[0].y;
+                double x2 = box.point[1].x, y2 = box.point[1].y;
+                byte[] wkb = WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ x1, y1 },
+                        new double[]{ x1, y2 },
+                        new double[]{ x2, y2 },
+                        new double[]{ x2, y1 },
+                        new double[]{ x1, y1 })));
+                r.deliver(Geometry.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")));
+            }
+        });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code lseg} (a line segment between two points) to a {@link Geometry}
+     * value encoded as a two-point line string.
+     */
+    protected Object convertLseg(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        return convertValue(column, fieldDefn, data, geometryFallback(schema, "lseg"), (r) -> {
+            // ReplicationMessage#asLseg is typed as Object, so accept any PGlseg the driver/decoder returns
+            PGlseg lseg = asGeometricValue(column, data, PGlseg.class, PGlseg::new);
+            if (lseg != null) {
+                byte[] wkb = WkbWriter.buildLineString(List.of(
+                        new double[]{ lseg.point[0].x, lseg.point[0].y },
+                        new double[]{ lseg.point[1].x, lseg.point[1].y }));
+                r.deliver(Geometry.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg")));
+            }
+        });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code path} to a {@link Geometry} value encoded as a line string. A path
+     * may be open or closed; that flag has no WKB representation, so it is preserved in the extensions.
+     */
+    protected Object convertPath(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        return convertValue(column, fieldDefn, data, geometryFallback(schema, "path"), (r) -> {
+            PGpath path = asGeometricValue(column, data, PGpath.class, PGpath::new);
+            if (path != null) {
+                List<double[]> points = new ArrayList<>(path.points.length);
+                for (PGpoint point : path.points) {
+                    points.add(new double[]{ point.x, point.y });
+                }
+                Map<String, String> extensions = new LinkedHashMap<>();
+                extensions.put(Geometry.EXTENSION_TYPE_KEY, "path");
+                extensions.put(Geometry.EXTENSION_CLOSED_KEY, String.valueOf(!path.open));
+                r.deliver(Geometry.createValue(schema, WkbWriter.buildLineString(points), null, extensions));
+            }
+        });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code polygon} to a {@link Geometry} value encoded as a single closed
+     * polygon ring.
+     */
+    protected Object convertPolygon(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        return convertValue(column, fieldDefn, data, geometryFallback(schema, "polygon"), (r) -> {
+            PGpolygon polygon = asGeometricValue(column, data, PGpolygon.class, PGpolygon::new);
+            if (polygon != null) {
+                List<double[]> ring = new ArrayList<>(polygon.points.length + 1);
+                for (PGpoint point : polygon.points) {
+                    ring.add(new double[]{ point.x, point.y });
+                }
+                closeRing(ring);
+                byte[] wkb = WkbWriter.buildPolygon(List.of(ring));
+                r.deliver(Geometry.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon")));
+            }
+        });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code circle} to a {@link Circle} value carrying its true center and
+     * radius. WKB has no curve primitive, so a circle cannot round-trip through {@link Geometry}.
+     */
+    protected Object convertCircle(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        return convertValue(column, fieldDefn, data, Circle.createValue(schema, 0, 0, 0), (r) -> {
+            PGcircle circle = asGeometricValue(column, data, PGcircle.class, PGcircle::new);
+            if (circle != null) {
+                r.deliver(Circle.createValue(schema, circle.center.x, circle.center.y, circle.radius));
+            }
+        });
+    }
+
+    /**
+     * Converts a PostgreSQL {@code line} (an infinite line {@code Ax + By + C = 0}) to a {@link Line}
+     * value carrying its three coefficients.
+     */
+    protected Object convertLine(Column column, Field fieldDefn, Object data) {
+        final Schema schema = fieldDefn.schema();
+        // PostgreSQL rejects a line whose A and B coefficients are both zero, so the NOT NULL fallback
+        // uses {0,1,0} (the y = 0 axis) rather than the all-zero triple.
+        return convertValue(column, fieldDefn, data, Line.createValue(schema, 0, 1, 0), (r) -> {
+            PGline line = asGeometricValue(column, data, PGline.class, PGline::new);
+            if (line != null) {
+                r.deliver(Line.createValue(schema, line.a, line.b, line.c));
+            }
+        });
+    }
+
+    /**
+     * Coerces incoming column data to the requested {@code org.postgresql.geometric} type. Logical
+     * decoding delivers the {@code PGxxx} object directly, while snapshots via the JDBC driver may
+     * hand back the canonical text, which the given factory parses. Returns {@code null} (leaving the
+     * value unconverted) when the type is unexpected or the text cannot be parsed.
+     */
+    private <T> T asGeometricValue(Column column, Object data, Class<T> type, PGobjectFactory<T> factory) {
+        if (type.isInstance(data)) {
+            return type.cast(data);
+        }
+        if (data instanceof String) {
+            String dataString = data.toString();
+            try {
+                return factory.parse(dataString);
+            }
+            catch (SQLException e) {
+                logger.warn("Error converting the string '{}' to a {} for the column '{}'", dataString, type.getSimpleName(), column);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the non-null fallback a NOT NULL geometric column falls back to when a null value is
+     * received with no column default (see {@link #convertValue}). The WKB must be shaped so the sink
+     * can reconstruct a value the target native type actually accepts: a {@code box} is rebuilt from
+     * ring vertices 0 and 2 (so it needs a full ring), an {@code lseg} is a two-point segment, while a
+     * {@code path}/{@code polygon} tolerate a single point. All coordinates are the origin.
+     */
+    private static Struct geometryFallback(Schema schema, String type) {
+        final byte[] wkb;
+        switch (type) {
+            case "box":
+                wkb = WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0, 0 }, new double[]{ 0, 0 }, new double[]{ 0, 0 },
+                        new double[]{ 0, 0 }, new double[]{ 0, 0 })));
+                break;
+            case "lseg":
+                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 0, 0 }));
+                break;
+            case "polygon":
+                wkb = WkbWriter.buildPolygon(List.of(List.of(new double[]{ 0, 0 })));
+                break;
+            default: // path
+                wkb = WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }));
+                break;
+        }
+        return Geometry.createValue(schema, wkb, null, Map.of(Geometry.EXTENSION_TYPE_KEY, type));
+    }
+
+    private static void closeRing(List<double[]> ring) {
+        if (ring.size() >= 2) {
+            double[] first = ring.get(0);
+            double[] last = ring.get(ring.size() - 1);
+            if (first[0] != last[0] || first[1] != last[1]) {
+                ring.add(new double[]{ first[0], first[1] });
+            }
+        }
+    }
+
+    /**
+     * Factory that parses a {@code org.postgresql.geometric} value from its canonical text form.
+     */
+    @FunctionalInterface
+    private interface PGobjectFactory<T> {
+        T parse(String value) throws SQLException;
     }
 
     protected Object convertArray(Column column, Field fieldDefn, PostgresType elementType, ValueConverter elementConverter, Object data) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,12 +68,15 @@ import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.VerifyRecord;
 import io.debezium.data.Xml;
+import io.debezium.data.geometry.Circle;
 import io.debezium.data.geometry.Geography;
 import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Line;
 import io.debezium.data.geometry.Point;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
 import io.debezium.relational.TableId;
+import io.debezium.spatial.WkbWriter;
 import io.debezium.time.Date;
 import io.debezium.time.Interval;
 import io.debezium.time.MicroDuration;
@@ -1005,12 +1009,42 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForDomainAliasTypes(boolean streaming) {
-        final ByteBuffer boxByteBuffer = ByteBuffer.wrap("(1.0,1.0),(0.0,0.0)".getBytes());
-        final ByteBuffer circleByteBuffer = ByteBuffer.wrap("<(10.0,4.0),10.0>".getBytes());
-        final ByteBuffer lineByteBuffer = ByteBuffer.wrap("{-1.0,0.0,0.0}".getBytes());
-        final ByteBuffer lsegByteBuffer = ByteBuffer.wrap("[(0.0,0.0),(0.0,1.0)]".getBytes());
-        final ByteBuffer pathByteBuffer = ByteBuffer.wrap("((0.0,0.0),(0.0,1.0),(0.0,2.0))".getBytes());
-        final ByteBuffer polygonByteBuffer = ByteBuffer.wrap("((0.0,0.0),(0.0,1.0),(1.0,0.0),(0.0,0.0))".getBytes());
+        // The six geometric types now map to first-class Connect schemas (DBZ-2135). The expected WKB is
+        // built with the same WkbWriter the converter uses, so only coordinate correctness (and PostgreSQL's
+        // box corner normalisation) is asserted here, not raw byte layout.
+        final Schema geometrySchema = Geometry.builder().build();
+
+        // PostgreSQL normalises a box so the upper-right corner is stored first: input '(0,0),(1,1)' becomes
+        // point[0]=(1,1), point[1]=(0,0), which the converter encodes as a closed 5-point rectangle ring.
+        final Struct boxValue = Geometry.createValue(geometrySchema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 1.0, 1.0 }, new double[]{ 1.0, 0.0 }, new double[]{ 0.0, 0.0 },
+                        new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 1.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box"));
+
+        final Struct lsegValue = Geometry.createValue(geometrySchema,
+                WkbWriter.buildLineString(List.of(new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 })),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg"));
+
+        final Map<String, String> pathExtensions = new LinkedHashMap<>();
+        pathExtensions.put(Geometry.EXTENSION_TYPE_KEY, "path");
+        pathExtensions.put(Geometry.EXTENSION_CLOSED_KEY, "true"); // '((...))' is a closed path
+        final Struct pathValue = Geometry.createValue(geometrySchema,
+                WkbWriter.buildLineString(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 0.0, 2.0 })),
+                null, pathExtensions);
+
+        final Struct polygonValue = Geometry.createValue(geometrySchema,
+                WkbWriter.buildPolygon(List.of(List.of(
+                        new double[]{ 0.0, 0.0 }, new double[]{ 0.0, 1.0 }, new double[]{ 1.0, 0.0 },
+                        new double[]{ 0.0, 0.0 }))),
+                null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon"));
+
+        final Schema circleSchema = Circle.builder().build();
+        final Struct circleValue = Circle.createValue(circleSchema, 10.0, 4.0, 10.0);
+
+        final Schema lineSchema = Line.builder().build();
+        final Struct lineValue = Line.createValue(lineSchema, -1.0, 0.0, 0.0); // PG normalises '(0,0),(0,1)' to {-1,0,0}
 
         return Arrays.asList(
                 new SchemaAndValueField(PK_FIELD, SchemaBuilder.int32().defaultValue(0).build(), 1),
@@ -1048,20 +1082,20 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
                         MicroDuration.durationMicros(1, 2, 3, 4, 5, 6, MicroDuration.DAYS_PER_MONTH_AVG)),
                 new SchemaAndValueField("interval_alias", MicroDuration.builder().build(),
                         MicroDuration.durationMicros(1, 2, 3, 4, 5, 6, MicroDuration.DAYS_PER_MONTH_AVG)),
-                new SchemaAndValueField("box_base", SchemaBuilder.BYTES_SCHEMA, boxByteBuffer),
-                new SchemaAndValueField("box_alias", SchemaBuilder.BYTES_SCHEMA, boxByteBuffer),
-                new SchemaAndValueField("circle_base", SchemaBuilder.BYTES_SCHEMA, circleByteBuffer),
-                new SchemaAndValueField("circle_alias", SchemaBuilder.BYTES_SCHEMA, circleByteBuffer),
-                new SchemaAndValueField("line_base", SchemaBuilder.BYTES_SCHEMA, lineByteBuffer),
-                new SchemaAndValueField("line_alias", SchemaBuilder.BYTES_SCHEMA, lineByteBuffer),
-                new SchemaAndValueField("lseg_base", SchemaBuilder.BYTES_SCHEMA, lsegByteBuffer),
-                new SchemaAndValueField("lseg_alias", SchemaBuilder.BYTES_SCHEMA, lsegByteBuffer),
-                new SchemaAndValueField("path_base", SchemaBuilder.BYTES_SCHEMA, pathByteBuffer),
-                new SchemaAndValueField("path_alias", SchemaBuilder.BYTES_SCHEMA, pathByteBuffer),
+                new SchemaAndValueField("box_base", geometrySchema, boxValue),
+                new SchemaAndValueField("box_alias", geometrySchema, boxValue),
+                new SchemaAndValueField("circle_base", circleSchema, circleValue),
+                new SchemaAndValueField("circle_alias", circleSchema, circleValue),
+                new SchemaAndValueField("line_base", lineSchema, lineValue),
+                new SchemaAndValueField("line_alias", lineSchema, lineValue),
+                new SchemaAndValueField("lseg_base", geometrySchema, lsegValue),
+                new SchemaAndValueField("lseg_alias", geometrySchema, lsegValue),
+                new SchemaAndValueField("path_base", geometrySchema, pathValue),
+                new SchemaAndValueField("path_alias", geometrySchema, pathValue),
                 new SchemaAndValueField("point_base", Point.builder().build(), Point.createValue(Point.builder().build(), 1, 1)),
                 new SchemaAndValueField("point_alias", Point.builder().build(), Point.createValue(Point.builder().build(), 1, 1)),
-                new SchemaAndValueField("polygon_base", SchemaBuilder.BYTES_SCHEMA, polygonByteBuffer),
-                new SchemaAndValueField("polygon_alias", SchemaBuilder.BYTES_SCHEMA, polygonByteBuffer),
+                new SchemaAndValueField("polygon_base", geometrySchema, polygonValue),
+                new SchemaAndValueField("polygon_alias", geometrySchema, polygonValue),
                 new SchemaAndValueField("char_base", SchemaBuilder.STRING_SCHEMA, "a"),
                 new SchemaAndValueField("char_alias", SchemaBuilder.STRING_SCHEMA, "a"),
                 new SchemaAndValueField("text_base", SchemaBuilder.STRING_SCHEMA, "Hello World"),

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
             +
             "'1000000000000000000000000000000000000000000000000000000000000000'::bit(64), '101', '111011010001000110000001000000001')";
     protected static final String INSERT_BYTEA_BINMODE_STMT = "INSERT INTO bytea_binmode_table (ba, bytea_array) VALUES (E'\\\\001\\\\002\\\\003'::bytea, array[E'\\\\000\\\\001\\\\002'::bytea, E'\\\\003\\\\004\\\\005'::bytea])";
-    protected static final String INSERT_CIRCLE_STMT = "INSERT INTO circle_table (ccircle) VALUES ('((10, 20),10)'::circle)";
+    protected static final String INSERT_UNKNOWN_TYPE_STMT = "INSERT INTO unknown_type_table (tsq) VALUES ('fat <-> cat'::tsquery)";
     protected static final String INSERT_GEOM_TYPES_STMT = "INSERT INTO geom_table(p) VALUES ('(1,1)'::point)";
     protected static final String INSERT_TEXT_TYPES_STMT = "INSERT INTO text_table(j, jb, x, u) " +
             "VALUES ('{\"bar\": \"baz\"}'::json, '{\"bar\": \"baz\"}'::jsonb, " +
@@ -464,19 +464,19 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBytes() {
-        return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("<(10.0,20.0),10.0>".getBytes(StandardCharsets.UTF_8))));
+        return Arrays.asList(new SchemaAndValueField("tsq", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("'fat' <-> 'cat'".getBytes(StandardCharsets.UTF_8))));
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBase64() {
-        return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_STRING_SCHEMA, "PCgxMC4wLDIwLjApLDEwLjA+"));
+        return Arrays.asList(new SchemaAndValueField("tsq", Schema.OPTIONAL_STRING_SCHEMA, "J2ZhdCcgPC0+ICdjYXQn"));
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBase64UrlSafe() {
-        return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_STRING_SCHEMA, "PCgxMC4wLDIwLjApLDEwLjA-"));
+        return Arrays.asList(new SchemaAndValueField("tsq", Schema.OPTIONAL_STRING_SCHEMA, "J2ZhdCcgPC0-ICdjYXQn"));
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnHex() {
-        return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_STRING_SCHEMA, "3c2831302e302c32302e30292c31302e303e"));
+        return Arrays.asList(new SchemaAndValueField("tsq", Schema.OPTIONAL_STRING_SCHEMA, "2766617427203c2d3e202763617427"));
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForStringTypesWithSourceColumnTypeInfo() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -1009,7 +1009,7 @@ public abstract class AbstractRecordsProducerTest extends AbstractAsyncEngineCon
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForDomainAliasTypes(boolean streaming) {
-        // The six geometric types now map to first-class Connect schemas (DBZ-2135). The expected WKB is
+        // The six geometric types now map to first-class Connect schemas (dbz#2135). The expected WKB is
         // built with the same WkbWriter the converter uses, so only coordinate correctness (and PostgreSQL's
         // box corner normalisation) is asserted here, not raw byte layout.
         final Schema geometrySchema = Geometry.builder().build();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/GeometryFallbackTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/GeometryFallbackTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.geometry.Geometry;
+import io.debezium.doc.FixFor;
+import io.debezium.spatial.WkbReader;
+
+/**
+ * Verifies the non-null fallback {@link PostgresValueConverter#geometryFallback} emits for a NOT NULL
+ * geometric column that receives a null with no default. When {@code column.propagate.source.type} is
+ * unset the sink binds these through PostGIS {@code ST_GeomFromWKB}, which enforces the OGC
+ * minimum-vertex rules, so each fallback ring/line must be a genuinely valid shape rather than a
+ * repeated origin point (see dbz#2135 review).
+ *
+ * @author Debezium Authors
+ */
+class GeometryFallbackTest {
+
+    @Test
+    @FixFor("debezium/dbz#2135")
+    void boxFallbackIsAValidClosedRing() {
+        // A box is rebuilt on the sink from ring vertices 0 and 2, so the ring must have both and
+        // ST_GeomFromWKB requires at least four points forming a valid ring.
+        assertValidRing(readRing("box"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2135")
+    void polygonFallbackIsAValidClosedRing() {
+        assertValidRing(readRing("polygon"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2135")
+    void lsegFallbackIsATwoDistinctPointLine() {
+        assertValidLine(readLine("lseg"));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2135")
+    void pathFallbackIsATwoDistinctPointLine() {
+        assertValidLine(readLine("path"));
+    }
+
+    private static List<double[]> readRing(String type) {
+        return WkbReader.readPolygonRing(fallbackWkb(type));
+    }
+
+    private static List<double[]> readLine(String type) {
+        return WkbReader.readLineString(fallbackWkb(type));
+    }
+
+    private static byte[] fallbackWkb(String type) {
+        final Struct fallback = PostgresValueConverter.geometryFallback(Geometry.schema(), type);
+        return fallback.getBytes(Geometry.WKB_FIELD);
+    }
+
+    /**
+     * A ring PostGIS accepts: closed (first == last) with at least four points and at least three
+     * distinct vertices.
+     */
+    private static void assertValidRing(List<double[]> ring) {
+        assertThat(ring.size()).as("ring vertex count").isGreaterThanOrEqualTo(4);
+        assertThat(ring.get(0)).as("ring is closed").containsExactly(ring.get(ring.size() - 1));
+        assertThat(distinctCount(ring)).as("distinct ring vertices").isGreaterThanOrEqualTo(3);
+    }
+
+    /**
+     * A line PostGIS accepts: at least two points and at least two distinct ones.
+     */
+    private static void assertValidLine(List<double[]> line) {
+        assertThat(line.size()).as("line point count").isGreaterThanOrEqualTo(2);
+        assertThat(distinctCount(line)).as("distinct line points").isGreaterThanOrEqualTo(2);
+    }
+
+    private static long distinctCount(List<double[]> points) {
+        return points.stream().map(p -> p[0] + "," + p[1]).distinct().count();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -1310,7 +1310,8 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestConsumer consumer = testConsumer(1, "public");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
-        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table", schemaAndValueForUnknownColumnBase64UrlSafe());
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table",
+                schemaAndValueForUnknownColumnBase64UrlSafe());
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -1264,7 +1264,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     public void shouldGenerateSnapshotForUnknownColumnAsBytes() throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
-        TestHelper.execute(INSERT_CIRCLE_STMT);
+        TestHelper.execute(INSERT_UNKNOWN_TYPE_STMT);
 
         buildNoStreamProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true));
@@ -1272,7 +1272,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestConsumer consumer = testConsumer(1, "public");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
-        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.circle_table", schemaAndValueForUnknownColumnBytes());
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table", schemaAndValueForUnknownColumnBytes());
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }
@@ -1282,7 +1282,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     public void shouldGenerateSnapshotForUnknownColumnAsBase64() throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
-        TestHelper.execute(INSERT_CIRCLE_STMT);
+        TestHelper.execute(INSERT_UNKNOWN_TYPE_STMT);
 
         buildNoStreamProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
@@ -1291,7 +1291,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestConsumer consumer = testConsumer(1, "public");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
-        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.circle_table", schemaAndValueForUnknownColumnBase64());
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table", schemaAndValueForUnknownColumnBase64());
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }
@@ -1301,7 +1301,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     public void shouldGenerateSnapshotForUnknownColumnAsBase64UrlSafe() throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
-        TestHelper.execute(INSERT_CIRCLE_STMT);
+        TestHelper.execute(INSERT_UNKNOWN_TYPE_STMT);
 
         buildNoStreamProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
@@ -1310,7 +1310,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestConsumer consumer = testConsumer(1, "public");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
-        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.circle_table", schemaAndValueForUnknownColumnBase64UrlSafe());
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table", schemaAndValueForUnknownColumnBase64UrlSafe());
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }
@@ -1320,7 +1320,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     public void shouldGenerateSnapshotForUnknownColumnAsHex() throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
-        TestHelper.execute(INSERT_CIRCLE_STMT);
+        TestHelper.execute(INSERT_UNKNOWN_TYPE_STMT);
 
         buildNoStreamProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
@@ -1329,7 +1329,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestConsumer consumer = testConsumer(1, "public");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
-        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.circle_table", schemaAndValueForUnknownColumnHex());
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.unknown_type_table", schemaAndValueForUnknownColumnHex());
 
         consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -482,7 +482,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             assertThat(before.get("cfloat8")).isEqualTo(0.0);
             assertThat(before.get("cnumeric")).isEqualTo(new BigDecimal("0.00"));
             assertThat(before.get("cvarchar")).isEqualTo("");
-            // The six geometric types now map to first-class schemas (DBZ-2135); an absent before-image
+            // The six geometric types now map to first-class schemas (dbz#2135); an absent before-image
             // value falls back to the converter's empty/zero geometry rather than an empty byte array.
             final Schema geometrySchema = Geometry.builder().build();
             assertThat(before.get("cbox")).isEqualTo(Geometry.createValue(geometrySchema,

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -82,6 +83,9 @@ import io.debezium.data.Envelope;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.VerifyRecord;
+import io.debezium.data.geometry.Circle;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Line;
 import io.debezium.data.geometry.Point;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.EmbeddedEngineConfig;
@@ -100,6 +104,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
+import io.debezium.spatial.WkbWriter;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
 import io.debezium.time.ZonedTime;
@@ -477,14 +482,27 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             assertThat(before.get("cfloat8")).isEqualTo(0.0);
             assertThat(before.get("cnumeric")).isEqualTo(new BigDecimal("0.00"));
             assertThat(before.get("cvarchar")).isEqualTo("");
-            assertThat(before.get("cbox")).isEqualTo(new byte[0]);
-            assertThat(before.get("ccircle")).isEqualTo(new byte[0]);
+            // The six geometric types now map to first-class schemas (DBZ-2135); an absent before-image
+            // value falls back to the converter's empty/zero geometry rather than an empty byte array.
+            final Schema geometrySchema = Geometry.builder().build();
+            assertThat(before.get("cbox")).isEqualTo(Geometry.createValue(geometrySchema,
+                    WkbWriter.buildPolygon(List.of(List.of(
+                            new double[]{ 0, 0 }, new double[]{ 0, 0 }, new double[]{ 0, 0 },
+                            new double[]{ 0, 0 }, new double[]{ 0, 0 }))),
+                    null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")));
+            assertThat(before.get("ccircle")).isEqualTo(Circle.createValue(Circle.builder().build(), 0, 0, 0));
             assertThat(before.get("cinterval")).isEqualTo(0L);
-            assertThat(before.get("cline")).isEqualTo(new byte[0]);
-            assertThat(before.get("clseg")).isEqualTo(new byte[0]);
-            assertThat(before.get("cpath")).isEqualTo(new byte[0]);
+            assertThat(before.get("cline")).isEqualTo(Line.createValue(Line.builder().build(), 0, 1, 0));
+            assertThat(before.get("clseg")).isEqualTo(Geometry.createValue(geometrySchema,
+                    WkbWriter.buildLineString(List.of(new double[]{ 0, 0 }, new double[]{ 0, 0 })),
+                    null, Map.of(Geometry.EXTENSION_TYPE_KEY, "lseg")));
+            assertThat(before.get("cpath")).isEqualTo(Geometry.createValue(geometrySchema,
+                    WkbWriter.buildLineString(List.of(new double[]{ 0, 0 })),
+                    null, Map.of(Geometry.EXTENSION_TYPE_KEY, "path")));
             assertThat(before.get("cpoint")).isEqualTo(Point.createValue(Point.builder().build(), 0, 0));
-            assertThat(before.get("cpolygon")).isEqualTo(new byte[0]);
+            assertThat(before.get("cpolygon")).isEqualTo(Geometry.createValue(geometrySchema,
+                    WkbWriter.buildPolygon(List.of(List.of(new double[]{ 0, 0 }))),
+                    null, Map.of(Geometry.EXTENSION_TYPE_KEY, "polygon")));
             assertThat(before.get("cchar")).isEqualTo("");
             assertThat(before.get("ctext")).isEqualTo("");
             assertThat(before.get("cjson")).isEqualTo("");
@@ -1383,7 +1401,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true));
 
-        assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnBytes());
+        assertInsert(INSERT_UNKNOWN_TYPE_STMT, 1, schemaAndValueForUnknownColumnBytes());
     }
 
     @Test
@@ -1394,7 +1412,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
                 .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.BASE64));
 
-        assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnBase64());
+        assertInsert(INSERT_UNKNOWN_TYPE_STMT, 1, schemaAndValueForUnknownColumnBase64());
     }
 
     @Test
@@ -1405,7 +1423,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
                 .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.BASE64_URL_SAFE));
 
-        assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnBase64UrlSafe());
+        assertInsert(INSERT_UNKNOWN_TYPE_STMT, 1, schemaAndValueForUnknownColumnBase64UrlSafe());
     }
 
     @Test
@@ -1416,7 +1434,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
                 .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.HEX));
 
-        assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnHex());
+        assertInsert(INSERT_UNKNOWN_TYPE_STMT, 1, schemaAndValueForUnknownColumnHex());
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -54,7 +54,7 @@ CREATE TABLE hstore_table (pk serial, hs hstore, PRIMARY KEY(pk));
 CREATE TABLE hstore_table_mul (pk serial, hs hstore, hsarr hstore[], PRIMARY KEY(pk));
 CREATE TABLE hstore_table_with_null (pk serial, hs hstore, PRIMARY KEY(pk));
 CREATE TABLE hstore_table_with_special (pk serial, hs hstore, PRIMARY KEY(pk));
-CREATE TABLE circle_table (pk serial, ccircle circle, PRIMARY KEY(pk));
+CREATE TABLE unknown_type_table (pk serial, tsq tsquery, PRIMARY KEY(pk));
 
 CREATE TABLE not_null_table (pk serial,
     val numeric(20,8), created_at timestamp not null, created_at_tz timestamptz not null, ctime time not null,

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -656,6 +656,20 @@ If the database does not support time or timestamps with time zones, the mapping
 |`sdo_geometry`
 |`geometry`
 
+|io.debezium.data.geometry.Circle
+|n/a
+|n/a
+|`circle`
+|n/a
+|n/a
+
+|io.debezium.data.geometry.Line
+|n/a
+|n/a
+|`line`
+|n/a
+|n/a
+
 |===
 
 ^1^ When a logical type maps to more than one type, the {prodname} JDBC connector defaults to the first more generalized data type.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1669,6 +1669,24 @@ Contains the string representation of a PostgreSQL UUID value.
 Contains a structure with two `FLOAT64` fields, `(x,y)`.
 Each field represents the coordinates of a geometric point.
 
+|`BOX`, `LSEG`, `PATH`, `POLYGON`
+|`STRUCT`
+|`io.debezium.data.geometry.Geometry` +
+ +
+Contains a structure with a `wkb` field holding the geometry encoded as OGC Well-Known Binary (a `box` as a coordinate-exact rectangle polygon, an `lseg`/open `path` as a line string, a `polygon`/closed `path` as a polygon), a `srid` field (always null for these unreferenced planar types), and an `extensions` map. The `extensions` map carries `type` (the originating native type: `box`, `lseg`, `path`, or `polygon`) and, for `path`, `closed` (`true` or `false`). These are native (non-PostGIS) geometric types; the Debezium JDBC sink connector reads `extensions.type` to rebuild the native value and bind it without requiring PostGIS.
+
+|`CIRCLE`
+|`STRUCT`
+|`io.debezium.data.geometry.Circle` +
+ +
+Contains a structure with a `center` field of type `io.debezium.data.geometry.Point` and a `FLOAT64` `radius` field. A circle has no OGC Well-Known Binary representation, so its true center and radius are carried losslessly rather than approximated at the source.
+
+|`LINE`
+|`STRUCT`
+|`io.debezium.data.geometry.Line` +
+ +
+Contains a structure with three `FLOAT64` fields, `a`, `b`, and `c`, representing the infinite line `Ax + By + C = 0`.
+
 |`LTREE`
 |`STRING`
 |`io.debezium.data.Ltree`


### PR DESCRIPTION
Fixes debezium/dbz#2135

## Description

The PostgreSQL connector mapped only `point` to a Connect schema. The other built-in geometric types — `box`, `circle`, `line`, `lseg`, `path`, `polygon` — had no converter, so they were emitted as opaque `bytea` (or dropped when `include.unknown.datatypes` was off). Their values were unusable downstream and PostgreSQL → PostgreSQL replication was broken because `bytea` does not re-insert into a geometric column.

This maps all six to first-class schemas and adds the PostgreSQL sink bindings needed to round-trip them, following the direction agreed on the issue.

## Source mapping (debezium-connector-postgres)

- `box`, `lseg`, `path`, `polygon` → `io.debezium.data.geometry.Geometry` (WKB). These four have a faithful OGC WKB form (a `box` is a coordinate-exact 5-point ring), so they reuse the existing cross-vendor `Geometry` type. An `extensions` map carries the originating native type, plus the open/closed flag for `path`, so the value can be rebuilt losslessly.
- `circle` → `io.debezium.data.geometry.Circle` `{ center: Point, radius }`.
- `line` → `io.debezium.data.geometry.Line` `{ a, b, c }`.

`circle` and `line` get dedicated types because WKB has no curve or infinite-line primitive; carrying the exact values lets each sink pick the best (possibly lossy) target representation instead of baking a polygon approximation into the wire at the source.

## connector-common

- `Geometry` gains an optional `MAP<STRING,STRING>` `extensions` field (schema version 1 → 2). The field is optional, so existing consumers that read only `wkb`/`srid` see no change from its addition.
- New `Circle` and `Line` semantic types, modelled on `Point`'s shape but as standalone structs (not `extends Geometry`, which would add always-null `wkb`/`srid` fields). `Geography` rejects a non-empty `extensions` map, since its v1 schema has no such field.
- New `io.debezium.spatial.WkbWriter` / `WkbReader` encode and decode `LineString` and `Polygon` coordinates, reusing the existing spatial tooling. `WkbReader` rejects a multi-ring (polygon-with-holes) geometry rather than flattening its rings, since a native PostgreSQL `polygon` is a single ring.

## JDBC sink (PostgreSQL)

- `GeometryType` reconstructs the native PostgreSQL text from the WKB and binds via `cast(? as box|lseg|path|polygon)` when the propagated source-column type is one of the native geometric types, so no PostGIS is required; otherwise it keeps the existing `ST_GeomFromWKB` binding. The native-vs-PostGIS decision is made from the schema rather than the value, because the batch SQL string is built once from the first record — a value-based decision would make the placeholder count unstable across a mixed or null-leading batch.
- New `CircleType` / `LineType` bind to native `circle` / `line`.
- The UNNEST batch path binds each column as a SQL array via `createArrayOf`, which cannot take a struct element, so a batch carrying any struct-valued column (the geometric types, including the existing `Point`) falls back to the row-wise path that runs the per-value reconstruction.
- Other dialects' `circle`/`line` sink types are left for a follow-up, matching how `Point` is currently bound only for PostgreSQL and the MySQL family.

## connect-plugins

`GeometryFormatTransformer` previously threw when asked to add an SRID to a geometry that has none. The native geometric types are emitted without an SRID, so it now leaves such a value unchanged instead of failing the record.

## Scope / limitation

- Native (non-PostGIS) reconstruction of `box`/`lseg`/`path`/`polygon` on the sink relies on the source type reaching the schema via `column.propagate.source.type`; without it, these fall back to the PostGIS `ST_GeomFromWKB` binding.
- `circle` / `line` are bound natively on the PostgreSQL sink only.
- For a NOT NULL geometric column with no default and a null value, the fallback is shaped so the sink can rebuild a value the native type accepts: a full ring for `box`, a two-point segment for `lseg`, and `{0,1,0}` for `line` (rather than the all-zero triple, which PostgreSQL rejects).

## Tests

- Unit: WKB round-trip, the new `Circle`/`Line`/`Geometry` schemas, and the PostgreSQL sink bindings.
- Integration: a PG → PG native round-trip with no PostGIS, plus the existing PostgreSQL domain-alias snapshot/streaming assertions updated to the structured schemas.

Documentation updated for both the PostgreSQL source and the JDBC sink type mappings.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
