### PR TITLE
debezium/dbz#815 Add StarRocks JDBC sink support

### DIFF
--- a/.github/workflows/connector-jdbc-workflow.yml
+++ b/.github/workflows/connector-jdbc-workflow.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Runs JDBC sink tests based on specific target platforms concurrently
-        test-tags: [ "it-mysql,e2e-mysql", "it-postgresql,e2e-postgresql", "it-sqlserver,e2e-sqlserver", "it-singlestore,e2e-singlestore", "it-cockroachdb,e2e-cockroachdb" ]
+        test-tags: [ "it-mysql,e2e-mysql", "it-postgresql,e2e-postgresql", "it-sqlserver,e2e-sqlserver", "it-singlestore,e2e-singlestore", "it-cockroachdb,e2e-cockroachdb", "it-starrocks,e2e-starrocks"]
         sink-framework: [ "false", "true" ]
     name: JDBC - ${{ matrix.test-tags }}
     runs-on: ubuntu-latest

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -265,6 +265,11 @@
                 <artifactId>singlestore-jdbc-client</artifactId>
                 <version>${version.singlestore.driver}</version>
             </dependency>
+            <dependency>
+                <groupId>com.starrocks</groupId>
+                <artifactId>starrocks-connector-j</artifactId>
+                <version>${version.starrocks.driver}</version>
+            </dependency>
 
             <!-- MongoDB Java driver -->
             <dependency>

--- a/debezium-connector-jdbc/README.md
+++ b/debezium-connector-jdbc/README.md
@@ -115,11 +115,11 @@ There are three types of types in the test suite:
 By default, all unit tests are executed as a part of the build.
 The sink-based integration tests are only executed for MySQL, PostgreSQL, and SQL Server by default, while none of the end-to-end matrix-based tests are executed.
 
-In order to execute the sink-based integration tests for Oracle, DB2, and SingleStore, the `-Dtest.tags` argument must be provided to include these in the build.
+In order to execute the sink-based integration tests for Oracle, DB2, SingleStore, and StarRocks, the `-Dtest.tags` argument must be provided to include these in the build.
 
 In order to do this, add all the integration tests to be executed, as shown below for all databases:
 
-    $ ./mvnw clean install -Dtest.tags=it-mysql,it-postgresql,it-sqlserver,it-oracle,it-db2,it-singlestore
+    $ ./mvnw clean install -Dtest.tags=it-mysql,it-postgresql,it-sqlserver,it-oracle,it-db2,it-singlestore,it-starrocks
 
 In order to run all sink-based integration tests for all databases, a short-cut tag is provided:
 
@@ -127,7 +127,7 @@ In order to run all sink-based integration tests for all databases, a short-cut 
 
 Similarly, in order to enable specific end-to-end tests, the `-Dtest.tags` argument can also be supplied with the necessary tags for each sink database type:
 
-    $ ./mvnw clean install -Dtest.tags=e2e-mysql,e2e-postgresql,e2e-sqlserver,e2e-oracle,e2e-db2,e2e-singlestore
+    $ ./mvnw clean install -Dtest.tags=e2e-mysql,e2e-postgresql,e2e-sqlserver,e2e-oracle,e2e-db2,e2e-singlestore,e2e-starrocks
 
 In order to run all end to end integration tests, a short-cut tag is provided as well:
 

--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -20,10 +20,11 @@
         <version.assertjdb>3.0.0</version.assertjdb>
         <!--
         By default only run the integration tests for MySQL, PostgreSQL, and SQL Server.
-        Other tags include it-db2, it-oracle, and it-singlestore for the DB2, Oracle, and SingleStore integration tests.
+        Other tags include it-db2, it-oracle, it-singlestore, and it-starrocks for the DB2, Oracle, SingleStore,
+        and StarRocks integration tests.
 
         Additionally, there are also end to end test tags that can be specified:
-        e2e-mysql, e2e-postgresql, e2e-sqlserver, e2e-db2, e2e-oracle, and e2e-singlestore
+        e2e-mysql, e2e-postgresql, e2e-sqlserver, e2e-db2, e2e-oracle, e2e-singlestore, and e2e-starrocks
 
         Finally, there are 3 all-inclusive tags that can be specified:
             it - runs all integration tests
@@ -236,6 +237,10 @@
         <dependency>
             <groupId>com.singlestore</groupId>
             <artifactId>singlestore-jdbc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>starrocks-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>mil.nga</groupId>

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -28,6 +29,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
+import io.debezium.connector.jdbc.dialect.starrocks.StarRocksDialectResolver;
 import io.debezium.connector.jdbc.naming.ColumnNamingStrategy;
 import io.debezium.connector.jdbc.naming.DefaultColumnNamingStrategy;
 import io.debezium.connector.jdbc.naming.TemporaryBackwardCompatibleCollectionNamingStrategyProxy;
@@ -64,6 +66,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String POSTGRES_POSTGIS_SCHEMA = "dialect.postgres.postgis.schema";
     public static final String POSTGRES_UNNEST_INSERT = "dialect.postgres.unnest.insert.enabled";
     public static final String SQLSERVER_IDENTITY_INSERT = "dialect.sqlserver.identity.insert";
+    public static final String STARROCKS_CATALOG_NAME = "dialect.starrocks.catalog.name";
+    // StarRocks identifiers may contain only letters, digits, and underscores, and must not start with a digit.
+    // The catalog name is concatenated into a 'SET CATALOG' statement, so it is validated to avoid SQL injection.
+    private static final Pattern STARROCKS_CATALOG_NAME_PATTERN = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
     public static final String USE_REDUCTION_BUFFER = "use.reduction.buffer";
     public static final String FLUSH_MAX_RETRIES = "flush.max.retries";
     public static final String FLUSH_RETRY_DELAY_MS = "flush.retry.delay.ms";
@@ -220,6 +226,17 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withDefault(false)
             .withDescription("Allowing to insert explicit value for identity column in table for SQLSERVER.");
 
+    public static final Field STARROCKS_CATALOG_NAME_FIELD = Field.create(STARROCKS_CATALOG_NAME)
+            .withDisplayName("Name of the StarRocks catalog the connector writes into")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(JdbcSinkConnectorConfig::validateStarRocksCatalogName)
+            .withDescription("Name of the StarRocks catalog the connector writes into. When set, 'SET CATALOG <name>' " +
+                    "is executed on every new connection before any session work. The StarRocks JDBC driver also " +
+                    "supports specifying the catalog directly in the connection URL.");
+
     public static final Field FLUSH_MAX_RETRIES_FIELD = Field.create(FLUSH_MAX_RETRIES)
             .withDisplayName("Max retry count")
             .withType(Type.INT)
@@ -294,6 +311,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     POSTGRES_POSTGIS_SCHEMA_FIELD,
                     POSTGRES_UNNEST_INSERT_FIELD,
                     SQLSERVER_IDENTITY_INSERT_FIELD,
+                    STARROCKS_CATALOG_NAME_FIELD,
                     BATCH_SIZE_FIELD,
                     KEYED_MESSAGE_BATCH_MODE_FIELD,
                     FIELD_INCLUDE_LIST_FIELD,
@@ -408,6 +426,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final String postgresPostgisSchema;
     private final boolean postgresUnnestInsert;
     private final boolean sqlServerIdentityInsert;
+    private final String starRocksCatalogName;
     private final int flushMaxRetries;
     private final long flushRetryDelayMs;
     private final int batchSize;
@@ -432,6 +451,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         this.postgresPostgisSchema = config.getString(POSTGRES_POSTGIS_SCHEMA_FIELD);
         this.postgresUnnestInsert = config.getBoolean(POSTGRES_UNNEST_INSERT_FIELD);
         this.sqlServerIdentityInsert = config.getBoolean(SQLSERVER_IDENTITY_INSERT_FIELD);
+        this.starRocksCatalogName = config.getString(STARROCKS_CATALOG_NAME_FIELD);
         this.batchSize = config.getInteger(BATCH_SIZE_FIELD);
         this.useReductionBuffer = config.getBoolean(USE_REDUCTION_BUFFER_FIELD);
         this.keyedMessageBatchMode = KeyedMessageBatchMode.parse(config.getString(KEYED_MESSAGE_BATCH_MODE_FIELD));
@@ -559,6 +579,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         return postgresUnnestInsert;
     }
 
+    public String getStarRocksCatalogName() {
+        return starRocksCatalogName;
+    }
+
     public int getFlushMaxRetries() {
         return flushMaxRetries;
     }
@@ -618,6 +642,17 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             hibernateConfig.setProperty(AvailableSettings.SHOW_SQL, Boolean.toString(true));
         }
 
+        if (!Strings.isNullOrBlank(starRocksCatalogName)) {
+            // The MySQL wire protocol has no notion of StarRocks catalogs, so the catalog is selected
+            // through an initial statement executed on every new pooled connection.
+            hibernateConfig.setProperty(AgroalSettings.AGROAL_CONFIG_PREFIX + ".initialSQL", "SET CATALOG " + starRocksCatalogName);
+        }
+
+        // The resolver is registered through configuration rather than META-INF/services so that the
+        // registration stays scoped to this session factory; a global service registration fails with
+        // a ServiceConfigurationError in runtimes that isolate classloaders, such as Quarkus.
+        hibernateConfig.setProperty(AvailableSettings.DIALECT_RESOLVERS, StarRocksDialectResolver.class.getName());
+
         // Allows users to pass additional configuration options to the sink connector using the "hibernate.*" namespace
         config.subset(HIBERNATE_PREFIX, false).forEach(hibernateConfig::setProperty);
 
@@ -658,6 +693,18 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                 LOGGER.error("When using UPSERT, please define '{}'.", PRIMARY_KEY_MODE);
                 return 1;
             }
