### PR TITLE
debezium/dbz#921 Optionally retain empty JSON array fields in outbox payload expansion

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -133,6 +133,41 @@ public class EventRouterConfigDefinition {
         }
     }
 
+    public enum JsonPayloadEmptyArrayBehavior implements EnumeratedValue {
+        IGNORE("ignore"),
+        OPTIONAL_STRING("optional_string");
+
+        private final String value;
+
+        JsonPayloadEmptyArrayBehavior(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static JsonPayloadEmptyArrayBehavior parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (JsonPayloadEmptyArrayBehavior option : JsonPayloadEmptyArrayBehavior.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+    }
+
     public enum AdditionalFieldMissingBehavior implements EnumeratedValue {
         ERROR("error"),
         IGNORE("ignore");
@@ -322,6 +357,15 @@ public class EventRouterConfigDefinition {
             .withDescription("Behavior when json payload including null value, the default will ignore null, optional_bytes" +
                     " will keep the null value, and treat null as optional bytes of connect.");
 
+    public static final Field TABLE_JSON_PAYLOAD_EMPTY_ARRAY_BEHAVIOR = Field.create("table.json.payload.empty.array.behavior")
+            .withDisplayName("Behavior when json payload including empty array value")
+            .withEnum(JsonPayloadEmptyArrayBehavior.class, JsonPayloadEmptyArrayBehavior.IGNORE)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Behavior when json payload including an empty array value, the default ignore will drop the" +
+                    " empty array field, optional_string will keep the field as an optional array with an optional string" +
+                    " element type.");
+
     static final Field[] CONFIG_FIELDS = {
             FIELD_EVENT_ID,
             FIELD_EVENT_KEY,
@@ -337,7 +381,8 @@ public class EventRouterConfigDefinition {
             ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD,
             OPERATION_INVALID_BEHAVIOR,
             EXPAND_JSON_PAYLOAD,
-            TABLE_JSON_PAYLOAD_NULL_BEHAVIOR
+            TABLE_JSON_PAYLOAD_NULL_BEHAVIOR,
+            TABLE_JSON_PAYLOAD_EMPTY_ARRAY_BEHAVIOR
     };
 
     /**
@@ -354,7 +399,8 @@ public class EventRouterConfigDefinition {
                 config,
                 "Table",
                 FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_EVENT_TIMESTAMP, FIELDS_ADDITIONAL_PLACEMENT,
-                FIELDS_ADDITIONAL_MISSING, FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD, TABLE_JSON_PAYLOAD_NULL_BEHAVIOR);
+                FIELDS_ADDITIONAL_MISSING, FIELD_SCHEMA_VERSION, OPERATION_INVALID_BEHAVIOR, EXPAND_JSON_PAYLOAD, TABLE_JSON_PAYLOAD_NULL_BEHAVIOR,
+                TABLE_JSON_PAYLOAD_EMPTY_ARRAY_BEHAVIOR);
         Field.group(
                 config,
                 "Router",

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -46,6 +46,7 @@ import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalField
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalFieldMissingBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalFieldPlacement;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.InvalidOperationBehavior;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadEmptyArrayBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadNullFieldBehavior;
 import io.debezium.transforms.tracing.ActivateTracingSpan;
 import io.debezium.util.BoundedConcurrentHashMap;
@@ -349,12 +350,14 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         JsonPayloadNullFieldBehavior jsonPayloadNullFieldBehavior = JsonPayloadNullFieldBehavior.parse(
                 config.getString(EventRouterConfigDefinition.TABLE_JSON_PAYLOAD_NULL_BEHAVIOR));
+        JsonPayloadEmptyArrayBehavior jsonPayloadEmptyArrayBehavior = JsonPayloadEmptyArrayBehavior.parse(
+                config.getString(EventRouterConfigDefinition.TABLE_JSON_PAYLOAD_EMPTY_ARRAY_BEHAVIOR));
         expandJsonPayload = config.getBoolean(EventRouterConfigDefinition.EXPAND_JSON_PAYLOAD);
         if (expandJsonPayload) {
             objectMapper = new ObjectMapper();
             FieldNameAdjustmentMode fieldNameAdjustmentMode = FieldNameAdjustmentMode.parse(
                     config.getString(CommonConnectorConfig.FIELD_NAME_ADJUSTMENT_MODE));
-            jsonSchemaData = new JsonSchemaData(jsonPayloadNullFieldBehavior,
+            jsonSchemaData = new JsonSchemaData(jsonPayloadNullFieldBehavior, jsonPayloadEmptyArrayBehavior,
                     FieldNameSelector.defaultNonRelationalSelector(fieldNameAdjustmentMode.createAdjuster()));
         }
 

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
@@ -29,20 +29,28 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import io.debezium.schema.FieldNameSelector;
 import io.debezium.schema.FieldNameSelector.FieldNamer;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadEmptyArrayBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadNullFieldBehavior;
 import io.debezium.util.Strings;
 
 public class JsonSchemaData {
     private final JsonPayloadNullFieldBehavior jsonPayloadNullFieldBehavior;
+    private final JsonPayloadEmptyArrayBehavior jsonPayloadEmptyArrayBehavior;
     private final FieldNamer<String> fieldNamer;
 
     public JsonSchemaData() {
-        this.jsonPayloadNullFieldBehavior = JsonPayloadNullFieldBehavior.IGNORE;
-        this.fieldNamer = FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP);
+        this(JsonPayloadNullFieldBehavior.IGNORE, JsonPayloadEmptyArrayBehavior.IGNORE,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP));
     }
 
     public JsonSchemaData(JsonPayloadNullFieldBehavior jsonPayloadNullFieldBehavior, FieldNamer<String> fieldNamer) {
+        this(jsonPayloadNullFieldBehavior, JsonPayloadEmptyArrayBehavior.IGNORE, fieldNamer);
+    }
+
+    public JsonSchemaData(JsonPayloadNullFieldBehavior jsonPayloadNullFieldBehavior,
+                          JsonPayloadEmptyArrayBehavior jsonPayloadEmptyArrayBehavior, FieldNamer<String> fieldNamer) {
         this.jsonPayloadNullFieldBehavior = jsonPayloadNullFieldBehavior;
+        this.jsonPayloadEmptyArrayBehavior = jsonPayloadEmptyArrayBehavior;
         this.fieldNamer = fieldNamer;
     }
 
@@ -65,7 +73,13 @@ public class JsonSchemaData {
                 return Schema.OPTIONAL_FLOAT64_SCHEMA;
             case ARRAY:
                 ArrayNode arrayNode = (ArrayNode) node;
-                return arrayNode.isEmpty() ? null : SchemaBuilder.array(toConnectSchemaWithCycles(key, arrayNode)).optional().build();
+                if (arrayNode.isEmpty()) {
+                    if (jsonPayloadEmptyArrayBehavior.equals(JsonPayloadEmptyArrayBehavior.OPTIONAL_STRING)) {
+                        return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+                    }
+                    return null;
+                }
+                return SchemaBuilder.array(toConnectSchemaWithCycles(key, arrayNode)).optional().build();
             case OBJECT:
                 final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(key).optional();
                 node.fields().forEachRemaining(entry -> {

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/JsonSchemaDataTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/outbox/JsonSchemaDataTest.java
@@ -13,10 +13,12 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import io.debezium.config.CommonConnectorConfig.FieldNameAdjustmentMode;
 import io.debezium.doc.FixFor;
 import io.debezium.schema.FieldNameSelector;
 import io.debezium.schema.FieldNameSelector.FieldNamer;
+import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadEmptyArrayBehavior;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.JsonPayloadNullFieldBehavior;
 
 /**
@@ -156,5 +159,57 @@ public class JsonSchemaDataTest {
         Field emailField = payloadSchema.field("email");
         assertThat(emailField).isNotNull();
         assertThat(emailField.schema().type()).isEqualTo(Schema.OPTIONAL_BYTES_SCHEMA.schema().type());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#921")
+    public void shouldDropEmptyArrayFieldByDefault() throws Exception {
+        String json = "{\"heartbeat\": 1, \"tags\": []}";
+        JsonNode testNode = mapper.readTree(json);
+        Schema payloadSchema = jsonSchemaData.toConnectSchema("payload", testNode);
+        assertThat(payloadSchema.field("heartbeat")).isNotNull();
+        assertThat(payloadSchema.field("tags")).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#921")
+    public void shouldKeepEmptyArrayFieldAsOptionalStringArray() throws Exception {
+        jsonSchemaData = new JsonSchemaData(JsonPayloadNullFieldBehavior.IGNORE,
+                JsonPayloadEmptyArrayBehavior.OPTIONAL_STRING, avroFieldNamer);
+        String json = "{\"heartbeat\": 1, \"tags\": []}";
+        JsonNode testNode = mapper.readTree(json);
+        Schema payloadSchema = jsonSchemaData.toConnectSchema("payload", testNode);
+        assertThat(payloadSchema.field("heartbeat")).isNotNull();
+        Field tagsField = payloadSchema.field("tags");
+        assertThat(tagsField).isNotNull();
+        assertThat(tagsField.schema().type()).isEqualTo(Schema.Type.ARRAY);
+        assertThat(tagsField.schema().valueSchema().type()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#921")
+    public void shouldKeepNestedEmptyArrayFieldAsOptionalStringArray() throws Exception {
+        jsonSchemaData = new JsonSchemaData(JsonPayloadNullFieldBehavior.IGNORE,
+                JsonPayloadEmptyArrayBehavior.OPTIONAL_STRING, avroFieldNamer);
+        String json = "{\"nested\": {\"tags\": []}}";
+        JsonNode testNode = mapper.readTree(json);
+        Schema payloadSchema = jsonSchemaData.toConnectSchema("payload", testNode);
+        Schema nestedSchema = payloadSchema.field("nested").schema();
+        Field tagsField = nestedSchema.field("tags");
+        assertThat(tagsField).isNotNull();
+        assertThat(tagsField.schema().type()).isEqualTo(Schema.Type.ARRAY);
+        assertThat(tagsField.schema().valueSchema().type()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#921")
+    public void shouldConvertEmptyArrayFieldToEmptyList() throws Exception {
+        jsonSchemaData = new JsonSchemaData(JsonPayloadNullFieldBehavior.IGNORE,
+                JsonPayloadEmptyArrayBehavior.OPTIONAL_STRING, avroFieldNamer);
+        String json = "{\"heartbeat\": 1, \"tags\": []}";
+        JsonNode testNode = mapper.readTree(json);
+        Schema payloadSchema = jsonSchemaData.toConnectSchema("payload", testNode);
+        Struct payload = (Struct) jsonSchemaData.toConnectData(testNode, payloadSchema);
+        assertThat(payload.get("tags")).isEqualTo(List.of());
     }
 }

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -451,6 +451,15 @@ a|When enable JSON expansion property `table.expand.json.payload`, determines th
 * `ignore` - Ignore the null value.
 * `optional_bytes` - Keep the null value, and treat null as optional bytes of connect.
 
+|[[outbox-event-router-property-table-json-payload-empty-array-behavior]]<<outbox-event-router-property-table-json-payload-empty-array-behavior, `table.json.payload.empty.array.behavior`>>
+|`ignore`
+|Table
+a|When the JSON expansion property `table.expand.json.payload` is enabled, it determines how a JSON payload containing an empty array value is handled in the outbox table. 
+Possible settings are:
+
+* `ignore` - Drop the empty array field.
+* `optional_string` - Keep the field as an optional array with an optional string element type.
+
 |[[outbox-event-router-property-table-fields-additional-placement]]<<outbox-event-router-property-table-fields-additional-placement, `table.fields.additional.placement`>>
 |
 |Table, Envelope


### PR DESCRIPTION
Fixes debezium/dbz#921

## Description

When `table.expand.json.payload` is enabled, the outbox `EventRouter` dropped any field whose value was an empty JSON array (e.g. `{"tags": []}` lost `tags`). The cause is in `JsonSchemaData.toConnectSchema`: an empty array has no element from which to infer a Connect element schema, so the `ARRAY` case returned `null`, and the parent object builder skips fields with a `null` schema.

This adds a `table.json.payload.empty.array.behavior` option that mirrors the existing `table.json.payload.null.behavior`:

- `ignore` (default) – keep the current behavior and drop the empty-array field. Backward compatible.
- `optional_string` – retain the field as an optional array with an optional string element type.

Because an empty array carries no element to infer from, `optional_string` uses `STRING` as a placeholder element type. This means a consumer sees an `ARRAY<STRING>` schema for the empty array even if a non-empty occurrence of that field would have held integers/objects. This is an unavoidable consequence of having zero elements to infer from, and the behavior is opt-in (default remains `ignore`). At data time the value is an empty list, so the placeholder element type is never materialized.

The existing 2-argument `JsonSchemaData` constructor is preserved (it delegates with `ignore`), so the other consumer, `DecodeLogicalDecodingMessageContent`, is unaffected. MongoDB's outbox router uses `MongoDataConverter` rather than `JsonSchemaData` and is not affected.

Tests cover: the default `ignore` still drops the field (backward-compat lock), `optional_string` retains it as `ARRAY<STRING>` at both top level and nested, sibling fields are unaffected, and the expanded data is an empty list.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
