### PR TITLE
debezium/dbz#2100 Bind numeric array element type without precision modifier

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -44,6 +44,26 @@ public class ArrayType extends AbstractType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, getElementTypeName(this.getDialect(), schema, false)));
+        final String elementTypeName = baseElementTypeName(getElementTypeName(this.getDialect(), schema, false));
+        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, elementTypeName));
+    }
+
+    /**
+     * Reduces a column type name to the base element type name that
+     * {@link java.sql.Connection#createArrayOf(String, Object[])} accepts. The JDBC driver looks the
+     * name up as a server type, so it rejects both the array brackets and any length/precision
+     * modifier: {@code numeric(10,2)} must be passed as {@code numeric}, {@code varchar(255)} as
+     * {@code varchar}. The DDL type name keeps the modifier; only the {@code createArrayOf} argument
+     * needs the bare base type.
+     */
+    static String baseElementTypeName(String typeName) {
+        // Strip any array brackets: numeric(10,2)[] -> numeric(10,2)
+        typeName = typeName.replaceAll("\\[]", "").trim();
+        // Strip the length/precision modifier: numeric(10,2) -> numeric
+        final int parenIndex = typeName.indexOf('(');
+        if (parenIndex > 0) {
+            typeName = typeName.substring(0, parenIndex).trim();
+        }
+        return typeName.toLowerCase();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the PostgreSQL {@link ArrayType} handler.
+ */
+@Tag("UnitTests")
+class ArrayTypeTest {
+
+    @Test
+    @DisplayName("Should strip the precision/scale modifier for createArrayOf element type")
+    void testStripsPrecisionAndScale() {
+        // dbz#2100: numeric(10,2)[] previously passed "decimal(10,2)" to Connection#createArrayOf,
+        // which the driver rejects with "Unable to find server array type for provided name decimal(10,2)".
+        assertThat(ArrayType.baseElementTypeName("decimal(10,2)")).isEqualTo("decimal");
+        assertThat(ArrayType.baseElementTypeName("numeric(10,2)")).isEqualTo("numeric");
+        assertThat(ArrayType.baseElementTypeName("varchar(255)")).isEqualTo("varchar");
+    }
+
+    @Test
+    @DisplayName("Should strip array brackets from the element type")
+    void testStripsArrayBrackets() {
+        assertThat(ArrayType.baseElementTypeName("numeric(10,2)[]")).isEqualTo("numeric");
+        assertThat(ArrayType.baseElementTypeName("text[]")).isEqualTo("text");
+        assertThat(ArrayType.baseElementTypeName("int[][]")).isEqualTo("int");
+    }
+
+    @Test
+    @DisplayName("Should leave a bare base type name unchanged")
+    void testLeavesBaseTypeUnchanged() {
+        assertThat(ArrayType.baseElementTypeName("numeric")).isEqualTo("numeric");
+        assertThat(ArrayType.baseElementTypeName("text")).isEqualTo("text");
+        assertThat(ArrayType.baseElementTypeName("uuid")).isEqualTo("uuid");
+    }
+
+    @Test
+    @DisplayName("Should lower-case the base type name")
+    void testLowerCasesBaseType() {
+        assertThat(ArrayType.baseElementTypeName("NUMERIC(10,2)")).isEqualTo("numeric");
+        assertThat(ArrayType.baseElementTypeName("VARCHAR(255)[]")).isEqualTo("varchar");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.integration.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.Tag;
@@ -576,6 +578,52 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getString(2)).isEqualTo("08:00:2b:01:02:03:04:05");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithNumericArrayWithPrecisionAndScale(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // A numeric(10,2)[] element schema carries the precision/scale, so the element type name is
+        // decimal(10,2). createArrayOf only accepts the base type name (numeric/decimal), so the
+        // precision/scale must be stripped before binding the array.
+        final Schema numericElementSchema = Decimal.builder(2)
+                .optional()
+                .parameter("connect.decimal.precision", "10")
+                .build();
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.array(numericElementSchema).optional().build(),
+                Arrays.asList(new BigDecimal("1.25"), new BigDecimal("2.50"), new BigDecimal("-9999999.99")),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        final String sql = "CREATE TABLE %s (id int not null, data numeric(10,2)[], primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getArray(2).getArray()).isEqualTo(new BigDecimal[]{
+                    new BigDecimal("1.25"), new BigDecimal("2.50"), new BigDecimal("-9999999.99") });
             return null;
         });
     }


### PR DESCRIPTION
Fixes debezium/dbz#2100 (PostgreSQL → PostgreSQL JDBC sink type-preservation audit), case 8.

## What

A `numeric(N,S)[]` source column fails to sink into a native PostgreSQL array column, even with the target table pre-created and `schema.evolution=none`:

```
org.postgresql.util.PSQLException: Unable to find server array type for provided name decimal(10,2)
```

`ArrayType.bind` passes the element type name straight to `Connection#createArrayOf`. For a decimal element that name is `decimal(10,2)` (it carries the precision/scale, which is correct for the DDL), but `createArrayOf` looks the argument up as a server type and only accepts the bare base type name — `numeric`/`decimal`, no brackets, no modifier.

## Fix

Strip the array brackets and the length/precision modifier from the element type name before binding, so `createArrayOf` receives the base type. The DDL type name (`getTypeName`) is untouched, so the target column is still created as `numeric(N,S)[]` and precision is preserved end to end.

The UNNEST batch path (`UnnestRecordWriter.getSqlTypeName`) already applies the same stripping; this brings the row-wise binding path in line. Keeping the change local to `ArrayType` avoids a `core → dialect.postgres` dependency.

## Tests

- Unit: `ArrayTypeTest` covers stripping the precision/scale modifier, stripping array brackets, and leaving a bare base type unchanged.
- Integration: `JdbcSinkColumnTypeMappingIT#testShouldWorkWithNumericArrayWithPrecisionAndScale` round-trips `numeric(10,2)[]` = `{1.25, 2.50, -9999999.99}` into a pre-created native `numeric(10,2)[]` column with `schema.evolution=none`, across both the standard and UNNEST insert paths. It fails on `main` and passes with this change.
