### PR TITLE
debezium/dbz#798 Skip ad-hoc snapshot signals with non-string data collections

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
@@ -267,6 +267,10 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
 
         // Extract database name from first data collection
         for (Array.Entry entry : dataCollectionsArray) {
+            if (!entry.getValue().isString()) {
+                LOGGER.debug("Skipping non-string data-collections element while resolving the signal partition");
+                continue;
+            }
             String dataCollection = entry.getValue().asString().trim();
 
             String[] parts = dataCollection.split(POINT_REGEX);

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/AbstractSnapshotSignal.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/AbstractSnapshotSignal.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.signal.actions;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -31,6 +32,16 @@ public abstract class AbstractSnapshotSignal<P extends Partition> implements Sig
     public enum SnapshotType {
         INCREMENTAL,
         BLOCKING
+    }
+
+    /**
+     * Result of parsing the {@code data-collections} field of a snapshot signal.
+     *
+     * @param valid whether the signal can be acted upon; {@code false} when the field is present but malformed
+     *            (for example a non-string element), so the signal must be skipped
+     * @param collections the parsed collections, or {@code null} when the field is missing or empty
+     */
+    public record DataCollections(boolean valid, List<String> collections) {
     }
 
     public static SnapshotType getSnapshotType(Document data) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
@@ -52,10 +52,11 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
     @Override
     public boolean arrived(SignalPayload<P> signalPayload) throws InterruptedException {
 
-        final List<String> dataCollections = getDataCollections(signalPayload.data);
-        if (dataCollections == null) {
+        final DataCollections dataCollectionsResult = getDataCollections(signalPayload.data);
+        if (!dataCollectionsResult.valid()) {
             return false;
         }
+        final List<String> dataCollections = dataCollectionsResult.collections();
         SnapshotType type = getSnapshotType(signalPayload.data);
 
         List<AdditionalCondition> additionalConditions = getAdditionalConditions(signalPayload.data, type);
@@ -100,18 +101,24 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
                 .build();
     }
 
-    public static List<String> getDataCollections(Document data) {
+    public static DataCollections getDataCollections(Document data) {
 
         final Array dataCollectionsArray = data.getArray(FIELD_DATA_COLLECTIONS);
         if (dataCollectionsArray == null || dataCollectionsArray.isEmpty()) {
             LOGGER.warn(
                     "Execute snapshot signal '{}' has arrived but the requested field '{}' is missing from data or is empty",
                     data, FIELD_DATA_COLLECTIONS);
-            return null;
+            return new DataCollections(false, null);
         }
-        return dataCollectionsArray.streamValues()
+        if (dataCollectionsArray.streamValues().anyMatch(v -> !v.isString())) {
+            LOGGER.warn(
+                    "Execute snapshot signal '{}' has arrived but the requested field '{}' contains a non-string data collection",
+                    data, FIELD_DATA_COLLECTIONS);
+            return new DataCollections(false, null);
+        }
+        return new DataCollections(true, dataCollectionsArray.streamValues()
                 .map(v -> v.asString().trim())
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
     public static Optional<String> getSurrogateKey(Document data) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/StopSnapshot.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/StopSnapshot.java
@@ -42,7 +42,11 @@ public class StopSnapshot<P extends Partition> extends AbstractSnapshotSignal<P>
 
     @Override
     public boolean arrived(SignalPayload<P> signalPayload) throws InterruptedException {
-        final List<String> dataCollections = getDataCollections(signalPayload.data);
+        final DataCollections dataCollectionsResult = getDataCollections(signalPayload.data);
+        if (!dataCollectionsResult.valid()) {
+            return false;
+        }
+        final List<String> dataCollections = dataCollectionsResult.collections();
         final SnapshotType type = getSnapshotType(signalPayload.data);
 
         LOGGER.info("Requested stop of snapshot '{}' for data collections '{}'", type, dataCollections);
@@ -56,13 +60,20 @@ public class StopSnapshot<P extends Partition> extends AbstractSnapshotSignal<P>
         return true;
     }
 
-    public static List<String> getDataCollections(Document data) {
+    public static DataCollections getDataCollections(Document data) {
         final Array dataCollectionsArray = data.getArray(FIELD_DATA_COLLECTIONS);
         if (dataCollectionsArray == null || dataCollectionsArray.isEmpty()) {
-            return null;
+            // A missing or empty data-collections means the entire in-progress snapshot is stopped.
+            return new DataCollections(true, null);
         }
-        return dataCollectionsArray.streamValues()
+        if (dataCollectionsArray.streamValues().anyMatch(v -> !v.isString())) {
+            LOGGER.warn(
+                    "Stop snapshot signal '{}' has arrived but the requested field '{}' contains a non-string data collection",
+                    data, FIELD_DATA_COLLECTIONS);
+            return new DataCollections(false, null);
+        }
+        return new DataCollections(true, dataCollectionsArray.streamValues()
                 .map(v -> v.asString().trim())
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/SnapshotSignalArrivedTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/SnapshotSignalArrivedTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.signal.actions.snapshotting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.document.Document;
+import io.debezium.document.DocumentReader;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+
+/**
+ * Verifies the behaviour of {@code arrived()} for the snapshot signals, in particular that a malformed
+ * {@code data-collections} is skipped rather than acted upon. A malformed stop signal must not escalate to
+ * stopping the entire in-progress snapshot, while a missing/empty one still does.
+ *
+ * @see <a href="https://github.com/debezium/dbz/issues/798">DBZ-6352</a>
+ */
+class SnapshotSignalArrivedTest {
+
+    private final DocumentReader reader = DocumentReader.defaultReader();
+
+    @SuppressWarnings("unchecked")
+    private final EventDispatcher<Partition, ?> dispatcher = mock(EventDispatcher.class);
+    @SuppressWarnings("unchecked")
+    private final IncrementalSnapshotChangeEventSource<Partition, ?> incrementalSource = mock(IncrementalSnapshotChangeEventSource.class);
+
+    @BeforeEach
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void setUp() {
+        when(dispatcher.getIncrementalSnapshotChangeEventSource()).thenReturn((IncrementalSnapshotChangeEventSource) incrementalSource);
+    }
+
+    private SignalPayload<Partition> payload(String json) throws IOException {
+        final Document data = reader.read(json);
+        return new SignalPayload<>(mock(Partition.class), "signal-id", "stop-snapshot", data, mock(OffsetContext.class), Map.of());
+    }
+
+    @Test
+    void stopSnapshotShouldNotStopAnythingForMalformedDataCollections() throws IOException, InterruptedException {
+        final StopSnapshot<Partition> action = new StopSnapshot<>(dispatcher);
+
+        final boolean result = action.arrived(payload("{\"data-collections\": [[\"schema.table1\"]]}"));
+
+        assertThat(result).isFalse();
+        // The whole point of the fix: a malformed stop signal must NOT escalate to stopping the snapshot.
+        verify(incrementalSource, never()).requestStopSnapshot(any(), any(), any(), any());
+    }
+
+    @Test
+    void stopSnapshotShouldStopAllForMissingDataCollections() throws IOException, InterruptedException {
+        final StopSnapshot<Partition> action = new StopSnapshot<>(dispatcher);
+
+        final boolean result = action.arrived(payload("{}"));
+
+        assertThat(result).isTrue();
+        // Missing data-collections is a valid request to stop the entire snapshot: null flows through to stop-all.
+        verify(incrementalSource).requestStopSnapshot(any(), any(), any(), isNull());
+    }
+
+    @Test
+    void stopSnapshotShouldStopSpecificCollections() throws IOException, InterruptedException {
+        final StopSnapshot<Partition> action = new StopSnapshot<>(dispatcher);
+
+        final boolean result = action.arrived(payload("{\"data-collections\": [\"schema.table1\"]}"));
+
+        assertThat(result).isTrue();
+        verify(incrementalSource).requestStopSnapshot(any(), any(), any(), eq(java.util.List.of("schema.table1")));
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/SnapshotSignalDataCollectionsTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/actions/snapshotting/SnapshotSignalDataCollectionsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.signal.actions.snapshotting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.document.Document;
+import io.debezium.document.DocumentReader;
+import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.pipeline.signal.actions.AbstractSnapshotSignal.DataCollections;
+
+/**
+ * Verifies that the {@code data-collections} parsing shared by the snapshot signals rejects malformed
+ * (non-string) entries instead of throwing a {@link NullPointerException} that stops the connector.
+ *
+ * @see <a href="https://github.com/debezium/dbz/issues/798">DBZ-6352</a>
+ */
+class SnapshotSignalDataCollectionsTest {
+
+    private final DocumentReader reader = DocumentReader.defaultReader();
+
+    private Document parse(String json) throws IOException {
+        return reader.read(json);
+    }
+
+    @Test
+    void executeSnapshotShouldParseStringDataCollections() throws IOException {
+        DataCollections result = ExecuteSnapshot.getDataCollections(parse("{\"data-collections\": [\"schema.table1\", \"schema.table2\"]}"));
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.collections()).containsExactly("schema.table1", "schema.table2");
+    }
+
+    @Test
+    void executeSnapshotShouldBeInvalidForNestedArrayDataCollections() throws IOException {
+        LogInterceptor logInterceptor = new LogInterceptor(ExecuteSnapshot.class);
+
+        DataCollections result = ExecuteSnapshot.getDataCollections(parse("{\"data-collections\": [[\"schema.table1\", \"schema.table2\"]]}"));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(logInterceptor.containsWarnMessage("contains a non-string data collection")).isTrue();
+    }
+
+    @Test
+    void executeSnapshotShouldBeInvalidWhenAnyDataCollectionIsNotAString() throws IOException {
+        DataCollections result = ExecuteSnapshot.getDataCollections(parse("{\"data-collections\": [\"schema.table1\", 42]}"));
+
+        assertThat(result.valid()).isFalse();
+    }
+
+    @Test
+    void executeSnapshotShouldBeInvalidWhenDataCollectionsMissingOrEmpty() throws IOException {
+        assertThat(ExecuteSnapshot.getDataCollections(parse("{}")).valid()).isFalse();
+        assertThat(ExecuteSnapshot.getDataCollections(parse("{\"data-collections\": []}")).valid()).isFalse();
+    }
+
+    @Test
+    void stopSnapshotShouldParseStringDataCollections() throws IOException {
+        DataCollections result = StopSnapshot.getDataCollections(parse("{\"data-collections\": [\"schema.table1\"]}"));
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.collections()).containsExactly("schema.table1");
+    }
+
+    @Test
+    void stopSnapshotShouldBeInvalidForNestedArrayDataCollections() throws IOException {
+        LogInterceptor logInterceptor = new LogInterceptor(StopSnapshot.class);
+
+        DataCollections result = StopSnapshot.getDataCollections(parse("{\"data-collections\": [[\"schema.table1\"]]}"));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(logInterceptor.containsWarnMessage("contains a non-string data collection")).isTrue();
+    }
+
+    @Test
+    void stopSnapshotShouldStopAllWhenDataCollectionsMissingOrEmpty() throws IOException {
+        // A missing or empty data-collections is a valid request to stop the entire snapshot, distinct from a
+        // malformed one; both must stay separable so a malformed signal is skipped rather than escalating to stop-all.
+        DataCollections missing = StopSnapshot.getDataCollections(parse("{}"));
+        assertThat(missing.valid()).isTrue();
+        assertThat(missing.collections()).isNull();
+
+        DataCollections empty = StopSnapshot.getDataCollections(parse("{\"data-collections\": []}"));
+        assertThat(empty.valid()).isTrue();
+        assertThat(empty.collections()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#798

## Description

An `execute-snapshot` (or `stop-snapshot`) signal whose `data-collections` array contains a non-string element — for example a nested array like `{"data-collections":[["tablea"]]}` instead of a flat `["tablea"]` — caused a `NullPointerException`.

`ExecuteSnapshot.getDataCollections` (and the identical code in `StopSnapshot.getDataCollections`) does:

```java
dataCollectionsArray.streamValues()
        .map(v -> v.asString().trim())
        .collect(Collectors.toList());
```

`Value.asString()` returns `null` for a non-string value, so `.trim()` throws NPE. Because the signal is processed inside the change-event producer, the exception propagates through `ErrorHandler` and stops the connector. On restart the same signal row is re-read from the log and fails again, so the connector is permanently unable to resume — the only workaround today is to remove `signal.data.collection` from the config and restart.

This matches the reporter's expectation that an invalid `data` value should be logged and skipped while log processing continues.

## Fix

When any `data-collections` element is not a string, log a warning and return `null`. This reuses the existing invalid-signal path (missing/empty `data-collections` already returns `null`), so the malformed signal is skipped:
- `ExecuteSnapshot.arrived` already treats a `null` result as "invalid signal" and returns `false` (no snapshot started).
- `StopSnapshot`: note that a `null`/empty `data-collections` means "stop the entire in-progress snapshot" per its contract. Routing a malformed signal through this path therefore escalates to stop-all rather than stopping specific collections. This is intentional and strictly safer than the previous behavior: over-stopping a snapshot is fully recoverable (just re-trigger it), whereas the prior NPE wedged the connector permanently. A warning is logged so the operator can see the signal was malformed.

## Tests

- New `SnapshotSignalDataCollectionsTest` covering both `ExecuteSnapshot` and `StopSnapshot`:
  - nested-array `data-collections` → returns `null` (previously NPE) and logs the warning
  - a non-string scalar element → returns `null`
  - valid string arrays → parsed as before
  - missing / empty `data-collections` → `null` (unchanged)
- Verified as a regression test: reverting the guard reproduces the exact `NullPointerException: Cannot invoke "String.trim()" because ... Value.asString() is null` on the malformed cases while the valid cases keep passing.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
