### PR TITLE
Dbz 9916 remove hard line breaks from postgresql.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -33,7 +33,11 @@ ifdef::product[]
 For information about the PostgreSQL versions that are compatible with the connector, see the link:{LinkDebeziumSupportedConfigurations}[{NameDebeziumSupportedConfigurations}].
 endif::product[]
 
-The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic.
+The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas.
+After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database.
+The connector generates data change event records and streams them to Kafka topics.
+For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table.
+Applications and services consume data change event records from that topic.
 
 ifdef::product[]
 Information and procedures for using a {prodname} PostgreSQL connector is organized as follows:
@@ -56,7 +60,8 @@ endif::product[]
 [[postgresql-overview]]
 == Overview
 
-PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. The output plug-in enables clients to consume the changes.
+PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_].
+The output plug-in enables clients to consume the changes.
 
 The PostgreSQL connector contains two main parts that work together to read and process database changes:
 
@@ -69,18 +74,27 @@ By default, provided that {prodname} connects to the database as a user that has
 In production environments, if you want to assert greater control over the setup process, you can create the replication slot manually.
 You can configure the connector to use either of the following plug-ins:
 link:https://github.com/debezium/postgres-decoderbufs[`decoderbufs`]::: Decoding plug-in that is based on Protobuf and maintained by the {prodname} community.
-`pgoutput`::: The standard logical decoding output plug-in in PostgreSQL 10+. It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+`pgoutput`::: The standard logical decoding output plug-in in PostgreSQL 10+.
+It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication].
+This plug-in is always present so no additional libraries need to be installed.
+The {prodname} connector interprets the raw replication event stream directly into change events.
 
-Java code:: The Kafka Connect connector that reads the changes produced by the chosen logical decoding output plug-in. The connector uses the PostgreSQL link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
+Java code:: The Kafka Connect connector that reads the changes produced by the chosen logical decoding output plug-in.
+The connector uses the PostgreSQL link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
 endif::community[]
 
 ifdef::product[]
-* `pgoutput` is the standard logical decoding output plug-in in PostgreSQL 10+. This is the only supported logical decoding output plug-in in this {prodname} release. This plug-in is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+* `pgoutput` is the standard logical decoding output plug-in in PostgreSQL 10+.
+This is the only supported logical decoding output plug-in in this {prodname} release.
+This plug-in is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication].
+This plug-in is always present so no additional libraries need to be installed.
+The {prodname} connector interprets the raw replication event stream directly into change events.
 
 * Java code (the actual Kafka Connect connector) that reads the changes produced by the logical decoding output plug-in by using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_] and the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_].
 endif::product[]
 
-The connector produces a _change event_ for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
+The connector produces a _change event_ for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic.
+Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
 PostgreSQL normally purges write-ahead log (WAL) segments after some period of time.
 This means that the connector does not have the complete history of all changes that have been made to the database.
@@ -99,8 +113,13 @@ If the connector stops during a snapshot, the connector begins a new snapshot wh
 ====
 The connector relies on and reflects the PostgreSQL logical decoding feature, which has the following limitations:
 
-* Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
-* Because logical decoding replication slots publish changes during commit -- and not post commit -- undesirable side-effects can occur. There are two main scenarios when clients can observe inconsistent states. First, publishing uncommitted changes when the master dies before replication completes. Second, publishing changes that cannot be read (i.e., read-after-write consistency) temporarily because they are being replicated. For example, a DebeziumEngine consumer receives a notification of a row that was created but it cannot be read by a transaction.
+* Logical decoding does not support DDL changes.
+This means that the connector is unable to report DDL change events back to consumers.
+* Because logical decoding replication slots publish changes during commit -- and not post commit -- undesirable side-effects can occur.
+There are two main scenarios when clients can observe inconsistent states.
+First, publishing uncommitted changes when the master dies before replication completes.
+Second, publishing changes that cannot be read (i.e., read-after-write consistency) temporarily because they are being replicated.
+For example, a DebeziumEngine consumer receives a notification of a row that was created but it cannot be read by a transaction.
 
 Additionally, the `pgoutput` logical decoding output plug-in does not capture values for generated columns, resulting in missing data for these columns in the connector's output.
 
@@ -323,19 +342,34 @@ include::{partialsdir}/modules/all-connectors/con-connector-blocking-snapshot.ad
 [[postgresql-streaming-changes]]
 === Streaming changes
 
-The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on link:https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_]. This protocol enables clients to receive changes from the server as they are committed in the server's transaction log at certain positions, which are referred to as Log Sequence Numbers (LSNs).
+The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected.
+This mechanism relies on link:https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_].
+This protocol enables clients to receive changes from the server as they are committed in the server's transaction log at certain positions, which are referred to as Log Sequence Numbers (LSNs).
 
-Whenever the server commits a transaction, a separate server process invokes a callback function from the xref:postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
+Whenever the server commits a transaction, a separate server process invokes a callback function from the xref:postgresql-output-plugin[logical decoding plug-in].
+This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
 
-The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
+The {prodname} PostgreSQL connector acts as a PostgreSQL client.
+When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event.
+The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process.
+The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
 
-Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic. The offset indicates source-specific position information that {prodname} includes with each event. For the PostgreSQL connector, the LSN recorded in each change event is the offset.
+Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic.
+The offset indicates source-specific position information that {prodname} includes with each event.
+For the PostgreSQL connector, the LSN recorded in each change event is the offset.
 
-When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector. When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset. When the connector restarts, it sends a request to the PostgreSQL server to send the events starting just after that position.
+When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector.
+When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset.
+When the connector restarts, it sends a request to the PostgreSQL server to send the events starting just after that position.
 
 [NOTE]
 ====
-The PostgreSQL connector retrieves schema information as part of the events sent by the logical decoding plug-in. However, the connector does not retrieve information about which columns compose the primary key. The connector obtains this information from the JDBC metadata (side channel). If the primary key definition of a table changes (by adding, removing or renaming primary key columns), there is a tiny period of time when the primary key information from JDBC is not synchronized with the change event that the logical decoding plug-in generates. During this tiny period, a message could be created with an inconsistent key structure. To prevent this inconsistency, update primary key structures as follows:
+The PostgreSQL connector retrieves schema information as part of the events sent by the logical decoding plug-in.
+However, the connector does not retrieve information about which columns compose the primary key.
+The connector obtains this information from the JDBC metadata (side channel).
+If the primary key definition of a table changes (by adding, removing or renaming primary key columns), there is a tiny period of time when the primary key information from JDBC is not synchronized with the change event that the logical decoding plug-in generates.
+During this tiny period, a message could be created with an inconsistent key structure.
+To prevent this inconsistency, update primary key structures as follows:
 
 . Put the database or an application into a read-only mode.
 . Let {prodname} process all remaining events.
@@ -348,7 +382,8 @@ The PostgreSQL connector retrieves schema information as part of the events sent
 [[postgresql-pgoutput]]
 === PostgreSQL 10+ logical decoding support (`pgoutput`)
 
-As of PostgreSQL 10+, there is a logical replication stream mode, called `pgoutput` that is natively supported by PostgreSQL. This means that a {prodname} PostgreSQL connector can consume that replication stream
+As of PostgreSQL 10+, there is a logical replication stream mode, called `pgoutput` that is natively supported by PostgreSQL.
+This means that a {prodname} PostgreSQL connector can consume that replication stream
 without the need for additional plug-ins.
 This is particularly valuable for environments where installation of plug-ins is not supported or not allowed.
 
@@ -371,14 +406,16 @@ _topicPrefix_:: The topic prefix as specified by the xref:postgresql-property-to
 _schemaName_:: The name of the database schema in which the change event occurred.
 _tableName_:: The name of the database table in which the change event occurred.
 
-For example, suppose that `fulfillment` is the logical server name in the configuration for a connector that is capturing changes in a PostgreSQL installation that has a `postgres` database and an `inventory` schema that contains four tables: `products`, `products_on_hand`, `customers`, and `orders`. The connector would stream records to these four Kafka topics:
+For example, suppose that `fulfillment` is the logical server name in the configuration for a connector that is capturing changes in a PostgreSQL installation that has a `postgres` database and an `inventory` schema that contains four tables: `products`, `products_on_hand`, `customers`, and `orders`.
+The connector would stream records to these four Kafka topics:
 
 * `fulfillment.inventory.products`
 * `fulfillment.inventory.products_on_hand`
 * `fulfillment.inventory.customers`
 * `fulfillment.inventory.orders`
 
-Now suppose that the tables are not part of a specific schema but were created in the default `public` PostgreSQL schema. The names of the Kafka topics would be:
+Now suppose that the tables are not part of a specific schema but were created in the default `public` PostgreSQL schema.
+The names of the Kafka topics would be:
 
 * `fulfillment.public.products`
 * `fulfillment.public.products_on_hand`
@@ -488,11 +525,20 @@ Following is an example of a message:
 [[postgresql-events]]
 == Data change events
 
-The {prodname} PostgreSQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed.
+The {prodname} PostgreSQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation.
+Each event contains a key and a value.
+The structure of the key and the value depends on the table that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_.
+However, the structure of these events may change over time, which can be difficult for consumers to handle.
+To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry.
+This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure:
+The following skeleton JSON shows the basic four parts of a change event.
+However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events.
+A `schema` field is in a change event only when you configure the converter to produce it.
+Likewise, the event key and event payload are in a change event only if you configure a converter to produce it.
+If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -519,21 +565,29 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 
 |1
 |`schema`
-a|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed.
+a|The first `schema` field is part of the event key.
+It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion.
+In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed.
 
-It is possible to override the table's primary key by setting the xref:postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:postgresql-property-message-key-columns[`message.key.columns` connector configuration property].
+In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
-|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
+|The first `payload` field is part of the event key.
+It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas.
+|The second `schema` field is part of the event value.
+It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion.
+In other words, the second `schema` describes the structure of the row that was changed.
+Typically, this schema contains nested schemas.
 
 |4
 |`payload`
-|The second `payload` field is part of the event value. It has the structure described by the previous `schema` field and it contains the actual data for the row that was changed.
+|The second `payload` field is part of the event value.
+It has the structure described by the previous `schema` field and it contains the actual data for the row that was changed.
 
 |===
 
@@ -547,7 +601,10 @@ Starting with Kafka 0.10, Kafka can optionally record the event key and value wi
 
 [WARNING]
 ====
-The PostgreSQL connector ensures that all Kafka Connect schema names adhere to the http://avro.apache.org/docs/current/spec.html#names[Avro schema name format]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
+The PostgreSQL connector ensures that all Kafka Connect schema names adhere to the http://avro.apache.org/docs/current/spec.html#names[Avro schema name format].
+This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_.
+Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_.
+If there is an invalid character it is replaced with an underscore character.
 
 This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contains invalid characters, and the only characters that distinguish names from one another are invalid and thus replaced with underscores.
 ====
@@ -566,7 +623,8 @@ endif::product[]
 [[postgresql-change-events-key]]
 === Change event keys
 
-For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created. Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint.
+For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created.
+Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint.
 
 Consider a `customers` table defined in the `public` database schema and the example of a change event key for that table.
 
@@ -620,7 +678,10 @@ If the `topic.prefix` connector configuration property has the value `PostgreSQL
 
 |2
 |`PostgreSQL_server.inventory.customers.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example:
+a|Name of the schema that defines the structure of the key's payload.
+This schema describes the structure of the primary key for the table that was changed.
+Key schema names have the format _connector-name_._database-name_._table-name_.`Key`.
+In this example:
 
 * `PostgreSQL_server` is the name of the connector that generated this event.
 * `inventory` is the database that contains the table that was changed.
@@ -628,7 +689,9 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 
 |3
 |`optional`
-|Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
+|Indicates whether the event key must contain a value in its `payload` field.
+In this example, a value in the key's payload is required.
+A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
 |`fields`
@@ -636,7 +699,8 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 
 |5
 |`payload`
-|Contains the key for the row for which this change event was generated. In this example, the key, contains a single `id` field whose value is `1`.
+|Contains the key for the row for which this change event was generated.
+In this example, the key, contains a single `id` field whose value is `1`.
 
 |===
 
@@ -647,7 +711,8 @@ Although the `column.exclude.list` and `column.include.list` connector configura
 
 [WARNING]
 ====
-If the table does not have a primary or unique key, then the change event's key is null. The rows in a table without a primary or unique key constraint cannot be uniquely identified.
+If the table does not have a primary or unique key, then the change event's key is null.
+The rows in a table without a primary or unique key constraint cannot be uniquely identified.
 ====
 
 // Type: concept
@@ -656,7 +721,10 @@ If the table does not have a primary or unique key, then the change event's key 
 [[postgresql-change-events-value]]
 === Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
+The value in a change event is a bit more complicated than the key.
+Like the key, the value has a `schema` section and a `payload` section.
+The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields.
+Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
 Consider the same sample table that was used to show an example of a change event key:
 
@@ -688,16 +756,21 @@ endif::product[]
 [[postgresql-replica-identity]]
 === Replica identity
 
-link:https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL-specific table-level setting that determines the amount of information that is available to the logical decoding plug-in for `UPDATE` and `DELETE` events. More specifically, the setting of `REPLICA IDENTITY` controls what (if any) information is available for the previous values of the table columns involved, whenever an `UPDATE` or `DELETE` event occurs.
+link:https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL-specific table-level setting that determines the amount of information that is available to the logical decoding plug-in for `UPDATE` and `DELETE` events.
+More specifically, the setting of `REPLICA IDENTITY` controls what (if any) information is available for the previous values of the table columns involved, whenever an `UPDATE` or `DELETE` event occurs.
 
 There are 4 possible values for `REPLICA IDENTITY`:
 
