### PR TITLE
Dbz 9920 3.6 rmv hard breaks in pp and smt docs

### DIFF
--- a/documentation/modules/ROOT/pages/post-processors/index.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/index.adoc
@@ -24,6 +24,7 @@ In turn, this access enhances efficiency when performing tasks that rely on such
 
 [IMPORTANT]
 ====
-Post processors are designed to modify change event records emitted by {prodname} source connectors only. +
+Post processors are designed to modify change event records emitted by {prodname} source connectors only.
+
 You cannot configure the {prodname} JDBC sink connector to use a post processor.
 ====

--- a/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
@@ -37,7 +37,7 @@ You can configure the post processor to reselect the following column types:
  * Columns that contain the `unavailable.value.placeholder` sentinel value.
 
 
-NOTE: You can use the `ReselectColumnsPostProcessor` post processor only with {prodname} source connectors. +
+NOTE: You can use the `ReselectColumnsPostProcessor` post processor only with {prodname} source connectors.
 The post processor is not designed to work with the {prodname} JDBC sink connector.
 
 ifdef::product[]
@@ -131,7 +131,7 @@ The following table lists the configuration options that you can set for the Res
 |[[reselect-columns-post-processor-property-reselect-columns-include-list]]<<reselect-columns-post-processor-property-reselect-columns-include-list, `+post.processors.reselect.columns.include.list+`>>
 |No default
 |Comma-separated list of column names to reselect from the source database.
-Use the following format to specify column names: +
+Use the following format to specify column names:
 
 `__<schema>__.__<table>__:__<column>__`
 
@@ -140,7 +140,7 @@ Do not set this property if you set the `post.processors.reselect.columns.exclud
 |[[reselect-columns-post-processor-property-reselect-columns-exclude-list]]<<reselect-columns-post-processor-property-reselect-columns-exclude-list, `+post.processors.reselect.columns.exclude.list+`>>
 |No default
 |Comma-separated list of column names in the source database to exclude from reselection.
-Use the following format to specify column names: +
+Use the following format to specify column names:
 
 `__<schema>__.__<table>__:__<column>__`
 
@@ -156,18 +156,18 @@ Do not set this property if you set the `post.processors.reselect.columns.includ
 
 |[[reselect-columns-post-processor-property-reselect-use-event-key]]<<reselect-columns-post-processor-property-reselect-use-event-key, `+post.processors.reselect.use.event.key+`>>
 |`false`
-|Specifies whether the post processor reselects based on the event's key field names or uses the relational table's primary key column names. +
- +
+|Specifies whether the post processor reselects based on the event's key field names or uses the relational table's primary key column names.
+
 By default, the reselection query is based on the relational table's primary key columns or unique key index.
 For tables that do not have a primary key, set this property to `true`, and configure the `message.key.columns` property in the connector configuration to specify a custom key for the connector to use when it creates events.
 The post processor then uses the specified key field names as the primary key in the SQL reselection query.
 
 |[[reselect-columns-post-processor-property-reselect-error-handling-mode]]<<reselect-columns-post-processor-property-reselect-error-handling-mode, `+post.processors.reselect.error.handling.mode+`>>
 |`WARN`
-|Specifies how the reselect post processor reacts to certain conditions. +
- +
-By default, the post-processor logs a warning message when the row cannot be found or if there is a database selection error. +
- +
+|Specifies how the reselect post processor reacts to certain conditions.
+
+By default, the post-processor logs a warning message when the row cannot be found or if there is a database selection error.
+
 When set to `FAIL`, the connector will stop processing changes if the row no longer exists at the time of reselection or if there is a database failure when reselecting the row.
 
 

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -195,12 +195,12 @@ Other languages use different methods to express the same condition.
 
 [TIP]
 ====
-The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures. +
-To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents. +
+The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
+To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents.
 ifdef::community[]
 You can do this by applying the {link-prefix}:{link-mongodb-event-flattening}#new-record-state-extraction[MongoDB `ExtractNewDocumentState`] SMT.
 
