### PR TITLE
debezium/dbz#2217 Map MySQL and MariaDB REAL columns to DOUBLE

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.binlog;
 
+import java.sql.Types;
 import java.time.Duration;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -117,6 +118,59 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                 default:
                     return BigIntUnsignedMode.PRECISE;
             }
+        }
+    }
+
+    /**
+     * Set of predefined modes for handling {@code REAL} values.
+     */
+    public enum RealHandlingMode implements EnumeratedValue {
+        /**
+         * Represents {@code REAL} values as single-precision floating-point values.
+         */
+        FLOAT("float", Types.REAL),
+        /**
+         * Represents {@code REAL} values as double-precision floating-point values.
+         */
+        DOUBLE("double", Types.DOUBLE);
+
+        private final String value;
+        private final int jdbcType;
+
+        RealHandlingMode(String value, int jdbcType) {
+            this.value = value;
+            this.jdbcType = jdbcType;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static RealHandlingMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (RealHandlingMode option : RealHandlingMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * @return the JDBC type used to represent {@code REAL} values
+         */
+        public int asJdbcType() {
+            return jdbcType;
         }
     }
 
@@ -513,6 +567,16 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "'precise' uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; "
                     + "'long' (the default) represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
 
+    public static final Field REAL_HANDLING_MODE = Field.create("real.handling.mode")
+            .withDisplayName("The mode for handling REAL values")
+            .withEnum(RealHandlingMode.class, RealHandlingMode.DOUBLE)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR))
+            .withDescription("Specify how REAL columns should be represented in change events, including: "
+                    + "'float' represents values using single-precision (32-bit) floating-point values; "
+                    + "'double' (the default) represents values using double-precision (64-bit) floating-point values.");
+
     /**
      * @deprecated Use {@link #EVENT_PROCESSING_FAILURE_HANDLING_MODE} instead, will be removed in Debezium 3.0.
      */
@@ -645,7 +709,8 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             .group(Field.Group.CONNECTION_ADVANCED, ON_CONNECT_STATEMENTS, SERVER_ID_OFFSET, CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
                     USE_NONGRACEFUL_DISCONNECT, BINLOG_NET_WRITE_TIMEOUT, BINLOG_NET_READ_TIMEOUT)
             .group(Field.Group.CONNECTION_ADVANCED_SSL, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD)
-            .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE, GTID_SOURCE_INCLUDES,
+            .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, REAL_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE,
+                    GTID_SOURCE_INCLUDES,
                     GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS)
             .group(Field.Group.CONNECTOR_ADVANCED, ROW_COUNT_FOR_STREAMING_RESULT_SETS, BUFFER_SIZE_FOR_BINLOG_READER, INCLUDE_SQL_QUERY, IGNORE_GTID_ON_RECOVERY)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
@@ -660,6 +725,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
     private final Duration connectionTimeout;
     private final EventProcessingFailureHandlingMode inconsistentSchemaFailureHandlingMode;
     private final BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode;
+    private final RealHandlingMode realHandlingMode;
     private final boolean readOnlyConnection;
     private final boolean ignoreGtidOnRecovery;
     private final boolean resolveLikeTableSchema;
@@ -688,6 +754,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
         this.connectionTimeout = Duration.ofMillis(config.getLong(CONNECTION_TIMEOUT_MS));
         this.inconsistentSchemaFailureHandlingMode = EventProcessingFailureHandlingMode.parse(config.getString(INCONSISTENT_SCHEMA_HANDLING_MODE));
         this.bigIntUnsignedHandlingMode = BigIntUnsignedHandlingMode.parse(config.getString(BIGINT_UNSIGNED_HANDLING_MODE));
+        this.realHandlingMode = RealHandlingMode.parse(config.getString(REAL_HANDLING_MODE));
         this.ignoreGtidOnRecovery = config.getBoolean(IGNORE_GTID_ON_RECOVERY);
         this.resolveLikeTableSchema = config.getBoolean(RESOLVE_LIKE_TABLE_SCHEMA);
     }
@@ -740,6 +807,13 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
      */
     public BigIntUnsignedHandlingMode getBigIntUnsignedHandlingMode() {
         return bigIntUnsignedHandlingMode;
+    }
+
+    /**
+     * @return the {@code REAL} handling mode
+     */
+    public RealHandlingMode getRealHandlingMode() {
+        return realHandlingMode;
     }
 
     /**

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.binlog;
 
+import java.sql.Types;
 import java.time.Duration;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -117,6 +118,59 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                 default:
                     return BigIntUnsignedMode.PRECISE;
             }
+        }
+    }
+
+    /**
+     * Set of predefined modes for handling {@code REAL} values.
+     */
+    public enum RealHandlingMode implements EnumeratedValue {
+        /**
+         * Represents {@code REAL} values as single-precision floating-point values.
+         */
+        FLOAT("float", Types.REAL),
+        /**
+         * Represents {@code REAL} values as double-precision floating-point values.
+         */
+        DOUBLE("double", Types.DOUBLE);
+
+        private final String value;
+        private final int jdbcType;
+
+        RealHandlingMode(String value, int jdbcType) {
+            this.value = value;
+            this.jdbcType = jdbcType;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static RealHandlingMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (RealHandlingMode option : RealHandlingMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * @return the JDBC type used to represent {@code REAL} values
+         */
+        public int asJdbcType() {
+            return jdbcType;
         }
     }
 
@@ -511,6 +565,16 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     + "'precise' uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; "
                     + "'long' (the default) represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
 
+    public static final Field REAL_HANDLING_MODE = Field.create("real.handling.mode")
+            .withDisplayName("The mode for handling REAL values")
+            .withEnum(RealHandlingMode.class, RealHandlingMode.DOUBLE)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR))
+            .withDescription("Specify how REAL columns should be represented in change events, including: "
+                    + "'float' represents values using single-precision (32-bit) floating-point values; "
+                    + "'double' (the default) represents values using double-precision (64-bit) floating-point values.");
+
     /**
      * @deprecated Use {@link #EVENT_PROCESSING_FAILURE_HANDLING_MODE} instead, will be removed in Debezium 3.0.
      */
