### PR TITLE
debezium/dbz#2227 Persist purged GTID set as offset floor on no-snapshot start

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -285,9 +285,14 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                 else {
                     LOGGER.info("No GTID stored in the offset, but there is non-empty purged GTID set. Registering binlog reader with purged GTID set: '{}'",
                             purgedServerGtidSet.toString());
-                    client.setGtidSet(purgedServerGtidSet.toString());
-                    // We don't have stored any GTID in the offset, so start from empty GTID set.
-                    initializeGtidSet("");
+                    final String purgedServerGtidSetStr = purgedServerGtidSet.toString();
+                    client.setGtidSet(purgedServerGtidSetStr);
+                    // The purged GTID set is the effective starting floor for a no-snapshot start: the connector
+                    // intentionally skips everything at or below it. Record it in the offset and seed the accumulator
+                    // with it (mirroring the stored-offset branch above and the snapshot path's setCompletedGtidSet),
+                    // so the committed offset carries this floor and subsequent restarts validate it correctly.
+                    effectiveOffsetContext.setCompletedGtidSet(purgedServerGtidSetStr);
+                    initializeGtidSet(purgedServerGtidSetStr);
                 }
             }
         }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
@@ -465,7 +465,7 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
 
             // Get the GTID set that is available on the server
             if (gtidSet.isContainedWithin(availableGtidSet)) {
-                LOGGER.info("The current GTID set '{}' does not contain the GTID set '{}' required by the connector",
+                LOGGER.info("The server's GTID set '{}' contains the connector's stored GTID set '{}'; checking whether any still-needed GTIDs have been purged",
                         availableGtidSet, gtidSet);
 
                 final GtidSet knownServerSet = availableGtidSet.retainAll(config.getGtidSourceFilter());

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
@@ -114,15 +114,16 @@ public abstract class ZZZBinlogGtidSetIT<C extends SourceConnector> extends Abst
         // Check that all records are valid, can be serialized and deserialized ...
         records.forEach(this::validate);
 
-        // Check that records have GTID that does not contain purged interval
+        // Records carry the purged GTID set as the offset's starting floor.
         records.recordsForTopic(ro_database.topicForTable("customers")).forEach(record -> {
             final String gtids = (String) record.sourceOffset().get("gtids");
 
-            // the format is <uuid:<start-tx>-<end-tx>; we don't expect any offsets with start tx = 1 due to the flush
+            // format is <uuid>:<start-tx>-<end-tx>; the offset now starts at tx 1 because the connector records
+            // the purged set as its floor (those GTIDs were intentionally skipped, not lost).
             final Pattern p = Pattern.compile(".*:(.*)-.*");
             final Matcher m = p.matcher(gtids);
             m.matches();
-            assertThat(m.group(1)).isNotEqualTo("1");
+            assertThat(m.group(1)).isEqualTo("1");
         });
 
         stopConnector();

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
@@ -80,7 +80,7 @@ public abstract class ZZZBinlogGtidSetIT<C extends SourceConnector> extends Abst
     }
 
     @Test
-    @FixFor("DBZ-1184")
+    @FixFor({ "DBZ-1184", "debezium/dbz#2227" })
     public void shouldProcessPurgedGtidSet() throws SQLException, InterruptedException {
         Files.delete(SCHEMA_HISTORY_PATH);
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/zzz/ZZZBinlogGtidSetIT.java
@@ -129,6 +129,50 @@ public abstract class ZZZBinlogGtidSetIT<C extends SourceConnector> extends Abst
         stopConnector();
     }
 
+    @Test
+    @FixFor("debezium/dbz#2227")
+    public void shouldResumeStreamingAfterRestartWithPurgedGtidSet() throws SQLException, InterruptedException {
+        Files.delete(SCHEMA_HISTORY_PATH);
+
+        purgeDatabaseLogs();
+        final UniqueDatabase database = TestHelper.getUniqueDatabase("myServer1", "connector_test")
+                .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+        database.createAndInitialize();
+
+        // Stream-only start (no snapshot) against a server with a non-empty purged GTID set.
+        config = database.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CONFIGURATION_BASED)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA, Boolean.FALSE)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA, Boolean.FALSE)
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE_CONFIGURATION_BASED_START_STREAM, Boolean.TRUE)
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, database.qualifiedTableName("customers"))
+                .build();
+
+        // Consume the initial customers rows streamed from the (unpurged) binlog.
+        start(getConnectorClass(), config);
+        SourceRecords records = consumeRecordsByTopic(4);
+        assertThat(records.recordsForTopic(database.topicForTable("customers")).size()).isEqualTo(4);
+
+        stopConnector();
+
+        // Insert more rows while the connector is down.
+        try (BinlogTestConnection db = getTestDatabaseConnection(database.getDatabaseName())) {
+            db.execute(
+                    "INSERT INTO customers VALUES(default,1001,1001,1001)",
+                    "INSERT INTO customers VALUES(default,1002,1002,1002)");
+        }
+
+        // Restart: the committed offset carries the purged GTID set as its floor, so the connector must
+        // resume from it rather than fail with "... is no longer available on the server".
+        start(getConnectorClass(), config);
+        records = consumeRecordsByTopic(2);
+        assertThat(records.recordsForTopic(database.topicForTable("customers")).size()).isEqualTo(2);
+        records.forEach(this::validate);
+
+        stopConnector();
+    }
+
     private void purgeDatabaseLogs() throws SQLException {
         try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());) {
             try (JdbcConnection connection = db.connect()) {


### PR DESCRIPTION
Fixes debezium/dbz#2227.

## Problem
A binlog connector started in a stream-only mode (no schema or data snapshot) against a MySQL server with a non-empty `gtid_purged` starts and streams fine, but permanently fails on the first task restart with `... is no longer available on the server`.

On such a first attach, `BinlogStreamingChangeEventSource` sets the binlog client's GTID set to the purged set (so the server skips those GTIDs) but seeds the in-process accumulator empty, so committed offsets start at `:P+1` — without the `:1-` floor. On restart, `isBinlogPositionAvailable` computes `server − offset`, sees the purged `:1-P` range as needed-and-purged, and fails the task, even though those GTIDs were intentionally skipped at first attach.

Every snapshot-running mode avoids this because it seeds the offset via `setCompletedGtidSet(Executed_Gtid_Set)`, which carries the `:1-` floor.

## Fix
Seed the offset (`setCompletedGtidSet`) and the accumulator (`initializeGtidSet`) with the purged GTID set, mirroring the stored-offset branch just above and the snapshot path. Committed offsets then carry the floor and restarts validate correctly. Also corrects an inverted log message in `isBinlogPositionAvailable` (it claimed the server "does not contain" the connector's set inside the branch where it does).

## Testing
Reproduced end-to-end against MySQL 8.0 with GTIDs enabled and a non-empty `gtid_purged`, using `snapshot.mode=configuration_based` stream-only:
- Before: the committed offset is `:P+1-…` and the task fails on the first restart.
- After: the committed offset carries the `:1-` floor and the task survives restart and continues streaming.

Note: `ZZZBinlogGtidSetIT#shouldProcessPurgedGtidSet` (`@FixFor("DBZ-1184")`) asserts the previous behavior (offset must not start at `:1`) and will need updating; a dedicated restart regression test will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
