### PR TITLE
debezium/dbz#2100 Guard pgvector sink DDL against unresolved dimension

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/DoubleVectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/DoubleVectorType.java
@@ -28,7 +28,12 @@ public class DoubleVectorType extends AbstractDoubleVectorType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final Optional<String> size = getSourceColumnSize(schema);
+        // pgvector types get dynamically assigned OIDs, so the PostgreSQL driver cannot resolve their
+        // dimension and the propagated column length arrives as Integer.MAX_VALUE. Emit an unqualified
+        // vector in that case rather than an invalid vector(2147483647). This mirrors BitType, which
+        // falls back to "bit varying" for the same Integer.MAX_VALUE sentinel.
+        final Optional<String> size = getSourceColumnSize(schema)
+                .filter(s -> Integer.parseInt(s) != Integer.MAX_VALUE);
         return size.map(s -> String.format("vector(%s)", s)).orElse("vector");
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/FloatVectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/FloatVectorType.java
@@ -28,7 +28,12 @@ public class FloatVectorType extends AbstractFloatVectorType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final Optional<String> size = getSourceColumnSize(schema);
+        // pgvector types get dynamically assigned OIDs, so the PostgreSQL driver cannot resolve their
+        // dimension and the propagated column length arrives as Integer.MAX_VALUE. Emit an unqualified
+        // halfvec in that case rather than an invalid halfvec(2147483647). This mirrors BitType, which
+        // falls back to "bit varying" for the same Integer.MAX_VALUE sentinel.
+        final Optional<String> size = getSourceColumnSize(schema)
+                .filter(s -> Integer.parseInt(s) != Integer.MAX_VALUE);
         return size.map(s -> String.format("halfvec(%s)", s)).orElse("halfvec");
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/SparseDoubleVectorType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/SparseDoubleVectorType.java
@@ -36,7 +36,12 @@ public class SparseDoubleVectorType extends AbstractSparseDoubleVectorType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final Optional<String> size = getSourceColumnSize(schema);
+        // pgvector types get dynamically assigned OIDs, so the PostgreSQL driver cannot resolve their
+        // dimension and the propagated column length arrives as Integer.MAX_VALUE. Emit an unqualified
+        // sparsevec in that case rather than an invalid sparsevec(2147483647). This mirrors BitType,
+        // which falls back to "bit varying" for the same Integer.MAX_VALUE sentinel.
+        final Optional<String> size = getSourceColumnSize(schema)
+                .filter(s -> Integer.parseInt(s) != Integer.MAX_VALUE);
         return size.map(s -> String.format("sparsevec(%s)", s)).orElse("sparsevec");
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/DoubleVectorTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/DoubleVectorTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.vector.DoubleVector;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the PostgreSQL {@link DoubleVectorType} handler.
+ */
+@Tag("UnitTests")
+class DoubleVectorTypeTest {
+
+    @Test
+    @DisplayName("Should render a qualified vector type when the source column dimension is propagated")
+    void testTypeNameWithDimension() {
+        final Schema schema = DoubleVector.builder()
+                .parameter("__debezium.source.column.length", "3")
+                .build();
+
+        assertThat(DoubleVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("vector(3)");
+    }
+
+    @Test
+    @DisplayName("Should render an unqualified vector type when the source column dimension is absent")
+    void testTypeNameWithoutDimension() {
+        assertThat(DoubleVectorType.INSTANCE.getTypeName(DoubleVector.schema(), false)).isEqualTo("vector");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render an unqualified vector type when the propagated dimension is Integer.MAX_VALUE")
+    void testTypeNameWithUnknownDimension() {
+        final Schema schema = DoubleVector.builder()
+                .parameter("__debezium.source.column.length", String.valueOf(Integer.MAX_VALUE))
+                .build();
+
+        assertThat(DoubleVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("vector");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/FloatVectorTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/FloatVectorTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.vector.FloatVector;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the PostgreSQL {@link FloatVectorType} handler.
+ */
+@Tag("UnitTests")
+class FloatVectorTypeTest {
+
+    @Test
+    @DisplayName("Should render a qualified halfvec type when the source column dimension is propagated")
+    void testTypeNameWithDimension() {
+        final Schema schema = FloatVector.builder()
+                .parameter("__debezium.source.column.length", "3")
+                .build();
+
+        assertThat(FloatVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("halfvec(3)");
+    }
+
+    @Test
+    @DisplayName("Should render an unqualified halfvec type when the source column dimension is absent")
+    void testTypeNameWithoutDimension() {
+        assertThat(FloatVectorType.INSTANCE.getTypeName(FloatVector.schema(), false)).isEqualTo("halfvec");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render an unqualified halfvec type when the propagated dimension is Integer.MAX_VALUE")
+    void testTypeNameWithUnknownDimension() {
+        final Schema schema = FloatVector.builder()
+                .parameter("__debezium.source.column.length", String.valueOf(Integer.MAX_VALUE))
+                .build();
+
+        assertThat(FloatVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("halfvec");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/SparseDoubleVectorTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/SparseDoubleVectorTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.vector.SparseDoubleVector;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the PostgreSQL {@link SparseDoubleVectorType} handler.
+ */
+@Tag("UnitTests")
+class SparseDoubleVectorTypeTest {
+
+    @Test
+    @DisplayName("Should render a qualified sparsevec type when the source column dimension is propagated")
+    void testTypeNameWithDimension() {
+        final Schema schema = SparseDoubleVector.builder()
+                .parameter("__debezium.source.column.length", "25")
+                .build();
+
+        assertThat(SparseDoubleVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("sparsevec(25)");
+    }
+
+    @Test
+    @DisplayName("Should render an unqualified sparsevec type when the source column dimension is absent")
+    void testTypeNameWithoutDimension() {
+        assertThat(SparseDoubleVectorType.INSTANCE.getTypeName(SparseDoubleVector.schema(), false)).isEqualTo("sparsevec");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2100")
+    @DisplayName("Should render an unqualified sparsevec type when the propagated dimension is Integer.MAX_VALUE")
+    void testTypeNameWithUnknownDimension() {
+        final Schema schema = SparseDoubleVector.builder()
+                .parameter("__debezium.source.column.length", String.valueOf(Integer.MAX_VALUE))
+                .build();
+
+        assertThat(SparseDoubleVectorType.INSTANCE.getTypeName(schema, false)).isEqualTo("sparsevec");
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2100, case 12.

## Description

pgvector types (`vector` / `halfvec` / `sparsevec`) are provided by an extension and get **dynamically assigned OIDs**, so they are not in the PostgreSQL JDBC driver's hard-coded type table. The driver therefore cannot resolve their dimension, and the propagated `__debezium.source.column.length` arrives as `Integer.MAX_VALUE` (`2147483647`) on both the snapshot and streaming paths. The JDBC sink rendered that verbatim, so automatic schema evolution attempted:

```sql
CREATE TABLE vecaudit_sink (id integer NOT NULL, vec vector(2147483647) NULL,
  half halfvec(2147483647) NULL, sparse sparsevec(2147483647) NULL, PRIMARY KEY(id))
```

which PostgreSQL rejects with `ERROR: dimensions for type vector cannot exceed 16000`.

This guards `getTypeName` in the three PostgreSQL vector handlers: when the propagated size is `Integer.MAX_VALUE`, emit an unqualified `vector` / `halfvec` / `sparsevec` instead of a qualified type. This mirrors the existing `BitType` guard, which emits `bit varying` for the same `Integer.MAX_VALUE` sentinel. An unqualified pgvector column accepts a vector of any dimension, so values still round-trip; only the dimension constraint (which the driver does not expose to us) is not replicated.

Recovering the real dimension on the source side is tracked separately as a longer-term follow-up, as discussed on the issue.

Tests:
- `DoubleVectorTypeTest` / `FloatVectorTypeTest` / `SparseDoubleVectorTypeTest` (unit) — each asserts a qualified type for a propagated dimension, the unqualified fallback when no size is present, and the unqualified fallback when the propagated size is `Integer.MAX_VALUE` (the regression pinned to this issue).
- Verified end-to-end (PG `vector(3)`/`halfvec(3)`/`sparsevec(25)` → JDBC sink): the sink now auto-creates unqualified `vector`/`halfvec`/`sparsevec` columns and round-trips the values, where `main` fails with the error above.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
