### PR TITLE
debezium/dbz#2185 Add CockroachDB target to the JDBC sink e2e pipeline tests

### DIFF
--- a/.github/workflows/connector-jdbc-workflow.yml
+++ b/.github/workflows/connector-jdbc-workflow.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Runs JDBC sink tests based on specific target platforms concurrently
-        test-tags: [ "it-mysql,e2e-mysql", "it-postgresql,e2e-postgresql", "it-sqlserver,e2e-sqlserver", "it-singlestore,e2e-singlestore", "it-cockroachdb" ]
+        test-tags: [ "it-mysql,e2e-mysql", "it-postgresql,e2e-postgresql", "it-sqlserver,e2e-sqlserver", "it-singlestore,e2e-singlestore", "it-cockroachdb,e2e-cockroachdb" ]
         sink-framework: [ "false", "true" ]
     name: JDBC - ${{ matrix.test-tags }}
     runs-on: ubuntu-latest

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
@@ -73,6 +73,26 @@ public class CockroachDBDatabaseDialect extends PostgresDatabaseDialect {
     }
 
     @Override
+    protected void registerTypes() {
+        super.registerTypes();
+        // Override inherited PostgreSQL type mappings that CockroachDB does not support, verified
+        // against CockroachDB v25.4 and v26.3: xml, ranges, macaddr, and cidr are stored as text;
+        // MAP is stored as jsonb rather than hstore; money as a fixed-scale decimal; the spatial
+        // types use CockroachDB's built-in geometry/geography without a PostGIS schema; float
+        // vectors use the native vector type since halfvec does not exist; sparse vectors are
+        // unsupported.
+        registerType(TextFallbackType.INSTANCE);
+        registerType(JsonType.INSTANCE);
+        registerType(MapToJsonbType.INSTANCE);
+        registerType(MoneyType.INSTANCE);
+        registerType(GeometryType.INSTANCE);
+        registerType(GeographyType.INSTANCE);
+        registerType(PointType.INSTANCE);
+        registerType(FloatVectorType.INSTANCE);
+        registerType(SparseDoubleVectorType.INSTANCE);
+    }
+
+    @Override
     public String getJdbcTypeName(int jdbcType) {
         // The Hibernate CockroachDialect names character types "string", a CockroachDB alias that is
         // valid in DDL but absent from pg_type, so the PgJDBC driver cannot resolve it as an array

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/FloatVectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/FloatVectorType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.AbstractFloatVectorType;
+import io.debezium.sink.column.ColumnDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.FloatVector} types.
+ * CockroachDB has no {@code halfvec} type; its native {@code vector} type stores four-byte floats,
+ * which matches the float vector element type exactly.
+ *
+ * @author Virag Tripathi
+ */
+class FloatVectorType extends AbstractFloatVectorType {
+
+    public static final FloatVectorType INSTANCE = new FloatVectorType();
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        final Optional<String> size = getSourceColumnSize(schema);
+        return size.map(s -> String.format("vector(%s)", s)).orElse("vector");
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "CAST (? as vector)";
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/GeographyType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/GeographyType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.geometry.Geography;
+import io.debezium.sink.column.ColumnDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Geography} types
+ * backed by CockroachDB's native {@code geography} type.
+ *
+ * @author Virag Tripathi
+ */
+class GeographyType extends GeometryType {
+
+    public static final GeographyType INSTANCE = new GeographyType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Geography.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(ST_GeomFromWKB(?, ?) as geography)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "geography";
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/GeometryType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/GeometryType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.AbstractGeometryType;
+import io.debezium.sink.column.ColumnDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Geometry} types.
+ * CockroachDB provides the spatial types and {@code ST_GeomFromWKB} natively, so unlike the
+ * PostgreSQL dialect no PostGIS extension schema qualification is used.
+ *
+ * @author Virag Tripathi
+ */
+class GeometryType extends AbstractGeometryType {
+
+    public static final GeometryType INSTANCE = new GeometryType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "ST_GeomFromWKB(?, ?)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "geometry";
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/JsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/JsonType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Json;
+import io.debezium.sink.column.ColumnDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.Json} types. CockroachDB's
+ * JSON type is an alias of JSONB, and there is no hstore type, so all JSON-based logical values,
+ * including propagated HSTORE columns, are stored as {@code jsonb} JSON documents.
+ *
+ * @author Virag Tripathi
+ */
+class JsonType extends AbstractType {
+
+    public static final JsonType INSTANCE = new JsonType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Json.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as jsonb)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "jsonb";
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/MapToJsonbType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/MapToJsonbType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectMapType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code MAP} schema types. The PostgreSQL dialect maps
+ * these to {@code hstore}, which CockroachDB does not provide; the map is serialized to JSON and
+ * stored in CockroachDB's native {@code jsonb} type instead.
+ *
+ * @author Virag Tripathi
+ */
+class MapToJsonbType extends AbstractConnectMapType {
+
+    public static final MapToJsonbType INSTANCE = new MapToJsonbType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as jsonb)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "jsonb";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Map) {
+            value = mapToJsonString(value);
+        }
+        return List.of(new ValueBindDescriptor(index, value));
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/MoneyType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/MoneyType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+
+/**
+ * An implementation of {@link JdbcType} for {@code MONEY} column types. CockroachDB has no money
+ * type, so the value is stored as a fixed-scale decimal.
+ *
+ * @author Virag Tripathi
+ */
+class MoneyType extends AbstractType {
+
+    public static final MoneyType INSTANCE = new MoneyType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ "MONEY" };
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "decimal(19,2)";
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/PointType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/PointType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.geometry.Point;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Point} types.
+ * CockroachDB has no PostgreSQL geometric {@code point} type, so points are stored in the native
+ * {@code geometry} type from their WKB representation.
+ *
+ * @author Virag Tripathi
+ */
+class PointType extends GeometryType {
+
+    public static final PointType INSTANCE = new PointType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Point.LOGICAL_NAME };
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/SparseDoubleVectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/SparseDoubleVectorType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.AbstractSparseDoubleVectorType;
+import io.debezium.data.vector.SparseDoubleVector;
+
+/**
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.SparseDoubleVector} types.
+ * CockroachDB has no sparse vector type, so this reports the standard unsupported-schema-type
+ * error instead of inheriting the PostgreSQL {@code sparsevec} mapping, whose DDL CockroachDB
+ * rejects.
+ *
+ * @author Virag Tripathi
+ */
+class SparseDoubleVectorType extends AbstractSparseDoubleVectorType {
+
+    public static final SparseDoubleVectorType INSTANCE = new SparseDoubleVectorType();
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        throw new ConnectException(
+                String.format(
+                        "Dialect does not support schema type %s. Please use the VectorToJsonConverter transform in " +
+                                "your connector configuration to ingest data of this type.",
+                        SparseDoubleVector.LOGICAL_NAME));
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/TextFallbackType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/TextFallbackType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Xml;
+
+/**
+ * An implementation of {@link JdbcType} that stores PostgreSQL native types CockroachDB does not
+ * provide as {@code text}. The source emits these values as strings, so the textual representation
+ * round-trips unchanged. Verified against CockroachDB v25.4 and v26.3: xml, the range types,
+ * macaddr, and cidr do not exist there.
+ *
+ * @author Virag Tripathi
+ */
+class TextFallbackType extends AbstractType {
+
+    public static final TextFallbackType INSTANCE = new TextFallbackType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Xml.LOGICAL_NAME, "XML", "INT4RANGE", "INT8RANGE", "NUMRANGE", "TSRANGE", "TSTZRANGE", "DATERANGE", "MACADDR", "CIDR" };
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "text";
+    }
+
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -118,6 +118,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                             assertColumn(sink, record, "data", getBooleanType(), 1);
                             break;
                         case POSTGRES:
