### PR TITLE
Dbz 9917 remove hard line breaks from notifications signalling topic auto create config

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -142,7 +142,7 @@ a|[source, json]
    "timestamp": "1695817046353"
 }
 ----
-Field `data_collection` are currently not supported for MongoDB connector
+The field `data_collection` is not supported for the MongoDB connector.
 
 |TABLE_SCAN_COMPLETED
 a|[source, json]

--- a/documentation/modules/ROOT/pages/configuration/notification.adoc
+++ b/documentation/modules/ROOT/pages/configuration/notification.adoc
@@ -466,8 +466,8 @@ Declare your implementation in the `META-INF/services/io.debezium.pipeline.notif
 * You have a custom notification channel Java program.
 
 .Procedure
-* To use a notification channel with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
- +
+* To use a notification channel with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with.
++
 For example, in a typical deployment, the {prodname} connector files are stored in subdirectories of a Kafka Connect directory (`/kafka/connect`), with each connector JAR in its own subdirectory (`/kafka/connect/debezium-connector-db2`, `/kafka/connect/debezium-connector-mysql`, and so forth).
 To use a signaling channel with a connector, add the converter JAR file to the connector's subdirectory.
 

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -123,29 +123,29 @@ The structure of the signaling table must conform to the following standard form
 |===
 |Field | Type | Description
 
-|`id` +
+|`id`
 (required)
 |`string`
 
-|An arbitrary unique string that identifies a signal instance. +
-You assign an `id` to each signal that you submit to the signaling table. +
-Typically, the ID is a UUID string. +
-You can use signal instances for logging, debugging, or de-duplication. +
+|An arbitrary unique string that identifies a signal instance.
+You assign an `id` to each signal that you submit to the signaling table.
+Typically, the ID is a UUID string.
+You can use signal instances for logging, debugging, or de-duplication.
 When a signal triggers {prodname} to perform an incremental snapshot, it generates a signal message with an arbitrary `id` string.
 The `id` string that the generated message contains is unrelated to the `id` string in the submitted signal.
 
-|`type` +
+|`type`
 (required)
 |`string`
 
-|Specifies the type of signal to send. +
+|Specifies the type of signal to send.
 You can use some signal types with any connector for which signaling is available, while other signal types are available for specific connectors only.
 
-|`data` +
+|`data`
 (optional)
 |`string`
 
-|Specifies JSON-formatted parameters to pass to a signal action. +
+|Specifies JSON-formatted parameters to pass to a signal action.
 Each signal type requires a specific set of data.
 
 |===
@@ -167,13 +167,13 @@ You create a signaling table by submitting a standard SQL DDL query to the sourc
 
 .Procedure
 
-* Submit a SQL query to the source database to create a table that is consistent with the xref:debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[required structure], as shown in the following example: +
- +
-`CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);` +
+* Submit a SQL query to the source database to create a table that is consistent with the xref:debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[required structure], as shown in the following example:
++
+`CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);`
 
 [NOTE]
 ====
-The amount of space that you allocate to the `VARCHAR` parameter of the `id` variable must be sufficient to accommodate the size of the ID strings of signals sent to the signaling table. +
+The amount of space that you allocate to the `VARCHAR` parameter of the `id` variable must be sufficient to accommodate the size of the ID strings of signals sent to the signaling table.
 If the size of an ID exceeds the available space, the connector cannot process the signal.
 ====
 
@@ -225,20 +225,20 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 
 |`data-collections`
 |_N/A_
-| An array of comma-separated regular expressions that match the fully qualified names of the data collections to include in the snapshot. +
+| An array of comma-separated regular expressions that match the fully qualified names of the data collections to include in the snapshot.
 The xref:format-for-specifying-fully-qualified-names-for-data-collections[naming format] depends on the database.
 
 |`additional-conditions`
 |_N/A_
-| An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
+| An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot.
 Each additional condition is an object that specifies the criteria for filtering the data that an ad hoc snapshot captures.
 You can set the following properties for each additional condition:
 
 `data-collection`:: The fully-qualified name of the data collection that the filter applies to.
 You can apply different filters to each data collection.
-`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
-The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values. +
- +
+`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`.
+The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values.
+
 The specific values that you assign to the `filter` property depend on the type of ad hoc snapshot:
 
 * For incremental snapshots, you specify a search condition fragment, such as `"color='blue'"`, that the snapshot appends to the condition clause of a query.
