### PR TITLE
debezium/dbz#2188 Mask RocketMQ ACL secret key in RocketMqConfig#toString()

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -839,3 +839,4 @@ Aleksandr Pavlyuk
 Roshni R
 刘镕通
 Sundong Kim
+Timur Rakhmatullin

--- a/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/RocketMqConfig.java
+++ b/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/RocketMqConfig.java
@@ -81,7 +81,7 @@ public class RocketMqConfig {
                 ", groupId='" + groupId + '\'' +
                 ", aclEnable=" + aclEnable +
                 ", accessKey='" + accessKey + '\'' +
-                ", secretKey='" + secretKey + '\'' +
+                ", secretKey='" + (secretKey == null ? null : "********") + '\'' +
                 '}';
     }
 

--- a/debezium-storage/debezium-storage-rocketmq/src/test/java/io/debezium/storage/rocketmq/RocketMqConfigTest.java
+++ b/debezium-storage/debezium-storage-rocketmq/src/test/java/io/debezium/storage/rocketmq/RocketMqConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.rocketmq;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class RocketMqConfigTest {
+
+    private static final String SECRET_KEY = "super-secret-key-value";
+
+    @Test
+    public void toStringShouldMaskSecretKey() {
+        RocketMqConfig config = RocketMqConfig.newBuilder()
+                .namesrvAddr("localhost:9876")
+                .groupId("group")
+                .aclEnable(true)
+                .accessKey("access-key")
+                .secretKey(SECRET_KEY)
+                .build();
+
+        String rendered = config.toString();
+
+        assertFalse(rendered.contains(SECRET_KEY), "toString() must not expose the raw secret key");
+        assertTrue(rendered.contains("secretKey='********'"), "toString() should mask the secret key");
+        // Non-sensitive fields must remain visible for troubleshooting.
+        assertTrue(rendered.contains("namesrvAddr='localhost:9876'"));
+        assertTrue(rendered.contains("accessKey='access-key'"));
+    }
+
+    @Test
+    public void toStringShouldNotMaskNullSecretKey() {
+        RocketMqConfig config = RocketMqConfig.newBuilder()
+                .namesrvAddr("localhost:9876")
+                .groupId("group")
+                .build();
+
+        assertTrue(config.toString().contains("secretKey='null'"));
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -381,3 +381,4 @@ Roshr2211,Roshni R
 sagnghos,Sagnik Ghosh
 leosanqing,刘镕通
 sundongkim-dev,Sundong Kim
+TimurRakhmatullin86,Timur Rakhmatullin


### PR DESCRIPTION
Fixes debezium/dbz#2188

This masks the RocketMQ ACL `secretKey` in `RocketMqConfig#toString()`, which was rendered in clear text and could leak into logs, exception messages, or debugger output. It uses the project's standard `"********"` placeholder (as in `Configuration#withMaskedPasswords`); a `null` secret is still shown as `null`, and the non-sensitive fields (including the `accessKey` identifier) remain visible. Adds `RocketMqConfigTest` covering the masked and null cases.