### PR TITLE
debezium/dbz#75 Recover schema history when the binlog base name changes

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
@@ -5,7 +5,12 @@
  */
 package io.debezium.connector.binlog.history;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.VisibleForTesting;
 import io.debezium.connector.binlog.BinlogOffsetContext;
@@ -22,8 +27,15 @@ import io.debezium.relational.history.HistoryRecordComparator;
  */
 public abstract class BinlogHistoryRecordComparator extends HistoryRecordComparator {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BinlogHistoryRecordComparator.class);
+
     private final Predicate<String> gtidSourceFilter;
     private final GtidSetFactory gtidSetFactory;
+
+    // isPositionAtOrBefore() is invoked once per recorded history entry during recovery, so a base-name
+    // change would otherwise log for every differing record. Track the transitions already reported to
+    // keep the warning to one line per distinct base-name change.
+    private final Set<String> warnedBaseNameChanges = ConcurrentHashMap.newKeySet();
 
     public BinlogHistoryRecordComparator(Predicate<String> gtidSourceFilter, GtidSetFactory gtidSetFactory) {
         this.gtidSourceFilter = gtidSourceFilter;
@@ -115,6 +127,13 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
             // than failing schema history recovery, treat the recorded position as at-or-before the desired
             // one so its DDL is applied and the in-memory schema is rebuilt completely. Skipping the DDL is
             // the unsafe direction: it would leave the schema incomplete and break parsing of later events.
+            final String change = recordedFileName.baseName + " -> " + desiredFileName.baseName;
+            if (warnedBaseNameChanges.add(change)) {
+                LOGGER.warn("Binlog base name changed during schema history recovery ({}); the recorded DDL is "
+                        + "applied because the numeric extensions are no longer comparable. This is expected after a "
+                        + "restore or log_bin_basename change, but if it results from switching back and forth between "
+                        + "primary and failover the recovered schema history may be incomplete.", change);
+            }
             return true;
         }
         final int fileNameCheck = recordedFileName.compareTo(desiredFileName);

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
@@ -109,6 +109,14 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
         // Compare binlog file names
         final BinlogFileName recordedFileName = getBinlogFileName(recorded);
         final BinlogFileName desiredFileName = getBinlogFileName(desired);
+        if (!recordedFileName.baseName.equals(desiredFileName.baseName)) {
+            // The binlog base name changed (e.g. after a restore, failover, or a log_bin_basename change),
+            // so the numeric extensions belong to unrelated coordinate spaces and cannot be compared. Rather
+            // than failing schema history recovery, treat the recorded position as at-or-before the desired
+            // one so its DDL is applied and the in-memory schema is rebuilt completely. Skipping the DDL is
+            // the unsafe direction: it would leave the schema incomplete and break parsing of later events.
+            return true;
+        }
         final int fileNameCheck = recordedFileName.compareTo(desiredFileName);
         if (fileNameCheck != 0) {
             return fileNameCheck < 0;

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
@@ -583,11 +583,16 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
     }
 
     @Test
-    void shouldNotComparePositionsWithDifferentFilenameFormats() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            Document history = positionWithoutGtids("mysql-bin.000001", 1, 0, 0);
-            assertThatDocument(history).isAtOrBefore(positionWithoutGtids("mysql-binlog-filename.000001", 1, 0, 0));
-        });
+    @FixFor("debezium/dbz#75")
+    void shouldNotFailWhenComparingPositionsWithDifferentBaseNames() {
+        // A changed binlog base name (e.g. after a restore, failover, or a log_bin_basename change) is a
+        // valid situation, not an error. The numeric extensions then belong to unrelated coordinate spaces,
+        // so instead of throwing the recorded position is treated as at-or-before the desired one and its
+        // DDL is applied during schema history recovery.
+        assertThatDocument(positionWithoutGtids("mysql-bin.000010", 100, 0, 0))
+                .isAtOrBefore(positionWithoutGtids("binlog.000002", 200, 0, 0));
+        assertThatDocument(positionWithoutGtids("binlog.000002", 200, 0, 0))
+                .isAtOrBefore(positionWithoutGtids("mysql-bin.000010", 100, 0, 0));
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#75

## Description

A MySQL/MariaDB connector fails on startup during schema history recovery with:

```
java.lang.IllegalArgumentException: Cannot compare binlog filenames with different base names
	at io.debezium.connector.binlog.history.BinlogHistoryRecordComparator$BinlogFileName.compareTo(BinlogHistoryRecordComparator.java:232)
	at io.debezium.connector.binlog.history.BinlogHistoryRecordComparator.isPositionAtOrBefore(...)
	...
	at io.debezium.relational.history.AbstractSchemaHistory.recover(...)
```

This happens whenever a recorded binlog position and the desired (restart) position have different **base names** — e.g. after an RDS restore, a failover, or a `log_bin_basename` change (`mysql-bin.000010` vs `binlog.000002`). `BinlogFileName.compareTo` threw because the numeric extensions of two different base names are not directly comparable.

`isPositionAtOrBefore` already handles an analogous "coordinates are unrelated" case: when the two positions come from different servers it does not compare binlog coordinates. This change treats a differing base name the same way — instead of throwing, the recorded position is considered at-or-before the desired one so its DDL is applied during recovery.

Because connector offsets advance monotonically, a differing base name means the recorded position predates the base-name change (an older coordinate space), so applying it rebuilds the complete schema. This is the safe direction during recovery: skipping the DDL (the alternative) would leave the in-memory schema incomplete and break parsing of later events.

The `compareTo` contract is left unchanged, so genuinely unparseable filenames (no extension / non-numeric extension) still fail fast as before.

## Tests

- `BinlogSourceInfoTest#shouldNotFailWhenComparingPositionsWithDifferentBaseNames` (runs for MySQL and MariaDB): asserts that comparing positions with different, parseable base names no longer throws and is treated as at-or-before in both directions. This replaces the previous `shouldNotComparePositionsWithDifferentFilenameFormats`, which asserted the now-removed throwing behavior.
- The existing tests that assert throwing for unparseable filenames (no extension, non-numeric extension) are retained unchanged.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