@@ -643,7 +707,8 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             .group(Field.Group.CONNECTION_ADVANCED, ON_CONNECT_STATEMENTS, SERVER_ID_OFFSET, CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
                     USE_NONGRACEFUL_DISCONNECT, BINLOG_NET_WRITE_TIMEOUT, BINLOG_NET_READ_TIMEOUT)
             .group(Field.Group.CONNECTION_ADVANCED_SSL, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD)
-            .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE, GTID_SOURCE_INCLUDES,
+            .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, REAL_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE,
+                    GTID_SOURCE_INCLUDES,
                     GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS)
             .group(Field.Group.CONNECTOR_ADVANCED, ROW_COUNT_FOR_STREAMING_RESULT_SETS, BUFFER_SIZE_FOR_BINLOG_READER, INCLUDE_SQL_QUERY, IGNORE_GTID_ON_RECOVERY)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
@@ -658,6 +723,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
     private final Duration connectionTimeout;
     private final EventProcessingFailureHandlingMode inconsistentSchemaFailureHandlingMode;
     private final BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode;
+    private final RealHandlingMode realHandlingMode;
     private final boolean readOnlyConnection;
     private final boolean ignoreGtidOnRecovery;
     private final boolean resolveLikeTableSchema;
@@ -686,6 +752,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
         this.connectionTimeout = Duration.ofMillis(config.getLong(CONNECTION_TIMEOUT_MS));
         this.inconsistentSchemaFailureHandlingMode = EventProcessingFailureHandlingMode.parse(config.getString(INCONSISTENT_SCHEMA_HANDLING_MODE));
         this.bigIntUnsignedHandlingMode = BigIntUnsignedHandlingMode.parse(config.getString(BIGINT_UNSIGNED_HANDLING_MODE));
+        this.realHandlingMode = RealHandlingMode.parse(config.getString(REAL_HANDLING_MODE));
         this.ignoreGtidOnRecovery = config.getBoolean(IGNORE_GTID_ON_RECOVERY);
         this.resolveLikeTableSchema = config.getBoolean(RESOLVE_LIKE_TABLE_SCHEMA);
     }
