### PR TITLE
debezium/dbz#815 Document StarRocks update limitations

### DIFF
--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkInsertModeIT.java
@@ -5,12 +5,25 @@
  */
 package io.debezium.connector.jdbc.integration.starrocks;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.InsertMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.SchemaEvolutionMode;
 import io.debezium.connector.jdbc.integration.AbstractJdbcSinkInsertModeTest;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.sink.SinkConnectorConfig.PrimaryKeyMode;
 
 /**
  * Insert mode tests for StarRocks.
@@ -23,5 +36,36 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
 
     public JdbcSinkInsertModeIT(Sink sink) {
         super(sink);
+    }
+
+    @Override
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    public void testInsertModeUpdateWithNoPrimaryKey(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.UPDATE.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord record = factory.createRecordNoKey(topicName, config);
+
+        try {
+            consume(record);
+            // Legacy mode reports a failed put on the next call, while the shared sink
+            // framework reports the failure during the first pre-commit flush.
+            consume(record);
+            fail("Expected StarRocks to reject UPDATE on a Duplicate Key table");
+        }
+        catch (Exception e) {
+            assertExceptionCauseMessage(e, "table .* does not support update");
+        }
+        finally {
+            stopSinkConnector();
+        }
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -85,6 +85,9 @@ StarRocks targets support idempotent writes through the same xref:jdbc-property-
 StarRocks executes `INSERT` statements against PRIMARY KEY tables as upserts, so the connector generates plain `INSERT` statements; `INSERT ... ON DUPLICATE KEY UPDATE ...` is not supported by StarRocks.
 Upsert and delete operations require the destination table to be a StarRocks PRIMARY KEY table.
 Tables that the connector creates automatically from events with key fields are always PRIMARY KEY tables.
+For events without key fields, the connector omits the `PRIMARY KEY` clause, and StarRocks creates its default DUPLICATE KEY table.
+DUPLICATE KEY tables retain rows with duplicate values and support append-only writes, but do not support modifying existing rows.
+As a result, xref:jdbc-property-insert-mode[`insert.mode=update`] cannot be used with xref:jdbc-property-primary-key-mode[`primary.key.mode=none`] when the connector creates the destination table.
 
 If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
 Tables that the connector creates use `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses based on the record key fields.
@@ -321,7 +324,9 @@ To adjust nullability settings or default values, you can introduce a custom sin
 For SingleStore targets, automatic table creation does not configure SingleStore-specific shard keys, sort keys, or other table options.
 For more information, see xref:jdbc-singlestore-targets[].
 
-For StarRocks targets, automatic table creation creates PRIMARY KEY tables from the record key fields, and does not configure StarRocks-specific distribution, partitioning, or other table options.
+For StarRocks targets, automatic table creation creates PRIMARY KEY tables from record key fields.
+For records without key fields, StarRocks creates its default append-only DUPLICATE KEY table.
+Automatic table creation does not configure StarRocks-specific distribution, partitioning, or other table options.
 For more information, see xref:jdbc-starrocks-targets[].
 
 A field's data type is resolved based on a predefined set of mappings.


### PR DESCRIPTION
This follow-up documents that auto-created StarRocks tables without key fields are Duplicate Key tables and do not support UPDATE. It also updates the StarRocks integration test to verify the expected behavior.

Tested with both the legacy and shared sink frameworks.