+                        case COCKROACHDB:
                             assertColumn(sink, record, "id", getBooleanType());
                             assertColumn(sink, record, "data", options.isColumnTypePropagated() ? "BIT" : getBooleanType());
                             break;
@@ -146,6 +147,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (rs, index) -> {
                     switch (sink.getType()) {
                         case POSTGRES:
+                        case COCKROACHDB:
                             return Integer.parseInt(rs.getString(index), 2);
                         case SQLSERVER:
                             return new BigInteger(rs.getBytes(index)).intValue();
@@ -157,7 +159,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
 
     @TestTemplate
     @SkipWhenSource(value = { SourceType.ORACLE, SourceType.SQLSERVER }, reason = "No BIT(n) data type support")
-    @SkipWhenSink(value = { SinkType.MYSQL, SinkType.POSTGRES, SinkType.SQLSERVER }, reason = "BIT(n) is only applicable to non-key columns")
+    @SkipWhenSink(value = { SinkType.MYSQL, SinkType.POSTGRES, SinkType.SQLSERVER, SinkType.COCKROACHDB }, reason = "BIT(n) is only applicable to non-key columns")
     public void testBitWithSizeDataTypeNotInKey(Source source, Sink sink) throws Exception {
         final String tableName = source.randomTableName();
         registerSourceConnector(source, tableName);
@@ -195,7 +197,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (record) -> {
                     final SourceConnectorOptions options = source.getOptions();
                     assertColumn(sink, record, "id", getBitsDataType(), 2);
-                    if (options.isColumnTypePropagated() && sink.getType() == SinkType.POSTGRES) {
+                    if (options.isColumnTypePropagated() && sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "data", "VARBIT", 2);
                     }
                     else {
@@ -205,6 +207,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (rs, index) -> {
                     switch (sink.getType()) {
                         case POSTGRES:
+                        case COCKROACHDB:
                             return Integer.parseInt(rs.getString(index), 2);
                         case SQLSERVER:
                             return new BigInteger(rs.getBytes(index)).intValue();
@@ -216,7 +219,8 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
 
     @TestTemplate
     @SkipWhenSource(value = { SourceType.MYSQL, SourceType.ORACLE, SourceType.SQLSERVER }, reason = "No BIT VARYING(n) data type support")
-    @SkipWhenSink(value = { SinkType.MYSQL, SinkType.POSTGRES, SinkType.SQLSERVER }, reason = "BIT VARYING(n) is only applicable to non-key columns")
+    @SkipWhenSink(value = { SinkType.MYSQL, SinkType.POSTGRES, SinkType.SQLSERVER,
+            SinkType.COCKROACHDB }, reason = "BIT VARYING(n) is only applicable to non-key columns")
     public void testBitVaryingDataTypeNotInKey(Source source, Sink sink) throws Exception {
         final String tableName = source.randomTableName();
         registerSourceConnector(source, tableName);
@@ -270,6 +274,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (rs, index) -> {
                     switch (sink.getType()) {
                         case POSTGRES:
+                        case COCKROACHDB:
                         case DB2:
                             return rs.getBoolean(index) ? 1 : 0;
                         case DB2I:
@@ -365,6 +370,10 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                     if (sink.getType().is(SinkType.POSTGRES) && options.isColumnTypePropagated()) {
                         assertColumn(sink, record, "data", "SMALLSERIAL");
                     }
+                    else if (sink.getType().is(SinkType.COCKROACHDB) && options.isColumnTypePropagated()) {
+                        // CockroachDB serial columns are INT8 backed by unique_rowid()
+                        assertColumn(sink, record, "data", getInt64Type());
+                    }
                     else {
                         assertColumn(sink, record, "data", getInt16Type());
                     }
@@ -384,6 +393,10 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                     assertColumn(sink, record, "id", getInt32Type());
                     if (sink.getType().is(SinkType.POSTGRES) && options.isColumnTypePropagated()) {
                         assertColumn(sink, record, "data", "SERIAL");
+                    }
+                    else if (sink.getType().is(SinkType.COCKROACHDB) && options.isColumnTypePropagated()) {
+                        // CockroachDB serial columns are INT8 backed by unique_rowid()
+                        assertColumn(sink, record, "data", getInt64Type());
                     }
                     else {
                         assertColumn(sink, record, "data", getInt32Type());
@@ -406,6 +419,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                         assertColumn(sink, record, "data", "BIGSERIAL");
                     }
                     else {
+                        // CockroachDB serial columns are also INT8 backed by unique_rowid()
                         assertColumn(sink, record, "data", getInt64Type());
                     }
                 },
@@ -1160,6 +1174,11 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                             break;
                         case POSTGRES:
                             assertColumn(sink, record, "id", "TEXT");
+                            assertColumn(sink, record, "data", "TEXT");
+                            break;
+                        case COCKROACHDB:
+                            // Key strings are created as sized varchar columns on CockroachDB
+                            assertColumn(sink, record, "id", "VARCHAR");
                             assertColumn(sink, record, "data", "TEXT");
                             break;
                     }
@@ -2388,7 +2407,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     @TestTemplate
     @SkipWhenSource(value = { SourceType.MYSQL, SourceType.ORACLE, SourceType.SQLSERVER }, reason = "No INTERVAL data type support")
     public void testIntervalDataTypeIntervalHandlingModeNumeric(Source source, Sink sink) throws Exception {
-        if (sink.getType().is(SinkType.POSTGRES)) {
+        if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
             assertDataTypeNonKeyOnly(source,
                     sink,
                     "interval",
@@ -2427,7 +2446,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     @SkipWhenSource(value = { SourceType.MYSQL, SourceType.POSTGRES, SourceType.SQLSERVER }, reason = "No INTERVAL DAY(m) TO SECOND data type support")
     public void testIntervalDayToSecondDataTypeIntervalHandlingModeNumeric(Source source, Sink sink) throws Exception {
         // todo: Should we attempt to map this to the proper data type for Oracle sinks?
-        if (sink.getType().is(SinkType.POSTGRES)) {
+        if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
             assertDataTypeNonKeyOnly(source,
                     sink,
                     "interval day to second",
@@ -2467,7 +2486,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     @SkipWhenSource(value = { SourceType.MYSQL, SourceType.POSTGRES, SourceType.SQLSERVER }, reason = "No INTERVAL YEAR(m) TO MONTH data type support")
     public void testIntervalYearToMonthDataTypeIntervalHandlingModeNumeric(Source source, Sink sink) throws Exception {
         // todo: Should we attempt to map this to the proper data type for Oracle sinks?
-        if (sink.getType().is(SinkType.POSTGRES)) {
+        if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
             assertDataTypeNonKeyOnly(source,
                     sink,
                     "interval year to month",
@@ -2528,7 +2547,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 List.of(3802),
                 (record) -> {
                     assertColumn(sink, record, "id", getInt64Type());
-                    if (source.getOptions().isColumnTypePropagated() && sink.getType().is(SinkType.POSTGRES)) {
+                    if (source.getOptions().isColumnTypePropagated() && sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "data", "OID");
                     }
                     else {
@@ -2549,7 +2568,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 List.of("abc.xyz"),
                 (config) -> config.with("include.unknown.datatypes", true),
                 (record) -> {
-                    if (sink.getType().is(SinkType.POSTGRES)) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "id", "LTREE");
                         assertColumn(sink, record, "data", "LTREE");
                     }
@@ -2573,7 +2592,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (config) -> config.with("include.unknown.datatypes", true),
                 (record) -> {
                     assertColumn(sink, record, "id", getStringType(source, true, false));
-                    if (sink.getType().is(SinkType.POSTGRES) && source.getOptions().isColumnTypePropagated()) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB) && source.getOptions().isColumnTypePropagated()) {
                         assertColumn(sink, record, "data", "CITEXT");
                     }
                     else {
@@ -2594,7 +2613,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 (config) -> config.with("include.unknown.datatypes", true),
                 (record) -> {
                     assertColumn(sink, record, "id", getStringType(source, true, false));
-                    if (sink.getType().is(SinkType.POSTGRES) && source.getOptions().isColumnTypePropagated()) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB) && source.getOptions().isColumnTypePropagated()) {
                         assertColumn(sink, record, "data", "INET");
                     }
                     else {
@@ -2739,7 +2758,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
             // when sinking to PostgreSQL, it will be returned in HSTORE format rather than JSON
             expectedValue = "\"key\"=>\"val\"";
         }
-        else if (sink.getType().is(SinkType.MYSQL)) {
+        else if (sink.getType().is(SinkType.MYSQL, SinkType.COCKROACHDB)) {
             expectedValue = "{\"key\": \"val\"}";
         }
 
@@ -2788,7 +2807,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
             // when sinking to PostgreSQL, it will be returned in HSTORE format rather than JSON
             expectedValue = "\"key\"=>\"val\"";
         }
-        else if (sink.getType().is(SinkType.MYSQL)) {
+        else if (sink.getType().is(SinkType.MYSQL, SinkType.COCKROACHDB)) {
             // when sinking to MySQL, it will be returned in JSON format
             expectedValue = "{\"key\": \"val\"}";
         }
@@ -2810,6 +2829,10 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                     else if (sink.getType().is(SinkType.MYSQL)) {
                         // MySQL will map the MAP schema types to JSON
                         assertColumn(sink, record, "data", getJsonType(source));
+                    }
+                    else if (sink.getType().is(SinkType.COCKROACHDB)) {
+                        // CockroachDB maps the MAP schema types to JSONB
+                        assertColumn(sink, record, "data", getJsonbType(source));
                     }
                     else {
                         // Other sink connectors will serialize the MAP as JSON into TEXT types
@@ -2863,7 +2886,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
 
     @TestTemplate
     @ForSource(value = SourceType.POSTGRES, reason = "The HALFVEC data type only applies to PostgreSQL")
-    @SkipWhenSink(value = { SinkType.POSTGRES, SinkType.MYSQL }, reason = "This mapping is not designed to fail for these sinks")
+    @SkipWhenSink(value = { SinkType.POSTGRES, SinkType.MYSQL, SinkType.COCKROACHDB }, reason = "This mapping is not designed to fail for these sinks")
     @WithPostgresExtension("vector")
     public void testHalfVectorDataTypeFails(Source source, Sink sink) throws Exception {
         // This mapping fails unless the user supplies the VectorToJsonConverter transform
@@ -2883,7 +2906,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
 
     @TestTemplate
     @ForSource(value = { SourceType.POSTGRES, SourceType.MYSQL }, reason = "The VECTOR data type only applies to PostgreSQL and MySQL")
-    @SkipWhenSink(value = { SinkType.POSTGRES, SinkType.MYSQL }, reason = "This mapping is not designed to fail for these sinks")
+    @SkipWhenSink(value = { SinkType.POSTGRES, SinkType.MYSQL, SinkType.COCKROACHDB }, reason = "This mapping is not designed to fail for these sinks")
     @WithPostgresExtension("vector")
     public void testVectorDataTypeFails(Source source, Sink sink) throws Exception {
         // This mapping fails unless the user supplies the VectorToJsonConverter transform
@@ -2955,7 +2978,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 List.of("to_tsvector('english', 'This is a test for direct tsvector insert')"),
                 List.of("'direct':6 'insert':8 'test':4 'tsvector':7"),
                 (record) -> {
-                    if (sink.getType().is(SinkType.POSTGRES)) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "data", "tsvector");
                     }
                     else {
@@ -2974,7 +2997,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 List.of("'full:3 postgre:1 search:5 support:2 text:4'"),
                 List.of("'full':3 'postgre':1 'search':5 'support':2 'text':4"),
                 (record) -> {
-                    if (sink.getType().is(SinkType.POSTGRES)) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "data", "tsvector");
                     }
                     else {
@@ -3443,8 +3466,8 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
         final String sinkTableName = collectionNamingStrategy.resolveCollectionName(
                 new KafkaDebeziumSinkRecord(record, getCurrentSinkConfig().cloudEventsSchemaNamePattern()),
                 getCurrentSinkConfig().getCollectionNameFormat());
-        // When quoted identifiers is not enabled, PostgreSQL saves table names as lower-case
-        return sink.getType().is(SinkType.POSTGRES) ? sinkTableName.toLowerCase() : sinkTableName;
+        // When quoted identifiers is not enabled, PostgreSQL and CockroachDB save table names as lower-case
+        return sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB) ? sinkTableName.toLowerCase() : sinkTableName;
     }
 
     protected Properties getDefaultSinkConfig(Sink sink) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -3011,13 +3011,19 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     @FixFor("debezium/dbz#2199")
     @ForSource(value = SourceType.POSTGRES, reason = "The tsvector data type only applies to PostgreSQL")
     public void testTsvectorDataTypePreservesQuotedLexemes(Source source, Sink sink) throws Exception {
+        // CockroachDB's tsvector parser splits apostrophe-containing lexemes differently;
+        // 'it''s' becomes two lexemes: 'it' and 's'.
+        final List<String> expectedValues = sink.getType().is(SinkType.COCKROACHDB)
+                ? List.of("'it' 'new york' 'plain' 's'")
+                : List.of("'it''s' 'new york' 'plain'");
+
         assertDataTypeNonKeyOnly(source,
                 sink,
                 "tsvector",
                 List.of("array_to_tsvector(array['new york', 'it''s', 'plain'])"),
-                List.of("'it''s' 'new york' 'plain'"),
+                expectedValues,
                 (record) -> {
-                    if (sink.getType().is(SinkType.POSTGRES)) {
+                    if (sink.getType().is(SinkType.POSTGRES, SinkType.COCKROACHDB)) {
                         assertColumn(sink, record, "data", "tsvector");
                     }
                     else {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToCockroachDbIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToCockroachDbIT.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.e2e;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.postgresql.util.PGobject;
+
+import io.debezium.connector.jdbc.junit.jupiter.CockroachDbSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.ForSource;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.WithTemporalPrecisionMode;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.source.Source;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourceType;
+import io.debezium.spatial.GeometryBytes;
+import io.debezium.util.HexConverter;
+
+/**
+ * Implementation of the JDBC sink connector multi-source pipeline that writes to CockroachDB.
+ *
+ * <p>CockroachDB is wire-compatible with PostgreSQL, so the expectations largely mirror the
+ * PostgreSQL pipeline. Differences stem from CockroachDB's type aliases: JSON is an alias of
+ * JSONB, character types surface through the pg_catalog as text or varchar, and the spatial
+ * types are built in rather than provided by the PostGIS extension.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Tag("all")
+@Tag("e2e")
+@Tag("e2e-cockroachdb")
+@ExtendWith(CockroachDbSinkDatabaseContextProvider.class)
+public class JdbcSinkPipelineToCockroachDbIT extends AbstractJdbcSinkPipelineIT {
+
+    @Override
+    protected boolean isBitCoercedToBoolean() {
+        return true;
+    }
+
+    @Override
+    protected String getBooleanType() {
+        return "BOOL";
+    }
+
+    @Override
+    protected String getBitsDataType() {
+        return "BIT";
+    }
+
+    @Override
+    protected String getInt8Type() {
+        return "INT2";
+    }
+
+    @Override
+    protected String getInt16Type() {
+        return "INT2";
+    }
+
+    @Override
+    protected String getInt32Type() {
+        return "INT4";
+    }
+
+    @Override
+    protected String getInt64Type() {
+        return "INT8";
+    }
+
+    @Override
+    protected String getVariableScaleDecimalType() {
+        return "FLOAT8";
+    }
+
+    @Override
+    protected String getDecimalType() {
+        return "NUMERIC";
+    }
+
+    @Override
+    protected String getFloat32Type() {
+        return "FLOAT4";
+    }
+
+    @Override
+    protected String getFloat64Type() {
+        return "FLOAT8";
+    }
+
+    @Override
+    protected String getCharType(Source source, boolean key, boolean nationalized) {
+        if (key) {
+            // Key strings are created as sized varchar columns on CockroachDB.
+            return "VARCHAR";
+        }
+        if (source.getOptions().isColumnTypePropagated()) {
+            // CockroachDB surfaces fixed-length character columns as BPCHAR through pg_catalog.
+            return "BPCHAR";
+        }
+        return getTextType();
+    }
+
+    @Override
+    protected String getStringType(Source source, boolean key, boolean nationalized, boolean maxLength) {
+        if (key) {
+            // Key strings are created as sized varchar columns on CockroachDB.
+            return "VARCHAR";
+        }
+        if (maxLength) {
+            return getTextType(nationalized);
+        }
+        if (!source.getOptions().isColumnTypePropagated()) {
+            return getTextType();
+        }
+        return "VARCHAR";
+    }
+
+    @Override
+    protected String getTextType(boolean nationalized) {
+        return "TEXT";
+    }
+
+    @Override
+    protected String getBinaryType(Source source, String sourceDataType) {
+        return "BYTEA";
+    }
+
+    @Override
+    protected String getJsonType(Source source) {
+        // JSON is an alias of JSONB in CockroachDB and is reported as JSONB by the driver.
+        return "JSONB";
+    }
+
+    @Override
+    protected String getJsonbType(Source source) {
+        return "JSONB";
+    }
+
+    @Override
+    protected String getXmlType(Source source) {
+        return "TEXT";
+    }
+
+    @Override
+    protected String getUuidType(Source source, boolean key) {
+        return "UUID";
+    }
+
+    @Override
+    protected String getEnumType(Source source, boolean key) {
+        if (key) {
+            // Key strings are created as sized varchar columns on CockroachDB.
+            return "VARCHAR";
+        }
+        return getTextType();
+    }
+
+    @Override
+    protected String getSetType(Source source, boolean key) {
+        if (key) {
+            // Key strings are created as sized varchar columns on CockroachDB.
+            return "VARCHAR";
+        }
+        return getTextType();
+    }
+
+    @Override
+    protected String getYearType() {
+        return getInt32Type();
+    }
+
+    @Override
+    protected String getDateType() {
+        return "DATE";
+    }
+
+    @Override
+    protected String getTimeType(Source source, boolean key, int precision) {
+        return "TIME";
+    }
+
+    @Override
+    protected String getTimeWithTimezoneType(Source source, boolean key, int precision) {
+        return "TIMETZ";
+    }
+
+    @Override
+    protected String getTimestampType(Source source, boolean key, int precision) {
+        return "TIMESTAMP";
+    }
+
+    @Override
+    protected String getTimestampWithTimezoneType(Source source, boolean key, int precision) {
+        return "TIMESTAMPTZ";
+    }
+
+    @Override
+    protected String getIntervalType(Source source, boolean numeric) {
+        return "INTERVAL";
+    }
+
+    @Override
+    protected String getGeographyType() {
+        // Spatial types are built into CockroachDB; there is no PostGIS extension schema.
+        return "GEOGRAPHY";
+    }
+
+    @Override
+    protected String getGeometryType() {
+        return "GEOMETRY";
+    }
+
+    @Override
+    protected GeometryBytes getGeometryValues(ResultSet resultSet, int index) throws SQLException {
+        final PGobject object = (PGobject) resultSet.getObject(index);
+        if (object == null || object.getValue() == null) {
+            return null;
+        }
+        // Tests expect WKB so convert it from EWKB that CockroachDB provides
+        return new GeometryBytes(HexConverter.convertFromHex(object.getValue())).asWkb();
+    }
+
+    @TestTemplate
+    @ForSource(value = { SourceType.POSTGRES }, reason = "The infinity value is valid only for PostgreSQL")
+    @WithTemporalPrecisionMode
+    @Override
+    public void testTimestampWithTimeZoneDataTypeWithInfinityValue(Source source, Sink sink) throws Exception {
+
+        final List<String> values = List.of("'-infinity'", "'infinity'");
+
+        // CockroachDB round-trips the PostgreSQL infinity literals.
+        List<String> expectedValues = values.stream()
+                .map(s -> s.replace("'", ""))
+                .collect(Collectors.toList());
+
+        assertDataTypesNonKeyOnly(source,
+                sink,
+                List.of("timestamptz", "timestamptz"),
+                values,
+                expectedValues,
+                (record) -> {
+                    assertColumn(sink, record, "data0", getTimestampWithTimezoneType(source, false, 6));
+                    assertColumn(sink, record, "data1", getTimestampWithTimezoneType(source, false, 6));
+                },
+                ResultSet::getString);
+    }
+
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
@@ -47,14 +47,14 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldCoerceStringTypeToUuidColumnType(SinkRecordFactory factory) throws Exception {
         shouldCoerceStringTypeToColumnType(factory, "uuid", "9bc6a215-84b5-4865-a058-9156427c887a", "f54c2926-076a-4db0-846f-14cad99a8307");
     }
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldCoerceStringTypeToJsonbColumnType(SinkRecordFactory factory) throws Exception {
         shouldCoerceStringTypeToColumnType(factory, "jsonb", "{\"id\": 12345}", "{\"id\": 67890}");
     }
@@ -101,7 +101,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldCoerceNioByteBufferTypeToByteArrayColumnType(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
@@ -142,7 +142,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldWorkWithTextArray(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
@@ -178,7 +178,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldWorkWithIntArray(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
@@ -214,14 +214,14 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-2197")
+    @FixFor("debezium/dbz#2197")
     public void testShouldWorkWithDoubleVector(SinkRecordFactory factory) throws Exception {
         shouldWorkWithVectorType(factory, DoubleVector.schema(), Arrays.asList(1.0, 2.0, 3.0));
     }
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-2197")
+    @FixFor("debezium/dbz#2197")
     public void testShouldWorkWithFloatVector(SinkRecordFactory factory) throws Exception {
         // CockroachDB has no halfvec type; float vectors are stored in the native vector type
         shouldWorkWithVectorType(factory, FloatVector.schema(), Arrays.asList(1.0f, 2.0f, 3.0f));
@@ -261,7 +261,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-1639")
+    @FixFor("debezium/dbz#1639")
     public void testShouldWorkWithBoolArray(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
@@ -25,6 +26,8 @@ import io.debezium.connector.jdbc.junit.jupiter.CockroachDbSinkDatabaseContextPr
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.vector.DoubleVector;
+import io.debezium.data.vector.FloatVector;
 import io.debezium.doc.FixFor;
 
 /**
@@ -205,6 +208,53 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new Integer[]{ 1, 2, 42 });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-2197")
+    public void testShouldWorkWithDoubleVector(SinkRecordFactory factory) throws Exception {
+        shouldWorkWithVectorType(factory, DoubleVector.schema(), Arrays.asList(1.0, 2.0, 3.0));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-2197")
+    public void testShouldWorkWithFloatVector(SinkRecordFactory factory) throws Exception {
+        // CockroachDB has no halfvec type; float vectors are stored in the native vector type
+        shouldWorkWithVectorType(factory, FloatVector.schema(), Arrays.asList(1.0f, 2.0f, 3.0f));
+    }
+
+    private void shouldWorkWithVectorType(SinkRecordFactory factory, Schema vectorSchema, List<?> vectorValue) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                vectorSchema,
+                vectorValue,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "vector");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("[1,2,3]");
             return null;
         });
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkTransactionConflictIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkTransactionConflictIT.java
@@ -62,7 +62,7 @@ public class JdbcSinkTransactionConflictIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-2180")
+    @FixFor("debezium/dbz#2180")
     public void testConflictingFlushRecoversWithRetriesEnabled(SinkRecordFactory factory) throws SQLException {
         final String tableName = randomTableName();
         final Connection connection = getSink().getConnection();
@@ -131,7 +131,7 @@ public class JdbcSinkTransactionConflictIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
-    @FixFor("DBZ-2180")
+    @FixFor("debezium/dbz#2180")
     public void testConflictingFlushFailsFastWithRetriesDisabled(SinkRecordFactory factory) throws SQLException {
         final String tableName = randomTableName();
         final Connection connection = getSink().getConnection();


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2185
Closes https://github.com/debezium/dbz/issues/2197

Follow-up to #7602, adding CockroachDB as a target in the JDBC sink end-to-end pipeline test matrix.

First commit (dbz#2197): the CockroachDB dialect inherits PostgreSQL type registrations that CockroachDB rejects, verified against CockroachDB v25.4.12 and v26.3.0-alpha.1 (both behave identically): xml, hstore, the range types, macaddr, cidr, money, point, halfvec, and sparsevec do not exist, and the spatial types were emitted with a PostGIS extension schema qualifier. The dialect now registers CockroachDB-compatible overrides: XML, ranges, macaddr, and cidr are stored as text; Json logical values, including propagated HSTORE columns, and MAP schema types are stored as jsonb; money as decimal(19,2); geometry, geography, and point use the built-in spatial types with unqualified names and ST_GeomFromWKB; FloatVector uses the native vector type; SparseDoubleVector reports the standard unsupported-schema-type error. Types verified as natively supported remain inherited: ltree, citext, inet, oid, tsvector, vector, bit, varbit, enum, interval, uuid.

Second commit (dbz#2185): JdbcSinkPipelineToCockroachDbIT tagged e2e-cockroachdb, modeled on the PostgreSQL target, with CockroachDB-specific expected types, an infinity timestamp override, COCKROACHDB arms in the shared expectation branches, vector coverage in the it-cockroachdb column type mapping suite, and the CI matrix entry extended to it-cockroachdb,e2e-cockroachdb.

Verification: the it-cockroachdb integration tests pass (66 tests) with formatting and checkstyle enabled. With the PostgreSQL source the e2e suite passes, including every data type affected by the dialect changes. With the MySQL source 93 tests pass with no failures; the remaining invocations and the SQL Server source could not be completed in the local environment due to container startup timeouts under emulation and rely on the CI matrix in this PR.