### PR TITLE
DBZ-9919 Removes hard line breaks from Debezium server,  CloudEvents, and Logging docs

### DIFF
--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -120,7 +120,8 @@ In this example, the PostgreSQL connector is configured to use JSON as the Cloud
 
 |4
 a|Connector type that generated the change event.
-The format of this field is `io.debezium.connector.__CONNECTOR_TYPE__.DataChangeEvent`. +
+The format of this field is `io.debezium.connector.__CONNECTOR_TYPE__.DataChangeEvent`.
+
 Valid values for `_CONNECTOR_TYPE_` are `db2`,
 ifdef::community[]
 `informix`,

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -1533,8 +1533,8 @@ It then uses the private key to cryptographically sign the nonce challenge that 
 
 |[[nats-jetstream-auth-user]]<<nats-jetstream-auth-user, `debezium.sink.nats-jetstream.auth.user`>>
 |No default value
-|Specifies the username of the authorized NAT user. +
-When this property is present in the configuration, password authentication with NATS is enabled. +
+|Specifies the username of the authorized NAT user.
+When this property is present in the configuration, password authentication with NATS is enabled.
 To use password authentication with NATS, specify a xref:nats-jetstream-auth-password[`debezium.sink.nats-jetstream.auth.password`].
 Do not enable password authentication if xref:nats-jetstream-auth-jwt[JWT authentication] is enabled.
 
@@ -2096,7 +2096,7 @@ You must explicitly set the value to `qdrant`.
 
 |[[qdrant-vector-field-names]]<<qdrant-vector-field-names, `debezium.sink.qdrant.vector.field.names`>>
 |No default value.
-|(Optional) Comma-separated list of `collection-name:field-name` pairs that explicitly define the vector fields to use for each collection. +
+|(Optional) Comma-separated list of `collection-name:field-name` pairs that explicitly define the vector fields to use for each collection.
 This field is mandatory for source tables and collections that contain multiple vector fields.
 
 |[[qdrant-field-include-list]]<<qdrant-field-include-list, `debezium.sink.qdrant.field.include.list.<collection-name>`>>

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -1507,11 +1507,17 @@ NATS has a built-in distributed persistence system called https://docs.nats.io/n
 
 |[[nats-jetstream-subjects]]<<nats-jetstream-subjects, `debezium.sink.nats-jetstream.subjects`>>
 | \*.*.*
-|A comma separated list of subjects, messaging channel names. Can contain wildcards like test.inventory.* +
-*Important:* To capture both schema change events and data change events, you must specify both the topic prefix and a wildcard pattern. For example, if your `debezium.source.topic.prefix` is `myapp`, configure subjects as `myapp,myapp.>` or `myapp,myapp.*.*`. +
-- Schema change events (DDL) are published to the exact topic prefix (e.g., `myapp`) and this is rejected by any subject that has a subtopic wildcard +
-- Data change events are published to table-specific subjects (e.g., `myapp.database.table`) +
-- Use `myapp.>` to match any number of subject levels, or `myapp.*.*` to match exactly two levels after the prefix
+|A comma separated list of JetStream subjects, or messaging channel names.
+You can specify entries that contain wildcards, such as `test.inventory.*`
+
+[IMPORTANT]
+====
+To capture both schema change events and data change events, you must specify both the topic prefix and a wildcard pattern.
+For example, if your `debezium.source.topic.prefix` is `myapp`, configure subjects as `myapp,myapp.>` or `myapp,myapp.*.*`
+====
+
+Data change events are published to table-specific subjects (for example, `myapp.database.table`)
+The value `myapp.>` matches any number of subject levels; similarly `myapp.*.*` matches exactly two levels after the prefix.
 
 |[[nats-jetstream-storage]]<<nats-jetstream-storage, `debezium.sink.nats-jetstream.storage`>>
 | memory

--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -140,7 +140,7 @@ This means that you can control all of the log messages for a specific class or 
 . Configure a logger for the connector.
 +
 The following example configures loggers for the MySQL connector and for the database schema history implementation used by the connector,
-and sets them to log `DEBUG` level messages: +
+and sets them to log `DEBUG` level messages:
 +
 .connect-log4j.properties configuration to enable loggers and set the log level to `DEBUG`
 ====


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9919](https://issues.redhat.atlassian.net/browse/DBZ-9919)

## Description
* Removes hard line breaks from `logging.adoc`, `cloud-events.adoc`. and `debezium-server.adoc`. 
* Edits description of `jetstream.subjects` property

Tested in a local Antora build

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
