### PR TITLE
debezium/dbz#2100 Bind PostgreSQL native array types to their element type

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.apache.kafka.connect.data.Schema;
 
@@ -24,6 +26,19 @@ public class ArrayType extends AbstractType {
 
     public static final ArrayType INSTANCE = new ArrayType();
 
+    /**
+     * PostgreSQL native array types whose element the source emits with a generic {@code STRING} or
+     * {@link io.debezium.data.Json} element schema, so the real element type cannot be recovered from
+     * the element schema alone. For these the element type is taken from the array field's propagated
+     * source column type instead. Numeric arrays are deliberately excluded: their element schema
+     * carries the precision/scale (e.g. {@code numeric(10,2)}) that must be preserved. {@code json} is
+     * excluded too: unlike {@code jsonb} it already resolves correctly from the element schema.
+     */
+    private static final Set<String> NATIVE_ELEMENT_TYPES = Set.of(
+            "inet", "cidr", "macaddr", "macaddr8",
+            "int4range", "int8range", "numrange", "tsrange", "tstzrange", "daterange",
+            "jsonb");
+
     @Override
     public String[] getRegistrationKeys() {
         return new String[]{ "ARRAY" };
@@ -35,8 +50,25 @@ public class ArrayType extends AbstractType {
     }
 
     private String getElementTypeName(DatabaseDialect dialect, Schema schema, boolean isKey) {
+        final String nativeElementType = nativeElementTypeName(getSourceColumnType(schema).orElse(null));
+        if (nativeElementType != null) {
+            return nativeElementType;
+        }
         JdbcType elementJdbcType = dialect.getSchemaType(schema.valueSchema());
         return elementJdbcType.getTypeName(schema.valueSchema(), isKey);
+    }
+
+    /**
+     * Maps an array source column type to its element type name, e.g. {@code _INET} to {@code inet}
+     * (PostgreSQL names an array type after its element with a {@code _} prefix). Returns {@code null}
+     * for anything not in {@link #NATIVE_ELEMENT_TYPES} so other arrays keep resolving via the element schema.
+     */
+    static String nativeElementTypeName(String arraySourceColumnType) {
+        if (arraySourceColumnType == null || !arraySourceColumnType.startsWith("_")) {
+            return null;
+        }
+        final String elementType = arraySourceColumnType.substring(1).toLowerCase(Locale.ROOT);
+        return NATIVE_ELEMENT_TYPES.contains(elementType) ? elementType : null;
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -49,4 +49,42 @@ class ArrayTypeTest {
         assertThat(ArrayType.baseElementTypeName("NUMERIC(10,2)")).isEqualTo("numeric");
         assertThat(ArrayType.baseElementTypeName("VARCHAR(255)[]")).isEqualTo("varchar");
     }
+
+    @Test
+    @DisplayName("Should resolve native array element types from the array source column type")
+    void testResolvesNativeElementType() {
+        // dbz#2100 case 11: the source emits inet[]/cidr[]/macaddr[]/range[]/jsonb[] with a generic
+        // STRING (or Json) element schema, so the element type is recovered from the "_"-prefixed
+        // array type propagated on the array field, e.g. "_INET" -> "inet".
+        assertThat(ArrayType.nativeElementTypeName("_INET")).isEqualTo("inet");
+        assertThat(ArrayType.nativeElementTypeName("_CIDR")).isEqualTo("cidr");
+        assertThat(ArrayType.nativeElementTypeName("_MACADDR")).isEqualTo("macaddr");
+        assertThat(ArrayType.nativeElementTypeName("_MACADDR8")).isEqualTo("macaddr8");
+        assertThat(ArrayType.nativeElementTypeName("_TSRANGE")).isEqualTo("tsrange");
+        assertThat(ArrayType.nativeElementTypeName("_TSTZRANGE")).isEqualTo("tstzrange");
+        assertThat(ArrayType.nativeElementTypeName("_DATERANGE")).isEqualTo("daterange");
+        assertThat(ArrayType.nativeElementTypeName("_INT4RANGE")).isEqualTo("int4range");
+        assertThat(ArrayType.nativeElementTypeName("_INT8RANGE")).isEqualTo("int8range");
+        assertThat(ArrayType.nativeElementTypeName("_NUMRANGE")).isEqualTo("numrange");
+        assertThat(ArrayType.nativeElementTypeName("_JSONB")).isEqualTo("jsonb");
+    }
+
+    @Test
+    @DisplayName("Should not override numeric or other precision-bearing arrays")
+    void testDoesNotOverrideNumericArray() {
+        // numeric[] must keep resolving through the element schema so numeric(10,2) precision survives.
+        assertThat(ArrayType.nativeElementTypeName("_NUMERIC")).isNull();
+        assertThat(ArrayType.nativeElementTypeName("_TEXT")).isNull();
+        assertThat(ArrayType.nativeElementTypeName("_INT4")).isNull();
+        assertThat(ArrayType.nativeElementTypeName("_UUID")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should return null when no array source column type is available")
+    void testNullWhenNoArraySourceType() {
+        // Column type propagation disabled, or a non-array (no leading underscore) type.
+        assertThat(ArrayType.nativeElementTypeName(null)).isNull();
+        assertThat(ArrayType.nativeElementTypeName("INET")).isNull();
+        assertThat(ArrayType.nativeElementTypeName("")).isNull();
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -32,6 +32,7 @@ import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvi
 import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.Json;
 import io.debezium.data.Uuid;
 import io.debezium.doc.FixFor;
 
@@ -624,6 +625,134 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new BigDecimal[]{
                     new BigDecimal("1.25"), new BigDecimal("2.50"), new BigDecimal("-9999999.99") });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithInetArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        assertNativeArrayRoundTrip(factory, insertMode, "_INET", Schema.OPTIONAL_STRING_SCHEMA, "inet[]",
+                Arrays.asList("192.168.1.1", "10.0.0.5"),
+                new String[]{ "192.168.1.1", "10.0.0.5" });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithCidrArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        assertNativeArrayRoundTrip(factory, insertMode, "_CIDR", Schema.OPTIONAL_STRING_SCHEMA, "cidr[]",
+                Arrays.asList("192.168.100.128/25", "10.0.0.0/8"),
+                new String[]{ "192.168.100.128/25", "10.0.0.0/8" });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithMacaddrArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        assertNativeArrayRoundTrip(factory, insertMode, "_MACADDR", Schema.OPTIONAL_STRING_SCHEMA, "macaddr[]",
+                Arrays.asList("08:00:2b:01:02:03", "08:00:2b:01:02:04"),
+                new String[]{ "08:00:2b:01:02:03", "08:00:2b:01:02:04" });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithTsrangeArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        assertNativeArrayRoundTrip(factory, insertMode, "_TSRANGE", Schema.OPTIONAL_STRING_SCHEMA, "tsrange[]",
+                Arrays.asList("[\"2010-01-01 14:30:00\",\"2010-01-01 15:30:00\")"),
+                new String[]{ "[\"2010-01-01 14:30:00\",\"2010-01-01 15:30:00\")" });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldWorkWithJsonbArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        assertNativeArrayRoundTrip(factory, insertMode, "_JSONB", Json.builder().optional().build(), "jsonb[]",
+                Arrays.asList("{\"a\": 1}", "[1, 2, 3]"),
+                new String[]{ "{\"a\": 1}", "[1, 2, 3]" });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testShouldEvolveNativeArrayColumnToNativeType(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        // With schema evolution on, the sink auto-creates the column: _inet (inet[]) after the fix, _text before.
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .parameter("__debezium.source.column.type", "_INET")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", arraySchema, Arrays.asList("192.168.1.1", "10.0.0.5"), config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "_inet");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            final Object[] actual = (Object[]) rs.getArray(2).getArray();
+            assertThat(Arrays.stream(actual).map(String::valueOf).toArray(String[]::new))
+                    .isEqualTo(new String[]{ "192.168.1.1", "10.0.0.5" });
+            return null;
+        });
+    }
+
+    /**
+     * Round-trips a record into a pre-created native array column ({@code schema.evolution=none}), with the
+     * array type carried on the field's {@code __debezium.source.column.type} as the source emits it (e.g. {@code _INET}).
+     */
+    private void assertNativeArrayRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode,
+                                            String sourceColumnType, Schema elementSchema, String columnType,
+                                            List<?> values, String[] expected)
+            throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema arraySchema = SchemaBuilder.array(elementSchema)
+                .optional()
+                .parameter("__debezium.source.column.type", sourceColumnType)
+                .build();
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", arraySchema, values, config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(String.format("CREATE TABLE %s (id int not null, data %s, primary key(id))",
+                destinationTable, columnType));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            // Native types such as inet/macaddr come back as driver-specific objects (PGobject) rather
+            // than String, so compare on their textual form which is stable across both representations.
+            final Object[] actual = (Object[]) rs.getArray(2).getArray();
+            assertThat(Arrays.stream(actual).map(String::valueOf).toArray(String[]::new)).isEqualTo(expected);
             return null;
         });
     }


### PR DESCRIPTION
Fixes debezium/dbz#2100, case 11.

## Description
PostgreSQL emits native array columns (`inet`, `cidr`, `macaddr`, `macaddr8`, the range types and `jsonb`) with a generic `STRING`/`Json` element schema, so the JDBC sink resolved the array element type from the element schema alone and produced `text[]`/`json[]`. Binding to a native array column then failed with `column "data" is of type inet[] but expression is of type text[]`.

The discriminating type is propagated on the array *field* schema as its `_`-prefixed array type name (e.g. `_INET`). This resolves the element type from there for the affected native types. Numeric arrays keep resolving through the element schema so `numeric(10,2)` precision (dbz#2100 case 8) is preserved; a narrow allowlist keeps every other array's resolution unchanged.

Verified with unit tests (`ArrayTypeTest`), integration tests (`JdbcSinkColumnTypeMappingIT` inet/cidr/macaddr/tsrange/jsonb round-trips plus a schema-evolution case asserting the auto-created `inet[]` column), and a full source→sink end-to-end run where native `inet[]`/`tsrange[]`/`jsonb[]` columns were auto-created and values preserved.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`