@@ -738,6 +805,13 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
      */
     public BigIntUnsignedHandlingMode getBigIntUnsignedHandlingMode() {
         return bigIntUnsignedHandlingMode;
+    }
+
+    /**
+     * @return the {@code REAL} handling mode
+     */
+    public RealHandlingMode getRealHandlingMode() {
+        return realHandlingMode;
     }
 
     /**

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
@@ -81,6 +81,8 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
 
     protected abstract P getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments);
 
+    protected abstract P getParser(SimpleDdlParserListener listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode);
+
     protected abstract V getValueConverters();
 
     protected abstract D getDefaultValueConverters(V valueConverters);
@@ -696,7 +698,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
 
     @Test
     @FixFor("debezium/dbz#2217")
-    public void shouldTreatRealDataTypeAsDouble() {
+    public void shouldTreatRealDataTypeAsDoubleByDefault() {
         // MySQL/MariaDB treat REAL as a synonym for DOUBLE unless the REAL_AS_FLOAT sql_mode is
         // enabled; values are stored and replicated as 8-byte doubles. Mapping REAL to Types.REAL
         // produced a FLOAT32 schema and narrowed values, diverging from the snapshot path where
@@ -718,6 +720,32 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         Column r1 = table.columnWithName("r1");
         ValueConverter converter = converters.converter(r1, new Field(r1.name(), -1, r1Schema));
         assertThat(converter.convert(3.141592653589793d)).isEqualTo(3.141592653589793d);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2217")
+    public void shouldTreatRealDataTypeAsFloatWhenConfigured() {
+        final P floatParser = getParser(new SimpleDdlParserListener(), BinlogConnectorConfig.RealHandlingMode.FLOAT);
+        final Tables floatTables = new Tables();
+        final String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r1 REAL DEFAULT 3.14, "
+                + "r2 REAL(8,2), r3 REAL UNSIGNED, f FLOAT, d DOUBLE);";
+        floatParser.parse(ddl, floatTables);
+        assertThat(floatParser.getParsingExceptionsFromWalker()).isEmpty();
+
+        final Table table = floatTables.forTable(null, null, "realtable");
+        assertThat(table.columnWithName("r1").jdbcType()).isEqualTo(Types.REAL);
+        assertThat(table.columnWithName("r2").jdbcType()).isEqualTo(Types.REAL);
+        assertThat(table.columnWithName("r3").jdbcType()).isEqualTo(Types.REAL);
+        assertThat(table.columnWithName("f").jdbcType()).isEqualTo(Types.FLOAT);
+        assertThat(table.columnWithName("d").jdbcType()).isEqualTo(Types.DOUBLE);
+
+        final Schema r1Schema = getColumnSchema(table, "r1");
+        assertThat(r1Schema.type()).isEqualTo(Schema.Type.FLOAT32);
+        assertThat(r1Schema.defaultValue()).isEqualTo(3.14f);
+
+        final Column r1 = table.columnWithName("r1");
+        final ValueConverter converter = converters.converter(r1, new Field(r1.name(), -1, r1Schema));
+        assertThat(converter.convert(3.141592653589793d)).isEqualTo(3.1415927f);
     }
 
     @Test

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogAntlrDdlParserTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ import io.debezium.relational.TableSchema;
 import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
+import io.debezium.relational.ValueConverter;
 import io.debezium.relational.ddl.DdlParserListener.Event;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -690,6 +692,32 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         assertThat(table.columnWithName("l").charsetName()).isEqualTo("LATIN2");
         assertThat(table.columnWithName("lvc").jdbcType()).isEqualTo(Types.VARCHAR);
         assertThat(table.columnWithName("lvb").jdbcType()).isEqualTo(Types.BLOB);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2217")
+    public void shouldTreatRealDataTypeAsDouble() {
+        // MySQL/MariaDB treat REAL as a synonym for DOUBLE unless the REAL_AS_FLOAT sql_mode is
+        // enabled; values are stored and replicated as 8-byte doubles. Mapping REAL to Types.REAL
+        // produced a FLOAT32 schema and narrowed values, diverging from the snapshot path where
+        // SHOW CREATE TABLE reports the column as DOUBLE.
+        String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r1 REAL, r2 REAL(8,2), r3 REAL UNSIGNED);";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker().size()).isEqualTo(0);
+
+        Table table = tables.forTable(null, null, "realtable");
+        assertThat(table.columnWithName("r1").jdbcType()).isEqualTo(Types.DOUBLE);
+        assertThat(table.columnWithName("r2").jdbcType()).isEqualTo(Types.DOUBLE);
+        assertThat(table.columnWithName("r3").jdbcType()).isEqualTo(Types.DOUBLE);
+
+        // The emitted schema must be FLOAT64, matching the snapshot path
+        Schema r1Schema = getColumnSchema(table, "r1");
+        assertThat(r1Schema.type()).isEqualTo(Schema.Type.FLOAT64);
+
+        // Values must not be narrowed to single precision
+        Column r1 = table.columnWithName("r1");
+        ValueConverter converter = converters.converter(r1, new Field(r1.name(), -1, r1Schema));
+        assertThat(converter.convert(3.141592653589793d)).isEqualTo(3.141592653589793d);
     }
 
     @Test
@@ -3226,7 +3254,7 @@ public abstract class BinlogAntlrDdlParserTest<V extends BinlogValueConverters, 
         assertThat(getColumnSchema(table, "decimal_un_z_c").defaultValue()).isEqualTo(20.0);
         assertThat(getColumnSchema(table, "numeric_c").defaultValue()).isEqualTo(21.0);
         assertThat(getColumnSchema(table, "big_decimal_c").defaultValue()).isEqualTo(22.0);
-        assertThat(getColumnSchema(table, "real_c").defaultValue()).isEqualTo(23.0f);
+        assertThat(getColumnSchema(table, "real_c").defaultValue()).isEqualTo(23.0d);
         assertThat(getColumnSchema(table, "float_c").defaultValue()).isEqualTo(24.0f);
         assertThat(getColumnSchema(table, "float_un_c").defaultValue()).isEqualTo(25.0f);
         assertThat(getColumnSchema(table, "float_un_z_c").defaultValue()).isEqualTo(26.0f);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueIT.java
@@ -1038,8 +1038,8 @@ public abstract class BinlogDefaultValueIT<C extends SourceConnector> extends Ab
         assertFieldDefaultValue(change, "C15", (short) 0);
         assertFieldDefaultValue(change, "C16", BigDecimal.valueOf(1.23));
         assertFieldDefaultValue(change, "C17", BigDecimal.valueOf(1.23));
-        assertFieldDefaultValue(change, "C18", 3.14f);
-        assertFieldDefaultValue(change, "C19", 3.14f);
+        assertFieldDefaultValue(change, "C18", 3.14d);
+        assertFieldDefaultValue(change, "C19", 3.14d);
     }
 
     private void assertFieldDefaultValue(Struct value, String fieldName, Object defaultValue) {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDefaultValueTest.java
@@ -332,7 +332,7 @@ public abstract class BinlogDefaultValueTest<V extends BinlogValueConverters, P 
                 ");";
         parser.parse(sql, tables);
         Table table = tables.forTable(new TableId(null, null, "REAL_TABLE"));
-        assertThat(getColumnSchema(table, "A").defaultValue()).isEqualTo(1f);
+        assertThat(getColumnSchema(table, "A").defaultValue()).isEqualTo(1d);
         assertThat(getColumnSchema(table, "B").defaultValue()).isEqualTo(null);
     }
 

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbDatabaseSchema.java
@@ -45,7 +45,8 @@ public class MariaDbDatabaseSchema extends BinlogDatabaseSchema<MariaDbPartition
                 false,
                 connectorConfig.isSchemaChangesHistoryEnabled(),
                 getTableFilter(),
-                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class),
+                connectorConfig.getRealHandlingMode());
     }
 
 }

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -163,7 +163,10 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
                 new DataTypeResolver.DataTypeEntry(Types.BIGINT, MariaDBParser.INT8)
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
-                new DataTypeResolver.DataTypeEntry(Types.REAL, MariaDBParser.REAL)
+                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
+                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
+                // for FLOAT instead (debezium/dbz#2217)
+                new DataTypeResolver.DataTypeEntry(Types.DOUBLE, MariaDBParser.REAL)
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
                 new DataTypeResolver.DataTypeEntry(Types.DOUBLE, MariaDBParser.DOUBLE)
                         .setSuffixTokens(MariaDBParser.PRECISION, MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -22,6 +22,7 @@ import io.debezium.annotation.VisibleForTesting;
 import io.debezium.antlr.AntlrDdlParser;
 import io.debezium.antlr.AntlrDdlParserListener;
 import io.debezium.antlr.DataTypeResolver;
+import io.debezium.connector.binlog.BinlogConnectorConfig.RealHandlingMode;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mariadb.antlr.listener.MariaDbAntlrDdlParserListener;
@@ -48,7 +49,7 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     private final ConcurrentHashMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final Tables.TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
-    private final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
+    private final DataTypeResolver dataTypeResolver;
 
     @VisibleForTesting
     public MariaDbAntlrDdlParser() {
@@ -62,10 +63,16 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
 
     public MariaDbAntlrDdlParser(boolean throwWerrorsFromTreeWalk, boolean includeViews, boolean includeComments,
                                  Tables.TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+        this(throwWerrorsFromTreeWalk, includeViews, includeComments, tableFilter, charsetRegistry, RealHandlingMode.DOUBLE);
+    }
+
+    public MariaDbAntlrDdlParser(boolean throwWerrorsFromTreeWalk, boolean includeViews, boolean includeComments,
+                                 Tables.TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry, RealHandlingMode realHandlingMode) {
         super(throwWerrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
+        this.dataTypeResolver = initializeDataTypeResolver(realHandlingMode);
     }
 
     @Override
@@ -103,7 +110,7 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
         return dataTypeResolver;
     }
 
-    private DataTypeResolver initializeDataTypeResolver() {
+    private DataTypeResolver initializeDataTypeResolver(RealHandlingMode realHandlingMode) {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
         dataTypeResolverBuilder.registerDataTypes(MariaDBParser.StringDataTypeContext.class.getCanonicalName(), Arrays.asList(
                 new DataTypeResolver.DataTypeEntry(Types.CHAR, MariaDBParser.CHAR),
@@ -163,10 +170,8 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
                 new DataTypeResolver.DataTypeEntry(Types.BIGINT, MariaDBParser.INT8)
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
-                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
-                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
-                // for FLOAT instead (debezium/dbz#2217)
-                new DataTypeResolver.DataTypeEntry(Types.DOUBLE, MariaDBParser.REAL)
+                // REAL defaults to DOUBLE, but can be mapped to FLOAT for REAL_AS_FLOAT compatibility.
+                new DataTypeResolver.DataTypeEntry(realHandlingMode.asJdbcType(), MariaDBParser.REAL)
                         .setSuffixTokens(MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),
                 new DataTypeResolver.DataTypeEntry(Types.DOUBLE, MariaDBParser.DOUBLE)
                         .setSuffixTokens(MariaDBParser.PRECISION, MariaDBParser.SIGNED, MariaDBParser.UNSIGNED, MariaDBParser.ZEROFILL),

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbAntlrDdlParserTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbAntlrDdlParserTest.java
@@ -46,6 +46,11 @@ public class MariaDbAntlrDdlParserTest extends BinlogAntlrDdlParserTest<MariaDbV
     }
 
     @Override
+    protected MariaDbAntlrDdlParser getParser(SimpleDdlParserListener listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+        return new MariaDbDdlParserWithSimpleTestListener(listener, realHandlingMode);
+    }
+
+    @Override
     protected MariaDbValueConverters getValueConverters() {
         return new MariaDbValueConvertersFactory().create(
                 RelationalDatabaseConnectorConfig.DecimalHandlingMode.DOUBLE,
@@ -82,8 +87,17 @@ public class MariaDbAntlrDdlParserTest extends BinlogAntlrDdlParserTest<MariaDbV
             this(listener, includeViews, includeComments, Tables.TableFilter.includeAll());
         }
 
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            this(listener, false, false, Tables.TableFilter.includeAll(), realHandlingMode);
+        }
+
         public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments, Tables.TableFilter tableFilter) {
-            super(false, includeViews, includeComments, tableFilter, new MariaDbCharsetRegistry());
+            this(listener, includeViews, includeComments, tableFilter, BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        }
+
+        public MariaDbDdlParserWithSimpleTestListener(DdlChanges listener, boolean includeViews, boolean includeComments, Tables.TableFilter tableFilter,
+                                                      BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            super(false, includeViews, includeComments, tableFilter, new MariaDbCharsetRegistry(), realHandlingMode);
             this.ddlChanges = listener;
         }
     }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorConfigTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorConfigTest.java
@@ -14,9 +14,29 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.binlog.BinlogOffsetContext;
 
 public class MariaDbConnectorConfigTest {
+
+    @Test
+    void shouldConfigureRealHandlingMode() {
+        final Configuration config = Configuration.create()
+                .with(MariaDbConnectorConfig.HOSTNAME, "localhost")
+                .with(MariaDbConnectorConfig.PORT, 3306)
+                .with(MariaDbConnectorConfig.USER, "mariadbuser")
+                .with(MariaDbConnectorConfig.PASSWORD, "mariadbpw")
+                .with(MariaDbConnectorConfig.SERVER_ID, 18765)
+                .with(MariaDbConnectorConfig.TOPIC_PREFIX, "mariadb-server")
+                .build();
+
+        assertThat(new MariaDbConnectorConfig(config).getRealHandlingMode()).isEqualTo(BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+
+        final Configuration floatConfig = config.edit()
+                .with(MariaDbConnectorConfig.REAL_HANDLING_MODE, BinlogConnectorConfig.RealHandlingMode.FLOAT)
+                .build();
+        assertThat(new MariaDbConnectorConfig(floatConfig).getRealHandlingMode()).isEqualTo(BinlogConnectorConfig.RealHandlingMode.FLOAT);
+    }
 
     @Test
     void shouldDefaultToUsingGtidOnRecovery() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -70,7 +70,8 @@ public class MySqlDatabaseSchema extends BinlogDatabaseSchema<MySqlPartition, My
                 false,
                 connectorConfig.isSchemaCommentsHistoryEnabled(),
                 getTableFilter(),
-                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class),
+                connectorConfig.getRealHandlingMode());
     }
 
     private DdlParser createLegacyPtParser(BinlogConnectorConfig connectorConfig) {
@@ -79,7 +80,8 @@ public class MySqlDatabaseSchema extends BinlogDatabaseSchema<MySqlPartition, My
                 false,
                 connectorConfig.isSchemaCommentsHistoryEnabled(),
                 getTableFilter(),
-                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class));
+                connectorConfig.getServiceRegistry().getService(BinlogCharsetRegistry.class),
+                connectorConfig.getRealHandlingMode());
     }
 
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -25,6 +25,7 @@ import io.debezium.antlr.AntlrDdlParser;
 import io.debezium.antlr.AntlrDdlParserListener;
 import io.debezium.antlr.DataTypeResolver;
 import io.debezium.antlr.DataTypeResolver.DataTypeEntry;
+import io.debezium.connector.binlog.BinlogConnectorConfig.RealHandlingMode;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mysql.antlr.listener.MySqlAntlrDdlParserListener;
@@ -76,7 +77,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     private final ConcurrentMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
-    private final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
+    private final DataTypeResolver dataTypeResolver;
 
     @VisibleForTesting
     public MySqlAntlrDdlParser() {
@@ -90,10 +91,16 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
 
     public MySqlAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
                                TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+        this(throwErrorsFromTreeWalk, includeViews, includeComments, tableFilter, charsetRegistry, RealHandlingMode.DOUBLE);
+    }
+
+    public MySqlAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
+                               TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry, RealHandlingMode realHandlingMode) {
         super(throwErrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
+        this.dataTypeResolver = initializeDataTypeResolver(realHandlingMode);
     }
 
     @Override
@@ -146,7 +153,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
         return dataTypeResolver;
     }
 
-    private DataTypeResolver initializeDataTypeResolver() {
+    private DataTypeResolver initializeDataTypeResolver(RealHandlingMode realHandlingMode) {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
 
         // In the new Oracle grammar, all data types are unified in DataTypeContext
@@ -190,10 +197,8 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.BIGINT, MySqlParser.BIGINT_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 // Floating point types
-                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
-                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
-                // for FLOAT instead (debezium/dbz#2217)
-                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL_SYMBOL)
+                // REAL defaults to DOUBLE, but can be mapped to FLOAT for REAL_AS_FLOAT compatibility.
+                new DataTypeEntry(realHandlingMode.asJdbcType(), MySqlParser.REAL_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE_SYMBOL)
                         .setSuffixTokens(MySqlParser.PRECISION_SYMBOL, MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -190,7 +190,10 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.BIGINT, MySqlParser.BIGINT_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 // Floating point types
-                new DataTypeEntry(Types.REAL, MySqlParser.REAL_SYMBOL)
+                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
+                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
+                // for FLOAT instead (debezium/dbz#2217)
+                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE_SYMBOL)
                         .setSuffixTokens(MySqlParser.PRECISION_SYMBOL, MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -201,7 +201,10 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.BIGINT, MySqlParser.BIGINT_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 // Floating point types
-                new DataTypeEntry(Types.REAL, MySqlParser.REAL_SYMBOL)
+                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
+                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
+                // for FLOAT instead (debezium/dbz#2217)
+                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE_SYMBOL)
                         .setSuffixTokens(MySqlParser.PRECISION_SYMBOL, MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -28,6 +28,7 @@ import io.debezium.antlr.DataTypeResolver;
 import io.debezium.antlr.DataTypeResolver.DataTypeEntry;
 import io.debezium.antlr.mysql.SqlMode;
 import io.debezium.antlr.mysql.SqlModes;
+import io.debezium.connector.binlog.BinlogConnectorConfig.RealHandlingMode;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mysql.antlr.listener.MySqlAntlrDdlParserListener;
@@ -79,7 +80,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     private final ConcurrentMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
-    private final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
+    private final DataTypeResolver dataTypeResolver;
 
     @VisibleForTesting
     public MySqlAntlrDdlParser() {
@@ -93,10 +94,16 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
 
     public MySqlAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
                                TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+        this(throwErrorsFromTreeWalk, includeViews, includeComments, tableFilter, charsetRegistry, RealHandlingMode.DOUBLE);
+    }
+
+    public MySqlAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
+                               TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry, RealHandlingMode realHandlingMode) {
         super(throwErrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
+        this.dataTypeResolver = initializeDataTypeResolver(realHandlingMode);
     }
 
     @Override
@@ -157,7 +164,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
         return dataTypeResolver;
     }
 
-    private DataTypeResolver initializeDataTypeResolver() {
+    private DataTypeResolver initializeDataTypeResolver(RealHandlingMode realHandlingMode) {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
 
         // In the new Oracle grammar, all data types are unified in DataTypeContext
@@ -201,10 +208,8 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.BIGINT, MySqlParser.BIGINT_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 // Floating point types
-                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
-                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
-                // for FLOAT instead (debezium/dbz#2217)
-                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL_SYMBOL)
+                // REAL defaults to DOUBLE, but can be mapped to FLOAT for REAL_AS_FLOAT compatibility.
+                new DataTypeEntry(realHandlingMode.asJdbcType(), MySqlParser.REAL_SYMBOL)
                         .setSuffixTokens(MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE_SYMBOL)
                         .setSuffixTokens(MySqlParser.PRECISION_SYMBOL, MySqlParser.SIGNED_SYMBOL, MySqlParser.UNSIGNED_SYMBOL, MySqlParser.ZEROFILL_SYMBOL),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
@@ -163,7 +163,10 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
                 new DataTypeEntry(Types.BIGINT, MySqlParser.INT8)
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
-                new DataTypeEntry(Types.REAL, MySqlParser.REAL)
+                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
+                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
+                // for FLOAT instead (debezium/dbz#2217)
+                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL)
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE)
                         .setSuffixTokens(MySqlParser.PRECISION, MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParser.java
@@ -24,6 +24,7 @@ import io.debezium.antlr.AntlrDdlParser;
 import io.debezium.antlr.AntlrDdlParserListener;
 import io.debezium.antlr.DataTypeResolver;
 import io.debezium.antlr.DataTypeResolver.DataTypeEntry;
+import io.debezium.connector.binlog.BinlogConnectorConfig.RealHandlingMode;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mysql.antlr.listener.legacy.MySqlAntlrDdlParserListener;
@@ -50,7 +51,7 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
     private final ConcurrentMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
-    private final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
+    private final DataTypeResolver dataTypeResolver;
 
     @VisibleForTesting
     public MySqlPtAntlrDdlParser() {
@@ -64,10 +65,16 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
 
     public MySqlPtAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
                                  TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry) {
+        this(throwErrorsFromTreeWalk, includeViews, includeComments, tableFilter, charsetRegistry, RealHandlingMode.DOUBLE);
+    }
+
+    public MySqlPtAntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments,
+                                 TableFilter tableFilter, BinlogCharsetRegistry charsetRegistry, RealHandlingMode realHandlingMode) {
         super(throwErrorsFromTreeWalk, includeViews, includeComments);
         systemVariables = new BinlogSystemVariables();
         this.tableFilter = tableFilter;
         this.charsetRegistry = charsetRegistry;
+        this.dataTypeResolver = initializeDataTypeResolver(realHandlingMode);
     }
 
     @Override
@@ -105,7 +112,7 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
         return dataTypeResolver;
     }
 
-    private DataTypeResolver initializeDataTypeResolver() {
+    private DataTypeResolver initializeDataTypeResolver(RealHandlingMode realHandlingMode) {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
 
         dataTypeResolverBuilder.registerDataTypes(MySqlParser.StringDataTypeContext.class.getCanonicalName(), Arrays.asList(
@@ -163,10 +170,8 @@ public class MySqlPtAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParse
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
                 new DataTypeEntry(Types.BIGINT, MySqlParser.INT8)
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
-                // REAL is by default a synonym for DOUBLE: the server stores and replicates such columns
-                // as 8-byte doubles. Only when the REAL_AS_FLOAT sql_mode is enabled is REAL a synonym
-                // for FLOAT instead (debezium/dbz#2217)
-                new DataTypeEntry(Types.DOUBLE, MySqlParser.REAL)
+                // REAL defaults to DOUBLE, but can be mapped to FLOAT for REAL_AS_FLOAT compatibility.
+                new DataTypeEntry(realHandlingMode.asJdbcType(), MySqlParser.REAL)
                         .setSuffixTokens(MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),
                 new DataTypeEntry(Types.DOUBLE, MySqlParser.DOUBLE)
                         .setSuffixTokens(MySqlParser.PRECISION, MySqlParser.SIGNED, MySqlParser.UNSIGNED, MySqlParser.ZEROFILL),

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Types;
 import java.util.List;
 
 import org.junit.jupiter.api.Disabled;
@@ -18,6 +19,7 @@ import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMo
 import io.debezium.connector.binlog.BinlogAntlrDdlParserTest;
 import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser;
 import io.debezium.connector.mysql.charset.MySqlCharsetRegistry;
 import io.debezium.connector.mysql.jdbc.MySqlDefaultValueConverter;
 import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
@@ -28,6 +30,7 @@ import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
+import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
@@ -56,6 +59,11 @@ public class MySqlAntlrDdlParserTest
     @Override
     protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments) {
         return new MySqlDdlParserWithSimpleTestListener(listener, includeViews, includeComments);
+    }
+
+    @Override
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+        return new MySqlDdlParserWithSimpleTestListener(listener, realHandlingMode);
     }
 
     @Override
@@ -98,6 +106,24 @@ public class MySqlAntlrDdlParserTest
     @Test
     @Override
     public void shouldParseMySql57InitializationStatements() {
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2217")
+    public void shouldApplyRealHandlingModeWithLegacyDdlParser() {
+        final String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r REAL);";
+
+        final Tables doubleTables = new Tables();
+        final MySqlPtAntlrDdlParser doubleParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        doubleParser.parse(ddl, doubleTables);
+        assertThat(doubleTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.DOUBLE);
+
+        final Tables floatTables = new Tables();
+        final MySqlPtAntlrDdlParser floatParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.FLOAT);
+        floatParser.parse(ddl, floatTables);
+        assertThat(floatTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.REAL);
     }
 
     @Disabled("CHARACTER SET = DEFAULT syntax is not valid in MySQL 8.0+. " +
@@ -242,8 +268,17 @@ public class MySqlAntlrDdlParserTest
             this(changesListener, includeViews, includeComments, TableFilter.includeAll());
         }
 
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            this(changesListener, false, false, TableFilter.includeAll(), realHandlingMode);
+        }
+
         private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter) {
-            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry());
+            this(changesListener, includeViews, includeComments, tableFilter, BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        }
+
+        private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter,
+                                                     BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry(), realHandlingMode);
             this.ddlChanges = changesListener;
         }
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Types;
 import java.util.List;
 
 import org.junit.jupiter.api.Disabled;
@@ -18,6 +19,7 @@ import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMo
 import io.debezium.connector.binlog.BinlogAntlrDdlParserTest;
 import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser;
 import io.debezium.connector.mysql.charset.MySqlCharsetRegistry;
 import io.debezium.connector.mysql.jdbc.MySqlDefaultValueConverter;
 import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
@@ -28,6 +30,7 @@ import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
+import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
@@ -56,6 +59,11 @@ public class MySqlAntlrDdlParserTest
     @Override
     protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, boolean includeViews, boolean includeComments) {
         return new MySqlDdlParserWithSimpleTestListener(listener, includeViews, includeComments);
+    }
+
+    @Override
+    protected MySqlAntlrDdlParser getParser(SimpleDdlParserListener listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+        return new MySqlDdlParserWithSimpleTestListener(listener, realHandlingMode);
     }
 
     @Override
@@ -98,6 +106,24 @@ public class MySqlAntlrDdlParserTest
     @Test
     @Override
     public void shouldParseMySql57InitializationStatements() {
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2217")
+    public void shouldApplyRealHandlingModeWithLegacyDdlParser() {
+        final String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r REAL);";
+
+        final Tables doubleTables = new Tables();
+        final MySqlPtAntlrDdlParser doubleParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        doubleParser.parse(ddl, doubleTables);
+        assertThat(doubleTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.DOUBLE);
+
+        final Tables floatTables = new Tables();
+        final MySqlPtAntlrDdlParser floatParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.FLOAT);
+        floatParser.parse(ddl, floatTables);
+        assertThat(floatTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.REAL);
     }
 
     @Disabled("CHARACTER SET = DEFAULT syntax is not valid in MySQL 8.0+. " +
@@ -252,8 +278,17 @@ public class MySqlAntlrDdlParserTest
             this(changesListener, includeViews, includeComments, TableFilter.includeAll());
         }
 
+        MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            this(changesListener, false, false, TableFilter.includeAll(), realHandlingMode);
+        }
+
         private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter) {
-            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry());
+            this(changesListener, includeViews, includeComments, tableFilter, BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        }
+
+        private MySqlDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter,
+                                                     BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry(), realHandlingMode);
             this.ddlChanges = changesListener;
         }
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -8,7 +8,6 @@ package io.debezium.connector.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.sql.Types;
 import java.util.List;
 
 import org.junit.jupiter.api.Disabled;
@@ -19,7 +18,6 @@ import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMo
 import io.debezium.connector.binlog.BinlogAntlrDdlParserTest;
 import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
-import io.debezium.connector.mysql.antlr.MySqlPtAntlrDdlParser;
 import io.debezium.connector.mysql.charset.MySqlCharsetRegistry;
 import io.debezium.connector.mysql.jdbc.MySqlDefaultValueConverter;
 import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
@@ -30,7 +28,6 @@ import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
-import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
@@ -106,24 +103,6 @@ public class MySqlAntlrDdlParserTest
     @Test
     @Override
     public void shouldParseMySql57InitializationStatements() {
-    }
-
-    @Test
-    @FixFor("debezium/dbz#2217")
-    public void shouldApplyRealHandlingModeWithLegacyDdlParser() {
-        final String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r REAL);";
-
-        final Tables doubleTables = new Tables();
-        final MySqlPtAntlrDdlParser doubleParser = new MySqlPtAntlrDdlParser(
-                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.DOUBLE);
-        doubleParser.parse(ddl, doubleTables);
-        assertThat(doubleTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.DOUBLE);
-
-        final Tables floatTables = new Tables();
-        final MySqlPtAntlrDdlParser floatParser = new MySqlPtAntlrDdlParser(
-                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.FLOAT);
-        floatParser.parse(ddl, floatTables);
-        assertThat(floatTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.REAL);
     }
 
     @Disabled("CHARACTER SET = DEFAULT syntax is not valid in MySQL 8.0+. " +

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorConfigTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorConfigTest.java
@@ -14,9 +14,29 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.binlog.BinlogOffsetContext;
 
 public class MySqlConnectorConfigTest {
+
+    @Test
+    void shouldConfigureRealHandlingMode() {
+        final Configuration config = Configuration.create()
+                .with(MySqlConnectorConfig.HOSTNAME, "localhost")
+                .with(MySqlConnectorConfig.PORT, 3306)
+                .with(MySqlConnectorConfig.USER, "mysqluser")
+                .with(MySqlConnectorConfig.PASSWORD, "mysqlpw")
+                .with(MySqlConnectorConfig.SERVER_ID, 18765)
+                .with(MySqlConnectorConfig.TOPIC_PREFIX, "mysql-server")
+                .build();
+
+        assertThat(new MySqlConnectorConfig(config).getRealHandlingMode()).isEqualTo(BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+
+        final Configuration floatConfig = config.edit()
+                .with(MySqlConnectorConfig.REAL_HANDLING_MODE, BinlogConnectorConfig.RealHandlingMode.FLOAT)
+                .build();
+        assertThat(new MySqlConnectorConfig(floatConfig).getRealHandlingMode()).isEqualTo(BinlogConnectorConfig.RealHandlingMode.FLOAT);
+    }
 
     @Test
     void shouldDefaultToUsingGtidOnRecovery() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParserTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mysql.antlr;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Types;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
@@ -78,6 +80,24 @@ public class MySqlPtAntlrDdlParserTest
     @Override
     protected List<String> extractEnumAndSetOptions(List<String> enumValues) {
         return MySqlPtAntlrDdlParser.extractEnumAndSetOptions(enumValues);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2217")
+    public void shouldApplyRealHandlingMode() {
+        final String ddl = "CREATE TABLE realtable (id INT PRIMARY KEY, r REAL);";
+
+        final Tables doubleTables = new Tables();
+        final MySqlPtAntlrDdlParser doubleParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        doubleParser.parse(ddl, doubleTables);
+        assertThat(doubleTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.DOUBLE);
+
+        final Tables floatTables = new Tables();
+        final MySqlPtAntlrDdlParser floatParser = new MySqlPtAntlrDdlParser(
+                false, false, false, TableFilter.includeAll(), new MySqlCharsetRegistry(), BinlogConnectorConfig.RealHandlingMode.FLOAT);
+        floatParser.parse(ddl, floatTables);
+        assertThat(floatTables.forTable(null, null, "realtable").columnWithName("r").jdbcType()).isEqualTo(Types.REAL);
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/MySqlPtAntlrDdlParserTest.java
@@ -56,6 +56,11 @@ public class MySqlPtAntlrDdlParserTest
     }
 
     @Override
+    protected MySqlPtAntlrDdlParser getParser(SimpleDdlParserListener listener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+        return new MySqlPtDdlParserWithSimpleTestListener(listener, realHandlingMode);
+    }
+
+    @Override
     protected MySqlValueConverters getValueConverters() {
         return new MySqlValueConvertersFactory().create(
                 RelationalDatabaseConnectorConfig.DecimalHandlingMode.parse(JdbcValueConverters.DecimalMode.DOUBLE.name()),
@@ -149,8 +154,17 @@ public class MySqlPtAntlrDdlParserTest
             this(changesListener, includeViews, includeComments, TableFilter.includeAll());
         }
 
+        MySqlPtDdlParserWithSimpleTestListener(DdlChanges changesListener, BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            this(changesListener, false, false, TableFilter.includeAll(), realHandlingMode);
+        }
+
         private MySqlPtDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter) {
-            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry());
+            this(changesListener, includeViews, includeComments, tableFilter, BinlogConnectorConfig.RealHandlingMode.DOUBLE);
+        }
+
+        private MySqlPtDdlParserWithSimpleTestListener(DdlChanges changesListener, boolean includeViews, boolean includeComments, TableFilter tableFilter,
+                                                       BinlogConnectorConfig.RealHandlingMode realHandlingMode) {
+            super(false, includeViews, includeComments, tableFilter, new MySqlCharsetRegistry(), realHandlingMode);
             this.ddlChanges = changesListener;
         }
     }

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-rqd-connector-cfg-props.adoc
@@ -521,6 +521,31 @@ If you attempt to use the same name to register multiple connectors, registratio
 This property is required by all Kafka Connect connectors.
 
 
+[id="{context}-property-real-handling-mode"]
+xref:{context}-property-real-handling-mode[`real.handling.mode`]::
+
+Default value::: `double`
+
+Description:::
+Specifies how the connector interprets the `REAL` type name when it parses DDL from a snapshot, the schema history, or the binlog.
+Set one of the following options:
+
+`double`:::: Represents `REAL` values as double-precision (`FLOAT64`) values.
+This default matches the default {connector-name} behavior, in which `REAL` is a synonym for `DOUBLE`.
+
+`float`:::: Represents `REAL` values as single-precision (`FLOAT32`) values.
+Use this option when the source server uses the `REAL_AS_FLOAT` SQL mode, or to retain an existing `FLOAT32` schema contract.
+
+The setting does not change the mapping of columns that are explicitly declared as `FLOAT` or `DOUBLE`.
++
+[IMPORTANT]
+====
+The default `double` mode changes the schema of `REAL` columns from `FLOAT32` to `FLOAT64` when the connector parses a `REAL` type name from the schema history or the binlog.
+Before upgrading an existing connector, verify that downstream schema compatibility rules permit this change.
+To retain the previous `FLOAT32` mapping, explicitly set `real.handling.mode` to `float`.
+====
+
+
 [id="{context}-property-schema-name-adjustment-mode"]
 xref:{context}-property-schema-name-adjustment-mode[`schema.name.adjustment.mode`]::
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1827,10 +1827,11 @@ a|_n/a_
 a|_n/a_
 
 |`REAL[(M,D)]`
-|`FLOAT64`
-a|_n/a_
+|`FLOAT32` or `FLOAT64`
+a|The mapping is controlled by the xref:{context}-property-real-handling-mode[`real.handling.mode`] connector configuration property.
 
-By default, `REAL` is a synonym for `DOUBLE`: the server stores and replicates such columns as 8-byte double-precision values. Only when the `REAL_AS_FLOAT` SQL mode is enabled is `REAL` a synonym for `FLOAT` instead.
+By default, `REAL` is a synonym for `DOUBLE`, and the connector maps it to `FLOAT64`.
+Set `real.handling.mode` to `float` to map `REAL` to `FLOAT32`, for example, when the server uses the `REAL_AS_FLOAT` SQL mode.
 
 |`FLOAT[(P)]`
 |`FLOAT32` or `FLOAT64`
@@ -2288,6 +2289,8 @@ jdbc-sink.treat.real.as.double=true
 ----
 
 In the preceding example, the `selector.*` and `treat.real.as.double` configuration properties are optional.
+
+If `selector.real` matches a column, the `treat.real.as.double` converter setting determines the emitted schema for that column and takes precedence over the connector-level `real.handling.mode` setting.
 
 The `selector.*` properties specify comma-separated lists of regular expressions that specify which tables and columns that the converter applies to.
 By default, the converter applies the following rules apply to all Boolean, real, and string-based column data types, across all tables:

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1827,8 +1827,10 @@ a|_n/a_
 a|_n/a_
 
 |`REAL[(M,D)]`
-|`FLOAT32`
+|`FLOAT64`
 a|_n/a_
+
+By default, `REAL` is a synonym for `DOUBLE`: the server stores and replicates such columns as 8-byte double-precision values. Only when the `REAL_AS_FLOAT` SQL mode is enabled is `REAL` a synonym for `FLOAT` instead.
 
 |`FLOAT[(P)]`
 |`FLOAT32` or `FLOAT64`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1831,8 +1831,10 @@ a|_n/a_
 a|_n/a_
 
 |`REAL[(M,D)]`
-|`FLOAT32`
+|`FLOAT64`
 a|_n/a_
+
+By default, `REAL` is a synonym for `DOUBLE`: the server stores and replicates such columns as 8-byte double-precision values. Only when the `REAL_AS_FLOAT` SQL mode is enabled is `REAL` a synonym for `FLOAT` instead.
 
 |`FLOAT[(P)]`
 |`FLOAT32` or `FLOAT64`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1831,10 +1831,11 @@ a|_n/a_
 a|_n/a_
 
 |`REAL[(M,D)]`
-|`FLOAT64`
-a|_n/a_
+|`FLOAT32` or `FLOAT64`
+a|The mapping is controlled by the xref:{context}-property-real-handling-mode[`real.handling.mode`] connector configuration property.
 
-By default, `REAL` is a synonym for `DOUBLE`: the server stores and replicates such columns as 8-byte double-precision values. Only when the `REAL_AS_FLOAT` SQL mode is enabled is `REAL` a synonym for `FLOAT` instead.
+By default, `REAL` is a synonym for `DOUBLE`, and the connector maps it to `FLOAT64`.
+Set `real.handling.mode` to `float` to map `REAL` to `FLOAT32`, for example, when the server uses the `REAL_AS_FLOAT` SQL mode.
 
 |`FLOAT[(P)]`
 |`FLOAT32` or `FLOAT64`
@@ -2326,6 +2327,8 @@ jdbc-sink.treat.real.as.double=true
 ----
 
 In the preceding example, the `selector.*` and `treat.real.as.double` configuration properties are optional.
+
+If `selector.real` matches a column, the `treat.real.as.double` converter setting determines the emitted schema for that column and takes precedence over the connector-level `real.handling.mode` setting.
 
 The `selector.*` properties specify comma-separated lists of regular expressions that specify which tables and columns that the converter applies to.
 By default, the converter applies the following rules apply to all Boolean, real, and string-based column data types, across all tables:


### PR DESCRIPTION
Fixes debezium/dbz#2217

## Description

MySQL and MariaDB treat `REAL` as a synonym for `DOUBLE` unless the `REAL_AS_FLOAT` sql_mode is enabled ([MySQL manual](https://dev.mysql.com/doc/refman/8.4/en/numeric-type-syntax.html)); the server rewrites the column type at DDL time (`SHOW CREATE TABLE` reports `double`), stores 8-byte doubles, and binlog row events carry 8-byte doubles.

The ANTLR DDL parsers resolved the `REAL` keyword to `java.sql.Types.REAL` (single precision in JDBC terms). As a result, the same column produced different schemas depending on the capture path:

| Capture path | Emitted schema | Value `3.141592653589793` |
|---|---|---|
| Snapshot (parses `SHOW CREATE TABLE`, already normalized to `double`) | `FLOAT64` | preserved |
| Streaming (parses original binlog DDL with `REAL`) | `FLOAT32` | **silently truncated to `3.1415927`** |

This PR resolves `REAL` to `Types.DOUBLE` in `MySqlAntlrDdlParser`, `MySqlPtAntlrDdlParser` and `MariaDbAntlrDdlParser`, so the streaming path matches the snapshot path and the server behavior, and no precision is lost. Default values for `REAL` columns are now emitted as `Double` accordingly (two existing test assertions updated). The shared data type mapping documentation row for `REAL` is updated to `FLOAT64` with a `REAL_AS_FLOAT` caveat.

This applies the conclusion of DBZ-6226 ("Regardless of when the table is created, REAL data types should be treated as a DOUBLE") to the default mapping; that issue shipped only the opt-in `JdbcSinkDataTypesConverter` workaround.

Note for existing deployments: tables captured before this fix keep their recorded schema-history model (`Types.REAL`) until the table model is rebuilt (re-snapshot or a subsequent DDL statement for the table); newly parsed DDL is emitted correctly.

Verified end-to-end against MySQL 8.0.46 (`sql_mode` without `REAL_AS_FLOAT`): with the patched plugin, a `CREATE TABLE ... (v REAL)` issued during streaming now emits `"type":"double"` and `3.141592653589793` intact; on the unpatched connector the same statement emitted `"type":"float"` and `3.1415927`. New regression test `shouldTreatRealDataTypeAsDouble` in the shared `BinlogAntlrDdlParserTest` fails before the fix (`Types.REAL` vs expected `Types.DOUBLE`) and passes after; full unit suites of the binlog, mysql and mariadb modules pass.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