-* `DEFAULT` - The default behavior is that `UPDATE` and `DELETE` events contain the previous values for the primary key columns of a table if that table has a primary key. For an `UPDATE` event, only the primary key columns with changed values are present.
+* `DEFAULT` - The default behavior is that `UPDATE` and `DELETE` events contain the previous values for the primary key columns of a table if that table has a primary key.
+For an `UPDATE` event, only the primary key columns with changed values are present.
 +
-If a table does not have a primary key, the connector does not emit `UPDATE` or `DELETE` events for that table. For a table without a primary key, the connector emits only _create_ events. Typically, a table without a primary key is used for appending messages to the end of the table, which means that `UPDATE` and `DELETE` events are not useful.
+If a table does not have a primary key, the connector does not emit `UPDATE` or `DELETE` events for that table.
+For a table without a primary key, the connector emits only _create_ events.
+Typically, a table without a primary key is used for appending messages to the end of the table, which means that `UPDATE` and `DELETE` events are not useful.
 * `NOTHING` - Emitted events for `UPDATE` and `DELETE` operations do not contain any information about the previous value of any table column.
 * `FULL` - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of all columns in the table.
-* `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
+* `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index.
+`UPDATE` events also contain the indexed columns with the updated values.
 
 
 // Type: reference
@@ -906,20 +979,24 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table.
+|The value's schema, which describes the structure of the value's payload.
+A change event's value schema is the same in every change event that the connector generates for a particular table.
 
 |2
 |`name`
 a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
 
-`PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
+`PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields.
+This schema is specific to the `customers` table.
 
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database.
 This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
-a|`io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates.
+a|`io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field.
+This schema is specific to the PostgreSQL connector.
+The connector uses it for all events that it generates.
 
 |4
 |`name`
@@ -927,14 +1004,17 @@ a|`PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall
 
 |5
 |`payload`
-a|The value's actual data. This is the information that the change event is providing.
+a|The value's actual data.
+This is the information that the change event is providing.
 
-It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
+It may appear that the JSON representations of the events are much larger than the rows they describe.
+This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`before`
-a|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.
+a|An optional field that specifies the state of the row before the event occurred.
+When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.
 
 [NOTE]
 ====
@@ -943,16 +1023,21 @@ Whether or not this field is available is dependent on the xref:postgresql-repli
 
 |7
 |`after`
-|An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
+|An optional field that specifies the state of the row after the event occurred.
+In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
 
 |8
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
+a|Mandatory field that describes the source metadata for the event.
+This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction.
+The source metadata includes:
 
 * {prodname} version
 * Connector type and name
 * Database and table that contains the new row
-* Stringified JSON array of additional offset information. The first value is always the last committed LSN, the second value is always the current LSN. Either value may be `null`.
+* Stringified JSON array of additional offset information.
+The first value is always the last committed LSN, the second value is always the current LSN.
+Either value may be `null`.
 * Schema name
 * If the event was part of a snapshot
 * ID of the transaction in which the operation was performed
@@ -961,7 +1046,9 @@ a|Mandatory field that describes the source metadata for the event. This field c
 
 |9
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are:
+a|Mandatory string that describes the type of operation that caused the connector to generate the event.
+In this example, `c` indicates that the operation created a row.
+Valid values are:
 
 * `c` = create
 * `u` = update
@@ -975,7 +1062,8 @@ a|Mandatory string that describes the type of operation that caused the connecto
 a|Optional field that displays the time at which the connector processed the event.
 The time is based on the system clock in the JVM running the Kafka Connect task.
 
-In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -984,7 +1072,10 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 [[postgresql-update-events]]
 === _update_ events
 
-The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table.
+Likewise, the event value's payload has the same structure.
+However, the event value payload contains different values in an _update_ event.
+Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
 
 [source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
@@ -1030,17 +1121,21 @@ The value of a change event for an update in the sample `customers` table has th
 
 |1
 |`before`
-|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
+|An optional field that contains values that were in the row before the database commit.
+In this example, only the primary key column, `id`, is present because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
 
 For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
 |2
 |`after`
-|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`.
+|An optional field that specifies the state of the row after the event occurred.
+In this example, the `first_name` value is now `Anne Marie`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes:
+a|Mandatory field that describes the source metadata for the event.
+The `source` field structure has the same fields as in a _create_ event, but some values are different.
+The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -1053,20 +1148,24 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 
 |4
 |`op`
-a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+a|Mandatory string that describes the type of operation.
+In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
 
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
 The time is based on the system clock in the JVM running the Kafka Connect task.
 
-In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
+Updating the columns for a row's primary/unique key changes the value of the row's key.
+When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row.
+Details are in the next section.
 ====
 
 
@@ -1075,18 +1174,23 @@ Updating the columns for a row's primary/unique key changes the value of the row
 === Primary key updates
 
 An `UPDATE` operation that changes a row's primary key field(s) is known
-as a primary key change. For a primary key change, in place of sending an `UPDATE` event record, the connector sends a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change:
+as a primary key change.
+For a primary key change, in place of sending an `UPDATE` event record, the connector sends a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key.
+These events have the usual structure and content, and in addition, each one has a message header related to the primary key change:
 
-* The `DELETE` event record has `__debezium.newkey` as a message header. The value of this header is the new primary key for the updated row.
+* The `DELETE` event record has `__debezium.newkey` as a message header.
+The value of this header is the new primary key for the updated row.
 
-* The `CREATE` event record has `__debezium.oldkey` as a message header. The value of this header is the previous (old) primary key that the updated row had.
+* The `CREATE` event record has `__debezium.oldkey` as a message header.
+The value of this header is the previous (old) primary key that the updated row had.
 
 
 // Type: reference
 [[postgresql-delete-events]]
 === _delete_ events
 
-The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table.
+The `payload` portion in a _delete_ event for the sample `customers` table looks like this:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -1127,17 +1231,23 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 
 |1
 |`before`
-a|Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit.
+a|Optional field that specifies the state of the row before the event occurred.
+In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit.
 
 In this example, the `before` field contains only the primary key column because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
 
 |2
 |`after`
-|Optional field that specifies the state of the row after the event occurred. In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
+|Optional field that specifies the state of the row after the event occurred.
+In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata:
+a|Mandatory field that describes the source metadata for the event.
+In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table.
+Many `source` field values are also the same.
+In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed.
+But the `source` field in a _delete_ event value provides the same metadata:
 
 * {prodname} version
 * Connector type and name
@@ -1150,14 +1260,16 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 
 |4
 |`op`
-a|Mandatory string that describes the type of operation. The `op` field value is `d`, signifying that this row was deleted.
+a|Mandatory string that describes the type of operation.
+The `op` field value is `d`, signifying that this row was deleted.
 
 |5
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
 The time is based on the system clock in the JVM running the Kafka Connect task.
 
-In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -1165,16 +1277,21 @@ A _delete_ change event record provides a consumer with the information it needs
 
 [WARNING]
 ====
-For a consumer to be able to process a _delete_ event generated for a table that does not have a primary key, set the table's `REPLICA IDENTITY` to `FULL`. When a table does not have a primary key and the table's `REPLICA IDENTITY` is set to `DEFAULT` or `NOTHING`, a _delete_ event has no `before` field.
+For a consumer to be able to process a _delete_ event generated for a table that does not have a primary key, set the table's `REPLICA IDENTITY` to `FULL`.
+When a table does not have a primary key and the table's `REPLICA IDENTITY` is set to `DEFAULT` or `NOTHING`, a _delete_ event has no `before` field.
 ====
 
-PostgreSQL connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
+PostgreSQL connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction].
+Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept.
+This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
 
 // Type: reference
 [[postgresql-tombstone-events]]
 .Tombstone events
-When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the PostgreSQL connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
+When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key.
+However, for Kafka to remove all messages that have that same key, the message value must be `null`.
+To make this possible, the PostgreSQL connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
 
 
 // Type: reference
@@ -1219,7 +1336,8 @@ The message key is `null` in this case, the message value looks like this:
 
 |1
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata:
+a|Mandatory field that describes the source metadata for the event.
+In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata:
 
 * {prodname} version
 * Connector type and name
@@ -1232,7 +1350,8 @@ a|Mandatory field that describes the source metadata for the event. In a _trunca
 
 |2
 |`op`
-a|Mandatory string that describes the type of operation. The `op` field value is `t`, signifying that this table was truncated.
+a|Mandatory string that describes the type of operation.
+The `op` field value is `t`, signifying that this table was truncated.
 
 |3
 |`ts_ms`, `ts_us`, `ts_ns`
@@ -1341,7 +1460,8 @@ The message value looks like this for non-transactional messages:
 
 |1
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _message_ event value, the `source` field structure will not have `table` or `schema` information for any _message_ events and will only have `txId` if the _message_ event is transactional.
+a|Mandatory field that describes the source metadata for the event.
+In a _message_ event value, the `source` field structure will not have `table` or `schema` information for any _message_ events and will only have `txId` if the _message_ event is transactional.
 
 * {prodname} version
 * Connector type and name
@@ -1356,16 +1476,19 @@ a|Mandatory field that describes the source metadata for the event. In a _messag
 
 |2
 |`op`
-a|Mandatory string that describes the type of operation. The `op` field value is `m`, signifying that this is a _message_ event.
+a|Mandatory string that describes the type of operation.
+The `op` field value is `m`, signifying that this is a _message_ event.
 
 |3
 |`ts_ms`, `ts_us`, `ts_ns`
 a|Optional field that displays the time at which the connector processed the event.
 The time is based on the system clock in the JVM running the Kafka Connect task.
 
-For transactional _message_ events, the `ts_ms` attribute of the `source` object indicates the time that the change was made in the database for transactional _message_ events. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+For transactional _message_ events, the `ts_ms` attribute of the `source` object indicates the time that the change was made in the database for transactional _message_ events.
+By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
-For non-transactional _message_ events, the `source` object's `ts_ms` indicates time at which the connector encounters the _message_ event, while the `payload.ts_ms` indicates the time at which the connector processed the event. This difference is due to the fact that the commit timestamp is not present in Postgres's generic logical message format and non-transactional logical messages are not preceded by a `BEGIN` event (which has timestamp information).
+For non-transactional _message_ events, the `source` object's `ts_ms` indicates time at which the connector encounters the _message_ event, while the `payload.ts_ms` indicates the time at which the connector processed the event.
+This difference is due to the fact that the commit timestamp is not present in Postgres's generic logical message format and non-transactional logical messages are not preceded by a `BEGIN` event (which has timestamp information).
 
 |4
 |`message`
@@ -1382,7 +1505,10 @@ a|Field that contains the message metadata
 [[postgresql-data-types]]
 == Data type mappings
 
-The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. The following sections describe how the connector maps PostgreSQL data types to a _literal type_ and a _semantic type_ in event fields.
+The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exists.
+The event contains a field for each column value.
+How that value is represented in the event depends on the PostgreSQL data type of the column.
+The following sections describe how the connector maps PostgreSQL data types to a _literal type_ and a _semantic type_ in event fields.
 
 * _literal type_ describes how the value is literally represented using Kafka Connect schema types: `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
 
@@ -1431,13 +1557,17 @@ The following table describes how the connector maps basic types.
 |`BYTES`
 |`io.debezium.data.Bits`
 
-The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits. For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
+The `length` schema parameter contains an integer that represents the number of bits.
+The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits.
+For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
 
 |`BIT VARYING[(M)]`
 |`BYTES`
 |`io.debezium.data.Bits`
 
-The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
+The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column).
+The resulting `byte[]` contains the bits in little-endian form and is sized based on the content.
+The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`
@@ -1536,7 +1666,8 @@ Contains the string representation of a PostgreSQL UUID value.
 |`STRUCT`
 |`io.debezium.data.geometry.Point`
 
-Contains a structure with two `FLOAT64` fields, `(x,y)`. Each field represents the coordinates of a geometric point.
+Contains a structure with two `FLOAT64` fields, `(x,y)`.
+Each field represents the coordinates of a geometric point.
 
 |`LTREE`
 |`STRING`
@@ -1586,20 +1717,25 @@ Contains the string representation of a timestamp range with the local system ti
 |`STRING`
 |n/a
 
-Contains the string representation of a date range. It always has an exclusive upper-bound.
+Contains the string representation of a date range.
+It always has an exclusive upper-bound.
 
 |`ENUM`
 |`STRING`
 |`io.debezium.data.Enum`
 
-Contains the string representation of the PostgreSQL `ENUM` value. The `allowed` schema parameter contains the comma-separated list of allowed values. The values are sorted using the logical sort order defined in PostgreSQL (`enumsortorder`), rather than the alphabetical order. This ensures that the schema remains deterministic even if new values are inserted into the enum later.
+Contains the string representation of the PostgreSQL `ENUM` value.
+The `allowed` schema parameter contains the comma-separated list of allowed values.
+The values are sorted using the logical sort order defined in PostgreSQL (`enumsortorder`), rather than the alphabetical order.
+This ensures that the schema remains deterministic even if new values are inserted into the enum later.
 
 |===
 
 [id="postgresql-temporal-types"]
 === Temporal types
 
-Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the xref:postgresql-property-time-precision-mode[`time.precision.mode`] connector configuration property. The following sections describe these mappings:
+Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the xref:postgresql-property-time-precision-mode[`time.precision.mode`] connector configuration property.
+The following sections describe these mappings:
 
 * xref:postgresql-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
 * xref:postgresql-time-precision-mode-adaptive-time-microseconds[`time.precision.mode=adaptive_time_microseconds`]
@@ -1610,7 +1746,8 @@ Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain tim
 
 [[postgresql-time-precision-mode-adaptive]]
 .`time.precision.mode=adaptive`
