### PR TITLE
DBZ-9922 3.6 remove hard breaks from partials files

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -34,26 +34,26 @@ Set the type of the `execute-snapshot` signal to `incremental` or `blocking`, an
 
 |`type`
 |`incremental`
-| Specifies the type of snapshot that you want to run. +
+| Specifies the type of snapshot that you want to run.
 Currently, you can request `incremental` or `blocking` snapshots.
 
 
 |`data-collections`
 |_N/A_
-| An array that contains regular expressions matching the fully-qualified names of the {data-collection}s to include in the snapshot. +
+| An array that contains regular expressions matching the fully-qualified names of the {data-collection}s to include in the snapshot.
 For the {connector-name} connector, use the following format to specify the fully qualified name of a {data-collection}: `{collection-container}.{data-collection}`.
 
 ifeval::['{context}' != 'mongodb']
 |`additional-conditions`
 |_N/A_
-|An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot. +
+|An optional array that specifies a set of additional conditions that the connector evaluates to determine the subset of records to include in a snapshot.
 Each additional condition is an object that specifies the criteria for filtering the data that an ad hoc snapshot captures.
 You can set the following parameters for each additional condition:
 
 `data-collection`:: The fully-qualified name of the {data-collection} that the filter applies to.
 You can apply different filters to each {data-collection}.
-`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`. +
- +
+`filter`:: Specifies column values that must be present in a database record for the snapshot to include it, for example,  `"color='blue'"`.
+
 The values that you assign to the `filter` parameter are the same types of values that you might specify in the `WHERE` clause of `SELECT` statements when you set the `snapshot.select.statement.overrides` property for a blocking snapshot.
 endif::[]
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-blocking-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-blocking-snapshot.adoc
@@ -17,10 +17,10 @@ After the snapshot completes, the streaming is resumed.
 You can set the following properties in the `data` component of a signal:
 
  * data-collections: to specify which {data-collection}s must be snapshot.
-* data-collections: Specifies the {data-collection}s that you want the snapshot to include. +
+* data-collections: Specifies the {data-collection}s that you want the snapshot to include.
 This property accepts a comma-separated list of regular expressions that match fully-qualified {data-collection} names.
 The behavior of the property is similar to the behavior of the `table.include.list` property, which specifies the tables to capture in a blocking snapshot.
- * additional-conditions: You can specify different filters for different {data-collection}. +
+ * additional-conditions: You can specify different filters for different {data-collection}.
  ** The `data-collection` property is the fully-qualified name of the {data-collection} for which the filter will be applied, and can be case-sensitive or case-insensitive depending on the database.
  ** The `filter` property will have the same value used in the  `snapshot.select.statement.overrides`, the fully-qualified name of the {data-collection} that should match by case.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -67,7 +67,7 @@ The following example illustrates how tags modify the default MBean name.
 .How custom tags modify the connector MBean name
 =======
 By default, the {connector-name} connector uses the following MBean name for streaming metrics:
- +
+
 [source,subs="attributes+,quotes"]
 ----
 debezium.{context}:type=connector-metrics,context=streaming,server=_<topic.prefix>_

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-kafka.adoc
@@ -14,12 +14,12 @@ The signal type is `stop-snapshot`, and the `data` field must have the following
 |`type`
 |`incremental`
 | The type of the snapshot to be executed.
-Currently {prodname} supports only the `incremental` type.  +
+Currently {prodname} supports only the `incremental` type.
 See the next section for more details.
 
 |`data-collections`
 |_N/A_
-| An optional array of comma-separated regular expressions that match the fully-qualified names of the tables an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+a| An optional array of comma-separated regular expressions that match the fully-qualified names of the tables an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot.
 Specify {data-collection} names by using the format `{collection-container}.{data-collection}`.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
@@ -12,7 +12,7 @@ You can also stop an incremental snapshot by sending a JSON message to the xref:
 
 .Prerequisites
 
-* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled].
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -11,7 +11,7 @@ You can also stop an incremental snapshot by sending a JSON message to the xref:
 
 .Prerequisites
 
-* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled].
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -42,24 +42,24 @@ The following table describes the parameters in the example:
 
 |2
 |`ad-hoc-1`
-| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+a| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request.
 Use this string to identify logging messages to entries in the signaling {data-collection}.
 {prodname} does not use this string.
 
 |3
 |`stop-snapshot`
-| Specifies `type` parameter specifies the operation that the signal is intended to trigger. +
+a| Specifies `type` parameter specifies the operation that the signal is intended to trigger.
 
 |4
 |`data-collections`
-|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+a|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot.
 The array lists regular expressions which match {data-collection}s by their fully-qualified names in the format `{collection-container}.table`
 
 If you omit this component from the `data` field, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
