### PR TITLE
debezium/dbz#683 Use unqualified type name for user-defined types in snapshot

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -726,13 +726,13 @@ public class PostgresConnection extends JdbcConnection {
             column.nativeType(nativeType.getRootType().getOid());
             column.jdbcType(nativeType.getRootType().getJdbcId());
 
-            // The JDBC driver reports a user-defined type with a schema-qualified name (for example
-            // "schema"."type") when the type's schema is not on the search_path, whereas the streaming
-            // path always uses the unqualified type name via PostgresType#getName(). Strip the schema
-            // qualifier so the column type name is consistent between snapshot and streaming
-            // (see debezium/dbz#683). Only the qualified form is normalized; type names the driver
-            // already reports unqualified (including built-in aliases such as serial) are left untouched.
-            if (typeName.contains(".")) {
+            // The JDBC driver reports a user-defined type schema-qualified (e.g. "schema"."type") when
+            // its schema is not on the search_path, whereas streaming always uses the unqualified name
+            // via PostgresType#getName(). Normalize to the unqualified form so snapshot and streaming
+            // agree (debezium/dbz#683), but skip it when the type did not resolve so an unrecognized
+            // name (e.g. from a PostgreSQL-compatible source) keeps the driver's spelling rather than
+            // the UNKNOWN placeholder.
+            if (typeName.contains(".") && nativeType != PostgresType.UNKNOWN) {
                 column.type(nativeType.getName());
             }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -726,6 +726,16 @@ public class PostgresConnection extends JdbcConnection {
             column.nativeType(nativeType.getRootType().getOid());
             column.jdbcType(nativeType.getRootType().getJdbcId());
 
+            // The JDBC driver reports a user-defined type with a schema-qualified name (for example
+            // "schema"."type") when the type's schema is not on the search_path, whereas the streaming
+            // path always uses the unqualified type name via PostgresType#getName(). Strip the schema
+            // qualifier so the column type name is consistent between snapshot and streaming
+            // (see debezium/dbz#683). Only the qualified form is normalized; type names the driver
+            // already reports unqualified (including built-in aliases such as serial) are left untouched.
+            if (typeName.contains(".")) {
+                column.type(nativeType.getName());
+            }
+
             // For domain types, the postgres driver is unable to traverse a nested unbounded
             // hierarchy of types and report the right length/scale of a given type. We use
             // the TypeRegistry to accomplish this since it is capable of traversing the type

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/ConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/ConnectionIT.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.postgresql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.SQLException;
@@ -14,7 +15,11 @@ import org.postgresql.util.PSQLException;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
 import io.debezium.util.Testing;
 
 public class ConnectionIT implements Testing {
@@ -49,6 +54,51 @@ public class ConnectionIT implements Testing {
             assertThatThrownBy(() -> conn.execute("SELECT pg_sleep(10)"))
                     .isInstanceOf(PSQLException.class)
                     .hasMessage("ERROR: canceling statement due to user request");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#683")
+    void shouldReadUnqualifiedUserDefinedTypeNameRegardlessOfSearchPath() throws SQLException {
+        try (PostgresConnection conn = TestHelper.create()) {
+            conn.connect();
+            conn.execute(
+                    "DROP SCHEMA IF EXISTS dbz5571 CASCADE",
+                    "CREATE SCHEMA dbz5571",
+                    "CREATE TYPE dbz5571.financial_asset AS (quantity numeric, instrument_code text)",
+                    "CREATE TYPE dbz5571.mood AS ENUM ('happy', 'sad')",
+                    "CREATE DOMAIN dbz5571.positive_int AS integer CHECK (VALUE > 0)",
+                    "CREATE TABLE dbz5571.t (id varchar PRIMARY KEY, asset dbz5571.financial_asset, "
+                            + "mood dbz5571.mood, amount dbz5571.positive_int, plain integer)");
+        }
+
+        // The JDBC driver reports a user-defined type with a schema-qualified name (e.g. "dbz5571"."mood")
+        // when the type's schema is not on the search_path, but with the unqualified name otherwise. The
+        // streaming path always uses the unqualified name, so the snapshot path must do the same
+        // (debezium/dbz#683).
+        try {
+            assertUnqualifiedTypeNames("public");
+            assertUnqualifiedTypeNames("dbz5571, public");
+        }
+        finally {
+            try (PostgresConnection conn = TestHelper.create()) {
+                conn.execute("DROP SCHEMA IF EXISTS dbz5571 CASCADE");
+            }
+        }
+    }
+
+    private void assertUnqualifiedTypeNames(String searchPath) throws SQLException {
+        try (PostgresConnection conn = TestHelper.createWithTypeRegistry()) {
+            conn.execute("SET search_path TO " + searchPath);
+            Tables tables = new Tables();
+            conn.readSchema(tables, null, "dbz5571", null, null, false);
+            Table table = tables.forTable(new TableId(null, "dbz5571", "t"));
+
+            assertThat(table.columnWithName("asset").typeName()).isEqualTo("financial_asset");
+            assertThat(table.columnWithName("mood").typeName()).isEqualTo("mood");
+            assertThat(table.columnWithName("amount").typeName()).isEqualTo("positive_int");
+            // built-in types are unaffected
+            assertThat(table.columnWithName("plain").typeName()).isEqualTo("int4");
         }
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterAll;
@@ -40,6 +41,7 @@ import io.debezium.kafka.KafkaClusterUtils;
 import io.debezium.pipeline.signal.channels.KafkaSignalChannel;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.mapping.PropagateSourceMetadataToSchemaParameter;
 import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<PostgresConnector> {
@@ -223,6 +225,39 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
             assertThat(((Struct) record.key()).getString("pk")).isEqualTo(enumValues.get(i));
             assertThat(((Struct) record.value()).getStruct("after").getInt32("aa")).isEqualTo(i);
         }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#683")
+    public void incrementalSnapshotReportsUnqualifiedUserDefinedTypeNames() throws Exception {
+        // Testing.Print.enable();
+
+        // The JDBC driver reports a UDT whose schema is off the search_path with a schema-qualified
+        // type name (e.g. "s1"."mood") during snapshot, whereas streaming uses the unqualified name.
+        // Incremental snapshot must match streaming so converters keyed on the type name work for both.
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute(
+                    "CREATE TYPE s1.mood AS ENUM ('happy', 'sad')",
+                    "CREATE DOMAIN s1.positive_int AS integer CHECK (VALUE > 0)",
+                    "CREATE TABLE s1.udt (pk SERIAL, mood s1.mood, amount s1.positive_int, PRIMARY KEY(pk))",
+                    "INSERT INTO s1.udt (mood, amount) VALUES ('happy', 5)");
+        }
+
+        startConnector(x -> x.with(RelationalDatabaseConnectorConfig.PROPAGATE_COLUMN_SOURCE_TYPE, ".*"));
+
+        sendAdHocSnapshotSignal("s1.udt");
+
+        // SNAPSHOT signal, OPEN WINDOW signal, the read record, CLOSE WINDOW signal
+        final SourceRecord record = consumeRecordsByTopic(4).recordsForTopic("test_server.s1.udt").get(0);
+        final Schema afterSchema = record.valueSchema().field("after").schema();
+
+        assertThat(sourceColumnType(afterSchema, "mood")).isEqualTo("MOOD");
+        assertThat(sourceColumnType(afterSchema, "amount")).isEqualTo("POSITIVE_INT");
+    }
+
+    private static String sourceColumnType(Schema afterSchema, String columnName) {
+        return afterSchema.field(columnName).schema().parameters()
+                .get(PropagateSourceMetadataToSchemaParameter.TYPE_NAME_PARAMETER_KEY);
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#683

## Description

For a PostgreSQL user-defined type (composite, enum, or domain), the column type name reported in change events differs between the snapshot and streaming paths:

- **Snapshot** (`PostgresConnection.doReadTableColumn`) takes the type name from the JDBC driver metadata (`ResultSet.getString(6)` / `TYPE_NAME`). The driver reports a **schema-qualified** name such as `"schema"."type"` when the type's schema is not on the `search_path`, and the unqualified name otherwise.
- **Streaming** (`PgOutputMessageDecoder`) always uses the **unqualified** name via `PostgresType#getName()`.

A custom converter that matches on `column.type.name` (via `converterFor`) therefore matches streaming change events but silently fails to match snapshot (initial or incremental) events. This was reported and confirmed as a bug by the maintainers, who asked for a test + PR to make the two paths consistent.

## Fix

In `doReadTableColumn`, after the type is resolved from the `TypeRegistry`, normalize the column type name to `PostgresType#getName()` — the same source the streaming path uses:

```java
PostgresType nativeType = getTypeRegistry().get(tableId.schema(), typeName);
...
column.type(nativeType.getName());
```

Notes:
- This uses the type's own name (`getName()`), **not** its root type (`getRootType().getName()`). The `nativeType`/`jdbcType` are still derived from the root type (unchanged), matching streaming, but the type *name* of a domain must stay its own name (e.g. `positive_int`) rather than collapsing to the base type (`int4`).
- Built-in types (e.g. `int4`, `numeric`, `text`, `jsonb`, arrays) are always reported unqualified by the driver, so normalizing them is a no-op — no special-casing is needed.
- The single-argument `ColumnEditor.type(String)` sets both the type name and the type expression, so both are normalized to the unqualified form.

## Tests

- New `ConnectionIT.shouldReadUnqualifiedUserDefinedTypeNameRegardlessOfSearchPath` reads the schema for a table with a composite, an enum, a domain, and a built-in column under two `search_path` settings (schema off-path → driver qualifies; schema on-path → driver already unqualified). In both cases the snapshot type names are asserted to be the unqualified names, matching streaming.
- Verified as a regression test: reverting the fix makes the assertion fail with `expected "financial_asset" but was ""dbz5571"."financial_asset""`.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
