### PR TITLE
debezium/dbz#2004 Fix duplicate transactional logical messages after connector restart

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
@@ -108,7 +108,7 @@ public class LogicalDecodingMessageMonitor {
         sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(), topicName,
                 keySchema, key, value.schema(), value));
 
-        if (message.isLastEventForLsn()) {
+        if (!message.isTransactional()) {
             offsetContext.getTransactionContext().endTransaction();
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -358,12 +358,13 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             maybeWarnAboutGrowingWalBacklog(true);
         }
         else if (message.getOperation() == Operation.MESSAGE) {
-            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, message.getCommitTime(), toLong(message.getTransactionId()),
+            final LogicalDecodingMessage logicalMessage = (LogicalDecodingMessage) message;
+            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, logicalMessage.getCommitTime(), toLong(logicalMessage.getTransactionId()),
                     getSlotXmin(),
-                    message.getOperation());
+                    logicalMessage.getOperation());
 
             // non-transactional message that will not be followed by a COMMIT message
-            if (message.isLastEventForLsn()) {
+            if (!logicalMessage.isTransactional()) {
                 offsetContext.resetLsnEventsProcessed();
                 commitMessage(partition, offsetContext, lsn);
             }
@@ -372,7 +373,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     partition,
                     offsetContext,
                     clock.currentTimeAsInstant().toEpochMilli(),
-                    (LogicalDecodingMessage) message);
+                    logicalMessage);
 
             maybeWarnAboutGrowingWalBacklog(true);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -367,12 +367,13 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             maybeWarnAboutGrowingWalBacklog(true);
         }
         else if (message.getOperation() == Operation.MESSAGE) {
-            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, message.getCommitTime(), toLong(message.getTransactionId()),
+            final LogicalDecodingMessage logicalMessage = (LogicalDecodingMessage) message;
+            offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, logicalMessage.getCommitTime(), toLong(logicalMessage.getTransactionId()),
                     getSlotXmin(),
-                    message.getOperation());
+                    logicalMessage.getOperation());
 
             // non-transactional message that will not be followed by a COMMIT message
-            if (message.isLastEventForLsn()) {
+            if (!logicalMessage.isTransactional()) {
                 offsetContext.resetLsnEventsProcessed();
                 commitMessage(partition, offsetContext, lsn);
             }
@@ -381,7 +382,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     partition,
                     offsetContext,
                     clock.currentTimeAsInstant().toEpochMilli(),
-                    (LogicalDecodingMessage) message);
+                    logicalMessage);
 
             maybeWarnAboutGrowingWalBacklog(true);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/LogicalDecodingMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/LogicalDecodingMessage.java
