### PR TITLE
debezium/dbz#304 Refresh cached enum metadata when a value is added at streaming time

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -136,20 +136,60 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
     }
 
     private DataCollectionSchema synchronizeTableSchema(DataCollectionSchema tableSchema) {
-        if (getOperation() == Operation.DELETE || !message.shouldSchemaBeSynchronized()) {
+        if (getOperation() == Operation.DELETE) {
             return tableSchema;
         }
         final TableId tableId = (TableId) tableSchema.id();
-        final Table table = schema.tableFor(tableId);
         final List<ReplicationMessage.Column> columns = message.getNewTupleList();
+        // dbz#304 ALTER TYPE ... ADD VALUE keeps the column's type OID, so the added value is invisible
+        // both to schemaChanged() and to the pgoutput RELATION messages. Refresh the stale enum metadata
+        // regardless of the decoder's shouldSchemaBeSynchronized() so the rebuilt schema exposes it.
+        final boolean enumRefreshed = refreshStaleEnumTypes(columns);
+        if (!message.shouldSchemaBeSynchronized()) {
+            if (enumRefreshed) {
+                refreshTableFromDatabase(tableId);
+                return schema.schemaFor(tableId);
+            }
+            return tableSchema;
+        }
+        final Table table = schema.tableFor(tableId);
         // check if we need to refresh our local schema due to DB schema changes for this table
-        if (schemaChanged(columns, table)) {
+        if (enumRefreshed || schemaChanged(columns, table)) {
             // Refresh the schema so we get information about primary keys
             refreshTableFromDatabase(tableId);
             // Update the schema with metadata coming from decoder message
             schema.refresh(tableFromFromMessage(columns, schema.tableFor(tableId)));
         }
         return schema.schemaFor(tableId);
+    }
+
+    /**
+     * Detects enum columns whose incoming value is missing from the cached enum type metadata
+     * (the result of an {@code ALTER TYPE ... ADD VALUE}) and refreshes those types from the
+     * database so the rebuilt schema exposes the up-to-date list of allowed values.
+     *
+     * @param columns the columns of the current replication message
+     * @return {@code true} if at least one enum type was refreshed
+     */
+    private boolean refreshStaleEnumTypes(List<ReplicationMessage.Column> columns) {
+        if (columns == null) {
+            return false;
+        }
+        boolean refreshed = false;
+        for (ReplicationMessage.Column column : columns) {
+            final PostgresType type = column.getType();
+            if (!type.isEnumType()) {
+                continue;
+            }
+            final Object value = column.getValue(() -> connection.connection().unwrap(BaseConnection.class),
+                    connectorConfig.includeUnknownDatatypes());
+            if (value instanceof String && !type.getEnumValues().contains(value)) {
+                LOGGER.info("Detected new value '{}' for enum type '{}'; refreshing type metadata", value, type.getName());
+                connection.getTypeRegistry().refresh(type.getOid());
+                refreshed = true;
+            }
+        }
+        return refreshed;
     }
 
     private Object[] columnValues(List<ReplicationMessage.Column> columns, TableId tableId, boolean refreshSchemaIfChanged,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -5,8 +5,10 @@
  */
 package io.debezium.connector.postgresql;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.postgresql.core.Oid;
 import org.postgresql.core.TypeInfo;
@@ -29,13 +31,13 @@ public class PostgresType {
     private final PostgresType elementType;
     private final TypeInfo typeInfo;
     private final int modifiers;
-    private final List<String> enumValues;
+    private final Set<String> enumValues;
 
-    private PostgresType(String name, int oid, int jdbcId, TypeInfo typeInfo, List<String> enumValues, PostgresType parentType, PostgresType elementType) {
+    private PostgresType(String name, int oid, int jdbcId, TypeInfo typeInfo, Set<String> enumValues, PostgresType parentType, PostgresType elementType) {
         this(name, oid, jdbcId, TypeRegistry.NO_TYPE_MODIFIER, typeInfo, enumValues, parentType, elementType);
     }
 
-    private PostgresType(String name, int oid, int jdbcId, int modifiers, TypeInfo typeInfo, List<String> enumValues, PostgresType parentType, PostgresType elementType) {
+    private PostgresType(String name, int oid, int jdbcId, int modifiers, TypeInfo typeInfo, Set<String> enumValues, PostgresType parentType, PostgresType elementType) {
         Objects.requireNonNull(name);
         this.name = name;
         this.oid = oid;
@@ -124,7 +126,7 @@ public class PostgresType {
         return rootType;
     }
 
-    public List<String> getEnumValues() {
+    public Set<String> getEnumValues() {
         return enumValues;
     }
 
@@ -308,7 +310,11 @@ public class PostgresType {
                 elementType = typeRegistry.get(elementTypeOid);
             }
 
-            return new PostgresType(name, oid, jdbcId, modifiers, typeInfo, enumValues, parentType, elementType);
+            // PostgreSQL enforces uniqueness of enum labels, so a LinkedHashSet preserves their
+            // sort order while giving O(1) membership checks on the streaming hot path.
+            Set<String> enumValueSet = enumValues == null ? null : new LinkedHashSet<>(enumValues);
+
+            return new PostgresType(name, oid, jdbcId, modifiers, typeInfo, enumValueSet, parentType, elementType);
         }
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -395,7 +396,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 }
                 else if (resolvedType.isArrayType()) {
                     if (resolvedType.getElementType().isEnumType()) {
-                        List<String> enumValues = resolvedType.getElementType().getEnumValues();
+                        Set<String> enumValues = resolvedType.getElementType().getEnumValues();
                         return SchemaBuilder.array(io.debezium.data.Enum.builder(Strings.join(",", enumValues)));
                     }
                     else {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -256,6 +256,27 @@ public class TypeRegistry {
     }
 
     /**
+     * Re-reads the type with the given OID from the database and replaces the cached entry. This
+     * is needed to pick up in-place type changes such as {@code ALTER TYPE ... ADD VALUE} on an
+     * enum, which keep the same OID and are therefore invisible to the regular schema-change
+     * detection.
+     *
+     * @param oid the PostgreSQL type OID to refresh
+     * @return the refreshed type, or {@link PostgresType#UNKNOWN} if it can no longer be resolved
+     */
+    public PostgresType refresh(int oid) {
+        // Evict the cached entries first: addType() keeps the first mapping for a given name, so
+        // without this the name-keyed lookups (used by the pgoutput decoder) would keep returning
+        // the stale type even though the oid-keyed entry is overwritten.
+        final PostgresType stale = oidToType.remove(oid);
+        if (stale != null) {
+            nameToType.values().removeIf(type -> type.getOid() == oid);
+        }
+        final PostgresType refreshed = resolveUnknownType(oid);
+        return refreshed != null ? refreshed : PostgresType.UNKNOWN;
+    }
+
+    /**
      *
      * @param schemaName - PostgreSQL schema name
      * @param typeName - PostgreSQL type name

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -3355,6 +3355,45 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#304")
+    public void shouldRefreshSchemaWhenEnumValueAddedViaAlterType() throws Exception {
+        // The enum type and column already exist before streaming starts, so the column's
+        // type OID never changes. Adding a value with ALTER TYPE ... ADD VALUE must still
+        // refresh the cached enum metadata; otherwise the emitted schema keeps the stale
+        // allowed-values list and omits the new value.
+        TestHelper.execute("CREATE TYPE test_type AS ENUM ('V1');");
+        TestHelper.execute("CREATE TABLE enum_table (pk SERIAL, value test_type NOT NULL, PRIMARY KEY (pk));");
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with("column.propagate.source.type", "public.enum_table.value")
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.enum_table"), false);
+
+        waitForStreamingToStart();
+
+        // Add a new enum value after streaming started to simulate a future schema change.
+        TestHelper.execute("ALTER TYPE test_type ADD VALUE 'V2'");
+
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO enum_table (value) VALUES ('V2');");
+
+        SourceRecord rec = assertRecordInserted("public.enum_table", PK_FIELD, 1);
+        assertSourceInfo(rec, "postgres", "public", "enum_table");
+
+        List<SchemaAndValueField> expected = Arrays.asList(
+                new SchemaAndValueField(PK_FIELD, SchemaBuilder.int32().defaultValue(0).build(), 1),
+                new SchemaAndValueField("value", Enum.builder("V1,V2")
+                        .parameter(TestHelper.TYPE_NAME_PARAMETER_KEY, "TEST_TYPE")
+                        .parameter(TestHelper.TYPE_LENGTH_PARAMETER_KEY, String.valueOf(Integer.MAX_VALUE))
+                        .parameter(TestHelper.TYPE_SCALE_PARAMETER_KEY, "0")
+                        .parameter(TestHelper.COLUMN_NAME_PARAMETER_KEY, "value")
+                        .build(), "V2"));
+
+        assertRecordSchemaAndValues(expected, rec, Envelope.FieldName.AFTER);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+
+    @Test
     @FixFor("DBZ-5038")
     public void shouldEmitEnumColumnDefaultValuesInSchema() throws Exception {
         // Specifically enable `column.propagate.source.type` here to validate later that the actual


### PR DESCRIPTION
Fixes debezium/dbz#304

## Problem

When an `ALTER TYPE <enum> ADD VALUE '<x>'` is executed while the connector is streaming, the enum column's type OID does not change. As a result the change is invisible to `PostgresChangeRecordEmitter.schemaChanged()` (which only reacts to column count / OID changes) and, for `pgoutput`, no new `RELATION` message is emitted either. The cached `PostgresType` therefore keeps its stale list of allowed values, and the emitted record schema advertises an incomplete enum:

```
allowed = "V1"        // expected "V1,V2"
```

The value itself is still streamed correctly as a string, but Avro / schema-registry consumers reject records carrying a value that is absent from the schema's `allowed` parameter.

This affects **both** logical-decoding plugins:
- `decoderbufs`: `schemaChanged()` never returns `true` for the added value.
- `pgoutput`: `shouldSchemaBeSynchronized()` is `false` (it relies on `RELATION` messages), so the schema is never re-synchronized at all — and `ALTER TYPE ... ADD VALUE` produces no `RELATION` message.

## Fix

- `TypeRegistry.refresh(int oid)` re-reads a type from the database and evicts both the oid-keyed and name-keyed cache entries (the latter is required because `addType()` keeps the first mapping for a given name, and the `pgoutput` decoder resolves column types by name on every row — without evicting it the lookup would stay stale and re-trigger a refresh on every subsequent row).
- `PostgresChangeRecordEmitter` detects, for either plugin, an enum column whose incoming value is missing from the cached type and refreshes that type before the table schema is rebuilt. This runs regardless of `shouldSchemaBeSynchronized()` so `pgoutput` is covered as well.

The behaviour is best-effort, as discussed on the original PR debezium/debezium#1477: the schema is updated when the first row carrying the new value arrives, and removed enum values are not detected.

## Testing

- Added `RecordsStreamProducerIT#shouldRefreshSchemaWhenEnumValueAddedViaAlterType`, which fails before the change (`allowed="V1"`) and passes after (`allowed="V1,V2"`).
- Verified on a live PostgreSQL 17 database with **both** `decoderbufs` and `pgoutput`; the existing enum and streaming tests pass on both.

## Notes / scope

Limited to scalar enum columns (the reported case). Enum arrays (`enum[]`) and domain types built on top of an enum are out of scope and could be addressed as follow-ups.
