### PR TITLE
debezium/dbz#1340 Pin era parsing to English locale in Postgres DateTimeFormat

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/DateTimeFormat.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/DateTimeFormat.java
@@ -19,6 +19,7 @@ import java.time.format.SignStyle;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -73,7 +74,7 @@ public interface DateTimeFormat {
                 .appendLiteral(" ")
                 .appendText(ChronoField.ERA, TextStyle.SHORT)
                 .optionalEnd()
-                .toFormatter();
+                .toFormatter(Locale.ENGLISH);
 
         private static final String TS_TZ_FORMAT_PATTERN_HINT = "y..y-MM-dd HH:mm:ss[.S]X";
         private static final DateTimeFormatter TS_TZ_FORMAT = new DateTimeFormatterBuilder()
@@ -85,7 +86,7 @@ public interface DateTimeFormat {
                 .appendLiteral(" ")
                 .appendText(ChronoField.ERA, TextStyle.SHORT)
                 .optionalEnd()
-                .toFormatter();
+                .toFormatter(Locale.ENGLISH);
         private static final DateTimeFormatter TS_TZ_WITH_SECONDS_FORMAT = new DateTimeFormatterBuilder()
                 .append(NON_ISO_LOCAL_DATE)
                 .appendLiteral(' ')
@@ -95,7 +96,7 @@ public interface DateTimeFormat {
                 .appendLiteral(" ")
                 .appendText(ChronoField.ERA, TextStyle.SHORT)
                 .optionalEnd()
-                .toFormatter();
+                .toFormatter(Locale.ENGLISH);
 
         private static final String SYSTEM_TS_FORMAT_PATTERN_HINT = "y..y-MM-dd HH:mm:ss.SSSSSSX";
         private static final DateTimeFormatter SYSTEM_TS_FORMAT = new DateTimeFormatterBuilder()
@@ -107,7 +108,7 @@ public interface DateTimeFormat {
                 .appendLiteral(" ")
                 .appendText(ChronoField.ERA, TextStyle.SHORT)
                 .optionalEnd()
-                .toFormatter();
+                .toFormatter(Locale.ENGLISH);
 
         private static final String DATE_FORMAT_OPT_ERA_PATTERN_HINT = "y..y-MM-dd[ GG]";
         private static final DateTimeFormatter DATE_FORMAT_OPT_ERA = new DateTimeFormatterBuilder()
@@ -116,7 +117,7 @@ public interface DateTimeFormat {
                 .appendLiteral(' ')
                 .appendText(ChronoField.ERA, TextStyle.SHORT)
                 .optionalEnd()
-                .toFormatter();
+                .toFormatter(Locale.ENGLISH);
 
         private static final String TIME_FORMAT_PATTERN = "HH:mm:ss[.S]";
         private static final DateTimeFormatter TIME_FORMAT = new DateTimeFormatterBuilder()

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ISODateTimeFormatTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ISODateTimeFormatTest.java
@@ -13,16 +13,39 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
-import java.time.chrono.IsoEra;
-import java.time.format.TextStyle;
 import java.util.Locale;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.doc.FixFor;
+
 public class ISODateTimeFormatTest {
-    private static final String BCE_DISPLAY_NAME = IsoEra.BCE.getDisplayName(TextStyle.SHORT, Locale.getDefault());
+    // PostgreSQL always emits the era in English ("BC"/"AD") regardless of the JVM locale.
+    private static final String BCE_DISPLAY_NAME = "BC";
+
+    private Locale defaultLocale;
+
+    @BeforeEach
+    void setUp() {
+        // Force a non-English locale to guard against locale-dependent era parsing (dbz#1340).
+        // NOTE: the formatters under test are static final fields, so this only exercises the
+        // regression when ISODateTimeFormat is first loaded here (currently the only unit test
+        // that touches it). If a future unit test loads the class under an English default
+        // locale first, the formatters would be initialized before this runs and the regression
+        // would no longer be caught -- in that case pin the locale via a surefire fork instead.
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.KOREAN);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Locale.setDefault(defaultLocale);
+    }
 
     @Test
+    @FixFor("debezium/dbz#1340")
     void testTimestampToInstant() {
         ZoneOffset offset = ZoneOffset.UTC;
         assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30"))
@@ -42,6 +65,7 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1340")
     void testTimestampWithTimeZoneToOffsetTime() {
         assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30+02"))
                 .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, ZoneOffset.ofHours(2)));
@@ -60,6 +84,7 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1340")
     void testDate() {
         assertThat(DateTimeFormat.get().date("2016-11-04")).isEqualTo(LocalDate.of(2016, 11, 4));
         assertThat(DateTimeFormat.get().date("2016-11-04 " + BCE_DISPLAY_NAME)).isEqualTo(LocalDate.of(-2015, 11, 4));
@@ -79,6 +104,7 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1340")
     void testSystemTimestampToInstant() {
         assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30Z"))
                 .isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC).toInstant());
@@ -94,5 +120,7 @@ public class ISODateTimeFormatTest {
                 .isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)).toInstant());
         assertThat(DateTimeFormat.get().systemTimestampToInstant("20180-03-22 12:30:56.824452+05"))
                 .isEqualTo(OffsetDateTime.of(20180, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)).toInstant());
+        assertThat(DateTimeFormat.get().systemTimestampToInstant("0002-12-01 17:00:00Z " + BCE_DISPLAY_NAME))
+                .isEqualTo(OffsetDateTime.of(-1, 12, 1, 17, 0, 0, 0, ZoneOffset.UTC).toInstant());
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ISODateTimeFormatTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ISODateTimeFormatTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.debezium.doc.FixFor;
-
 public class ISODateTimeFormatTest {
     // PostgreSQL always emits the era in English ("BC"/"AD") regardless of the JVM locale.
     private static final String BCE_DISPLAY_NAME = "BC";
@@ -30,11 +28,6 @@ public class ISODateTimeFormatTest {
     @BeforeEach
     void setUp() {
         // Force a non-English locale to guard against locale-dependent era parsing (dbz#1340).
-        // NOTE: the formatters under test are static final fields, so this only exercises the
-        // regression when ISODateTimeFormat is first loaded here (currently the only unit test
-        // that touches it). If a future unit test loads the class under an English default
-        // locale first, the formatters would be initialized before this runs and the regression
-        // would no longer be caught -- in that case pin the locale via a surefire fork instead.
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.KOREAN);
     }
@@ -45,7 +38,6 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    @FixFor("debezium/dbz#1340")
     void testTimestampToInstant() {
         ZoneOffset offset = ZoneOffset.UTC;
         assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30"))
@@ -65,7 +57,6 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    @FixFor("debezium/dbz#1340")
     void testTimestampWithTimeZoneToOffsetTime() {
         assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30+02"))
                 .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, ZoneOffset.ofHours(2)));
@@ -84,7 +75,6 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    @FixFor("debezium/dbz#1340")
     void testDate() {
         assertThat(DateTimeFormat.get().date("2016-11-04")).isEqualTo(LocalDate.of(2016, 11, 4));
         assertThat(DateTimeFormat.get().date("2016-11-04 " + BCE_DISPLAY_NAME)).isEqualTo(LocalDate.of(-2015, 11, 4));
@@ -104,7 +94,6 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    @FixFor("debezium/dbz#1340")
     void testSystemTimestampToInstant() {
         assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30Z"))
                 .isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC).toInstant());


### PR DESCRIPTION
Fixes debezium/dbz#1340

## Problem

PostgreSQL always emits the era literally as English `BC`/`AD` on the wire. The ERA-aware formatters in `ISODateTimeFormat` were built without pinning a locale, so on a JVM whose default locale is non-English (e.g. `ko_KR`, where the short era text is `기원전`) the `BC` token cannot be parsed. As reported, timestamp/date values before Christ such as `0002-11-30 00:00:00 BC` fail with:

```
DateTimeParseException: Text '0002-11-30 00:00:00 BC' could not be parsed, unparsed text found at index 19
```

## Fix

Build the five ERA-aware formatters (`TS_FORMAT`, `TS_TZ_FORMAT`, `TS_TZ_WITH_SECONDS_FORMAT`, `SYSTEM_TS_FORMAT`, `DATE_FORMAT_OPT_ERA`) with `toFormatter(Locale.ENGLISH)` so the era text is always resolved in English, matching what PostgreSQL sends. Formatters that do not use `ChronoField.ERA` are left untouched.

## Tests

`ISODateTimeFormatTest` previously derived the expected era text from `Locale.getDefault()`, so on English CI machines the test passed even with the bug present. This PR:

- hardcodes the expected era text to `"BC"` (what PostgreSQL actually sends), and
- forces a non-English default locale (`Locale.KOREAN`) in `@BeforeEach`, restoring it in `@AfterEach`, so the regression is actually exercised.

Verified: against the pre-fix source the BC assertions fail at the era offset (index 10/19/20/26); with the fix all cases pass.

## Question for maintainers

The formatters are `static final` fields, so the test only exercises the regression when `ISODateTimeFormat` is first loaded by this test (currently the only unit test that touches it). If a future unit test loads the class under an English default locale first, the formatters would already be initialized and the regression would no longer be caught. I noted this in a code comment. Would you prefer I pin the locale via a surefire fork (e.g. `-Duser.language=ko`) instead, to make it robust regardless of class-load order?
