### PR TITLE
debezium/dbz#2221 Skip corrupted records during Redis schema history recovery instead of silently truncating it

### DIFF
--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.ThreadSafe;
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.config.Configuration;
 import io.debezium.document.DocumentReader;
 import io.debezium.document.DocumentWriter;
@@ -58,6 +59,11 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
         RedisConnection redisConnection = RedisConnection.getInstance(config);
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_SCHEMA_HISTORY, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
+    }
+
+    @VisibleForTesting
+    void setRedisClient(RedisClient client) {
+        this.client = client;
     }
 
     @Override
@@ -111,15 +117,16 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
     protected synchronized void recoverRecords(Consumer<HistoryRecord> records) {
         // read the entries from Redis
         final List<Map<String, String>> entries = doWithRetry(() -> client.xrange(config.getRedisKeyName()),
-                "Writing to database schema history stream");
+                "Reading from database schema history stream");
 
         for (Map<String, String> item : entries) {
             try {
                 records.accept(new HistoryRecord(reader.read(item.get("schema"))));
             }
             catch (IOException e) {
-                LOGGER.error("Failed to convert record to string: {}", item, e);
-                return;
+                // Skip the corrupted record and continue recovering the rest of the history instead of
+                // silently dropping every remaining record, which would leave the schema history incomplete.
+                Loggings.logErrorAndTraceRecord(LOGGER, item, "Failed to read database schema history record, skipping it", e);
             }
         }
     }

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/history/RedisSchemaHistoryTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/history/RedisSchemaHistoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis.history;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryListener;
+import io.debezium.storage.redis.RedisClient;
+
+public class RedisSchemaHistoryTest {
+
+    private static final String VALID_RECORD_1 = "{\"source\":{\"server\":\"test\"},\"position\":{\"file\":\"binlog.000001\",\"pos\":100},\"ddl\":\"CREATE TABLE first (id INT)\"}";
+    // truncated JSON, e.g. after a partial write to the stream
+    private static final String CORRUPTED_RECORD = "{\"source\":{\"server\":\"test\"},\"position\":";
+    private static final String VALID_RECORD_2 = "{\"source\":{\"server\":\"test\"},\"position\":{\"file\":\"binlog.000001\",\"pos\":200},\"ddl\":\"CREATE TABLE second (id INT)\"}";
+
+    @Test
+    @FixFor("debezium/dbz#2221")
+    public void shouldSkipCorruptedRecordAndRecoverSubsequentOnes() {
+        final RedisSchemaHistory history = new RedisSchemaHistory();
+        history.configure(
+                Configuration.create()
+                        .with(SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + "redis.address", "localhost:6379")
+                        .build(),
+                null, SchemaHistoryListener.NOOP, false);
+        history.setRedisClient(new XRangeRedisClient(List.of(
+                Map.of("schema", VALID_RECORD_1),
+                Map.of("schema", CORRUPTED_RECORD),
+                Map.of("schema", VALID_RECORD_2))));
+
+        final List<HistoryRecord> recovered = new ArrayList<>();
+        history.recoverRecords(recovered::add);
+
+        assertEquals(2, recovered.size(), "corrupted record should be skipped, all remaining records recovered");
+        assertEquals("CREATE TABLE first (id INT)", recovered.get(0).document().getString(HistoryRecord.Fields.DDL_STATEMENTS));
+        assertEquals("CREATE TABLE second (id INT)", recovered.get(1).document().getString(HistoryRecord.Fields.DDL_STATEMENTS));
+    }
+
+    private static class XRangeRedisClient implements RedisClient {
+
+        private final List<Map<String, String>> entries;
+
+        XRangeRedisClient(List<Map<String, String>> entries) {
+            this.entries = entries;
+        }
+
+        @Override
+        public List<Map<String, String>> xrange(String key) {
+            return entries;
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public String xadd(String key, Map<String, String> hash) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> xadd(List<SimpleEntry<String, Map<String, String>>> hashes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long xlen(String key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> hgetAll(String key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long hset(byte[] key, byte[] field, byte[] value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long waitReplicas(int replicas, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String info(String section) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String clientList() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2221

`RedisSchemaHistory.recoverRecords()` aborts on the first schema history entry that fails to deserialize:

```java
catch (IOException e) {
    LOGGER.error("Failed to convert record to string: {}", item, e);
    return;
}
```

A single corrupted entry in the Redis stream (e.g. truncated JSON) makes the method return early, silently discarding every record that comes after it. The connector then proceeds with a partially recovered schema history — no error is raised at recovery time, and the damage only shows up later as "table schema unknown" failures or wrong parsing for tables whose DDL lived in the dropped tail.

This makes the Redis store strictly worse than its siblings on the same input:

- `KafkaSchemaHistory` catches `IOException` per record, logs it via `Loggings.logErrorAndTraceRecord` and continues with the remaining records;
- `RocketMqSchemaHistory` skips invalid records and throws on read errors;
- `RedisSchemaHistory` neither fails nor recovers fully — it silently truncates.

Changes:

- Skip the corrupted record and continue recovering the remaining ones, aligning with the Kafka implementation. The record content is logged via `Loggings.logErrorAndTraceRecord` (record body at TRACE), consistent with `storeRecord()` in the same class.
- Fix the retry description for the `XRANGE` call in `recoverRecords()`: it said "Writing to database schema history stream" although the operation is a read, so retry warnings for a failed read were reported as a failed write.
- Add a unit test (no Redis instance needed): a fake `RedisClient` returns valid + corrupted + valid entries and the test asserts both valid records are recovered. It fails on the previous code with `expected: <2> but was: <1>`. To inject the fake client, `RedisSchemaHistory` gets a `@VisibleForTesting` package-private `setRedisClient()`, mirroring the existing `RedisOffsetBackingStore.setRedisClient()`.

If maintainers would rather fail loudly (`SchemaHistoryException`) than skip, happy to change it — either is an improvement over silent truncation; skipping matches the Kafka behaviour.
