### PR TITLE
debezium/dbz#2208 Remove dead undeliveredToastableColumns set in PostgreSQL columnValues()

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -8,13 +8,11 @@ package io.debezium.connector.postgresql;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
@@ -172,11 +170,9 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
         // JSON does not deliver a list of all columns for REPLICA IDENTITY DEFAULT
         Object[] values = new Object[columnsWithoutToasted.size() < schemaColumns.size() ? schemaColumns.size() : columnsWithoutToasted.size()];
 
-        final Set<String> undeliveredToastableColumns = new HashSet<>(schema.getToastableColumnsForTableId(table.id()));
         for (ReplicationMessage.Column column : columns) {
             // DBZ-298 Quoted column names will be sent like that in messages, but stored unquoted in the column names
             final String columnName = Strings.unquoteIdentifierPart(column.getName());
-            undeliveredToastableColumns.remove(columnName);
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {


### PR DESCRIPTION
Fixes debezium/dbz#2208

## Description

`PostgresChangeRecordEmitter#columnValues()` builds a per-record `Set` of toastable column names that is never read:

```java
final Set<String> undeliveredToastableColumns = new HashSet<>(schema.getToastableColumnsForTableId(table.id()));
for (ReplicationMessage.Column column : columns) {
    // DBZ-298 Quoted column names will be sent like that in messages, but stored unquoted in the column names
    final String columnName = Strings.unquoteIdentifierPart(column.getName());
    undeliveredToastableColumns.remove(columnName);
    ...
}
```

The set is only ever written to — created and then `remove(...)`-ed per column — but its contents are never read afterwards. The `remove(...)` return value is discarded, and the set is a defensive copy so removing entries does not affect the source list either.

This is leftover bookkeeping from the wal2json removal: commit d299c9e707 ([DBZ-4156](https://issues.redhat.com/browse/DBZ-4156), "Remove wal2json support") deleted the *only* consumer of this set — a `if (unchangedToastColumnMarkerMissing) { for (String columnName : undeliveredToastableColumns) { ... } }` block that recovered missing toasted values for the wal2json decoder — but left the declaration and the `remove(...)` call behind.

This PR removes the dead declaration and `remove(...)` call, along with the now-unused `HashSet` / `Set` imports. The change is behavior-preserving:

- the set was never read, so nothing downstream depends on it
- `schema.getToastableColumnsForTableId(...)` is a pure getter (returns a stored list or `Collections.emptyList()`), so dropping the call that only fed the discarded copy is observably inert

As a side effect it also avoids a per-record `HashSet` allocation and a `remove(...)` hash lookup per column on the streaming hot path (`columnValues()` runs once per INSERT/DELETE and twice per UPDATE, for every captured row), but the primary motivation is dead-code removal.

## Verification

`RecordsStreamProducerIT` toasted-column and REPLICA IDENTITY FULL streaming tests pass against PostgreSQL 17 (pgoutput): `shouldNotPropagateUnchangedToastedData`, `shouldHandleToastedArrayColumn`, `shouldHandleToastedByteArrayColumn`, `shouldHandleToastedIntegerArrayColumn`, `shouldHandleToastedArrayColumnForReplicaIdentityFullTable`, `shouldHandleToastedByteArrayColumnForReplicaIdentityFullTable`, `shouldHandleToastedIntegerArrayColumnForReplicaIdentityFullTable` — 7 run, 0 failures.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