-When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database.
+When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition.
+This ensures that events _exactly_ represent the values in the database.
 
 .Mappings when `time.precision.mode` is `adaptive`
 [cols="25%a,20%a,55%a",options="header"]
@@ -1653,7 +1790,8 @@ Represents the number of microseconds since the epoch, and does not include time
 
 [[postgresql-time-precision-mode-adaptive-time-microseconds]]
 .`time.precision.mode=adaptive_time_microseconds`
-When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, the connector determines the literal type and semantic type for temporal types based on the column's data type definition. This ensures that events _exactly_ represent the values in the database, except all `TIME` fields are captured as microseconds.
+When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, the connector determines the literal type and semantic type for temporal types based on the column's data type definition.
+This ensures that events _exactly_ represent the values in the database, except all `TIME` fields are captured as microseconds.
 
 .Mappings when `time.precision.mode` is `adaptive_time_microseconds`
 [cols="25%a,20%a,55%a",options="header"]
@@ -1672,7 +1810,8 @@ Represents the number of days since the epoch.
 |`INT64`
 |`io.debezium.time.MicroTime`
 
-Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
+Represents the time value in microseconds and does not include timezone information.
+PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
 
 |`TIMESTAMP(1)` , `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
@@ -1690,7 +1829,9 @@ Represents the number of microseconds past the epoch, and does not include timez
 
 [[postgresql-time-precision-mode-connect]]
 .`time.precision.mode=connect`
-When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers can handle only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
+When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types.
+This may be useful when consumers can handle only the built-in Kafka Connect logical types and are unable to handle variable-precision time values.
+However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
 
 .Mappings when `time.precision.mode` is `connect`
 [cols="25%a,20%a,55%a",options="header"]
@@ -1709,13 +1850,15 @@ Represents the number of days since the epoch.
 |`INT64`
 |`org.apache.kafka.connect.data.Time`
 
-Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+Represents the number of milliseconds since midnight, and does not include timezone information.
+PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`TIMESTAMP([P])`
 |`INT64`
 |`org.apache.kafka.connect.data.Timestamp`
 
-Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+Represents the number of milliseconds since the epoch, and does not include timezone information.
+PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |===
 
@@ -1841,7 +1984,8 @@ If the source schema may contain values outside the representable range, use `ti
 === TIMESTAMP type
 
 The `TIMESTAMP` type represents a timestamp without time zone information.
-Such columns are converted into an equivalent Kafka Connect value based on UTC. For example, the `TIMESTAMP` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.MicroTimestamp` with the value "1529507596945104" when `time.precision.mode` is not set to `connect`.
+Such columns are converted into an equivalent Kafka Connect value based on UTC.
+For example, the `TIMESTAMP` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.MicroTimestamp` with the value "1529507596945104" when `time.precision.mode` is not set to `connect`.
 
 The timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 
@@ -1855,7 +1999,8 @@ For reference, see the https://jdbc.postgresql.org/documentation/publicapi/org/p
 
 The setting of the PostgreSQL connector configuration property xref:postgresql-property-decimal-handling-mode[`decimal.handling.mode`] determines how the connector maps decimal types.
 
-When the `decimal.handling.mode` property is set to `precise`, the connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL`, `NUMERIC` and `MONEY` columns. This is the default mode.
+When the `decimal.handling.mode` property is set to `precise`, the connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL`, `NUMERIC` and `MONEY` columns.
+This is the default mode.
 
 .Mappings when `decimal.handling.mode` is `precise`
 [cols="28%a,17%a,55%a",options="header"]
@@ -1886,7 +2031,8 @@ The `scale` schema parameter is determined by the xref:postgresql-property-money
 |===
 
 There is an exception to this rule.
-When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the values coming from the database have a different (variable) scale for each value. In this case, the connector uses `io.debezium.data.VariableScaleDecimal`, which contains both the value and the scale of the transferred value.
+When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the values coming from the database have a different (variable) scale for each value.
+In this case, the connector uses `io.debezium.data.VariableScaleDecimal`, which contains both the value and the scale of the transferred value.
 
 .Mappings of `DECIMAL` and `NUMERIC` types when there are no scale constraints
 [cols="25%a,20%a,55%a",options="header"]
@@ -1932,7 +2078,8 @@ When the `decimal.handling.mode` property is set to `double`, the connector repr
 
 |===
 
-The last possible setting for the `decimal.handling.mode` configuration property is `string`. In this case, the connector represents `DECIMAL`, `NUMERIC` and `MONEY` values as their formatted string representation, and encodes them as shown in the following table.
+The last possible setting for the `decimal.handling.mode` configuration property is `string`.
+In this case, the connector represents `DECIMAL`, `NUMERIC` and `MONEY` values as their formatted string representation, and encodes them as shown in the following table.
 
 .Mappings when `decimal.handling.mode` is `string`
 [cols="30%a,30%a,40%a",options="header"]
@@ -1955,7 +2102,8 @@ The last possible setting for the `decimal.handling.mode` configuration property
 
 |===
 
-PostgreSQL supports `NaN` (not a number) as a special value to be stored in `DECIMAL`/`NUMERIC` values when the setting of `decimal.handling.mode` is `string` or `double`. In this case, the connector encodes `NaN` as either `Double.NaN` or the string constant `NAN`.
+PostgreSQL supports `NaN` (not a number) as a special value to be stored in `DECIMAL`/`NUMERIC` values when the setting of `decimal.handling.mode` is `string` or `double`.
+In this case, the connector encodes `NaN` as either `Double.NaN` or the string constant `NAN`.
 
 [id="postgresql-hstore-type"]
 === HSTORE type
@@ -1989,11 +2137,13 @@ Example: output representation  using the JSON converter is `{"key" : "val"}`
 [id="postgresql-domain-types"]
 === Domain types
 
-PostgreSQL supports user-defined types that are based on other underlying types. When such column types are used, {prodname} exposes the column's representation based on the full type hierarchy.
+PostgreSQL supports user-defined types that are based on other underlying types.
+When such column types are used, {prodname} exposes the column's representation based on the full type hierarchy.
 
 [IMPORTANT]
 ====
-Capturing changes in columns that use PostgreSQL domain types requires special consideration. When a column is defined to contain a domain type that extends one of the default database types and the domain type defines a custom length or scale, the generated schema inherits that defined length or scale.
+Capturing changes in columns that use PostgreSQL domain types requires special consideration.
+When a column is defined to contain a domain type that extends one of the default database types and the domain type defines a custom length or scale, the generated schema inherits that defined length or scale.
 
 When a column is defined to contain a domain type that extends another domain type that defines a custom length or scale, the generated schema does *not* inherit the defined length or scale because that information is not available in the PostgreSQL driver's column metadata.
 ====
@@ -2001,7 +2151,9 @@ When a column is defined to contain a domain type that extends another domain ty
 [id="postgresql-network-address-types"]
 === Network address types
 
-PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is better to use these types instead of plain text types to store network addresses. Network address types offer input error checking and specialized operators and functions.
+PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses.
+It is better to use these types instead of plain text types to store network addresses.
+Network address types offer input error checking and specialized operators and functions.
 
 .Mappings for network address types
 [cols="25%a,20%a,55%a",options="header"]
@@ -2162,7 +2314,8 @@ Most common data types are supported, including the following:
 
 Note that for temporal types, parsing of the default value is provided by PostgreSQL libraries; therefore, any string representation which is normally supported by PostgreSQL should also be supported by the connector.
 
-In the case that the default value is generated by a function rather than being directly specified in-line, the connector will instead export the equivalent of `0` for the given data type. These values include:
+In the case that the default value is generated by a function rather than being directly specified in-line, the connector will instead export the equivalent of `0` for the given data type.
+These values include:
 
 * `FALSE` for `BOOLEAN`
 * `0` with appropriate precision, for numeric types
@@ -2173,16 +2326,22 @@ In the case that the default value is generated by a function rather than being 
 * `EPOCH` for `INTERVAL`
 * `00000000-0000-0000-0000-000000000000` for `UUID`
 
-This support currently extends only to explicit usage of functions. For example, `CURRENT_TIMESTAMP(6)` is supported with parentheses, but `CURRENT_TIMESTAMP` is not.
+This support currently extends only to explicit usage of functions.
+For example, `CURRENT_TIMESTAMP(6)` is supported with parentheses, but `CURRENT_TIMESTAMP` is not.
 
 [IMPORTANT]
 ====
-Support for the propagation of default values exists primarily to allow for safe schema evolution when using the PostgreSQL connector with a schema registry which enforces compatibility between schema versions. Due to this primary concern, as well as the refresh behaviours of the different plug-ins, the default value present in the Kafka schema is not guaranteed to always be in-sync with the default value in the database schema.
+Support for the propagation of default values exists primarily to allow for safe schema evolution when using the PostgreSQL connector with a schema registry which enforces compatibility between schema versions.
+Due to this primary concern, as well as the refresh behaviours of the different plug-ins, the default value present in the Kafka schema is not guaranteed to always be in-sync with the default value in the database schema.
 
-* Default values may appear 'late' in the Kafka schema, depending on when/how a given plugin triggers refresh of the in-memory schema. Values may never appear/be skipped in the Kafka schema if the default changes multiple times in-between refreshes
-* Default values may appear 'early' in the Kafka schema, if a schema refresh is triggered while the connector has records waiting to be processed. This is due to the column metadata being read from the database at refresh time, rather than being present in the replication message. This may occur if the connector is behind and a refresh occurs, or on connector start if the connector was stopped for a time while updates continued to be written to the source database.
+* Default values may appear 'late' in the Kafka schema, depending on when/how a given plugin triggers refresh of the in-memory schema.
+Values may never appear/be skipped in the Kafka schema if the default changes multiple times in-between refreshes
+* Default values may appear 'early' in the Kafka schema, if a schema refresh is triggered while the connector has records waiting to be processed.
+This is due to the column metadata being read from the database at refresh time, rather than being present in the replication message.
+This may occur if the connector is behind and a refresh occurs, or on connector start if the connector was stopped for a time while updates continued to be written to the source database.
 
-This behaviour may be unexpected, but it is still safe. Only the schema definition is affected, while the real values present in the message will remain consistent with what was written to the source database.
+This behaviour may be unexpected, but it is still safe.
+Only the schema definition is affected, while the real values present in the message will remain consistent with what was written to the source database.
 ====
 
 // Type: concept
@@ -2337,7 +2496,8 @@ ifdef::community[]
 [[postgresql-on-amazon-rds]]
 ==== PostgreSQL on Amazon RDS
 
-It is possible to capture changes in a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To do this:
+It is possible to capture changes in a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS].
+To do this:
 
 * Set the instance parameter `rds.logical_replication` to `1`.
 * Verify that the `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as the database RDS master user.
@@ -2351,11 +2511,13 @@ It is possible to capture changes in a PostgreSQL database that is running in li
   The role grants permissions to manage logical slots and to stream data using logical slots.
   By default, only the master user account on AWS has the `rds_replication` role on Amazon RDS.
   To enable a user account other than the master account to initiate logical replication, you must grant the account the `rds_replication` role.
-  For example, `grant rds_replication to _<my_user>_`. You must have `superuser` access to grant the `rds_replication` role to a user.
+  For example, `grant rds_replication to _<my_user>_`.
+You must have `superuser` access to grant the `rds_replication` role to a user.
   To enable accounts other than the master account to create an initial snapshot, you must grant `SELECT` permission to the accounts on the tables to be captured.
   For more information about security for PostgreSQL logical replication, see the link:https://www.postgresql.org/docs/current/logical-replication-security.html[PostgreSQL documentation].
 * To use AWS IAM Authentication, set `database.connection.factory.class` to `io.debezium.connector.postgresql.connection.PostgresAwsIamConnectionFactory`, and add the
-  link:https://github.com/aws/aws-advanced-jdbc-wrapper[AWS Advanced JDBC Wrapper] in your classpath. More documentation
+  link:https://github.com/aws/aws-advanced-jdbc-wrapper[AWS Advanced JDBC Wrapper] in your classpath.
+More documentation
   link:https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md[here].
 
 [[postgresql-on-azure]]
@@ -2363,7 +2525,9 @@ It is possible to capture changes in a PostgreSQL database that is running in li
 
 It is possible to use {prodname} with link:https://docs.microsoft.com/azure/postgresql/[Azure Database for PostgreSQL], which has support for the `pgoutput` logical decoding plug-in, which is supported by {prodname}.
 
-Set the Azure replication support to `logical`. You can use the link:https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-cli[Azure CLI] or the link:https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-portal[Azure Portal] to configure this. For example, to use the Azure CLI, here are the link:https://docs.microsoft.com/cli/azure/postgres/server?view=azure-cli-latest[`az postgres server`] commands that you need to execute:
+Set the Azure replication support to `logical`.
+You can use the link:https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-cli[Azure CLI] or the link:https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-portal[Azure Portal] to configure this.
+For example, to use the Azure CLI, here are the link:https://docs.microsoft.com/cli/azure/postgres/server?view=azure-cli-latest[`az postgres server`] commands that you need to execute:
 
 ```
 az postgres server configuration set --resource-group mygroup --server-name myserver --name azure.replication_support --value logical
