### PR TITLE
[docs] Add CockroachDB connector metrics to the monitoring page (3.6)

### DIFF
--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -46,6 +46,7 @@ ifdef::community[]
 * {link-prefix}:{link-vitess-connector}#vitess-monitoring[Vitess connector metrics]
 * {link-prefix}:{link-spanner-connector}#spanner-monitoring[Spanner connector metrics]
 * {link-prefix}:{link-informix-connector}#informix-monitoring[Informix connector metrics]
+* {link-prefix}:{link-cockroachdb-connector}#cockroachdb-monitoring[CockroachDB connector metrics]
 endif::community[]
 
 


### PR DESCRIPTION
Backport of #7619 to the 3.6 branch so the stable monitoring page lists the CockroachDB connector metrics. The stable CockroachDB connector page links to the monitoring page from its Monitoring section, but the connector metrics list there does not include CockroachDB.