### PR TITLE
debezium/dbz#2169 Fix RowIdCodec data loss when encoding Oracle ROWIDs with non-zero high bits

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -575,6 +575,7 @@ Randall Hauch
 Raphael Auv
 Raúl Estrada
 Raúl Tovar
+Regi Çallmori
 Renato Mefi
 René Kerner
 René Rütter

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionCommitConsumer.java
@@ -559,7 +559,7 @@ public class TransactionCommitConsumer implements AutoCloseable {
     }
 
     private boolean hasRowId(DmlEvent event) {
-        return event.getRowId() != null && event.getRowId() != RowIdCodec.EMPTY_ROW_ID;
+        return event.getRowId() != null && !event.getRowId().equals(RowIdCodec.EMPTY_ROW_ID);
     }
 
     static class ConstructionDetails {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/ehcache/EhcacheLogMinerTransactionCache.java
@@ -155,12 +155,12 @@ public class EhcacheLogMinerTransactionCache extends AbstractLogMinerTransaction
 
     @Override
     public boolean rollbackTransactionEventWithRowId(EhcacheTransaction transaction, String rowId) {
-        final long encodedRowId = RowIdCodec.encode(rowId);
+        final RowIdCodec.Packed encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
             final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
+            if (event != null && event.getRowId().equals(encodedRowId) && !rollbackCache.containsKey(eventKey)) {
                 rollbackCache.put(eventKey, Boolean.TRUE);
                 return true;
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/infinispan/InfinispanLogMinerTransactionCache.java
@@ -143,12 +143,12 @@ public class InfinispanLogMinerTransactionCache extends AbstractLogMinerTransact
 
     @Override
     public boolean rollbackTransactionEventWithRowId(InfinispanTransaction transaction, String rowId) {
-        final long encodedRowId = RowIdCodec.encode(rowId);
+        final RowIdCodec.Packed encodedRowId = RowIdCodec.encode(rowId);
         final TreeSet<Integer> eventIds = eventIdsByTransactionId.get(transaction.getTransactionId());
         for (Integer eventId : eventIds.descendingSet()) {
             final String eventKey = transaction.getEventId(eventId);
             final LogMinerEvent event = eventCache.get(eventKey);
-            if (event != null && event.getRowId() == encodedRowId && !rollbackCache.containsKey(eventKey)) {
+            if (event != null && event.getRowId().equals(encodedRowId) && !rollbackCache.containsKey(eventKey)) {
                 rollbackCache.put(eventKey, Boolean.TRUE);
                 return true;
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/memory/MemoryLogMinerTransactionCache.java
@@ -131,13 +131,13 @@ public class MemoryLogMinerTransactionCache extends AbstractLogMinerTransactionC
 
     @Override
     public boolean rollbackTransactionEventWithRowId(MemoryTransaction transaction, String rowId) {
-        final long encodedRowId = RowIdCodec.encode(rowId);
+        final RowIdCodec.Packed encodedRowId = RowIdCodec.encode(rowId);
         final var events = eventsByTransactionId.get(transaction.getTransactionId());
         if (events != null) {
             final Set<Integer> rollbacks = rollbacksByTransactionId.computeIfAbsent(transaction.getTransactionId(), k -> new HashSet<>());
             for (int i = events.size() - 1; i >= 0; i--) {
                 final LogMinerEventEntry entry = events.get(i);
-                if (entry.event.getRowId() == encodedRowId && !rollbacks.contains(entry.eventId)) {
+                if (entry.event.getRowId().equals(encodedRowId) && !rollbacks.contains(entry.eventId)) {
                     rollbacks.add(entry.eventId);
                     return true;
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEvent.java
@@ -21,7 +21,7 @@ public class LogMinerEvent {
     private final EventType eventType;
     private final Scn scn;
     private final TableId tableId;
-    private final long rowId;
+    private final RowIdCodec.Packed rowId;
     private final String rsId;
     private final long changeTime;
 
@@ -50,7 +50,7 @@ public class LogMinerEvent {
         return tableId;
     }
 
-    public Long getRowId() {
+    public RowIdCodec.Packed getRowId() {
         return rowId;
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/RowIdCodec.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/RowIdCodec.java
@@ -6,11 +6,16 @@
 package io.debezium.connector.oracle.logminer.events;
 
 /**
- * A specialized codec for Oracle {@code ROWID} values to pack them into an 8-byte long value.
+ * A specialized codec for Oracle {@code ROWID} values, packing the 18-character
+ * base-64 string (108 bits) losslessly into a {@link Packed} record of two {@code long} fields.
  *
  * @author Chris Cranford
  */
 public class RowIdCodec {
+
+    /** Lossless 108-bit container for an Oracle ROWID. */
+    public record Packed(long high, long low) {
+    }
 
     // Oracle ROWID base64 alphabet
     private static final String BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -22,50 +27,58 @@ public class RowIdCodec {
         }
     }
 
-    public static long EMPTY_ROW_ID = RowIdCodec.encode("AAAAAAAAAAAAAAAAAA");
+    public static final Packed EMPTY_ROW_ID = RowIdCodec.encode("AAAAAAAAAAAAAAAAAA");
 
     private RowIdCodec() {
     }
 
     /**
-     * Decode Oracle ROWID string to packed long
-     * @param rowId the row id
-     * @return the packed 8-byte value
+     * Encodes an Oracle ROWID string into a lossless {@link Packed} representation.
+     *
+     * @param rowId the 18-character Oracle ROWID string
+     * @return the packed representation holding all 108 bits across two {@code long} fields
      */
-    public static long encode(String rowId) {
+    public static Packed encode(String rowId) {
         if (rowId == null || rowId.length() != 18) {
             throw new IllegalArgumentException("Invalid ROWID length: " + rowId);
         }
 
-        long result = 0;
+        long high = 0, low = 0;
 
-        // Decode each character as 6-bit value and pack into long
+        // Pack each character's 6-bit value into the high/low register pair.
+        // Bits that would overflow the top of low are captured first and carried into high.
         for (int i = 0; i < 18; i++) {
             char c = rowId.charAt(i);
             if (c >= 128) {
                 throw new IllegalArgumentException("Invalid ROWID character: " + c);
             }
 
-            int value = BASE64_VALUES[c];
-            result = (result << 6) | value;
+            long overflow = low >>> 58; // capture the 6 bits about to leave low
+            low = (low << 6) | BASE64_VALUES[c];
+            high = (high << 6) | overflow;
+
         }
 
-        return result;
+        return new Packed(high, low);
     }
 
     /**
-     * Encode packed long back to Oracle ROWID string
-     * @param packed the packed 8-byte value.
-     * @return the decoded ROWID string
+     * Decodes a {@link Packed} representation back to the original Oracle ROWID string.
+     *
+     * @param packed the packed representation returned by {@link #encode}
+     * @return the original 18-character Oracle ROWID string
      */
-    public static String decode(long packed) {
+    public static String decode(Packed packed) {
         char[] chars = new char[18];
+        long high = packed.high, low = packed.low;
 
-        // Extract 6 bits at a time from right to left
+        // Extract 6 bits at a time from the right, working right to left.
         for (int i = 17; i >= 0; i--) {
-            int value = (int) (packed & 0x3F); // Get lowest 6 bits
+            int value = (int) (low & 0x3F); // lowest 6 bits of low
             chars[i] = BASE64_CHARS.charAt(value);
-            packed >>>= 6; // Unsigned right shift by 6 bits
+            low >>>= 6; // discard the 6 bits just consumed
+            low |= (high & 0x3F) << 58; // borrow the bottom 6 bits of high into the top of low
+            high >>>= 6; // discard the 6 bits just borrowed
         }
 
         return new String(chars);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/events/RowIdCodecTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/events/RowIdCodecTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class RowIdCodecTest {
+
+    // A real Oracle ROWID whose chars at indices 3–5 are S, J, q (non-zero).
+    // These bits fall in the upper 44 bits; the original single-long encode() silently
+    // discarded them, producing "AAAAAAAANAAAAnkAAI" on decode instead of this value.
+    private static final String ROWID_WITH_HIGH_BITS = "AAASJqAANAAAAnkAAI";
+
+    // -------------------------------------------------------------------------
+    // encode() — input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void encodeShouldThrowWhenRowIdIsNull() {
+        assertThatThrownBy(() -> RowIdCodec.encode(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void encodeShouldThrowWhenRowIdIsTooShort() {
+        assertThatThrownBy(() -> RowIdCodec.encode("AAAAAAAAAAAAAAAAA")) // 17 chars
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void encodeShouldThrowWhenRowIdIsTooLong() {
+        assertThatThrownBy(() -> RowIdCodec.encode("AAAAAAAAAAAAAAAAAAA")) // 19 chars
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void encodeShouldThrowWhenRowIdContainsNonAsciiCharacter() {
+        // 'é' = U+00E9 = 233 > 127; length is still 18 so only the character check fires
+        assertThatThrownBy(() -> RowIdCodec.encode("AAAAAAAAAAAAAAAAAé"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // decode(encode()) round-trip — correctness
+    // -------------------------------------------------------------------------
+
+    @Test
+    void roundTripShouldBeExactForAllARowId() {
+        // All chars are 'A' (value 0); high=0, no overflow path exercised
+        String allA = "AAAAAAAAAAAAAAAAAA";
+        assertThat(RowIdCodec.decode(RowIdCodec.encode(allA))).isEqualTo(allA);
+    }
+
+    @Test
+    void roundTripShouldBeExactForMaxValueRowId() {
+        // All chars are '/' (value 63 = 0b111111); all 108 bits set
+        String maxRowId = "//////////////////";
+        assertThat(RowIdCodec.decode(RowIdCodec.encode(maxRowId))).isEqualTo(maxRowId);
+    }
+
+    @Test
+    void roundTripShouldBeExactWhenChar7HasNonZeroUpperBits() {
+        // char[7] straddles the 64-bit boundary: its upper 2 bits go into high,
+        // lower 4 bits remain in low. 'Q' = 16 = 0b010000, so bit4=1 overflows into high.
+        String rowId = "AAAAAAAQAAAAAAAAAA";
+        assertThat(RowIdCodec.decode(RowIdCodec.encode(rowId))).isEqualTo(rowId);
+    }
+
+    @Test
+    void roundTripShouldBeExactWhenHighBitsAreNonZero() {
+        // Chars 3–5 (S=18, J=9, q=42) sit entirely above bit 63 and are recovered
+        // via the high register — this is the data-loss regression case
+        assertThat(RowIdCodec.decode(RowIdCodec.encode(ROWID_WITH_HIGH_BITS)))
+                .isEqualTo(ROWID_WITH_HIGH_BITS);
+    }
+
+    @Test
+    void roundTripShouldBeExactForMultipleDistinctRowIds() {
+        String[] rowIds = {
+                "AAASJqAANAAAAnkAAI",
+                "AAAR/aAANAAAAPtAAA",
+                "AAAR/aAANAAAAPtAAB",
+                "AAANewAAEAAAAwTAAA",
+        };
+        for (String rowId : rowIds) {
+            assertThat(RowIdCodec.decode(RowIdCodec.encode(rowId)))
+                    .as("round-trip for %s", rowId)
+                    .isEqualTo(rowId);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // EMPTY_ROW_ID constant
+    // -------------------------------------------------------------------------
+
+    @Test
+    void emptyRowIdShouldDecodeToAllA() {
+        assertThat(RowIdCodec.decode(RowIdCodec.EMPTY_ROW_ID)).isEqualTo("AAAAAAAAAAAAAAAAAA");
+    }
+
+    @Test
+    void emptyRowIdShouldEqualEncodeOfAllA() {
+        assertThat(RowIdCodec.EMPTY_ROW_ID).isEqualTo(RowIdCodec.encode("AAAAAAAAAAAAAAAAAA"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Packed record — value equality
+    // -------------------------------------------------------------------------
+
+    @Test
+    void twoPackedInstancesEncodingSameRowIdShouldBeEqual() {
+        RowIdCodec.Packed a = RowIdCodec.encode(ROWID_WITH_HIGH_BITS);
+        RowIdCodec.Packed b = RowIdCodec.encode(ROWID_WITH_HIGH_BITS);
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void twoPackedInstancesEncodingDifferentRowIdsShouldNotBeEqual() {
+        RowIdCodec.Packed a = RowIdCodec.encode("AAASJqAANAAAAnkAAI");
+        RowIdCodec.Packed b = RowIdCodec.encode("AAAR/aAANAAAAPtAAA");
+        assertThat(a).isNotEqualTo(b);
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -385,3 +385,4 @@ Paul_Kim,Sundong Kim
 TimurRakhmatullin86,Timur Rakhmatullin
 lekhrocks,Lekhraj Kumar
 zach-all,Zach All
+regi-c,Regi Çallmori


### PR DESCRIPTION
Fixes debezium/dbz#2169

## Description
The original `RowIdCodec.encode()` packed an 18-character Oracle ROWID (108 bits) into a
single 64-bit `long`, silently discarding the top 44 bits. Any ROWID whose first seven
base-64 characters are non-zero would decode to a different string, corrupting `source.row_id`
in every affected change event.

Replaced the single `long` with a `Packed` record (`high` + `low` long fields) that stores
all 108 bits without loss. Added `RowIdCodecTest` covering all encode/decode branches.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
