### PR TITLE
debezium/dbz#2199 Bind PostgreSQL tsvector verbatim instead of stripping quotes

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TsvectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/TsvectorType.java
@@ -5,13 +5,10 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
-import java.util.List;
-
 import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.sink.column.ColumnDescriptor;
-import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
  * An implementation of {@link AbstractType} for the PostgreSQL {@code tsvector} data type.
@@ -58,12 +55,5 @@ public class TsvectorType extends AbstractType {
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
         return "cast(? as tsvector)";
-    }
-
-    @Override
-    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-
-        Object finalValue = value == null ? null : ((String) value).replaceAll("'", "");
-        return List.of(new ValueBindDescriptor(index, finalValue));
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -66,6 +66,7 @@ import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourcePipelineInvocat
 import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourceType;
 import io.debezium.connector.jdbc.junit.jupiter.e2e.source.ValueBinder;
 import io.debezium.data.vector.FloatVector;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.sink.SinkConnectorConfig.PrimaryKeyMode;
@@ -2972,6 +2973,26 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 "tsvector",
                 List.of("'full:3 postgre:1 search:5 support:2 text:4'"),
                 List.of("'full':3 'postgre':1 'search':5 'support':2 'text':4"),
+                (record) -> {
+                    if (sink.getType().is(SinkType.POSTGRES)) {
+                        assertColumn(sink, record, "data", "tsvector");
+                    }
+                    else {
+                        assertColumn(sink, record, "data", getTextType(false));
+                    }
+                },
+                ResultSet::getString);
+    }
+
+    @TestTemplate
+    @FixFor("debezium/dbz#2199")
+    @ForSource(value = SourceType.POSTGRES, reason = "The tsvector data type only applies to PostgreSQL")
+    public void testTsvectorDataTypePreservesQuotedLexemes(Source source, Sink sink) throws Exception {
+        assertDataTypeNonKeyOnly(source,
+                sink,
+                "tsvector",
+                List.of("array_to_tsvector(array['new york', 'it''s', 'plain'])"),
+                List.of("'it''s' 'new york' 'plain'"),
                 (record) -> {
                     if (sink.getType().is(SinkType.POSTGRES)) {
                         assertColumn(sink, record, "data", "tsvector");


### PR DESCRIPTION
Fixes debezium/dbz#2199

## Description

`TsvectorType` overrode `bind()` only to run `replaceAll("'", "")` on the value. PostgreSQL tsvector text wraps each lexeme in single quotes and escapes an internal apostrophe by doubling it, so stripping every quote merges the wrapping quotes into the lexeme content: a space then reads as a lexeme boundary and a doubled apostrophe collapses. This silently corrupts any lexeme containing a space or apostrophe — e.g. `'new york'` became `'new' 'york'`, and `'it''s'` became `'its'`.

The source connector always emits the canonical quoted tsvector text, so no unquoting is needed on the sink side. This removes the `bind()` override so the value binds verbatim through `cast(? as tsvector)`, matching how `LtreeType` handles its native cast. This is a pure removal of an unnecessary override, not new logic.

`TsvectorType` is registered only for the PostgreSQL dialect, so non-PostgreSQL sinks (which map tsvector to text) never ran the quote-stripping and are unaffected.

## Tests

- Added an end-to-end regression test (`testTsvectorDataTypePreservesQuotedLexemes`) covering a space-containing lexeme (`new york`) and an escaped apostrophe (`it's`), run across the sink matrix. Verified it fails on `main` with the reported corruption and passes with this change.
- The existing `testTsvectorDataTypeWithStaticValue` is unchanged: its value has no space or apostrophe, so it round-trips identically.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
