### PR TITLE
DBZ-2187 Fix DATETIME(4-6) precision truncation in ZeroDateFallbackConverter

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -841,3 +841,4 @@ Roshni R
 刘镕通
 Sundong Kim
 Timur Rakhmatullin
+skdus531

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverter.java
@@ -37,9 +37,15 @@ import io.debezium.util.Strings;
  * <h2>Supported types</h2>
  * <ul>
  *   <li>{@code DATE} &rarr; {@code io.debezium.time.Date} (INT32 epoch days)</li>
- *   <li>{@code DATETIME} &rarr; {@code io.debezium.time.Timestamp} (INT64 epoch millis)</li>
+ *   <li>{@code DATETIME(0-3)} &rarr; {@code io.debezium.time.Timestamp} (INT64 epoch millis)</li>
+ *   <li>{@code DATETIME(4-6)} &rarr; {@code io.debezium.time.MicroTimestamp} (INT64 epoch micros)</li>
  *   <li>{@code TIMESTAMP} &rarr; {@code io.debezium.time.ZonedTimestamp} (STRING ISO-8601)</li>
  * </ul>
+ *
+ * The {@code DATETIME} semantic type follows the column's fractional-second precision
+ * ({@link RelationalColumn#length()}): {@code 0-3} maps to {@code Timestamp} (millis) and
+ * {@code 4-6} to {@code MicroTimestamp} (micros). The converter does not consult
+ * {@code time.precision.mode}.
  *
  * <h2>Two policies, selectable per type</h2>
  * <ul>
@@ -219,10 +225,18 @@ public class ZeroDateFallbackConverter
     private void registerDatetime(RelationalColumn field, ConverterRegistration<SchemaBuilder> registration) {
         final String columnRaw = lookupColumnFallback(field);
         final LocalDateTime effective = (columnRaw != null) ? parseDatetimeFallback(columnRaw) : fallbackDatetime;
-        final Long fallback = effective == null ? null : effective.toInstant(ZoneOffset.UTC).toEpochMilli();
         final boolean hasDefault = field.hasDefaultValue();
+        final boolean isMicro = field.length().isPresent() && field.length().getAsInt() >= 4;
 
-        SchemaBuilder schema = SchemaBuilder.int64().name(io.debezium.time.Timestamp.SCHEMA_NAME).version(SCHEMA_VERSION);
+        final String schemaName = isMicro
+                ? io.debezium.time.MicroTimestamp.SCHEMA_NAME
+                : io.debezium.time.Timestamp.SCHEMA_NAME;
+        final Long fallback = effective == null ? null
+                : isMicro
+                        ? io.debezium.time.Conversions.toEpochMicros(effective.toInstant(ZoneOffset.UTC))
+                        : effective.toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        SchemaBuilder schema = SchemaBuilder.int64().name(schemaName).version(SCHEMA_VERSION);
         if (fallback == null) {
             schema = schema.optional();
         }
@@ -236,11 +250,21 @@ public class ZeroDateFallbackConverter
             if (input == null) {
                 return fallback;
             }
-            if (input instanceof Timestamp ts) {
-                return ts.getTime();
+            if (isMicro) {
+                if (input instanceof Timestamp ts) {
+                    return io.debezium.time.Conversions.toEpochMicros(ts.toInstant());
+                }
+                if (input instanceof LocalDateTime ldt) {
+                    return io.debezium.time.Conversions.toEpochMicros(ldt.toInstant(ZoneOffset.UTC));
+                }
             }
-            if (input instanceof LocalDateTime ldt) {
-                return ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+            else {
+                if (input instanceof Timestamp ts) {
+                    return ts.getTime();
+                }
+                if (input instanceof LocalDateTime ldt) {
+                    return ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+                }
             }
             if (input instanceof Long l) {
                 return l;

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/ZeroDateFallbackConverterTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -201,6 +202,58 @@ class ZeroDateFallbackConverterTest {
         assertThat(reg.converter.convert("garbage")).isEqualTo(expected);
     }
 
+    // -- DATETIME(4-6) branch: MicroTimestamp precision ----------------------------------------
+
+    @Test
+    void datetimeLambda_precision4_schemaIsMicroTimestamp() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false, 4));
+        assertThat(reg.schema.name()).isEqualTo(io.debezium.time.MicroTimestamp.SCHEMA_NAME);
+    }
+
+    @Test
+    void datetimeLambda_precision6_schemaIsMicroTimestamp() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false, 6));
+        assertThat(reg.schema.name()).isEqualTo(io.debezium.time.MicroTimestamp.SCHEMA_NAME);
+    }
+
+    @Test
+    void datetimeLambda_precision3_schemaIsTimestamp() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false, 3));
+        assertThat(reg.schema.name()).isEqualTo(io.debezium.time.Timestamp.SCHEMA_NAME);
+    }
+
+    @Test
+    void datetimeLambda_noPrecision_schemaIsTimestamp() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false));
+        assertThat(reg.schema.name()).isEqualTo(io.debezium.time.Timestamp.SCHEMA_NAME);
+    }
+
+    @Test
+    void datetimeLambda_precision5_inputNull_returnsFallbackInMicros() {
+        final Registration reg = registerOn(
+                newConfigured(propsWith("fallback.datetime", "2000-01-01 00:00:00")),
+                datetimeColumn("dt", false, 5));
+        final long expected = io.debezium.time.Conversions
+                .toEpochMicros(LocalDateTime.parse("2000-01-01T00:00:00").toInstant(ZoneOffset.UTC));
+        assertThat(reg.converter.convert(null)).isEqualTo(expected);
+    }
+
+    @Test
+    void datetimeLambda_precision6_javaSqlTimestamp_returnsEpochMicros() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false, 6));
+        final Timestamp ts = Timestamp.valueOf("2024-06-15 12:34:56.123456");
+        final long expected = io.debezium.time.Conversions.toEpochMicros(ts.toInstant());
+        assertThat(reg.converter.convert(ts)).isEqualTo(expected);
+    }
+
+    @Test
+    void datetimeLambda_precision4_localDateTime_returnsEpochMicros() {
+        final Registration reg = registerOn(newConfigured(new Properties()), datetimeColumn("dt", false, 4));
+        final LocalDateTime ldt = LocalDateTime.parse("2024-06-15T12:34:56.1234");
+        final long expected = io.debezium.time.Conversions.toEpochMicros(ldt.toInstant(ZoneOffset.UTC));
+        assertThat(reg.converter.convert(ldt)).isEqualTo(expected);
+    }
+
     // -- TIMESTAMP branch ----------------------------------------------------------------------
 
     @Test