@@ -35,7 +35,7 @@ public class LogicalDecodingMessage implements ReplicationMessage {
 
     @Override
     public boolean isLastEventForLsn() {
-        return !isTransactional;
+        return true;
     }
 
     @Override
@@ -74,5 +74,9 @@ public class LogicalDecodingMessage implements ReplicationMessage {
 
     public byte[] getContent() {
         return content;
+    }
+
+    public boolean isTransactional() {
+        return isTransactional;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -49,6 +49,7 @@ public class WalPositionLocator {
     private Set<Lsn> lsnSeen = new HashSet<>(1_000);
     private long currentLsnEventCount = 0;
     private long startStreamingEventsToSkip = 0;
+    private boolean skipProcessedLogicalMessage = false;
 
     public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn, Operation lastProcessedMessageType) {
         this(lastCommitStoredLsn, lastEventStoredLsn, lastProcessedMessageType, 0);
@@ -120,6 +121,19 @@ public class WalPositionLocator {
                     LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);
+                }
+
+                // PostgreSQL currently reports the end LSN of the MESSAGE rather than its start
+                // LSN. Since this LSN can also identify the next decoded operation, resume from
+                // that LSN and skip the already processed MESSAGE operation.
+                //
+                // This PostgreSQL behavior is under discussion and may change in a future version:
+                // https://www.postgresql.org/message-id/flat/d99c688994ab3a998afe26e61fe4f69f%40oss.nttdata.com
+                if (lastProcessedMessageType == Operation.MESSAGE) {
+                    startStreamingLsn = currentLsn;
+                    skipProcessedLogicalMessage = true;
+                    LOGGER.info("Last processed event was MESSAGE operation; will restart from LSN '{}' and skip that MESSAGE operation", currentLsn);
+                    return Optional.of(currentLsn);
                 }
                 return Optional.empty();
             }
@@ -228,6 +242,17 @@ public class WalPositionLocator {
         }
         LOGGER.debug("Message with LSN '{}' filtered", lsn);
         return true;
+    }
+
+    public boolean skipProcessedLogicalMessage(Lsn lsn) {
+        if (skipProcessedLogicalMessage && startStreamingLsn != null && startStreamingLsn.equals(lsn)) {
+            skipProcessedLogicalMessage = false;
+            passMessages = true;
+            lsnSeen = new HashSet<>();
+            LOGGER.info("Processed MESSAGE operation with LSN '{}' skipped, switching off the filtering", lsn);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -49,6 +49,7 @@ public class WalPositionLocator {
     private Set<Lsn> lsnSeen = new HashSet<>(1_000);
     private long currentLsnEventCount = 0;
     private long startStreamingEventsToSkip = 0;
+    private boolean skipProcessedLogicalMessage = false;
 
     public WalPositionLocator(Lsn lastCommitStoredLsn, Lsn lastEventStoredLsn, Operation lastProcessedMessageType) {
         this(lastCommitStoredLsn, lastEventStoredLsn, lastProcessedMessageType, 0);
@@ -120,6 +121,19 @@ public class WalPositionLocator {
                     LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);
+                }
+
+                // PostgreSQL currently reports the end LSN of the MESSAGE rather than its start
+                // LSN. Since this LSN can also identify the next decoded operation, resume from
+                // that LSN and skip the already processed MESSAGE operation.
+                //
+                // This PostgreSQL behavior is under discussion and may change in a future version:
+                // https://www.postgresql.org/message-id/flat/d99c688994ab3a998afe26e61fe4f69f%40oss.nttdata.com
+                if (lastProcessedMessageType == Operation.MESSAGE) {
+                    startStreamingLsn = currentLsn;
+                    skipProcessedLogicalMessage = true;
+                    LOGGER.info("Last processed event was MESSAGE operation; will restart from LSN '{}' and skip that MESSAGE operation", currentLsn);
+                    return Optional.of(currentLsn);
                 }
                 return Optional.empty();
             }
@@ -241,6 +255,17 @@ public class WalPositionLocator {
         }
         LOGGER.debug("Message with LSN '{}' filtered", lsn);
         return true;
+    }
+
+    public boolean skipProcessedLogicalMessage(Lsn lsn) {
+        if (skipProcessedLogicalMessage && startStreamingLsn != null && startStreamingLsn.equals(lsn)) {
+            skipProcessedLogicalMessage = false;
+            passMessages = true;
+            lsnSeen = new HashSet<>();
+            LOGGER.info("Processed MESSAGE operation with LSN '{}' skipped, switching off the filtering", lsn);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -148,6 +148,9 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 default:
                     // call super.shouldMessageBeSkipped for rest of the types
             }
+            if (type == MessageType.LOGICAL_DECODING_MESSAGE && walPosition.skipProcessedLogicalMessage(lastReceivedLsn)) {
+                return true;
+            }
             final boolean candidateForSkipping = super.shouldMessageBeSkipped(buffer, lastReceivedLsn, startLsn, walPosition);
             switch (type) {
                 case COMMIT:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -147,6 +147,9 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 default:
                     // call super.shouldMessageBeSkipped for rest of the types
             }
+            if (type == MessageType.LOGICAL_DECODING_MESSAGE && walPosition.skipProcessedLogicalMessage(lastReceivedLsn)) {
+                return true;
+            }
             final boolean candidateForSkipping = super.shouldMessageBeSkipped(buffer, lastReceivedLsn, startLsn, walPosition);
             switch (type) {
                 case COMMIT:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4217,6 +4217,46 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertThat(recordsAfterRestart.allRecordsInOrder().size()).isEqualTo(0);
     }
 
+    @Test
+    @FixFor("debezium/dbz#2004")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
+    public void shouldEmitRecordsOnlyOnceForTransactionContainingLogicalMessage() throws Exception {
+        TestHelper.dropPublication("cdc");
+        TestHelper.execute(CREATE_TABLES_STMT);
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false");
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
+
+        TestHelper.execute("BEGIN;" +
+                "INSERT INTO s1.a (aa) VALUES (1);" +
+                "SELECT pg_logical_emit_message(true, 'txn_foo', 'txn_bar');" +
+                "INSERT INTO s1.a (aa) VALUES (2);" +
+                "COMMIT;");
+        SourceRecords records = consumeRecordsByTopic(3);
+
+        assertThat(records.allRecordsInOrder().size()).isEqualTo(3);
+        assertThat(records.recordsForTopic(topicName("s1.a"))).hasSize(2);
+        assertThat(records.recordsForTopic(topicName("message"))).hasSize(1);
+
+        stopConnector();
+        assertConnectorNotRunning();
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+
+        // Since all records have been already consumed before restart, verify that no records can
+        // be consumed after restart.
+        // Note consumeRecordsByTopic(1) is expected to return due to consumer timeout rather
+        // than receiving a record.
+        SourceRecords recordsAfterRestart = consumeRecordsByTopic(1);
+        assertThat(recordsAfterRestart.allRecordsInOrder().size()).isEqualTo(0);
+    }
+
     /**
      * Postgres override for getting TX ID, as due to DBZ-5329 Postgres TX ID is in form of {@code txId:LSN}.
      */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4179,8 +4179,7 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
 
     @Test
     @FixFor("debezium/dbz#2004")
-    @Disabled // Disabled until debezium/dbz#2004 is fixed
-    // @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
     public void shouldNotReemitConsumedLogicalMessageAfterRestart() throws Exception {
         // The issue only occurred for transactional logical messages, where the first
         // parameter of pg_logical_emit_message() is set to true.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4217,46 +4217,6 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertThat(recordsAfterRestart.allRecordsInOrder().size()).isEqualTo(0);
     }
 
-    @Test
-    @FixFor("debezium/dbz#2004")
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
-    public void shouldEmitRecordsOnlyOnceForTransactionContainingLogicalMessage() throws Exception {
-        TestHelper.dropPublication("cdc");
-        TestHelper.execute(CREATE_TABLES_STMT);
-
-        Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false");
-
-        start(PostgresConnector.class, configBuilder.build());
-        assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted();
-
-        TestHelper.execute("BEGIN;" +
-                "INSERT INTO s1.a (aa) VALUES (1);" +
-                "SELECT pg_logical_emit_message(true, 'txn_foo', 'txn_bar');" +
-                "INSERT INTO s1.a (aa) VALUES (2);" +
-                "COMMIT;");
-        SourceRecords records = consumeRecordsByTopic(3);
-
-        assertThat(records.allRecordsInOrder().size()).isEqualTo(3);
-        assertThat(records.recordsForTopic(topicName("s1.a"))).hasSize(2);
-        assertThat(records.recordsForTopic(topicName("message"))).hasSize(1);
-
-        stopConnector();
-        assertConnectorNotRunning();
-
-        start(PostgresConnector.class, configBuilder.build());
-        assertConnectorIsRunning();
-
-        // Since all records have been already consumed before restart, verify that no records can
-        // be consumed after restart.
-        // Note consumeRecordsByTopic(1) is expected to return due to consumer timeout rather
-        // than receiving a record.
-        SourceRecords recordsAfterRestart = consumeRecordsByTopic(1);
-        assertThat(recordsAfterRestart.allRecordsInOrder().size()).isEqualTo(0);
-    }
-
     /**
      * Postgres override for getting TX ID, as due to DBZ-5329 Postgres TX ID is in form of {@code txId:LSN}.
      */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.junit.EqualityCheck;
@@ -107,6 +108,84 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
         assertRecordTransactionMetadata(records.get(1), beginTxId, 1, 1);
         assertRecordTransactionMetadata(records.get(2), beginTxId, 2, 1);
         assertEndTransaction(records.get(3), beginTxId, 2, Collect.hashMapOf("s1.a", 1, "s2.a", 1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2004")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Logical decoding messages are only supported by the PGOUTPUT decoder")
+    void shouldEmitTransactionMetadataForTransactionContainingTransactionalLogicalMessage() throws Exception {
+        assertTransactionMetadataForTransactionContainingLogicalMessage(true);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2004")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Logical decoding messages are only supported by the PGOUTPUT decoder")
+    void shouldEmitTransactionMetadataForTransactionContainingNonTransactionalLogicalMessage() throws Exception {
+        assertTransactionMetadataForTransactionContainingLogicalMessage(false);
+    }
+
+    private void assertTransactionMetadataForTransactionContainingLogicalMessage(boolean transactional) throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.execute(SETUP_TABLES_STMT);
+        final Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA.getValue())
+                .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitForDefaultReplicationSlotBeActive();
+        assertNoRecordsToConsume();
+
+        TestHelper.execute("BEGIN;" +
+                "INSERT INTO s1.a (aa) VALUES (2);" +
+                "SELECT pg_logical_emit_message(" + transactional + ", 'txn_foo', 'txn_bar');" +
+                "INSERT INTO s1.a (aa) VALUES (3);" +
+                "COMMIT;");
+
+        final List<SourceRecord> records = consumeRecordsByTopic(5).allRecordsInOrder();
+
+        final String transactionTopic = TestHelper.topicName("transaction");
+        final String tableTopic = TestHelper.topicName("s1.a");
+        final String messageTopic = TestHelper.topicName("message");
+
+        if (transactional) {
+            assertThat(records).extracting(SourceRecord::topic)
+                    .containsExactly(transactionTopic, tableTopic, messageTopic, tableTopic, transactionTopic);
+
+            final String beginTxId = assertBeginTransaction(records.get(0));
+            assertRecordTransactionMetadata(records.get(1), beginTxId, 1, 1);
+            assertRecordTransactionMetadata(records.get(2), beginTxId, 2, 1);
+            assertRecordTransactionMetadata(records.get(3), beginTxId, 3, 2);
+            assertEndTransactionMetadata(records.get(4), beginTxId, 3, 2);
+        }
+        else {
+            assertThat(records).extracting(SourceRecord::topic)
+                    .containsExactly(messageTopic, transactionTopic, tableTopic, tableTopic, transactionTopic);
+            assertThat(((Struct) records.get(0).value()).getStruct("transaction")).isNull();
+
+            final String beginTxId = assertBeginTransaction(records.get(1));
+            assertRecordTransactionMetadata(records.get(2), beginTxId, 1, 1);
+            assertRecordTransactionMetadata(records.get(3), beginTxId, 2, 2);
+            assertEndTransaction(records.get(4), beginTxId, 2, Collect.hashMapOf("s1.a", 2));
+        }
+    }
+
+    private void assertEndTransactionMetadata(SourceRecord record, String beginTxId, long expectedEventCount, int expectedDataCollectionCount) {
+        final Struct end = (Struct) record.value();
+        final Struct endKey = (Struct) record.key();
+        final Map<String, Object> offset = (Map<String, Object>) record.sourceOffset();
+        final String expectedId = toTransactionNumber(beginTxId);
+        final String expectedTxId = String.format("%s:%s", expectedId, offset.get("lsn"));
+
+        assertThat(end.getString("status")).isEqualTo("END");
+        assertThat(end.getString("id")).isEqualTo(expectedTxId);
+        assertThat(end.getInt64("event_count")).isEqualTo(expectedEventCount);
+        assertThat(endKey.getString("id")).isEqualTo(expectedTxId);
+        assertThat(end.getArray("data_collections")).hasSize(expectedDataCollectionCount);
+        assertThat(end.getArray("data_collections").stream().map(item -> ((Struct) item).getInt64("event_count")))
+                .containsExactlyInAnyOrder(1L, 2L);
+        assertThat(offset.get("transaction_id")).isEqualTo(expectedId);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/WALPositionLocatorTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/WALPositionLocatorTest.java
@@ -8,12 +8,14 @@ package io.debezium.connector.postgresql.junit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.postgresql.connection.LogicalDecodingMessage;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.connector.postgresql.connection.TransactionMessage;
@@ -346,6 +348,35 @@ public class WALPositionLocatorTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2058")
+    void whenTransactionalLogicalMessageOffsetWasStoredShouldSkipOnlyThatMessage() {
+        final Lsn lastCommitStoredLsn = Lsn.valueOf(100L);
+        final Lsn lastEventStoredLsn = Lsn.valueOf(120L);
+        final var locator = new WalPositionLocator(lastCommitStoredLsn, lastEventStoredLsn, ReplicationMessage.Operation.MESSAGE);
+
+        // PostgreSQL reports a logical MESSAGE at the next WAL position rather than
+        // at the MESSAGE operation start, so the following DML can share that LSN.
+        final Lsn messageLsn = lastEventStoredLsn;
+        final Lsn insertLsn = lastEventStoredLsn;
+
+        final var beginMessage = createBeginMessage(1L);
+        final var logicalMessage = createLogicalMessage(1L);
+
+        assertThat(locator.resumeFromLsn(messageLsn, beginMessage)).isEmpty();
+
+        final Optional<Lsn> result = locator.resumeFromLsn(messageLsn, logicalMessage);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(messageLsn);
+
+        locator.enableFiltering();
+
+        // The already-processed MESSAGE is skipped.
+        assertThat(locator.skipProcessedLogicalMessage(messageLsn)).isTrue();
+        // The following INSERT at the same LSN is emitted.
+        assertThat(locator.skipMessage(insertLsn)).isFalse();
+    }
+
+    @Test
     @FixFor("debezium/dbz#1554")
     void whenMultipleEventsShareSameLsnShouldResumeAfterProcessedCount() {
         // Simulate: 5 events all at LSN 140, we processed 3 before crash
@@ -582,6 +613,11 @@ public class WALPositionLocatorTest {
 
     private ReplicationMessage createCommitMessage(long txId) {
         return new TransactionMessage(ReplicationMessage.Operation.COMMIT, txId, Instant.now());
+    }
+
+    private ReplicationMessage createLogicalMessage(long txId) {
+        return new LogicalDecodingMessage(ReplicationMessage.Operation.MESSAGE, Instant.now(), txId, true, "foo",
+                "msg".getBytes(StandardCharsets.UTF_8));
     }
 
     private ReplicationMessage createInsertMessage(long txId) {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2004 and debezium/dbz#2058 <the Debezium Issue Number>

## Description
In the previous PR (#7492), we reverted the change because of an issue [#2058](https://github.com/debezium/dbz/issues/2058) that could cause data loss due to PostgreSQL reporting a different kind of LSN for decoded logical messages than for other operations.

As discussed in https://github.com/debezium/dbz/issues/2058, if PostgreSQL changes the LSN reported for logical messages only in a future major release, Debezium will still need to handle the current special behavior for earlier PostgreSQL major versions.

I was not entirely sure whether such handling would be feasible, so I tried implementing it to confirm. This is done in commit 0ab1dc4d2ab848d769d7efd4ab1e830df7067147.


If PostgreSQL decides to fix this behavior in a future major or minor release, we need to add a version check so that this special handling is applied only to the affected PostgreSQL versions. I'm going to do it after PostgreSQL-side discussion reaches a conclusion.

The other commits reintroduce the changes that were reverted previously.

WDYT?

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
