### PR TITLE
debezium/dbz#2220 Propagate the real pgvector dimension from the PostgreSQL source

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -55,6 +55,16 @@ public class PostgresType {
     }
 
     /**
+     * @return true if this is a pgvector type ({@code vector}, {@code halfvec} or {@code sparsevec}),
+     *         whose dimension is carried verbatim in {@code atttypmod}
+     */
+    public boolean isVector() {
+        return TypeRegistry.TYPE_NAME_VECTOR.equals(name)
+                || TypeRegistry.TYPE_NAME_HALF_VECTOR.equals(name)
+                || TypeRegistry.TYPE_NAME_SPARSE_VECTOR.equals(name);
+    }
+
+    /**
      * The type system allows for the creation of user defined types (UDTs) which can be based
      * on any existing type.  When a type does not extend another type, it is considered to be
      * a base or root type in the type hierarchy.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.relational.Column;
 import io.debezium.util.LRUCacheMap;
 
 /**
@@ -59,6 +60,12 @@ public abstract class AbstractReplicationMessageColumn implements ReplicationMes
             // TODO: make this more elegant/type-specific
             length = type.getDefaultLength();
             scale = type.getDefaultScale();
+            if (type.isVector() && typeModifiers.length == 0) {
+                // A dimensionless vector has no length; getDefaultLength() would yield MAX_VALUE. A
+                // declared dimension is applied from the modifier below.
+                length = Column.UNSET_INT_VALUE;
+                scale = 0;
+            }
             if (typeModifiers.length > 0) {
                 try {
                     final String typMod = typeModifiers[0];

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
@@ -701,7 +702,8 @@ public class PostgresConnection extends JdbcConnection {
 
             // first source the length/scale from the column metadata provided by the driver
             // this may be overridden below if the column type is a user-defined domain type
-            column.length(columnMetadata.getInt(7));
+            final int driverLength = columnMetadata.getInt(7);
+            column.length(driverLength);
             if (columnMetadata.getObject(9) != null) {
                 column.scale(columnMetadata.getInt(9));
             }
@@ -735,6 +737,17 @@ public class PostgresConnection extends JdbcConnection {
                 column.scale(nativeType.getDefaultScale());
             }
 
+            // The driver reports COLUMN_SIZE as MAX_VALUE for vectors (see PostgresType#isVector);
+            // recover the real dimension from the catalog instead.
+            if (nativeType.isVector() && driverLength == Integer.MAX_VALUE) {
+                final OptionalInt dimension = readVectorDimension(tableId, columnName);
+                // Real dimension, or clear the bogus MAX_VALUE for a bare vector so no length is propagated.
+                column.length(dimension.orElse(Column.UNSET_INT_VALUE));
+                if (dimension.isPresent()) {
+                    column.scale(0);
+                }
+            }
+
             final String defaultValueExpression = columnMetadata.getString(13);
             if (defaultValueExpression != null && getDefaultValueConverter().supportConversion(nativeType.getName())) {
                 column.defaultValueExpression(defaultValueExpression);
@@ -744,6 +757,35 @@ public class PostgresConnection extends JdbcConnection {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Reads a pgvector column's dimension from {@code pg_attribute.atttypmod}, which the JDBC driver
+     * cannot expose for these extension types (see {@link PostgresType#isVector()}).
+     *
+     * @return the dimension, or empty when the column has no dimension modifier
+     */
+    private OptionalInt readVectorDimension(TableId tableId, String columnName) throws SQLException {
+        final String schema = tableId.schema() != null && !tableId.schema().isEmpty() ? tableId.schema() : "public";
+        return prepareQueryAndMap(
+                "SELECT a.atttypmod FROM pg_attribute a "
+                        + "JOIN pg_class c ON a.attrelid = c.oid "
+                        + "JOIN pg_namespace n ON c.relnamespace = n.oid "
+                        + "WHERE n.nspname = ? AND c.relname = ? AND a.attname = ? AND a.attnum > 0 AND NOT a.attisdropped",
+                statement -> {
+                    statement.setString(1, schema);
+                    statement.setString(2, tableId.table());
+                    statement.setString(3, columnName);
+                },
+                rs -> {
+                    if (rs.next()) {
+                        final int typmod = rs.getInt(1);
+                        if (typmod > 0) {
+                            return OptionalInt.of(typmod);
+                        }
+                    }
+                    return OptionalInt.empty();
+                });
     }
 
     public PostgresDefaultValueConverter getDefaultValueConverter() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql.connection.pgoutput;
 import io.debezium.annotation.Immutable;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.relational.Column;
 
 /**
  * Defines the relational column mapping for a table.
@@ -52,7 +53,13 @@ public class ColumnMetaData {
         // for specific types and ideally for PgOutput, we should always delegate if a modifier
         // is provided. For now, I've allowed PostgresType to expose the TypeInfo object where
         // I will use it here for now until further research can be done.
-        if (TypeRegistry.NO_TYPE_MODIFIER != typeModifier && postgresType.getTypeInfo() != null) {
+        if (postgresType.isVector()) {
+            // Take the dimension straight from atttypmod: getPrecision() would yield MAX_VALUE (see
+            // PostgresType#isVector). A bare vector without a declared dimension has none.
+            length = TypeRegistry.NO_TYPE_MODIFIER != typeModifier ? typeModifier : Column.UNSET_INT_VALUE;
+            scale = 0;
+        }
+        else if (TypeRegistry.NO_TYPE_MODIFIER != typeModifier && postgresType.getTypeInfo() != null) {
             length = postgresType.getTypeInfo().getPrecision(postgresType.getOid(), typeModifier);
             scale = postgresType.getTypeInfo().getScale(postgresType.getOid(), typeModifier);
         }
@@ -63,7 +70,13 @@ public class ColumnMetaData {
 
         // Constructs a fully qualified type name, including dimensions if applicable
         String type = postgresType.getName();
-        if (!(length == postgresType.getDefaultLength() && scale == 0)) {
+        if (postgresType.isVector()) {
+            // pgvector uses a single dimension modifier, e.g. vector(3) rather than vector(3,0)
+            if (length != Column.UNSET_INT_VALUE) {
+                type += "(" + length + ")";
+            }
+        }
+        else if (!(length == postgresType.getDefaultLength() && scale == 0)) {
             type += "(" + length + "," + scale + ")";
         }
         this.typeName = type;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/VectorDatabaseIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/VectorDatabaseIT.java
@@ -11,6 +11,7 @@ import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,9 @@ import org.junit.jupiter.api.Test;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.doc.FixFor;
 import io.debezium.junit.SkipWhenDatabaseVersion;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 /**
  * Integration test to verify PgVector types.
@@ -38,8 +41,8 @@ public class VectorDatabaseIT extends AbstractRecordsProducerTest {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("init_pgvector.ddl");
         TestHelper.execute(
-                "CREATE TABLE pgvector.table_vector (pk SERIAL, f_vector pgvector.vector(3), f_halfvec pgvector.halfvec(3), f_sparsevec pgvector.sparsevec(3000), PRIMARY KEY(pk));",
-                "INSERT INTO pgvector.table_vector (f_vector, f_halfvec, f_sparsevec) VALUES ('[1,2,3]', '[101,102,103]', '{1: 201, 9: 209}/3000');");
+                "CREATE TABLE pgvector.table_vector (pk SERIAL, f_vector pgvector.vector(3), f_halfvec pgvector.halfvec(3), f_sparsevec pgvector.sparsevec(3000), f_vector_raw pgvector.vector, PRIMARY KEY(pk));",
+                "INSERT INTO pgvector.table_vector (f_vector, f_halfvec, f_sparsevec, f_vector_raw) VALUES ('[1,2,3]', '[101,102,103]', '{1: 201, 9: 209}/3000', '[7,8,9]');");
 
         // Re-initialize the connector framework AFTER database cleanup to ensure clean state
         initializeConnectorTestFramework();
@@ -79,6 +82,56 @@ public class VectorDatabaseIT extends AbstractRecordsProducerTest {
         Assertions.assertThat(rec.getStruct("after").getArray("f_halfvec")).isEqualTo(List.of(110.0f, 120.0f, 130.0f));
         Assertions.assertThat(rec.getStruct("after").getStruct("f_sparsevec").getInt16("dimensions")).isEqualTo((short) 3000);
         Assertions.assertThat(rec.getStruct("after").getStruct("f_sparsevec").getMap("vector")).isEqualTo(Map.of((short) 1, 301.0, (short) 9, 309.0));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2220")
+    void shouldPropagateVectorDimensions() throws Exception {
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(RelationalDatabaseConnectorConfig.PROPAGATE_COLUMN_SOURCE_TYPE, ".*")
+                .build());
+        assertConnectorIsRunning();
+
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO pgvector.table_vector (f_vector, f_halfvec, f_sparsevec) VALUES ('[10,20,30]', '[110,120,130]', '{1: 301, 9: 309}/3000');");
+
+        var actualRecords = consumeRecordsByTopic(2);
+        var recs = actualRecords.recordsForTopic("test_server.pgvector.table_vector");
+        Assertions.assertThat(recs).hasSize(2);
+
+        // The first record is the snapshot read, the second is the streamed insert. Both paths must
+        // propagate the real pgvector dimension instead of Integer.MAX_VALUE (dbz#2220).
+        for (var record : recs) {
+            var after = ((Struct) record.value()).schema().field("after").schema();
+            assertPropagatedLength(after, "f_vector", "3");
+            assertPropagatedLength(after, "f_halfvec", "3");
+            assertPropagatedLength(after, "f_sparsevec", "3000");
+            // A bare vector has no declared dimension, so no length must be propagated (rather than
+            // the bogus Integer.MAX_VALUE).
+            assertNoPropagatedLength(after, "f_vector_raw");
+        }
+    }
+
+    private static void assertPropagatedLength(Schema afterSchema, String field, String expectedLength) {
+        var parameters = afterSchema.field(field).schema().parameters();
+        Assertions.assertThat(parameters).as("propagated parameters for %s", field).isNotNull();
+        Assertions.assertThat(parameters.get("__debezium.source.column.length"))
+                .as("propagated dimension for %s", field)
+                .isEqualTo(expectedLength);
+        Assertions.assertThat(parameters.get("__debezium.source.column.scale"))
+                .as("propagated scale for %s", field)
+                .isEqualTo("0");
+    }
+
+    private static void assertNoPropagatedLength(Schema afterSchema, String field) {
+        var parameters = afterSchema.field(field).schema().parameters();
+        if (parameters != null) {
+            Assertions.assertThat(parameters.get("__debezium.source.column.length"))
+                    .as("no dimension should be propagated for a bare vector column %s", field)
+                    .isNull();
+        }
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.Column;
+
+/**
+ * Unit tests for {@link ColumnMetaData}, in particular the pgvector dimension handling (dbz#2220).
+ */
+public class ColumnMetaDataTest {
+
+    private static PostgresType vectorType() {
+        // No parent/element type, so the builder never touches the (null) TypeRegistry; the vector
+        // branch resolves length from the modifier without touching TypeInfo, so null is fine here.
+        return new PostgresType.Builder(null, "vector", 99999, Types.OTHER, TypeRegistry.NO_TYPE_MODIFIER, null).build();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2220")
+    public void shouldReadPgVectorDimensionFromModifier() {
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, 3);
+        assertThat(column.getLength()).isEqualTo(3);
+        assertThat(column.getScale()).isEqualTo(0);
+        // Single dimension modifier: vector(3), not vector(3,0).
+        assertThat(column.getTypeName()).isEqualTo("vector(3)");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2220")
+    public void shouldLeavePgVectorWithoutDimensionUnset() {
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, TypeRegistry.NO_TYPE_MODIFIER);
+        assertThat(column.getLength()).isEqualTo(Column.UNSET_INT_VALUE);
+        assertThat(column.getTypeName()).isEqualTo("vector");
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2220

## Description
pgvector types (`vector`, `halfvec`, `sparsevec`) get their OIDs assigned dynamically by the extension, so they are absent from pgjdbc's hard-coded type table and `TypeInfo.getPrecision()` collapses their length to `Integer.MAX_VALUE`. With `column.propagate.source.type` enabled the propagated `__debezium.source.column.length` was therefore `2147483647` instead of the real dimension (the JDBC sink symptom `vector(2147483647)` was previously guarded sink-side in #7648). The real dimension is carried verbatim in `atttypmod` (no offset encoding), so it is recoverable.

This recovers it on every capture path that lost it:
- **pgoutput streaming** (`ColumnMetaData`): take the dimension straight from the attribute modifier for vector types instead of delegating to `getPrecision()`, and emit the type name as `vector(3)` (single modifier) rather than `vector(3,0)`.
- **snapshot** (`PostgresConnection`): the driver reports `COLUMN_SIZE` as `Integer.MAX_VALUE`, so read the dimension from `pg_attribute.atttypmod` via a catalog lookup.
- **dimensionless `vector`** (no modifier): all paths — including decoderbufs, which was already correct for a declared dimension — now report no length rather than `Integer.MAX_VALUE`.

Verified with a unit test (`ColumnMetaDataTest`), an integration test (`VectorDatabaseIT#shouldPropagateVectorDimensions`, run under both pgoutput and decoderbufs, covering snapshot + streaming, asserting the propagated dimension for `vector(3)`/`halfvec(3)`/`sparsevec(3000)` and that a bare `vector` propagates no length), and a full source→sink end-to-end run where the JDBC sink auto-creates `vector(3)`/`halfvec(3)`/`sparsevec(3000)` columns.

### Notes
- The snapshot catalog lookup runs while iterating `DatabaseMetaData.getColumns()`; pgjdbc materializes that ResultSet client-side, so the nested query on the same connection is safe (and it runs inside the snapshot transaction for a consistent read).
- `vector`/`halfvec`/`sparsevec` are classified by type name, matching how `TypeRegistry` already resolves their OIDs.
- Out of scope (still report no dimension): arrays of vectors (`vector(3)[]`) and domains over vector.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`