### PR TITLE
debezium/dbz#2196 Shut down RocketMQ producer in RocketMqSchemaHistory stop()

### DIFF
--- a/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/history/RocketMqSchemaHistory.java
+++ b/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/history/RocketMqSchemaHistory.java
@@ -188,6 +188,19 @@ public class RocketMqSchemaHistory extends AbstractSchemaHistory {
     }
 
     @Override
+    public synchronized void stop() {
+        try {
+            if (this.producer != null) {
+                this.producer.shutdown();
+            }
+        }
+        finally {
+            this.producer = null;
+            super.stop();
+        }
+    }
+
+    @Override
     protected void storeRecord(HistoryRecord record) throws SchemaHistoryException {
         if (this.producer == null) {
             throw new IllegalStateException("No producer is available. Ensure that 'initializeStorage()'"


### PR DESCRIPTION
### Describe the broken behaviour

`RocketMqSchemaHistory#start()` creates and starts a `DefaultMQProducer`, but the class never overrides `stop()`. `AbstractSchemaHistory#stop()` only notifies the listener, so the producer — and its client instance (netty event loops, scheduled tasks, broker connections) — is never released when the schema history is stopped, e.g. on connector stop or restart. These resources leak and accumulate over repeated restarts.

The sibling implementations release their client in `stop()`: `KafkaSchemaHistory#stop()` flushes and closes the producer, and `JdbcSchemaHistory#stop()` closes the connection. `RocketMqSchemaHistory` already shuts down its recovery consumer in `recoverRecords()`.

### How the change fixes it

Override `stop()` to shut the producer down, mirroring `KafkaSchemaHistory#stop()`: cleanup in `try`, `producer = null` and `super.stop()` in `finally`. `shutdown()` is the `DefaultMQProducer` cleanup API (there is no `close()`); it is idempotent and a no-op for a producer whose `start()` failed, and no `flush()` equivalent is needed because `storeRecord()` sends synchronously.

Fixes debezium/dbz#2196
