### PR TITLE
debezium/dbz#2210 Fix hardcoded MySQL connector type in CdcSourceTaskContext

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -423,6 +423,7 @@ Lukas Langegger
 Lukasz Korzeniowski
 Lukasz Selwa
 Luke Alexander
+Lekhraj Kumar
 lyidataminr
 M Sazzadul Hoque
 Maarten Vercruysse

--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
@@ -79,7 +79,7 @@ public class CdcSourceTaskContext<T extends CommonConnectorConfig> {
      * @throws IllegalArgumentException if any of the parameters are null
      */
     public void temporaryLoggingContext(CommonConnectorConfig connectorConfig, String contextName, Runnable operation) {
-        LoggingContext.temporarilyForConnector("MySQL", connectorConfig.getLogicalName(), contextName, operation);
+        LoggingContext.temporarilyForConnector(connectorType, connectorConfig.getLogicalName(), contextName, operation);
     }
 
     /**

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -383,3 +383,4 @@ leosanqing,刘镕通
 sundongkim-dev,Sundong Kim
 Paul_Kim,Sundong Kim
 TimurRakhmatullin86,Timur Rakhmatullin
+lekhrocks,Lekhraj Kumar


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2210

## Description
<!-- Briefly describe your changes here. -->
`CdcSourceTaskContext.temporaryLoggingContext()` hardcodes `"MySQL"` as the firstargument to LoggingContext.temporarilyForConnector() instead of using the actual connector type. Replace it with the existing `connectorType` field which correctly reflects the connector (e.g. "Postgres", "Oracle", "SqlServer").

The only current caller is `BinlogStreamingChangeEventSource` (MySQL/MariaDB), so this bug has no observable effect today, but fixes the method for future use by other connectors.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
