### PR TITLE
debezium/dbz#2215 Make RocketMQ schema history recovery resilient to empty polls and corrupted records

### DIFF
--- a/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/history/RocketMqSchemaHistory.java
+++ b/debezium-storage/debezium-storage-rocketmq/src/main/java/io/debezium/storage/rocketmq/history/RocketMqSchemaHistory.java
@@ -44,6 +44,7 @@ import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.storage.rocketmq.RocketMqAdminUtil;
 import io.debezium.storage.rocketmq.RocketMqConfig;
 import io.debezium.storage.rocketmq.ZeroMessageQueueSelector;
+import io.debezium.util.Loggings;
 
 @NotThreadSafe
 public class RocketMqSchemaHistory extends AbstractSchemaHistory {
@@ -265,16 +266,37 @@ public class RocketMqSchemaHistory extends AbstractSchemaHistory {
 
                 for (MessageExt message : recoveredRecords) {
                     if (message.getQueueOffset() > lastProcessedOffset) {
-                        HistoryRecord recordObj = new HistoryRecord(reader.read(message.getBody()));
-                        LOGGER.trace("Recovering database history: {}", recordObj);
-                        if (recordObj == null || !recordObj.isValid()) {
-                            LOGGER.warn("Skipping invalid database history record '{}'. " +
-                                    "This is often not an issue, but if it happens repeatedly please check the '{}' topic.",
-                                    recordObj, topicName);
+                        try {
+                            if (message.getBody() == null) {
+                                LOGGER.warn("Skipping null database history record. " +
+                                        "This is often not an issue, but if it happens repeatedly please check the '{}' topic.",
+                                        topicName);
+                            }
+                            else {
+                                HistoryRecord recordObj = new HistoryRecord(reader.read(message.getBody()));
+                                LOGGER.trace("Recovering database history: {}", recordObj);
+                                if (!recordObj.isValid()) {
+                                    LOGGER.warn("Skipping invalid database history record '{}'. " +
+                                            "This is often not an issue, but if it happens repeatedly please check the '{}' topic.",
+                                            recordObj, topicName);
+                                }
+                                else {
+                                    records.accept(recordObj);
+                                    LOGGER.trace("Recovered database history: {}", recordObj);
+                                }
+                            }
                         }
-                        else {
-                            records.accept(recordObj);
-                            LOGGER.trace("Recovered database history: {}", recordObj);
+                        catch (IOException e) {
+                            Loggings.logErrorAndTraceRecord(
+                                    LOGGER,
+                                    message,
+                                    "Error while deserializing database history record, skipping it. " +
+                                            "If this happens repeatedly please check the '%s' topic.".formatted(topicName),
+                                    e);
+                        }
+                        catch (Exception e) {
+                            Loggings.logErrorAndTraceRecord(LOGGER, message, "Unexpected exception while processing record", e);
+                            throw e;
                         }
                         lastProcessedOffset = message.getQueueOffset();
                         ++numRecordsProcessed;
@@ -286,13 +308,18 @@ public class RocketMqSchemaHistory extends AbstractSchemaHistory {
                 }
                 else {
                     LOGGER.debug("Processed {} records from database schema history", numRecordsProcessed);
+                    recoveryAttempts = 0;
                 }
 
             } while (lastProcessedOffset < maxOffset - 1);
 
         }
-        catch (MQClientException | MQBrokerException | IOException | RemotingException | InterruptedException ce) {
-            throw new SchemaHistoryException(ce);
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SchemaHistoryException(e);
+        }
+        catch (MQClientException | MQBrokerException | RemotingException e) {
+            throw new SchemaHistoryException(e);
         }
         finally {
             if (consumer != null) {


### PR DESCRIPTION
Fixes debezium/dbz#2215

`RocketMqSchemaHistory#recoverRecords()` has two failure modes that abort connector startup even though the schema history topic is healthy:

1. **False `IllegalStateException` on long recoveries.** `recoveryAttempts` is only ever incremented and never reset after a batch of records is processed, while the `schema.history.internal.rocketmq.recovery.attempts` option documents "the number of attempts *in a row* that no data are returned". On a large history (or a slow broker) the cumulative count of empty polls eventually exceeds the limit and recovery fails with "The database schema history couldn't be recovered." even though it is still making progress.

2. **A single corrupted record aborts the whole recovery.** `DocumentReader#read` throwing `IOException` (malformed JSON) escaped the per-record loop and was rethrown as `SchemaHistoryException`; a null message body would fail similarly. `KafkaSchemaHistory` logs and skips such records instead.

Changes, mirroring `KafkaSchemaHistory#recoverRecords()`:

* Reset `recoveryAttempts` to 0 after a batch with progress, so only consecutive empty polls count towards the limit.
* Guard against null message bodies and handle deserialization `IOException` per record: log and skip instead of aborting. The offset bookkeeping still advances for a skipped record; unlike the Kafka consumer, the RocketMQ lite pull consumer does not redeliver, so not advancing would stall the recovery loop on a corrupted trailing record until the attempts limit is hit.
* Catch `InterruptedException` separately and restore the interrupt flag before wrapping, consistent with `storeRecord()` in the same class. `IOException` is removed from the outer multi-catch since it is now handled per record (nothing else in the outer try throws it).

No configuration or API changes.
