### PR TITLE
debezium/dbz#1439 Add MySQL instant ADD COLUMN regression tests

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -137,7 +137,7 @@ public class MySqlAntlrDdlParserTest
     }
 
     @Test
-    @FixFor("DBZ-9704")
+    @FixFor("debezium/dbz#1439")
     public void shouldParseMultipleAddColumnsWithRepeatedInstantAlgorithm() {
         final String ddl = "CREATE TABLE `test_lot` ("
                 + "`lot_id` bigint unsigned NOT NULL,"

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -22,6 +22,7 @@ import io.debezium.connector.mysql.charset.MySqlCharsetRegistry;
 import io.debezium.connector.mysql.jdbc.MySqlDefaultValueConverter;
 import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
 import io.debezium.connector.mysql.util.MySqlValueConvertersFactory;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
@@ -133,6 +134,33 @@ public class MySqlAntlrDdlParserTest
         assertThat(c.typeName()).isEqualTo("TIME");
         assertThat(c.defaultValueExpression()).isPresent();
         assertThat(c.defaultValueExpression().get()).isEqualTo("08:00");
+    }
+
+    @Test
+    @FixFor("DBZ-9704")
+    public void shouldParseMultipleAddColumnsWithRepeatedInstantAlgorithm() {
+        final String ddl = "CREATE TABLE `test_lot` ("
+                + "`lot_id` bigint unsigned NOT NULL,"
+                + "`trade_date` date NOT NULL,"
+                + "PRIMARY KEY (`lot_id`,`trade_date`)"
+                + ") ENGINE=InnoDB;"
+                + "ALTER TABLE test_lot ADD COLUMN event_ref_type_id INTEGER, algorithm=instant, "
+                + "ADD COLUMN event_ref_id BIGINT, algorithm=instant;";
+
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        final Table table = tables.forTable(null, null, "test_lot");
+        assertThat(table).isNotNull();
+        assertThat(table.columns()).hasSize(4);
+
+        final Column eventRefTypeId = table.columnWithName("event_ref_type_id");
+        final Column eventRefId = table.columnWithName("event_ref_id");
+
+        assertThat(eventRefTypeId).isNotNull();
+        assertThat(eventRefTypeId.typeName()).isEqualTo("INTEGER");
+        assertThat(eventRefId).isNotNull();
+        assertThat(eventRefId.typeName()).isEqualTo("BIGINT");
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -5,19 +5,29 @@
  */
 package io.debezium.connector.mysql;
 
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.common.config.Config;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.binlog.BinlogConnectorIT;
+import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.SkipWhenDatabaseVersion;
 
 /**
  * @author Randall Hauch
@@ -58,6 +68,51 @@ public class MySqlConnectorIT extends BinlogConnectorIT<MySqlConnector, MySqlPar
         assertThat(successResult.get()).isEqualTo(false);
         assertThat(message.get()).contains("Unable to obtain a JDBC connection");
         assertConnectorNotRunning();
+    }
+
+    @Test
+    @FixFor("DBZ-9704")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 8, reason = "Instant ADD COLUMN requires MySQL 8.0+")
+    void shouldStreamMultipleAddColumnsWithRepeatedInstantAlgorithm() throws Exception {
+        final String tableName = "test_lot";
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(getDatabase().getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("CREATE TABLE `test_lot` ("
+                    + "`lot_id` bigint unsigned NOT NULL,"
+                    + "`trade_date` date NOT NULL,"
+                    + "PRIMARY KEY (`lot_id`,`trade_date`)"
+                    + ") ENGINE=InnoDB");
+        }
+
+        final Configuration config = getDatabase().defaultConfig()
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(CommonConnectorConfig.TOMBSTONES_ON_DELETE, false)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, getDatabase().qualifiedTableName(tableName))
+                .build();
+
+        start(getConnectorClass(), config);
+        waitForStreamingRunning(getConnectorName(), getDatabase().getServerName(), getStreamingNamespace());
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(getDatabase().getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("ALTER TABLE test_lot ADD COLUMN event_ref_type_id INTEGER, algorithm=instant, "
+                    + "ADD COLUMN event_ref_id BIGINT, algorithm=instant");
+            connection.execute("INSERT INTO test_lot VALUES (1, '2026-07-07', 2, 3)");
+        }
+
+        final SourceRecords records = consumeRecordsByTopic(1);
+        final List<SourceRecord> tableRecords = records.recordsForTopic(getDatabase().topicForTable(tableName));
+        assertThat(tableRecords).hasSize(1);
+
+        final SourceRecord record = tableRecords.get(0);
+        validate(record);
+
+        final Struct after = ((Struct) record.value()).getStruct("after");
+        assertThat(after.schema().field("event_ref_type_id")).isNotNull();
+        assertThat(after.schema().field("event_ref_id")).isNotNull();
+        assertThat(after.getInt32("event_ref_type_id")).isEqualTo(2);
+        assertThat(after.getInt64("event_ref_id")).isEqualTo(3L);
     }
 
     @Override

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -71,7 +71,7 @@ public class MySqlConnectorIT extends BinlogConnectorIT<MySqlConnector, MySqlPar
     }
 
     @Test
-    @FixFor("DBZ-9704")
+    @FixFor("debezium/dbz#1439")
     @SkipWhenDatabaseVersion(check = LESS_THAN, major = 8, reason = "Instant ADD COLUMN requires MySQL 8.0+")
     void shouldStreamMultipleAddColumnsWithRepeatedInstantAlgorithm() throws Exception {
         final String tableName = "test_lot";


### PR DESCRIPTION
https://github.com/debezium/dbz/issues/1439

This issue appears to have affected older parser behavior, but I could not reproduce it with the current MySQL connector. This PR therefore adds regression coverage only and does not change production code.

Adds MySQL coverage for ALTER TABLE statements that repeat ALGORITHM=INSTANT after ADD COLUMN clauses.

+ add parser coverage for multiple ADD COLUMN clauses with repeated ALGORITHM=INSTANT
+ add MySQL streaming coverage that verifies both added columns are present in the emitted change event

The streaming test is skipped for MySQL versions before 8.0 because instant ADD COLUMN requires MySQL 8.0+.

Tests:
+ JAVA_HOME=/opt/homebrew/opt/openjdk ./mvnw -pl debezium-connector-mysql -Dtest=MySqlAntlrDdlParserTest#shouldParseMultipleAddColumnsWithRepeatedInstantAlgorithm -Dsurefire.failIfNoSpecifiedTests=false test
+ JAVA_HOME=/opt/homebrew/opt/openjdk ./mvnw -pl debezium-connector-mysql -Dit.test=MySqlConnectorIT#shouldStreamMultipleAddColumnsWithRepeatedInstantAlgorithm -DskipITs=false -Ddatabase.hostname=localhost -Ddatabase.port=3307 -Ddatabase.user=mysqluser -Ddatabase.password=mysqlpw -Ddatabase.replica.hostname=localhost -Ddatabase.replica.port=3307 -Ddatabase.replica.user=mysqluser -Ddatabase.replica.password=mysqlpw failsafe:integration-test failsafe:verify