### PR TITLE
[docs] Document CockroachDB sink target behavior in the JDBC connector page

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -114,7 +114,7 @@ ifdef::community[]
 === CockroachDB sink targets
 
 To enable the JDBC connector to write to CockroachDB, you must specify a PostgreSQL JDBC URL in the connector's xref:jdbc-property-connection-url[`connection.url`] property, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
-CockroachDB is wire compatible with PostgreSQL and uses the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
+Because CockroachDB supports the PostgreSQL communication protocol, it works with the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
 
 As a sink target, CockroachDB supports idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
 For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
@@ -124,7 +124,7 @@ As a result, if CockroachDB detects a conflict between concurrent transactions, 
 The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
 Setting `flush.max.retries` to `0` disables the retries so that a conflicting flush fails immediately.
 
-For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following differences:
+For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following exceptions:
 
 * `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
 * `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -46,7 +46,9 @@ The {prodname} JDBC connector provides the following features:
 * xref:jdbc-schema-evolution[Schema evolution]
 * xref:jdbc-singlestore-targets[SingleStore sink targets]
 * xref:jdbc-starrocks-targets[StarRocks sink targets]
+ifdef::community[]
 * xref:jdbc-cockroachdb-targets[CockroachDB sink targets]
+endif::community[]
 * xref:jdbc-quoting-case-sensitivity[JDBC quoting and case-sensitivity]
 * xref:jdbc-connection-idle-timeouts[Connection idle timeouts]
 
