### PR TITLE
debezium/dbz#1174 Trigger Debezium Server build when the JDBC sink connector changes

### DIFF
--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -611,7 +611,7 @@ jobs:
     name: "Debezium Server"
     needs: [ check_style, file_changes, build_core ]
     runs-on: ubuntu-latest
-    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.debezium-testing-changed == 'true' || needs.file_changes.outputs.mysql-ddl-parser-changed == 'true' }}
+    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.debezium-testing-changed == 'true' || needs.file_changes.outputs.mysql-ddl-parser-changed == 'true' || needs.file_changes.outputs.jdbc-changed == 'true' }}
     steps:
       - name: Checkout Action (Core)
         uses: actions/checkout@v7


### PR DESCRIPTION
Follow-up to https://github.com/debezium/debezium/pull/7576#issuecomment-4912719246.

The `build_server` job in the PR workflow is only triggered by `common-changed`, `debezium-testing-changed`, and `mysql-ddl-parser-changed`, so #7576 — which only touched `debezium-connector-jdbc` — was merged without building Debezium Server, and the compilation break in the Debezium Server JDBC sink adapter surfaced only after merge (fixed by https://github.com/debezium/debezium-server/pull/291).

This adds the existing `jdbc-changed` output (which covers `debezium-sink/**` and `debezium-connector-jdbc/**`, exactly the modules the Debezium Server JDBC sink consumes) to the `build_server` job condition, so such breakages are caught at PR time.

Note: since this PR modifies `debezium-workflow-pr.yml` (part of the Common filter), the Debezium Server build runs on this PR itself. It may fail until https://github.com/debezium/debezium-server/pull/291 is merged, in which case a re-run after that merge should turn it green.