### PR TITLE
debezium/dbz#2100 Escape special characters and null values in HSTORE binding

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -838,3 +838,4 @@ Davyd Eliosidze
 Aleksandr Pavlyuk
 Roshni R
 刘镕通
+Sundong Kim

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/HstoreConverter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/HstoreConverter.java
@@ -68,7 +68,22 @@ public class HstoreConverter {
     }
 
     private static String formatHstoreEntry(Map.Entry<String, String> entry) {
-        return String.format("\"%s\" => \"%s\"", entry.getKey(), entry.getValue());
+        final String value = entry.getValue();
+        // A null value is rendered as the unquoted NULL keyword, which PostgreSQL interprets as a
+        // SQL null rather than the literal string "NULL".
+        final String renderedValue = value == null ? "NULL" : quote(value);
+        return quote(entry.getKey()) + " => " + renderedValue;
+    }
+
+    /**
+     * Quotes a HSTORE key or value, escaping the backslash and double-quote characters as required
+     * by the PostgreSQL HSTORE text input syntax.
+     *
+     * @param value the key or value to quote, should not be {@code null}.
+     * @return the escaped, double-quoted representation
+     */
+    private static String quote(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/HstoreConverterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/HstoreConverterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the PostgreSQL {@link HstoreConverter} helper.
+ */
+@Tag("UnitTests")
+class HstoreConverterTest {
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should quote plain keys and values")
+    void testMapToStringQuotesEntries() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("key", "value");
+        assertThat(HstoreConverter.mapToString(map)).isEqualTo("\"key\" => \"value\"");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should escape double quotes in keys and values")
+    void testMapToStringEscapesDoubleQuotes() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("na\"me", "a \" b");
+        assertThat(HstoreConverter.mapToString(map)).isEqualTo("\"na\\\"me\" => \"a \\\" b\"");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should escape backslashes in keys and values")
+    void testMapToStringEscapesBackslashes() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("pa\\th", "c:\\tmp");
+        assertThat(HstoreConverter.mapToString(map)).isEqualTo("\"pa\\\\th\" => \"c:\\\\tmp\"");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render null values as the unquoted NULL keyword")
+    void testMapToStringRendersNullValueAsKeyword() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("nullkey", null);
+        assertThat(HstoreConverter.mapToString(map)).isEqualTo("\"nullkey\" => NULL");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render the literal string NULL as a quoted value")
+    void testMapToStringRendersLiteralNullStringQuoted() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("key", "NULL");
+        assertThat(HstoreConverter.mapToString(map)).isEqualTo("\"key\" => \"NULL\"");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should return null for a null map")
+    void testMapToStringReturnsNullForNullMap() {
+        assertThat(HstoreConverter.mapToString(null)).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should escape quotes and backslashes when converting from JSON")
+    void testJsonToStringEscapesSpecialCharacters() {
+        assertThat(HstoreConverter.jsonToString("{\"quote\":\"a \\\" b\"}"))
+                .isEqualTo("\"quote\" => \"a \\\" b\"");
+        assertThat(HstoreConverter.jsonToString("{\"path\":\"c:\\\\tmp\"}"))
+                .isEqualTo("\"path\" => \"c:\\\\tmp\"");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render JSON null values as the unquoted NULL keyword")
+    void testJsonToStringRendersNullValueAsKeyword() {
+        assertThat(HstoreConverter.jsonToString("{\"nullkey\":null}"))
+                .isEqualTo("\"nullkey\" => NULL");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should return null for a null or blank JSON string")
+    void testJsonToStringReturnsNullForBlank() {
+        assertThat(HstoreConverter.jsonToString(null)).isNull();
+        assertThat(HstoreConverter.jsonToString("")).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -485,6 +486,53 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new String[]{ "a", "b" });
             assertThat(rs.getArray(3).getArray()).isEqualTo(uuids.toArray());
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithHstoreContainingQuotesBackslashesAndNulls(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // A MAP whose keys/values contain the HSTORE special characters (double quote, backslash) as
+        // well as a null value, all of which must be escaped or rendered as the NULL keyword.
+        final Map<String, String> data = new LinkedHashMap<>();
+        data.put("quote", "a \" b");
+        data.put("back\\slash", "c:\\tmp");
+        data.put("nullkey", null);
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
+                data,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute("CREATE EXTENSION IF NOT EXISTS hstore");
+        final String sql = "CREATE TABLE %s (id int not null, data hstore, primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).contains("\"quote\"=>\"a \\\" b\"");
+            assertThat(rs.getString(2)).contains("\"back\\\\slash\"=>\"c:\\\\tmp\"");
+            assertThat(rs.getString(2)).contains("\"nullkey\"=>NULL");
             return null;
         });
     }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -380,3 +380,4 @@ vincadrn,Vincentius Adrian
 Roshr2211,Roshni R
 sagnghos,Sagnik Ghosh
 leosanqing,刘镕通
+sundongkim-dev,Sundong Kim


### PR DESCRIPTION
Fixes debezium/dbz#2100, case 7.

## Description

`HstoreConverter` builds each HSTORE entry with `String.format("\"%s\" => \"%s\"", key, value)`, which leaves double quotes and backslashes inside keys/values unescaped and renders a `null` value as the literal string `"null"`. A value containing either special character produces an invalid HSTORE literal and the batch fails with `ERROR: syntax error in hstore, near "b"`.

This escapes `\` → `\\` and `"` → `\"` in both keys and values per the PostgreSQL HSTORE text input syntax, and renders a `null` value as the unquoted `NULL` keyword so it is stored as a SQL null rather than the string `"null"`. Both handling modes (`hstore.handling.mode=json` via `jsonToString`, and `map` via `MapToHstoreType.bind`) converge on the shared `formatHstoreEntry` helper, so the single change covers both paths.

Tests:
- `HstoreConverterTest` (unit) — quoting, quote/backslash escaping, null-value → `NULL`, literal `"NULL"` string stays quoted, and the JSON path.
- `JdbcSinkColumnTypeMappingIT#testShouldWorkWithHstoreContainingQuotesBackslashesAndNulls` (IT) — round-trips a MAP with a quote, a backslash and a null value into a native `hstore` column across all insert modes. Without the fix it reproduces `syntax error in hstore, near "b"`.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