@@ -107,19 +109,18 @@ When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to
 {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
 The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
 
-// Type: concept
-// Title: Using CockroachDB as a sink target
-// ModuleID: debezium-jdbc-connector-using-cockroachdb-as-a-sink-target
+ifdef::community[]
 [[jdbc-cockroachdb-targets]]
 === CockroachDB sink targets
 
-To write to CockroachDB, configure xref:jdbc-property-connection-url[`connection.url`] with a PostgreSQL JDBC URL, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
+To enable the JDBC connector to write to CockroachDB, you must specify a PostgreSQL JDBC URL in the connector's xref:jdbc-property-connection-url[`connection.url`] property, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
 CockroachDB is wire compatible with PostgreSQL and uses the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
 
-CockroachDB targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+As a sink target, CockroachDB supports idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
 For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
 
-CockroachDB runs transactions at `SERIALIZABLE` isolation and reports transient transaction conflicts with SQLSTATE 40001.
+CockroachDB uses the `SERIALIZABLE` transaction isolation level.
+As a result, if CockroachDB detects a conflict between concurrent transactions, it might temporarily abort one of the transactions and return SQLSTATE `40001`.
 The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
 Setting `flush.max.retries` to `0` disables the retries so that a conflicting flush fails immediately.
 
@@ -127,9 +128,11 @@ For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most
 
 * `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
 * `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.
-* Propagated `money` column types are written as `decimal(19,2)`.
+* Propagated `money` column types are written as `decimal(19,2)` types.
 * `io.debezium.data.geometry.Geometry`, `io.debezium.data.geometry.Geography`, and `io.debezium.data.geometry.Point` logical values are written to the built-in CockroachDB `geometry` and `geography` types; no PostGIS extension schema is required.
-* `io.debezium.data.FloatVector` logical values are written to the CockroachDB `vector` column type, because CockroachDB has no `halfvec` type. `io.debezium.data.SparseDoubleVector` is not supported.
+* `io.debezium.data.FloatVector` logical values are written to the CockroachDB `vector` column type, because CockroachDB has no `halfvec` type.
+* `io.debezium.data.SparseDoubleVector` is not supported.
+endif::community[]
 
 // Type: concept
 // Title: Description of how the {prodname} JDBC connector consumes complex change events
@@ -777,11 +780,13 @@ SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
 Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
 {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values are written to SingleStore `geography` columns, and `io.debezium.data.geometry.Point` logical values are written to SingleStore `geographypoint` columns.
 
-For CockroachDB targets, {prodname} uses the PostgreSQL-compatible mappings for most dialect-specific logical types.
-`io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to CockroachDB `jsonb` columns.
-`io.debezium.data.Xml` logical values are written to `text` columns because CockroachDB has no XML type.
-Geometry, geography, and point values are written to the built-in CockroachDB `geometry` and `geography` types without a PostGIS extension schema.
-`io.debezium.data.FloatVector` logical values are written to `vector` columns; sparse double vectors are not supported.
+When you configure the JDBC connector to use CockroachDB as a sink target, {prodname} uses the PostgreSQL-compatible mappings for most dialect-specific logical types.
+For example, the connector uses the following mappings:
+
+* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to CockroachDB `jsonb` columns.
+* `io.debezium.data.Xml` logical values are written to `text` columns because CockroachDB has no XML type.
+* Geometry, geography, and point values are written to the built-in CockroachDB `geometry` and `geography` types without a PostGIS extension schema.
+* `io.debezium.data.FloatVector` logical values are written to `vector` columns; sparse double vectors are not supported.
 The SingleStore dialect writes supported `POINT`, `LINESTRING`, and `POLYGON` WKB values as WKT strings.
 
 For StarRocks targets, see xref:jdbc-starrocks-targets[] for the dialect-specific type mappings, including the string-based representation that the dialect uses for time types.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -46,6 +46,7 @@ The {prodname} JDBC connector provides the following features:
 * xref:jdbc-schema-evolution[Schema evolution]
 * xref:jdbc-singlestore-targets[SingleStore sink targets]
 * xref:jdbc-starrocks-targets[StarRocks sink targets]
+* xref:jdbc-cockroachdb-targets[CockroachDB sink targets]
 * xref:jdbc-quoting-case-sensitivity[JDBC quoting and case-sensitivity]
 * xref:jdbc-connection-idle-timeouts[Connection idle timeouts]
 
@@ -105,6 +106,30 @@ StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so t
 When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
 {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
 The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
+
+// Type: concept
+// Title: Using CockroachDB as a sink target
+// ModuleID: debezium-jdbc-connector-using-cockroachdb-as-a-sink-target
+[[jdbc-cockroachdb-targets]]
+=== CockroachDB sink targets
+
+To write to CockroachDB, configure xref:jdbc-property-connection-url[`connection.url`] with a PostgreSQL JDBC URL, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
+CockroachDB is wire compatible with PostgreSQL and uses the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
+
+CockroachDB targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
+
+CockroachDB runs transactions at `SERIALIZABLE` isolation and reports transient transaction conflicts with SQLSTATE 40001.
+The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
+Setting `flush.max.retries` to `0` disables the retries so that a conflicting flush fails immediately.
+
+For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following differences:
+
+* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
+* `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.
+* Propagated `money` column types are written as `decimal(19,2)`.
+* `io.debezium.data.geometry.Geometry`, `io.debezium.data.geometry.Geography`, and `io.debezium.data.geometry.Point` logical values are written to the built-in CockroachDB `geometry` and `geography` types; no PostGIS extension schema is required.
+* `io.debezium.data.FloatVector` logical values are written to the CockroachDB `vector` column type, because CockroachDB has no `halfvec` type. `io.debezium.data.SparseDoubleVector` is not supported.
 
 // Type: concept
 // Title: Description of how the {prodname} JDBC connector consumes complex change events
@@ -751,6 +776,12 @@ For SingleStore targets, {prodname} uses MySQL/MariaDB-compatible mappings for m
 SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
 Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
 {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values are written to SingleStore `geography` columns, and `io.debezium.data.geometry.Point` logical values are written to SingleStore `geographypoint` columns.
+
+For CockroachDB targets, {prodname} uses the PostgreSQL-compatible mappings for most dialect-specific logical types.
+`io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to CockroachDB `jsonb` columns.
+`io.debezium.data.Xml` logical values are written to `text` columns because CockroachDB has no XML type.
+Geometry, geography, and point values are written to the built-in CockroachDB `geometry` and `geography` types without a PostGIS extension schema.
+`io.debezium.data.FloatVector` logical values are written to `vector` columns; sparse double vectors are not supported.
 The SingleStore dialect writes supported `POINT`, `LINESTRING`, and `POLYGON` WKB values as WKT strings.
 
 For StarRocks targets, see xref:jdbc-starrocks-targets[] for the dialect-specific type mappings, including the string-based representation that the dialect uses for time types.

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -2215,7 +2215,11 @@ Use this option when you want to map the value of a specific static constant to 
 ==== JDBC
 
 The JDBC sink writes change events directly to a relational database using JDBC.
-It leverages the xref:connectors/jdbc.adoc[{prodname} JDBC connector] under the hood, supporting a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
+It uses the xref:connectors/jdbc.adoc[{prodname} JDBC connector] to support a wide variety of database dialects, including
+ifdef::community[]
+CockroachDB,
+endif::community[]
+ Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
 
 The sink supports idempotent writes by using upsert semantics, basic schema evolution to automatically create or alter destination tables, and delete propagation.
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -2215,7 +2215,7 @@ Use this option when you want to map the value of a specific static constant to 
 ==== JDBC
 
 The JDBC sink writes change events directly to a relational database using JDBC.
-It leverages the xref:connectors/jdbc.adoc[{prodname} JDBC connector] under the hood, supporting a wide variety of database dialects, including Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
+It leverages the xref:connectors/jdbc.adoc[{prodname} JDBC connector] under the hood, supporting a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
 
 The sink supports idempotent writes by using upsert semantics, basic schema evolution to automatically create or alter destination tables, and delete propagation.
 


### PR DESCRIPTION
Follow-up to #7618 and companion to #7617.

Adds a CockroachDB sink targets section to the JDBC connector page: the PostgreSQL JDBC connection URL, the upsert statement, transaction conflict retries through flush.max.retries and flush.retry.delay.ms with 0 disabling retries, and the CockroachDB-specific data type mappings from https://github.com/debezium/dbz/issues/2197. Adds a CockroachDB paragraph to the dialect-specific data type mappings section and includes CockroachDB in the dialect list of the Debezium Server JDBC sink description.

Targets main only; the CockroachDB dialect is not part of the 3.6 release. The data type mapping content describes the behavior introduced in #7617.