-You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item. +
+You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item.
 endif::community[]
 ifdef::product[]
 You can use a JSON parser within an expression to generate separate output documents for each array item.

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -291,46 +291,50 @@ If the topic name is not correct for your use case, you can configure `route.by.
 |Set this optional string to prefix a field.
 
 |[[extract-new-record-state-add-fields]]xref:extract-new-record-state-add-fields[`add.fields`]
-|No default value.
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value.
-When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
+|No default value
+|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the `value` element of the simplified Kafka message.
+If the original message contains duplicate field names, you can specify the field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
 
-Optionally, you can use the following syntax to specify a case-sensitive replacement label for an existing field name: `__<field name>__:__<new field name>__`
+Optionally, you can override the original name of a field and assign it a case-sensitive new name by adding an entry in the following format to the list:
+
+`__<field_name>__:__<new_field_name>__`.
 
 For example:
 
- version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+[source]
+----
+version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+----
 
-The replacement label that you specify overrides the original field name.
-
-
-When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore.
+When the SMT adds metadata fields to the `value` element of the simplified message, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
 
-If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.
+If you specify a field that is not present in the original change event message, the SMT still adds the specified field to the `value` element of the modified message.
 
 |[[extract-new-record-state-add-headers-prefix]]xref:extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
 | __ (double-underscore)
 |Specifies an optional string to prefix a header.
 
 |[[extract-new-record-state-add-headers]]xref:extract-new-record-state-add-headers[`add.headers`]
-|No default value.
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record.
-When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
+|No default value
+|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the header of the simplified Kafka message.
+If the original message contains duplicate field names, you can specify the field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
 
-Optionally, you can use the following syntax to specify a case-sensitive replacement label for an existing field: `__<field name>__:__<new field name>__`
+Optionally, you can override the original name of a field and assign it a case-sensitive new name by adding an entry in the following format to the list:
+
+`__<field_name>__:__<new_field_name>__`.
 
 For example:
 
- version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+[source]
+----
+version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+----
 
-The replacement label that you specify overrides the original field name.
-
-
-When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore.
+When the SMT adds metadata fields to the header of the simplified message, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
 
-If you specify a field that is not in the change event header, the SMT does not add the field to the header.
+If you specify a field that is not present in the header of the original change event message, the SMT does not add the field to the header.
 
 |[[extract-new-record-state-drop-fields-header-name]]xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`]
 |No default value.

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -276,11 +276,15 @@ This setting provides another way to indicate that the record has been deleted.
 
 |[[extract-new-record-state-route-by-field]]xref:extract-new-record-state-route-by-field[`route.by.field`]
 |
-|To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
- +
-For example, configuration of `route.by.field=destination` routes records to the topic whose name is the value of `after.destination`. The default behavior is that a {prodname} connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. +
- +
-If you are configuring the event flattening SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
+|To use row data to determine the topic to route the record to, set this option to an `after` field attribute.
+The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute.
+For a `DELETE` operation, set this option to a `before` field attribute.
+
+For example, configuration of `route.by.field=destination` routes records to the topic whose name is the value of `after.destination`.
+The default behavior is that a {prodname} connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made.
+
+If you are configuring the event flattening SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record.
+If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
 |[[extract-new-record-state-add-fields-prefix]]xref:extract-new-record-state-add-fields-prefix[`add.fields.prefix`]
 | __ (double-underscore)
@@ -288,12 +292,15 @@ If you are configuring the event flattening SMT on a sink connector, setting thi
 
 |[[extract-new-record-state-add-fields]]xref:extract-new-record-state-add-fields[`add.fields`]
 |
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
- +
-Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`. Please note that the `new field name` is case-sensitive. +
- +
-When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
- +
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value.
+When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
+
+Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`.
+Please note that the `new field name` is case-sensitive.
+
+When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore.
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
+
 If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.
 
 |[[extract-new-record-state-add-headers-prefix]]xref:extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
@@ -302,12 +309,15 @@ If you specify a field that is not in the change event record, the SMT still add
 
 |[[extract-new-record-state-add-headers]]xref:extract-new-record-state-add-headers[`add.headers`]
 |
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
- +
-Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`. Please note that the `new field name` is case-sensitive. +
- +
-When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
- +
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record.
+When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
+
+Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`.
+Please note that the `new field name` is case-sensitive.
+
+When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore.
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
+
 If you specify a field that is not in the change event record, the SMT does not add the field to the header.
 
 |[[extract-new-record-state-drop-fields-header-name]]xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`]
@@ -321,8 +331,8 @@ If you specify a field that is not in the change event record, the SMT does not 
 
 |[[extract-new-record-state-drop-fields-keep-schema-compatible]]xref:extract-new-record-state-drop-fields-keep-schema-compatible[`drop.fields.keep.schema.compatible`]
 |`true`
-|Specifies whether you want the SMT to remove non-optional fields that are included in the xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`] configuration property. +
- +
+|Specifies whether you want the SMT to remove non-optional fields that are included in the xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`] configuration property.
+
 By default, the SMT only removes fields that are marked `optional`.
 
 |[[replace-null-with-default]]xref:replace-null-with-default[`replace.null.with.default`]

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -248,7 +248,7 @@ endif::community[]
 The following table describes the options that you can specify to configure the event flattening SMT.
 
 .Descriptions of event flattening SMT configuration options
-[cols="30%a,25%a,45%a",subs="+attributes",options="header"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Option
 |Default
@@ -291,12 +291,18 @@ If the topic name is not correct for your use case, you can configure `route.by.
 |Set this optional string to prefix a field.
 
 |[[extract-new-record-state-add-fields]]xref:extract-new-record-state-add-fields[`add.fields`]
