### PR TITLE
debezium/dbz#1639 Document CockroachDB support in the JDBC sink connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -22,7 +22,7 @@ toc::[]
 endif::community[]
 
 The {prodname} JDBC connector is a Kafka Connect sink connector implementation that can consume events from multiple source topics, and then write those events to a relational database by using a JDBC driver.
-This connector supports a wide variety of database dialects, including Db2, MySQL, Oracle, PostgreSQL, SingleStore, and SQL Server.
+This connector supports a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, and SQL Server.
 
 // Type: assembly
 // ModuleID: debezium-jdbc-connector-how-the-debezium-connector-works
@@ -220,6 +220,9 @@ The following table shows the `upsert` DML syntax for the database dialects that
 
 |===
 |Dialect |Upsert Syntax
+
+|CockroachDB
+|`INSERT ... ON CONFLICT ... DO UPDATE SET ...`
 
 |Db2
 |`MERGE ...`


### PR DESCRIPTION
Documentation follow-up to #7570: adds CockroachDB to the supported dialect list and to the upsert syntax table in the JDBC sink connector page. The CockroachDB dialect uses the PostgreSQL-style INSERT ... ON CONFLICT ... DO UPDATE SET syntax.

Targets main only; the dialect is not part of the 3.6 release.