@@ -2413,13 +2577,16 @@ If you use `all_tables`, which is the default value for `publication.autocreate.
 For more detailed instructions about setting up and testing logical decoding plug-ins, see xref:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] .
 ====
 
-As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
+As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in.
+Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server.
+Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
 
 The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to receive change events from the database in either the link:https://github.com/google/protobuf[Protobuf format] or the link:https://github.com/postgres/postgres/blob/master/src/backend/replication/pgoutput/pgoutput.c[pgoutput] format.
 The `pgoutput` plugin comes out-of-the-box with the PostgreSQL database.
 For more details on using Protobuf via the `decoderbufs` plug-in, see the plug-in link:https://github.com/debezium/postgres-decoderbufs/blob/main/README.md[`documentation`] which discusses its requirements, limitations, and how to compile it.
 
-For simplicity, {prodname} also provides a container image based on the upstream PostgreSQL server image, on top of which it compiles and installs the plug-ins. You can link:https://github.com/debezium/container-images/tree/main/postgres/13[use this image] as an example of the detailed steps required for the installation.
+For simplicity, {prodname} also provides a container image based on the upstream PostgreSQL server image, on top of which it compiles and installs the plug-ins.
+You can link:https://github.com/debezium/container-images/tree/main/postgres/13[use this image] as an example of the detailed steps required for the installation.
 
 [WARNING]
 ====
@@ -2433,7 +2600,8 @@ For Windows and other operating systems, different installation steps might be r
 Plug-in behavior is not completely the same for all cases.
 These differences have been identified:
 
-* While all plug-ins will refresh schema metadata from the database upon detection of a schema change during streaming, the `pgoutput` plug-in is somewhat more 'eager' about triggering such refreshes. For example, a change to the default value for a column will trigger a refresh with `pgoutput`, while other plug-ins will not be aware of this change until another change triggers a refresh (eg. addition of a new column.) This is due to the behaviour of `pgoutput`, rather than {prodname} itself.
+* While all plug-ins will refresh schema metadata from the database upon detection of a schema change during streaming, the `pgoutput` plug-in is somewhat more 'eager' about triggering such refreshes.
+For example, a change to the default value for a column will trigger a refresh with `pgoutput`, while other plug-ins will not be aware of this change until another change triggers a refresh (eg. addition of a new column.) This is due to the behaviour of `pgoutput`, rather than {prodname} itself.
 
 All up-to-date differences are tracked in a test suite link:https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java[Java class].
 
@@ -2667,7 +2835,8 @@ For {prodname} to create a PostgreSQL publication, it must run as a user that ha
 
 * Replication privileges in the database to add the table to a publication.
 * `CREATE` privileges on the database to add publications.
-* `SELECT` privileges on the tables to copy the initial table data. Table owners automatically have `SELECT` permission for the table.
+* `SELECT` privileges on the tables to copy the initial table data.
+Table owners automatically have `SELECT` permission for the table.
 
 To add tables to a publication, the user must be an owner of the table.
 But because the source table already exists, you need a mechanism to share ownership with the original owner.
@@ -2794,13 +2963,18 @@ In environments where automatic replication is enabled, if a failure occurs, an 
 In certain cases, it is possible for PostgreSQL disk space consumed by WAL files to spike or increase out of usual proportions.
 There are several possible reasons for this situation:
 
-* The LSN up to which the connector has received data is available in the `confirmed_flush_lsn` column of the server's `pg_replication_slots` view. Data that is older than this LSN is no longer available, and the database is responsible for reclaiming the disk space.
+* The LSN up to which the connector has received data is available in the `confirmed_flush_lsn` column of the server's `pg_replication_slots` view.
+Data that is older than this LSN is no longer available, and the database is responsible for reclaiming the disk space.
 +
-Also in the `pg_replication_slots` view, the `restart_lsn` column contains the LSN of the oldest WAL that the connector might require. If the value for `confirmed_flush_lsn` is regularly increasing and the value of  `restart_lsn` lags then the database needs to reclaim the space.
+Also in the `pg_replication_slots` view, the `restart_lsn` column contains the LSN of the oldest WAL that the connector might require.
+If the value for `confirmed_flush_lsn` is regularly increasing and the value of  `restart_lsn` lags then the database needs to reclaim the space.
 +
-The database typically reclaims disk space in batch blocks. This is expected behavior and no action by a user is necessary.
+The database typically reclaims disk space in batch blocks.
+This is expected behavior and no action by a user is necessary.
 
-* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the xref:postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
+* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes.
+This situation can be easily solved with periodic heartbeat events.
+Set the xref:postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
 +
 [NOTE]
 ====
@@ -2811,7 +2985,11 @@ If the publication is not already configured to automatically replicate changes 
 `ALTER PUBLICATION  _<publicationName>_ ADD TABLE _<heartbeatTableName>_;`
 ====
 
-* The PostgreSQL instance contains multiple databases and one of them is a high-traffic database. {prodname} captures changes in another database that is low-traffic in comparison to the other database. {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked. As WAL is shared by all databases, the amount used tends to grow until an event is emitted by the database for which {prodname} is capturing changes. To overcome this, it is necessary to:
+* The PostgreSQL instance contains multiple databases and one of them is a high-traffic database.
+{prodname} captures changes in another database that is low-traffic in comparison to the other database.
+{prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked.
+As WAL is shared by all databases, the amount used tends to grow until an event is emitted by the database for which {prodname} is capturing changes.
+To overcome this, it is necessary to:
 
 ** Enable periodic heartbeat record generation with the `heartbeat.interval.ms` connector configuration property.
 ** Regularly emit change events from the database for which {prodname} is capturing changes.
@@ -2824,7 +3002,8 @@ This task can be automated by means of the xref:postgresql-property-heartbeat-ac
 ifdef::community[]
 [TIP]
 ====
-For users on AWS RDS with PostgreSQL, a situation similar to the high traffic/low traffic scenario can occur in an idle environment. AWS RDS causes writes to its own system tables to be invisible to clients on a frequent basis (5 minutes).
+For users on AWS RDS with PostgreSQL, a situation similar to the high traffic/low traffic scenario can occur in an idle environment.
+AWS RDS causes writes to its own system tables to be invisible to clients on a frequent basis (5 minutes).
 Again, regularly emitting events solves the problem.
 ====
 endif::community[]
@@ -3227,7 +3406,8 @@ The topic prefix is the logical identifier for the PostgreSQL server or cluster 
 This string is prefixed to the names of all Kafka topics that receive change event records from the connector.
 
 |6
-|The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose.
+|The connector captures changes in only the `public` schema.
+It is possible to configure the connector to capture changes in only the tables that you choose.
 For more information, see xref:postgresql-property-table-include-list[`table.include.list`].
 
 |7
@@ -3283,7 +3463,8 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <6> The password for the PostgreSQL user that has the xref:postgresql-permissions[required privileges].
 <7> The name of the PostgreSQL database to connect to
 <8> The topic prefix for the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<9> A list of all tables hosted by this server that this connector will monitor. This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
+<9> A list of all tables hosted by this server that this connector will monitor.
+This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
 
 See the xref:postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
 
@@ -3317,7 +3498,8 @@ endif::community[]
 
 .Results
 
-After the connector starts, it xref:postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+After the connector starts, it xref:postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for.
+The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
 // Type: procedure
@@ -3333,7 +3515,9 @@ endif::product[]
 [[postgresql-connector-properties]]
 === Connector properties
 
-The {prodname} PostgreSQL connector has many configuration properties that you can use to achieve the right connector behavior for your application. Many properties have default values. Information about the properties is organized as follows:
+The {prodname} PostgreSQL connector has many configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
 
 * xref:postgresql-required-configuration-properties[Required configuration properties]
 * xref:postgresql-advanced-configuration-properties[Advanced configuration properties]
@@ -3359,15 +3543,19 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-name]]<<postgresql-property-name, `+name+`>>
 |No default
-|Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
+|Unique name for the connector.
+Attempting to register again with the same name will fail.
+This property is required by all Kafka Connect connectors.
 
 |[[postgresql-property-connector-class]]<<postgresql-property-connector-class, `+connector.class+`>>
 |No default
-|The name of the Java class for the connector. Always use a value of `io.debezium.connector.postgresql.PostgresConnector` for the PostgreSQL connector.
+|The name of the Java class for the connector.
+Always use a value of `io.debezium.connector.postgresql.PostgresConnector` for the PostgreSQL connector.
 
 |[[postgresql-property-tasks-max]]<<postgresql-property-tasks-max, `+tasks.max+`>>
 |`1`
-|The maximum number of tasks that should be created for this connector. The PostgreSQL connector always uses a single task and therefore does not use this value, so the default is always acceptable.
+|The maximum number of tasks that should be created for this connector.
+The PostgreSQL connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
 |[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `+plugin.name+`>>
 |`decoderbufs`
@@ -3399,9 +3587,13 @@ Slot names must conform to link:https://www.postgresql.org/docs/current/static/w
 
 |[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `+slot.drop.on.stop+`>>
 |`false`
-|Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way. The default behavior is that the replication slot remains configured for the connector when the connector stops. When the connector restarts, having the same replication slot enables the connector to start processing where it left off.
+|Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way.
+The default behavior is that the replication slot remains configured for the connector when the connector stops.
+When the connector restarts, having the same replication slot enables the connector to start processing where it left off.
 
-Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic.
+Set to `true` in only testing or development environments.
+Dropping the slot allows the database to discard WAL segments.
+When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic.
 
 |[[postgresql-property-slot-failover]]<<postgresql-property-slot-failover, `+slot.failover+`>>
 |`false`
@@ -3578,7 +3770,8 @@ If you include this property in the configuration, do not set the `column.includ
 
 |[[postgresql-property-skip-messages-without-change]]<<postgresql-property-skip-messages-without-change, `+skip.messages.without.change+`>>
 |`false`
-| Specifies whether to skip publishing messages when there is no change in included columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties.
+| Specifies whether to skip publishing messages when there is no change in included columns.
+This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties.
 
 [NOTE]
 This property is applied only when the REPLICA IDENTITY of the table is set to `FULL`.
@@ -3613,7 +3806,8 @@ For more information, see xref:postgresql-decimal-types[Decimal types].
 
 `map` represents values by using `MAP`.
 
-`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`.
+`json` represents values by using `json string`.
+This setting encodes values as formatted strings such as `{"key" : "val"}`.
 For more information, see xref:postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `+interval.handling.mode+`>>
@@ -3628,7 +3822,8 @@ For more information, see xref:postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
 |`prefer`
-|Whether to use an encrypted connection to the PostgreSQL server. Options include:
+|Whether to use an encrypted connection to the PostgreSQL server.
+Options include:
 
 `disable` uses an unencrypted connection.
 
@@ -4186,7 +4381,8 @@ That is, the specified expression is matched against the entire name string of t
 
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. xref:postgresql-snapshots[How the connector performs snapshots] provides details.
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
+If the connector cannot acquire table locks in this time interval, the snapshot fails. xref:postgresql-snapshots[How the connector performs snapshots] provides details.
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -4264,21 +4460,29 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 
 |[[postgresql-property-poll-interval-ms]]<<postgresql-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`500`