-|
+|No default value.
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value.
 When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
 
-Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`.
-Please note that the `new field name` is case-sensitive.
+Optionally, you can use the following syntax to specify a case-sensitive replacement label for an existing field name: `__<field name>__:__<new field name>__`
+
+For example:
+
+ version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+
+The replacement label that you specify overrides the original field name.
+
 
 When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
@@ -305,23 +311,29 @@ If you specify a field that is not in the change event record, the SMT still add
 
 |[[extract-new-record-state-add-headers-prefix]]xref:extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
 | __ (double-underscore)
-|Set this optional string to prefix a header.
+|Specifies an optional string to prefix a header.
 
 |[[extract-new-record-state-add-headers]]xref:extract-new-record-state-add-headers[`add.headers`]
-|
+|No default value.
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record.
 When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`.
 
-Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`.
-Please note that the `new field name` is case-sensitive.
+Optionally, you can use the following syntax to specify a case-sensitive replacement label for an existing field: `__<field name>__:__<new field name>__`
+
+For example:
+
+ version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+
+The replacement label that you specify overrides the original field name.
+
 
 When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
 
-If you specify a field that is not in the change event record, the SMT does not add the field to the header.
+If you specify a field that is not in the change event header, the SMT does not add the field to the header.
 
 |[[extract-new-record-state-drop-fields-header-name]]xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`]
-|
+|No default value.
 |The Kafka message header name to use for listing field names in the source message that you want to drop from the output message.
 
 |[[extract-new-record-state-drop-fields-from-key]]xref:extract-new-record-state-drop-fields-from-key[`drop.fields.from.key`]

--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -267,12 +267,12 @@ Other languages use different methods to express the same condition.
 
 [TIP]
 ====
-The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures. +
-To use the filter SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents. +
+The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
+To use the filter SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents.
 ifdef::community[]
 You can do this by applying the {link-prefix}:{link-mongodb-event-flattening}#new-record-state-extraction[MongoDB `ExtractNewDocumentState`] SMT.
 
-You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item. +
+You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item.
 endif::community[]
 ifdef::product[]
 You can use a JSON parser within an expression to generate separate output documents for each array item.

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -510,14 +510,14 @@ This setting provides another way to indicate that the record has been deleted.
 
 |[[mongodb-extract-new-record-state-add-headers-prefix]]<<mongodb-extract-new-record-state-add-headers-prefix, `add.headers.prefix`>>
 |__ (double-underscore)
-|Set this optional string to prefix a header.
+|Specifies an optional string to prefix a header.
 
 |[[mongodb-extract-new-record-state-add-headers]]<<mongodb-extract-new-record-state-add-headers, `add.headers`>>
 |No default
-|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the header of simplified messages.
-When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
+|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the header of the simplified Kafka message.
+If the original message contains duplicate field names, you can specify the field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
 
-Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list:
+Optionally, you can override the original name of a field and assign it a case-sensitive new name by adding an entry in the following format to the list:
 
 `__<field_name>__:__<new_field_name>__`.
 
@@ -528,12 +528,10 @@ For example:
 version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
 ----
 
-The new name values that you specify are case-sensitive.
-
 When the SMT adds metadata fields to the header of the simplified message, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
 
-If you specify a field that is not in the change event original message, the SMT does not add the field to the header.
+If you specify a field that is not present in the header of the original change event message, the SMT does not add the field to the header.
 
 |[[mongodb-extract-new-record-state-add-fields-prefix]]<<mongodb-extract-new-record-state-add-fields-prefix, `add.fields.prefix`>>
 |__ (double-underscore)
@@ -541,10 +539,10 @@ If you specify a field that is not in the change event original message, the SMT
 
 |[[mongodb-extract-new-record-state-add-fields]]<<mongodb-extract-new-record-state-add-fields, `add.fields`>>
 |No default
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the `value` element of the simplified Kafka message.
-When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
+|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the `value` element of the simplified Kafka message.
+If the original message contains duplicate field names, you can specify the field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
 
-Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list:
+Optionally, you can override the original name of a field and assign it a case-sensitive new name by adding an entry in the following format to the list:
 
 `__<field_name>__:__<new_field_name>__`.
 
@@ -554,8 +552,6 @@ For example:
 ----
 version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
 ----
-
-The new name values that you specify are case-sensitive.
 
 When the SMT adds metadata fields to the `value` element of the simplified message, it prefixes each metadata field name with a double underscore.
 For a struct specification, the SMT also inserts an underscore between the struct name and the field name.

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -517,9 +517,9 @@ This setting provides another way to indicate that the record has been deleted.
 |Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the header of simplified messages.
 When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
 
-Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list: +
+Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list:
 
-`__<field_name>__:__<new_field_name>__`. +
+`__<field_name>__:__<new_field_name>__`.
 
 For example:
 
@@ -528,11 +528,11 @@ For example:
 version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
 ----
 
-The new name values that you specify are case-sensitive. +
- +
+The new name values that you specify are case-sensitive.
+
 When the SMT adds metadata fields to the header of the simplified message, it prefixes each metadata field name with a double underscore.
-For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
- +
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
+
 If you specify a field that is not in the change event original message, the SMT does not add the field to the header.
 
 |[[mongodb-extract-new-record-state-add-fields-prefix]]<<mongodb-extract-new-record-state-add-fields-prefix, `add.fields.prefix`>>
@@ -543,10 +543,10 @@ If you specify a field that is not in the change event original message, the SMT
 |No default
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the `value` element of the simplified Kafka message.
 When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
- +
-Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list: +
 
-`__<field_name>__:__<new_field_name>__`. +
+Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list:
+
+`__<field_name>__:__<new_field_name>__`.
 
 For example:
 
@@ -555,11 +555,11 @@ For example:
 version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
 ----
 
-The new name values that you specify are case-sensitive. +
+The new name values that you specify are case-sensitive.
 
 When the SMT adds metadata fields to the `value` element of the simplified message, it prefixes each metadata field name with a double underscore.
-For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
- +
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name.
+
 If you specify a field that is not present in the original change event message, the SMT still adds the specified field to the `value` element of the modified message.
 
 |[[mongodb-extract-new-record-state-field-name-adjustment-mode]]xref:mongodb-extract-new-record-state-field-name-adjustment-mode[`field.name.adjustment.mode`]

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -141,6 +141,7 @@ To obtain the unique ID of the event from a different outbox collection field, s
 The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
 
 For example, in a default configuration, the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option is set to `outbox.event.pass:[${routedByValue}]`.
+
 Suppose that your application adds two documents to the outbox collection.
 In the first document, the value in the `aggregatetype` field is `customers`.
 In the second document, the value in the `aggregatetype` field is `orders`.

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -131,27 +131,29 @@ To apply the default MongoDB outbox event router SMT configuration, your outbox 
 |Effect
 
 |`id`
-|Contains the unique ID of the event. In an outbox message, this value is a header. You can use this ID, for example, to remove duplicate messages. +
- +
+|Contains the unique ID of the event. In an outbox message, this value is a header.
+You can use this ID, for example, to remove duplicate messages.
+
 To obtain the unique ID of the event from a different outbox collection field, set the xref:mongodb-outbox-event-router-property-collection-field-event-id[`collection.field.event.id`] SMT option in the connector configuration.
 
 |[[mongodb-outbox-route-by-field-example]]`aggregatetype`
 |Contains a value that the SMT appends to the name of the topic to which the connector emits an outbox message.
-The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
- +
+The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
+
 For example, in a default configuration, the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option is set to `outbox.event.pass:[${routedByValue}]`.
-Suppose that your application adds two documents to the outbox collection. In the first document, the value in the `aggregatetype` field is `customers`.
+Suppose that your application adds two documents to the outbox collection.
+In the first document, the value in the `aggregatetype` field is `customers`.
 In the second document, the value in the `aggregatetype` field is `orders`.
 The connector emits the first document to the `outbox.event.customers` topic.
-The connector emits the second document to the `outbox.event.orders` topic. +
- +
+The connector emits the second document to the `outbox.event.orders` topic.
+
 To obtain this value from a different outbox collection field, set the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] SMT option in the connector configuration.
 
 |`aggregateid`
 |Contains the event key, which provides an ID for the payload.
 The SMT uses this value as the key in the emitted outbox message.
-This is important for maintaining correct order in Kafka partitions. +
- +
+This is important for maintaining correct order in Kafka partitions.
+
 To obtain the event key from a different outbox collection field, set the xref:mongodb-outbox-event-router-property-collection-field-event-key[`collection.field.event.key`] SMT option in the connector configuration.
 
 |`payload`
@@ -159,13 +161,13 @@ To obtain the event key from a different outbox collection field, set the xref:m
 The default structure is JSON.
 By default, the Kafka message value is solely comprised of the `payload` value.
 However, if the outbox event is configured to include additional fields, the Kafka message value contains an envelope encapsulating both payload and the additional fields, and each field is represented separately.
