### PR TITLE
debezium/dbz#731 Added MongoDB json.serialization.mode configuration

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/JsonSerialization.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/JsonSerialization.java
@@ -46,10 +46,29 @@ class JsonSerialization {
             .newLineCharacters("")
             .build();
 
-    private final Transformer transformer;
+    private static final JsonWriterSettings EXTENDED_JSON_SETTINGS = JsonWriterSettings.builder()
+            .outputMode(JsonMode.EXTENDED)
+            .indent(true)
+            .indentCharacters("")
+            .newLineCharacters("")
+            .build();
 
-    JsonSerialization() {
-        transformer = (doc) -> doc.toJson(COMPACT_JSON_SETTINGS);
+    private final Transformer transformer;
+    private final Transformer updatedFieldsTransformer;
+
+    JsonSerialization(MongoDbConnectorConfig.JsonSerializationMode mode) {
+        final JsonWriterSettings documentJsonWriterSettings = switch (mode) {
+            case LEGACY, STRICT -> COMPACT_JSON_SETTINGS;
+            case EXTENDED -> EXTENDED_JSON_SETTINGS;
+            case RELAXED -> SIMPLE_JSON_SETTINGS;
+        };
+        this.transformer = (doc) -> doc.toJson(documentJsonWriterSettings);
+        this.updatedFieldsTransformer = switch (mode) {
+            case LEGACY -> BsonDocument::toJson;
+            case RELAXED -> (doc) -> doc.toJson(SIMPLE_JSON_SETTINGS);
+            case EXTENDED -> (doc) -> doc.toJson(EXTENDED_JSON_SETTINGS);
+            case STRICT -> (doc) -> doc.toJson(COMPACT_JSON_SETTINGS);
+        };
     }
 
     public String getDocumentId(BsonDocument document) {
@@ -72,6 +91,10 @@ class JsonSerialization {
 
     public String getDocumentValue(BsonDocument document) {
         return transformer.apply(document);
+    }
+
+    public String getUpdatedFields(BsonDocument document) {
+        return updatedFieldsTransformer.apply(document);
     }
 
     public Transformer getTransformer() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbCollectionSchema.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbCollectionSchema.java
@@ -39,17 +39,19 @@ public class MongoDbCollectionSchema implements DataCollectionSchema {
     private final Schema valueSchema;
     private final Function<BsonDocument, Object> keyGenerator;
     private final Function<BsonDocument, String> valueGenerator;
+    private final Function<BsonDocument, String> updatedFieldsGenerator;
 
     public MongoDbCollectionSchema(CollectionId id, FieldFilter fieldFilter, Schema keySchema,
                                    Function<BsonDocument, Object> keyGenerator, Envelope envelopeSchema, Schema valueSchema,
-                                   Function<BsonDocument, String> valueGenerator) {
+                                   Function<BsonDocument, String> valueGenerator, Function<BsonDocument, String> updatedFieldsGenerator) {
         this.id = id;
         this.fieldFilter = fieldFilter;
         this.keySchema = keySchema;
         this.envelopeSchema = envelopeSchema;
         this.valueSchema = valueSchema;
         this.keyGenerator = keyGenerator != null ? keyGenerator : (BsonDocument) -> null;
-        this.valueGenerator = valueGenerator != null ? valueGenerator : (Document) -> null;
+        this.valueGenerator = valueGenerator != null ? valueGenerator : (BsonDocument) -> null;
+        this.updatedFieldsGenerator = updatedFieldsGenerator != null ? updatedFieldsGenerator : (BsonDocument) -> null;
     }
 
     @Override
@@ -118,7 +120,7 @@ public class MongoDbCollectionSchema implements DataCollectionSchema {
 
                     final BsonDocument updatedFields = document.getUpdateDescription().getUpdatedFields();
                     if (updatedFields != null) {
-                        updateDescription.put(MongoDbFieldName.UPDATED_FIELDS, fieldFilter.applyChange(updatedFields).toJson());
+                        updateDescription.put(MongoDbFieldName.UPDATED_FIELDS, updatedFieldsGenerator.apply(fieldFilter.applyChange(updatedFields)));
                     }
 
                     // TODO Test filters for truncated arrays

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -607,6 +607,73 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         }
     }
 
+    /**
+     * The set of different ways the connector serializes MongoDB Extended JSON in event payloads.
+     */
+    public enum JsonSerializationMode implements EnumeratedValue {
+        /**
+         * Serializes full documents using MongoDB Extended JSON v1 strict mode and updated fields using MongoDB Extended JSON v2 relaxed mode.
+         */
+        LEGACY("legacy"),
+        /**
+         * Serializes using MongoDB Extended JSON v1 strict mode (deprecated legacy format).
+         */
+        STRICT("strict"),
+        /**
+         * Serializes using MongoDB Extended JSON v2 canonical mode.
+         */
+        EXTENDED("extended"),
+        /**
+         * Serializes using MongoDB Extended JSON v2 relaxed mode.
+         */
+        RELAXED("relaxed");
+
+        private final String value;
+
+        JsonSerializationMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static JsonSerializationMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (JsonSerializationMode option : JsonSerializationMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static JsonSerializationMode parse(String value, String defaultValue) {
+            JsonSerializationMode mode = parse(value);
+            if (mode == null && defaultValue != null) {
+                mode = parse(defaultValue);
+            }
+            return mode;
+        }
+    }
+
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 0;
 
     public static final Field ALLOW_OFFSET_INVALIDATION = Field.createInternal("mongodb.allow.offset.invalidation")
@@ -889,6 +956,19 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
                     + "'lookup' (the default) use separate lookup to get the updated document; "
                     + "'post_image' use MongoDB post images (requires Mongo 6.0 or newer");
 
+    public static final Field JSON_SERIALIZATION_MODE = Field.create("json.serialization.mode")
+            .withDisplayName("JSON serialization mode")
+            .withEnum(JsonSerializationMode.class, JsonSerializationMode.LEGACY)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Controls the Extended JSON serialization mode used for MongoDB event payload fields. "
+                    + "Options include: "
+                    + "'legacy' (the default) uses MongoDB Extended JSON v1 strict mode for full document fields and MongoDB Extended JSON v2 relaxed mode for update fields. "
+                    + "'strict' uses MongoDB Extended JSON v1 strict mode. "
+                    + "'extended' uses MongoDB Extended JSON v2 canonical mode. "
+                    + "'relaxed' uses MongoDB Extended JSON v2 relaxed mode.");
+
     public static final Field CAPTURE_START_OP_TIME = Field.create("capture.start.op.time")
             .withDisplayName("Capture from operation time")
             .withType(Type.LONG)
@@ -1023,7 +1103,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
                     CURSOR_MAX_AWAIT_TIME_MS)
             .group(Field.Group.FILTERS, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, COLLECTION_INCLUDE_LIST, COLLECTION_EXCLUDE_LIST, FIELD_EXCLUDE_LIST, FIELD_RENAMES,
                     SNAPSHOT_FILTER_QUERY_BY_COLLECTION)
-            .group(Field.Group.CONNECTOR, TOPIC_PREFIX, SNAPSHOT_MODE, CAPTURE_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, SOURCE_INFO_STRUCT_MAKER)
+            .group(Field.Group.CONNECTOR, TOPIC_PREFIX, SNAPSHOT_MODE, CAPTURE_MODE, JSON_SERIALIZATION_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, SOURCE_INFO_STRUCT_MAKER)
             .create();
 
     /**
@@ -1038,6 +1118,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
     private final SnapshotMode snapshotMode;
     private final Long startOperationTime;
     private final CaptureMode captureMode;
+    private final JsonSerializationMode jsonSerializationMode;
     private final FullUpdateType captureModeFullUpdateType;
     private final CaptureScope captureScope;
     private final String captureTarget;
@@ -1099,6 +1180,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         this.captureMode = CaptureMode.parse(captureModeValue, MongoDbConnectorConfig.CAPTURE_MODE.defaultValueAsString());
         String fullUpdateTypeValue = config.getString(MongoDbConnectorConfig.CAPTURE_MODE_FULL_UPDATE_TYPE);
         this.captureModeFullUpdateType = FullUpdateType.parse(fullUpdateTypeValue, MongoDbConnectorConfig.CAPTURE_MODE_FULL_UPDATE_TYPE.defaultValueAsString());
+
+        String jsonSerializationModeValue = config.getString(MongoDbConnectorConfig.JSON_SERIALIZATION_MODE);
+        this.jsonSerializationMode = JsonSerializationMode.parse(jsonSerializationModeValue, MongoDbConnectorConfig.JSON_SERIALIZATION_MODE.defaultValueAsString());
 
         this.offsetInvalidationAllowed = config.getBoolean(ALLOW_OFFSET_INVALIDATION);
 
@@ -1259,6 +1343,10 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
 
     public FullUpdateType getCaptureModeFullUpdateType() {
         return captureModeFullUpdateType;
+    }
+
+    public JsonSerializationMode getJsonSerializationMode() {
+        return jsonSerializationMode;
     }
 
     public CaptureScope getCaptureScope() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
@@ -54,7 +54,7 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
     private final Schema sourceSchema;
     private final SchemaNameAdjuster adjuster;
     private final ConcurrentMap<CollectionId, MongoDbCollectionSchema> collections = new ConcurrentHashMap<>();
-    private final JsonSerialization serialization = new JsonSerialization();
+    private final JsonSerialization serialization;
     private final MongoDbTaskContext taskContext;
 
     public MongoDbSchema(MongoDbConnectorConfig config, MongoDbTaskContext taskContext, TopicNamingStrategy<CollectionId> topicNamingStrategy, Schema sourceSchema,
@@ -64,6 +64,7 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
         this.topicNamingStrategy = topicNamingStrategy;
         this.sourceSchema = sourceSchema;
         this.adjuster = schemaNameAdjuster;
+        this.serialization = new JsonSerialization(config.getJsonSerializationMode());
         this.taskContext = taskContext;
     }
 
@@ -109,7 +110,8 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
                     serialization::getDocumentId,
                     envelope,
                     valueSchema,
-                    serialization::getDocumentValue);
+                    serialization::getDocumentValue,
+                    serialization::getUpdatedFields);
         });
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
@@ -370,7 +370,7 @@ public class IncrementalSnapshotIT extends AbstractMongoConnectorIT {
                 this::extractFieldValue,
                 topicName(), null);
 
-        var serialization = new JsonSerialization();
+        var serialization = new JsonSerialization(MongoDbConnectorConfig.JsonSerializationMode.LEGACY);
 
         try (var connection = connect()) {
             var codecs = connection.getDatabase(DATABASE_NAME)

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/JsonSerializationModeIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/JsonSerializationModeIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.doc.FixFor;
+
+public class JsonSerializationModeIT extends AbstractMongoConnectorIT {
+
+    private static final String DATABASE_NAME = "dbJson";
+    private static final String COLLECTION_NAME = "c1";
+    private static final String SERVER_NAME = "serverX";
+    private static final long CREATE_DATE = 1_783_078_553_473L;
+    private static final long UPDATE_DATE = 1_783_078_851_680L;
+
+    @Test
+    @FixFor("dbz#731")
+    void shouldSerializeEventPayloadsUsingDefaultLegacyJsonMode() throws Exception {
+        assertJsonMode(null,
+                "\"phone\": {\"$numberLong\": \"123\"}",
+                "\"created\": {\"$date\": " + CREATE_DATE + "}",
+                "\"phone\": 456",
+                "\"created\": {\"$date\": \"");
+    }
+
+    @Test
+    @FixFor("dbz#731")
+    void shouldSerializeEventPayloadsUsingStrictJsonMode() throws Exception {
+        assertJsonMode(MongoDbConnectorConfig.JsonSerializationMode.STRICT,
+                "\"phone\": {\"$numberLong\": \"123\"}",
+                "\"created\": {\"$date\": " + CREATE_DATE + "}",
+                "\"phone\": {\"$numberLong\": \"456\"}",
+                "\"created\": {\"$date\": " + UPDATE_DATE + "}");
+    }
+
+    @Test
+    @FixFor("dbz#731")
+    void shouldSerializeEventPayloadsUsingExtendedJsonMode() throws Exception {
+        assertJsonMode(MongoDbConnectorConfig.JsonSerializationMode.EXTENDED,
+                "\"phone\": {\"$numberLong\": \"123\"}",
+                "\"created\": {\"$date\": {\"$numberLong\": \"" + CREATE_DATE + "\"}}",
+                "\"phone\": {\"$numberLong\": \"456\"}",
+                "\"created\": {\"$date\": {\"$numberLong\": \"" + UPDATE_DATE + "\"}}");
+    }
+
+    @Test
+    @FixFor("dbz#731")
+    void shouldSerializeEventPayloadsUsingRelaxedJsonMode() throws Exception {
+        assertJsonMode(MongoDbConnectorConfig.JsonSerializationMode.RELAXED,
+                "\"phone\": 123",
+                "\"created\": {\"$date\": \"",
+                "\"phone\": 456",
+                "\"created\": {\"$date\": \"");
+    }
+
+    private void assertJsonMode(MongoDbConnectorConfig.JsonSerializationMode mode, String expectedAfterPhone, String expectedAfterCreated,
+                                String expectedUpdatedFieldsPhone, String expectedUpdatedFieldsCreated)
+            throws Exception {
+        final Configuration.Builder builder = TestHelper.getConfiguration(mongo).edit()
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DATABASE_NAME + "." + COLLECTION_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME);
+        if (mode != null) {
+            builder.with(MongoDbConnectorConfig.JSON_SERIALIZATION_MODE, mode);
+        }
+        config = builder.build();
+        context = new MongoDbTaskContext(config);
+
+        TestHelper.cleanDatabase(mongo, DATABASE_NAME);
+
+        start(MongoDbConnector.class, config);
+        waitForSnapshotToBeCompleted("mongodb", SERVER_NAME);
+        waitForStreamingRunning("mongodb", SERVER_NAME);
+
+        final ObjectId objectId = new ObjectId();
+        insertDocuments(DATABASE_NAME, COLLECTION_NAME, new Document()
+                .append("_id", objectId)
+                .append("phone", 123L)
+                .append("created", new Date(CREATE_DATE)));
+
+        final SourceRecord createRecord = consumeRecordsByTopic(1).allRecordsInOrder().get(0);
+        final Struct createValue = (Struct) createRecord.value();
+        final String after = createValue.getString(Envelope.FieldName.AFTER);
+
+        assertThat(createValue.getString(Envelope.FieldName.OPERATION)).isEqualTo(Operation.CREATE.code());
+        assertThat(after).contains(expectedAfterPhone);
+        assertThat(after).contains(expectedAfterCreated);
+
+        updateDocument(DATABASE_NAME, COLLECTION_NAME,
+                new Document("_id", objectId),
+                new Document("$set", new Document()
+                        .append("phone", 456L)
+                        .append("created", new Date(UPDATE_DATE))));
+
+        final SourceRecord updateRecord = consumeRecordsByTopic(1).allRecordsInOrder().get(0);
+        final Struct updateValue = (Struct) updateRecord.value();
+        final Struct updateDescription = updateValue.getStruct(MongoDbFieldName.UPDATE_DESCRIPTION);
+        final String updatedFields = updateDescription.getString(MongoDbFieldName.UPDATED_FIELDS);
+
+        assertThat(updateValue.getString(Envelope.FieldName.OPERATION)).isEqualTo(Operation.UPDATE.code());
+        assertThat(updatedFields).contains(expectedUpdatedFieldsPhone);
+        assertThat(updatedFields).contains(expectedUpdatedFieldsCreated);
+        assertThat(updateDescription.getArray(MongoDbFieldName.REMOVED_FIELDS)).isNull();
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/JsonSerializationTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/JsonSerializationTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 public class JsonSerializationTest {
 
-    private JsonSerialization serialization = new JsonSerialization();
+    private JsonSerialization serialization = new JsonSerialization(MongoDbConnectorConfig.JsonSerializationMode.LEGACY);
 
     @Test
     void shouldGeOnlyIdFromCompositeKey() {
@@ -38,6 +38,14 @@ public class JsonSerializationTest {
         var compositeKey = serialization.getDocumentId(composite);
 
         Assertions.assertThat(compositeKey).isEqualTo(simpleKey);
+    }
+
+    @Test
+    void shouldPreserveLegacyUpdatedFieldsFormatting() {
+        var updatedFields = new BsonDocument("name", new BsonString("Mary"))
+                .append("zipcode", new BsonString("11111"));
+
+        Assertions.assertThat(serialization.getUpdatedFields(updatedFields)).isEqualTo("{\"name\": \"Mary\", \"zipcode\": \"11111\"}");
     }
 
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedIncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedIncrementalSnapshotIT.java
@@ -96,7 +96,7 @@ public class ShardedIncrementalSnapshotIT extends AbstractShardedMongoConnectorI
                 this::extractFieldValue,
                 topicName(), null);
 
-        var serialization = new JsonSerialization();
+        var serialization = new JsonSerialization(MongoDbConnectorConfig.JsonSerializationMode.LEGACY);
 
         var expected = documents.values()
                 .stream()

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -726,6 +726,10 @@ This example uses a document with an integer identifier, but any valid MongoDB d
 === Change event values
 
 The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
+The `after`, `before`, and `updateDescription.updatedFields` fields contain MongoDB Extended JSON strings.
+The connector's xref:mongodb-property-json-serialization-mode[`json.serialization.mode`] property controls how the connector serializes BSON values in these fields.
+By default, the connector preserves the legacy behavior: it serializes full document fields by using MongoDB Extended JSON v1 strict representation and serializes `updateDescription.updatedFields` by using MongoDB Extended JSON v2 relaxed representation.
+To use MongoDB Extended JSON v2 canonical representation, set `json.serialization.mode` to `extended`.
 
 Consider the same sample document that was used to show an example of a change event key:
 
@@ -1057,7 +1061,9 @@ An _update_ event value does not contain an `after` field if the capture mode is
 
 |5
 |`updatedFields`
-|Contains the JSON string representation of the updated field values of the document. In this example, the update changed the `first_name` field to a new value.
+|Contains the JSON string representation of the updated field values of the document.
+The connector serializes this field using the mode specified by the xref:mongodb-property-json-serialization-mode[`json.serialization.mode`] connector property.
+In this example, the update changed the `first_name` field to a new value.
 
 |6
 |`source`
@@ -1752,6 +1758,49 @@ Set xref:mongodb-property-capture-mode-full-update-type[capture.mode.full.update
 
 `change_streams_with_pre_image`::
 `update` events do not include the full document, but include a field that represents the state of the document `before` the change.
+
+|[[mongodb-property-json-serialization-mode]]<<mongodb-property-json-serialization-mode, `+json.serialization.mode+`>>
+|`legacy`
+a|Specifies the MongoDB Extended JSON serialization mode that the connector uses for MongoDB document fields in change event values, including `after`, `before`, and `updateDescription.updatedFields`.
+Set this property to one of the following values:
+
+`legacy`:: Preserves the historical JSON behavior.
+The connector serializes full document fields, such as `after` and `before`, by using the MongoDB Extended JSON v1 strict representation, and serializes `updateDescription.updatedFields` by using the MongoDB Extended JSON v2 relaxed representation.
+
+`strict`:: Uses the MongoDB Extended JSON v1 strict representation.
+
+`extended`:: Uses the MongoDB Extended JSON v2 canonical representation.
+
+`relaxed`:: Uses the MongoDB Extended JSON v2 relaxed representation.
++
+Compared with the default `legacy` mode, the non-default settings can change how BSON values are represented inside the JSON strings in `after`, `before`, and `updateDescription.updatedFields`.
+For example, DateTime, Binary, RegExp, and Int64 values can use different Extended JSON forms.
+For the complete list of BSON type representations, see the MongoDB documentation for https://www.mongodb.com/docs/manual/reference/mongodb-extended-json-v1/[Extended JSON v1] and https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[Extended JSON v2].
+
+.Example DateTime representations for `json.serialization.mode` settings
+[cols="1,2,2",options="header"]
+!===
+!`json.serialization.mode` value !`after` and `before` representation !`updateDescription.updatedFields` representation
+
+!`legacy`
+!`{"timestamp": {"$date": 1783101585729}}`
+!`{"timestamp": {"$date": "2026-07-03T17:59:45.729Z"}}`
+
+!`strict`
+!`{"timestamp": {"$date": 1783101585729}}`
+!`{"timestamp": {"$date": 1783101585729}}`
+
+!`extended`
+!`{"timestamp": {"$date": {"$numberLong": "1783101585729"}}}`
+!`{"timestamp": {"$date": {"$numberLong": "1783101585729"}}}`
+
+!`relaxed`
+!`{"timestamp": {"$date": "2026-07-03T17:59:45.729Z"}}`
+!`{"timestamp": {"$date": "2026-07-03T17:59:45.729Z"}}`
+
+!===
+
+This setting does not affect the representation of document identifiers in change event keys.
 
 |[[mongodb-property-capture-start-op-time]]<<mongodb-property-capture-start-op-time, `+capture.start.op.time+`>>
 |No default value


### PR DESCRIPTION
Fixes debezium/dbz#731

## Description

This PR adds a MongoDB connector `json.serialization.mode` option to control how MongoDB BSON values are serialized in change event JSON payload fields.

The new option supports:

- `legacy`, the default, which preserves existing behavior
- `strict`, which uses MongoDB Extended JSON v1 strict representation
- `extended`, which uses MongoDB Extended JSON v2 canonical representation
- `relaxed`, which uses MongoDB Extended JSON v2 relaxed representation

Before this change, full document fields such as `after` and `before` used Debezium's MongoDB JSON serialization, while `updateDescription.updatedFields` used the MongoDB driver's relaxed JSON default. As a result, the same BSON value types could be represented differently between create and update events.

**Example of the historical behavior**

Create event `after` payload:

```json
{
  "_meta": {
    "tsVersion": { "$numberLong": "1783078553473428000" },
    "timestamp": { "$date": 1783078553473 }
  }
}
```

Update event updateDescription.updatedFields payload:

```json
{
  "_meta": {
    "tsVersion": "1783078851680986000",
    "timestamp": { "$date": "2026-07-03T11:40:51.68Z" }
  }
}
```

The default legacy mode keeps this existing behavior for backward compatibility. Users who want one consistent representation across `after`, `before`, and `updateDescription.updatedFields` can set `json.serialization.mode` to `strict`, `extended`, or `relaxed`.

I used OpenCode `1.17.13` with GPT-5.5 from OpenAI to help update tests and update the documentation.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
