### PR TITLE
debezium/dbz#2100 Bind macaddr8 to its native PostgreSQL type

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressType.java
@@ -12,7 +12,7 @@ import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.sink.column.ColumnDescriptor;
 
 /**
- * An implementation of {@link JdbcType} for {@code MACADDR} column types.
+ * An implementation of {@link JdbcType} for {@code MACADDR} and {@code MACADDR8} column types.
  *
  * @author Chris Cranford
  */
@@ -22,17 +22,17 @@ class MacAddressType extends AbstractType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ "MACADDR" };
+        return new String[]{ "MACADDR", "MACADDR8" };
     }
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        return "cast(? as macaddr)";
+        return "cast(? as " + getSourceColumnType(schema).orElseThrow() + ")";
     }
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        return "macaddr";
+        return getSourceColumnType(schema).orElseThrow();
     }
 
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressType.java
@@ -27,12 +27,12 @@ class MacAddressType extends AbstractType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        return "cast(? as " + getSourceColumnType(schema).orElseThrow() + ")";
+        return "cast(? as " + getSourceColumnType(schema).orElse("macaddr") + ")";
     }
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        return getSourceColumnType(schema).orElseThrow();
+        return getSourceColumnType(schema).orElse("macaddr");
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressTypeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the PostgreSQL {@link MacAddressType} handler.
+ */
+@Tag("UnitTests")
+class MacAddressTypeTest {
+
+    private final MacAddressType type = MacAddressType.INSTANCE;
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should register for both macaddr and macaddr8 source column types")
+    void shouldRegisterForMacAddressSourceColumnTypes() {
+        assertThat(type.getRegistrationKeys()).containsExactly("MACADDR", "MACADDR8");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should resolve type name and query binding to macaddr")
+    void shouldResolveMacaddr() {
+        final Schema schema = SchemaBuilder.string()
+                .parameter("__debezium.source.column.type", "MACADDR")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("MACADDR");
+        assertThat(type.getQueryBinding(null, schema, "08:00:2b:01:02:03")).isEqualTo("cast(? as MACADDR)");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should resolve type name and query binding to macaddr8")
+    void shouldResolveMacaddr8() {
+        final Schema schema = SchemaBuilder.string()
+                .parameter("__debezium.source.column.type", "MACADDR8")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("MACADDR8");
+        assertThat(type.getQueryBinding(null, schema, "08:00:2b:01:02:03:04:05")).isEqualTo("cast(? as MACADDR8)");
+    }
+
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/MacAddressTypeTest.java
@@ -54,4 +54,14 @@ class MacAddressTypeTest {
         assertThat(type.getQueryBinding(null, schema, "08:00:2b:01:02:03:04:05")).isEqualTo("cast(? as MACADDR8)");
     }
 
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should fall back to macaddr when the source column type is not propagated")
+    void shouldFallBackToMacaddrWithoutSourceColumnType() {
+        final Schema schema = SchemaBuilder.string().build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("macaddr");
+        assertThat(type.getQueryBinding(null, schema, "08:00:2b:01:02:03")).isEqualTo("cast(? as macaddr)");
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -537,4 +537,47 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         });
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldCoerceStringTypeToMacaddr8ColumnType(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // The source column type parameter drives the sink to map the plain STRING schema to a native
+        // macaddr8 column (schema evolution) and to bind the value with cast(? as macaddr8).
+        final Schema macaddr8Schema = SchemaBuilder.string()
+                .optional()
+                .parameter("__debezium.source.column.type", "MACADDR8")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                macaddr8Schema,
+                "08:00:2b:01:02:03:04:05",
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "MACADDR8");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("08:00:2b:01:02:03:04:05");
+            return null;
+        });
+    }
+
 }


### PR DESCRIPTION
Fixes debezium/dbz#2100, case 10.

## Description

`MacAddressType` only registered the `MACADDR` source column type and always emitted `cast(? as macaddr)` with a hard-coded `macaddr` type name. As a result a PostgreSQL `macaddr8` column was mapped to `text` on the sink (type downgrade), and inserting into a pre-created native `macaddr8` column failed with `column "..." is of type macaddr8 but expression is of type character varying`.

This registers `MACADDR8` as well and derives both the query-binding cast and the DDL type name from the source column type (`getSourceColumnType(schema)`), following the existing `RangeType` pattern. Both `macaddr` and `macaddr8` now resolve to their native PostgreSQL type. The 6-byte vs 8-byte distinction needs no special handling because the source connector already reports the exact type via `__debezium.source.column.type`.

Tests:
- `MacAddressTypeTest` (unit) — registration keys, and `macaddr` / `macaddr8` each resolving to the correct cast and type name.
- `JdbcSinkColumnTypeMappingIT#testShouldCoerceStringTypeToMacaddr8ColumnType` (IT) — round-trips a value into a native `macaddr8` column (auto-created via schema evolution) across all insert modes. Without the fix it reproduces the column being created as `text` instead of `macaddr8`.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