-For more information, see xref:mongodb-outbox-emitting-messages-with-additional-fields[Emitting messages with additional fields]. +
- +
+For more information, see xref:mongodb-outbox-emitting-messages-with-additional-fields[Emitting messages with additional fields].
+
 To obtain the event payload from a different outbox collection field, set the xref:mongodb-outbox-event-router-property-collection-field-event-payload[`collection.field.event.payload`] SMT option in the connector configuration.
 
 |Additional custom fields
-|Any additional fields from the outbox collection can be xref:mongodb-outbox-emitting-messages-with-additional-fields[added to outbox events] either within the payload section or as a message header. +
- +
+|Any additional fields from the outbox collection can be xref:mongodb-outbox-emitting-messages-with-additional-fields[added to outbox events] either within the payload section or as a message header.
+
 One example could be a field `eventType` which conveys a user-defined value that helps to categorize or organize events.
 
 |===
@@ -387,9 +389,10 @@ This ID will be stored in the emitted event's headers under the `id` key.
 |[[mongodb-outbox-event-router-property-collection-expand-json-payload]]<<mongodb-outbox-event-router-property-collection-expand-json-payload, `collection.expand.json.payload`>>
 |`false`
 |Collection
-a|Specifies whether the JSON expansion of a String payload should be done. If no content found or in case of parsing error, the content is kept "as is". +
- +
-Fore more details, please see the xref:mongodb-outbox-expanding-escaped-json-string-as-json[expanding escaped json] section.
+a|Specifies whether the JSON expansion of a String payload should be done.
+If no content found or in case of parsing error, the content is kept "as is".
+
+For more details, please see the xref:mongodb-outbox-expanding-escaped-json-string-as-json[expanding escaped json] section.
 
 |[[mongodb-outbox-event-router-property-collection-fields-additional-placement]]<<mongodb-outbox-event-router-property-collection-fields-additional-placement, `collection.fields.additional.placement`>>
 |
@@ -430,18 +433,18 @@ For an example, see the xref:mongodb-outbox-route-by-field-example[description o
 |`(?<routedByValue>.*)`
 |Router
 |Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox collection documents.
-This regular expression is part of the setting of the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
- +
+This regular expression is part of the setting of the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
+
 When this property is set to the default `Router` value, the SMT replaces the default `pass:[${routedByValue}]` variable that is set in the xref:mongodb-outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] property with the value that is specified for the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] property.
 
 |[[mongodb-outbox-event-router-property-route-topic-replacement]]<<mongodb-outbox-event-router-property-route-topic-replacement, `route.topic.replacement`>>
 |`outbox.event{zwsp}.pass:[${routedByValue}]`
 |Router
 a|Specifies the name of the topic to which the connector emits outbox messages.
-The default topic name is prefixed by the string `outbox.event.`, followed by the value of the `aggregatetype` field that is assigned to the outbox collection document. +
- +
-For example, if the `aggregatetype` value is `customers`, then connector emits outbox messages to the topic `outbox.event.customers`. +
- +
+The default topic name is prefixed by the string `outbox.event.`, followed by the value of the `aggregatetype` field that is assigned to the outbox collection document.
+
+For example, if the `aggregatetype` value is `customers`, then connector emits outbox messages to the topic `outbox.event.customers`.
+
 To change the default name of the destination topic, perform one of the following actions:
 
 * Set the xref:mongodb-outbox-event-router-property-route-by-field[`route.by.field`] option to a different field.

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -389,7 +389,7 @@ This ID will be stored in the emitted event's headers under the `id` key.
 |[[mongodb-outbox-event-router-property-collection-expand-json-payload]]<<mongodb-outbox-event-router-property-collection-expand-json-payload, `collection.expand.json.payload`>>
 |`false`
 |Collection
-a|Specifies whether the JSON expansion of a String payload should be done.
+a|Specifies whether the SMT performs JSON expansion of a String payload.
 If no content found or in case of parsing error, the content is kept "as is".
 
 For more details, please see the xref:mongodb-outbox-expanding-escaped-json-string-as-json[expanding escaped json] section.

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -442,7 +442,7 @@ This ID will be stored in the emitted event's headers under the `id` key.
 |[[outbox-event-router-property-table-expand-json-payload]]<<outbox-event-router-property-table-expand-json-payload, `table.expand.json.payload`>>
 |`false`
 |Table
-a|Specifies whether the JSON expansion of a String payload should be done.
+a|Specifies whether the SMT performs JSON expansion of a String payload.
 If no content found or in case of parsing error, the content is kept "as is".
 
 For more details, please see the xref:expanding-escaped-json-string-as-json[expanding escaped json] section.

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -147,6 +147,7 @@ To obtain the unique ID of the event from a different outbox table column, set t
 The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
 
 For example, in a default configuration, the xref:outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option is set to `outbox.event.pass:[${routedByValue}]`.
