### PR TITLE
debezium/dbz#2192 Use new interface to detect a server sink for descriptors

### DIFF
--- a/debezium-config/src/main/java/io/debezium/metadata/ComponentDescriptor.java
+++ b/debezium-config/src/main/java/io/debezium/metadata/ComponentDescriptor.java
@@ -35,7 +35,7 @@ public class ComponentDescriptor {
             "org.apache.kafka.connect.transforms.predicates.Predicate", PREDICATE_TYPE,
             "org.apache.kafka.connect.storage.Converter", CONVERTER_TYPE,
             "org.apache.kafka.connect.storage.HeaderConverter", CONVERTER_TYPE,
-            "io.debezium.engine.DebeziumEngine$ChangeConsumer", SERVER_SINK_TYPE,
+            "io.debezium.server.api.DebeziumServerConsumer", SERVER_SINK_TYPE,
             "io.debezium.spi.converter.CustomConverter", CUSTOM_CONVERTER_TYPE);
 
     private final String id;


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2192

## Description
With https://github.com/debezium/debezium-server/pull/266 the sink does no more implement the `io.debezium.engine.DebeziumEngine$ChangeConsumer` in favor of `io.debezium.server.api.DebeziumServerConsumer` this broke the type auto-discovery for component descriptor.  

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