-Currently, the only valid option is `incremental`. +
+a|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped.
+Currently, the only valid option is `incremental`.
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -48,7 +48,7 @@ Use this string to identify logging messages to entries in the signaling {data-c
 
 |3
 |`stop-snapshot`
-a| Specifies `type` parameter specifies the operation that the signal is intended to trigger.
+a| The `type` parameter, which identifies the operation that the signal is intended to trigger.
 
 |4
 |`data-collections`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
@@ -80,13 +80,13 @@ Use this string to identify logging messages to entries in the signaling {data-c
 
 |3
 |`stop-snapshot`
-a| Specifies `type` parameter specifies the operation that the signal is intended to trigger.
+a| The `type` parameter, which specifies the operation that the signal is intended to trigger.
 
 |4
 |`data-collections`
 a|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot.
 The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
-If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
+If you omit this component of the `data` field, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
@@ -11,7 +11,7 @@ The query that you submit specifies the snapshot operation of `incremental`, and
 
 .Prerequisites
 
-* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled].
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -74,24 +74,24 @@ tag::sql-based-snapshot[]
 
 |2
 |`ad-hoc-1`
-| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+a| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request.
 Use this string to identify logging messages to entries in the signaling {data-collection}.
 {prodname} does not use this string.
 
 |3
 |`stop-snapshot`
-| Specifies `type` parameter specifies the operation that the signal is intended to trigger. +
+a| Specifies `type` parameter specifies the operation that the signal is intended to trigger.
 
 |4
 |`data-collections`
-|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+a|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot.
 The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
 If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
-Currently, the only valid option is `incremental`. +
+a|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped.
+Currently, the only valid option is `incremental`.
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===
 end::sql-based-snapshot[]
@@ -108,25 +108,25 @@ tag::nosql-based-snapshot[]
 
 |2
 |null
-|The insert method in the preceding example omits use of the optional `_id` parameter.
-Because the document does not explicitly assign a value for the parameter, the arbitrary id that MongoDB automatically assigns to the document becomes the `id` identifier for the signal request. +
+a|The insert method in the preceding example omits use of the optional `_id` parameter.
+Because the document does not explicitly assign a value for the parameter, the arbitrary id that MongoDB automatically assigns to the document becomes the `id` identifier for the signal request.
 Use this string to identify logging messages to entries in the signaling {data-collection}.
 {prodname} does not use this identifier string.
 
 |3
 |`stop-snapshot`
-| The `type` parameter specifies the operation that the signal is intended to trigger. +
+a| The `type` parameter specifies the operation that the signal is intended to trigger.
 
 |4
 |`data-collections`
-|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+a|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot.
 The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
 If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
 
 |5
 |`incremental`
-|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped. +
-Currently, the only valid option is `incremental`. +
+a|A required component of the `data` field of a signal that specifies the type of snapshot operation that is to be stopped.
+Currently, the only valid option is `incremental`.
 If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
 |===
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-kafka.adoc
@@ -14,7 +14,7 @@ The signal type is `execute-snapshot`, and the `data` field must have the follow
 |`type`
 |`incremental`
 | The type of the snapshot to be executed.
-Currently {prodname} supports the `incremental` and `blocking` types. +
+Currently {prodname} supports the `incremental` and `blocking` types.
 See the next section for more details.
 
 |`data-collections`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
@@ -7,8 +7,8 @@ After {prodname} detects the change in the signaling {data-collection}, it reads
 The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
 Currently, the only valid options for snapshots operations are `incremental` and `blocking`.
 
-To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
-`{"data-collections": ["public.Collection1", "public.Collection2"]}` +
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example,
+`{"data-collections": ["public.Collection1", "public.Collection2"]}`
 
 The `data-collections` array for an incremental snapshot signal has no default value.
 If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
@@ -21,7 +21,7 @@ For example, to include a data collection that exists in the `*public*` database
 
 .Prerequisites
 
-* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-source-signaling-channel[Signaling is enabled].
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -6,7 +6,7 @@ After {prodname} detects the change in the signaling {data-collection}, it reads
 The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the type of snapshot operation.
 {prodname} currently supports the `incremental` and `blocking` snapshot types.
 
-To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s, or an array of regular expressions used to match {data-collection}s, for example, +
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s, or an array of regular expressions used to match {data-collection}s, for example,
 
 `{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}`
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ifx-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ifx-ora-pg-connector.adoc
@@ -30,7 +30,7 @@ For more information about ImageStreams, see link:{LinkCreatingManagingOpenShift
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
@@ -43,11 +43,11 @@ include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-kafka-conn
 oc create -f dbz-connect.yaml
 ----
 +
-Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy.
 After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
 The connector artifacts that you listed in the configuration are available in the cluster.
 
-. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy.
 For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
 +
 .`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
@@ -84,9 +84,9 @@ The password that {prodname} uses to connect to the database user account.
 The name of the database to capture changes from.
 
 `topic.prefix`::
-The topic prefix for the database instance or cluster. +
-The specified name must be formed only from alphanumeric characters or underscores. +
-Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+The topic prefix for the database instance or cluster.
+The specified name must be formed only from alphanumeric characters or underscores.
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster.
 This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
 
 `table.include.list`::

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -30,7 +30,7 @@ For more information about ImageStreams, see link:{LinkCreatingManagingOpenShift
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
@@ -43,11 +43,11 @@ include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-kafka-conn
 oc create -f dbz-connect.yaml
 ----
 +
-Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy.
 After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
 The connector artifacts that you listed in the configuration are available in the cluster.
 
-. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy.
 For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
 +
 .`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
@@ -99,9 +99,9 @@ spec:
 |The password that {prodname} uses to connect to the database user account.
 
 |8
-|The topic prefix for the database instance or cluster. +
-The specified name must be formed only from alphanumeric characters or underscores. +
-Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+a|The topic prefix for the database instance or cluster.
+The specified name must be formed only from alphanumeric characters or underscores.
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster.
 This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
 
 |9

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -30,7 +30,7 @@ For more information about ImageStreams, see link:{LinkCreatingManagingOpenShift
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
 For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
-The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource.
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
@@ -43,11 +43,11 @@ include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-kafka-conn
 oc create -f dbz-connect.yaml
 ----
 +
-Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy.
 After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
 The connector artifacts that you listed in the configuration are available in the cluster.
 
-. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy.
 For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
 +
 .`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -38,7 +38,7 @@ Skipping should be used only with care as it can lead to data loss or mangling w
 
 |[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+schema.history.internal.store.only.captured.tables.ddl+`>>
 |`false`
-|A Boolean value that specifies whether the connector records schema structures from all tables in a schema or database, or only from tables that are designated for capture. +
+|A Boolean value that specifies whether the connector records schema structures from all tables in a schema or database, or only from tables that are designated for capture.
 Specify one of the following values:
 
 `false` (default):: During a database snapshot, the connector records the schema data for all non-system tables in the database, including tables that are not designated for capture.
@@ -47,15 +47,24 @@ If you later decide to capture changes from tables that you did not originally d
 {prodname} requires the schema history of a table so that it can identify the structure that was present at the time that a change event occurred.
 
 `true`:: During a database snapshot, the connector records the table schemas only for the tables from which {prodname} captures change events.
-If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables. +
+If you change the default value, and you later configure the connector to capture data from other tables in the database, the connector lacks the schema information that it requires to capture change events from the tables.
 
 |[[{context}-property-database-history-store-only-captured-databases-ddl]]<<{context}-property-database-history-store-only-captured-databases-ddl, `+schema.history.internal.store.only.captured.databases.ddl+`>>
 |
 include::{snippetsdir}/frag-{context}-props-snippets.adoc[leveloffset=+1,tags=schema-hist-prop-store-only-cap-db-ddl-boolean]
-|A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance. +
+|A Boolean value that specifies whether the connector records schema structures from all logical databases in the database instance.
 Specify one of the following values:
 
 `true`:: The connector records schema structures only for tables in the logical database and schema from which {prodname} captures change events.
 `false`:: The connector records schema structures for all logical databases.
+
+|[[{context}-property-database-history-memory-optimization]]<<{context}-property-database-history-memory-optimization, `+schema.history.internal.memory.optimization+`>>
+|`off`
+|Controls how {prodname} deduplicates identical schema objects (tables, columns, attributes) in memory using an interner.
+Specify one of the following values:
+
+`off`:: No deduplication is performed (the default).
+`on`:: Each connector uses its own isolated intern pool. Reduces heap usage within a single connector without interfering with other connectors.
+`shared`:: All connectors configured with `shared` share a single global intern pool. Maximises deduplication when many connectors track tables with similar structures.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/db2-frag-signaling-fq-table-formats.adoc
@@ -8,7 +8,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*public*` schema and that has the name `*My.Table*`, use the following format: `*"public.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/informix-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/informix-frag-signaling-fq-table-formats.adoc
@@ -9,7 +9,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*public*` schema in the `*db1*` database, and that has the name `*My.Table*`, use the following format: `*"db1.public.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mariadb-frag-signaling-fq-table-formats.adoc
@@ -9,7 +9,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*db1*` database, and that has the name `*My.Table*`, use the following format: `*"db1.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/mysql-frag-signaling-fq-table-formats.adoc
@@ -8,7 +8,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*db1*` database, and that has the name `*My.Table*`, use the following format: `*"db1.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/oracle-frag-signaling-fq-table-formats.adoc
@@ -8,7 +8,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*public*` schema in the `*db1*` database, and that has the name `*My.Table*`, use the following format: `*"db1.public.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/postgresql-frag-signaling-fq-table-formats.adoc
@@ -9,7 +9,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*public*` schema and that has the name `*My.Table*`, use the following format: `*"public.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]

--- a/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
+++ b/documentation/modules/ROOT/partials/modules/snippets/sqlserver-frag-signaling-fq-table-formats.adoc
@@ -9,7 +9,7 @@
 tag::fq-table-name-format-note[]
 [NOTE]
 ====
-If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes. +
+If the name of a table that you want to include in a snapshot contains a dot (`.`), a space, or some other non-alphanumeric character, you must escape the table name in double quotes.
 For example, to include a table that exists in the `*public*` schema in the `*db1*` database, and that has the name `*My.Table*`, use the following format: `*"db1.public.\"My.Table\""*`.
 ====
 end::fq-table-name-format-note[]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Applies [DBZ-9922](https://redhat.atlassian.net/browse/DBZ-9922) changes to `3.6`
## Description
Removes hard line breaks from database history, deployment, signaling, and snapshot partials files.
Tested in local Antora build.
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