+
 Suppose that your application adds two records to the outbox table.
 In the first record, the value in the `aggregatetype` column is `customers`.
 In the second record, the value in the `aggregatetype` column is `orders`.

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -137,26 +137,29 @@ payload       | jsonb                  |
 |Effect
 
 |`id`
-|Contains the unique ID of the event. In an outbox message, this value is a header. You can use this ID, for example, to remove duplicate messages. +
- +
+|Contains the unique ID of the event. In an outbox message, this value is a header.
+You can use this ID, for example, to remove duplicate messages.
+
 To obtain the unique ID of the event from a different outbox table column, set the xref:outbox-event-router-property-table-field-event-id[`table.field.event.id`]  SMT option in the connector configuration.
 
 |[[route-by-field-example]]`aggregatetype`
-|Contains a value that the SMT appends to the name of the topic to which the connector emits an outbox message. The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
- +
+|Contains a value that the SMT appends to the name of the topic to which the connector emits an outbox message.
+The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
+
 For example, in a default configuration, the xref:outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option is set to `outbox.event.pass:[${routedByValue}]`.
-Suppose that your application adds two records to the outbox table. In the first record, the value in the `aggregatetype` column is `customers`.
+Suppose that your application adds two records to the outbox table.
+In the first record, the value in the `aggregatetype` column is `customers`.
 In the second record, the value in the `aggregatetype` column is `orders`.
 The connector emits the first record to the `outbox.event.customers` topic.
-The connector emits the second record to the `outbox.event.orders` topic. +
- +
+The connector emits the second record to the `outbox.event.orders` topic.
+
 To obtain this value from a different outbox table column, set the xref:outbox-event-router-property-route-by-field[`route.by.field`] SMT option in the connector configuration.
 
 |`aggregateid`
 |Contains the event key, which provides an ID for the payload.
 The SMT uses this value as the key in the emitted outbox message.
-This is important for maintaining correct order in Kafka partitions. +
- +
+This is important for maintaining correct order in Kafka partitions.
+
 To obtain the event key from a different outbox table column, set the xref:outbox-event-router-property-table-field-event-key[`table.field.event.key` SMT option] in the connector configuration.
 
 |`payload`
@@ -164,13 +167,13 @@ To obtain the event key from a different outbox table column, set the xref:outbo
 The default structure is JSON.
 By default, the Kafka message value is solely comprised of the `payload` value.
 However, if the outbox event is configured to include additional fields, the Kafka message value contains an envelope encapsulating both payload and the additional fields, and each field is represented separately.
-For more information, see xref:emitting-messages-with-additional-fields[Emitting messages with additional fields]. +
- +
+For more information, see xref:emitting-messages-with-additional-fields[Emitting messages with additional fields].
+
 To obtain the event payload from a different outbox table column, set the xref:outbox-event-router-property-table-field-event-payload[`table.field.event.payload`] SMT option in the connector configuration.
 
 |Additional custom columns
-|Any additional columns from the outbox table can be xref:emitting-messages-with-additional-fields[added to outbox events] either within the payload section or as a message header. +
- +
+|Any additional columns from the outbox table can be xref:emitting-messages-with-additional-fields[added to outbox events] either within the payload section or as a message header.
+
 One example could be a column `eventType` which conveys a user-defined value that helps to categorize or organize events.
 
 |===
@@ -439,9 +442,10 @@ This ID will be stored in the emitted event's headers under the `id` key.
 |[[outbox-event-router-property-table-expand-json-payload]]<<outbox-event-router-property-table-expand-json-payload, `table.expand.json.payload`>>
 |`false`
 |Table
-a|Specifies whether the JSON expansion of a String payload should be done. If no content found or in case of parsing error, the content is kept "as is". +
- +
-Fore more details, please see the xref:expanding-escaped-json-string-as-json[expanding escaped json] section.
+a|Specifies whether the JSON expansion of a String payload should be done.
+If no content found or in case of parsing error, the content is kept "as is".
+
+For more details, please see the xref:expanding-escaped-json-string-as-json[expanding escaped json] section.
 
 |[[outbox-event-router-property-table-json-payload-null-behavior]]<<outbox-event-router-property-table-json-payload-null-behavior, `table.json.payload.null.behavior`>>
 |`ignore`
