### PR TITLE
[docs] Fix data type syntax notation in the MySQL/MariaDB type mapping tables

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1842,21 +1842,21 @@ include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=ba
 |`FLOAT64`
 a|_n/a_
 
-|`CHAR(M)]`
+|`CHAR[(M)]`
 |`STRING`
 a|_n/a_
 
-|`VARCHAR(M)]`
+|`VARCHAR(M)`
 |`STRING`
 a|_n/a_
 
-|`BINARY(M)]`
+|`BINARY[(M)]`
 |`BYTES` or `STRING`
 a|_n/a_
 
 Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{context}-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
-|`VARBINARY(M)]`
+|`VARBINARY(M)`
 |`BYTES` or `STRING`
 a|_n/a_
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -1806,7 +1806,7 @@ a|`io.debezium.data.Bits`
 The `length` schema parameter contains an integer that represents the number of bits. The `byte[]` contains the bits in _little-endian_ form and is sized to contain the specified number of bits. For example, where `n` is bits:
 `numBytes = n/8 + (n%8== 0 ? 0 : 1)`
 
-|`TINYINT`
+|`TINYINT[(M)]`
 |`INT16`
 a|_n/a_
 
@@ -1818,7 +1818,7 @@ a|_n/a_
 |`INT32`
 a|_n/a_
 
-|`INT, INTEGER[(M)]`
+|`INT[(M)], INTEGER[(M)]`
 |`INT32`
 a|_n/a_
 
@@ -1872,7 +1872,7 @@ Either the raw bytes (the default), a base64-encoded String, or a base64-url-saf
 |`STRING`
 a|_n/a_
 
-|`BLOB`
+|`BLOB[(M)]`
 |`BYTES` or `STRING`
 a|_n/a_
 
@@ -1880,7 +1880,7 @@ Either the raw bytes (the default), a base64-encoded String, or a base64-url-saf
 
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
-|`TEXT`
+|`TEXT[(M)]`
 |`STRING`
 a|_n/a_
 
@@ -1928,16 +1928,16 @@ a|`io.debezium.data.EnumSet`
 
 The `allowed` schema parameter contains the comma-separated list of allowed values.
 
-|`YEAR[(2\|4)]`
+|`YEAR[(4)]`
 |`INT32`
 |`io.debezium.time.Year`
 
-|`TIMESTAMP[(M)]`
+|`TIMESTAMP[(fsp)]`
 |`STRING`
 a|`io.debezium.time.ZonedTimestamp`
 
 In link:https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601] format with microsecond precision.
-{connector-name} allows `M` to be in the range of `0-6`.
+{connector-name} allows the fractional seconds precision `fsp` to be in the range of `0-6`.
 
 |===
 end::basic-data-types[]
@@ -1984,11 +1984,11 @@ The {connector-name} connector determines the literal type and semantic type bas
 a|`io.debezium.time.Date`
 Represents the number of days since the epoch.
 
-|`TIME[(M)]`
+|`TIME[(fsp)]`
 |`INT64`
 a|`io.debezium.time.MicroTime`
 Represents the time value in microseconds and does not include time zone information.
-{connector-name} allows `M` to be in the range of `0-6`.
+{connector-name} allows the fractional seconds precision `fsp` to be in the range of `0-6`.
 
 |`DATETIME, DATETIME(0), DATETIME(1), DATETIME(2), DATETIME(3)`
 |`INT64`
@@ -2019,12 +2019,12 @@ The `connect` setting is expected to be removed in a future version of {prodname
 a|`org.apache.kafka.connect.data.Date`
 Represents the number of days since the epoch.
 
-|`TIME[(M)]`
+|`TIME[(fsp)]`
 |`INT64`
 a|`org.apache.kafka.connect.data.Time`
 Represents the time value in microseconds since midnight and does not include time zone information.
 
-|`DATETIME[(M)]`
+|`DATETIME[(fsp)]`
 |`INT64`
 a|`org.apache.kafka.connect.data.Timestamp`
 Represents the number of milliseconds since the epoch, and does not include time zone information.
@@ -2046,13 +2046,13 @@ a|`io.debezium.time.IsoDate`
 
 Represents the date value in UTC format, according to the ISO 8601 standard, for example, `2017-09-15Z`.
 
-|`TIME[(M)]`
+|`TIME[(fsp)]`
 |`STRING`
 a|`io.debezium.time.IsoTime`
 
 Represents the time value in UTC format, according to the ISO 8601 standard, for example, `04:05:11.789Z`.
 
-|`DATETIME[(M)]`
+|`DATETIME[(fsp)]`
 |`STRING`
 a|`io.debezium.time.IsoTimestamp`
 


### PR DESCRIPTION
## Description

Fixes the type syntax notation in the shared MySQL/MariaDB data type mapping tables (`shared-mariadb-mysql.adoc`, rendered into both connector pages).

**Broken bracket notation** (present since 2019): the `CHAR`, `VARCHAR`, `BINARY` and `VARBINARY` rows carried a dangling closing bracket without its opening counterpart, e.g. `CHAR(M)]`. Corrected per the [MySQL string type syntax](https://dev.mysql.com/doc/refman/8.4/en/string-type-syntax.html): `CHAR[(M)]` and `BINARY[(M)]` take an optional length, while `VARCHAR(M)` and `VARBINARY(M)` require it (no brackets).

**Notation aligned with the database manuals**:

| Before | After | Reason |
|---|---|---|
| `TINYINT` | `TINYINT[(M)]` | [Numeric type syntax](https://dev.mysql.com/doc/refman/8.4/en/numeric-type-syntax.html); consistent with the SMALLINT/MEDIUMINT/BIGINT rows |
| `INT, INTEGER[(M)]` | `INT[(M)], INTEGER[(M)]` | both synonyms take the optional display width |
| `BLOB`, `TEXT` | `BLOB[(M)]`, `TEXT[(M)]` | both accept an optional length that selects the smallest sufficient variant |
| `YEAR[(2\|4)]` | `YEAR[(4)]` | `YEAR(2)` was removed in MySQL 5.7.5 and is not accepted by any MySQL version Debezium supports; the [MariaDB manual](https://mariadb.com/kb/en/year-data-type/) also documents the syntax as `YEAR[(4)]` |
| `TIME[(M)]`, `DATETIME[(M)]`, `TIMESTAMP[(M)]` | `TIME[(fsp)]`, `DATETIME[(fsp)]`, `TIMESTAMP[(fsp)]` | the manuals use `fsp` (fractional seconds precision, range 0-6) for the temporal precision argument ([date and time type syntax](https://dev.mysql.com/doc/refman/8.4/en/date-and-time-type-syntax.html)); `M` elsewhere in the table means display width/length |

The two accompanying "allows `M` to be in the range of `0-6`" sentences are updated to spell out "fractional seconds precision `fsp`".

Not touched: `FLOAT[(P)]` (already accurate), the `REAL` row (updated separately in #7641), the `DATETIME, DATETIME(0)..(3)` adaptive-mode rows (they deliberately enumerate specific precisions), and TINY/MEDIUM/LONG BLOB/TEXT variants (they take no length argument).

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
