### PR TITLE
[docs] Add CockroachDB connector metrics to the monitoring page

### DIFF
--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -46,6 +46,7 @@ ifdef::community[]
 * {link-prefix}:{link-vitess-connector}#vitess-monitoring[Vitess connector metrics]
 * {link-prefix}:{link-spanner-connector}#spanner-monitoring[Spanner connector metrics]
 * {link-prefix}:{link-informix-connector}#informix-monitoring[Informix connector metrics]
+* {link-prefix}:{link-cockroachdb-connector}#cockroachdb-monitoring[CockroachDB connector metrics]
 endif::community[]
 
 


### PR DESCRIPTION
The metrics for monitoring Debezium connectors section on the monitoring page links each connector's metrics documentation. The CockroachDB connector page links back to this page from its Monitoring section, but the CockroachDB entry was missing from the connector metrics list. Adds it to the community connector block.