### PR TITLE
debezium/dbz#2100 Bind PostgreSQL point to its native type without PostGIS

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PointType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PointType.java
@@ -5,29 +5,26 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
-import org.apache.kafka.connect.data.Schema;
+import java.util.List;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.data.geometry.Point;
 import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
- * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Point} types.
+ * An implementation of {@link JdbcType} for {@code io.debezium.data.geometry.Point} values, binding
+ * them to the native PostgreSQL {@code point} type without requiring PostGIS.
  *
  * @author Chris Cranford
  */
-class PointType extends GeometryType {
+class PointType extends AbstractType {
 
     public static final PointType INSTANCE = new PointType();
-
-    private static final String TYPE_NAME = "point";
-
-    private static final String GEO_FROM_WKB_FUNCTION_AS_POINT = "cast(" + GEO_FROM_WKB_FUNCTION + " as point)";
-
-    @Override
-    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        return String.format(GEO_FROM_WKB_FUNCTION_AS_POINT, postgisSchema);
-    }
 
     @Override
     public String[] getRegistrationKeys() {
@@ -35,7 +32,24 @@ class PointType extends GeometryType {
     }
 
     @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as point)";
+    }
+
+    @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        return TYPE_NAME;
+        return "point";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+
+        final Struct point = requireStruct(value);
+        final double x = point.getFloat64(Point.X_FIELD);
+        final double y = point.getFloat64(Point.Y_FIELD);
+        return List.of(new ValueBindDescriptor(index, "(" + x + "," + y + ")"));
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/GeometricTypesBindingTest.java
@@ -22,13 +22,14 @@ import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.data.geometry.Circle;
 import io.debezium.data.geometry.Geometry;
 import io.debezium.data.geometry.Line;
+import io.debezium.data.geometry.Point;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.spatial.WkbWriter;
 
 /**
- * Unit tests for the PostgreSQL sink binding of the geometric types added in dbz#2135:
- * {@link GeometryType} native reconstruction (box/lseg/path/polygon), and the standalone
- * {@link CircleType}/{@link LineType}.
+ * Unit tests for the PostgreSQL sink binding of the geometric types: {@link GeometryType} native
+ * reconstruction (box/lseg/path/polygon) and the standalone {@link CircleType}/{@link LineType} added
+ * in dbz#2135, plus {@link PointType} for the built-in point (dbz#2100, case 9).
  *
  * @author Debezium Authors
  */
@@ -174,6 +175,22 @@ class GeometricTypesBindingTest {
 
         assertThat(LineType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as line)");
         assertThat(bindValue(LineType.INSTANCE, schema, value)).isEqualTo("{-1.0,0.0,0.0}");
+    }
+
+    @Test
+    void pointShouldBindAsNativeText() {
+        final Schema schema = Point.builder().build();
+        final Struct value = Point.createValue(schema, 1.5, -2.0);
+
+        assertThat(PointType.INSTANCE.getQueryBinding(null, schema, value)).isEqualTo("cast(? as point)");
+        assertThat(bindValue(PointType.INSTANCE, schema, value)).isEqualTo("(1.5,-2.0)");
+    }
+
+    @Test
+    void nullPointShouldBindAsNull() {
+        final Schema schema = Point.builder().build();
+
+        assertThat(bindValue(PointType.INSTANCE, schema, null)).isNull();
     }
 
     private static Object bindValue(JdbcType type, Schema schema, Object value) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkGeometricTypesIT.java
@@ -33,14 +33,16 @@ import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.geometry.Circle;
 import io.debezium.data.geometry.Geometry;
 import io.debezium.data.geometry.Line;
+import io.debezium.data.geometry.Point;
 import io.debezium.doc.FixFor;
 import io.debezium.spatial.WkbWriter;
 
 /**
- * Round-trip tests that the six PostgreSQL geometric types added in dbz#2135 bind to their native
- * column types on a plain (non-PostGIS) PostgreSQL sink. The target table is pre-created with native
- * column types, and the connector runs with source-type propagation so the sink can reconstruct the
- * native values for box/lseg/path/polygon.
+ * Round-trip tests that PostgreSQL geometric types bind to their native column types on a plain
+ * (non-PostGIS) PostgreSQL sink: the six types added in dbz#2135 (box/circle/line/lseg/path/polygon)
+ * and the built-in point (dbz#2100, case 9). The target table is pre-created with native column types,
+ * and the connector runs with source-type propagation so the sink can reconstruct the native values
+ * for box/lseg/path/polygon.
  *
  * @author Debezium Authors
  */
@@ -130,6 +132,16 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
         assertRoundTrip(factory, insertMode, "line", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("{-1,0,0}"));
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testPointRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = Point.builder().build();
+        final Struct value = Point.createValue(schema, 1.5, -2.0);
+
+        assertRoundTrip(factory, insertMode, "point", schema, value, rs -> assertThat(rs.getString(2)).isEqualTo("(1.5,-2)"));
+    }
+
     /**
      * A batch of more than one record is what triggers PostgreSQL's UNNEST path (a single record
      * short-circuits to a row-wise INSERT). Since the native geometric types reconstruct their value in
@@ -156,6 +168,25 @@ public class JdbcSinkGeometricTypesIT extends AbstractJdbcSinkTest {
                         null, Map.of(Geometry.EXTENSION_TYPE_KEY, "box")));
 
         assertBatchRoundTrip(factory, insertMode, "box", schema, values, expected);
+    }
+
+    /**
+     * The point counterpart to {@link #testBoxBatchRoundTrip}: a batch of more than one record is what
+     * triggers PostgreSQL's UNNEST path, and since {@code point} is a {@code STRUCT} schema the sink must
+     * fall back to the row-wise path (which reconstructs the {@code (x,y)} literal in {@code bind()})
+     * rather than hand raw Structs to {@code createArrayOf}. Guards dbz#2100, case 9.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2100")
+    public void testPointBatchRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Schema schema = Point.builder().build();
+        final List<Struct> values = List.of(
+                Point.createValue(schema, 1.5, -2.0),
+                Point.createValue(schema, 3.0, 4.0));
+        final List<String> expected = List.of("(1.5,-2)", "(3,4)");
+
+        assertBatchRoundTrip(factory, insertMode, "point", schema, values, expected);
     }
 
     private void assertRoundTrip(SinkRecordFactory factory, PostgresInsertMode insertMode, String columnType,


### PR DESCRIPTION
Fixes debezium/dbz#2100, case 9.

## Description

Case 9 of the `dbz#2100` sink type-preservation audit: a built-in PostgreSQL `point` column cannot be
replicated to a sink that does not have the PostGIS extension installed. The JDBC sink's `PointType`
always emits `cast(<schema>.ST_GeomFromWKB(?, ?) as point)`, so the sink fails with:

```
ERROR: function public.st_geomfromwkb(bytea, integer) does not exist
```

A built-in `point` needs no PostGIS at all — its coordinates are already carried on the
`io.debezium.data.geometry.Point` struct (`x`/`y` FLOAT64 fields). This aligns `PointType` with the
sibling `CircleType`/`LineType` added in `dbz#2135`: it now extends `AbstractType`, binds
`cast(? as point)`, and reconstructs the native text `(x,y)` directly from the struct. Because the
`Point` logical type is used only for the built-in `point` (genuine PostGIS geometry uses the
`Geometry` logical type), no source-type gating is required.

Verified end to end (source PostgreSQL `point` → pgoutput → Kafka → JDBC sink) against a plain,
non-PostGIS sink: the column is auto-created as native `point` and values round-trip exactly, including
updates. Reverting the fix reproduces the `st_geomfromwkb does not exist` failure on the same sink.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