-|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 500 milliseconds.
+|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events.
+Defaults to 500 milliseconds.
 
 |[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `+include.unknown.datatypes+`>>
 |`false`
-|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning.
+|Specifies connector behavior when the connector encounters a field whose data type is unknown.
+The default behavior is that the connector omits the field from the change event and logs a warning.
 
-Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the xref:postgresql-property-binary-handling-mode[`binary handling mode`] property.
+Set this property to `true` if you want the change event to contain an opaque binary representation of the field.
+This lets consumers decode the field.
+You can control the exact representation by setting the xref:postgresql-property-binary-handling-mode[`binary handling mode`] property.
 
-NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
+NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`.
+Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers.
+In general, when encountering unsupported data types, create a feature request so that support can be added.
 
 |[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `+database.initial.statements+`>>
 |No default
-|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`.
+|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database.
+To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`.
 
-The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements.
+The connector may establish JDBC connections at its own discretion.
+Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements.
 
 The connector does not execute these statements when it creates a connection for reading the transaction log.
 
@@ -4290,17 +4494,25 @@ The property also controls how frequently the database status is checked to dete
 
 |[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
-|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages.
+|Controls how frequently the connector sends heartbeat messages to a Kafka topic.
+The default behavior is that the connector does not send heartbeat messages.
 
-Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database.
+Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts.
+To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
 
-Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files.
+Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes.
+In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka.
+This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database.
+The database retains WAL files that contain events that have already been processed by the connector.
+Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files.
 
 |[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `+heartbeat.action.query+`>>
 |No default
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message.
 
-This is useful for resolving the situation described in xref:postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:
+This is useful for resolving the situation described in xref:postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database.
+To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:
 
 `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')`
 
@@ -4310,16 +4522,19 @@ This allows the connector to receive changes from the low-traffic database and a
 |`columns_diff`
 |Specify the conditions that trigger a refresh of the in-memory schema for a table.
 
-`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times.
+`columns_diff` is the safest mode.
+It ensures that the in-memory schema stays in sync with the database table's schema at all times.
 
 `columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
 
-This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates. However, it is possible for the in-memory schema to
+This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates.
+However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 
 |[[postgresql-property-snapshot-delay-ms]]<<postgresql-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |No default
-|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
+|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts.
+If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
 |[[postgresql-property-statistics-metrics-enabled]]<<postgresql-property-statistics-metrics-enabled, `+statistics.metrics.enabled+`>>
 |`true`
@@ -4349,7 +4564,8 @@ Set a delay value that is higher than the value of the {link-kafka-docs}/#connec
 
 |[[postgresql-property-snapshot-fetch-size]]<<postgresql-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`10240`
-|During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
+|During a snapshot, the connector reads table content in batches of rows.
+This property specifies the maximum number of rows in a batch.
 
 |[[postgresql-property-slot-stream-params]]<<postgresql-property-slot-stream-params, `+slot.stream.params+`>>
 |No default
@@ -4392,7 +4608,8 @@ For more information, see xref:postgresql-toasted-values[toasted values].
 
 |[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata.
+Specify `true` if you want the connector to do this.
 For more information, see xref:postgresql-transaction-metadata[Transaction metadata].
 
 |[[postgresql-property-publish-via-partition-root]]<<postgresql-property-publish-via-partition-root, `+publish.via.partition.root+`>>
@@ -4555,11 +4772,13 @@ The default value of `0` disables tracking XMIN tracking.
 
 |[[postgresql-property-topic-cache-size]]<<postgresql-property-topic-cache-size, `topic.cache.size`>>
 |`10000`
-|The size used for holding the topic names in bounded concurrent hash map. This cache will help to determine the topic name corresponding to a given data collection.
+|The size used for holding the topic names in bounded concurrent hash map.
+This cache will help to determine the topic name corresponding to a given data collection.
 
 |[[postgresql-property-topic-heartbeat-prefix]]<<postgresql-property-topic-heartbeat-prefix, `+topic.heartbeat.prefix+`>>
 |`__debezium-heartbeat`
-|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern:
+|Controls the name of the topic to which the connector sends heartbeat messages.
+The topic name has this pattern:
 
 _topic.heartbeat.prefix_._topic.prefix_
 
@@ -4571,7 +4790,8 @@ This property is ignored if `topic.heartbeat.name` is set.
 |_empty_
 |Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`.
 
-When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
+When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`.
+This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
 
 For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`.
 
@@ -4579,7 +4799,8 @@ If this property is empty or unset, the connector falls back to the default beha
 
 |[[postgresql-property-topic-transaction]]<<postgresql-property-topic-transaction, `topic.transaction`>>
 |`transaction`
-|Controls the name of the topic to which the connector sends transaction metadata messages. The topic name has this pattern:
+|Controls the name of the topic to which the connector sends transaction metadata messages.
+The topic name has this pattern:
 
 _topic.prefix_._topic.transaction_
 
@@ -4645,9 +4866,11 @@ The pattern that you specify for the `custom.sanitize.pattern` property override
 |Specifies how the connector responds after an operation that results in a retriable error, such as a connection error.
 Set one of the following options:
 
-`-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
+`-1`:: No limit.
+The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.
 
-`0`:: Disabled. The connector fails immediately, and never retries the operation.
+`0`:: Disabled.
+The connector fails immediately, and never retries the operation.
 User intervention is required to restart the connector.
 
 `> 0`:: The connector restarts automatically until it reaches the specified maximum number of retries.
@@ -4800,14 +5023,19 @@ In the following situations, the connector fails when trying to start, reports a
 * The connector cannot successfully connect to PostgreSQL by using the specified connection parameters.
 * The connector is restarting from a previously-recorded position in the PostgreSQL WAL (by using the LSN) and PostgreSQL no longer has that history available.
 
-In these cases, the error message has details about the problem and possibly a suggested workaround. After you correct the configuration or address the PostgreSQL problem, restart the connector.
+In these cases, the error message has details about the problem and possibly a suggested workaround.
+After you correct the configuration or address the PostgreSQL problem, restart the connector.
 
 [id="postgresql-becomes-unavailable"]
 === PostgreSQL becomes unavailable
 
-When the connector is running, the PostgreSQL server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
+When the connector is running, the PostgreSQL server that it is connected to could become unavailable for any number of reasons.
+If this happens, the connector fails with an error and stops.
+When the server is available again, restart the connector.
 
-The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data.
+The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN.
+After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset.
+This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data.
 For information about failure cases in which a slot has been removed, see the next section.
 
 [id="postgresql-cluster-failures"]
@@ -4908,25 +5136,43 @@ For more information about how to configure the PostgreSQL server to work with {
 [id="postgresql-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully
 
-Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully. Prior to shutting down that process, Kafka Connect migrates the process's connector tasks to another Kafka Connect process in that group. The new connector tasks start processing exactly where the prior tasks stopped. There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
+Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully.
+Prior to shutting down that process, Kafka Connect migrates the process's connector tasks to another Kafka Connect process in that group.
+The new connector tasks start processing exactly where the prior tasks stopped.
+There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
 
 [id="postgresql-kafka-connect-process-crashes"]
 === Kafka Connect process crashes
 
-If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminate without recording their most recently processed offsets. When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes. However, PostgreSQL connectors resume from the last offset that was _recorded_ by the earlier processes. This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash. The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
+If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminate without recording their most recently processed offsets.
+When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes.
+However, PostgreSQL connectors resume from the last offset that was _recorded_ by the earlier processes.
+This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash.
+The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
 
-Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events. {prodname} changes are idempotent, so a sequence of events always results in the same state.
+Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events.
+{prodname} changes are idempotent, so a sequence of events always results in the same state.
 
-In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate.
+In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written.
+Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate.
 
 [id="postgresql-kafka-becomes-unavailable"]
 === Kafka becomes unavailable
 
-As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API. Periodically, at a frequency that you specify in the Kafka Connect configuration, Kafka Connect records the latest offset that appears in those change events. If the Kafka brokers become unavailable, the Kafka Connect process that is running the connectors repeatedly tries to reconnect to the Kafka brokers. In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
+As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API.
+Periodically, at a frequency that you specify in the Kafka Connect configuration, Kafka Connect records the latest offset that appears in those change events.
+If the Kafka brokers become unavailable, the Kafka Connect process that is running the connectors repeatedly tries to reconnect to the Kafka brokers.
+In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
 
 [id="postgresql-connector-is-stopped-for-a-duration"]
 === Connector is stopped for a duration
 
-If the connector is gracefully stopped, the database can continue to be used. Any changes are recorded in the PostgreSQL WAL. When the connector restarts, it resumes streaming changes where it left off. That is, it generates change event records for all database changes that were made while the connector was stopped.
+If the connector is gracefully stopped, the database can continue to be used.
+Any changes are recorded in the PostgreSQL WAL.
+When the connector restarts, it resumes streaming changes where it left off.
+That is, it generates change event records for all database changes that were made while the connector was stopped.
 
-A properly configured Kafka cluster is able to handle massive throughput. Kafka Connect is written according to Kafka best practices, and given enough resources a Kafka Connect connector can also handle very large numbers of database change events. Because of this, after being stopped for a while, when a {prodname} connector restarts, it is very likely to catch up with the database changes that were made while it was stopped. How quickly this happens depends on the capabilities and performance of Kafka and the volume of changes being made to the data in PostgreSQL.
+A properly configured Kafka cluster is able to handle massive throughput.
+Kafka Connect is written according to Kafka best practices, and given enough resources a Kafka Connect connector can also handle very large numbers of database change events.
+Because of this, after being stopped for a while, when a {prodname} connector restarts, it is very likely to catch up with the database changes that were made while it was stopped.
+How quickly this happens depends on the capabilities and performance of Kafka and the volume of changes being made to the data in PostgreSQL.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -190,9 +190,9 @@ If the connector stops again for any reason, after it restarts, it continues str
 |`always`
 |The connector always performs a snapshot when it starts.
 After the snapshot completes, the connector continues streaming changes from step 3 in the above sequence.
-This mode is useful in the following situations: +
+This mode is useful in the following situations:
 
-* It is known that some WAL segments have been deleted and are no longer available. +
+* It is known that some WAL segments have been deleted and are no longer available.
 * After a cluster failure, if a new primary is promoted.
   The `always` snapshot mode ensures that the connector does not miss any changes that were made after the new primary had been promoted but before the connector was restarted on the new primary.
 
@@ -519,8 +519,8 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 
 |1
 |`schema`
-|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
- +
+a|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed.
+
 It is possible to override the table's primary key by setting the xref:postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
@@ -620,10 +620,10 @@ If the `topic.prefix` connector configuration property has the value `PostgreSQL
 
 |2
 |`PostgreSQL_server.inventory.customers.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: +
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example:
 
-* `PostgreSQL_server` is the name of the connector that generated this event. +
-* `inventory` is the database that contains the table that was changed. +
+* `PostgreSQL_server` is the name of the connector that generated this event.
+* `inventory` is the database that contains the table that was changed.
 * `customers` is the table that was updated.
 
 |3
@@ -910,10 +910,10 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
- +
-`PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
- +
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
+
+`PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
+
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database.
 This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
@@ -927,8 +927,8 @@ a|`PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall
 
 |5
 |`payload`
-|The value's actual data. This is the information that the change event is providing. +
- +
+a|The value's actual data. This is the information that the change event is providing.
+
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
@@ -1127,8 +1127,8 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 
 |1
 |`before`
-|Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit. +
- +
+a|Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit.
+
 In this example, the `before` field contains only the primary key column because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
 
 |2
@@ -1429,14 +1429,14 @@ The following table describes how the connector maps basic types.
 
 |`BIT( > 1)`
 |`BYTES`
-|`io.debezium.data.Bits` +
- +
+|`io.debezium.data.Bits`
+
 The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits. For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
 
 |`BIT VARYING[(M)]`
 |`BYTES`
-|`io.debezium.data.Bits` +
- +
+|`io.debezium.data.Bits`
+
 The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
 
 |`SMALLINT`, `SMALLSERIAL`
@@ -1481,67 +1481,67 @@ The `length` schema parameter contains an integer that represents the number of 
 
 |`TIMESTAMPTZ`, `TIMESTAMP WITH TIME ZONE`
 |`STRING`
-|`io.debezium.time.ZonedTimestamp` +
- +
+|`io.debezium.time.ZonedTimestamp`
+
 A string representation of a timestamp with timezone information, where the timezone is GMT.
 
 |`TIMETZ`, `TIME WITH TIME ZONE`
 |`STRING`
-|`io.debezium.time.ZonedTime` +
- +
+|`io.debezium.time.ZonedTime`
+
 A string representation of a time value with timezone information, where the timezone is GMT.
 
 |`INTERVAL [P]`
 |`INT64`
-|`io.debezium.time.MicroDuration` +
-(default) +
- +
+|`io.debezium.time.MicroDuration`
+(default)
+
 The approximate number of microseconds for a time interval using the `365.25 / 12.0` formula for days per month average.
 
 |`INTERVAL [P]`
 |`STRING`
-|`io.debezium.time.Interval` +
-(when `interval.handling.mode` is set to `string`) +
- +
+|`io.debezium.time.Interval`
+(when `interval.handling.mode` is set to `string`)
+
 The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`BYTEA`
 |`BYTES` or `STRING`
-|n/a +
- +
-Either the raw bytes (the default), a base64-encoded string, or a base64-url-safe-encoded String, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting. +
- +
+|n/a
+
+Either the raw bytes (the default), a base64-encoded string, or a base64-url-safe-encoded String, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting.
+
 Debezium only supports Postgres `bytea_output` configuration of value `hex`.
 For more information about PostgreSQL binary data types, see the link:https://www.postgresql.org/docs/current/datatype-binary.html[PostgreSQL documentation].
 
 |`JSON`, `JSONB`
 |`STRING`
-|`io.debezium.data.Json` +
- +
+|`io.debezium.data.Json`
+
 Contains the string representation of a JSON document, array, or scalar.
 
 |`XML`
 |`STRING`
-|`io.debezium.data.Xml` +
- +
+|`io.debezium.data.Xml`
+
 Contains the string representation of an XML document.
 
 |`UUID`
 |`STRING`
-|`io.debezium.data.Uuid` +
- +
+|`io.debezium.data.Uuid`
+
 Contains the string representation of a PostgreSQL UUID value.
 
 |`POINT`
 |`STRUCT`
-|`io.debezium.data.geometry.Point` +
- +
+|`io.debezium.data.geometry.Point`
+
 Contains a structure with two `FLOAT64` fields, `(x,y)`. Each field represents the coordinates of a geometric point.
 
 |`LTREE`
 |`STRING`
-|`io.debezium.data.Ltree` +
- +
+|`io.debezium.data.Ltree`
+
 Contains the string representation of a PostgreSQL LTREE value.
 
 |`CITEXT`
@@ -1554,44 +1554,44 @@ Contains the string representation of a PostgreSQL LTREE value.
 
 |`INT4RANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Range of integer.
 
 |`INT8RANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Range of `bigint`.
 
 |`NUMRANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Range of `numeric`.
 
 |`TSRANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Contains the string representation of a timestamp range without a time zone.
 
 |`TSTZRANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Contains the string representation of a timestamp range with the local system time zone.
 
 |`DATERANGE`
 |`STRING`
-|n/a +
- +
+|n/a
+
 Contains the string representation of a date range. It always has an exclusive upper-bound.
 
 |`ENUM`
 |`STRING`
-|`io.debezium.data.Enum` +
- +
+|`io.debezium.data.Enum`
+
 Contains the string representation of the PostgreSQL `ENUM` value. The `allowed` schema parameter contains the comma-separated list of allowed values. The values are sorted using the logical sort order defined in PostgreSQL (`enumsortorder`), rather than the alphabetical order. This ensures that the schema remains deterministic even if new values are inserted into the enum later.
 
 |===
@@ -1621,32 +1621,32 @@ When the `time.precision.mode` property is set to `adaptive`, the default, the c
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
-|`io.debezium.time.Time` +
- +
+|`io.debezium.time.Time`
+
 Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
-|`io.debezium.time.MicroTime` +
- +
+|`io.debezium.time.MicroTime`
+
 Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
-|`io.debezium.time.Timestamp` +
- +
+|`io.debezium.time.Timestamp`
+
 Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp` +
- +
+|`io.debezium.time.MicroTimestamp`
+
 Represents the number of microseconds since the epoch, and does not include timezone information.
 
 |===
@@ -1664,26 +1664,26 @@ When the `time.precision.mode` configuration property is set to `adaptive_time_m
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`io.debezium.time.MicroTime` +
- +
+|`io.debezium.time.MicroTime`
+
 Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
 
 |`TIMESTAMP(1)` , `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
-|`io.debezium.time.Timestamp` +
- +
+|`io.debezium.time.Timestamp`
+
 Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp` +
- +
+|`io.debezium.time.MicroTimestamp`
+
 Represents the number of microseconds past the epoch, and does not include timezone information.
 
 |===
@@ -1701,20 +1701,20 @@ When the `time.precision.mode` configuration property is set to `connect`, the c
 
 |`DATE`
 |`INT32`
-|`org.apache.kafka.connect.data.Date` +
- +
+|`org.apache.kafka.connect.data.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Time` +
- +
+|`org.apache.kafka.connect.data.Time`
+
 Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`TIMESTAMP([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp` +
- +
+|`org.apache.kafka.connect.data.Timestamp`
+
 Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |===
@@ -1733,20 +1733,20 @@ When you apply this setting, the connector uses the semantic types `io.debezium.
 
 |`DATE`
 |`STRING`
-|`io.debezium.time.IsoDate` +
- +
+|`io.debezium.time.IsoDate`
+
 Represents date values in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
 
 |`TIME([P])`
 |`STRING`
-|`io.debezium.time.IsoTime` +
- +
+|`io.debezium.time.IsoTime`
+
 Represents time values in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
 
 |`TIMESTAMP([P])`
 |`STRING`
-|`io.debezium.time.IsoTimestamp` +
- +
+|`io.debezium.time.IsoTimestamp`
+
 Represents timestamp values in UTC format, according to the ISO 8601 standard, for example, `2019-07-09T02:28:57.123456Z`.
 
 |===
@@ -1766,22 +1766,22 @@ When you apply this setting, the connector uses the semantic types `io.debezium.
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`io.debezium.time.MicroTime` +
- +
+|`io.debezium.time.MicroTime`
+
 Represents the time value in microseconds and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
 
 |`TIMESTAMP([P])`
 |`INT64`
-|`io.debezium.time.MicroTimestamp` +
- +
+|`io.debezium.time.MicroTimestamp`
+
 Represents the number of microseconds past the epoch, and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
@@ -1802,26 +1802,26 @@ When you apply this setting, the connector uses the semantic types `io.debezium.
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date` +
- +
+|`io.debezium.time.Date`
+
 Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`io.debezium.time.NanoTime` +
- +
+|`io.debezium.time.NanoTime`
+
 Represents the time value in nanoseconds and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
 The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
 
 |`TIMESTAMP([P])`
 |`INT64`
-|`io.debezium.time.NanoTimestamp` +
- +
+|`io.debezium.time.NanoTimestamp`
+
 Represents the number of nanoseconds past the epoch, and does not include timezone information.
 In PostgreSQL, the precision `p` parameter specifies the number of decimal places in the seconds part of a time value.
-The precision can range from 0 (no fractional seconds) to 6 (microsecond precision). +
- +
+The precision can range from 0 (no fractional seconds) to 6 (microsecond precision).
+
 PostgreSQL supports using `+/-infinite` values in `TIMESTAMP` columns.
 When `time.precision.mode` is set to `nanoseconds`, these special values are converted to `Long.MAX_VALUE` (`9223372036854775807`) for positive infinity and `Long.MIN_VALUE` (`-9223372036854775808`) for negative infinity to prevent overflow when representing timestamps as nanoseconds.
 
@@ -1866,20 +1866,20 @@ When the `decimal.handling.mode` property is set to `precise`, the connector use
 
 |`NUMERIC[(M[,D])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
+|`org.apache.kafka.connect.data.Decimal`
+
 The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |`DECIMAL[(M[,D])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
+|`org.apache.kafka.connect.data.Decimal`
+
 The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |`MONEY[(M[,D])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
+|`org.apache.kafka.connect.data.Decimal`
+
 The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 The `scale` schema parameter is determined by the xref:postgresql-property-money-fraction-digits[`money.fraction.digits`] connector configuration property.
 
@@ -1897,14 +1897,14 @@ When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the va
 
 |`NUMERIC`
 |`STRUCT`
-|`io.debezium.data.VariableScaleDecimal` +
- +
+|`io.debezium.data.VariableScaleDecimal`
+
 Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
 
 |`DECIMAL`
 |`STRUCT`
-|`io.debezium.data.VariableScaleDecimal` +
- +
+|`io.debezium.data.VariableScaleDecimal`
+
 Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
 
 |===
@@ -1974,14 +1974,14 @@ When the `hstore.handling.mode` property is set to `map`, the connector uses the
 
 |`HSTORE`
 |`STRING`
-|`io.debezium.data.Json` +
- +
+|`io.debezium.data.Json`
+
 Example: output representation using the JSON converter is ``{"key" : "val"}``
 
 |`HSTORE`
 |`MAP`
-|n/a +
- +
+|n/a
+
 Example: output representation  using the JSON converter is `{"key" : "val"}`
 
 |===
@@ -2012,26 +2012,26 @@ PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is be
 
 |`INET`
 |`STRING`
-|n/a +
- +
+|n/a
+
 IPv4 and IPv6 networks
 
 |`CIDR`
 |`STRING`
-|n/a +
- +
+|n/a
+
 IPv4 and IPv6 hosts and networks
 
 |`MACADDR`
 |`STRING`
-|n/a +
- +
+|n/a
+
 MAC addresses
 
 |`MACADDR8`
 |`STRING`
-|n/a +
- +
+|n/a
+
 MAC addresses in EUI-64 format
 
 |===
@@ -2048,27 +2048,27 @@ The PostgreSQL connector supports all link:http://postgis.net[PostGIS data types
 |Literal type (schema type)
 |Semantic type (schema name) and Notes
 
-|`GEOMETRY` +
+|`GEOMETRY`
 (planar)
 |`STRUCT`
-a|`io.debezium.data.geometry.Geometry` +
- +
-Contains a structure with two fields: +
+a|`io.debezium.data.geometry.Geometry`
+
+Contains a structure with two fields:
 
 * `srid (INT32)` - Spatial Reference System Identifier that defines what type of geometry object is stored in the structure.
-* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
+* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format.
 
 For format details, see link:http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification].
 
-|`GEOGRAPHY` +
+|`GEOGRAPHY`
 (spherical)
 |`STRUCT`
-|`io.debezium.data.geometry.Geography` +
- +
-Contains a structure with two fields: +
+|`io.debezium.data.geometry.Geography`
+
+Contains a structure with two fields:
 
 * `srid (INT32)` - Spatial Reference System Identifier that defines what type of geography object is stored in the structure.
-* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
+* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format.
 
 For format details, see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification].
 
@@ -2088,11 +2088,11 @@ The PostgreSQL connector supports all link:https://github.com/pgvector/pgvector[
 
 |`VECTOR`
 |`ARRAY (FLOAT64)`
-|`io.debezium.data.DoubleVector` +
+|`io.debezium.data.DoubleVector`
 
 |`HALFVEC`
 |`ARRAY (FLOAT32)`
-|`io.debezium.data.FloatVector` +
+|`io.debezium.data.FloatVector`
 
 |`SPARSEVEC`
 |`STRUCT`
@@ -2806,7 +2806,7 @@ The database typically reclaims disk space in batch blocks. This is expected beh
 ====
 For the connector to detect and process events from a heartbeat table, you must add the table to the PostgreSQL publication specified by the xref:postgresql-property-publication-name[publication.name] property.
 If this publication predates your {prodname} deployment, the connector uses the publications as defined.
-If the publication is not already configured to automatically replicate changes `FOR ALL TABLES` in the database, you must explicitly add the heartbeat table to the publication, for example, +
+If the publication is not already configured to automatically replicate changes `FOR ALL TABLES` in the database, you must explicitly add the heartbeat table to the publication, for example,
 
 `ALTER PUBLICATION  _<publicationName>_ ADD TABLE _<heartbeatTableName>_;`
 ====
@@ -2900,13 +2900,13 @@ For guidance about how to perform a PostgreSQL database upgrade so that {prodnam
 
 4. Verify that any changes that occurred in the database before you blocked write operations are saved to the write-ahead log (WAL), and that the WAL LSN is reflected on the replication slot.
 
-5. Provide the connector with enough time to capture all event records that are written to the replication slot. +
+5. Provide the connector with enough time to capture all event records that are written to the replication slot.
 This step ensures that all change events that occurred before the downtime are accounted for, and that they are saved to Kafka.
 
 6. Verify that the connector has finished consuming entries from the replication slot by checking the value of the flushed LSN.
 
-7. Shut down the connector gracefully by stopping Kafka Connect. +
-Kafka Connect stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector. +
+7. Shut down the connector gracefully by stopping Kafka Connect.
+Kafka Connect stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector.
 +
 [NOTE]
 ====
@@ -2923,7 +2923,7 @@ This property is for testing only.
 
 10. Perform the upgrade using an approved PostgreSQL upgrade procedure, such as `pg_upgrade`, or `pg_dump` and `pg_restore`.
 
-11. (Optional) Use a standard Kafka tool to remove the connector offsets from the offset storage topic. +
+11. (Optional) Use a standard Kafka tool to remove the connector offsets from the offset storage topic.
 For an example of how to remove connector offsets, see https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector[how to remove connector offsets] in the {prodname} community FAQ.
 
 12. Restart the database.
@@ -3007,7 +3007,7 @@ You can use either of the following methods to deploy a {prodname} PostgreSQL co
 * xref:openshift-streams-postgresql-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
-* xref:deploying-debezium-postgresql-connectors[Build a custom Kafka Connect container image from a Dockerfile]. +
+* xref:deploying-debezium-postgresql-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 This Containerfile deployment method is deprecated.
 The instructions for this method are scheduled for removal in future versions of the documentation.
 
@@ -3123,7 +3123,7 @@ docker push _<myregistry.io>_/debezium-container-for-postgresql:latest
 
 .. Create a new {prodname} PostgreSQL `KafkaConnect` custom resource (CR).
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -3170,7 +3170,7 @@ The connector configuration might instruct {prodname} to produce events for a su
 For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see xref:descriptions-of-debezium-postgresql-connector-configuration-properties[PostgreSQL connector properties].
 +
 The following example shows an excerpt from a custom resource that configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`.
-This host has a database named `sampledb`, a schema named `public`, and `inventory-connector-{context}` is the server's logical name. +
+This host has a database named `sampledb`, a schema named `public`, and `inventory-connector-{context}` is the server's logical name.
 +
 =====================================================================
 .PostgreSQL `inventory-connector.yaml`
@@ -3510,8 +3510,8 @@ endif::community[]
 |No default
 |Topic prefix that provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes.
 The prefix should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
-Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. +
- +
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
+
 [WARNING]
 ====
 Do not change the value of this property.
@@ -3522,19 +3522,19 @@ If you change the name value, after a restart, instead of continuing to emit eve
 |No default
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes.
 Any schema name not included in `schema.include.list` is excluded from having its changes captured.
-By default, all non-system schemas have their changes captured. +
+By default, all non-system schemas have their changes captured.
 
 To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire identifier for the schema; it does not match substrings that might be present in a schema name. +
+That is, the specified expression is matched against the entire identifier for the schema; it does not match substrings that might be present in a schema name.
 If you include this property in the configuration, do not also set the `schema.exclude.list` property.
 
 |[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `+schema.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes.
-Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. +
+Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas.
 
 To match the name of a schema, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire identifier for the schema; it does not match substrings that might be present in a schema name. +
+That is, the specified expression is matched against the entire identifier for the schema; it does not match substrings that might be present in a schema name.
 If you include this property in the configuration, do not set the `schema.include.list` property.
 
 |[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `+table.include.list+`>>
@@ -3542,38 +3542,38 @@ If you include this property in the configuration, do not set the `schema.includ
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture.
 When this property is set, the connector captures changes only from the specified tables.
 Each identifier is of the form _schemaName_._tableName_.
-By default, the connector captures changes in every non-system table in each schema whose changes are being captured. +
+By default, the connector captures changes in every non-system table in each schema whose changes are being captured.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire identifier for the table; it does not match substrings that might be present in a table name. +
+That is, the specified expression is matched against the entire identifier for the table; it does not match substrings that might be present in a table name.
 If you include this property in the configuration, do not also set the `table.exclude.list` property.
 
 |[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `+table.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want to capture.
 Each identifier is of the form _schemaName_._tableName_.
-When this property is set, the connector captures changes from every table that you do not specify. +
+When this property is set, the connector captures changes from every table that you do not specify.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the specified expression is matched against the entire identifier for the table; it does not match substrings that might be present in a table name. +
+That is, the specified expression is matched against the entire identifier for the table; it does not match substrings that might be present in a table name.
 If you include this property in the configuration, do not set the `table.include.list` property.
 
 |[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `+column.include.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values.
-Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the expression is used to match the entire name string of the column; it does not match substrings that might be present in a column name. +
+That is, the expression is used to match the entire name string of the column; it does not match substrings that might be present in a column name.
 If you include this property in the configuration, do not also set the `column.exclude.list` property.
 
 |[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `+column.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values.
-Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. +
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
-That is, the expression is used to match the entire name string of the column; it does not match substrings that might be present in a column name. +
+That is, the expression is used to match the entire name string of the column; it does not match substrings that might be present in a column name.
 If you include this property in the configuration, do not set the `column.include.list` property.
 
 |[[postgresql-property-skip-messages-without-change]]<<postgresql-property-skip-messages-without-change, `+skip.messages.without.change+`>>
@@ -3586,60 +3586,60 @@ This property is applied only when the REPLICA IDENTITY of the table is set to `
 
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
-|Time, date, and timestamps can be represented with different kinds of precision: +
- +
-`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
- +
+|Time, date, and timestamps can be represented with different kinds of precision:
+
+`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type.
+
 `adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type.
-An exception is `TIME` type fields, which are always captured as microseconds. +
- +
+An exception is `TIME` type fields, which are always captured as microseconds.
+
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision.
 For more information, see xref:postgresql-temporal-types[temporal values].
 
 |[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
-|Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
- +
-`precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events. +
- +
-`double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. +
- +
+|Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns:
+
+`precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events.
+
+`double` represents values by using `double` values, which might result in a loss of precision but which is easier to use.
+
 `string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost.
 For more information, see xref:postgresql-decimal-types[Decimal types].
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `+hstore.handling.mode+`>>
 |`json`
-| Specifies how the connector should handle values for `hstore` columns: +
- +
-`map` represents values by using `MAP`. +
- +
+| Specifies how the connector should handle values for `hstore` columns:
+
+`map` represents values by using `MAP`.
+
 `json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`.
 For more information, see xref:postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `+interval.handling.mode+`>>
 |`numeric`
-| Specifies how the connector should handle values for `interval` columns: +
- +
-`numeric` represents intervals using approximate number of microseconds. +
- +
+| Specifies how the connector should handle values for `interval` columns:
+
+`numeric` represents intervals using approximate number of microseconds.
+
 `string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`.
 For example: `P1Y2M3DT4H5M6.78S`.
 For more information, see xref:postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
 |`prefer`
-|Whether to use an encrypted connection to the PostgreSQL server. Options include: +
- +
-`disable` uses an unencrypted connection. +
- +
-`allow` attempts to use an unencrypted connection first and, failing that, a secure (encrypted) connection. +
- +
-`prefer` attempts to use a secure (encrypted) connection first and, failing that, an unencrypted connection. +
- +
-`require` uses a secure (encrypted) connection, and fails if one cannot be established. +
- +
-`verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found. +
- +
+|Whether to use an encrypted connection to the PostgreSQL server. Options include:
+
+`disable` uses an unencrypted connection.
+
+`allow` attempts to use an unencrypted connection first and, failing that, a secure (encrypted) connection.
+
+`prefer` attempts to use a secure (encrypted) connection first and, failing that, an unencrypted connection.
+
+`require` uses a secure (encrypted) connection, and fails if one cannot be established.
+
+`verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found.
+
 `verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect.
 For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
@@ -3712,26 +3712,26 @@ You can specify multiple properties with different lengths in a single configura
 [[postgresql-property-column-mask-hash-v2]]<<postgresql-property-column-mask-hash-v2, `column.mask.hash.v2._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.
-Fully-qualified names for columns are of the form _<schemaName>_._<tableName>_._<columnName>_. +
+Fully-qualified names for columns are of the form _<schemaName>_._<tableName>_._<columnName>_.
 To match the name of a column {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
-In the resulting change event record, the values for the specified columns are replaced with pseudonyms. +
+In the resulting change event record, the values for the specified columns are replaced with pseudonyms.
 
 A pseudonym consists of the hashed value that results from applying the specified _hashAlgorithm_ and _salt_.
 Based on the hash function that is used, referential integrity is maintained, while column values are replaced with pseudonyms.
-Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation. +
- +
-In the following example, `CzQMA0cB5K` is a randomly selected salt. +
+Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
+
+In the following example, `CzQMA0cB5K` is a randomly selected salt.
 
 ----
 column.mask.hash.SHA-256.with.salt.CzQMA0cB5K = inventory.orders.customerName, inventory.shipment.customerName
 ----
 
 If necessary, the pseudonym is automatically shortened to the length of the column.
-The connector configuration can include multiple properties that specify different hash algorithms and salts. +
- +
-Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked. +
- +
+The connector configuration can include multiple properties that specify different hash algorithms and salts.
+
+Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting data set might not be completely masked.
+
 Hashing strategy version 2 should be used to ensure fidelity if the value is being hashed in different places or systems.
 
 |[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `+column.propagate.source.type+`>>
@@ -3739,14 +3739,14 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns for which you want the connector to emit extra parameters that represent column metadata.
 When this property is set, the connector adds the following fields to the schema of event records:
 
-* `pass:[_]pass:[_]debezium.source.column.type` +
-* `pass:[_]pass:[_]debezium.source.column.length` +
-* `pass:[_]pass:[_]debezium.source.column.scale` +
+* `pass:[_]pass:[_]debezium.source.column.type`
+* `pass:[_]pass:[_]debezium.source.column.length`
+* `pass:[_]pass:[_]debezium.source.column.scale`
 
-These parameters propagate a column's original type name and length (for variable-width types), respectively. +
+These parameters propagate a column's original type name and length (for variable-width types), respectively.
 Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases.
 
-The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
+The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 To match the name of a column, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the column; the expression does not match substrings that might be present in a column name.
 
@@ -3755,14 +3755,14 @@ That is, the specified expression is matched against the entire name string of t
 |An optional, comma-separated list of regular expressions that specify the fully-qualified names of data types that are defined for columns in a database.
 When this property is set, for columns with matching data types, the connector emits event records that include the following extra fields in their schema:
 
-* `pass:[_]pass:[_]debezium.source.column.type` +
-* `pass:[_]pass:[_]debezium.source.column.length` +
-* `pass:[_]pass:[_]debezium.source.column.scale` +
+* `pass:[_]pass:[_]debezium.source.column.type`
+* `pass:[_]pass:[_]debezium.source.column.length`
+* `pass:[_]pass:[_]debezium.source.column.scale`
 
-These parameters propagate a column's original type name and length (for variable-width types), respectively. +
+These parameters propagate a column's original type name and length (for variable-width types), respectively.
 Enabling the connector to emit this extra data can assist in properly sizing specific numeric or character-based columns in sink databases.
 
-The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
+The fully-qualified name of a column observes one of the following formats: _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
 To match the name of a data type, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the data type; the expression does not match substrings that might be present in a type name.
 
@@ -3773,26 +3773,26 @@ For the list of PostgreSQL-specific data type names, see the xref:postgresql-dat
 |A list of expressions that specify the columns that the connector uses to form custom message keys for change event records that it publishes to the Kafka topics for specified tables.
 
 By default, {prodname} uses the primary key column of a table as the message key for records that it emits.
-In place of the default, or to specify a key for tables that lack a primary key, you can configure custom message keys based on one or more columns. +
- +
+In place of the default, or to specify a key for tables that lack a primary key, you can configure custom message keys based on one or more columns.
+
 To establish a custom message key for a table, list the table, followed by the columns to use as the message key.
-Each list entry takes the following format: +
- +
-`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_` +
- +
+Each list entry takes the following format:
+
+`_<fully-qualified_tableName>_:__<keyColumn>__,_<keyColumn>_`
+
 To base a table key on multiple column names, insert commas between the column names.
 
-Each fully-qualified table name is a regular expression in the following format: +
- +
-`_<schemaName>_._<tableName>_` +
- +
+Each fully-qualified table name is a regular expression in the following format:
+
+`_<schemaName>_._<tableName>_`
+
 The property can include entries for multiple tables.
-Use a semicolon to separate table entries in the list. +
- +
-The following example sets the message key for the tables `inventory.customers` and `purchase.orders`: +
- +
-`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4` +
- +
+Use a semicolon to separate table entries in the list.
+
+The following example sets the message key for the tables `inventory.customers` and `purchase.orders`:
+
+`inventory.customers:pk1,pk2;(.*).purchaseorders:pk3,pk4`
+
 In the example, the columns `pk1` and `pk2` are specified as the message key for the table `inventory.customer`.
 For the `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as the message key.
 
@@ -3818,14 +3818,14 @@ For more information, see xref:postgresql-replication-user-privileges[Setting pr
 Specify one of the following values:
 
 `all_tables`::
-If a publication exists, the connector uses it. +
+If a publication exists, the connector uses it.
 If a publication does not exist, the connector creates a publication for all tables in the database from which the connector captures changes.
-The connector runs the following SQL command to create a publication: +
- +
+The connector runs the following SQL command to create a publication:
+
 `CREATE PUBLICATION <__publication_name__> FOR ALL TABLES;`
- +
-If the xref:postgresql-property-skipped-operations[`skipped.operations`] property is configured, the connector appends a `WITH (publish = '...')` clause to restrict the publication to non-skipped operation types: +
- +
+
+If the xref:postgresql-property-skipped-operations[`skipped.operations`] property is configured, the connector appends a `WITH (publish = '...')` clause to restrict the publication to non-skipped operation types:
+
 `CREATE PUBLICATION <__publication_name__> FOR ALL TABLES WITH (publish = '<__allowed_operations__>');`
 
 `disabled`::
@@ -3834,26 +3834,26 @@ A database administrator or the user configured to perform replications must hav
 If the connector cannot find the publication, the connector throws an exception and stops.
 
 `filtered`::
-If a publication does not exist, the connector creates one by running a SQL command in the following format: +
- +
+If a publication does not exist, the connector creates one by running a SQL command in the following format:
+
 `CREATE PUBLICATION <__publication_name__> FOR TABLE <tbl1, tbl2, tbl3>`
- +
+
 The resulting publication includes tables that match the current filter configuration, as specified by the `schema.include.list`, `schema.exclude.list`, `table.include.list`, and `table.exclude.list` connector configuration properties.
- +
-If the publication exists, the connector updates the publication for tables that match the current filter configuration by running a SQL command in the following format: +
- +
+
+If the publication exists, the connector updates the publication for tables that match the current filter configuration by running a SQL command in the following format:
+
 `ALTER PUBLICATION <publication_name> SET TABLE <tbl1, tbl2, tbl3>`.
- +
+
 In both cases, if the xref:postgresql-property-skipped-operations[`skipped.operations`] property is configured, the connector appends a `WITH (publish = '...')` clause to restrict the publication to non-skipped operation types.
 
 `no_tables`::
 If a publication exists, the connector uses it.
-If a publication does not exist, the connector creates a publication without specifying any table by running a SQL command in the following format: +
- +
-`CREATE PUBLICATION <__publication_name__>;` +
- +
-Set the `no_tables` option if you want the connector to capture only logical decoding messages, and not capture any other change events, such as those caused by `INSERT`, `UPDATE`, and `DELETE` operations on any table. +
- +
+If a publication does not exist, the connector creates a publication without specifying any table by running a SQL command in the following format:
+
+`CREATE PUBLICATION <__publication_name__>;`
+
+Set the `no_tables` option if you want the connector to capture only logical decoding messages, and not capture any other change events, such as those caused by `INSERT`, `UPDATE`, and `DELETE` operations on any table.
+
 If you select this option, to prevent the connector from emitting and processing `READ` events, you can specify names of schemas or tables for which you do not want to capture changes, for example, by using `"table.exclude.list": "public.*"` or `"schema.exclude.list": "public"`.
 
 |[[postgresql-replica-autoset-type]]<<postgresql-replica-autoset-type, `+replica.identity.autoset.values+`>>
@@ -3867,7 +3867,7 @@ For example:
 
 `__<fqTableNameA>__:__<replicaIdentity1>__,__<fqTableNameB>__:__<replicaIdentity2>__,__<fqTableNameC>__:__<replicaIdentity3>__`
 
-Use the following format to specify the fully qualified table name: +
+Use the following format to specify the fully qualified table name:
 `_SchemaName_._TableName_`
 
 Set the replica identity to one of the following values:
@@ -3960,13 +3960,13 @@ For information about the structure of _message_ events and about their ordering
 |No default
 |An optional, comma-separated list of regular expressions that match the names of the logical decoding message prefixes that you do not want the connector to capture.
 When this property is set, the connector does not capture logical decoding messages that use the specified prefixes.
-All other messages are captured. +
+All other messages are captured.
 To exclude all logical decoding messages, set the value of this property to `.*`.
 
 To match the name of a message prefix, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire message prefix string; the expression does not match substrings that might be present in a prefix.
 
-If you include this property in the configuration, do not also set xref:postgresql-property-logical-decoding-message-prefix-include-list[`message.prefix.include.list`] property. +
+If you include this property in the configuration, do not also set xref:postgresql-property-logical-decoding-message-prefix-include-list[`message.prefix.include.list`] property.
 
 For information about the structure of _message_ events and about their ordering semantics, see xref:postgresql-message-events[].
 
@@ -3987,24 +3987,24 @@ The following _advanced_ configuration properties have defaults that work in mos
 |[[postgresql-property-converters]]<<postgresql-property-converters, `converters`>>
 |No default
 |Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
-For example, +
+For example,
 
 `isbn`
 
 You must set the `converters` property to enable the connector to use a custom converter.
 
 For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualified name of the class that implements the converter interface.
-The `.type` property uses the following format: +
+The `.type` property uses the following format:
 
-`_<converterSymbolicName>_.type` +
+`_<converterSymbolicName>_.type`
 
-For example, +
+For example,
 
  isbn.type: io.debezium.test.IsbnConverter
 
 If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
-To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter. +
-For example, +
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter.
+For example,
 
  isbn.schema.name: io.debezium.postgresql.type.Isbn
 
@@ -4021,8 +4021,8 @@ Specify one of the following isolation levels:
 
 `serializable`::
 The default, and most restrictive isolation level.
-This option prevents serialization anomalies and provides the highest degree of data integrity. +
- +
+This option prevents serialization anomalies and provides the highest degree of data integrity.
+
 To ensure the data consistency of captured tables, a snapshot runs in a transaction that uses a repeatable read isolation level, blocking concurrent DDL changes on the tables, and locking the database to index creation.
 When this option is set, users or administrators cannot perform certain operations, such as creating a table index, until the snapshot concludes.
 The entire range of table keys remains locked until the snapshot completes.
@@ -4038,8 +4038,8 @@ Allows for serialization anomalies.
 `read_committed`::
 In PostgreSQL, there is no difference between the behavior of the Read Uncommitted and Read Committed isolation modes.
 As a result, for this property, the `read_committed` option effectively provides the least restrictive level of isolation.
-Setting this option sacrifices some consistency for initial and ad hoc blocking snapshots, but provides better database performance for other users during the snapshot. +
- +
+Setting this option sacrifices some consistency for initial and ad hoc blocking snapshots, but provides better database performance for other users during the snapshot.
+
 In general, this transaction consistency level is appropriate for data mirroring.
 Other transactions cannot update table rows during the snapshot.
 However, minor data inconsistencies can occur when a record is added during the initial snapshot, and the connector later recaptures the record after the streaming phase begins.
@@ -4056,7 +4056,7 @@ However, as explained in the description for the `read-committed` option, for th
 
 |[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
-|Specifies the criteria for performing a snapshot when the connector starts: +
+|Specifies the criteria for performing a snapshot when the connector starts:
 
 `always`:: The connector performs a snapshot every time that it starts.
 The snapshot includes the structure and data of the captured tables.
@@ -4116,7 +4116,7 @@ endif::community[]
 ifdef::community[]
 |[[postgresql-property-snapshot-mode-configuration-based-snapshot-on-data-error]]<<postgresql-property-configuration-based-snapshot-on-data-error, `+snapshot.mode.configuration.based.snapshot.on.data.error+`>>
 |false
-|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log. +
+|If the `snapshot.mode` is set to `configuration_based`, this property specifies whether the connector attempts to snapshot table data if it does not find the last committed offset in the transaction log.
 Set the value to `true` to instruct the connector to perform a new snapshot.
 endif::community[]
 
@@ -4130,7 +4130,7 @@ endif::community[]
 
 |[[postgresql-property-snapshot-locking-mode]]<<postgresql-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |`none`
-|Specifies how the connector holds locks on tables while performing a schema snapshot. +
+|Specifies how the connector holds locks on tables while performing a schema snapshot.
 Set one of the following options:
 
 `shared`:: The connector holds a table lock that prevents exclusive table access during the initial portion phase of the snapshot in which database schemas and other metadata are read.
@@ -4156,13 +4156,13 @@ endif::community[]
 
 |[[postgresql-property-snapshot-query-mode]]<<postgresql-property-snapshot-query-mode, `+snapshot.query.mode+`>>
 |`select_all`
-|Specifies how the connector queries data while performing a snapshot. +
+|Specifies how the connector queries data while performing a snapshot.
 Set one of the following options:
 
 `select_all`:: The connector performs a `select all` query by default, optionally adjusting the columns selected based on the column include and exclude list configurations.
 
 ifdef::community[]
-`custom`:: The connector performs a snapshot query according to the implementation specified by the xref:postgresql-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface. +
+`custom`:: The connector performs a snapshot query according to the implementation specified by the xref:postgresql-property-snapshot-snapshot-query-mode-custom-name[`snapshot.query.mode.custom.name`] property, which defines a custom implementation of the `io.debezium.spi.snapshot.SnapshotQuery` interface.
 endif::community[]
 
 This setting enables you to manage snapshot content in a more flexible manner compared to using the xref:postgresql-property-snapshot-select-statement-overrides[`snapshot.select.statement.overrides`] property.
@@ -4178,8 +4178,8 @@ endif::community[]
 | All tables specified in `table.include.list`
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>.<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
-This property takes effect only if the connector's xref:postgresql-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`. +
-This property does not affect the behavior of incremental snapshots. +
+This property takes effect only if the connector's xref:postgresql-property-snapshot-mode[`snapshot.mode`] property is set to a value other than `no_data`.
+This property does not affect the behavior of incremental snapshots.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
@@ -4233,12 +4233,12 @@ The following example shows how to configure the `snapshot.select.statement.over
 
 |[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
-| Specifies how the connector should react to exceptions during processing of events: +
- +
-`fail` propagates the exception, indicates the offset of the problematic event, and causes the connector to stop. +
- +
-`warn` logs the offset of the problematic event, skips that event, and continues processing. +
- +
+| Specifies how the connector should react to exceptions during processing of events:
+
+`fail` propagates the exception, indicates the offset of the problematic event, and causes the connector to stop.
+
+`warn` logs the offset of the problematic event, skips that event, and continues processing.
+
 `skip` skips the problematic event and continues processing.
 
 |[[postgresql-property-max-batch-size]]<<postgresql-property-max-batch-size, `+max.batch.size+`>>
@@ -4258,7 +4258,7 @@ Always set the value of `max.queue.size` to be larger than the value of xref:{co
 |`0`
 |A long integer value that specifies the maximum volume of the blocking queue in bytes.
 By default, volume limits are not specified for the blocking queue.
-To specify the number of bytes that the queue can consume, set this property to a positive long value. +
+To specify the number of bytes that the queue can consume, set this property to a positive long value.
 If xref:postgresql-property-max-queue-size[`max.queue.size`] is also set, writing to the queue is blocked when the size of the queue reaches the limit specified by either property.
 For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000`, writing to the queue is blocked after the queue contains 1000 records, or after the volume of the records in the queue reaches 5000 bytes.
 
@@ -4268,32 +4268,32 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 
 |[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `+include.unknown.datatypes+`>>
 |`false`
-|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
- +
+|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning.
+
 Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the xref:postgresql-property-binary-handling-mode[`binary handling mode`] property.
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
 |[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `+database.initial.statements+`>>
 |No default
-|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. +
- +
-The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements. +
- +
-The connector does not execute these statements when it creates a connection for reading the transaction log. +
+|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`.
+
+The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements.
+
+The connector does not execute these statements when it creates a connection for reading the transaction log.
 
 |[[postgresql-property-status-update-interval-ms]]<<postgresql-property-status-update-interval-ms, `+status.update.interval.ms+`>>
 |`10000`
 |Frequency for sending replication connection status updates to the server, given in milliseconds.
- +
+
 The property also controls how frequently the database status is checked to detect a dead connection in case the database was shut down.
 
 |[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
-|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
- +
-Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. +
- +
+|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages.
+
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
+
 Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files.
 
 |[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `+heartbeat.action.query+`>>
@@ -4308,12 +4308,12 @@ This allows the connector to receive changes from the low-traffic database and a
 
 |[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `+schema.refresh.mode+`>>
 |`columns_diff`
-|Specify the conditions that trigger a refresh of the in-memory schema for a table. +
- +
-`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times. +
- +
-`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy. +
- +
+|Specify the conditions that trigger a refresh of the in-memory schema for a table.
+
+`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times.
+
+`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
+
 This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates. However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 
@@ -4380,7 +4380,7 @@ For example to request the publisher to send all changes, that is, changes that 
 |`6`
 |If connecting to a replication slot fails, this is the maximum number of consecutive attempts to connect.
 
-|[[postgresql-property-slot-retry-delay-ms]]<<postgresql-property-slot-retry-delay-ms, `+slot.retry.delay.ms+`>> +
+|[[postgresql-property-slot-retry-delay-ms]]<<postgresql-property-slot-retry-delay-ms, `+slot.retry.delay.ms+`>>
 |`10000` (10 seconds)
 |The number of milliseconds to wait between retry attempts when the connector fails to connect to a replication slot.
 
@@ -4404,13 +4404,13 @@ Set one of the following options:
 
 `true`::
 The connector emits change events for all partitions to a topic with the name of the base table.
- +
+
 When the connector creates a publication, it submits a `CREATE PUBLICATION` statement in which the `publish_via_partition_root` parameter is set to `true`.
 As a result, the publication ignores the partition in which changes originate, and only records the name of the name of the source table.
 
 `false`::
 The connector emits changes from each source partition to a topic that reflects the name of the partition.
- +
+
 When the connector creates the publication, the `CREATE PUBLICATION` statement omits the `publish_via_partition_root` parameter so that the publication always uses the name of the source partition to publish change events.
 
 |[[postgresql-property-flush-lsn-source]]<<postgresql-property-flush-lsn-source, `+flush.lsn.source+`>>
@@ -4462,7 +4462,7 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 If you use an ephemeral offset store such as `org.apache.kafka.connect.storage.MemoryOffsetBackingStore`, no additional configuration is needed because the connector always defers to the replication slot position on startup.
 ====
 
-|[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>> +
+|[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>>
 |10000 (10 seconds)
 |The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 
@@ -4522,7 +4522,7 @@ Adjust the chunk size to a value that provides the best performance in your envi
 
 |[[postgresql-property-incremental-snapshot-watermarking-strategy]]<<postgresql-property-incremental-snapshot-watermarking-strategy, `+incremental.snapshot.watermarking.strategy+`>>
 |`insert_insert`
-|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes. +
+|Specifies the watermarking mechanism that the connector uses during an incremental snapshot to deduplicate events that might be captured by an incremental snapshot and then recaptured after streaming resumes.
 You can specify one of the following options:
 
 `insert_insert`:: When you send a signal to initiate an incremental snapshot, for every chunk that {prodname} reads during the snapshot, it writes an entry to the signaling data collection to record the signal to open the snapshot window.
@@ -4559,30 +4559,30 @@ The default value of `0` disables tracking XMIN tracking.
 
 |[[postgresql-property-topic-heartbeat-prefix]]<<postgresql-property-topic-heartbeat-prefix, `+topic.heartbeat.prefix+`>>
 |`__debezium-heartbeat`
-|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
- +
-_topic.heartbeat.prefix_._topic.prefix_ +
- +
-For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`. +
- +
+|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern:
+
+_topic.heartbeat.prefix_._topic.prefix_
+
+For example, if the topic prefix is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
+
 This property is ignored if `topic.heartbeat.name` is set.
 
 |[[postgresql-property-topic-heartbeat-name]]<<postgresql-property-topic-heartbeat-name, `+topic.heartbeat.name+`>>
 |_empty_
-|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`. +
- +
-When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics. +
- +
-For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`. +
- +
+|Specifies an explicit, full name for the topic to which the connector sends heartbeat messages, overriding the prefix-based naming derived from `topic.heartbeat.prefix` and `topic.prefix`.
+
+When set, all heartbeat messages are routed to this exact topic name, regardless of the connector's `topic.prefix`. This is useful when running multiple connectors and you want to consolidate heartbeat events into a single shared topic, avoiding the creation of a large number of single-partition heartbeat topics.
+
+For example, setting this to `debezium-heartbeat` routes all heartbeat messages to a topic named `debezium-heartbeat`.
+
 If this property is empty or unset, the connector falls back to the default behavior: _topic.heartbeat.prefix_._topic.prefix_.
 
 |[[postgresql-property-topic-transaction]]<<postgresql-property-topic-transaction, `topic.transaction`>>
 |`transaction`
-|Controls the name of the topic to which the connector sends transaction metadata messages. The topic name has this pattern: +
- +
-_topic.prefix_._topic.transaction_ +
- +
+|Controls the name of the topic to which the connector sends transaction metadata messages. The topic name has this pattern:
+
+_topic.prefix_._topic.transaction_
+
 For example, if the topic prefix is `fulfillment`, the default topic name is `fulfillment.transaction`.
 
 |[[postgresql-property-snapshot-max-threads]]<<postgresql-property-snapshot-max-threads, `snapshot.max.threads`>>
@@ -4590,14 +4590,14 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 |Specifies the number of threads that the connector uses when performing an initial snapshot.
 To enable parallel initial snapshots, set the property to a value greater than 1.
 In a parallel initial snapshot, the connector processes multiple tables concurrently.
- +
+
 [NOTE]
 ====
 When you enable parallel initial snapshots, the threads that perform each table snapshot can require varying times to complete their work.
 If a snapshot for one table requires significantly more time to complete than the snapshots for other tables, threads that have completed their work sit idle.
 In some environments, a network device such as a load balancer or firewall, terminates connections that remain idle for an extended interval.
-After the snapshot completes, the connector is unable to close the connection, resulting in an exception, and an incomplete snapshot, even in cases where the connector successfully transmitted all snapshot data. +
- +
+After the snapshot completes, the connector is unable to close the connection, resulting in an exception, and an incomplete snapshot, even in cases where the connector successfully transmitted all snapshot data.
+
 If you experience this problem, revert the value of `snapshot.max.threads` to `1`, and retry the snapshot.
 ====
 
@@ -4642,7 +4642,7 @@ The pattern that you specify for the `custom.sanitize.pattern` property override
 
 |[[postgresql-property-errors-max-retires]]<<postgresql-property-errors-max-retires, `errors.max.retries`>>
 |`-1`
-|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error. +
+|Specifies how the connector responds after an operation that results in a retriable error, such as a connection error.
 Set one of the following options:
 
 `-1`:: No limit. The connector always restarts automatically, and retries the operation, regardless of the number of previous failures.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2431,7 +2431,7 @@ Familiarity with the mechanics and link:https://www.postgresql.org/docs/current/
 
 // Type: concept
 [id="postgresql-automatic-replication-slot-creation"]
-===== Automatic replication slot creation
+==== Automatic replication slot creation
 
 By default, when the {prodname} PostgreSQL connector starts, if the configured replication slot does not exist, the connector creates it automatically.
 For automatic slot creation to succeed, the following prerequisites must be met:


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#<the Debezium Issue Number>

## Description
* Removes hard line break characters from `postgresql.adoc`.
* Places each sentence in the file on its own line, per standard guidance.
* Adjust heading level for one topic to resolve build warning.

Tested in local Antora and downstream builds.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