@@ -272,7 +272,7 @@ The Mbean exposes `signal` operations that accept the following input parameters
 p0:: The id of the signal.
 p1:: The type of the signal, for example, `execute-snapshot`.
 p2:: A JSON data field that contains additional information about the specified signal type.
-3. Send an `execute-snapshot` signal by providing value for the input parameters. +
+3. Send an `execute-snapshot` signal by providing value for the input parameters.
 In the JSON data field, include the information that is listed in the following table:
 +
 .Execute snapshot data fields
@@ -287,20 +287,20 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 
 |`data-collections`
 |_N/A_
-| An array of comma-separated regular expressions that match the xref:format-for-specifying-fully-qualified-names-for-data-collections[fully-qualified names of the tables] to include in the snapshot. +
+| An array of comma-separated regular expressions that match the xref:format-for-specifying-fully-qualified-names-for-data-collections[fully-qualified names of the tables] to include in the snapshot.
 
 |`additional-conditions`
 |_N/A_
-|An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
+|An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot.
 Each additional condition is an object that specifies the criteria for filtering the data that an ad hoc snapshot captures.
 You can set the following properties for each additional condition:
 
 `data-collection`:: The fully-qualified name of the data collection that the filter applies to.
 You can apply different filters to each data collection.
 
-`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
-The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values. +
- +
+`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`.
+The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values.
+
 The specific values that you assign to the `filter` property depend on the type of ad hoc snapshot:
 
 * For incremental snapshots, you specify a search condition fragment, such as `"color='blue'"`, that the snapshot appends to the condition clause of a query.
@@ -339,20 +339,20 @@ Currently {prodname} supports the `incremental` and `blocking` types.
 
 |`data-collections`
 |_N/A_
-| An array of comma-separated regular expressions that match the fully qualified names of the data collections to include in the snapshot. +
+| An array of comma-separated regular expressions that match the fully qualified names of the data collections to include in the snapshot.
 The xref:format-for-specifying-fully-qualified-names-for-data-collections[naming format] depends on the database.
 
 |`additional-conditions`
 |_N/A_
-| An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
+| An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot.
 Each additional condition is an object that specifies the criteria for filtering the data that an ad hoc snapshot captures.
 You can set the following properties for each additional condition:
 
 `data-collection`:: The fully-qualified name of the data collection that the filter applies to.
 You can apply different filters to each data collection.
-`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
-The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values. +
- +
+`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`.
+The snapshot process evaluates records in the data collection against the `filter` value and captures only records that contain matching values.
+
 The specific values that you assign to the `filter` property depend on the type of ad hoc snapshot:
 
 * For incremental snapshots, you specify a search condition fragment, such as `"color='blue'"`, that the snapshot appends to the condition clause of a query.
@@ -446,8 +446,8 @@ Declare your implementation in the `META-INF/services/io.debezium.pipeline.signa
 * You have a custom signaling channel Java program.
 
 .Procedure
-* To use a custom signaling channel with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
- +
+* To use a custom signaling channel with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with.
++
 For example, in a typical deployment, the {prodname} connector files are stored in subdirectories of a Kafka Connect directory (`/kafka/connect`), with each connector JAR in its own subdirectory (`/kafka/connect/debezium-connector-db2`, `/kafka/connect/debezium-connector-mysql`, and so forth).
 
 NOTE: To use a custom signaling channel with multiple connectors, you must place a copy of the custom signaling channel JAR file in the subdirectory for each connector.
@@ -512,7 +512,7 @@ a|
 ----
 {"message": "Signal message at offset {}"}
 ----
-| The `message` parameter specifies the string to print to the log. +
+| The `message` parameter specifies the string to print to the log.
 If you add a placeholder (`{}`) to the message, it is replaced with streaming coordinates.
 |===
 
@@ -903,8 +903,8 @@ Declare your provider implementation in the `META-INF/services/io.debezium.pipel
 * You have a custom actions Java program.
 
 .Procedure