@@ -487,17 +491,19 @@ a|Determines the behavior of the SMT when a field specified by the `table.fields
 |[[outbox-event-router-property-route-topic-regex]]<<outbox-event-router-property-route-topic-regex, `route.topic.regex`>>
 |`(?<routedByValue>.*)`
 |Router
-|Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox table records. This regular expression is part of the setting of the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
- +
+|Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox table records.
+This regular expression is part of the setting of the xref:outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option.
+
 The default behavior is that the SMT replaces the default `pass:[${routedByValue}]` variable in the setting of the `route.topic.replacement` SMT option with the setting of the xref:outbox-event-router-property-route-by-field[`route.by.field`] outbox SMT option.
 
 |[[outbox-event-router-property-route-topic-replacement]]<<outbox-event-router-property-route-topic-replacement, `route.topic.replacement`>>
 |`outbox.event{zwsp}.pass:[${routedByValue}]`
 |Router
 a|Specifies the name of the topic to which the connector emits outbox messages.
-The default topic name is `outbox.event.` followed by the `aggregatetype` column value in the outbox table record. For example, if the `aggregatetype` value is `customers`, the topic name is `outbox.event.customers`. +
- +
-To change the topic name, you can: +
+The default topic name is `outbox.event.` followed by the `aggregatetype` column value in the outbox table record.
+For example, if the `aggregatetype` value is `customers`, the topic name is `outbox.event.customers`.
+
+To change the topic name, you can:
 
 * Set the xref:outbox-event-router-property-route-by-field[`route.by.field`] option to a different column.
 * Set the xref:outbox-event-router-property-route-topic-regex[route.topic.regex] option to a different regular expression.

--- a/documentation/modules/ROOT/pages/transformations/partition-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/partition-routing.adoc
@@ -272,13 +272,13 @@ Use the `TopicNameMatches` predicate to filter records by topic.
 |[[partition-routing-partition-hash-function]]<<partition-routing-partition-hash-function, `partition.hash.function`>>
 | `java`
 |Hash function to be used when computing hash of the fields which would determine number of the destination partition.
-Possible values are:
+Set one of the following values:
 
-`java` - standard Java `Object::hashCode` function
+`java`:: Standard Java `Object::hashCode` function
 
-`murmur` - latest version of http://en.wikipedia.org/wiki/MurmurHash[MurmurHash] function, MurmurHash3
+`murmur`:: Latest version of http://en.wikipedia.org/wiki/MurmurHash[MurmurHash] function, MurmurHash3
 
-This configuration is optional.
-If not specified or invalid value is used, the default value will be used.
+This property is optional.
+If you do not specify a value, or if you specify an invalid value, the default value is used.
 
 |===

--- a/documentation/modules/ROOT/pages/transformations/partition-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/partition-routing.adoc
@@ -272,12 +272,12 @@ Use the `TopicNameMatches` predicate to filter records by topic.
 |[[partition-routing-partition-hash-function]]<<partition-routing-partition-hash-function, `partition.hash.function`>>
 | `java`
 |Hash function to be used when computing hash of the fields which would determine number of the destination partition.
-Possible values are: +
- +
-`java` - standard Java `Object::hashCode` function +
- +
-`murmur` - latest version of http://en.wikipedia.org/wiki/MurmurHash[MurmurHash] function, MurmurHash3 +
- +
+Possible values are:
+
+`java` - standard Java `Object::hashCode` function
+
+`murmur` - latest version of http://en.wikipedia.org/wiki/MurmurHash[MurmurHash] function, MurmurHash3
+
 This configuration is optional.
 If not specified or invalid value is used, the default value will be used.
 

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -75,8 +75,8 @@ transforms.Reroute.topic.replacement=$1customers_all_shards
 +
 In the example, the regular expression, `pass:[(.*)customers_shard(.*)]` matches records for changes to tables whose names include the `customers_shard` string. This would re-route records for tables with the following names:
 +
-`myserver.mydb.customers_shard1` +
-`myserver.mydb.customers_shard2` +
+`myserver.mydb.customers_shard1`
+`myserver.mydb.customers_shard2`
 `myserver.mydb.customers_shard3`
 
 `topic.replacement`:: Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. In this example, records for the three sharded tables listed above would be routed to the `myserver.mydb.customers_all_shards` topic.
@@ -125,8 +125,8 @@ transforms.Reroute.key.field.replacement=$2
 
 With this configuration, suppose that the default destination topic names are:
 
-`myserver.mydb.customers_shard1` +
-`myserver.mydb.customers_shard2` +
+`myserver.mydb.customers_shard1`
+`myserver.mydb.customers_shard2`
 `myserver.mydb.customers_shard3`
 
 The transformation uses the values in the second captured group, the shard numbers, as the value of the key's new field. In this example, the inserted key field's values would be `1`, `2`, or `3`.
@@ -182,9 +182,12 @@ The following table describes topic routing SMT configuration options.
 
 |[[by-logical-table-router-key-enforce-uniqueness]]xref:by-logical-table-router-key-enforce-uniqueness[`key.enforce{zwsp}.uniqueness`]
 |`true`
-|Indicates whether to add a field to the record's change event key. Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic. This helps to prevent collisions of change events for records that have the same key but that originate from different source tables. +
- +
-Specify `false` if you do not want the transformation to add a key field.  For example, if you are routing records from a partitioned PostgreSQL table to one topic, you can configure `key.enforce.uniqueness=false` because unique keys are guaranteed in partitioned PostgreSQL tables.
+|Indicates whether to add a field to the record's change event key.
+Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic.
+This helps to prevent collisions of change events for records that have the same key but that originate from different source tables.
+
+Specify `false` if you do not want the transformation to add a key field.
+For example, if you are routing records from a partitioned PostgreSQL table to one topic, you can configure `key.enforce.uniqueness=false` because unique keys are guaranteed in partitioned PostgreSQL tables.
 
 |[[by-logical-table-router-key-field-name]]xref:by-logical-table-router-key-field-name[`key.field.name`]
 |`+__dbz__physicalTableIdentifier+`

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -74,10 +74,10 @@ transforms.Reroute.topic.replacement=$1customers_all_shards
 `topic.regex`:: Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.
 +
 In the example, the regular expression, `pass:[(.*)customers_shard(.*)]` matches records for changes to tables whose names include the `customers_shard` string. This would re-route records for tables with the following names:
-+
-`myserver.mydb.customers_shard1`
-`myserver.mydb.customers_shard2`
-`myserver.mydb.customers_shard3`
+
+* `myserver.mydb.customers_shard1`
+* `myserver.mydb.customers_shard2`
+* `myserver.mydb.customers_shard3`
 
 `topic.replacement`:: Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. In this example, records for the three sharded tables listed above would be routed to the `myserver.mydb.customers_all_shards` topic.
 
@@ -123,11 +123,11 @@ transforms.Reroute.key.field.regex=(.*)customers_shard(.*)
 transforms.Reroute.key.field.replacement=$2
 ----
 
-With this configuration, suppose that the default destination topic names are:
+With this configuration, suppose that the following default destination topic names are in effect:
 
-`myserver.mydb.customers_shard1`
-`myserver.mydb.customers_shard2`
-`myserver.mydb.customers_shard3`
+* `myserver.mydb.customers_shard1`
+* `myserver.mydb.customers_shard2`
+* `myserver.mydb.customers_shard3`
 
 The transformation uses the values in the second captured group, the shard numbers, as the value of the key's new field. In this example, the inserted key field's values would be `1`, `2`, or `3`.
 
@@ -173,11 +173,11 @@ The following table describes topic routing SMT configuration options.
 |Description
 
 |[[by-logical-table-router-topic-regex]]xref:by-logical-table-router-topic-regex[`topic.regex`]
-|
+|No default value.
 |Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.
 
 |[[by-logical-table-router-topic-replacement]]xref:by-logical-table-router-topic-replacement[`topic.replacement`]
-|
+|No default value.
 |Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. This expression can refer to groups captured by the regular expression that you specify for `topic.regex`. To refer to a group, specify `$1`, `$2`, and so on.
 
 |[[by-logical-table-router-key-enforce-uniqueness]]xref:by-logical-table-router-key-enforce-uniqueness[`key.enforce{zwsp}.uniqueness`]
@@ -194,15 +194,15 @@ For example, if you are routing records from a partitioned PostgreSQL table to o
 |Name of a field to be added to the change event key. The value of this field identifies the original table name. For the SMT to add this field, `key.enforce.uniqueness` must be `true`, which is the default.
 
 |[[by-logical-table-router-key-field-regex]]xref:by-logical-table-router-key-field-regex[`key.field.regex`]
-|
+|No default value.
 |Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default.
 
 |[[by-logical-table-router-key-field-replacement]]xref:by-logical-table-router-key-field-replacement[`key.field{zwsp}.replacement`]
-|
+|No default value.
 |Specifies a regular expression for determining the value of the inserted key field in terms of the groups captured by the expression specified for `key.field.regex`. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default.
 
 |[[by-logical-table-router-schema-name-adjustment-mode]]xref:by-logical-table-router-schema-name-adjustment-mode[`schema.name.adjustment.mode`]
-|none
+|`none`
 |Specify how the message key schema names derived from the resulting topic name should be adjusted for compatibility with the message converter used by the connector, including: `none` does not apply any adjustment (default), `avro` replaces the characters that cannot be used in the Avro type name with underscore.
 
 |[[by-logical-table-router-logical-table-cache-size]]xref:by-logical-table-router-logical-table-cache-size[`logical.table.cache.size`]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9920](https://redhat/atlassian.net/browse/DBZ-9920)

## Description
Cherry-pick from `main`

Removes hard line breaks in the post processors and SMT docs.
Also applies language and formatting edits for style and consistency.

Tested in a local Antora build.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
