### PR TITLE
debezium/dbz#633 Add transaction-metadata restart IT coverage for the Postgres connector

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.junit.EqualityCheck;
 import io.debezium.junit.SkipWhenKafkaVersion;
@@ -105,6 +107,134 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
         assertRecordTransactionMetadata(records.get(1), beginTxId, 1, 1);
         assertRecordTransactionMetadata(records.get(2), beginTxId, 2, 1);
         assertEndTransaction(records.get(3), beginTxId, 2, Collect.hashMapOf("s1.a", 1, "s2.a", 1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#633")
+    public void shouldContinueTransactionEventCountersAfterRestartInMiddleOfTransaction() throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.execute(SETUP_TABLES_STMT);
+        final Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue())
+                // Keep the replication slot and the offsets across the restart so that the interrupted
+                // transaction is resumed and replayed from its beginning instead of being dropped
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                // Keep the engine batches small so that stopping the connector cannot deliver records
+                // past the middle of the transaction before the stop takes effect
+                .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+
+        // Write a single transaction interleaving two tables that is much larger than the record queue
+        // of the test framework, so the connector is stopped before the whole transaction is delivered
+        final int insertsPerTable = 150;
+        try (PostgresConnection connection = TestHelper.create()) {
+            connection.setAutoCommit(false);
+            final String[] inserts = new String[2 * insertsPerTable];
+            for (int i = 0; i < insertsPerTable; i++) {
+                inserts[2 * i] = "INSERT INTO s1.a (aa) VALUES (" + i + ")";
+                inserts[2 * i + 1] = "INSERT INTO s2.a (aa) VALUES (" + i + ")";
+            }
+            connection.executeWithoutCommitting(inserts);
+            connection.commit();
+        }
+
+        // Consume the beginning of the transaction, then stop the connector while the rest of the
+        // transaction is still being delivered
+        final List<SourceRecord> records = new ArrayList<>(consumeRecordsByTopic(51).allRecordsInOrder());
+        final String txId = findTransactionId(records);
+        assertThat(txId).as("Failed to find the transaction id").isNotNull();
+        stopConnector();
+        assertConnectorNotRunning();
+
+        // The connector has to stop in the middle of the transaction, i.e. the last committed offset
+        // still references the in-progress transaction id (it is cleared once a transaction ends)
+        final Map<String, Object> committedOffset = readLastCommittedOffset(config, records.get(0).sourcePartition());
+        assertThat(committedOffset.get("transaction_id"))
+                .as("Connector has to stop in the middle of the transaction")
+                .isEqualTo(txId);
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        // Consume the rest of the transaction including its END event
+        for (int i = 0; findTransactionStatusRecords(records, txId, "END").isEmpty() && i < 30; i++) {
+            records.addAll(consumeRecordsByTopic(100).allRecordsInOrder());
+        }
+
+        // Only a single BEGIN must be emitted for the transaction, the transaction start replayed
+        // after the restart must not be propagated
+        final List<SourceRecord> beginRecords = findTransactionStatusRecords(records, txId, "BEGIN");
+        assertThat(beginRecords).as("Duplicate BEGIN event emitted after restart").hasSize(1);
+        assertBeginTransaction(beginRecords.get(0));
+
+        // Event counters must continue after the restart instead of being reset
+        assertDataCollectionOrderContinues(records, TestHelper.topicName("s1.a"), txId, insertsPerTable);
+        assertDataCollectionOrderContinues(records, TestHelper.topicName("s2.a"), txId, insertsPerTable);
+
+        final List<SourceRecord> endRecords = findTransactionStatusRecords(records, txId, "END");
+        assertThat(endRecords).as("Failed to find the transaction END event").isNotEmpty();
+        assertEndTransaction(endRecords.get(0), txId, 2 * insertsPerTable,
+                Collect.hashMapOf("s1.a", insertsPerTable, "s2.a", insertsPerTable));
+    }
+
+    /**
+     * Finds the numeric transaction id of the first data change record. Postgres transaction ids used in the
+     * transaction metadata are of the form {@code <txid>:<lsn>}; the numeric {@code <txid>} part is stable across
+     * a restart while the {@code <lsn>} part differs between the BEGIN, data and END events of a transaction.
+     */
+    private String findTransactionId(List<SourceRecord> records) {
+        return records.stream()
+                .filter(record -> record.topic().equals(TestHelper.topicName("s1.a"))
+                        || record.topic().equals(TestHelper.topicName("s2.a")))
+                .map(record -> ((Struct) record.value()).getStruct("transaction").getString("id"))
+                .map(TransactionMetadataIT::toTransactionNumber)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<SourceRecord> findTransactionStatusRecords(List<SourceRecord> records, String txId, String status) {
+        final String transactionTopic = TestHelper.topicName("transaction");
+        final List<SourceRecord> statusRecords = new ArrayList<>();
+        for (SourceRecord record : records) {
+            if (transactionTopic.equals(record.topic())) {
+                final Struct value = (Struct) record.value();
+                if (status.equals(value.getString("status")) && txId.equals(toTransactionNumber(value.getString("id")))) {
+                    statusRecords.add(record);
+                }
+            }
+        }
+        return statusRecords;
+    }
+
+    private void assertDataCollectionOrderContinues(List<SourceRecord> records, String topic, String txId, int expectedLastOrder) {
+        long previousOrder = 0;
+        long lastOrder = 0;
+        for (SourceRecord record : records) {
+            if (!topic.equals(record.topic())) {
+                continue;
+            }
+            final Struct transaction = ((Struct) record.value()).getStruct("transaction");
+            assertThat(toTransactionNumber(transaction.getString("id"))).isEqualTo(txId);
+            final long order = transaction.getInt64("data_collection_order");
+            assertThat(order)
+                    .as("data_collection_order was reset within transaction %s on topic %s", txId, topic)
+                    .isGreaterThanOrEqualTo(previousOrder);
+            previousOrder = order;
+            lastOrder = order;
+        }
+        assertThat(lastOrder).as("Unexpected last data_collection_order for %s", topic).isEqualTo((long) expectedLastOrder);
+    }
+
+    private static String toTransactionNumber(String transactionId) {
+        return transactionId == null ? null : transactionId.split(":")[0];
     }
 
     @Override


### PR DESCRIPTION

> **Stacked on #7624.** This branch is forked off `dbz-633-tx-restart`, so until #7624 merges the
> diff here also contains #7624's commit — please review only the last commit (the Postgres test),
> and merge this after #7624. The diff will reduce to the single test file once #7624 is merged.

Follow-up to #7624, addressing the review request to extend the "continue transaction event
counters after a mid-transaction restart" IT coverage to the other core connectors that already
have transaction-metadata IT classes.

Fixes debezium/dbz#633

## What this adds

`TransactionMetadataIT#shouldContinueTransactionEventCountersAfterRestartInMiddleOfTransaction`
for the Postgres connector, the direct analogue of the binlog test added in #7624:

- streams a single 300-row transaction interleaving `s1.a` and `s2.a`,
- stops the connector deterministically in the middle of the transaction (small engine batches +
  the test framework's bounded record queue), verifying via the committed offset's
  `transaction_id` key that the stop really happened inside the transaction,
- restarts, and asserts a single `BEGIN`, `data_collection_order` continuing monotonically to 150
  per table (not reset), and an `END` with `event_count=300` and the correct per-collection counts.

Postgres is the connector — besides the binlog family — that both exercises the fixed
`TransactionMonitor.transactionStartedEvent()` path and reproduces the failure: on a
mid-transaction restart pgoutput replays the interrupted transaction from its `BEGIN`
(`WalPositionLocator` resumes at the transaction start LSN), and `PostgresOffsetContext.load()`
restores the `TransactionContext`, so without the #7624 fix the replayed `BEGIN` would emit a
duplicate transaction-start record and reset the counters.

## Why only Postgres

I looked at every connector that has a transaction-metadata IT class:

- **SQL Server** — already covered. `TransactionMetadataIT.restartInTheMiddleOfTx(...)` (three
  `@Test` variants) already asserts that the counters continue under the same transaction id after
  a mid-transaction restart. SQL Server never uses the `transactionStartedEvent()` path (it emits
  BEGIN/END through `TransactionMonitor.dataEvent()` txId-change detection), so it cannot hit the
  duplicate-BEGIN bug and needs no new test.
- **MongoDB** — not reproducible. Change streams deliver each operation with its own resume token
  and restart via `resumeAfter(...)`, so events are never replayed from a transaction's start;
  there is no duplicate `BEGIN` to guard against. (MongoDB also never calls
  `transactionStartedEvent()`.)
- **Oracle** — only the OpenLogReplicator adapter emits transaction-start events (LogMiner does
  not), and an OLR-based IT requires heavy external infrastructure that is out of scope for this
  follow-up.

So Postgres is the only remaining connector where an equivalent test is both meaningful (exercises
the fixed code path) and reproducible.

## Tests

- `debezium-connector-postgres` `TransactionMetadataIT#shouldContinueTransactionEventCountersAfterRestartInMiddleOfTransaction`