-* To use a custom action with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
- +
+* To use a custom action with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with.
++
 For example, in a typical deployment, the {prodname} connector files are stored in subdirectories of a Kafka Connect directory (`/kafka/connect`), with each connector JAR in its own subdirectory (`/kafka/connect/debezium-connector-db2`, `/kafka/connect/debezium-connector-mysql`, and so forth).
 
 NOTE: To use a custom action with multiple connectors, you must place a copy of the custom signaling channel JAR file in the subdirectory for each connector.

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -121,12 +121,11 @@ The structure of the signaling table must conform to the following standard form
 .Required structure of a signaling data collection
 [cols="1,1,9",options="header"]
 |===
+
 |Field | Type | Description
 
-|`id`
-(required)
+|`id` (required)
 |`string`
-
 |An arbitrary unique string that identifies a signal instance.
 You assign an `id` to each signal that you submit to the signaling table.
 Typically, the ID is a UUID string.
@@ -134,17 +133,13 @@ You can use signal instances for logging, debugging, or de-duplication.
 When a signal triggers {prodname} to perform an incremental snapshot, it generates a signal message with an arbitrary `id` string.
 The `id` string that the generated message contains is unrelated to the `id` string in the submitted signal.
 
-|`type`
-(required)
+|`type` (required)
 |`string`
-
 |Specifies the type of signal to send.
 You can use some signal types with any connector for which signaling is available, while other signal types are available for specific connectors only.
 
-|`data`
-(optional)
+|`data` (optional)
 |`string`
-
 |Specifies JSON-formatted parameters to pass to a signal action.
 Each signal type requires a specific set of data.
 
@@ -494,7 +489,7 @@ Optionally, you can configure the signal so that the resulting message includes 
 
 [id="debezium-signaling-example-of-a-logging-record"]
 .Example of a signaling record for adding a log message
-[cols="1,9,9",options="header"]
+[cols="3,9,9",options="header"]
 |===
 |Column | Value | Description
 

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -58,7 +58,7 @@ However, the broker cannot create topics with unique settings for different conn
 All topics that a broker creates have the same retention period, compaction settings, partition count, replication factors and so forth.
 If you have multiple connectors and each requires its own topic configuration, use xref:enabling-automatic-topic-creation[Kafka Connect automatic topic creation].
 
-If Kafka Connect topic creation is unavailable, as in deployments that use Kafka 2.6 or earlier, the only way to guarantee custom topic properties is to pre-create the topics yourself.
+If Kafka Connect topic creation is unavailable, as in deployments that use Kafka 2.6 or earlier, the only way to guarantee custom topic properties is to pre-create the topics yourself, either manually, or through a custom deployment process.
 
 As noted earlier, broker topic creation and Kafka Connect topic creation are independent, so to use the Kafka Connect mechanism, it's not strictly necessary to disable topic creation at the broker.
 That said, preventing the broker from creating topics provides the following advantages:

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -54,9 +54,19 @@ endif::product[]
 == Disabling automatic topic creation for the Kafka broker
 
 By default, the Kafka broker configuration enables the broker to create topics at runtime if the topics do not already exist.
-Topics created by the broker cannot be configured with custom properties.
-If you use a Kafka version earlier than 2.6.0, and you want to create topics with specific configurations, you must to disable automatic topic creation at the broker,
-and then explicitly create the topics, either manually, or through a custom deployment process.
+However, the broker cannot create topics with unique settings for different connectors.
+All topics that a broker creates have the same retention period, compaction settings, partition count, replication factors and so forth.
+If you have multiple connectors and each requires its own topic configuration, use xref:enabling-automatic-topic-creation[Kafka Connect automatic topic creation].
+
+If Kafka Connect topic creation is unavailable, as in deployments that use Kafka 2.6 or earlier, the only way to guarantee custom topic properties is to pre-create the topics yourself.
+
+As noted earlier, broker topic creation and Kafka Connect topic creation are independent, so to use the Kafka Connect mechanism, it's not strictly necessary to disable topic creation at the broker.
+That said, preventing the broker from creating topics provides the following advantages:
+
+* Prevents accidental topic creation.
+* Ensures all connector topics are created through the Connect configuration.
+* Makes topic configuration more predictable and auditable.
+
 
 .Procedure
 
