### PR TITLE
debezium/dbz#960 Allow filtering SQL Server CDC capture instances by name

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -560,11 +560,15 @@ public class SqlServerConnection extends JdbcConnection {
         final ResultSetMapper<List<SqlServerChangeTable>> mapper = rs -> {
             final List<SqlServerChangeTable> changeTables = new ArrayList<>();
             while (rs.next()) {
+                final String captureInstance = rs.getString(3);
+                if (!config.getCaptureInstanceFilter().test(captureInstance)) {
+                    continue;
+                }
                 int changeTableObjectId = rs.getInt(4);
                 changeTables.add(
                         new SqlServerChangeTable(
                                 new TableId(databaseName, rs.getString(1), rs.getString(2)),
-                                rs.getString(3),
+                                captureInstance,
                                 changeTableObjectId,
                                 Lsn.valueOf(rs.getBytes(5)),
                                 columns.get(changeTableObjectId)));
@@ -604,8 +608,12 @@ public class SqlServerConnection extends JdbcConnection {
                 rs -> {
                     final List<SqlServerChangeTable> changeTables = new ArrayList<>();
                     while (rs.next()) {
+                        final String captureInstance = rs.getString(4);
+                        if (!config.getCaptureInstanceFilter().test(captureInstance)) {
+                            continue;
+                        }
                         changeTables.add(new SqlServerChangeTable(
-                                rs.getString(4),
+                                captureInstance,
                                 rs.getInt(1),
                                 Lsn.valueOf(rs.getBytes(5))));
                     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -500,16 +500,16 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withDescription("Specifies the maximum number of rows that should be read in one go from each table while streaming. "
                     + "The connector will read the table contents in multiple batches of this size. Defaults to 0 which means no limit.");
 
-    public static final Field CAPTURE_INSTANCE_INCLUDE_LIST = Field.create("capture.instance.include.list")
+    public static final Field CAPTURE_INSTANCE_INCLUDE_LIST = Field.createInternal("capture.instance.include.list")
             .withDisplayName("Include capture instances")
             .withType(Type.LIST)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withValidation(Field::isListOfRegex)
             .withDescription("A comma-separated list of regular expressions that match the names of the CDC capture instances to include for streaming. "
-                    + "When set, only matching capture instances are used. May not be used with '" + "capture.instance.exclude.list" + "'.");
+                    + "When set, only matching capture instances are used. May not be used with '" + Field.INTERNAL_PREFIX + "capture.instance.exclude.list" + "'.");
 
-    public static final Field CAPTURE_INSTANCE_EXCLUDE_LIST = Field.create("capture.instance.exclude.list")
+    public static final Field CAPTURE_INSTANCE_EXCLUDE_LIST = Field.createInternal("capture.instance.exclude.list")
             .withDisplayName("Exclude capture instances")
             .withType(Type.LIST)
             .withWidth(Width.LONG)
@@ -518,7 +518,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withDescription("A comma-separated list of regular expressions that match the names of the CDC capture instances to exclude from streaming. "
                     + "Any capture instance whose name matches is ignored, so the connector never enumerates it or queries its cdc.fn_cdc_get_all_changes_# function. "
                     + "Useful when several capture instances exist for the same source table (for example one the connector's account is not granted to read). "
-                    + "May not be used with '" + "capture.instance.include.list" + "'.");
+                    + "May not be used with '" + CAPTURE_INSTANCE_INCLUDE_LIST.name() + "'.");
 
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("SQL Server")

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -28,6 +30,7 @@ import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.document.Document;
+import io.debezium.function.Predicates;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
@@ -497,6 +500,26 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withDescription("Specifies the maximum number of rows that should be read in one go from each table while streaming. "
                     + "The connector will read the table contents in multiple batches of this size. Defaults to 0 which means no limit.");
 
+    public static final Field CAPTURE_INSTANCE_INCLUDE_LIST = Field.create("capture.instance.include.list")
+            .withDisplayName("Include capture instances")
+            .withType(Type.LIST)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(Field::isListOfRegex)
+            .withDescription("A comma-separated list of regular expressions that match the names of the CDC capture instances to include for streaming. "
+                    + "When set, only matching capture instances are used. May not be used with '" + "capture.instance.exclude.list" + "'.");
+
+    public static final Field CAPTURE_INSTANCE_EXCLUDE_LIST = Field.create("capture.instance.exclude.list")
+            .withDisplayName("Exclude capture instances")
+            .withType(Type.LIST)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(Field::isListOfRegex, SqlServerConnectorConfig::validateCaptureInstanceExcludeList)
+            .withDescription("A comma-separated list of regular expressions that match the names of the CDC capture instances to exclude from streaming. "
+                    + "Any capture instance whose name matches is ignored, so the connector never enumerates it or queries its cdc.fn_cdc_get_all_changes_# function. "
+                    + "Useful when several capture instances exist for the same source table (for example one the connector's account is not granted to read). "
+                    + "May not be used with '" + "capture.instance.include.list" + "'.");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("SQL Server")
             .excluding(
@@ -506,7 +529,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     RelationalDatabaseConnectorConfig.DATABASE_NAME)
             .group(Field.Group.CONNECTION, DATABASE_NAMES, HOSTNAME, PORT, USER, PASSWORD, QUERY_TIMEOUT_MS, INSTANCE)
             .group(Field.Group.CONNECTOR, BINARY_HANDLING_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, DATA_QUERY_MODE, SOURCE_INFO_STRUCT_MAKER)
-            .group(Field.Group.CONNECTOR_ADVANCED, MAX_TRANSACTIONS_PER_ITERATION, QUERY_FETCH_SIZE, STREAMING_FETCH_SIZE)
+            .group(Field.Group.CONNECTOR_ADVANCED, MAX_TRANSACTIONS_PER_ITERATION, QUERY_FETCH_SIZE, STREAMING_FETCH_SIZE,
+                    CAPTURE_INSTANCE_INCLUDE_LIST, CAPTURE_INSTANCE_EXCLUDE_LIST)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_ISOLATION_MODE, INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE, INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .create();
@@ -532,6 +556,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final int queryFetchSize;
     private final DataQueryMode dataQueryMode;
     private final int streamingFetchSize;
+    private final Predicate<String> captureInstanceFilter;
 
     public SqlServerConnectorConfig(Configuration config) {
         super(
@@ -582,6 +607,34 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         this.dataQueryMode = DataQueryMode.parse(config.getString(DATA_QUERY_MODE), DATA_QUERY_MODE.defaultValueAsString());
         this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
         this.streamingFetchSize = config.getInteger(STREAMING_FETCH_SIZE);
+        this.captureInstanceFilter = buildCaptureInstanceFilter(config);
+    }
+
+    private static Predicate<String> buildCaptureInstanceFilter(Configuration config) {
+        final String includeList = config.getString(CAPTURE_INSTANCE_INCLUDE_LIST);
+        final String excludeList = config.getString(CAPTURE_INSTANCE_EXCLUDE_LIST);
+        final Predicate<String> inclusions = !Strings.isNullOrBlank(includeList) ? Predicates.includes(includeList, Pattern.CASE_INSENSITIVE) : null;
+        final Predicate<String> exclusions = !Strings.isNullOrBlank(excludeList) ? Predicates.excludes(excludeList, Pattern.CASE_INSENSITIVE) : null;
+        if (inclusions == null && exclusions == null) {
+            return captureInstance -> true;
+        }
+        return captureInstance -> {
+            if (inclusions != null && !inclusions.test(captureInstance)) {
+                return false;
+            }
+            return exclusions == null || exclusions.test(captureInstance);
+        };
+    }
+
+    private static int validateCaptureInstanceExcludeList(Configuration config, Field field, Field.ValidationOutput problems) {
+        String includeList = config.getString(CAPTURE_INSTANCE_INCLUDE_LIST);
+        String excludeList = config.getString(CAPTURE_INSTANCE_EXCLUDE_LIST);
+
+        if (includeList != null && excludeList != null) {
+            problems.accept(CAPTURE_INSTANCE_EXCLUDE_LIST, excludeList, "\"%s\" is already specified".formatted(CAPTURE_INSTANCE_INCLUDE_LIST.name()));
+            return 1;
+        }
+        return 0;
     }
 
     public List<String> getDatabaseNames() {
@@ -734,6 +787,15 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         return count;
+    }
+
+    /**
+     * A filter that decides whether a CDC capture instance (by name) should be used by the connector,
+     * derived from {@link #CAPTURE_INSTANCE_INCLUDE_LIST} / {@link #CAPTURE_INSTANCE_EXCLUDE_LIST}.
+     * Defaults to accepting every capture instance when neither option is set.
+     */
+    public Predicate<String> getCaptureInstanceFilter() {
+        return captureInstanceFilter;
     }
 
     public int getStreamingFetchSize() {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -881,5 +882,50 @@ public class SqlServerChangeTableSetIT extends AbstractAsyncEngineConnectorTest 
         Schema colbSchema = records.get(0).valueSchema().field("after").schema().field("colb").schema();
         assertThat(colbSchema.defaultValue()).isNotNull();
         assertThat(colbSchema.defaultValue()).isEqualTo("new_default_value");
+    }
+
+    @Test
+    @FixFor("DBZ-7587")
+    void excludedCaptureInstanceIsNotEnumerated() throws Exception {
+        // tableb already has its default capture instance "dbo_tableb"; add a second one for the same source table.
+        TestHelper.enableTableCdc(connection, "tableb", "tableb_v2");
+
+        // Without a filter, both capture instances of tableb are enumerated.
+        assertThat(captureInstancesFor(connection, "dbo", "tableb"))
+                .containsExactlyInAnyOrder("dbo_tableb", "tableb_v2");
+
+        // With the second instance excluded, only the default one is enumerated (its function is never queried).
+        try (SqlServerConnection filtered = TestHelper.testConnection(TestHelper.TEST_DATABASE_1,
+                builder -> builder.with(SqlServerConnectorConfig.CAPTURE_INSTANCE_EXCLUDE_LIST, "tableb_v2"))) {
+            filtered.connect();
+            assertThat(captureInstancesFor(filtered, "dbo", "tableb"))
+                    .containsExactly("dbo_tableb");
+            // Capture instances of other tables are unaffected.
+            assertThat(captureInstancesFor(filtered, "dbo", "tablea"))
+                    .containsExactly("dbo_tablea");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-7587")
+    void includeListLimitsEnumerationToMatchingCaptureInstances() throws Exception {
+        TestHelper.enableTableCdc(connection, "tableb", "tableb_v2");
+
+        try (SqlServerConnection filtered = TestHelper.testConnection(TestHelper.TEST_DATABASE_1,
+                builder -> builder.with(SqlServerConnectorConfig.CAPTURE_INSTANCE_INCLUDE_LIST, "dbo_table.*"))) {
+            filtered.connect();
+            // Only capture instances whose names match the include pattern survive; "tableb_v2" does not.
+            assertThat(captureInstancesFor(filtered, "dbo", "tableb"))
+                    .containsExactly("dbo_tableb");
+            assertThat(captureInstancesFor(filtered, "dbo", "tablea"))
+                    .containsExactly("dbo_tablea");
+        }
+    }
+
+    private static List<String> captureInstancesFor(SqlServerConnection connection, String schema, String table) throws SQLException {
+        return connection.getChangeTables(TestHelper.TEST_DATABASE_1).stream()
+                .filter(ct -> schema.equals(ct.getSourceTableId().schema()) && table.equals(ct.getSourceTableId().table()))
+                .map(SqlServerChangeTable::getCaptureInstance)
+                .collect(Collectors.toList());
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -885,7 +885,7 @@ public class SqlServerChangeTableSetIT extends AbstractAsyncEngineConnectorTest 
     }
 
     @Test
-    @FixFor("DBZ-7587")
+    @FixFor("debezium/dbz#960")
     void excludedCaptureInstanceIsNotEnumerated() throws Exception {
         // tableb already has its default capture instance "dbo_tableb"; add a second one for the same source table.
         TestHelper.enableTableCdc(connection, "tableb", "tableb_v2");
@@ -907,7 +907,7 @@ public class SqlServerChangeTableSetIT extends AbstractAsyncEngineConnectorTest 
     }
 
     @Test
-    @FixFor("DBZ-7587")
+    @FixFor("debezium/dbz#960")
     void includeListLimitsEnumerationToMatchingCaptureInstances() throws Exception {
         TestHelper.enableTableCdc(connection, "tableb", "tableb_v2");
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +105,54 @@ public class SqlServerConnectorConfigTest {
                         .with(SqlServerConnectorConfig.QUERY_FETCH_SIZE, 20_000)
                         .build());
         assertEquals(connectorConfig.getQueryFetchSize(), 20_000);
+    }
+
+    @Test
+    void captureInstanceFilterAppliesIncludeAndExcludeLists() {
+        // No list configured: every capture instance is accepted.
+        assertTrue(captureInstanceFilter(null, null).test("anything"));
+
+        // Include list: only matching instances are accepted.
+        final Predicate<String> included = captureInstanceFilter("dbo_tablea,dbo_tableb", null);
+        assertTrue(included.test("dbo_tablea"));
+        assertTrue(included.test("dbo_tableb"));
+        assertFalse(included.test("dbo_tablec"));
+
+        // Exclude list: matching instances are rejected, everything else accepted.
+        final Predicate<String> excluded = captureInstanceFilter(null, "dbo_tableb");
+        assertFalse(excluded.test("dbo_tableb"));
+        assertTrue(excluded.test("dbo_tablea"));
+    }
+
+    @Test
+    void captureInstanceFilterMatchingIsAnchoredAndCaseInsensitive() {
+        final Predicate<String> filter = captureInstanceFilter(null, "dbo_table.*");
+        // Case-insensitive.
+        assertFalse(filter.test("DBO_TableA"));
+        // Anchored: a leading segment that is not part of the pattern must not match.
+        assertTrue(filter.test("other_dbo_tablea"));
+    }
+
+    @Test
+    void captureInstanceIncludeAndExcludeListsAreMutuallyExclusive() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig()
+                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB1")
+                        .with(SqlServerConnectorConfig.CAPTURE_INSTANCE_INCLUDE_LIST, "dbo_tablea")
+                        .with(SqlServerConnectorConfig.CAPTURE_INSTANCE_EXCLUDE_LIST, "dbo_tableb")
+                        .build());
+        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    private Predicate<String> captureInstanceFilter(String includeList, String excludeList) {
+        final Configuration.Builder config = defaultConfig();
+        if (includeList != null) {
+            config.with(SqlServerConnectorConfig.CAPTURE_INSTANCE_INCLUDE_LIST, includeList);
+        }
+        if (excludeList != null) {
+            config.with(SqlServerConnectorConfig.CAPTURE_INSTANCE_EXCLUDE_LIST, excludeList);
+        }
+        return new SqlServerConnectorConfig(config.build()).getCaptureInstanceFilter();
     }
 
     private Configuration.Builder defaultConfig() {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.management.InstanceNotFoundException;
@@ -268,6 +269,17 @@ public class TestHelper {
                 .build();
 
         return testConnection(config);
+    }
+
+    /**
+     * Returns a connection to the given database whose connector config carries the additional options applied by the
+     * supplied customizer, e.g. {@code internal.capture.instance.exclude.list}.
+     */
+    public static SqlServerConnection testConnection(String databaseName, Consumer<Configuration.Builder> customizer) {
+        Configuration.Builder builder = defaultConnectorConfig()
+                .with(ConfigurationNames.DATABASE_CONFIG_PREFIX + JdbcConfiguration.ON_CONNECT_STATEMENTS, "USE [" + databaseName + "]");
+        customizer.accept(builder);
+        return testConnection(builder.build());
     }
 
     public static SqlServerConnection testConnection(Configuration config) {

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3539,23 +3539,6 @@ Set the value to `0` (zero) to remove the timeout limit.
 |Specifies the maximum number of rows that should be read in one go from each table while streaming.
 The connector will read the table contents in multiple batches of this size. Defaults to `0` which means no limit.
 
-|[[sqlserver-property-capture-instance-include-list]]<<sqlserver-property-capture-instance-include-list, `+capture.instance.include.list+`>>
-|No default
-|An optional, comma-separated list of regular expressions that match the names of the CDC capture instances to stream from.
-The connector uses only capture instances whose names match one of the expressions, and ignores all others.
-Matching is by capture instance name across the connector, not per table.
-Each expression is matched, case-insensitively, against the entire capture instance name.
-Cannot be used with `capture.instance.exclude.list`.
-
-|[[sqlserver-property-capture-instance-exclude-list]]<<sqlserver-property-capture-instance-exclude-list, `+capture.instance.exclude.list+`>>
-|No default
-|An optional, comma-separated list of regular expressions that match the names of the CDC capture instances to ignore.
-The connector streams from every capture instance except those whose names match; an excluded instance is never queried.
-Useful when a table has more than one capture instance and you want to skip one, for example one that the connector's database user cannot read.
-Matching is by capture instance name across the connector, not per table.
-Each expression is matched, case-insensitively, against the entire capture instance name.
-Cannot be used with `capture.instance.include.list`.
-
 |[[sqlserver-property-guardrail-collections-max]]<<sqlserver-property-guardrail-collections-max, `+guardrail.collections.max+`>>
 |`0`
 |Specifies the maximum number of tables that the connector can capture.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -3539,6 +3539,23 @@ Set the value to `0` (zero) to remove the timeout limit.
 |Specifies the maximum number of rows that should be read in one go from each table while streaming.
 The connector will read the table contents in multiple batches of this size. Defaults to `0` which means no limit.
 
+|[[sqlserver-property-capture-instance-include-list]]<<sqlserver-property-capture-instance-include-list, `+capture.instance.include.list+`>>
+|No default
+|An optional, comma-separated list of regular expressions that match the names of the CDC capture instances to stream from.
+The connector uses only capture instances whose names match one of the expressions, and ignores all others.
+Matching is by capture instance name across the connector, not per table.
+Each expression is matched, case-insensitively, against the entire capture instance name.
+Cannot be used with `capture.instance.exclude.list`.
+
+|[[sqlserver-property-capture-instance-exclude-list]]<<sqlserver-property-capture-instance-exclude-list, `+capture.instance.exclude.list+`>>
+|No default
+|An optional, comma-separated list of regular expressions that match the names of the CDC capture instances to ignore.
+The connector streams from every capture instance except those whose names match; an excluded instance is never queried.
+Useful when a table has more than one capture instance and you want to skip one, for example one that the connector's database user cannot read.
+Matching is by capture instance name across the connector, not per table.
+Each expression is matched, case-insensitively, against the entire capture instance name.
+Cannot be used with `capture.instance.include.list`.
+
 |[[sqlserver-property-guardrail-collections-max]]<<sqlserver-property-guardrail-collections-max, `+guardrail.collections.max+`>>
 |`0`
 |Specifies the maximum number of tables that the connector can capture.


### PR DESCRIPTION
Fixes debezium/dbz#960

## Description

SQL Server allows more than one CDC capture instance for the same source table. The connector enumerates every capture instance from `cdc.change_tables` and, on finding more than one for a source table, treats them as a schema-migration pair and streams from each via `cdc.fn_cdc_get_all_changes_<instance>`. When a second, permanent instance exists that the connector's account is not granted to read, this fails with `SELECT permission was denied on the object 'fn_cdc_get_all_changes_<instance>'`, and there is currently no way to exclude it.

This adds two options so operators can select which capture instances the connector uses:

- `internal.capture.instance.include.list` — only stream from capture instances whose names match.
- `internal.capture.instance.exclude.list` — stream from all except capture instances whose names match.

They are comma-separated, anchored, case-insensitive regexes (following the existing `*.include.list` / `*.exclude.list` convention, `Field::isListOfRegex` + an exclude-side mutual-exclusion validator), and are mutually exclusive. The filter is applied when change tables are enumerated (`SqlServerConnection#getChangeTables` / `#getNewChangeTables`), so an excluded instance is never queried.

Integration tests are not yet added; opening as a draft to confirm the direction and naming first.

## AI usage disclosure
<!-- Required by AI_USAGE_POLICY.md. Edit this to accurately reflect YOUR involvement before submitting. -->
I used an AI assistant to help investigate the root cause and draft this change and its documentation. I have reviewed and tested it, understand every line, and take responsibility for it.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
