### PR TITLE
debezium/dbz#870 Declare schema history field as STRING to avoid eager class loading

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -54,7 +54,9 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
      */
     public static final Field SCHEMA_HISTORY = Field.create("schema.history.internal")
             .withDisplayName("Database schema history class")
-            .withType(Type.CLASS)
+            // STRING rather than CLASS so the default class is not eagerly loaded when the config definition is
+            // built; the default lives in an optional module that may be absent (e.g. the embedded engine).
+            .withType(Type.STRING)
             .withWidth(Width.LONG)
             .withImportance(Importance.LOW)
             .withInvisibleRecommender()

--- a/debezium-connector-common/src/test/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfigTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Field;
+
+public class HistorizedRelationalDatabaseConnectorConfigTest {
+
+    /**
+     * The {@code schema.history.internal} field defaults to the Kafka schema history implementation, which lives in
+     * an optional module. When the field was declared as {@link ConfigDef.Type#CLASS}, building the configuration
+     * definition eagerly loaded that default class, so any environment that does not ship the Kafka storage module on
+     * the classpath (for example the embedded engine) failed with a {@link org.apache.kafka.common.config.ConfigException}.
+     */
+    @Test
+    @io.debezium.doc.FixFor("debezium/dbz#870")
+    public void schemaHistoryFieldShouldNotEagerlyLoadDefaultClass() {
+        // The Kafka schema history class is not on this module's test classpath, mirroring an embedded-engine setup.
+        final ConfigDef configDef = new ConfigDef();
+
+        assertThatCode(() -> Field.group(configDef, "history", HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY))
+                .doesNotThrowAnyException();
+
+        // The default is still advertised so environments that do ship the Kafka storage module keep working.
+        assertThat(configDef.configKeys().get(HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.name()).defaultValue)
+                .isEqualTo(HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.defaultValue());
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
@@ -75,8 +75,11 @@ public class OracleConnectorTest {
             assertThat(key.importance).isEqualTo(expected.importance());
             assertThat(key.documentation).isEqualTo(expected.description());
             assertThat(key.type).isEqualTo(expected.type());
-            if (expected.equals(OracleConnectorConfig.SCHEMA_HISTORY) || expected.equals(CommonConnectorConfig.TOPIC_NAMING_STRATEGY)) {
+            if (expected.equals(CommonConnectorConfig.TOPIC_NAMING_STRATEGY)) {
                 assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo((String) expected.defaultValue());
+            }
+            else if (expected.equals(OracleConnectorConfig.SCHEMA_HISTORY)) {
+                assertThat(key.defaultValue).isEqualTo(expected.defaultValue());
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
@@ -69,8 +69,11 @@ public class SqlServerConnectorTest {
             assertThat(key.importance).isEqualTo(expected.importance());
             assertThat(key.documentation).isEqualTo(expected.description());
             assertThat(key.type).isEqualTo(expected.type());
-            if (expected.equals(SqlServerConnectorConfig.SCHEMA_HISTORY) || expected.equals(CommonConnectorConfig.TOPIC_NAMING_STRATEGY)) {
+            if (expected.equals(CommonConnectorConfig.TOPIC_NAMING_STRATEGY)) {
                 assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo((String) expected.defaultValue());
+            }
+            else if (expected.equals(SqlServerConnectorConfig.SCHEMA_HISTORY)) {
+                assertThat(key.defaultValue).isEqualTo(expected.defaultValue());
             }
             else if (expected.type() == ConfigDef.Type.LIST && key.defaultValue != null) {
                 assertThat(key.defaultValue).isEqualTo(Arrays.asList(expected.defaultValue()));


### PR DESCRIPTION
Fixes debezium/dbz#870

## Description

The `schema.history.internal` field defaults to the Kafka schema history implementation (`io.debezium.storage.kafka.history.KafkaSchemaHistory`) and was declared with `Type.CLASS`. Kafka's `ConfigDef` eagerly resolves a `CLASS` default via `Class.forName` when the configuration definition is built (`ConfigDef.define` → `parseType`). As a result, any runtime that does not ship the optional `debezium-storage-kafka` module on the classpath — for example the embedded engine, or a deployment using a different schema history store — fails to start with a `ConfigException`, even when a different schema history is configured.

This matches the root cause and the fix direction outlined by @jpechane in the original discussion (DBZ-6804).

**Change:** declare the field as `Type.STRING` while keeping the default value. Class resolution is deferred to when the history is actually instantiated in `getSchemaHistory()` (which resolves the class from the string value via `Configuration.getInstance` regardless of the field type). Behaviour is unchanged for Kafka-based deployments, and an invalid custom class name still fails clearly at instantiation time.

A regression test (`HistorizedRelationalDatabaseConnectorConfigTest`) builds the config definition in a module whose test classpath does not contain the Kafka storage implementation, reproducing the embedded scenario; it fails on `Type.CLASS` and passes on `Type.STRING`. The `OracleConnectorTest`/`SqlServerConnectorTest` config-definition assertions are adjusted because the field default is now surfaced as a `String` rather than a `Class`.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