@@ -92,8 +102,8 @@ ifdef::community[]
 [NOTE]
 ====
 If you don't want to allow automatic topic creation by Kafka Connect, set the value of `topic.creation.enable` to `false`
-in the Kafka Connect configuration (_connect-distributed.properties_ file or via environment variable
-_CONNECT_TOPIC_CREATION_ENABLE_ when using https://quay.io/repository/debezium/connect[{prodname}'s container image for Kafka Connect]).
+in the Kafka Connect configuration (_connect-distributed.properties_ file, or via the environment variable
+_CONNECT_TOPIC_CREATION_ENABLE_ when using the https://quay.io/repository/debezium/connect[{prodname} container image for Kafka Connect]).
 ====
 endif::community[]
 

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -249,7 +249,7 @@ spec:
 endif::product[]
 +
 You can include any {link-kafka-docs}/#topicconfigs[Kafka topic-level configuration property] in the configuration for the `default` group.
-
++
 .Connector configuration for the `default` topic creation group
 [cols="1,9",options="header"]
 |===
@@ -360,7 +360,7 @@ spec:
 ...
 ----
 endif::product[]
-
++
 .Connector configuration for custom `inventory` and `applicationlogs` topic creation groups
 [cols="1,9",options="header"]
 |===

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -257,17 +257,17 @@ You can include any {link-kafka-docs}/#topicconfigs[Kafka topic-level configurat
 
 |1
 |`topic.creation.default.replication.factor` defines the replication factor for topics created by
-the default group.{empty} +
-`replication.factor` is mandatory for the `default` group but optional for custom groups. Custom
-groups will fall back to the `default` group's value if not set. Use `-1` to use the Kafka
-broker's default value.
+the default group.
+`replication.factor` is mandatory for the `default` group but optional for custom groups.
+Custom groups will fall back to the `default` group's value if not set.
+Use `-1` to use the Kafka broker's default value.
 
 |2
 |`topic.creation.default.partitions` defines the number of partitions for topics created by
-the default group.{empty} +
-`partitions` is mandatory for the `default` group but optional for custom groups. Custom
-groups will fall back to the `default` group's value if not set. Use `-1` to use the Kafka
-broker's default value.
+the default group.
+`partitions` is mandatory for the `default` group but optional for custom groups.
+Custom groups will fall back to the `default` group's value if not set.
+Use `-1` to use the Kafka broker's default value.
 
 |3
 |`topic.creation.default.cleanup.policy` is mapped to the {link-kafka-docs}/#cleanup.policy[`cleanup.policy`]
@@ -367,9 +367,10 @@ endif::product[]
 |Item |Description
 
 |1
-|Defines the configuration for the `inventory` group.{empty} +
-The `replication.factor` and `partitions` properties are optional for custom groups. If no value is set, custom
-groups fall back to the value set for the `default` group. Set the value to `-1` to use the value that is set for the Kafka broker.
+|Defines the configuration for the `inventory` group.
+The `replication.factor` and `partitions` properties are optional for custom groups.
+If no value is set, custom groups fall back to the value set for the `default` group.
+Set the value to `-1` to use the value that is set for the Kafka broker.
 
 |2
 |`topic.creation.inventory.include` defines a regular expression to match all topics that start with
@@ -377,9 +378,10 @@ groups fall back to the value set for the `default` group. Set the value to `-1`
 topics with names that match the specified regular expression.
 
 |3
-|Defines the configuration for the `applicationlogs` group.{empty} +
-The `replication.factor` and `partitions` properties are optional for custom groups. If no value is set,
-custom groups fall back to the value set for the `default` group. Set the value to `-1` to use the value that is set for the Kafka broker.
+|Defines the configuration for the `applicationlogs` group.
+The `replication.factor` and `partitions` properties are optional for custom groups.
+If no value is set, custom groups fall back to the value set for the `default` group.
+Set the value to `-1` to use the value that is set for the Kafka broker.
 
 |4
 |`topic.creation.applicationlogs.include` defines a regular expression to match all topics that start


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9917](https://redhat.atlassian.net/browse/DBZ-9917)

## Description
Removes hard line breaks from the Notifications, Signaling, and Auto-create topics files.

Tested in local Antora and downstream builds.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