@@ -363,24 +416,29 @@ class ZeroDateFallbackConverterTest {
     }
 
     private static RelationalColumn dateColumn(String name, boolean hasDefault) {
-        return mockColumn(name, Types.DATE, "DATE", hasDefault);
+        return mockColumn(name, Types.DATE, "DATE", hasDefault, OptionalInt.empty());
     }
 
     private static RelationalColumn datetimeColumn(String name, boolean hasDefault) {
-        return mockColumn(name, Types.TIMESTAMP, "DATETIME", hasDefault);
+        return mockColumn(name, Types.TIMESTAMP, "DATETIME", hasDefault, OptionalInt.empty());
+    }
+
+    private static RelationalColumn datetimeColumn(String name, boolean hasDefault, int precision) {
+        return mockColumn(name, Types.TIMESTAMP, "DATETIME", hasDefault, OptionalInt.of(precision));
     }
 
     private static RelationalColumn timestampColumn(String name, boolean hasDefault) {
-        return mockColumn(name, Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP", hasDefault);
+        return mockColumn(name, Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP", hasDefault, OptionalInt.empty());
     }
 
-    private static RelationalColumn mockColumn(String name, int jdbcType, String typeName, boolean hasDefault) {
+    private static RelationalColumn mockColumn(String name, int jdbcType, String typeName, boolean hasDefault, OptionalInt length) {
         final RelationalColumn col = Mockito.mock(RelationalColumn.class);
         Mockito.when(col.name()).thenReturn(name);
         Mockito.when(col.dataCollection()).thenReturn(DATA_COLLECTION);
         Mockito.when(col.jdbcType()).thenReturn(jdbcType);
         Mockito.when(col.typeName()).thenReturn(typeName);
         Mockito.when(col.hasDefaultValue()).thenReturn(hasDefault);
+        Mockito.when(col.length()).thenReturn(length);
         return col;
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2187

## Description

`ZeroDateFallbackConverter.registerDatetime()` previously hardcoded the `io.debezium.time.Timestamp` (milliseconds) schema for every `DATETIME` column, regardless of the column's fractional-second precision. Because the converter registers itself as a `CustomConverter` and fully replaces the schema/value conversion for the column, this silently truncated `DATETIME(4-6)` values to milliseconds — even though the normal Debezium converter path (`JdbcValueConverters` / `TemporalPrecisionMode`) maps `DATETIME(4-6)` to `io.debezium.time.MicroTimestamp` (microseconds).

For example, `2024-06-15 12:34:56.123456` in a `DATETIME(6)` column was emitted as `1718454896123` (`Timestamp`, millis) instead of `1718454896123456` (`MicroTimestamp`, micros).

Changes:

* Branch on `RelationalColumn.length()` to select `MicroTimestamp` (INT64 micros) for precision `>= 4`, and keep `Timestamp` (INT64 millis) for precision `0-3` or when length is absent.
* Use `io.debezium.time.Conversions.toEpochMicros` for the fallback value and row-level conversion on the micros path.
* Add unit tests for `DATETIME(3)`, `DATETIME(4)`, `DATETIME(5)`, `DATETIME(6)` and the no-precision case; extend `mockColumn()` to stub `RelationalColumn.length()`.

MySQL/MariaDB cap `DATETIME` precision at 6, so no nanosecond mapping is required.

**Scope note:** this change only aligns the converter with the precision-based *adaptive* mapping. It intentionally does not make the converter honor `time.precision.mode` (`connect`, `isostring`,`microseconds`, `nanoseconds`) — the converter already hardcodes semantic types for `DATE` and `TIMESTAMP` and never consulted that property. Wiring `time.precision.mode` through the converter is a larger, separate change and is left as a follow-up, keeping this PR minimal.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`