### PR TITLE
debezium/dbz#1234 Skip empty tags and ownership facets in OpenLineage job events

### DIFF
--- a/debezium-openlineage/debezium-openlineage-core/src/main/java/io/debezium/openlineage/OpenLineageJobCreator.java
+++ b/debezium-openlineage/debezium-openlineage-core/src/main/java/io/debezium/openlineage/OpenLineageJobCreator.java
@@ -32,14 +32,21 @@ public class OpenLineageJobCreator {
                 .map(pair -> context.getOpenLineage().newOwnershipJobFacetOwners(pair.getKey(), pair.getValue()))
                 .toList();
 
-        OpenLineage.JobFacets jobFacets = context.getOpenLineage().newJobFacetsBuilder()
+        OpenLineage.JobFacetsBuilder jobFacetsBuilder = context.getOpenLineage().newJobFacetsBuilder()
                 .documentation(
                         context.getOpenLineage().newDocumentationJobFacet(
                                 context.getConfiguration().job().description()))
-                .ownership(context.getOpenLineage().newOwnershipJobFacet(owners))
-                .tags(context.getOpenLineage().newTagsJobFacet(tags))
-                .jobType(context.getOpenLineage().newJobTypeJobFacet(PROCESSING_TYPE, INTEGRATION, JOB_TYPE))
-                .build();
+                .jobType(context.getOpenLineage().newJobTypeJobFacet(PROCESSING_TYPE, INTEGRATION, JOB_TYPE));
+
+        if (!owners.isEmpty()) {
+            jobFacetsBuilder.ownership(context.getOpenLineage().newOwnershipJobFacet(owners));
+        }
+
+        if (!tags.isEmpty()) {
+            jobFacetsBuilder.tags(context.getOpenLineage().newTagsJobFacet(tags));
+        }
+
+        OpenLineage.JobFacets jobFacets = jobFacetsBuilder.build();
 
         return context.getOpenLineage().newJobBuilder()
                 .namespace(context.getJobIdentifier().namespace())

--- a/debezium-openlineage/debezium-openlineage-core/src/test/java/io/debezium/openlineage/OpenLineageJobCreatorTest.java
+++ b/debezium-openlineage/debezium-openlineage-core/src/test/java/io/debezium/openlineage/OpenLineageJobCreatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.openlineage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.openlineage.client.OpenLineage;
+
+class OpenLineageJobCreatorTest {
+
+    private static final URI PRODUCER = URI.create("https://github.com/debezium/debezium");
+
+    private OpenLineage.Job createJob(Map<String, String> tags, Map<String, String> owners) {
+        OpenLineage openLineage = new OpenLineage(PRODUCER);
+        DebeziumOpenLineageConfiguration configuration = new DebeziumOpenLineageConfiguration(
+                true,
+                new DebeziumOpenLineageConfiguration.Config("openlineage.yml"),
+                new DebeziumOpenLineageConfiguration.Job("namespace", "a description", tags, owners));
+        OpenLineageContext context = new OpenLineageContext(
+                openLineage, configuration, new OpenLineageJobIdentifier("namespace", "job"), UUID.randomUUID());
+
+        return new OpenLineageJobCreator(context).create();
+    }
+
+    @Test
+    void shouldNotAddTagsAndOwnershipFacetsWhenTagsAndOwnersAreEmpty() {
+        OpenLineage.Job job = createJob(Map.of(), Map.of());
+
+        assertNull(job.getFacets().getTags());
+        assertNull(job.getFacets().getOwnership());
+    }
+
+    @Test
+    void shouldAddTagsFacetWhenTagsArePresent() {
+        OpenLineage.Job job = createJob(Map.of("env", "prod"), Map.of());
+
+        assertNotNull(job.getFacets().getTags());
+        assertEquals("env", job.getFacets().getTags().getTags().get(0).getKey());
+        assertEquals("prod", job.getFacets().getTags().getTags().get(0).getValue());
+        assertNull(job.getFacets().getOwnership());
+    }
+
+    @Test
+    void shouldAddOwnershipFacetWhenOwnersArePresent() {
+        OpenLineage.Job job = createJob(Map.of(), Map.of("team", "cdc"));
+
+        assertNotNull(job.getFacets().getOwnership());
+        assertEquals("team", job.getFacets().getOwnership().getOwners().get(0).getName());
+        assertNull(job.getFacets().getTags());
+    }
+
+    @Test
+    void shouldAlwaysAddDocumentationAndJobTypeFacets() {
+        OpenLineage.Job job = createJob(Map.of(), Map.of());
+
+        assertNotNull(job.getFacets().getDocumentation());
+        assertEquals("a description", job.getFacets().getDocumentation().getDescription());
+        assertNotNull(job.getFacets().getJobType());
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1234

## Description

The OpenLineage integration always attached the `tags` and `ownership` facets to every job event, even when no tags or owners were configured. This emitted empty facets (an empty tags list / empty owners list) to lineage consumers, cluttering the events with meaningless structure.

`OpenLineageJobCreator.create()` now adds the `tags` and `ownership` facets only when their respective collections are non-empty.

The issue also mentions the `documentation` facet, but it is **intentionally left unconditional**: the job description always resolves to a non-empty value — either the configured `openlineage.integration.job.description` or the default template `"Debezium CDC job for <connector>"` (`DebeziumOpenLineageConfiguration`). A guard on it would be dead code. The `jobType` facet is likewise always meaningful and unchanged.

## Tests

- New `OpenLineageJobCreatorTest` exercises the real `create()` path with a real OpenLineage client:
  - empty tags and owners → neither `tags` nor `ownership` facet is present
  - tags present → `tags` facet added (with correct key/value), `ownership` still absent
  - owners present → `ownership` facet added, `tags` still absent
  - `documentation` and `jobType` facets are always present
- The existing connector OpenLineage integration tests (PostgreSQL, SQL Server, MongoDB, JDBC sink) configure tags and owners, so they continue to assert populated facets and remain green.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
