### PR TITLE
debezium/dbz#27 Mask connection string values in logged configuration

### DIFF
--- a/debezium-config/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-config/src/main/java/io/debezium/config/Configuration.java
@@ -65,7 +65,7 @@ public interface Configuration {
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     Pattern PASSWORD_PATTERN = Pattern.compile(
-            ".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
+            ".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$|.*connectionstring$|.*connection\\.string$",
             Pattern.CASE_INSENSITIVE);
 
     String CUSTOM_SANITIZE_PATTERN_KEY = "custom.sanitize.pattern";

--- a/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -214,6 +214,21 @@ public class ConfigurationTest {
         assertThat(config.getString("column.password")).isEqualTo("warning");
     }
 
+    @Test
+    @FixFor("debezium/dbz#27")
+    public void shouldMaskConnectionString() {
+        config = Configuration.create()
+                .with("eventhubs.connectionstring",
+                        "Endpoint=sb://eh-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123secret")
+                .with("mongodb.connection.string", "mongodb://user:secretpass@host:27017/")
+                .build();
+        assertThat(config.withMaskedPasswords().getString("eventhubs.connectionstring")).isEqualTo("********");
+        assertThat(config.withMaskedPasswords().getString("mongodb.connection.string")).isEqualTo("********");
+        assertThat(config.withMaskedPasswords().toString().contains("SharedAccessKey")).isFalse();
+        assertThat(config.withMaskedPasswords().toString().contains("secretpass")).isFalse();
+        assertThat(config.getString("eventhubs.connectionstring")).contains("SharedAccessKey=abc123secret");
+    }
+
     /**
      * On Amazon RDS we'll see INSERT (sic!) statements for a heartbeat table in the DDL even stream, they should
      * be filtered out by default (the reason being that those statements are sent using STATEMENT binlog format,


### PR DESCRIPTION
Fixes debezium/dbz#27

## Description

Debezium Server logs the Azure Event Hubs connection string in plaintext, exposing the embedded `SharedAccessKey`. This happens when a JDBC offset/schema-history store logs its configuration subset via `JdbcCommonConfig` — `jdbc.password` is masked, but `eventhubs.connectionstring` is printed verbatim.

The configuration masking (`Configuration.PASSWORD_PATTERN`) is key-name based and does full-value replacement with `********`. The connection-string key names did not match any pattern alternative, so their credential-bearing values were logged in the clear.

This change adds `.*connectionstring$` and `.*connection.string$` to the pattern. As confirmed by grepping the tree, the only keys matched are `eventhubs.connectionstring`, `mongodb.connection.string`, and `azure.storage.account.connectionstring` — all three embed credentials in their value (SharedAccessKey / inline `user:password` in the MongoDB URI / Azure `AccountKey`), so masking them is correct and there is no over-masking of endpoint-only keys.

Per the discussion on the issue, the ideal would be to print the connection string with only the secret portion removed. Debezium has no partial-value masking mechanism (masking replaces the whole value, keyed by regex) and the masking lives in the generic `Configuration` layer that must not know sink-specific string formats, so this follows the "hide it completely" option that was approved as acceptable.

Only the masked/`toString` copy used for logging is affected; the raw configuration values consumers read are unchanged (asserted in the test).

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
