### PR TITLE
debezium/dbz#633 Continue transaction event counters when restarting in the middle of a transaction

### DIFF
--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTransactionMetadataIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTransactionMetadataIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.kafka.connect.data.Struct;
@@ -23,12 +24,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.txmetadata.TransactionStatus;
 import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
@@ -172,6 +175,118 @@ public abstract class BinlogTransactionMetadataIT<C extends SourceConnector> ext
         SourceRecords records = consumeRecordsByTopic(1 + 4 + 1);
         List<SourceRecord> txnEvents = records.recordsForTopic(DATABASE.getServerName() + ".mytransactions");
         assertThat(txnEvents).hasSize(2);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#633")
+    public void shouldContinueTransactionEventCountersAfterRestartInMiddleOfTransaction() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                // Keep the engine batches small so that stopping the connector cannot deliver records
+                // past the middle of the transaction before the stop takes effect
+                .with(CommonConnectorConfig.MAX_BATCH_SIZE, 32)
+                .build();
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // Write a single transaction interleaving two tables that is much larger than the record queue
+        // of the test framework, so the connector is stopped before the whole transaction is delivered
+        final int insertsPerTable = 150;
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                final String[] inserts = new String[2 * insertsPerTable];
+                for (int i = 0; i < insertsPerTable; i++) {
+                    inserts[2 * i] = "INSERT INTO customers (first_name, last_name, email) VALUES ('first" + i + "', 'last" + i + "', 'customer" + i + "@test.com');";
+                    inserts[2 * i + 1] = "INSERT INTO products (name, description, weight) VALUES ('product" + i + "', 'description " + i + "', 1.5);";
+                }
+                connection.setAutoCommit(false);
+                connection.execute(inserts);
+                connection.commit();
+            }
+        }
+
+        // Consume the beginning of the transaction, then stop the connector while the rest of the
+        // transaction is still being delivered
+        final List<SourceRecord> records = new ArrayList<>(consumeRecordsByTopic(51).allRecordsInOrder());
+        final String txId = findTransactionId(records);
+        assertNotNull(txId, "Failed to find the transaction id");
+        stopConnector();
+
+        final Map<String, Object> committedOffset = readLastCommittedOffset(config, records.get(0).sourcePartition());
+        assertThat(committedOffset)
+                .as("Connector has to stop in the middle of the transaction")
+                .containsKey(BinlogOffsetContext.EVENTS_TO_SKIP_OFFSET_KEY);
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+
+        // Consume the rest of the transaction including its END event
+        for (int i = 0; findTransactionStatusRecords(records, txId, TransactionStatus.END).isEmpty() && i < 15; i++) {
+            records.addAll(consumeRecordsByTopic(100).allRecordsInOrder());
+        }
+
+        // Only a single BEGIN must be emitted for the transaction, the transaction start replayed
+        // after the restart must not be propagated
+        final List<SourceRecord> beginRecords = findTransactionStatusRecords(records, txId, TransactionStatus.BEGIN);
+        assertEquals(1, beginRecords.size(), "Duplicate BEGIN event emitted after restart");
+        assertBeginTransaction(beginRecords.get(0));
+
+        // Event counters must continue after the restart instead of being reset
+        assertDataCollectionOrderContinues(records, DATABASE.topicForTable("customers"), txId, insertsPerTable);
+        assertDataCollectionOrderContinues(records, DATABASE.topicForTable("products"), txId, insertsPerTable);
+
+        final List<SourceRecord> endRecords = findTransactionStatusRecords(records, txId, TransactionStatus.END);
+        assertFalse(endRecords.isEmpty(), "Failed to find the transaction END event");
+        final String databaseName = DATABASE.getDatabaseName();
+        assertEndTransaction(endRecords.get(0), txId, 2 * insertsPerTable, Collect.hashMapOf(
+                databaseName + ".customers", insertsPerTable,
+                databaseName + ".products", insertsPerTable));
+    }
+
+    private String findTransactionId(List<SourceRecord> records) {
+        return records.stream()
+                .filter(record -> record.topic().equals(DATABASE.topicForTable("customers"))
+                        || record.topic().equals(DATABASE.topicForTable("products")))
+                .map(record -> ((Struct) record.value()).getStruct("transaction").getString("id"))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<SourceRecord> findTransactionStatusRecords(List<SourceRecord> records, String txId, TransactionStatus status) {
+        final String transactionTopic = DATABASE.getServerName() + ".transaction";
+        final List<SourceRecord> statusRecords = new ArrayList<>();
+        for (SourceRecord record : records) {
+            if (transactionTopic.equals(record.topic())) {
+                final Struct value = (Struct) record.value();
+                if (status.name().equals(value.getString("status")) && txId.equals(value.getString("id"))) {
+                    statusRecords.add(record);
+                }
+            }
+        }
+        return statusRecords;
+    }
+
+    private void assertDataCollectionOrderContinues(List<SourceRecord> records, String topic, String txId, int expectedLastOrder) {
+        long previousOrder = 0;
+        long lastOrder = 0;
+        for (SourceRecord record : records) {
+            if (!topic.equals(record.topic())) {
+                continue;
+            }
+            final Struct transaction = ((Struct) record.value()).getStruct("transaction");
+            assertEquals(txId, transaction.getString("id"));
+            final long order = transaction.getInt64("data_collection_order");
+            assertThat(order)
+                    .as("data_collection_order was reset within transaction %s on topic %s", txId, topic)
+                    .isGreaterThanOrEqualTo(previousOrder);
+            previousOrder = order;
+            lastOrder = order;
+        }
+        assertEquals(expectedLastOrder, lastOrder, "Unexpected last data_collection_order for " + topic);
     }
 
     private String getTxId(List<SourceRecord> records) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
@@ -122,7 +122,14 @@ public class TransactionMonitor {
         if (!connectorConfig.shouldProvideTransactionMetadata()) {
             return;
         }
-        offset.getTransactionContext().beginTransaction(transactionInfo);
+        final TransactionContext transactionContext = offset.getTransactionContext();
+        if (transactionContext.isTransactionInProgress() && Objects.equals(transactionContext.getTransactionId(), transactionInfo.getTransactionId())) {
+            // A start event for the transaction restored from offsets is a replay of the transaction start
+            // after a restart, so the restored event counters must be kept and no duplicate BEGIN is emitted
+            LOGGER.debug("Event counters of transaction {} restored from offsets are continued after restart", transactionInfo.getTransactionId());
+            return;
+        }
+        transactionContext.beginTransaction(transactionInfo);
         beginTransaction(partition, offset, timestamp);
     }
 

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.txmetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.pipeline.txmetadata.spi.TransactionMetadataFactory;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaNameAdjuster;
+
+@ExtendWith(MockitoExtension.class)
+public class TransactionMonitorTest {
+
+    private static final String TOPIC_NAME = "server.transaction";
+    private static final TableId TABLE_A = new TableId("db", null, "a");
+    private static final TableId TABLE_B = new TableId("db", null, "b");
+
+    @Mock
+    private CommonConnectorConfig connectorConfig;
+
+    @Mock
+    private EventMetadataProvider eventMetadataProvider;
+
+    @Mock
+    private TransactionMetadataFactory transactionMetadataFactory;
+
+    @Mock
+    private Partition partition;
+
+    @Mock
+    private OffsetContext offsetContext;
+
+    private List<SourceRecord> sentRecords;
+    private TransactionMonitor monitor;
+
+    @BeforeEach
+    public void beforeEach() {
+        sentRecords = new ArrayList<>();
+        when(connectorConfig.getTransactionMetadataFactory()).thenReturn(transactionMetadataFactory);
+        when(transactionMetadataFactory.getTransactionStructMaker()).thenReturn(new DefaultTransactionStructMaker(Configuration.empty()));
+        monitor = new TransactionMonitor(connectorConfig, eventMetadataProvider, SchemaNameAdjuster.NO_OP, sentRecords::add, TOPIC_NAME);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#633")
+    public void shouldContinueEventCountersWhenRestoredTransactionIsStartedAgain() throws Exception {
+        when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
+
+        // Transaction context restored on restart from offsets that were committed in the middle of
+        // transaction tx-1, after three events for table a and two events for table b
+        final TransactionContext preRestartContext = new TransactionContext();
+        preRestartContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
+        preRestartContext.event(TABLE_A);
+        preRestartContext.event(TABLE_A);
+        preRestartContext.event(TABLE_A);
+        preRestartContext.event(TABLE_B);
+        preRestartContext.event(TABLE_B);
+        final TransactionContext transactionContext = TransactionContext.load(preRestartContext.store(new HashMap<>()));
+        when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
+
+        // The connector replays the start of the restored transaction after restart
+        monitor.transactionStartedEvent(partition, new DefaultTransactionInfo("tx-1"), offsetContext, Instant.ofEpochMilli(1_000));
+
+        assertThat(sentRecords).as("No duplicate BEGIN is emitted for the restored transaction").isEmpty();
+        assertThat(transactionContext.getTransactionId()).isEqualTo("tx-1");
+        assertThat(transactionContext.event(TABLE_A)).as("Event counters continue where the restored offsets ended").isEqualTo(4);
+        assertThat(transactionContext.getTotalEventCount()).isEqualTo(6);
+
+        when(partition.getSourcePartition()).thenReturn(Map.of());
+        when(offsetContext.getOffset()).thenReturn(Map.of());
+        monitor.transactionCommittedEvent(partition, offsetContext, Instant.ofEpochMilli(2_000));
+
+        assertThat(sentRecords).hasSize(1);
+        final Struct end = (Struct) sentRecords.get(0).value();
+        assertThat(end.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.END.name());
+        assertThat(end.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-1");
+        assertThat(end.getInt64(TransactionStructMaker.DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY)).isEqualTo(6L);
+        final List<Struct> dataCollections = end.getArray(TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTIONS_KEY);
+        assertThat(dataCollections)
+                .extracting(
+                        collection -> collection.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_COLLECTION_KEY),
+                        collection -> collection.getInt64(TransactionStructMaker.DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY))
+                .containsExactlyInAnyOrder(tuple("db.a", 4L), tuple("db.b", 2L));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#633")
+    public void shouldBeginNewTransactionWhenStartEventHasDifferentTransactionId() throws Exception {
+        when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
+        when(partition.getSourcePartition()).thenReturn(Map.of());
+        when(offsetContext.getOffset()).thenReturn(Map.of());
+
+        final TransactionContext transactionContext = new TransactionContext();
+        transactionContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
+        transactionContext.event(TABLE_A);
+        when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
+
+        monitor.transactionStartedEvent(partition, new DefaultTransactionInfo("tx-2"), offsetContext, Instant.ofEpochMilli(1_000));
+
+        assertThat(sentRecords).hasSize(1);
+        final Struct begin = (Struct) sentRecords.get(0).value();
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-2");
+        assertThat(transactionContext.getTransactionId()).isEqualTo("tx-2");
+        assertThat(transactionContext.getTotalEventCount()).isZero();
+    }
+
+    @Test
+    public void shouldBeginTransactionWhenNoTransactionIsInProgress() throws Exception {
+        when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
+        when(partition.getSourcePartition()).thenReturn(Map.of());
+        when(offsetContext.getOffset()).thenReturn(Map.of());
+
+        final TransactionContext transactionContext = new TransactionContext();
+        when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
+
+        monitor.transactionStartedEvent(partition, new DefaultTransactionInfo("tx-1"), offsetContext, Instant.ofEpochMilli(1_000));
+
+        assertThat(sentRecords).hasSize(1);
+        final Struct begin = (Struct) sentRecords.get(0).value();
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-1");
+        assertThat(transactionContext.getTransactionId()).isEqualTo("tx-1");
+    }
+}


### PR DESCRIPTION
# PR title

debezium/dbz#633 Continue transaction event counters when restarting in the middle of a transaction

# PR body

Closes https://github.com/debezium/dbz/issues/633 (migrated from DBZ-5127)

## Problem

With `provide.transaction.metadata=true`, when a connector task is restarted (e.g. Kafka Connect
rebalance) while it is in the middle of streaming a transaction, the transaction event counters
are reset: the remaining events of the transaction are emitted with `data_collection_order`
starting again from 1 and a duplicate `BEGIN` record is written to the transaction metadata
topic. The final `END` record then reports an `event_count` covering only the events processed
after the restart.

## Root cause

The in-progress transaction state is already persisted in offsets (`transaction_id`,
`transaction_data_collection_order_<collection>`) and correctly restored by
`TransactionContext.load()` on restart. However, binlog-based connectors re-read the interrupted
transaction from its start on reconnect (restart offset points at the transaction `BEGIN`, with
`event`/`row` skip counters). The replayed `BEGIN` reaches
`TransactionMonitor.transactionStartedEvent()`, which unconditionally called
`TransactionContext.beginTransaction()`, resetting the just-restored counters and emitting a
second `BEGIN`.

`TransactionMonitor.dataEvent()` already handles this situation correctly by comparing
transaction ids and only starting a new transaction when the id changes.

## Fix

`transactionStartedEvent()` now keeps the restored counters and skips the duplicate `BEGIN`
emission when a transaction with the same transaction id is already in progress. A transaction
start for the id already in progress can only be the replay of the restored transaction after a
restart, because the id is cleared when a transaction ends. Transaction ids are stable across
restarts for both GTID (`<uuid>:<txno>`) and non-GTID (`file=<binlog>,pos=<begin position>`)
modes, and `BinlogEventMetadataProvider` derives the per-event transaction id from the same
source, so the counters continue seamlessly.

This also improves the restart-at-commit-boundary case: the `END` record is emitted before
`commitTransaction()` advances the restart offset, so a restart from the `END` record's offset
replays the whole transaction and previously produced a spurious `BEGIN` plus an `END` with
`event_count=0`; now it produces at most a duplicate `END` with correct counts (regular
at-least-once semantics).

## Tests

- `TransactionMonitorTest` (new, debezium-connector-common): transaction start for the
  restored in-progress transaction id keeps counters and emits no `BEGIN`; a different id or no
  in-progress transaction begins a new transaction as before.
- `BinlogTransactionMetadataIT#shouldContinueTransactionEventCountersAfterRestartInMiddleOfTransaction`
  (runs for MySQL and MariaDB): streams a 300-row transaction across two tables, stops the
  connector deterministically in the middle (record queue backpressure, committed offset verified
  to contain the `event` skip counter), restarts, and asserts a single `BEGIN`,
  `data_collection_order` continuing monotonically to 150 per table, and `END` with
  `event_count=300` and correct per-collection counts.