+        }
+        return 0;
+    }
+
+    private static int validateStarRocksCatalogName(Configuration config, Field field, ValidationOutput problems) {
+        final String catalogName = config.getString(field);
+        if (!Strings.isNullOrBlank(catalogName) && !STARROCKS_CATALOG_NAME_PATTERN.matcher(catalogName).matches()) {
+            LOGGER.error("The '{}' value '{}' is invalid: a StarRocks catalog name may contain only letters, digits, and "
+                    + "underscores, and must not start with a digit.", field.name(), catalogName);
+            problems.accept(field, catalogName, "A StarRocks catalog name may contain only letters, digits, and "
+                    + "underscores, and must not start with a digit");
+            return 1;
         }
         return 0;
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/AbstractTimeToStringType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/AbstractTimeToStringType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An abstract {@link JdbcType} implementation for time column types for StarRocks, which has
+ * no TIME type. Values are stored as {@code HH:mm:ss.ffffff} formatted strings in
+ * {@code VARCHAR} columns.
+ *
+ * MySQL TIME columns accept values from {@code -838:59:59} to {@code 838:59:59}, so values
+ * outside the 24-hour clock range are formatted with the same sign and rolled-over hour
+ * notation that MySQL uses rather than a time-of-day representation.
+ */
+abstract class AbstractTimeToStringType extends AbstractType {
+
+    private static final long MICROS_PER_NANO = 1_000L;
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof Number number) {
+            return String.format("'%s'", format(toDuration(number)));
+        }
+        return null;
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "varchar(18)";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        if (value instanceof Number number) {
+            return List.of(new ValueBindDescriptor(index, format(toDuration(number))));
+        }
+        throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
+                value, value.getClass().getName()));
+    }
+
+    protected abstract Duration toDuration(Number value);
+
+    protected static String format(Duration duration) {
+        final boolean negative = duration.isNegative();
+        final Duration absolute = duration.abs();
+        return String.format("%s%02d:%02d:%02d.%06d",
+                negative ? "-" : "",
+                absolute.toHours(),
+                absolute.toMinutesPart(),
+                absolute.toSecondsPart(),
+                absolute.toNanosPart() / MICROS_PER_NANO);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/BigIntUnsignedType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/BigIntUnsignedType.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} that provides support for {@code BIGINT UNSIGNED}
+ * column types for StarRocks, which has no unsigned integer types; values are stored in
+ * {@code LARGEINT} (128-bit) columns so the full unsigned 64-bit range is preserved.
+ */
+class BigIntUnsignedType extends AbstractType {
+
+    public static final BigIntUnsignedType INSTANCE = new BigIntUnsignedType();
+    private static final String[] REGISTRATION_KEYS = new String[]{ "BIGINT UNSIGNED", "BIGINT UNSIGNED ZEROFILL", "INT8 UNSIGNED", "INT8 UNSIGNED ZEROFILL" };
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return REGISTRATION_KEYS;
+    }
+
+    public boolean matchesSourceColumnType(Schema schema) {
+        if (schema.parameters() == null) {
+            return false;
+        }
+
+        final String columnType = schema.parameters().get("__debezium.source.column.type");
+        if (columnType == null) {
+            return false;
+        }
+
+        for (String registrationKey : REGISTRATION_KEYS) {
+            if (registrationKey.equalsIgnoreCase(columnType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "largeint";
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return toUnsignedBigInt(value).toString();
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return super.bind(index, schema, null);
+        }
+        return List.of(new ValueBindDescriptor(index, toUnsignedBigInt(value)));
+    }
+
+    private BigDecimal toUnsignedBigInt(Object value) {
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof BigInteger integer) {
+            return new BigDecimal(integer);
+        }
+        if (value instanceof Long longValue) {
+            // Values above Long.MAX_VALUE arrive as negative two's-complement longs when the
+            // source uses bigint.unsigned.handling.mode=long; restore the unsigned value.
+            return new BigDecimal(Long.toUnsignedString(longValue));
+        }
+        if (value instanceof Number number) {
+            return new BigDecimal(number.toString());
+        }
+        if (value instanceof String string) {
+            return new BigDecimal(string);
+        }
+
+        throw unexpectedValue(value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/BytesType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/BytesType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.sql.Types;
+
+import org.apache.kafka.connect.data.Schema;
+import org.hibernate.engine.jdbc.Size;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.AbstractBytesType;
+import io.debezium.connector.jdbc.type.JdbcType;
+
+/**
+ * An implementation of {@link JdbcType} for {@code BYTES} column types for StarRocks; values
+ * are stored in {@code VARBINARY} columns. The StarRocks JDBC driver cannot bind
+ * {@link java.nio.ByteBuffer} values directly, which the base class converts to byte arrays.
+ */
+class BytesType extends AbstractBytesType {
+
+    public static final BytesType INSTANCE = new BytesType();
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
+        final DatabaseDialect dialect = getDialect();
+        if (columnSize > 0) {
+            return dialect.getJdbcTypeName(Types.VARBINARY, Size.length(columnSize));
+        }
+        return dialect.getJdbcTypeName(Types.VARBINARY);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        // No default values permitted
+        return null;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ConnectTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ConnectTimeType.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.DateTimeUtils;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@link Time} values for StarRocks; times are
+ * stored as formatted strings.
+ */
+class ConnectTimeType extends AbstractTimeToStringType {
+
+    public static final ConnectTimeType INSTANCE = new ConnectTimeType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Time.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof Date date) {
+            return String.format("'%s'", format(toDurationFromDate(date)));
+        }
+        return null;
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        if (value instanceof Date date) {
+            return List.of(new ValueBindDescriptor(index, format(toDurationFromDate(date))));
+        }
+        throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
+                value, value.getClass().getName()));
+    }
+
+    @Override
+    protected Duration toDuration(Number value) {
+        return Duration.ofMillis(value.longValue());
+    }
+
+    private static Duration toDurationFromDate(Date value) {
+        return Duration.ofNanos(DateTimeUtils.toLocalTimeFromUtcDate(value).toNanoOfDay());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/EnumType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/EnumType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Enum;
+
+/**
+ * An implementation of {@link JdbcType} for {@code ENUM} column types for StarRocks, which
+ * has no native ENUM type; values are stored as strings. The allowed value set is not
+ * enforced by the sink database.
+ */
+class EnumType extends AbstractType {
+
+    public static final EnumType INSTANCE = new EnumType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Enum.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "string";
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/JsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/JsonType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Json;
+import io.debezium.sink.column.ColumnDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@link Json} types for StarRocks.
+ */
+class JsonType extends AbstractType {
+
+    public static final JsonType INSTANCE = new JsonType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Json.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "?";
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        // No default value is permitted
+        return null;
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "json";
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/MapToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/MapToJsonType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectMapType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code MAP} schema types that are mapped to a
+ * StarRocks {@code JSON} column type.
+ */
+class MapToJsonType extends AbstractConnectMapType {
+
+    public static final MapToJsonType INSTANCE = new MapToJsonType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return JsonType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return JsonType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Map) {
+            value = mapToJsonString(value);
+        }
+        return JsonType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/MicroTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/MicroTimeType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.time.MicroTime;
+
+/**
+ * An implementation of {@link JdbcType} for {@link MicroTime} values for StarRocks; times are
+ * stored as formatted strings.
+ */
+class MicroTimeType extends AbstractTimeToStringType {
+
+    public static final MicroTimeType INSTANCE = new MicroTimeType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ MicroTime.SCHEMA_NAME };
+    }
+
+    @Override
+    protected Duration toDuration(Number value) {
+        return Duration.of(value.longValue(), ChronoUnit.MICROS);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/NanoTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/NanoTimeType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.time.Duration;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.time.NanoTime;
+
+/**
+ * An implementation of {@link JdbcType} for {@link NanoTime} values for StarRocks; times are
+ * stored as formatted strings with microsecond precision (nanoseconds are truncated).
+ */
+class NanoTimeType extends AbstractTimeToStringType {
+
+    public static final NanoTimeType INSTANCE = new NanoTimeType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ NanoTime.SCHEMA_NAME };
+    }
+
+    @Override
+    protected Duration toDuration(Number value) {
+        return Duration.ofNanos(value.longValue());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/SetType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/SetType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.EnumSet;
+
+/**
+ * An implementation of {@link JdbcType} for {@code SET} column types for StarRocks, which
+ * has no native SET type; values are stored as comma-separated strings.
+ */
+class SetType extends AbstractType {
+
+    public static final SetType INSTANCE = new SetType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ EnumSet.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "string";
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.Schema;
+import org.hibernate.PessimisticLockException;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.Size;
+import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.LockTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkRecord;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
+import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
+import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
+import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.metadata.CollectionId;
+import io.debezium.sink.field.FieldDescriptor;
+import io.debezium.time.ZonedTimestamp;
+import io.debezium.util.Strings;
+
+/**
+ * A {@link DatabaseDialect} implementation for StarRocks.
+ *
+ * StarRocks speaks the MySQL wire protocol but diverges from MySQL in its SQL surface:
+ * upserts are performed with plain {@code INSERT} statements against PRIMARY KEY tables,
+ * the {@code PRIMARY KEY} and {@code DISTRIBUTED BY} clauses live outside the column list
+ * in {@code CREATE TABLE}, {@code VARCHAR} lengths are measured in bytes rather than
+ * characters, and several MySQL types (TIME, ENUM, SET, YEAR, the TEXT/BLOB families)
+ * do not exist.
+ */
+public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StarRocksDatabaseDialect.class);
+
+    private static final List<String> NO_DEFAULT_VALUE_TYPES = List.of("json");
+
+    private static final String NO_DEFAULT_VALUE_TYPE_PREFIX = "varbinary";
+
+    /**
+     * StarRocks VARCHAR/CHAR lengths are byte lengths. Source connectors propagate character
+     * lengths, so lengths are multiplied by the maximum UTF-8 sequence size to avoid overflow
+     * for multi-byte data.
+     */
+    private static final int UTF8_MAX_BYTES_PER_CHARACTER = 4;
+
+    private static final int MAX_VARCHAR_LENGTH = 1_048_576;
+
+    private static final int MAX_CHAR_LENGTH = 255;
+
+    private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral(' ')
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .toFormatter();
+
+    public static class StarRocksDatabaseDialectProvider implements DatabaseDialectProvider {
+        @Override
+        public boolean supports(Dialect dialect) {
+            return dialect instanceof StarRocksDialect;
+        }
+
+        @Override
+        public Class<?> name() {
+            return StarRocksDatabaseDialect.class;
+        }
+
+        @Override
+        public DatabaseDialect instantiate(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
+            LOGGER.info("StarRocks Dialect instantiated.");
+            return new StarRocksDatabaseDialect(config, sessionFactory);
+        }
+    }
+
+    private final boolean connectionTimeZoneSet;
+
+    protected StarRocksDatabaseDialect(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
+        super(config, sessionFactory);
+
+        try (StatelessSession session = sessionFactory.openStatelessSession()) {
+            this.connectionTimeZoneSet = session.doReturningWork((connection) -> connection.getMetaData().getURL().contains("connectionTimeZone="));
+        }
+    }
+
+    @Override
+    public boolean tableExists(Connection connection, CollectionId collectionId) throws SQLException {
+        return super.tableExists(connection, qualifyWithCurrentDatabase(connection, collectionId));
+    }
+
+    @Override
+    public TableDescriptor readTable(Connection connection, CollectionId collectionId) throws SQLException {
+        return super.readTable(connection, qualifyWithCurrentDatabase(connection, collectionId));
+    }
+
+    /**
+     * The StarRocks JDBC driver iterates over every database when JDBC metadata methods are
+     * invoked without a database qualifier, and StarRocks raises an analyzing error rather than
+     * returning an empty result for databases that do not contain the table, so metadata lookups
+     * are qualified with the connection's current database.
+     */
+    private CollectionId qualifyWithCurrentDatabase(Connection connection, CollectionId collectionId) throws SQLException {
+        if (collectionId.realm() == null && collectionId.namespace() == null) {
+            final String database = connection.getCatalog();
+            if (!Strings.isNullOrBlank(database)) {
+                return new CollectionId(database, null, collectionId.name());
+            }
+        }
+        return collectionId;
+    }
+
+    @Override
+    protected Optional<String> getDatabaseTimeZoneQuery() {
+        return Optional.of("SELECT @@global.time_zone, @@session.time_zone");
+    }
+
+    @Override
+    protected String getDatabaseTimeZoneQueryResult(ResultSet rs) throws SQLException {
+        return rs.getString(1) + " (global), " + rs.getString(2) + " (system)";
+    }
+
+    @Override
+    public boolean isTimeZoneSet() {
+        return connectionTimeZoneSet || super.isTimeZoneSet();
+    }
+
+    @Override
+    protected void registerTypes() {
+        super.registerTypes();
+
+        registerType(BigIntUnsignedType.INSTANCE);
+        registerType(BytesType.INSTANCE);
+        registerType(EnumType.INSTANCE);
+        registerType(SetType.INSTANCE);
+        registerType(YearType.INSTANCE);
+        registerType(JsonType.INSTANCE);
+        registerType(MapToJsonType.INSTANCE);
+        registerType(TimeType.INSTANCE);
+        registerType(MicroTimeType.INSTANCE);
+        registerType(NanoTimeType.INSTANCE);
+        registerType(ConnectTimeType.INSTANCE);
+        registerType(ZonedTimeType.INSTANCE);
+        registerType(ZonedTimestampType.INSTANCE);
+    }
+
+    @Override
+    public JdbcType getSchemaType(Schema schema) {
+        if (BigIntUnsignedType.INSTANCE.matchesSourceColumnType(schema)) {
+            return BigIntUnsignedType.INSTANCE;
+        }
+        return super.getSchemaType(schema);
+    }
+
+    @Override
+    public String getJdbcTypeName(int jdbcType, Size size) {
+        // StarRocks CHAR/VARCHAR lengths are byte lengths while source connectors propagate
+        // character lengths; scale the length so multi-byte (UTF-8) data cannot overflow.
+        switch (jdbcType) {
+            case Types.CHAR:
+            case Types.NCHAR:
+                if (size.getLength() != null && size.getLength() > 0) {
+                    final long length = toByteLength(size.getLength());
+                    if (length <= MAX_CHAR_LENGTH) {
+                        return "char(" + length + ")";
+                    }
+                    return "varchar(" + length + ")";
+                }
+                break;
+            case Types.VARCHAR:
+            case Types.NVARCHAR:
+                if (size.getLength() != null && size.getLength() > 0) {
+                    return "varchar(" + toByteLength(size.getLength()) + ")";
+                }
+                break;
+            case Types.VARBINARY:
+                if (size.getLength() != null && size.getLength() > 0) {
+                    return "varbinary(" + Math.min(size.getLength(), MAX_VARCHAR_LENGTH) + ")";
+                }
+                break;
+            default:
+                break;
+        }
+        return super.getJdbcTypeName(jdbcType, size);
+    }
+
+    private long toByteLength(long characterLength) {
+        return Math.min(characterLength * UTF8_MAX_BYTES_PER_CHARACTER, MAX_VARCHAR_LENGTH);
+    }
+
+    @Override
+    public int getMaxVarcharLengthInKey() {
+        // StarRocks enforces a 128-byte limit on the encoded size of all primary key column
+        // values of a PRIMARY KEY table at write time. The returned character length is scaled
+        // by four for byte semantics, aligning the declared column limit with that bound.
+        return 32;
+    }
+
+    @Override
+    public String getCreateTableStatement(JdbcSinkRecord record, CollectionId collectionId) {
+        final SqlStatementBuilder builder = new SqlStatementBuilder();
+        builder.append("CREATE TABLE ");
+        builder.append(getQualifiedTableName(collectionId));
+        builder.append(" (");
+
+        final Map<String, FieldDescriptor> allFields = record.allFields();
+
+        // Key columns must be defined first for StarRocks PRIMARY KEY tables.
+        builder.appendLists(", ", record.keyFieldNames(), record.nonKeyFieldNames(), (name) -> {
+            final FieldDescriptor field = allFields.get(name);
+            final String columnName = toIdentifier(resolveColumnName(field));
+
+            final Schema fieldSchema = field.getSchema();
+            final String columnType = getSchemaType(fieldSchema).getTypeName(fieldSchema, field.isKey());
+
+            final StringBuilder columnSpec = new StringBuilder();
+            columnSpec.append(columnName).append(" ").append(columnType);
+
+            // StarRocks requires the NULL/NOT NULL constraint before the DEFAULT clause.
+            if (field.isKey()) {
+                columnSpec.append(" NOT NULL");
+            }
+            else {
+                columnSpec.append(fieldSchema.isOptional() ? " NULL" : " NOT NULL");
+            }
+            addColumnDefaultValue(field, columnSpec);
+
+            return columnSpec.toString();
+        });
+
+        builder.append(")");
+
+        // Unlike MySQL, the PRIMARY KEY clause is defined outside the column list and creates a
+        // StarRocks PRIMARY KEY table, which treats INSERT operations as upserts. Without key
+        // fields a duplicate key table is created, which only supports appends.
+        if (!record.keyFieldNames().isEmpty()) {
+            builder.append(" PRIMARY KEY (");
+            builder.appendList(", ", record.keyFieldNames(), (name) -> {
+                final FieldDescriptor field = allFields.get(name);
+                return toIdentifier(getConfig().getColumnNamingStrategy().resolveColumnName(field.getColumnName()));
+            });
+            builder.append(") DISTRIBUTED BY HASH (");
+            builder.appendList(", ", record.keyFieldNames(), (name) -> {
+                final FieldDescriptor field = allFields.get(name);
+                return toIdentifier(getConfig().getColumnNamingStrategy().resolveColumnName(field.getColumnName()));
+            });
+            builder.append(")");
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public String getAlterTableStatement(TableDescriptor table, JdbcSinkRecord record, Set<String> missingFields) {
+        final SqlStatementBuilder builder = new SqlStatementBuilder();
+        builder.append("ALTER TABLE ");
+        builder.append(getQualifiedTableName(table.getId()));
+        builder.append(" ");
+        builder.append(getAlterTablePrefix());
+        builder.appendList(getAlterTableColumnDelimiter(), missingFields, (name) -> {
+            final FieldDescriptor field = record.allFields().get(name);
+            final StringBuilder addColumnSpec = new StringBuilder();
+            addColumnSpec.append(getAlterTableColumnPrefix());
+            addColumnSpec.append(" ");
+            addColumnSpec.append(toIdentifier(getConfig().getColumnNamingStrategy().resolveColumnName(field.getColumnName())));
+            final Schema fieldSchema = field.getSchema();
+            addColumnSpec.append(" ").append(getSchemaType(fieldSchema).getTypeName(fieldSchema, field.isKey()));
+
+            // StarRocks requires the NULL/NOT NULL constraint before the DEFAULT clause.
+            addColumnSpec.append(fieldSchema.isOptional() ? " NULL" : " NOT NULL");
+            addColumnDefaultValue(field, addColumnSpec);
+
+            addColumnSpec.append(getAlterTableColumnSuffix());
+            return addColumnSpec.toString();
+        });
+        builder.append(getAlterTableSuffix());
+        return builder.build();
+    }
+
+    @Override
+    public String getUpsertStatement(TableDescriptor table, JdbcSinkRecord record) {
+        // StarRocks does not support INSERT ... ON DUPLICATE KEY UPDATE; an INSERT that lists
+        // all columns of a PRIMARY KEY table is executed as an upsert.
+        return getInsertStatement(table, record);
+    }
+
+    @Override
+    public String getAlterTablePrefix() {
+        return "ADD COLUMN (";
+    }
+
+    @Override
+    public String getFormattedDateTime(TemporalAccessor value) {
+        return String.format("'%s'", ISO_LOCAL_DATE_TIME_WITH_SPACE.format(value));
+    }
+
+    @Override
+    public String getFormattedTimestamp(TemporalAccessor value) {
+        return String.format("'%s'", ISO_LOCAL_DATE_TIME_WITH_SPACE.format(value));
+    }
+
+    @Override
+    public String getFormattedTimestampWithTimeZone(String value) {
+        final ZonedDateTime zonedDateTime = ZonedDateTime.parse(value, ZonedTimestamp.FORMATTER);
+        return String.format("'%s'", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(zonedDateTime));
+    }
+
+    @Override
+    public String getTimestampPositiveInfinityValue() {
+        // StarRocks DATETIME supports 0000-01-01 through 9999-12-31; leave a day of headroom
+        // for time zone conversions.
+        return "9999-12-31T00:00:00+00:00";
+    }
+
+    @Override
+    public String getTimestampNegativeInfinityValue() {
+        return "0000-01-02T00:00:00+00:00";
+    }
+
+    @Override
+    public Set<Class<? extends Exception>> getCommunicationExceptions() {
+        Set<Class<? extends Exception>> exceptions = super.getCommunicationExceptions();
+        exceptions.addAll(
+                Set.of(LockTimeoutException.class,
+                        LockAcquisitionException.class,
+                        PessimisticLockException.class));
+        return Collections.unmodifiableSet(exceptions);
+    }
+
+    @Override
+    protected void addColumnDefaultValue(FieldDescriptor field, StringBuilder columnSpec) {
+        final Schema fieldSchema = field.getSchema();
+        final String fieldType = getSchemaType(fieldSchema).getTypeName(fieldSchema, field.isKey());
+        if (!Strings.isNullOrBlank(fieldType)) {
+            final String type = fieldType.toLowerCase();
+            if (NO_DEFAULT_VALUE_TYPES.contains(type) || type.startsWith(NO_DEFAULT_VALUE_TYPE_PREFIX)) {
+                // StarRocks does not permit DEFAULT clauses for these types.
+                return;
+            }
+        }
+        super.addColumnDefaultValue(field, columnSpec);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialect.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.hibernate.type.SqlTypes.BLOB;
+import static org.hibernate.type.SqlTypes.BOOLEAN;
+import static org.hibernate.type.SqlTypes.CHAR;
+import static org.hibernate.type.SqlTypes.CLOB;
+import static org.hibernate.type.SqlTypes.DOUBLE;
+import static org.hibernate.type.SqlTypes.FLOAT;
+import static org.hibernate.type.SqlTypes.NCHAR;
+import static org.hibernate.type.SqlTypes.NCLOB;
+import static org.hibernate.type.SqlTypes.NVARCHAR;
+import static org.hibernate.type.SqlTypes.REAL;
+import static org.hibernate.type.SqlTypes.TIME;
+import static org.hibernate.type.SqlTypes.TIMESTAMP;
+import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.TIME_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.VARBINARY;
+import static org.hibernate.type.SqlTypes.VARCHAR;
+
+import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
+import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
+
+/**
+ * A Hibernate {@link org.hibernate.dialect.Dialect} for StarRocks.
+ *
+ * StarRocks implements the MySQL wire protocol, so this dialect extends {@link MySQLDialect}
+ * (mirroring Hibernate's own {@code TiDBDialect} precedent) and overrides only the column
+ * types where StarRocks diverges from MySQL. The version reported by a StarRocks frontend
+ * reflects the StarRocks release and must not be interpreted as a MySQL server version, so
+ * a fixed MySQL compatibility baseline is used instead.
+ */
+public class StarRocksDialect extends MySQLDialect {
+
+    private static final DatabaseVersion MYSQL_COMPATIBILITY_VERSION = DatabaseVersion.make(8, 0, 33);
+
+    private static final int MAX_VARCHAR_LENGTH = 1_048_576;
+
+    public StarRocksDialect() {
+        super(MYSQL_COMPATIBILITY_VERSION);
+    }
+
+    public StarRocksDialect(DialectResolutionInfo info) {
+        this();
+    }
+
+    @Override
+    protected String columnType(int sqlTypeCode) {
+        return switch (sqlTypeCode) {
+            // StarRocks has a native BOOLEAN type; MySQL maps this to "bit", which StarRocks lacks.
+            case BOOLEAN -> "boolean";
+            // StarRocks FLOAT and DOUBLE do not accept precision arguments or the
+            // "double precision" spelling.
+            case FLOAT, REAL -> "float";
+            case DOUBLE -> "double";
+            // StarRocks only offers DATETIME; there is no TIMESTAMP column type.
+            case TIMESTAMP, TIMESTAMP_WITH_TIMEZONE -> "datetime";
+            // StarRocks has no TIME type; times are persisted as ISO-8601 formatted strings.
+            case TIME, TIME_WITH_TIMEZONE -> "varchar(18)";
+            // StarRocks does not support column-level character sets.
+            case NCHAR -> columnType(CHAR);
+            case NVARCHAR -> columnType(VARCHAR);
+            // StarRocks has no TEXT/BLOB families; a maximum-length VARCHAR/VARBINARY is the
+            // largest available representation (the STRING alias only covers 65533 bytes).
+            case BLOB -> "varbinary(" + MAX_VARCHAR_LENGTH + ")";
+            case CLOB, NCLOB -> "varchar(" + MAX_VARCHAR_LENGTH + ")";
+            default -> super.columnType(sqlTypeCode);
+        };
+    }
+
+    @Override
+    protected void registerColumnTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+        super.registerColumnTypes(typeContributions, serviceRegistry);
+        final DdlTypeRegistry ddlTypeRegistry = typeContributions.getTypeConfiguration().getDdlTypeRegistry();
+
+        // Replace MySQL's text/blob capacity ladders, which fall back to the tinytext/text/mediumtext
+        // and blob families that StarRocks does not support.
+        ddlTypeRegistry.addDescriptor(
+                CapacityDependentDdlType.builder(VARCHAR, CapacityDependentDdlType.LobKind.BIGGEST_LOB,
+                        columnType(CLOB), columnType(CHAR), castType(CHAR), this)
+                        .withTypeCapacity(getMaxVarcharLength(), "varchar($l)")
+                        .build());
+        ddlTypeRegistry.addDescriptor(
+                CapacityDependentDdlType.builder(NVARCHAR, CapacityDependentDdlType.LobKind.BIGGEST_LOB,
+                        columnType(NCLOB), columnType(NCHAR), castType(NCHAR), this)
+                        .withTypeCapacity(getMaxVarcharLength(), "varchar($l)")
+                        .build());
+        ddlTypeRegistry.addDescriptor(
+                CapacityDependentDdlType.builder(VARBINARY, CapacityDependentDdlType.LobKind.BIGGEST_LOB,
+                        columnType(BLOB), "binary", "binary", this)
+                        .withTypeCapacity(getMaxVarbinaryLength(), "varbinary($l)")
+                        .build());
+    }
+
+    @Override
+    public int getMaxVarcharLength() {
+        // StarRocks VARCHAR lengths are expressed in bytes, with an upper bound of 1048576.
+        return MAX_VARCHAR_LENGTH;
+    }
+
+    @Override
+    public int getMaxVarbinaryLength() {
+        return MAX_VARCHAR_LENGTH;
+    }
+
+    @Override
+    public int getDefaultDecimalPrecision() {
+        // StarRocks DECIMAL supports a maximum precision of 38.
+        return 38;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectResolver.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolver;
+
+/**
+ * A Hibernate {@link DialectResolver} that resolves the {@link StarRocksDialect} when the JDBC
+ * driver reports the {@code StarRocks} database product name, as the StarRocks JDBC driver
+ * ({@code com.starrocks:starrocks-connector-j}) does. This enables automatic dialect detection
+ * without requiring the {@code hibernate.dialect} property to be supplied. The resolver is
+ * registered through the {@code hibernate.dialect_resolvers} setting by
+ * {@link io.debezium.connector.jdbc.JdbcSinkConnectorConfig}.
+ */
+public class StarRocksDialectResolver implements DialectResolver {
+
+    private static final String STARROCKS_PRODUCT_NAME = "StarRocks";
+
+    @Override
+    public Dialect resolveDialect(DialectResolutionInfo info) {
+        if (STARROCKS_PRODUCT_NAME.equalsIgnoreCase(info.getDatabaseName())) {
+            return new StarRocksDialect(info);
+        }
+        return null;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/TimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/TimeType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.time.Duration;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.time.Time;
+
+/**
+ * An implementation of {@link JdbcType} for {@link Time} values for StarRocks; times are
+ * stored as formatted strings.
+ */
+class TimeType extends AbstractTimeToStringType {
+
+    public static final TimeType INSTANCE = new TimeType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Time.SCHEMA_NAME };
+    }
+
+    @Override
+    protected Duration toDuration(Number value) {
+        return Duration.ofMillis(value.longValue());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/YearType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/YearType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.time.Year;
+
+/**
+ * An implementation of {@link JdbcType} for {@code YEAR} column types for StarRocks, which
+ * has no native YEAR type; values are stored as integers without loss.
+ */
+class YearType extends AbstractType {
+
+    public static final YearType INSTANCE = new YearType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ Year.SCHEMA_NAME };
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "int";
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimeType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.ZonedTime;
+
+/**
+ * An implementation of {@link JdbcType} for {@link ZonedTime} values for StarRocks, which has
+ * no time-with-time-zone type. The ISO-8601 offset time representation emitted by the source
+ * is stored verbatim in a {@code VARCHAR} column, preserving the original offset without loss.
+ */
+class ZonedTimeType extends AbstractType {
+
+    public static final ZonedTimeType INSTANCE = new ZonedTimeType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ ZonedTime.SCHEMA_NAME };
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof String string) {
+            return String.format("'%s'", string);
+        }
+        return null;
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "varchar(32)";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        if (value instanceof String) {
+            return List.of(new ValueBindDescriptor(index, value));
+        }
+        throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),
+                value, value.getClass().getName()));
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimestampType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.sql.Types;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.DebeziumZonedTimestampType;
+import io.debezium.time.ZonedTimestamp;
+
+/**
+ * An implementation of {@link JdbcType} for {@link ZonedTimestamp} values for StarRocks, which
+ * has no timestamp-with-time-zone type. Values are normalized to the database time zone and
+ * stored in {@code DATETIME} columns; the original offset is not preserved.
+ */
+class ZonedTimestampType extends DebeziumZonedTimestampType {
+
+    public static final ZonedTimestampType INSTANCE = new ZonedTimestampType();
+
+    @Override
+    protected int getJdbcBindType() {
+        return Types.TIMESTAMP; // TIMESTAMP_WITH_TIMEZONE not supported
+    }
+}

--- a/debezium-connector-jdbc/src/main/resources/META-INF/services/io.debezium.connector.jdbc.dialect.DatabaseDialectProvider
+++ b/debezium-connector-jdbc/src/main/resources/META-INF/services/io.debezium.connector.jdbc.dialect.DatabaseDialectProvider
@@ -1,6 +1,7 @@
 io.debezium.connector.jdbc.dialect.db2i.Db2iDatabaseDialect$Db2iDatabaseProvider
 io.debezium.connector.jdbc.dialect.db2.Db2DatabaseDialect$Db2DatabaseProvider
 io.debezium.connector.jdbc.dialect.singlestore.SingleStoreDatabaseDialect$SingleStoreDatabaseDialectProvider
+io.debezium.connector.jdbc.dialect.starrocks.StarRocksDatabaseDialect$StarRocksDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.mysql.MariaDbDatabaseDialect$MariaDbDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.mysql.MySqlDatabaseDialect$MySqlDatabaseDialectProvider
 io.debezium.connector.jdbc.dialect.oracle.OracleDatabaseDialect$OracleDatabaseDialectProvider

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -16,9 +16,12 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.hibernate.cfg.AgroalSettings;
 import org.hibernate.cfg.AvailableSettings;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,6 +144,61 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
         assertThat(ormProperties.get(AvailableSettings.JAKARTA_JDBC_URL)).isEqualTo("jdbc://url");
         assertThat(ormProperties.get(AvailableSettings.JAKARTA_JDBC_USER)).isEqualTo("user");
         assertThat(ormProperties.get(AvailableSettings.JAKARTA_JDBC_PASSWORD)).isEqualTo("pass");
+    }
+
+    @Test
+    public void testStarRocksDialectResolverIsRegistered() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(connectionProperties());
+        final Properties ormProperties = config.getHibernateConfiguration().getProperties();
+        assertThat(ormProperties.get(AvailableSettings.DIALECT_RESOLVERS))
+                .isEqualTo("io.debezium.connector.jdbc.dialect.starrocks.StarRocksDialectResolver");
+    }
+
+    @Test
+    public void testStarRocksCatalogNameConfiguresInitialSql() {
+        final Map<String, String> properties = connectionProperties();
+        properties.put(JdbcSinkConnectorConfig.STARROCKS_CATALOG_NAME, "external_catalog");
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final Properties ormProperties = config.getHibernateConfiguration().getProperties();
+        assertThat(ormProperties.get(AgroalSettings.AGROAL_CONFIG_PREFIX + ".initialSQL")).isEqualTo("SET CATALOG external_catalog");
+
+        final Properties defaultProperties = new JdbcSinkConnectorConfig(connectionProperties()).getHibernateConfiguration().getProperties();
+        assertThat(defaultProperties.get(AgroalSettings.AGROAL_CONFIG_PREFIX + ".initialSQL")).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "external_catalog", "_catalog", "Catalog1", "iceberg" })
+    public void testValidStarRocksCatalogNameIsAccepted(String catalogName) {
+        final Map<String, String> properties = connectionProperties();
+        properties.put(JdbcSinkConnectorConfig.STARROCKS_CATALOG_NAME, catalogName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.STARROCKS_CATALOG_NAME_FIELD), LOGGER::error)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "cat; DROP DATABASE important",
+            "cat`; DROP DATABASE important",
+            "1catalog",
+            "my-catalog",
+            "my catalog",
+            "cat.alog" })
+    public void testInvalidStarRocksCatalogNameIsRejected(String catalogName) {
+        final Map<String, String> properties = connectionProperties();
+        properties.put(JdbcSinkConnectorConfig.STARROCKS_CATALOG_NAME, catalogName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        assertThat(config.validateAndRecord(List.of(JdbcSinkConnectorConfig.STARROCKS_CATALOG_NAME_FIELD), LOGGER::error)).isFalse();
+    }
+
+    private static Map<String, String> connectionProperties() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(JdbcSinkConnectorConfig.CONNECTION_URL, "jdbc://url");
+        properties.put(JdbcSinkConnectorConfig.CONNECTION_USER, "user");
+        properties.put(JdbcSinkConnectorConfig.CONNECTION_PASSWORD, "pass");
+        return properties;
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/BigIntUnsignedTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/BigIntUnsignedTypeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the StarRocks {@link BigIntUnsignedType} handler, including the unsigned
+ * 64-bit boundary values.
+ */
+@Tag("UnitTests")
+class BigIntUnsignedTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.int64()
+            .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+            .build();
+
+    @Test
+    @DisplayName("Should match propagated BIGINT UNSIGNED source column types")
+    void testMatchesSourceColumnType() {
+        assertThat(BigIntUnsignedType.INSTANCE.matchesSourceColumnType(SCHEMA)).isTrue();
+        assertThat(BigIntUnsignedType.INSTANCE.matchesSourceColumnType(Schema.INT64_SCHEMA)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should map BIGINT UNSIGNED to largeint to preserve the full unsigned range")
+    void testTypeName() {
+        assertThat(BigIntUnsignedType.INSTANCE.getTypeName(SCHEMA, false)).isEqualTo("largeint");
+    }
+
+    @Test
+    @DisplayName("Should restore unsigned values above Long.MAX_VALUE from wrapped longs")
+    void testBindWrappedUnsignedBoundary() {
+        // 18446744073709551615 (2^64 - 1) arrives as -1 when handled as a long
+        assertThat(bind(-1L)).isEqualTo(new BigDecimal("18446744073709551615"));
+
+        // 9223372036854775808 (2^63) arrives as Long.MIN_VALUE
+        assertThat(bind(Long.MIN_VALUE)).isEqualTo(new BigDecimal("9223372036854775808"));
+    }
+
+    @Test
+    @DisplayName("Should pass through values within the signed range")
+    void testBindSignedRange() {
+        assertThat(bind(Long.MAX_VALUE)).isEqualTo(new BigDecimal("9223372036854775807"));
+        assertThat(bind(0L)).isEqualTo(new BigDecimal("0"));
+    }
+
+    private static Object bind(long value) {
+        final List<ValueBindDescriptor> bindings = BigIntUnsignedType.INSTANCE.bind(0, SCHEMA, value);
+        assertThat(bindings).hasSize(1);
+        return bindings.get(0).getValue();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/ConnectTimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/ConnectTimeTypeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the StarRocks {@link ConnectTimeType} handler.
+ */
+@Tag("UnitTests")
+class ConnectTimeTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.int32().name(Time.LOGICAL_NAME).build();
+
+    @Test
+    @DisplayName("Should register for Kafka Connect Time logical name")
+    void testRegistrationKeys() {
+        assertThat(ConnectTimeType.INSTANCE.getRegistrationKeys()).containsExactly(Time.LOGICAL_NAME);
+    }
+
+    @Test
+    @DisplayName("Should format Kafka Connect time values")
+    void testBind() {
+        // 01:02:03.456 as milliseconds past midnight (UTC)
+        final Date value = new Date(((1 * 3600 + 2 * 60 + 3) * 1_000L) + 456);
+
+        final List<ValueBindDescriptor> bindings = ConnectTimeType.INSTANCE.bind(0, SCHEMA, value);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo("01:02:03.456000");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/EnumTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/EnumTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Enum;
+
+/**
+ * Unit tests for the StarRocks {@link EnumType} handler.
+ */
+@Tag("UnitTests")
+class EnumTypeTest {
+
+    @Test
+    @DisplayName("Should register for ENUM logical name")
+    void testRegistrationKeys() {
+        assertThat(EnumType.INSTANCE.getRegistrationKeys()).containsExactly(Enum.LOGICAL_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map ENUM to string as StarRocks has no ENUM type")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.string().name(Enum.LOGICAL_NAME).parameter("allowed", "a,b,c").build();
+
+        assertThat(EnumType.INSTANCE.getTypeName(schema, false)).isEqualTo("string");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/JsonTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/JsonTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Json;
+
+/**
+ * Unit tests for the StarRocks {@link JsonType} handler.
+ */
+@Tag("UnitTests")
+class JsonTypeTest {
+
+    @Test
+    @DisplayName("Should register for JSON logical name")
+    void testRegistrationKeys() {
+        assertThat(JsonType.INSTANCE.getRegistrationKeys()).containsExactly(Json.LOGICAL_NAME);
+    }
+
+    @Test
+    @DisplayName("Should return simple parameter binding for StarRocks")
+    void testQueryBinding() {
+        assertThat(JsonType.INSTANCE.getQueryBinding(null, null, null)).isEqualTo("?");
+    }
+
+    @Test
+    @DisplayName("Should return null for default value binding")
+    void testDefaultValueBinding() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+
+        assertThat(JsonType.INSTANCE.getDefaultValueBinding(schema, "{}")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should return json as type name for StarRocks")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+
+        assertThat(JsonType.INSTANCE.getTypeName(schema, false)).isEqualTo("json");
+        assertThat(JsonType.INSTANCE.getTypeName(schema, true)).isEqualTo("json");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/MapToJsonTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/MapToJsonTypeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the StarRocks {@link MapToJsonType} handler.
+ */
+@Tag("UnitTests")
+class MapToJsonTypeTest {
+
+    @Test
+    @DisplayName("Should register for MAP schema type")
+    void testRegistrationKeys() {
+        assertThat(MapToJsonType.INSTANCE.getRegistrationKeys()).containsExactly("MAP");
+    }
+
+    @Test
+    @DisplayName("Should return json as type name for StarRocks")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
+
+        assertThat(MapToJsonType.INSTANCE.getTypeName(schema, false)).isEqualTo("json");
+    }
+
+    @Test
+    @DisplayName("Should bind map values as JSON strings")
+    void testBind() {
+        Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
+
+        List<ValueBindDescriptor> bindings = MapToJsonType.INSTANCE.bind(0, schema, Map.of("key", "value"));
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo("{\"key\":\"value\"}");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/MicroTimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/MicroTimeTypeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.MicroTime;
+
+/**
+ * Unit tests for the StarRocks {@link MicroTimeType} handler, including the MySQL TIME
+ * boundary values of {@code -838:59:59} and {@code 838:59:59}.
+ */
+@Tag("UnitTests")
+class MicroTimeTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.int64().name(MicroTime.SCHEMA_NAME).build();
+
+    @Test
+    @DisplayName("Should register for MicroTime logical name")
+    void testRegistrationKeys() {
+        assertThat(MicroTimeType.INSTANCE.getRegistrationKeys()).containsExactly(MicroTime.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map times to varchar as StarRocks has no TIME type")
+    void testTypeName() {
+        assertThat(MicroTimeType.INSTANCE.getTypeName(SCHEMA, false)).isEqualTo("varchar(18)");
+    }
+
+    @Test
+    @DisplayName("Should format time-of-day values with microsecond precision")
+    void testBindTimeOfDay() {
+        // 23:59:59.999999
+        final long micros = ((23L * 3600 + 59 * 60 + 59) * 1_000_000) + 999_999;
+
+        assertThat(bind(micros)).isEqualTo("23:59:59.999999");
+    }
+
+    @Test
+    @DisplayName("Should format the MySQL TIME positive boundary of 838:59:59")
+    void testBindPositiveBoundary() {
+        final long micros = (838L * 3600 + 59 * 60 + 59) * 1_000_000;
+
+        assertThat(bind(micros)).isEqualTo("838:59:59.000000");
+    }
+
+    @Test
+    @DisplayName("Should format the MySQL TIME negative boundary of -838:59:59")
+    void testBindNegativeBoundary() {
+        final long micros = -(838L * 3600 + 59 * 60 + 59) * 1_000_000;
+
+        assertThat(bind(micros)).isEqualTo("-838:59:59.000000");
+    }
+
+    @Test
+    @DisplayName("Should format midnight")
+    void testBindMidnight() {
+        assertThat(bind(0L)).isEqualTo("00:00:00.000000");
+    }
+
+    @Test
+    @DisplayName("Should bind null values")
+    void testBindNull() {
+        final List<ValueBindDescriptor> bindings = MicroTimeType.INSTANCE.bind(0, SCHEMA, null);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isNull();
+    }
+
+    private static String bind(long micros) {
+        final List<ValueBindDescriptor> bindings = MicroTimeType.INSTANCE.bind(0, SCHEMA, micros);
+        assertThat(bindings).hasSize(1);
+        return (String) bindings.get(0).getValue();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/NanoTimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/NanoTimeTypeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.NanoTime;
+
+/**
+ * Unit tests for the StarRocks {@link NanoTimeType} handler.
+ */
+@Tag("UnitTests")
+class NanoTimeTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.int64().name(NanoTime.SCHEMA_NAME).build();
+
+    @Test
+    @DisplayName("Should register for NanoTime logical name")
+    void testRegistrationKeys() {
+        assertThat(NanoTimeType.INSTANCE.getRegistrationKeys()).containsExactly(NanoTime.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should truncate nanoseconds to microsecond precision")
+    void testBindTruncatesNanoseconds() {
+        // 12:34:56.123456789
+        final long nanos = ((12L * 3600 + 34 * 60 + 56) * 1_000_000_000L) + 123_456_789L;
+
+        final List<ValueBindDescriptor> bindings = NanoTimeType.INSTANCE.bind(0, SCHEMA, nanos);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo("12:34:56.123456");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/SetTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/SetTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.EnumSet;
+
+/**
+ * Unit tests for the StarRocks {@link SetType} handler.
+ */
+@Tag("UnitTests")
+class SetTypeTest {
+
+    @Test
+    @DisplayName("Should register for SET logical name")
+    void testRegistrationKeys() {
+        assertThat(SetType.INSTANCE.getRegistrationKeys()).containsExactly(EnumSet.LOGICAL_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map SET to string as StarRocks has no SET type")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.string().name(EnumSet.LOGICAL_NAME).parameter("allowed", "a,b,c").build();
+
+        assertThat(SetType.INSTANCE.getTypeName(schema, false)).isEqualTo("string");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialectProviderTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialectProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
+import io.debezium.connector.jdbc.dialect.starrocks.StarRocksDatabaseDialect.StarRocksDatabaseDialectProvider;
+
+/**
+ * Unit tests for the StarRocks dialect provider.
+ */
+@Tag("UnitTests")
+class StarRocksDatabaseDialectProviderTest {
+
+    private final DatabaseDialectProvider provider = new StarRocksDatabaseDialectProvider();
+
+    @Test
+    @DisplayName("Should support Hibernate StarRocks dialect")
+    void testSupportsStarRocksDialect() {
+        assertThat(provider.supports(new StarRocksDialect())).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should not support a MySQL Hibernate dialect")
+    void testDoesNotSupportMySqlDialect() {
+        // StarRocksDialect extends MySQLDialect, so the StarRocks provider must be registered
+        // before the MySQL provider; the reverse containment must never match.
+        assertThat(provider.supports(new MySQLDialect())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should not support a MariaDB Hibernate dialect")
+    void testDoesNotSupportMariaDbDialect() {
+        assertThat(provider.supports(new MariaDBDialect())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should name StarRocks database dialect")
+    void testName() {
+        assertThat(provider.name()).isEqualTo(StarRocksDatabaseDialect.class);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectResolverTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectResolverTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link StarRocksDialectResolver}.
+ */
+@Tag("UnitTests")
+class StarRocksDialectResolverTest {
+
+    private final StarRocksDialectResolver resolver = new StarRocksDialectResolver();
+
+    @Test
+    @DisplayName("Should resolve the StarRocks dialect for the StarRocks database product name")
+    void testResolvesStarRocks() {
+        final DialectResolutionInfo info = mock(DialectResolutionInfo.class);
+        when(info.getDatabaseName()).thenReturn("StarRocks");
+
+        assertThat(resolver.resolveDialect(info)).isInstanceOf(StarRocksDialect.class);
+    }
+
+    @Test
+    @DisplayName("Should not resolve a dialect for other database product names")
+    void testDoesNotResolveOtherDatabases() {
+        final DialectResolutionInfo info = mock(DialectResolutionInfo.class);
+        when(info.getDatabaseName()).thenReturn("MySQL");
+
+        assertThat(resolver.resolveDialect(info)).isNull();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDialectTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.type.SqlTypes.BIGINT;
+import static org.hibernate.type.SqlTypes.BLOB;
+import static org.hibernate.type.SqlTypes.BOOLEAN;
+import static org.hibernate.type.SqlTypes.CLOB;
+import static org.hibernate.type.SqlTypes.DOUBLE;
+import static org.hibernate.type.SqlTypes.FLOAT;
+import static org.hibernate.type.SqlTypes.INTEGER;
+import static org.hibernate.type.SqlTypes.NCLOB;
+import static org.hibernate.type.SqlTypes.NVARCHAR;
+import static org.hibernate.type.SqlTypes.REAL;
+import static org.hibernate.type.SqlTypes.TIME;
+import static org.hibernate.type.SqlTypes.TIMESTAMP;
+import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.TIME_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.VARCHAR;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests that pin the StarRocks-specific column type mappings of {@link StarRocksDialect},
+ * guarding against behavior changes inherited from Hibernate's {@code MySQLDialect}.
+ */
+@Tag("UnitTests")
+class StarRocksDialectTest {
+
+    private static class TestableStarRocksDialect extends StarRocksDialect {
+        String resolveColumnType(int sqlTypeCode) {
+            return columnType(sqlTypeCode);
+        }
+    }
+
+    private final TestableStarRocksDialect dialect = new TestableStarRocksDialect();
+
+    @Test
+    @DisplayName("Should map BOOLEAN to boolean rather than MySQL's bit")
+    void testBooleanColumnType() {
+        assertThat(dialect.resolveColumnType(BOOLEAN)).isEqualTo("boolean");
+    }
+
+    @Test
+    @DisplayName("Should map timestamp types to datetime without precision")
+    void testTimestampColumnTypes() {
+        // StarRocks rejects a precision argument on DATETIME; the bare type retains
+        // microsecond precision from v3.3.5 onward.
+        assertThat(dialect.resolveColumnType(TIMESTAMP)).isEqualTo("datetime");
+        assertThat(dialect.resolveColumnType(TIMESTAMP_WITH_TIMEZONE)).isEqualTo("datetime");
+    }
+
+    @Test
+    @DisplayName("Should map time types to varchar as StarRocks has no TIME type")
+    void testTimeColumnTypes() {
+        assertThat(dialect.resolveColumnType(TIME)).isEqualTo("varchar(18)");
+        assertThat(dialect.resolveColumnType(TIME_WITH_TIMEZONE)).isEqualTo("varchar(18)");
+    }
+
+    @Test
+    @DisplayName("Should map large character types to maximum-length varchar rather than MySQL's longtext")
+    void testLargeCharacterColumnTypes() {
+        // The STRING alias only covers 65533 bytes; a maximum-length VARCHAR is larger.
+        assertThat(dialect.resolveColumnType(CLOB)).isEqualTo("varchar(1048576)");
+        assertThat(dialect.resolveColumnType(NCLOB)).isEqualTo("varchar(1048576)");
+    }
+
+    @Test
+    @DisplayName("Should map BLOB to varbinary rather than MySQL's longblob")
+    void testBlobColumnType() {
+        assertThat(dialect.resolveColumnType(BLOB)).isEqualTo("varbinary(1048576)");
+    }
+
+    @Test
+    @DisplayName("Should not use MySQL's deprecated character set clause for nationalized types")
+    void testNationalizedColumnTypes() {
+        assertThat(dialect.resolveColumnType(NVARCHAR)).isEqualTo(dialect.resolveColumnType(VARCHAR));
+    }
+
+    @Test
+    @DisplayName("Should retain MySQL-compatible integer mappings")
+    void testIntegerColumnTypes() {
+        assertThat(dialect.resolveColumnType(INTEGER)).isEqualTo("integer");
+        assertThat(dialect.resolveColumnType(BIGINT)).isEqualTo("bigint");
+    }
+
+    @Test
+    @DisplayName("Should map floating point types without precision arguments")
+    void testFloatingPointColumnTypes() {
+        // StarRocks rejects float(p) and the "double precision" spelling.
+        assertThat(dialect.resolveColumnType(FLOAT)).isEqualTo("float");
+        assertThat(dialect.resolveColumnType(REAL)).isEqualTo("float");
+        assertThat(dialect.resolveColumnType(DOUBLE)).isEqualTo("double");
+    }
+
+    @Test
+    @DisplayName("Should limit VARCHAR to StarRocks byte-length maximum")
+    void testMaxVarcharLength() {
+        assertThat(dialect.getMaxVarcharLength()).isEqualTo(1_048_576);
+        assertThat(dialect.getMaxVarbinaryLength()).isEqualTo(1_048_576);
+    }
+
+    @Test
+    @DisplayName("Should limit DECIMAL precision to StarRocks maximum of 38")
+    void testDefaultDecimalPrecision() {
+        assertThat(dialect.getDefaultDecimalPrecision()).isEqualTo(38);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/TimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/TimeTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.Time;
+
+/**
+ * Unit tests for the StarRocks {@link TimeType} handler.
+ */
+@Tag("UnitTests")
+class TimeTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.int32().name(Time.SCHEMA_NAME).build();
+
+    @Test
+    @DisplayName("Should register for Time logical name")
+    void testRegistrationKeys() {
+        assertThat(TimeType.INSTANCE.getRegistrationKeys()).containsExactly(Time.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map times to varchar as StarRocks has no TIME type")
+    void testTypeName() {
+        assertThat(TimeType.INSTANCE.getTypeName(SCHEMA, false)).isEqualTo("varchar(18)");
+    }
+
+    @Test
+    @DisplayName("Should format millisecond time-of-day values")
+    void testBind() {
+        // 01:02:03.456
+        final int millis = ((1 * 3600 + 2 * 60 + 3) * 1_000) + 456;
+
+        final List<ValueBindDescriptor> bindings = TimeType.INSTANCE.bind(0, SCHEMA, millis);
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo("01:02:03.456000");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/YearTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/YearTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.time.Year;
+
+/**
+ * Unit tests for the StarRocks {@link YearType} handler.
+ */
+@Tag("UnitTests")
+class YearTypeTest {
+
+    @Test
+    @DisplayName("Should register for YEAR logical name")
+    void testRegistrationKeys() {
+        assertThat(YearType.INSTANCE.getRegistrationKeys()).containsExactly(Year.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map YEAR to int as StarRocks has no YEAR type")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.int32().name(Year.SCHEMA_NAME).build();
+
+        assertThat(YearType.INSTANCE.getTypeName(schema, false)).isEqualTo("int");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimeTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/ZonedTimeTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.ZonedTime;
+
+/**
+ * Unit tests for the StarRocks {@link ZonedTimeType} handler.
+ */
+@Tag("UnitTests")
+class ZonedTimeTypeTest {
+
+    private static final Schema SCHEMA = SchemaBuilder.string().name(ZonedTime.SCHEMA_NAME).build();
+
+    @Test
+    @DisplayName("Should register for ZonedTime logical name")
+    void testRegistrationKeys() {
+        assertThat(ZonedTimeType.INSTANCE.getRegistrationKeys()).containsExactly(ZonedTime.SCHEMA_NAME);
+    }
+
+    @Test
+    @DisplayName("Should map zoned times to varchar as StarRocks has no time zone aware types")
+    void testTypeName() {
+        assertThat(ZonedTimeType.INSTANCE.getTypeName(SCHEMA, false)).isEqualTo("varchar(32)");
+    }
+
+    @Test
+    @DisplayName("Should store the ISO-8601 offset time representation verbatim")
+    void testBind() {
+        final List<ValueBindDescriptor> bindings = ZonedTimeType.INSTANCE.bind(0, SCHEMA, "10:15:30.123456+09:00");
+
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getValue()).isEqualTo("10:15:30.123456+09:00");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToStarRocksIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/JdbcSinkPipelineToStarRocksIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.ForSource;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.SkipColumnTypePropagation;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.SkipExtractNewRecordState;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.source.Source;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourcePipelineInvocationContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.source.SourceType;
+import io.debezium.sink.SinkConnectorConfig.PrimaryKeyMode;
+
+/**
+ * End-to-end pipeline tests that write to StarRocks.
+ */
+@Tag("all")
+@Tag("e2e")
+@Tag("e2e-starrocks")
+@SkipExtractNewRecordState
+@SkipColumnTypePropagation
+@ExtendWith(SourcePipelineInvocationContextProvider.class)
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkPipelineToStarRocksIT extends AbstractJdbcSinkIT {
+
+    @TestTemplate
+    @ForSource(value = SourceType.MYSQL, reason = "Verifies a MySQL source can write to a StarRocks sink")
+    public void testMySqlSourceToStarRocksSink(Source source, Sink sink) throws Exception {
+        final String tableName = source.randomTableName();
+        final String createSql = String.format("CREATE TABLE %s (id int primary key, data varchar(50))", tableName);
+        final String insertSql = String.format("INSERT INTO %s VALUES (1, 'test')", tableName);
+
+        registerSourceConnector(source, tableName, createSql, insertSql);
+
+        final Properties sinkProperties = getDefaultSinkConfig(sink);
+        sinkProperties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        sinkProperties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+        sinkProperties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSink(source, sinkProperties, tableName);
+
+        final SinkRecord record = consumeSinkRecord();
+        final String destinationTable = record.topic().replace(".", "_");
+        sink.assertColumn(destinationTable, "id", "INT");
+        sink.assertColumn(destinationTable, "data", "VARCHAR");
+        sink.assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt("id")).isEqualTo(1);
+            assertThat(rs.getString("data")).isEqualTo("test");
+            return null;
+        });
+    }
+
+    private void registerSourceConnector(Source source, String tableName, String createSql, String insertSql) throws Exception {
+        if (source.getOptions().useSnapshot()) {
+            source.execute(createSql);
+            source.streamTable(tableName);
+            source.execute(insertSql);
+            source.registerSourceConnector(getSourceConnectorConfig(source, tableName));
+        }
+        else {
+            source.execute(createSql);
+            source.streamTable(tableName);
+            source.registerSourceConnector(getSourceConnectorConfig(source, tableName));
+            source.execute(insertSql);
+        }
+    }
+
+    private Properties getDefaultSinkConfig(Sink sink) {
+        final Properties sinkProperties = new Properties();
+        sinkProperties.put(JdbcSinkConnectorConfig.CONNECTION_URL, sink.getJdbcUrl());
+        sinkProperties.put(JdbcSinkConnectorConfig.CONNECTION_USER, sink.getUsername());
+        sinkProperties.put(JdbcSinkConnectorConfig.CONNECTION_PASSWORD, sink.getPassword());
+        sinkProperties.put(JdbcSinkConnectorConfig.USE_TIME_ZONE, TestHelper.getSinkTimeZone());
+        return sinkProperties;
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractOpenLineageJdbcSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractOpenLineageJdbcSinkTest.java
@@ -200,6 +200,7 @@ public abstract class AbstractOpenLineageJdbcSinkTest extends AbstractJdbcSinkTe
         return switch (getSink().getType()) {
             case MYSQL -> List.of("id;TINYINT", "name;LONGTEXT", "nick_name$;VARCHAR");
             case SINGLESTORE -> List.of("id;BIT", "name;LONGTEXT", "nick_name$;VARCHAR");
+            case STARROCKS -> List.of("id;TINYINT", "name;VARCHAR", "nick_name$;VARCHAR");
             case POSTGRES -> List.of("id;int2", "name;text", "nick_name$;varchar");
             case COCKROACHDB -> List.of("id;int2", "name;text", "nick_name$;varchar");
             case SQLSERVER -> List.of("id;smallint", "name;varchar", "nick_name$;varchar");

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkCloudEventIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkCloudEventIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.assertj.core.data.Index;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkCloudEventTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * Converted CloudEvent saving tests for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkCloudEventIT extends AbstractJdbcSinkCloudEventTest {
+
+    public JdbcSinkCloudEventIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected void assertHasPrimaryKeyColumns(String tableName, boolean caseInsensitive, String... columnNames) {
+        // The StarRocks JDBC driver does not expose primary keys through JDBC metadata.
+        List<String> pkColumnNames = StarRocksTestUtils.getPrimaryKeyColumnNames(dataSource(), tableName);
+        if (columnNames.length == 0) {
+            assertThat(pkColumnNames).isEmpty();
+        }
+        else if (caseInsensitive) {
+            pkColumnNames = pkColumnNames.stream().map(String::toLowerCase).collect(Collectors.toList());
+            assertThat(pkColumnNames.size()).isEqualTo(columnNames.length);
+            for (int columnIndex = 0; columnIndex < columnNames.length; ++columnIndex) {
+                assertThat(pkColumnNames).contains(columnNames[columnIndex].toLowerCase(), Index.atIndex(columnIndex));
+            }
+        }
+        else {
+            // noinspection ConfusingArgumentToVarargsMethod
+            assertThat(pkColumnNames).containsExactly(columnNames);
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+
+/**
+ * Column type mappings for StarRocks, including boundary cases for byte-length string
+ * semantics, unsigned 64-bit integers, maximum decimal precision, microsecond datetime
+ * precision and the TIME-as-string representation.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkColumnTypeMappingIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-6967")
+    public void testShouldCoerceNioByteBufferTypeToByteArrayColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final ByteBuffer buffer = ByteBuffer.allocate(3);
+        buffer.put((byte) 1);
+        buffer.put((byte) 2);
+        buffer.put((byte) 3);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_BYTES_SCHEMA,
+                buffer,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(String.format(
+                "CREATE TABLE %s (id tinyint NOT NULL, data varbinary(3) NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
+                destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getBytes(2)).isEqualTo(new byte[]{ 1, 2, 3 });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldPreserveMicrosecondDatetimePrecision(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // 2024-01-02 03:04:05.123456 as microseconds past epoch
+        final long micros = 1704164645123456L;
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                MicroTimestamp.builder().optional().build(),
+                micros,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "DATETIME");
+        // The StarRocks JDBC driver reports DATETIME columns without fractional second
+        // precision and truncates values on read; a cast to VARCHAR exposes the stored value.
+        try (var connection = dataSource().getConnection();
+                var statement = connection.createStatement();
+                var rs = statement.executeQuery("SELECT CAST(data AS VARCHAR(32)) FROM " + destinationTable)) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString(1)).isEqualTo("2024-01-02 03:04:05.123456");
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldWriteTimeValuesAsFormattedStrings(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // 23:59:59.999999 as microseconds past midnight
+        final long micros = ((23L * 3600 + 59 * 60 + 59) * 1_000_000) + 999_999;
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                MicroTime.builder().optional().build(),
+                micros,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        // StarRocks has no TIME data type; times are stored as ISO-8601 formatted strings
+        getSink().assertColumn(destinationTable, "data", "VARCHAR");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo("23:59:59.999999");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldMapBigIntUnsignedToLargeInt(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema bigintUnsignedSchema = SchemaBuilder.int64()
+                .optional()
+                .parameter("__debezium.source.column.type", "BIGINT UNSIGNED")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                bigintUnsignedSchema,
+                // 18446744073709551615 (2^64 - 1) wrapped into a signed long
+                -1L,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        // The column is created as LARGEINT, which StarRocks surfaces through JDBC metadata as
+        // an unsigned bigint; the value assertion confirms the full unsigned range round-trips.
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo("18446744073709551615");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldRoundTripMaximumDecimalPrecision(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // decimal(38,10) with all digits populated
+        final BigDecimal value = new BigDecimal("1234567890123456789012345678.0123456789");
+        final Schema decimalSchema = Decimal.builder(10)
+                .optional()
+                .parameter("connect.decimal.precision", "38")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                decimalSchema,
+                value,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getBigDecimal("data")).isEqualByComparingTo(value);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldWidenCharacterLengthsForMultiByteData(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // A VARCHAR(10) source column filled with 10 three-byte characters (30 bytes); StarRocks
+        // VARCHAR lengths are bytes, so the sink must widen the declared length.
+        final String value = "한".repeat(10);
+        final Schema stringSchema = SchemaBuilder.string()
+                .optional()
+                .parameter("__debezium.source.column.type", "VARCHAR")
+                .parameter("__debezium.source.column.length", "10")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                stringSchema,
+                value,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "VARCHAR", 40);
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo(value);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldWriteIntoPreCreatedTableWithStringColumn(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_STRING_SCHEMA,
+                "한글 텍스트",
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        // Users typically declare text columns with the idiomatic STRING alias when creating
+        // StarRocks tables themselves; ensure the sink writes into such tables.
+        getSink().execute(String.format(
+                "CREATE TABLE %s (id tinyint NOT NULL, data string NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
+                destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString("data")).isEqualTo("한글 텍스트");
+            return null;
+        });
+
+        // Upserting into the STRING column also replaces the row
+        final JdbcKafkaSinkRecord updateRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_STRING_SCHEMA,
+                "updated",
+                config);
+        consume(updateRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo("updated");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldPromoteWideCharColumnsToVarchar(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema smallCharSchema = SchemaBuilder.string()
+                .optional()
+                .parameter("__debezium.source.column.type", "CHAR")
+                .parameter("__debezium.source.column.length", "10")
+                .build();
+        final Schema wideCharSchema = SchemaBuilder.string()
+                .optional()
+                .parameter("__debezium.source.column.type", "CHAR")
+                .parameter("__debezium.source.column.length", "100")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("small_char", "wide_char"),
+                List.of(smallCharSchema, wideCharSchema),
+                List.of("한글", "한".repeat(100)),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        // Byte-scaled CHAR lengths that fit within StarRocks' 255 byte CHAR maximum stay CHAR;
+        // wider columns are promoted to VARCHAR.
+        getSink().assertColumn(destinationTable, "small_char", "CHAR", 40);
+        getSink().assertColumn(destinationTable, "wide_char", "VARCHAR", 400);
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("small_char")).isEqualTo("한글");
+            assertThat(rs.getString("wide_char")).isEqualTo("한".repeat(100));
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldMapFloatingPointTypes(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("float_data", "double_data"),
+                List.of(Schema.OPTIONAL_FLOAT32_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA),
+                List.of(3.14f, 2.718281828459045d),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        // StarRocks rejects float(p) and "double precision"; the dialect emits the plain names
+        getSink().assertColumn(destinationTable, "float_data", "FLOAT");
+        getSink().assertColumn(destinationTable, "double_data", "DOUBLE");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getFloat("float_data")).isEqualTo(3.14f);
+            assertThat(rs.getDouble("double_data")).isEqualTo(2.718281828459045d);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldMapBooleanToNativeBooleanType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_BOOLEAN_SCHEMA,
+                Boolean.TRUE,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getBoolean("data")).isTrue();
+            return null;
+        });
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkDeleteEnabledIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkDeleteEnabledIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkDeleteEnabledTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * Delete enabled tests for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkDeleteEnabledIT extends AbstractJdbcSinkDeleteEnabledTest {
+
+    public JdbcSinkDeleteEnabledIT(Sink sink) {
+        super(sink);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkInsertModeIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkInsertModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * Insert mode tests for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
+
+    public JdbcSinkInsertModeIT(Sink sink) {
+        super(sink);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkJsonTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkJsonTypeMappingIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.Json;
+
+/**
+ * JSON type mappings for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkJsonTypeMappingIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkJsonTypeMappingIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testShouldCreateAndWriteJsonAndMapColumnTypes(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("json_data", "map_data"),
+                List.of(Json.schema(), mapSchema),
+                List.of("{\"a\":1}", Map.of("b", "2")),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "json_data", "JSON");
+        getSink().assertColumn(destinationTable, "map_data", "JSON");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("json_data")).contains("\"a\"");
+            assertThat(rs.getString("map_data")).contains("\"b\"");
+            return null;
+        });
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkPrimaryKeyModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkPrimaryKeyModeIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.assertj.core.data.Index;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkPrimaryKeyModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * Primary key mode tests for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkPrimaryKeyModeIT extends AbstractJdbcSinkPrimaryKeyModeTest {
+
+    public JdbcSinkPrimaryKeyModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected void assertHasPrimaryKeyColumns(String tableName, boolean caseInsensitive, String... columnNames) {
+        // The StarRocks JDBC driver does not expose primary keys through JDBC metadata.
+        List<String> pkColumnNames = StarRocksTestUtils.getPrimaryKeyColumnNames(dataSource(), tableName);
+        if (columnNames.length == 0) {
+            assertThat(pkColumnNames).isEmpty();
+        }
+        else if (caseInsensitive) {
+            pkColumnNames = pkColumnNames.stream().map(String::toLowerCase).collect(Collectors.toList());
+            assertThat(pkColumnNames.size()).isEqualTo(columnNames.length);
+            for (int columnIndex = 0; columnIndex < columnNames.length; ++columnIndex) {
+                assertThat(pkColumnNames).contains(columnNames[columnIndex].toLowerCase(), Index.atIndex(columnIndex));
+            }
+        }
+        else {
+            // noinspection ConfusingArgumentToVarargsMethod
+            assertThat(pkColumnNames).containsExactly(columnNames);
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/OpenLineageJdbcSinkTestIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/OpenLineageJdbcSinkTestIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractOpenLineageJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * OpenLineage integration tests for StarRocks.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class OpenLineageJdbcSinkTestIT extends AbstractOpenLineageJdbcSinkTest {
+
+    public OpenLineageJdbcSinkTestIT(Sink sink) {
+        super(sink);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/StarRocksTestUtils.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/StarRocksTestUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+/**
+ * Test utilities for StarRocks.
+ */
+final class StarRocksTestUtils {
+
+    private StarRocksTestUtils() {
+    }
+
+    /**
+     * The StarRocks JDBC driver does not expose primary keys through the JDBC metadata API,
+     * as {@code SHOW KEYS} returns an empty result for StarRocks PRIMARY KEY tables; the key
+     * columns are read from {@code information_schema} instead.
+     */
+    static List<String> getPrimaryKeyColumnNames(DataSource dataSource, String tableName) {
+        final List<String> primaryKeyColumnNames = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT column_name FROM information_schema.columns " +
+                                "WHERE table_schema = DATABASE() AND table_name = ? AND column_key = 'PRI' " +
+                                "ORDER BY ordinal_position")) {
+            statement.setString(1, tableName);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    primaryKeyColumnNames.add(rs.getString(1));
+                }
+            }
+            return primaryKeyColumnNames;
+        }
+        catch (SQLException e) {
+            throw new IllegalStateException("Failed to read table '" + tableName + "' primary key columns", e);
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/SinkType.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/SinkType.java
@@ -14,6 +14,7 @@ public enum SinkType {
 
     MYSQL("mysql"),
     SINGLESTORE("singlestore"),
+    STARROCKS("starrocks"),
     POSTGRES("postgres"),
     COCKROACHDB("cockroachdb"),
     SQLSERVER("sqlserver"),

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/StarRocksContainer.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/StarRocksContainer.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.junit.jupiter;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.testing.testcontainers.ImageNames;
+
+/**
+ * A Testcontainers database container for the StarRocks all-in-one image.
+ */
+public class StarRocksContainer<SELF extends StarRocksContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+
+    public static final String NAME = "starrocks";
+    public static final Integer STARROCKS_QUERY_PORT = 9030;
+
+    // The all-in-one image can take several minutes to become writable when it starts
+    // alongside other containers; this timeout also bounds the readiness probe loop.
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(10);
+
+    private static final String DEFAULT_USER = "root";
+    private static final String DEFAULT_PASSWORD = "";
+
+    private String databaseName = "test";
+    private String username = DEFAULT_USER;
+    private String password = DEFAULT_PASSWORD;
+
+    public StarRocksContainer() {
+        this(ImageNames.STARROCKS_DOCKER_IMAGE_NAME);
+    }
+
+    public StarRocksContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public StarRocksContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(ImageNames.STARROCKS_DOCKER_IMAGE_NAME);
+        addExposedPort(STARROCKS_QUERY_PORT);
+        withStartupTimeout(STARTUP_TIMEOUT);
+        withStartupTimeoutSeconds((int) STARTUP_TIMEOUT.toSeconds());
+    }
+
+    @Override
+    protected void configure() {
+        // Without a database qualifier the driver iterates every database for JDBC metadata
+        // lookups, which StarRocks answers with analyzing errors for non-matching databases.
+        withUrlParam("nullDatabaseMeansCurrent", "true");
+        setStartupAttempts(1);
+    }
+
+    @Override
+    protected void waitUntilContainerStarted() {
+        // The all-in-one image starts a frontend and a backend node; the frontend accepts
+        // connections before the backend has registered, so wait until the backend reports
+        // itself alive and create the test database before the JDBC readiness probe (which
+        // connects to getJdbcUrl(), i.e. the "/<databaseName>" schema) runs.
+        final String baseUrl = "jdbc:starrocks://" + getHost() + ":" + getMappedPort(STARROCKS_QUERY_PORT)
+                + "/" + constructUrlParameters("?", "&");
+        Unreliables.retryUntilSuccess((int) STARTUP_TIMEOUT.toSeconds(), TimeUnit.SECONDS, () -> {
+            try (Connection connection = DriverManager.getConnection(baseUrl, getUsername(), getPassword());
+                    Statement statement = connection.createStatement()) {
+                try (ResultSet rs = statement.executeQuery("SHOW BACKENDS")) {
+                    if (!rs.next() || !Boolean.parseBoolean(rs.getString("Alive"))) {
+                        throw new IllegalStateException("StarRocks backend is not alive yet");
+                    }
+                }
+                statement.execute("CREATE DATABASE IF NOT EXISTS " + databaseName);
+                // An alive backend only becomes eligible for tablet placement once the frontend
+                // has received its first disk report; probe with a real table creation so tests
+                // cannot start before tables can actually be created.
+                statement.execute("CREATE TABLE IF NOT EXISTS " + databaseName + ".readiness_probe (id int NOT NULL) "
+                        + "PRIMARY KEY (id) DISTRIBUTED BY HASH (id)");
+                statement.execute("DROP TABLE IF EXISTS " + databaseName + ".readiness_probe");
+            }
+            return null;
+        });
+        super.waitUntilContainerStarted();
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "com.starrocks.cj.jdbc.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        final String additionalUrlParams = constructUrlParameters("?", "&");
+        return "jdbc:starrocks://" + getHost() + ":" + getMappedPort(STARROCKS_QUERY_PORT) + "/" + databaseName + additionalUrlParams;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getTestQueryString() {
+        return "SELECT 1";
+    }
+
+    @Override
+    public SELF withDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+        return self();
+    }
+
+    @Override
+    public SELF withUsername(String username) {
+        this.username = username;
+        return self();
+    }
+
+    @Override
+    public SELF withPassword(String password) {
+        this.password = password;
+        return self();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/StarRocksSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/StarRocksSinkDatabaseContextProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.junit.jupiter;
+
+import org.testcontainers.containers.Network;
+
+import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
+
+/**
+ * An implementation of {@link AbstractSinkDatabaseContextProvider} for StarRocks.
+ */
+public class StarRocksSinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
+
+    @SuppressWarnings("resource")
+    public StarRocksSinkDatabaseContextProvider() {
+        super(SinkType.STARROCKS, createContainer());
+    }
+
+    private static StarRocksContainer<?> createContainer() {
+        final StarRocksContainer<?> container = new StarRocksContainer<>(ImageNames.STARROCKS_DOCKER_IMAGE_NAME)
+                .withNetwork(Network.SHARED)
+                .withEnv("TZ", TestHelper.getSinkTimeZone());
+        if (TestHelper.isConnectionTimeZoneUsed()) {
+            container.withUrlParam("connectionTimeZone", TestHelper.getSinkTimeZone());
+        }
+        return container;
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
@@ -15,6 +15,10 @@ public final class ImageNames {
 
     private static final String SINGLESTORE_IMAGE = "ghcr.io/singlestore-labs/singlestoredb-dev:0.2.77";
 
+    // The explicit registry prevents the image name from being rewritten by the
+    // hub.image.name.prefix substitution; the image is only published on Docker Hub.
+    private static final String STARROCKS_IMAGE = "docker.io/starrocks/allin1-ubuntu:4.1.1";
+
     public static final String OFFICIAL_MONGODB_IMAGE = "quay.io/debezium/official-mongo:8.0";
 
     public static final DockerImageName POSTGRES_DOCKER_IMAGE_NAME = DockerImageName.parse(POSTGRES_IMAGE)
@@ -24,6 +28,8 @@ public final class ImageNames {
             .asCompatibleSubstituteFor("postgres");
 
     public static final DockerImageName SINGLESTORE_DOCKER_IMAGE_NAME = DockerImageName.parse(SINGLESTORE_IMAGE);
+
+    public static final DockerImageName STARROCKS_DOCKER_IMAGE_NAME = DockerImageName.parse(STARROCKS_IMAGE);
 
     public static final DockerImageName OFFICIAL_DOCKER_IMAGE_NAME = DockerImageName.parse(OFFICIAL_MONGODB_IMAGE)
             .asCompatibleSubstituteFor("mongodb");

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -22,7 +22,7 @@ toc::[]
 endif::community[]
 
 The {prodname} JDBC connector is a Kafka Connect sink connector implementation that can consume events from multiple source topics, and then write those events to a relational database by using a JDBC driver.
-This connector supports a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, and SQL Server.
+This connector supports a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
 
 // Type: assembly
 // ModuleID: debezium-jdbc-connector-how-the-debezium-connector-works
@@ -45,6 +45,7 @@ The {prodname} JDBC connector provides the following features:
 * xref:jdbc-idempotent-writes[Idempotent writes]
 * xref:jdbc-schema-evolution[Schema evolution]
 * xref:jdbc-singlestore-targets[SingleStore sink targets]
+* xref:jdbc-starrocks-targets[StarRocks sink targets]
 * xref:jdbc-quoting-case-sensitivity[JDBC quoting and case-sensitivity]
 * xref:jdbc-connection-idle-timeouts[Connection idle timeouts]
 
@@ -68,6 +69,42 @@ For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logi
 The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values to the SingleStore `GEOGRAPHY` column type, and `io.debezium.data.geometry.Point` logical values to the SingleStore `GEOGRAPHYPOINT` column type.
 SingleStore supports a subset of WKT geospatial values.
 The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.
+
+// Type: concept
+// Title: Using StarRocks as a sink target
+// ModuleID: debezium-jdbc-connector-using-starrocks-as-a-sink-target
+[[jdbc-starrocks-targets]]
+=== StarRocks sink targets
+
+To write to StarRocks, configure xref:jdbc-property-connection-url[`connection.url`] with a StarRocks JDBC URL, for example, `jdbc:starrocks://<_host_>:9030/<_database_>`.
+The StarRocks JDBC driver is included in the {prodname} JDBC connector archive, so Kafka Connect deployments that use the connector archive do not require an additional StarRocks driver JAR.
+The connector automatically detects a StarRocks target from the driver, so no dialect configuration is required.
+To write to a database in a catalog other than `default_catalog`, specify a fully qualified `<_catalog_>.<_database_>` path in the connection URL, or set the xref:jdbc-property-dialect-starrocks-catalog-name[`dialect.starrocks.catalog.name`] property.
+
+StarRocks targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+StarRocks executes `INSERT` statements against PRIMARY KEY tables as upserts, so the connector generates plain `INSERT` statements; `INSERT ... ON DUPLICATE KEY UPDATE ...` is not supported by StarRocks.
+Upsert and delete operations require the destination table to be a StarRocks PRIMARY KEY table.
+Tables that the connector creates automatically from events with key fields are always PRIMARY KEY tables.
+
+If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
+Tables that the connector creates use `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses based on the record key fields.
+StarRocks limits the encoded size of all primary key column values of a PRIMARY KEY table to 128 bytes and does not permit `FLOAT`, `DOUBLE`, or `DECIMAL` key columns.
+Automatic table creation does not expose StarRocks-specific distribution, partitioning, or other table option settings.
+If the target table requires explicit table options, create the destination table in StarRocks before the connector writes to it.
+StarRocks applies `ALTER TABLE` schema changes asynchronously; writes that arrive while a schema change is still running can fail transiently and are retried by the connector.
+
+StarRocks has no `TIME` data type.
+The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.MicroTime`, and `io.debezium.time.NanoTime` logical values, and Kafka Connect `Time` values, to `VARCHAR` columns as `HH:mm:ss.ffffff` formatted strings.
+MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
+`io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
+StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
+Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
+StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so the connector multiplies propagated character lengths by four, up to the maximum length of 1048576; `CHAR` columns whose scaled length exceeds the 255 byte `CHAR` maximum are promoted to `VARCHAR`.
+`BYTES` values are written to `VARBINARY` columns, which are limited to the same 1048576 byte maximum.
+`DECIMAL` columns support a maximum precision of 38; the connector caps larger propagated precisions at 38, and values that exceed the capped precision fail on write.
+When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
+{prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
+The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
 
 // Type: concept
 // Title: Description of how the {prodname} JDBC connector consumes complex change events
@@ -242,6 +279,9 @@ The following table shows the `upsert` DML syntax for the database dialects that
 |SQL Server
 |`MERGE ...`
 
+|StarRocks
+|`INSERT ...` (PRIMARY KEY tables execute inserts as upserts)
+
 |===
 
 // Type: reference
@@ -280,6 +320,9 @@ To adjust nullability settings or default values, you can introduce a custom sin
 
 For SingleStore targets, automatic table creation does not configure SingleStore-specific shard keys, sort keys, or other table options.
 For more information, see xref:jdbc-singlestore-targets[].
+
+For StarRocks targets, automatic table creation creates PRIMARY KEY tables from the record key fields, and does not configure StarRocks-specific distribution, partitioning, or other table options.
+For more information, see xref:jdbc-starrocks-targets[].
 
 A field's data type is resolved based on a predefined set of mappings.
 For more information, see xref:jdbc-field-types[JDBC field types].
@@ -683,6 +726,8 @@ SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
 Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
 {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values are written to SingleStore `geography` columns, and `io.debezium.data.geometry.Point` logical values are written to SingleStore `geographypoint` columns.
 The SingleStore dialect writes supported `POINT`, `LINESTRING`, and `POLYGON` WKB values as WKT strings.
+
+For StarRocks targets, see xref:jdbc-starrocks-targets[] for the dialect-specific type mappings, including the string-based representation that the dialect uses for time types.
 
 // Type: reference
 // Title: Mappings between {prodname} vector data types and RDBMS column types
@@ -1804,6 +1849,13 @@ For information about the performance benefits of enabling the UNNEST function, 
 |`false`
 |Specifies whether the connector automatically sets an `IDENTITY_INSERT` before an `INSERT` or `UPSERT` operation into the identity column of SQL Server tables, and then unsets it immediately after the operation.
 When the default setting (`false`) is in effect, an `INSERT` or `UPSERT` operation into the `IDENTITY` column of a table results in a SQL exception.
+
+|[[jdbc-property-dialect-starrocks-catalog-name]]<<jdbc-property-dialect-starrocks-catalog-name, `+dialect.starrocks.catalog.name+`>>
+|No default
+|Specifies the name of the StarRocks catalog that the connector writes into.
+When this property is set, the connector executes `SET CATALOG <_name_>` on every new connection before any session work.
+The value must be a valid StarRocks catalog name, that is, it may contain only letters, digits, and underscores, and must not start with a digit; other values are rejected during configuration validation.
+The StarRocks JDBC driver also supports specifying the catalog directly in the connection URL, for example, `jdbc:starrocks://<_host_>:9030/<_catalog_>.<_database_>`.
 
 |[[jdbc-property-batch-size]]<<jdbc-property-batch-size, `+batch.size+`>>
 |`500`

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -2215,7 +2215,7 @@ Use this option when you want to map the value of a specific static constant to 
 ==== JDBC
 
 The JDBC sink writes change events directly to a relational database using JDBC.
-It leverages the xref:connectors/jdbc.adoc[{prodname} JDBC connector] under the hood, supporting a wide variety of database dialects, including Db2, MySQL, Oracle, PostgreSQL, SingleStore, and SQL Server.
+It leverages the xref:connectors/jdbc.adoc[{prodname} JDBC connector] under the hood, supporting a wide variety of database dialects, including Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
 
 The sink supports idempotent writes by using upsert semantics, basic schema evolution to automatically create or alter destination tables, and delete propagation.
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.41.0</version.mysql.binlog>
         <version.singlestore.driver>1.2.11</version.singlestore.driver>
+        <version.starrocks.driver>1.1.1</version.starrocks.driver>
         <version.mongo.driver>5.6.2</version.mongo.driver>
         <version.sqlserver.driver>12.4.2.jre8</version.sqlserver.driver>
         <version.db2.driver>11.5.0.0</version.db2.driver>


### PR DESCRIPTION
### Related issues

- Fixes https://github.com/debezium/dbz/issues/815 — Introduce dialect support for StarRocks database
- Fixes https://github.com/debezium/dbz/issues/979 — Support setting target schema for JDBC sink with StarRocks target

### Summary

Adds initial StarRocks support to the Debezium JDBC sink connector, following the structure of the SingleStore support in #7566.

- **Dialect & automatic detection**: StarRocks speaks the MySQL wire protocol but is not DDL-compatible with MySQL, so the Debezium dialect extends `GeneralDatabaseDialect` while a minimal Hibernate `StarRocksDialect` (mirroring Hibernate's `TiDBDialect` precedent) pins the diverging column types. The bundled `com.starrocks:starrocks-connector-j` driver reports the `StarRocks` product name, which a registered Hibernate `DialectResolver` resolves automatically — no `hibernate.dialect` configuration is needed.
- **Upserts & table creation**: StarRocks executes `INSERT` statements against PRIMARY KEY tables as upserts (it has no `ON DUPLICATE KEY UPDATE`), so `insert.mode=upsert` generates plain inserts. Auto-created tables emit `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses from the record key fields, with `NULL/NOT NULL` placed before `DEFAULT` as StarRocks requires.
- **Type mappings** (verified against StarRocks 4.1.1): time logical types are stored as `HH:mm:ss.ffffff` strings (StarRocks has no TIME type; MySQL's ±838h range keeps its notation), `DATETIME` retains microsecond precision, `VARCHAR` character lengths are scaled ×4 for StarRocks' byte semantics (wide `CHAR` promotes to `VARCHAR`), `BIGINT UNSIGNED` maps to `LARGEINT` preserving the full unsigned range, `DECIMAL` precision is capped at 38, JSON/MAP map to `JSON`, and `BOOLEAN` maps to native `boolean`.
- **Metadata handling**: JDBC metadata lookups are qualified with the current database (the driver otherwise iterates every database and StarRocks errors on non-matching ones), and `BYTES` binding converts `ByteBuffer` values the driver cannot bind.
- **Catalog option** (dbz#979): `dialect.starrocks.catalog.name` executes `SET CATALOG <name>` on every new pooled connection, enabling writes into catalogs other than `default_catalog`; the driver URL's `<catalog>.<database>` form is documented as the primary path.
- **Tests & docs**: unit tests pin the dialect mappings and boundary cases; 108 integration tests (insert/delete/primary-key modes, CloudEvents, JSON, column type mappings including boundary values and writes into user-created `STRING` tables, OpenLineage) all pass against a StarRocks 4.1.1 Testcontainer; an e2e MySQL→StarRocks pipeline test and the `it-starrocks,e2e-starrocks` CI matrix entry are included, along with connector documentation covering the type mappings and limitations.

### Out of scope

- Geospatial and vector logical types, and mapping Kafka Connect `ARRAY`/`STRUCT` schemas to StarRocks `ARRAY`/`STRUCT` columns.
- StarRocks Stream Load based ingestion (this dialect uses the standard JDBC write path).
- `DECIMAL` precisions above StarRocks' maximum of 38.
