### PR TITLE
debezium/dbz#2119 Preserve structured temporal fidelity across JDBC pipelines

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogValueConverters.java
@@ -156,7 +156,7 @@ public abstract class BinlogValueConverters extends JdbcValueConverters {
             return Year.builder();
         }
         if (matches(typeName, "TIME") && temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-            return StructuredDuration.builder();
+            return StructuredDuration.builder(getTimePrecision(column), StructuredDuration.Kind.ELAPSED_TIME);
         }
         if (matches(typeName, "ENUM")) {
             String commaSeparatedOptions = extractEnumAndSetOptionsAsString(column);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
@@ -920,6 +920,6 @@ public abstract class BinlogSnapshotSourceIT<C extends SourceConnector> extends 
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) hour);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) minute);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) second);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(nanos);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(nanos * StructuredTemporal.PICOSECONDS_PER_NANOSECOND);
     }
 }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSnapshotSourceIT.java
@@ -179,12 +179,12 @@ public abstract class BinlogSnapshotSourceIT<C extends SourceConnector> extends 
         assertDate(after.getStruct("d_zero"), 0, 0, 0);
         assertDate(after.getStruct("d_invalid"), 2026, 2, 31);
 
-        assertThat(after.schema().field("dt_zero").schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(after.schema().field("dt_zero").schema().name()).isEqualTo(StructuredTimestamp.schemaName(6));
         assertTimestamp(after.getStruct("dt_zero"), 0, 0, 0, 0, 0, 0, 0);
         assertTimestamp(after.getStruct("dt_invalid"), 2026, 2, 31, 12, 13, 14, 123_456_000);
         assertTimestamp(after.getStruct("dt_max"), 9999, 12, 31, 23, 59, 59, 999_999_000);
 
-        assertThat(after.schema().field("ts_zero").schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(after.schema().field("ts_zero").schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(6));
         assertTimestamp(after.getStruct("ts_zero"), 0, 0, 0, 0, 0, 0, 0);
         assertThat(after.getStruct("ts_zero").getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isZero();
     }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
@@ -456,11 +456,13 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
         Column datetimeColumn = table.columnWithName("DT");
         Field datetimeField = new Field(datetimeColumn.name(), -1, converters.schemaBuilder(datetimeColumn).build());
         assertThat(datetimeField.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(datetimeField.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6");
         Struct datetime = (Struct) converters.converter(datetimeColumn, datetimeField).convert(new BinlogDateTimeValue(2026, 2, 31, 12, 13, 14, 123_456_000));
         assertThat(datetime.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(2026);
         assertThat(datetime.getInt8(StructuredTemporal.MONTH_FIELD)).isEqualTo((byte) 2);
         assertThat(datetime.getInt8(StructuredTemporal.DAY_FIELD)).isEqualTo((byte) 31);
-        assertThat(datetime.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(123_456_000);
+        assertThat(datetime.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(123_456_000_000L);
         datetime = (Struct) converters.converter(datetimeColumn, datetimeField).convert(new BinlogDateTimeValue(9999, 12, 31, 23, 59, 59, 999_999_000));
         assertThat(datetime.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
         assertThat(datetime.getInt8(StructuredTemporal.MONTH_FIELD)).isEqualTo((byte) 12);
@@ -468,11 +470,13 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
         assertThat(datetime.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(datetime.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(datetime.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(datetime.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_000);
+        assertThat(datetime.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_000_000L);
 
         Column timestampColumn = table.columnWithName("TS");
         Field timestampField = new Field(timestampColumn.name(), -1, converters.schemaBuilder(timestampColumn).build());
         assertThat(timestampField.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(timestampField.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6");
         Struct timestamp = (Struct) converters.converter(timestampColumn, timestampField).convert(new BinlogDateTimeValue(0, 0, 0, 0, 0, 0, 0));
         assertThat(timestamp.getInt32(StructuredTemporal.YEAR_FIELD)).isZero();
         assertThat(timestamp.getInt8(StructuredTemporal.MONTH_FIELD)).isEqualTo((byte) 0);
@@ -482,21 +486,24 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
         Column timeColumn = table.columnWithName("T");
         Field timeField = new Field(timeColumn.name(), -1, converters.schemaBuilder(timeColumn).build());
         assertThat(timeField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(timeField.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6")
+                .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.ELAPSED_TIME.getValue());
         Struct duration = (Struct) converters.converter(timeColumn, timeField).convert(Duration.ofHours(-13).minusMinutes(14).minusSeconds(15).minusNanos(123_456_000));
         assertThat(duration.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-13);
         assertThat(duration.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-14);
         assertThat(duration.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-15L);
-        assertThat(duration.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-123_456_000);
+        assertThat(duration.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-123_456_000_000L);
         duration = (Struct) converters.converter(timeColumn, timeField).convert(Duration.ofHours(838).plusMinutes(59).plusSeconds(59).plusNanos(999_999_000));
         assertThat(duration.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(838);
         assertThat(duration.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(59);
         assertThat(duration.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(59L);
-        assertThat(duration.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_000);
+        assertThat(duration.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_000_000L);
         duration = (Struct) converters.converter(timeColumn, timeField).convert(Duration.ofHours(-838).minusMinutes(59).minusSeconds(59).minusNanos(999_999_000));
         assertThat(duration.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-838);
         assertThat(duration.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-59);
         assertThat(duration.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-59L);
-        assertThat(duration.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-999_999_000);
+        assertThat(duration.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-999_999_000_000L);
     }
 
     protected LocalDate localDateWithYear(int year) {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogValueConvertersTest.java
@@ -455,7 +455,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
 
         Column datetimeColumn = table.columnWithName("DT");
         Field datetimeField = new Field(datetimeColumn.name(), -1, converters.schemaBuilder(datetimeColumn).build());
-        assertThat(datetimeField.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(datetimeField.schema().name()).isEqualTo(StructuredTimestamp.schemaName(6));
         assertThat(datetimeField.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6");
         Struct datetime = (Struct) converters.converter(datetimeColumn, datetimeField).convert(new BinlogDateTimeValue(2026, 2, 31, 12, 13, 14, 123_456_000));
@@ -474,7 +474,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
 
         Column timestampColumn = table.columnWithName("TS");
         Field timestampField = new Field(timestampColumn.name(), -1, converters.schemaBuilder(timestampColumn).build());
-        assertThat(timestampField.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(timestampField.schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(6));
         assertThat(timestampField.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6");
         Struct timestamp = (Struct) converters.converter(timestampColumn, timestampField).convert(new BinlogDateTimeValue(0, 0, 0, 0, 0, 0, 0));
@@ -485,7 +485,7 @@ public abstract class BinlogValueConvertersTest<C extends SourceConnector> imple
 
         Column timeColumn = table.columnWithName("T");
         Field timeField = new Field(timeColumn.name(), -1, converters.schemaBuilder(timeColumn).build());
-        assertThat(timeField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(timeField.schema().name()).isEqualTo(StructuredDuration.schemaName(6, StructuredDuration.Kind.ELAPSED_TIME));
         assertThat(timeField.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "6")
                 .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.ELAPSED_TIME.getValue());

--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -234,12 +234,12 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 return temporalPrecisionMode.getTimestampBuilder(getTimePrecision(column));
             case Types.TIME_WITH_TIMEZONE:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTime.builder();
+                    return StructuredZonedTime.builder(getTimePrecision(column));
                 }
                 return ZonedTime.builder();
             case Types.TIMESTAMP_WITH_TIMEZONE:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTimestamp.builder();
+                    return StructuredZonedTimestamp.builder(getTimePrecision(column));
                 }
                 return ZonedTimestamp.builder();
 

--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
@@ -75,7 +75,7 @@ public enum TemporalPrecisionMode implements EnumeratedValue {
     /**
      * Represent date, time, timestamp and datetime values as structured temporal components.
      */
-    STRUCTURED("structured", StructuredDate::builder, x -> StructuredTime.builder(), x -> StructuredTimestamp.builder());
+    STRUCTURED("structured", StructuredDate::builder, StructuredTime::builder, StructuredTimestamp::builder);
 
     private final String value;
     private final Supplier<SchemaBuilder> dateBuilder;

--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -36,6 +36,7 @@ import io.debezium.schema.FieldNameSelector.FieldNamer;
 import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.time.StructuredTemporal;
 import io.debezium.util.Loggings;
 
 /**
@@ -411,10 +412,13 @@ public class TableSchemaBuilder {
     protected void addField(SchemaBuilder builder, Table table, Column column, ColumnMapper mapper) {
         final Object defaultValue = parseDefaultValue(table.id(), column);
 
-        final SchemaBuilder fieldBuilder = customConverterRegistry.registerConverterFor(table.id(), column, defaultValue)
+        SchemaBuilder fieldBuilder = customConverterRegistry.registerConverterFor(table.id(), column, defaultValue)
                 .orElse(valueConverterProvider.schemaBuilder(column));
 
         if (fieldBuilder != null) {
+            if (mapper != null || column.comment() != null) {
+                fieldBuilder = StructuredTemporal.qualifySchemaBuilderWithSourceColumn(fieldBuilder, column.name());
+            }
             if (mapper != null) {
                 // Let the mapper add properties to the schema ...
                 mapper.alterFieldSchema(column, fieldBuilder);

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredDuration.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredDuration.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.time;
 
+import java.util.Locale;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -16,8 +18,42 @@ public final class StructuredDuration {
 
     public static final String SCHEMA_NAME = "io.debezium.time.StructuredDuration";
 
+    public enum Kind {
+        ELAPSED_TIME("elapsed-time"),
+        YEAR_MONTH("year-month"),
+        DAY_TIME("day-time"),
+        MIXED("mixed");
+
+        private final String value;
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Kind parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            final String normalized = value.toLowerCase(Locale.ENGLISH);
+            for (Kind kind : values()) {
+                if (kind.value.equals(normalized)) {
+                    return kind;
+                }
+            }
+            return null;
+        }
+    }
+
     public static SchemaBuilder builder() {
-        return SchemaBuilder.struct()
+        return builder(-1, null);
+    }
+
+    public static SchemaBuilder builder(int precision, Kind kind) {
+        final SchemaBuilder builder = StructuredTemporal.withPrecision(SchemaBuilder.struct()
                 .name(SCHEMA_NAME)
                 .version(1)
                 .field(StructuredTemporal.YEARS_FIELD, StructuredTemporal.optionalInt32())
@@ -26,8 +62,12 @@ public final class StructuredDuration {
                 .field(StructuredTemporal.HOURS_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.MINUTES_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.SECONDS_FIELD, StructuredTemporal.optionalInt64())
-                .field(StructuredTemporal.NANOS_FIELD, StructuredTemporal.optionalInt32())
-                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32());
+                .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
+                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
+        if (kind != null) {
+            builder.parameter(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, kind.getValue());
+        }
+        return builder;
     }
 
     public static Schema schema() {
@@ -39,6 +79,11 @@ public final class StructuredDuration {
     }
 
     public static Struct from(Schema schema, int years, int months, int days, int hours, int minutes, long seconds, int nanos, int precision) {
+        return fromPicoseconds(schema, years, months, days, hours, minutes, seconds, StructuredTemporal.picosecondsFromNanoseconds(nanos), precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, int years, int months, int days, int hours, int minutes, long seconds, long picoseconds,
+                                         int precision) {
         return StructuredTemporal.withPrecision(new Struct(schema)
                 .put(StructuredTemporal.YEARS_FIELD, years)
                 .put(StructuredTemporal.MONTHS_FIELD, months)
@@ -46,7 +91,7 @@ public final class StructuredDuration {
                 .put(StructuredTemporal.HOURS_FIELD, hours)
                 .put(StructuredTemporal.MINUTES_FIELD, minutes)
                 .put(StructuredTemporal.SECONDS_FIELD, seconds)
-                .put(StructuredTemporal.NANOS_FIELD, nanos), precision);
+                .put(StructuredTemporal.PICOSECONDS_FIELD, picoseconds), precision);
     }
 
     private StructuredDuration() {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredDuration.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredDuration.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.time;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.kafka.connect.data.Schema;
@@ -54,7 +56,7 @@ public final class StructuredDuration {
 
     public static SchemaBuilder builder(int precision, Kind kind) {
         final SchemaBuilder builder = StructuredTemporal.withPrecision(SchemaBuilder.struct()
-                .name(SCHEMA_NAME)
+                .name(schemaName(precision, kind))
                 .version(1)
                 .field(StructuredTemporal.YEARS_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.MONTHS_FIELD, StructuredTemporal.optionalInt32())
@@ -68,6 +70,30 @@ public final class StructuredDuration {
             builder.parameter(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, kind.getValue());
         }
         return builder;
+    }
+
+    public static String schemaName(int precision, Kind kind) {
+        final String baseName = StructuredTemporal.schemaName(SCHEMA_NAME, precision);
+        return kind == null ? baseName : baseName + kind.name();
+    }
+
+    public static String[] schemaNames() {
+        final List<String> names = new ArrayList<>();
+        names.add(SCHEMA_NAME);
+        addSchemaNames(names, -1);
+        for (int precision = 0; precision <= StructuredTemporal.MAX_FRACTIONAL_SECOND_PRECISION; ++precision) {
+            addSchemaNames(names, precision);
+        }
+        return names.toArray(String[]::new);
+    }
+
+    private static void addSchemaNames(List<String> names, int precision) {
+        if (precision >= 0) {
+            names.add(schemaName(precision, null));
+        }
+        for (Kind kind : Kind.values()) {
+            names.add(schemaName(precision, kind));
+        }
     }
 
     public static Schema schema() {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTemporal.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTemporal.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.time;
 
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -13,6 +16,10 @@ import org.apache.kafka.connect.data.Struct;
  * Shared constants and helpers for structured temporal semantic types.
  */
 public final class StructuredTemporal {
+
+    static final int MAX_FRACTIONAL_SECOND_PRECISION = 12;
+
+    private static final String SOURCE_COLUMN_SCHEMA_NAME_MARKER = "SourceColumn";
 
     public static final String YEAR_FIELD = "year";
     public static final String MONTH_FIELD = "month";
@@ -89,6 +96,91 @@ public final class StructuredTemporal {
             builder.parameter(PRECISION_PARAMETER_KEY, Integer.toString(precision));
         }
         return builder;
+    }
+
+    static String schemaName(String baseName, int precision) {
+        return precision < 0 ? baseName : baseName + "Precision" + precision;
+    }
+
+    static String[] schemaNames(String baseName) {
+        final String[] names = new String[MAX_FRACTIONAL_SECOND_PRECISION + 2];
+        names[0] = baseName;
+        for (int precision = 0; precision <= MAX_FRACTIONAL_SECOND_PRECISION; ++precision) {
+            names[precision + 1] = schemaName(baseName, precision);
+        }
+        return names;
+    }
+
+    /**
+     * Qualifies a structured temporal schema name with the source column name. This keeps Avro named records distinct when
+     * otherwise identical structured temporal schemas carry column-specific metadata.
+     *
+     * @param builder the field schema builder
+     * @param columnName the source column name
+     */
+    public static SchemaBuilder qualifySchemaBuilderWithSourceColumn(SchemaBuilder builder, String columnName) {
+        final String schemaName = schemaNameWithoutSourceColumn(builder.name());
+        if (!isStructuredTemporalSchemaName(schemaName)) {
+            return builder;
+        }
+
+        final SchemaBuilder qualifiedBuilder = SchemaBuilder.struct()
+                .name(schemaName + SOURCE_COLUMN_SCHEMA_NAME_MARKER + encodeSchemaNameComponent(columnName));
+        if (builder.version() != null) {
+            qualifiedBuilder.version(builder.version());
+        }
+        if (builder.doc() != null) {
+            qualifiedBuilder.doc(builder.doc());
+        }
+        if (builder.parameters() != null) {
+            qualifiedBuilder.parameters(builder.parameters());
+        }
+        if (builder.isOptional()) {
+            qualifiedBuilder.optional();
+        }
+        for (Field field : builder.fields()) {
+            qualifiedBuilder.field(field.name(), field.schema());
+        }
+        return qualifiedBuilder;
+    }
+
+    /**
+     * Returns the structured temporal schema name without its source-column qualifier.
+     *
+     * @param schemaName the schema name
+     * @return the canonical schema name
+     */
+    public static String schemaNameWithoutSourceColumn(String schemaName) {
+        if (schemaName == null) {
+            return null;
+        }
+        final int markerIndex = schemaName.indexOf(SOURCE_COLUMN_SCHEMA_NAME_MARKER);
+        if (markerIndex > 0) {
+            final String candidate = schemaName.substring(0, markerIndex);
+            if (isStructuredTemporalSchemaName(candidate)) {
+                return candidate;
+            }
+        }
+        return schemaName;
+    }
+
+    private static boolean isStructuredTemporalSchemaName(String schemaName) {
+        return schemaName != null && (StructuredDate.SCHEMA_NAME.equals(schemaName)
+                || schemaName.startsWith(StructuredDuration.SCHEMA_NAME)
+                || schemaName.startsWith(StructuredZonedTimestamp.SCHEMA_NAME)
+                || schemaName.startsWith(StructuredZonedTime.SCHEMA_NAME)
+                || schemaName.startsWith(StructuredTimestamp.SCHEMA_NAME)
+                || schemaName.startsWith(StructuredTime.SCHEMA_NAME));
+    }
+
+    private static String encodeSchemaNameComponent(String value) {
+        final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        final StringBuilder encoded = new StringBuilder(bytes.length * 2);
+        for (byte current : bytes) {
+            encoded.append(Character.forDigit((current >>> 4) & 0x0f, 16));
+            encoded.append(Character.forDigit(current & 0x0f, 16));
+        }
+        return encoded.toString();
     }
 
     static long picosecondsFromNanoseconds(int nanoseconds) {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTemporal.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTemporal.java
@@ -20,11 +20,21 @@ public final class StructuredTemporal {
     public static final String HOUR_FIELD = "hour";
     public static final String MINUTE_FIELD = "minute";
     public static final String SECOND_FIELD = "second";
-    public static final String NANOS_FIELD = "nanos";
+    public static final String PICOSECONDS_FIELD = "picoseconds";
     public static final String OFFSET_SECONDS_FIELD = "offsetSeconds";
     public static final String ZONE_ID_FIELD = "zoneId";
     public static final String SPECIAL_VALUE_FIELD = "specialValue";
     public static final String PRECISION_FIELD = "precision";
+
+    /**
+     * Schema parameter that describes the source column's fractional-second precision.
+     */
+    public static final String PRECISION_PARAMETER_KEY = "io.debezium.time.precision";
+
+    /**
+     * Schema parameter that describes the semantic kind of a structured duration.
+     */
+    public static final String DURATION_KIND_PARAMETER_KEY = "io.debezium.time.duration.kind";
 
     public static final String YEARS_FIELD = "years";
     public static final String MONTHS_FIELD = "months";
@@ -35,6 +45,9 @@ public final class StructuredTemporal {
 
     public static final String POSITIVE_INFINITY = "POSITIVE_INFINITY";
     public static final String NEGATIVE_INFINITY = "NEGATIVE_INFINITY";
+
+    public static final long PICOSECONDS_PER_NANOSECOND = 1_000L;
+    public static final long PICOSECONDS_PER_SECOND = 1_000_000_000_000L;
 
     static Schema optionalInt8() {
         return SchemaBuilder.int8().optional().build();
@@ -69,6 +82,17 @@ public final class StructuredTemporal {
             struct.put(PRECISION_FIELD, precision);
         }
         return struct;
+    }
+
+    static SchemaBuilder withPrecision(SchemaBuilder builder, int precision) {
+        if (precision >= 0) {
+            builder.parameter(PRECISION_PARAMETER_KEY, Integer.toString(precision));
+        }
+        return builder;
+    }
+
+    static long picosecondsFromNanoseconds(int nanoseconds) {
+        return nanoseconds * PICOSECONDS_PER_NANOSECOND;
     }
 
     public static boolean isPositiveInfinity(Struct value) {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTime.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTime.java
@@ -20,14 +20,18 @@ public final class StructuredTime {
     public static final String SCHEMA_NAME = "io.debezium.time.StructuredTime";
 
     public static SchemaBuilder builder() {
-        return SchemaBuilder.struct()
+        return builder(-1);
+    }
+
+    public static SchemaBuilder builder(int precision) {
+        return StructuredTemporal.withPrecision(SchemaBuilder.struct()
                 .name(SCHEMA_NAME)
                 .version(1)
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.SECOND_FIELD, StructuredTemporal.optionalInt8())
-                .field(StructuredTemporal.NANOS_FIELD, StructuredTemporal.optionalInt32())
-                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32());
+                .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
+                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
     }
 
     public static Schema schema() {
@@ -43,11 +47,16 @@ public final class StructuredTime {
     }
 
     public static Struct from(Schema schema, LocalTime value, int precision) {
+        return fromPicoseconds(schema, value.getHour(), value.getMinute(), value.getSecond(),
+                StructuredTemporal.picosecondsFromNanoseconds(value.getNano()), precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, int hour, int minute, int second, long picoseconds, int precision) {
         return StructuredTemporal.withPrecision(new Struct(schema)
-                .put(StructuredTemporal.HOUR_FIELD, (byte) value.getHour())
-                .put(StructuredTemporal.MINUTE_FIELD, (byte) value.getMinute())
-                .put(StructuredTemporal.SECOND_FIELD, (byte) value.getSecond())
-                .put(StructuredTemporal.NANOS_FIELD, value.getNano()), precision);
+                .put(StructuredTemporal.HOUR_FIELD, (byte) hour)
+                .put(StructuredTemporal.MINUTE_FIELD, (byte) minute)
+                .put(StructuredTemporal.SECOND_FIELD, (byte) second)
+                .put(StructuredTemporal.PICOSECONDS_FIELD, picoseconds), precision);
     }
 
     public static Struct toStructuredTime(Schema schema, Object value, TemporalAdjuster adjuster) {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTime.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTime.java
@@ -25,13 +25,21 @@ public final class StructuredTime {
 
     public static SchemaBuilder builder(int precision) {
         return StructuredTemporal.withPrecision(SchemaBuilder.struct()
-                .name(SCHEMA_NAME)
+                .name(schemaName(precision))
                 .version(1)
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.SECOND_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
+    }
+
+    public static String schemaName(int precision) {
+        return StructuredTemporal.schemaName(SCHEMA_NAME, precision);
+    }
+
+    public static String[] schemaNames() {
+        return StructuredTemporal.schemaNames(SCHEMA_NAME);
     }
 
     public static Schema schema() {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTimestamp.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTimestamp.java
@@ -20,7 +20,11 @@ public final class StructuredTimestamp {
     public static final String SCHEMA_NAME = "io.debezium.time.StructuredTimestamp";
 
     public static SchemaBuilder builder() {
-        return SchemaBuilder.struct()
+        return builder(-1);
+    }
+
+    public static SchemaBuilder builder(int precision) {
+        return StructuredTemporal.withPrecision(SchemaBuilder.struct()
                 .name(SCHEMA_NAME)
                 .version(1)
                 .field(StructuredTemporal.YEAR_FIELD, StructuredTemporal.optionalInt32())
@@ -29,9 +33,9 @@ public final class StructuredTimestamp {
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.SECOND_FIELD, StructuredTemporal.optionalInt8())
-                .field(StructuredTemporal.NANOS_FIELD, StructuredTemporal.optionalInt32())
+                .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.SPECIAL_VALUE_FIELD, StructuredTemporal.optionalString())
-                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32());
+                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
     }
 
     public static Schema schema() {
@@ -56,6 +60,16 @@ public final class StructuredTimestamp {
     }
 
     public static Struct from(Schema schema, int year, int month, int day, int hour, int minute, int second, int nanos, int precision) {
+        return fromPicoseconds(schema, year, month, day, hour, minute, second,
+                StructuredTemporal.picosecondsFromNanoseconds(nanos), precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, LocalDateTime value, long picoseconds, int precision) {
+        return fromPicoseconds(schema, value.getYear(), value.getMonthValue(), value.getDayOfMonth(), value.getHour(), value.getMinute(), value.getSecond(),
+                picoseconds, precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, int year, int month, int day, int hour, int minute, int second, long picoseconds, int precision) {
         return StructuredTemporal.withPrecision(new Struct(schema)
                 .put(StructuredTemporal.YEAR_FIELD, year)
                 .put(StructuredTemporal.MONTH_FIELD, (byte) month)
@@ -63,7 +77,7 @@ public final class StructuredTimestamp {
                 .put(StructuredTemporal.HOUR_FIELD, (byte) hour)
                 .put(StructuredTemporal.MINUTE_FIELD, (byte) minute)
                 .put(StructuredTemporal.SECOND_FIELD, (byte) second)
-                .put(StructuredTemporal.NANOS_FIELD, nanos), precision);
+                .put(StructuredTemporal.PICOSECONDS_FIELD, picoseconds), precision);
     }
 
     public static Struct toStructuredTimestamp(Schema schema, Object value, TemporalAdjuster adjuster) {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredTimestamp.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredTimestamp.java
@@ -25,7 +25,7 @@ public final class StructuredTimestamp {
 
     public static SchemaBuilder builder(int precision) {
         return StructuredTemporal.withPrecision(SchemaBuilder.struct()
-                .name(SCHEMA_NAME)
+                .name(schemaName(precision))
                 .version(1)
                 .field(StructuredTemporal.YEAR_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.MONTH_FIELD, StructuredTemporal.optionalInt8())
@@ -36,6 +36,14 @@ public final class StructuredTimestamp {
                 .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.SPECIAL_VALUE_FIELD, StructuredTemporal.optionalString())
                 .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
+    }
+
+    public static String schemaName(int precision) {
+        return StructuredTemporal.schemaName(SCHEMA_NAME, precision);
+    }
+
+    public static String[] schemaNames() {
+        return StructuredTemporal.schemaNames(SCHEMA_NAME);
     }
 
     public static Schema schema() {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTime.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTime.java
@@ -23,15 +23,19 @@ public final class StructuredZonedTime {
     public static final String SCHEMA_NAME = "io.debezium.time.StructuredZonedTime";
 
     public static SchemaBuilder builder() {
-        return SchemaBuilder.struct()
+        return builder(-1);
+    }
+
+    public static SchemaBuilder builder(int precision) {
+        return StructuredTemporal.withPrecision(SchemaBuilder.struct()
                 .name(SCHEMA_NAME)
                 .version(1)
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.SECOND_FIELD, StructuredTemporal.optionalInt8())
-                .field(StructuredTemporal.NANOS_FIELD, StructuredTemporal.optionalInt32())
+                .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.OFFSET_SECONDS_FIELD, StructuredTemporal.optionalInt32())
-                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32());
+                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
     }
 
     public static Schema schema() {
@@ -57,11 +61,15 @@ public final class StructuredZonedTime {
      * boundary hour {@code 24}, which {@link OffsetTime}/{@link LocalTime} cannot represent.
      */
     public static Struct from(Schema schema, int hour, int minute, int second, int nanos, int offsetSeconds, int precision) {
+        return fromPicoseconds(schema, hour, minute, second, StructuredTemporal.picosecondsFromNanoseconds(nanos), offsetSeconds, precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, int hour, int minute, int second, long picoseconds, int offsetSeconds, int precision) {
         return StructuredTemporal.withPrecision(new Struct(schema)
                 .put(StructuredTemporal.HOUR_FIELD, (byte) hour)
                 .put(StructuredTemporal.MINUTE_FIELD, (byte) minute)
                 .put(StructuredTemporal.SECOND_FIELD, (byte) second)
-                .put(StructuredTemporal.NANOS_FIELD, nanos)
+                .put(StructuredTemporal.PICOSECONDS_FIELD, picoseconds)
                 .put(StructuredTemporal.OFFSET_SECONDS_FIELD, offsetSeconds), precision);
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTime.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTime.java
@@ -28,7 +28,7 @@ public final class StructuredZonedTime {
 
     public static SchemaBuilder builder(int precision) {
         return StructuredTemporal.withPrecision(SchemaBuilder.struct()
-                .name(SCHEMA_NAME)
+                .name(schemaName(precision))
                 .version(1)
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
@@ -36,6 +36,14 @@ public final class StructuredZonedTime {
                 .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.OFFSET_SECONDS_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
+    }
+
+    public static String schemaName(int precision) {
+        return StructuredTemporal.schemaName(SCHEMA_NAME, precision);
+    }
+
+    public static String[] schemaNames() {
+        return StructuredTemporal.schemaNames(SCHEMA_NAME);
     }
 
     public static Schema schema() {

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTimestamp.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTimestamp.java
@@ -25,7 +25,11 @@ public final class StructuredZonedTimestamp {
     public static final String SCHEMA_NAME = "io.debezium.time.StructuredZonedTimestamp";
 
     public static SchemaBuilder builder() {
-        return SchemaBuilder.struct()
+        return builder(-1);
+    }
+
+    public static SchemaBuilder builder(int precision) {
+        return StructuredTemporal.withPrecision(SchemaBuilder.struct()
                 .name(SCHEMA_NAME)
                 .version(1)
                 .field(StructuredTemporal.YEAR_FIELD, StructuredTemporal.optionalInt32())
@@ -34,11 +38,11 @@ public final class StructuredZonedTimestamp {
                 .field(StructuredTemporal.HOUR_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.MINUTE_FIELD, StructuredTemporal.optionalInt8())
                 .field(StructuredTemporal.SECOND_FIELD, StructuredTemporal.optionalInt8())
-                .field(StructuredTemporal.NANOS_FIELD, StructuredTemporal.optionalInt32())
+                .field(StructuredTemporal.PICOSECONDS_FIELD, StructuredTemporal.optionalInt64())
                 .field(StructuredTemporal.OFFSET_SECONDS_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.ZONE_ID_FIELD, StructuredTemporal.optionalString())
                 .field(StructuredTemporal.SPECIAL_VALUE_FIELD, StructuredTemporal.optionalString())
-                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32());
+                .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
     }
 
     public static Schema schema() {
@@ -64,6 +68,17 @@ public final class StructuredZonedTimestamp {
 
     public static Struct from(Schema schema, int year, int month, int day, int hour, int minute, int second, int nanos, int offsetSeconds, String zoneId,
                               int precision) {
+        return fromPicoseconds(schema, year, month, day, hour, minute, second, StructuredTemporal.picosecondsFromNanoseconds(nanos), offsetSeconds, zoneId,
+                precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, OffsetDateTime value, long picoseconds, String zoneId, int precision) {
+        return fromPicoseconds(schema, value.getYear(), value.getMonthValue(), value.getDayOfMonth(), value.getHour(), value.getMinute(), value.getSecond(),
+                picoseconds, value.getOffset().getTotalSeconds(), zoneId, precision);
+    }
+
+    public static Struct fromPicoseconds(Schema schema, int year, int month, int day, int hour, int minute, int second, long picoseconds, int offsetSeconds,
+                                         String zoneId, int precision) {
         final Struct struct = new Struct(schema)
                 .put(StructuredTemporal.YEAR_FIELD, year)
                 .put(StructuredTemporal.MONTH_FIELD, (byte) month)
@@ -71,7 +86,7 @@ public final class StructuredZonedTimestamp {
                 .put(StructuredTemporal.HOUR_FIELD, (byte) hour)
                 .put(StructuredTemporal.MINUTE_FIELD, (byte) minute)
                 .put(StructuredTemporal.SECOND_FIELD, (byte) second)
-                .put(StructuredTemporal.NANOS_FIELD, nanos)
+                .put(StructuredTemporal.PICOSECONDS_FIELD, picoseconds)
                 .put(StructuredTemporal.OFFSET_SECONDS_FIELD, offsetSeconds);
         if (zoneId != null) {
             struct.put(StructuredTemporal.ZONE_ID_FIELD, zoneId);

--- a/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTimestamp.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/StructuredZonedTimestamp.java
@@ -30,7 +30,7 @@ public final class StructuredZonedTimestamp {
 
     public static SchemaBuilder builder(int precision) {
         return StructuredTemporal.withPrecision(SchemaBuilder.struct()
-                .name(SCHEMA_NAME)
+                .name(schemaName(precision))
                 .version(1)
                 .field(StructuredTemporal.YEAR_FIELD, StructuredTemporal.optionalInt32())
                 .field(StructuredTemporal.MONTH_FIELD, StructuredTemporal.optionalInt8())
@@ -43,6 +43,14 @@ public final class StructuredZonedTimestamp {
                 .field(StructuredTemporal.ZONE_ID_FIELD, StructuredTemporal.optionalString())
                 .field(StructuredTemporal.SPECIAL_VALUE_FIELD, StructuredTemporal.optionalString())
                 .field(StructuredTemporal.PRECISION_FIELD, StructuredTemporal.optionalInt32()), precision);
+    }
+
+    public static String schemaName(int precision) {
+        return StructuredTemporal.schemaName(SCHEMA_NAME, precision);
+    }
+
+    public static String[] schemaNames() {
+        return StructuredTemporal.schemaNames(SCHEMA_NAME);
     }
 
     public static Schema schema() {

--- a/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
@@ -156,12 +156,12 @@ public class JdbcValueConvertersTemporalPrecisionTest {
 
         assertThat(structuredConverters.schemaBuilder(zonedTime).build())
                 .satisfies(schema -> {
-                    assertThat(schema.name()).isEqualTo(StructuredZonedTime.SCHEMA_NAME);
+                    assertThat(schema.name()).isEqualTo(StructuredZonedTime.schemaName(7));
                     assertThat(schema.parameters()).containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
                 });
         assertThat(structuredConverters.schemaBuilder(zonedTimestamp).build())
                 .satisfies(schema -> {
-                    assertThat(schema.name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+                    assertThat(schema.name()).isEqualTo(StructuredZonedTimestamp.schemaName(7));
                     assertThat(schema.parameters()).containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
                 });
     }

--- a/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcValueConvertersTemporalPrecisionTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
+import io.debezium.time.StructuredTemporal;
+import io.debezium.time.StructuredZonedTime;
+import io.debezium.time.StructuredZonedTimestamp;
 
 /**
  * Test to test temporal to ISO 8601 String conversions.
@@ -140,5 +143,26 @@ public class JdbcValueConvertersTemporalPrecisionTest {
         Duration valDuration = Duration.ofHours(2).plusMinutes(30).plusMillis(4).plusNanos(5);
         assertThat(timeMicroValConverter.convert(valDuration)).isEqualTo(9000004000L);
         assertThat(timeNanoValConverter.convert(valDuration)).isEqualTo(9000004000005L);
+    }
+
+    @Test
+    public void shouldDescribeStructuredZonedTemporalPrecision() {
+        final JdbcValueConverters structuredConverters = new JdbcValueConverters(
+                null, TemporalPrecisionMode.STRUCTURED, ZoneOffset.UTC, null, null, null);
+        final Column zonedTime = Column.editor().name("zt").type("TIME WITH TIME ZONE").length(7)
+                .jdbcType(Types.TIME_WITH_TIMEZONE).create();
+        final Column zonedTimestamp = Column.editor().name("zts").type("TIMESTAMP WITH TIME ZONE").length(7)
+                .jdbcType(Types.TIMESTAMP_WITH_TIMEZONE).create();
+
+        assertThat(structuredConverters.schemaBuilder(zonedTime).build())
+                .satisfies(schema -> {
+                    assertThat(schema.name()).isEqualTo(StructuredZonedTime.SCHEMA_NAME);
+                    assertThat(schema.parameters()).containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
+                });
+        assertThat(structuredConverters.schemaBuilder(zonedTimestamp).build())
+                .satisfies(schema -> {
+                    assertThat(schema.name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+                    assertThat(schema.parameters()).containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
+                });
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Types;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -23,11 +24,13 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.apicurio.registry.utils.converter.avro.AvroData;
 import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMode;
 import io.debezium.config.Configuration;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.junit.relational.TestRelationalDatabaseConfig;
 import io.debezium.relational.Key.CustomKeyMapper;
@@ -42,6 +45,8 @@ import io.debezium.schema.SchemaTopicNamingStrategy;
 import io.debezium.spi.common.ReplacementFunction;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.time.Date;
+import io.debezium.time.StructuredTemporal;
+import io.debezium.time.StructuredTimestamp;
 
 public class TableSchemaBuilderTest {
 
@@ -655,6 +660,46 @@ public class TableSchemaBuilderTest {
 
         Struct value = schema.valueFromColumnData(data);
         assertThat(value.get("C1")).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldKeepPropagatedStructuredTemporalAvroSchemasDistinctBySourceColumn() {
+        final TableId tableId = new TableId("catalog", "schema", "timestamps");
+        final Table timestampTable = Table.editor()
+                .tableId(tableId)
+                .addColumns(
+                        Column.editor().name("first_timestamp")
+                                .type("TIMESTAMP").jdbcType(Types.TIMESTAMP).length(6)
+                                .comment("first timestamp")
+                                .optional(true)
+                                .create(),
+                        Column.editor().name("second_timestamp")
+                                .type("TIMESTAMP").jdbcType(Types.TIMESTAMP).length(6)
+                                .comment("second timestamp")
+                                .optional(true)
+                                .create())
+                .create();
+        final Configuration config = Configuration.create()
+                .with("column.propagate.source.type", tableId + ".*")
+                .build();
+        final ColumnMappers mappers = ColumnMappers.create(new TestRelationalDatabaseConfig(config, null, null, 0));
+        final JdbcValueConverters converters = new JdbcValueConverters(
+                null, TemporalPrecisionMode.STRUCTURED, ZoneOffset.UTC, null, null, null);
+
+        schema = new TableSchemaBuilder(converters, null, adjuster, customConverterRegistry,
+                SchemaBuilder.struct().build(), defaultFieldNamer, false, EventConvertingFailureHandlingMode.FAIL)
+                .create(topicNamingStrategy, timestampTable, null, mappers, null);
+
+        final Schema firstSchema = schema.valueSchema().field("first_timestamp").schema();
+        final Schema secondSchema = schema.valueSchema().field("second_timestamp").schema();
+        assertThat(firstSchema.name()).isNotEqualTo(secondSchema.name());
+        assertThat(firstSchema.doc()).isEqualTo("first timestamp");
+        assertThat(secondSchema.doc()).isEqualTo("second timestamp");
+        assertThat(StructuredTemporal.schemaNameWithoutSourceColumn(firstSchema.name()))
+                .isEqualTo(StructuredTimestamp.schemaName(6));
+        assertThat(StructuredTemporal.schemaNameWithoutSourceColumn(secondSchema.name()))
+                .isEqualTo(StructuredTimestamp.schemaName(6));
+        assertThat(new AvroData(100).fromConnectSchema(schema.valueSchema())).isNotNull();
     }
 
     @Test

--- a/debezium-connector-common/src/test/java/io/debezium/time/StructuredTemporalTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/time/StructuredTemporalTest.java
@@ -17,6 +17,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
+import io.apicurio.registry.utils.converter.avro.AvroData;
 import io.debezium.data.VerifyRecord;
 
 class StructuredTemporalTest {
@@ -137,19 +138,31 @@ class StructuredTemporalTest {
     }
 
     @Test
-    void shouldSerializeRepeatedStructuredTimestampSchemasWithDifferentPrecisionValues() {
-        final Schema timestamp3Schema = StructuredTimestamp.builder().build();
-        final Schema timestamp6Schema = StructuredTimestamp.builder().build();
+    void shouldSerializeRepeatedStructuredSchemasWithDifferentMetadata() {
+        final Schema timestamp3Schema = StructuredTimestamp.builder(3).build();
+        final Schema timestamp6Schema = StructuredTimestamp.builder(6).build();
+        final Schema optionalTimestamp6Schema = StructuredTimestamp.builder(6).optional().build();
+        final Schema yearMonthSchema = StructuredDuration.builder(9, StructuredDuration.Kind.YEAR_MONTH).build();
+        final Schema dayTimeSchema = StructuredDuration.builder(9, StructuredDuration.Kind.DAY_TIME).build();
         final Schema valueSchema = SchemaBuilder.struct()
                 .name("server.schema.table.Value")
                 .field("ts3", timestamp3Schema)
                 .field("ts6", timestamp6Schema)
+                .field("optionalTs6", optionalTimestamp6Schema)
+                .field("yearMonth", yearMonthSchema)
+                .field("dayTime", dayTimeSchema)
                 .build();
         final Struct value = new Struct(valueSchema)
                 .put("ts3", StructuredTimestamp.from(timestamp3Schema, 2026, 6, 20, 12, 13, 14, 123_000_000, 3))
-                .put("ts6", StructuredTimestamp.from(timestamp6Schema, 2026, 6, 20, 12, 13, 14, 123_456_000, 6));
+                .put("ts6", StructuredTimestamp.from(timestamp6Schema, 2026, 6, 20, 12, 13, 14, 123_456_000, 6))
+                .put("optionalTs6", StructuredTimestamp.from(optionalTimestamp6Schema, 2026, 6, 20, 12, 13, 14, 123_456_000, 6))
+                .put("yearMonth", StructuredDuration.fromPicoseconds(yearMonthSchema, 1, 2, 0, 0, 0, 0, 0, 9))
+                .put("dayTime", StructuredDuration.fromPicoseconds(dayTimeSchema, 0, 0, 3, 4, 5, 6, 789_000_000_000L, 9));
         final SourceRecord record = new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), "server.schema.table", null, null, valueSchema, value);
 
+        assertThat(timestamp3Schema.name()).isNotEqualTo(timestamp6Schema.name());
+        assertThat(yearMonthSchema.name()).isNotEqualTo(dayTimeSchema.name());
+        assertThat(new AvroData(100).fromConnectSchema(valueSchema)).isNotNull();
         VerifyRecord.isValid(record);
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/time/StructuredTemporalTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/time/StructuredTemporalTest.java
@@ -63,7 +63,7 @@ class StructuredTemporalTest {
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_000);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_000_000L);
         assertThat(value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(32_400);
         assertThat(value.getString(StructuredTemporal.ZONE_ID_FIELD)).isEqualTo("Asia/Seoul");
     }
@@ -78,7 +78,7 @@ class StructuredTemporalTest {
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 24);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 0);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 0);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isZero();
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isZero();
         assertThat(value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(19_800);
         assertThat(StructuredTemporal.isFinite(value)).isTrue();
     }
@@ -95,7 +95,7 @@ class StructuredTemporalTest {
         assertThat(value.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-4);
         assertThat(value.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-5);
         assertThat(value.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-6L);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-7);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-7_000L);
     }
 
     @Test
@@ -112,6 +112,28 @@ class StructuredTemporalTest {
         assertThat(durationSchema.parameters()).isNullOrEmpty();
         assertThat(duration.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(6);
         assertThat(StructuredTimestamp.schema().parameters()).isNullOrEmpty();
+    }
+
+    @Test
+    void shouldDescribeStructuredPrecisionAndDurationKindInSchemaParameters() {
+        final Schema timestampSchema = StructuredTimestamp.builder(7).build();
+        final Schema durationSchema = StructuredDuration.builder(9, StructuredDuration.Kind.DAY_TIME).build();
+
+        assertThat(timestampSchema.parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
+        assertThat(durationSchema.parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9")
+                .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.DAY_TIME.getValue());
+    }
+
+    @Test
+    void shouldPreservePicosecondTimestampPrecisionInVersionOneSchema() {
+        final Schema schema = StructuredTimestamp.builder(12).build();
+        final Struct value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+
+        assertThat(schema.version()).isEqualTo(1);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(123_456_789_012L);
+        assertThat(value.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(12);
     }
 
     @Test

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
@@ -107,10 +108,28 @@ public class DefaultRecordWriter implements RecordWriter {
     }
 
     /**
+     * Bind key field values to the query for a single record with access to the target table.
+     */
+    protected int bindKeyValuesToQuery(TableDescriptor table, JdbcSinkRecord record, QueryBinder query, int index) {
+        final Struct keySource = record.filteredKey();
+        if (keySource != null) {
+            index = bindFieldValuesToQuery(table, record, query, index, keySource, record.keyFieldNames());
+        }
+        return index;
+    }
+
+    /**
      * Bind non-key field values to the query for a single record.
      */
     protected int bindNonKeyValuesToQuery(JdbcSinkRecord record, QueryBinder query, int index) {
         return bindFieldValuesToQuery(record, query, index, record.getPayload(), record.nonKeyFieldNames());
+    }
+
+    /**
+     * Bind non-key field values to the query for a single record with access to the target table.
+     */
+    protected int bindNonKeyValuesToQuery(TableDescriptor table, JdbcSinkRecord record, QueryBinder query, int index) {
+        return bindFieldValuesToQuery(table, record, query, index, record.getPayload(), record.nonKeyFieldNames());
     }
 
     /**
@@ -128,6 +147,30 @@ public class DefaultRecordWriter implements RecordWriter {
                 value = source.get(fieldName);
             }
             List<ValueBindDescriptor> boundValues = dialect.bindValue(field, index, value);
+
+            boundValues.forEach(query::bind);
+            index += boundValues.size();
+        }
+
+        return index;
+    }
+
+    /**
+     * Bind field values to the query for a single record with access to the target table.
+     */
+    protected int bindFieldValuesToQuery(TableDescriptor table, JdbcSinkRecord record, QueryBinder query, int index, Struct source, Set<String> fieldNames) {
+        for (String fieldName : fieldNames) {
+            final JdbcFieldDescriptor field = record.jdbcFields().get(fieldName);
+            final var column = dialect.resolveColumn(table, field);
+
+            Object value;
+            if (field.getSchema().isOptional()) {
+                value = source.getWithoutDefault(fieldName);
+            }
+            else {
+                value = source.get(fieldName);
+            }
+            List<ValueBindDescriptor> boundValues = dialect.bindValue(field, column, index, value);
 
             boundValues.forEach(query::bind);
             index += boundValues.size();
@@ -401,7 +444,7 @@ public class DefaultRecordWriter implements RecordWriter {
         final Transaction transaction = getSession().beginTransaction();
 
         try {
-            getSession().doWork(processBatch(statementInfo, records));
+            getSession().doWork(processBatch(tableDescriptor, statementInfo, records));
             transaction.commit();
             processMetrics(records, statementInfo);
         }
@@ -445,22 +488,33 @@ public class DefaultRecordWriter implements RecordWriter {
      * Subclasses can override to change the write strategy (e.g., UNNEST).
      */
     protected void performTableWrite(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
-        performWrite(conn, getSqlStatementInfo(table, records), records);
+        performWrite(conn, table, getSqlStatementInfo(table, records), records);
     }
 
-    private Work processBatch(SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
-        return conn -> performWrite(conn, statementInfo, records);
+    private Work processBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
+        return conn -> performWrite(conn, table, statementInfo, records);
     }
 
     protected void performWrite(Connection conn, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {
+        performWrite(conn, statementInfo, records, this::bindValues);
+    }
+
+    protected void performWrite(Connection conn, TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {
+        performWrite(conn, statementInfo, records, (record, queryBinder) -> bindValues(table, record, queryBinder));
+    }
+
+    private void performWrite(Connection conn, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records,
+                              BiConsumer<JdbcSinkRecord, QueryBinder> valueBinder)
+            throws SQLException {
         try (PreparedStatement prepareStatement = conn.prepareStatement(statementInfo.statement())) {
             QueryBinder queryBinder = getQueryBinderResolver().resolve(prepareStatement);
             Stopwatch allbindStopwatch = Stopwatch.reusable();
             allbindStopwatch.start();
+
             for (JdbcSinkRecord record : records) {
                 Stopwatch singlebindStopwatch = Stopwatch.reusable();
                 singlebindStopwatch.start();
-                bindValues(record, queryBinder);
+                valueBinder.accept(record, queryBinder);
                 singlebindStopwatch.stop();
 
                 Stopwatch addBatchStopwatch = Stopwatch.reusable();
@@ -471,6 +525,7 @@ public class DefaultRecordWriter implements RecordWriter {
                 LOGGER.trace("[PERF] Bind single record execution time {}", singlebindStopwatch.durations());
                 LOGGER.trace("[PERF] Add batch execution time {}", addBatchStopwatch.durations());
             }
+
             allbindStopwatch.stop();
             LOGGER.trace("[PERF] All records bind execution time {}", allbindStopwatch.durations());
 
@@ -507,6 +562,26 @@ public class DefaultRecordWriter implements RecordWriter {
         }
     }
 
+    protected void bindValues(TableDescriptor table, JdbcSinkRecord record, QueryBinder queryBinder) {
+        int index;
+        if (record.isDelete()) {
+            bindKeyValuesToQuery(table, record, queryBinder, 1);
+            return;
+        }
+
+        switch (getConfig().getInsertMode()) {
+            case INSERT:
+            case UPSERT:
+                index = bindKeyValuesToQuery(table, record, queryBinder, 1);
+                bindNonKeyValuesToQuery(table, record, queryBinder, index);
+                break;
+            case UPDATE:
+                index = bindNonKeyValuesToQuery(table, record, queryBinder, 1);
+                bindKeyValuesToQuery(table, record, queryBinder, index);
+                break;
+        }
+    }
+
     /**
      * Get SQL statement for a list of records.
      * Tries to use batch operations (like UNNEST for PostgreSQL) if available and enabled,
@@ -516,6 +591,8 @@ public class DefaultRecordWriter implements RecordWriter {
         if (records.isEmpty()) {
             throw new DataException("Cannot generate SQL statement for empty record list");
         }
+
+        validateRecords(table, records);
 
         // Get first record for basic checks and fallback
         JdbcSinkRecord firstRecord = records.get(0);
@@ -553,6 +630,30 @@ public class DefaultRecordWriter implements RecordWriter {
             return new SqlStatementInfo(dialect.getDeleteStatement(table, firstRecord), false, true);
         }
         throw new DataException(String.format("Unable to get SQL statement for %s", firstRecord));
+    }
+
+    protected void validateRecords(TableDescriptor table, List<JdbcSinkRecord> records) {
+        for (JdbcSinkRecord record : records) {
+            if (record.isDelete()) {
+                validateFieldValues(table, record, record.filteredKey(), record.keyFieldNames());
+            }
+            else {
+                validateFieldValues(table, record, record.filteredKey(), record.keyFieldNames());
+                validateFieldValues(table, record, record.getPayload(), record.nonKeyFieldNames());
+            }
+        }
+    }
+
+    private void validateFieldValues(TableDescriptor table, JdbcSinkRecord record, Struct source, Set<String> fieldNames) {
+        if (source == null) {
+            return;
+        }
+        for (String fieldName : fieldNames) {
+            final JdbcFieldDescriptor field = record.jdbcFields().get(fieldName);
+            final var column = dialect.resolveColumn(table, field);
+            final Object value = field.getSchema().isOptional() ? source.getWithoutDefault(fieldName) : source.get(fieldName);
+            dialect.validateValue(field, column, value);
+        }
     }
 
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -59,6 +59,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String INSERT_MODE = "insert.mode";
     public static final String TRUNCATE_ENABLED = "truncate.enabled";
     public static final String SCHEMA_EVOLUTION = "schema.evolution";
+    public static final String TEMPORAL_PRECISION_LOSS_HANDLING_MODE = "temporal.precision.loss.handling.mode";
     public static final String QUOTE_IDENTIFIERS = "quote.identifiers";
     public static final String COLUMN_NAMING_STRATEGY = "column.naming.strategy";
     public static final String COLLECTION_TABLE_FORMAT = "collection.table.format";
@@ -161,6 +162,15 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withWidth(ConfigDef.Width.SHORT)
             .withImportance(ConfigDef.Importance.LOW)
             .withDescription("Controls how schema evolution is handled by the sink connector");
+
+    public static final Field TEMPORAL_PRECISION_LOSS_HANDLING_MODE_FIELD = Field.create(TEMPORAL_PRECISION_LOSS_HANDLING_MODE)
+            .withDisplayName("Controls how structured temporal precision loss is handled")
+            .withEnum(TemporalPrecisionLossHandlingMode.class, TemporalPrecisionLossHandlingMode.FAIL)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Controls how the connector handles structured temporal values whose fractional-second precision exceeds the target column precision. "
+                    + "The default 'fail' mode rejects values with non-zero discarded digits. The 'truncate' and 'round' modes explicitly reduce the value to the target precision.");
 
     public static final Field QUOTE_IDENTIFIERS_FIELD = Field.create(QUOTE_IDENTIFIERS)
             .withDisplayName("Controls whether table, column, or other identifiers are quoted")
@@ -303,6 +313,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     PRIMARY_KEY_MODE_FIELD,
                     PRIMARY_KEY_FIELDS_FIELD,
                     SCHEMA_EVOLUTION_FIELD,
+                    TEMPORAL_PRECISION_LOSS_HANDLING_MODE_FIELD,
                     QUOTE_IDENTIFIERS_FIELD,
                     COLLECTION_NAMING_STRATEGY_FIELD,
                     COLUMN_NAMING_STRATEGY_FIELD,
@@ -429,6 +440,32 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     }
 
+    public enum TemporalPrecisionLossHandlingMode implements EnumeratedValue {
+        FAIL("fail"),
+        TRUNCATE("truncate"),
+        ROUND("round");
+
+        private final String mode;
+
+        TemporalPrecisionLossHandlingMode(String mode) {
+            this.mode = mode;
+        }
+
+        public static TemporalPrecisionLossHandlingMode parse(String value) {
+            for (TemporalPrecisionLossHandlingMode option : values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return FAIL;
+        }
+
+        @Override
+        public String getValue() {
+            return mode;
+        }
+    }
+
     private final Configuration config;
 
     private final InsertMode insertMode;
@@ -436,6 +473,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final boolean truncateEnabled;
     private final String collectionNameFormat;
     private final SchemaEvolutionMode schemaEvolutionMode;
+    private final TemporalPrecisionLossHandlingMode temporalPrecisionLossHandlingMode;
     private final boolean quoteIdentifiers;
     private final CollectionNamingStrategy collectionNamingStrategy;
     private final ColumnNamingStrategy columnNamingStrategy;
@@ -463,6 +501,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         this.truncateEnabled = config.getBoolean(TRUNCATE_ENABLED_FIELD);
         this.collectionNameFormat = config.getString(COLLECTION_NAME_FORMAT_FIELD);
         this.schemaEvolutionMode = SchemaEvolutionMode.parse(config.getString(SCHEMA_EVOLUTION));
+        this.temporalPrecisionLossHandlingMode = TemporalPrecisionLossHandlingMode.parse(config.getString(TEMPORAL_PRECISION_LOSS_HANDLING_MODE));
         this.quoteIdentifiers = config.getBoolean(QUOTE_IDENTIFIERS_FIELD);
         this.databaseTimezone = config.getString(USE_TIME_ZONE_FIELD);
         this.postgresPostgisSchema = config.getString(POSTGRES_POSTGIS_SCHEMA_FIELD);
@@ -545,6 +584,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     public SchemaEvolutionMode getSchemaEvolutionMode() {
         return schemaEvolutionMode;
+    }
+
+    public TemporalPrecisionLossHandlingMode getTemporalPrecisionLossHandlingMode() {
+        return temporalPrecisionLossHandlingMode;
     }
 
     public boolean isQuoteIdentifiers() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -60,6 +60,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String TRUNCATE_ENABLED = "truncate.enabled";
     public static final String SCHEMA_EVOLUTION = "schema.evolution";
     public static final String TEMPORAL_PRECISION_LOSS_HANDLING_MODE = "temporal.precision.loss.handling.mode";
+    public static final String TEMPORAL_RANGE_LOSS_HANDLING_MODE = "temporal.range.loss.handling.mode";
     public static final String QUOTE_IDENTIFIERS = "quote.identifiers";
     public static final String COLUMN_NAMING_STRATEGY = "column.naming.strategy";
     public static final String COLLECTION_TABLE_FORMAT = "collection.table.format";
@@ -171,6 +172,15 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("Controls how the connector handles structured temporal values whose fractional-second precision exceeds the target column precision. "
                     + "The default 'fail' mode rejects values with non-zero discarded digits. The 'truncate' and 'round' modes explicitly reduce the value to the target precision.");
+
+    public static final Field TEMPORAL_RANGE_LOSS_HANDLING_MODE_FIELD = Field.create(TEMPORAL_RANGE_LOSS_HANDLING_MODE)
+            .withDisplayName("Controls how structured temporal range loss is handled")
+            .withEnum(TemporalRangeLossHandlingMode.class, TemporalRangeLossHandlingMode.FAIL)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Controls how the connector handles structured date and timestamp values outside the target column range. "
+                    + "The default 'fail' mode rejects the value. The 'saturate' mode maps it to the nearest target boundary.");
 
     public static final Field QUOTE_IDENTIFIERS_FIELD = Field.create(QUOTE_IDENTIFIERS)
             .withDisplayName("Controls whether table, column, or other identifiers are quoted")
@@ -314,6 +324,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     PRIMARY_KEY_FIELDS_FIELD,
                     SCHEMA_EVOLUTION_FIELD,
                     TEMPORAL_PRECISION_LOSS_HANDLING_MODE_FIELD,
+                    TEMPORAL_RANGE_LOSS_HANDLING_MODE_FIELD,
                     QUOTE_IDENTIFIERS_FIELD,
                     COLLECTION_NAMING_STRATEGY_FIELD,
                     COLUMN_NAMING_STRATEGY_FIELD,
@@ -466,6 +477,31 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         }
     }
 
+    public enum TemporalRangeLossHandlingMode implements EnumeratedValue {
+        FAIL("fail"),
+        SATURATE("saturate");
+
+        private final String mode;
+
+        TemporalRangeLossHandlingMode(String mode) {
+            this.mode = mode;
+        }
+
+        public static TemporalRangeLossHandlingMode parse(String value) {
+            for (TemporalRangeLossHandlingMode option : values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return FAIL;
+        }
+
+        @Override
+        public String getValue() {
+            return mode;
+        }
+    }
+
     private final Configuration config;
 
     private final InsertMode insertMode;
@@ -474,6 +510,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final String collectionNameFormat;
     private final SchemaEvolutionMode schemaEvolutionMode;
     private final TemporalPrecisionLossHandlingMode temporalPrecisionLossHandlingMode;
+    private final TemporalRangeLossHandlingMode temporalRangeLossHandlingMode;
     private final boolean quoteIdentifiers;
     private final CollectionNamingStrategy collectionNamingStrategy;
     private final ColumnNamingStrategy columnNamingStrategy;
@@ -502,6 +539,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         this.collectionNameFormat = config.getString(COLLECTION_NAME_FORMAT_FIELD);
         this.schemaEvolutionMode = SchemaEvolutionMode.parse(config.getString(SCHEMA_EVOLUTION));
         this.temporalPrecisionLossHandlingMode = TemporalPrecisionLossHandlingMode.parse(config.getString(TEMPORAL_PRECISION_LOSS_HANDLING_MODE));
+        this.temporalRangeLossHandlingMode = TemporalRangeLossHandlingMode.parse(config.getString(TEMPORAL_RANGE_LOSS_HANDLING_MODE));
         this.quoteIdentifiers = config.getBoolean(QUOTE_IDENTIFIERS_FIELD);
         this.databaseTimezone = config.getString(USE_TIME_ZONE_FIELD);
         this.postgresPostgisSchema = config.getString(POSTGRES_POSTGIS_SCHEMA_FIELD);
@@ -588,6 +626,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     public TemporalPrecisionLossHandlingMode getTemporalPrecisionLossHandlingMode() {
         return temporalPrecisionLossHandlingMode;
+    }
+
+    public TemporalRangeLossHandlingMode getTemporalRangeLossHandlingMode() {
+        return temporalRangeLossHandlingMode;
     }
 
     public boolean isQuoteIdentifiers() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
@@ -59,7 +59,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         // Otherwise delegate to parent's standard row-wise binding
         SqlStatementInfo sqlStatementInfo = getSqlStatementInfo(tableDescriptor, records);
         if (sqlStatementInfo.isBatchStatement()) {
-            writeUnnestBatch(sqlStatementInfo, records);
+            writeUnnestBatch(tableDescriptor, sqlStatementInfo, records);
         }
         else {
             super.write(tableDescriptor, records);
@@ -70,7 +70,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
     protected void performTableWrite(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
         SqlStatementInfo statementInfo = getSqlStatementInfo(table, records);
         if (statementInfo.isBatchStatement()) {
-            performUnnestBatch(conn, statementInfo.statement(), records);
+            performUnnestBatch(conn, table, statementInfo.statement(), records);
         }
         else {
             super.performTableWrite(conn, table, records);
@@ -80,12 +80,12 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
     /**
      * Write records using UNNEST approach with column-wise binding.
      */
-    private void writeUnnestBatch(SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
+    private void writeUnnestBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
         Stopwatch writeStopwatch = Stopwatch.reusable();
         writeStopwatch.start();
         final Transaction transaction = getSession().beginTransaction();
         try {
-            getSession().doWork(processUnnestBatch(statementInfo.statement(), records));
+            getSession().doWork(processUnnestBatch(table, statementInfo.statement(), records));
             transaction.commit();
             processMetrics(records, statementInfo);
         }
@@ -97,14 +97,14 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         LOGGER.trace("[PERF] Total UNNEST write execution time {}", writeStopwatch.durations());
     }
 
-    void performUnnestBatch(Connection conn, String sqlStatement, List<JdbcSinkRecord> records) throws SQLException {
+    void performUnnestBatch(Connection conn, TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) throws SQLException {
         try (PreparedStatement prepareStatement = conn.prepareStatement(sqlStatement)) {
 
             Stopwatch allbindStopwatch = Stopwatch.reusable();
             allbindStopwatch.start();
 
             // Bind column arrays for UNNEST using setArray()
-            bindArraysForUnnest(records, conn, prepareStatement);
+            bindArraysForUnnest(table, records, conn, prepareStatement);
 
             allbindStopwatch.stop();
             LOGGER.trace("[PERF] All records bind execution time for UNNEST {}", allbindStopwatch.durations());
@@ -127,9 +127,9 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Process a batch using UNNEST approach where each column's values are passed as a SQL array.
      * Uses PreparedStatement.setArray() for optimal performance and query plan caching.
      */
-    private Work processUnnestBatch(String sqlStatement, List<JdbcSinkRecord> records) {
+    private Work processUnnestBatch(TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) {
         return conn -> {
-            performUnnestBatch(conn, sqlStatement, records);
+            performUnnestBatch(conn, table, sqlStatement, records);
         };
     }
 
@@ -141,7 +141,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * For UPDATE: bind non-key fields first, then key fields
      * For DELETE: bind only key fields
      */
-    private void bindArraysForUnnest(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps) throws SQLException {
+    private void bindArraysForUnnest(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps) throws SQLException {
         if (records.isEmpty()) {
             return;
         }
@@ -150,20 +150,20 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         int parameterIndex = 1;
 
         if (firstRecord.isDelete()) {
-            bindKeyFieldArrays(records, conn, ps, parameterIndex);
+            bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
         }
         else {
             switch (getConfig().getInsertMode()) {
                 case INSERT:
                 case UPSERT:
                     // For INSERT/UPSERT: key fields first, then non-key fields
-                    parameterIndex = bindKeyFieldArrays(records, conn, ps, parameterIndex);
-                    bindNonKeyFieldArrays(records, conn, ps, parameterIndex);
+                    parameterIndex = bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
+                    bindNonKeyFieldArrays(table, records, conn, ps, parameterIndex);
                     break;
                 case UPDATE:
                     // For UPDATE: non-key fields first, then key fields
-                    parameterIndex = bindNonKeyFieldArrays(records, conn, ps, parameterIndex);
-                    bindKeyFieldArrays(records, conn, ps, parameterIndex);
+                    parameterIndex = bindNonKeyFieldArrays(table, records, conn, ps, parameterIndex);
+                    bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
                     break;
             }
         }
@@ -173,7 +173,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Bind key field arrays using setArray().
      * Each column's values across all records are collected into an array and bound as a single parameter.
      */
-    private int bindKeyFieldArrays(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
+    private int bindKeyFieldArrays(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
         JdbcSinkRecord firstRecord = records.get(0);
         Set<String> keyFieldNames = firstRecord.keyFieldNames();
 
@@ -196,7 +196,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
                     }
                 }
 
-                columnValues.add(transformValue(field, value));
+                columnValues.add(transformValue(table, field, value));
             }
 
             // Convert to array and bind using setArray()
@@ -212,7 +212,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Bind non-key field arrays using setArray().
      * Each column's values across all records are collected into an array and bound as a single parameter.
      */
-    private int bindNonKeyFieldArrays(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
+    private int bindNonKeyFieldArrays(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
         JdbcSinkRecord firstRecord = records.get(0);
         Set<String> nonKeyFieldNames = firstRecord.nonKeyFieldNames();
 
@@ -233,7 +233,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
                     value = payload.get(fieldName);
                 }
 
-                columnValues.add(transformValue(field, value));
+                columnValues.add(transformValue(table, field, value));
             }
 
             // Convert to array and bind using setArray()
@@ -245,8 +245,9 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         return parameterIndex;
     }
 
-    private Object transformValue(JdbcFieldDescriptor field, Object value) {
-        List<ValueBindDescriptor> boundValues = getDialect().bindValue(field, 1, value);
+    private Object transformValue(TableDescriptor table, JdbcFieldDescriptor field, Object value) {
+        final var column = getDialect().resolveColumn(table, field);
+        List<ValueBindDescriptor> boundValues = getDialect().bindValue(field, column, 1, value);
         if (boundValues.size() != 1) {
             throw new ConnectException(
                     String.format("UNNEST does not support types that expand to multiple bind parameters (field: '%s', type: '%s'). "

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -20,6 +20,7 @@ import io.debezium.connector.jdbc.JdbcSinkRecord;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -76,6 +77,17 @@ public interface DatabaseDialect {
      * @return a collection of field names that are missing from the database table, can be {@code empty}.
      */
     Set<String> resolveMissingFields(JdbcSinkRecord record, TableDescriptor table);
+
+    /**
+     * Resolves the target column for an incoming field using the configured naming rules.
+     *
+     * @param table target table descriptor, never {@code null}
+     * @param field incoming field descriptor, never {@code null}
+     * @return the resolved target column, never {@code null}
+     */
+    default ColumnDescriptor resolveColumn(TableDescriptor table, JdbcFieldDescriptor field) {
+        return table.getColumnByName(field.getColumnName());
+    }
 
     /**
      * Construct a {@code CREATE TABLE} statement specific for this dialect based on the provided record.
@@ -265,6 +277,15 @@ public interface DatabaseDialect {
     }
 
     /**
+     * Gets the structured temporal values that this target dialect can preserve.
+     *
+     * @return the target temporal capabilities
+     */
+    default TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision());
+    }
+
+    /**
      * Get the default decimal data type precision for the dialect.
      *
      * @return default decimal precision
@@ -414,6 +435,30 @@ public interface DatabaseDialect {
      * @return the list of bounded values
      */
     List<ValueBindDescriptor> bindValue(JdbcFieldDescriptor field, int startIndex, Object value);
+
+    /**
+     * Bind the specified value with access to the actual target column definition.
+     *
+     * @param field the field being bound, should never be {@code null}
+     * @param column the target column, should never be {@code null}
+     * @param startIndex the starting index of the parameter binding
+     * @param value the value to be bound, may be {@code null}
+     * @return the list of bounded values
+     */
+    default List<ValueBindDescriptor> bindValue(JdbcFieldDescriptor field, ColumnDescriptor column, int startIndex, Object value) {
+        return bindValue(field, startIndex, value);
+    }
+
+    /**
+     * Validates a value against the actual target column before statement execution.
+     *
+     * @param field the field being validated, should never be {@code null}
+     * @param column the target column, should never be {@code null}
+     * @param value the value to validate, may be {@code null}
+     */
+    default void validateValue(JdbcFieldDescriptor field, ColumnDescriptor column, Object value) {
+        getSchemaType(field.getSchema()).validate(column, field.getSchema(), value);
+    }
 
     /**
      * Set of retriable exceptions if flush fails.

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -243,6 +243,11 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         return missingFields;
     }
 
+    @Override
+    public ColumnDescriptor resolveColumn(TableDescriptor table, JdbcFieldDescriptor field) {
+        return table.getColumnByName(resolveColumnName(field));
+    }
+
     protected String resolveColumnName(FieldDescriptor field) {
         String columnName = columnNamingStrategy.resolveColumnName(field.getColumnName());
         if (!getConfig().isQuoteIdentifiers()) {
@@ -424,6 +429,13 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         var schemaType = getSchemaType(field.getSchema());
         LOGGER.trace("Bind field '{}' at position {} with type {}: {}", field.getName(), startIndex, schemaType.getClass().getName(), value);
         return field.bind(startIndex, value, schemaType);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bindValue(JdbcFieldDescriptor field, ColumnDescriptor column, int startIndex, Object value) {
+        var schemaType = getSchemaType(field.getSchema());
+        LOGGER.trace("Bind field '{}' at position {} with type {}: {}", field.getName(), startIndex, schemaType.getClass().getName(), value);
+        return field.bind(startIndex, column, value, schemaType);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -90,6 +90,7 @@ import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.StructuredTemporal;
 import io.debezium.util.Strings;
 
 /**
@@ -467,7 +468,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
     @Override
     public JdbcType getSchemaType(Schema schema) {
         if (!Objects.isNull(schema.name())) {
-            final JdbcType type = typeRegistry.get(schema.name());
+            final JdbcType type = typeRegistry.get(StructuredTemporal.schemaNameWithoutSourceColumn(schema.name()));
             if (!Objects.isNull(type)) {
                 LOGGER.trace("Schema '{}' resolved by name from registry to type '{}'", schema.name(), type);
                 return type;

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/cockroachdb/CockroachDBDatabaseDialect.java
@@ -18,6 +18,9 @@ import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
 import io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 
 /**
  * A {@link DatabaseDialect} implementation for CockroachDB.
@@ -30,6 +33,17 @@ import io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect;
  * @author Virag Tripathi
  */
 public class CockroachDBDatabaseDialect extends PostgresDatabaseDialect {
+
+    private static final TemporalRange TIMESTAMP_RANGE = new TemporalRange(
+            Boundary.timestamp(-4714, 11, 24, 0, 0, 0, 0),
+            Boundary.timestamp(294_276, 12, 31, 23, 59, 59, 999_999_000_000L));
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return super.getTargetTemporalCapabilities()
+                .withTimestampRange(TIMESTAMP_RANGE)
+                .withTimestampInfinitySupported(false);
+    }
 
     public static class CockroachDBDatabaseDialectProvider implements DatabaseDialectProvider {
         @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/Db2DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/Db2DatabaseDialect.java
@@ -92,6 +92,13 @@ public class Db2DatabaseDialect extends GeneralDatabaseDialect {
         registerType(TimeType.INSTANCE);
         registerType(NanoTimeType.INSTANCE);
         registerType(MicroTimeType.INSTANCE);
+        registerType(new StructuredTimestampType());
+        registerType(new StructuredZonedTimestampType());
+    }
+
+    @Override
+    public int getMaxTimestampPrecision() {
+        return 12;
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/Db2DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/Db2DatabaseDialect.java
@@ -31,6 +31,8 @@ import io.debezium.connector.jdbc.dialect.db2.debezium.NanoTimestampType;
 import io.debezium.connector.jdbc.dialect.db2.debezium.TimeType;
 import io.debezium.connector.jdbc.dialect.db2.debezium.TimestampType;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.time.ZonedTimestamp;
@@ -41,6 +43,13 @@ import io.debezium.time.ZonedTimestamp;
  * @author Chris Cranford
  */
 public class Db2DatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(1, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(1, 9999));
+    }
 
     private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
@@ -47,11 +47,17 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         validate(column, schema, value);
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
         return List.of(new ValueBindDescriptor(index,
-                StructuredTemporalSupport.toLocalDateTimeLiteral(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+                StructuredTemporalSupport.toLocalDateTimeLiteral(
+                        requireStruct(value), precision, getPrecisionLossHandlingMode(),
+                        getDialect().getTargetTemporalCapabilities().targetTimestampRange(column), getRangeLossHandlingMode(),
+                        targetDescription(column)),
+                Types.VARCHAR));
     }
 
     protected String toLiteral(Schema schema, org.apache.kafka.connect.data.Struct value) {
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
         return StructuredTemporalSupport.toLocalDateTimeLiteral(
-                value, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode());
+                value, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
@@ -51,8 +51,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
     }
 
     protected String toLiteral(Schema schema, org.apache.kafka.connect.data.Struct value) {
-        final int sourcePrecision = getTimePrecision(schema);
-        final int precision = sourcePrecision < 0 ? getDialect().getDefaultTimestampPrecision() : sourcePrecision;
-        return StructuredTemporalSupport.toLocalDateTimeLiteral(value, precision, getPrecisionLossHandlingMode());
+        return StructuredTemporalSupport.toLocalDateTimeLiteral(
+                value, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode());
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredTimestampType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.db2;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Db2 binding for structured timestamps, using a server-side cast so fractional precision up to picoseconds is not
+ * reduced by the standard JDBC temporal types.
+ */
+public class StructuredTimestampType extends io.debezium.connector.jdbc.type.debezium.StructuredTimestampType {
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        return String.format("cast(? as timestamp(%d))", precision);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return "'" + toLiteral(schema, requireStruct(value)) + "'";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        return List.of(new ValueBindDescriptor(index, toLiteral(schema, requireStruct(value)), Types.VARCHAR));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        return List.of(new ValueBindDescriptor(index,
+                StructuredTemporalSupport.toLocalDateTimeLiteral(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+    }
+
+    protected String toLiteral(Schema schema, org.apache.kafka.connect.data.Struct value) {
+        final int sourcePrecision = getTimePrecision(schema);
+        final int precision = sourcePrecision < 0 ? getDialect().getDefaultTimestampPrecision() : sourcePrecision;
+        return StructuredTemporalSupport.toLocalDateTimeLiteral(value, precision, getPrecisionLossHandlingMode());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredZonedTimestampType.java
@@ -20,7 +20,7 @@ public class StructuredZonedTimestampType extends StructuredTimestampType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredZonedTimestamp.SCHEMA_NAME };
+        return StructuredZonedTimestamp.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/StructuredZonedTimestampType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.db2;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredZonedTimestamp;
+
+/**
+ * Db2 binding for structured zoned timestamps. Db2 LUW has no zoned timestamp type, so only values whose zone
+ * metadata can be discarded without changing their meaning pass validation.
+ */
+public class StructuredZonedTimestampType extends StructuredTimestampType {
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ StructuredZonedTimestamp.SCHEMA_NAME };
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final Struct struct = requireStruct(value);
+            StructuredTemporalPreflightValidator.validateZonedTimestamp(struct, getDialect().getTargetTemporalCapabilities());
+        }
+        super.validate(column, schema, value);
+    }
+
+    @Override
+    protected String toLiteral(Schema schema, Struct value) {
+        StructuredTemporalPreflightValidator.validateZonedTimestamp(value, getDialect().getTargetTemporalCapabilities());
+        return super.toLiteral(schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/Db2iDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/Db2iDatabaseDialect.java
@@ -33,6 +33,8 @@ import io.debezium.connector.jdbc.dialect.db2i.debezium.NanoTimestampType;
 import io.debezium.connector.jdbc.dialect.db2i.debezium.TimeType;
 import io.debezium.connector.jdbc.dialect.db2i.debezium.TimestampType;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.field.FieldDescriptor;
@@ -44,6 +46,13 @@ import io.debezium.time.ZonedTimestamp;
  * @author Andrew Love
  */
 public class Db2iDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(1, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(1, 9999));
+    }
 
     private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/Db2iDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/Db2iDatabaseDialect.java
@@ -21,6 +21,8 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
 import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
+import io.debezium.connector.jdbc.dialect.db2.StructuredTimestampType;
+import io.debezium.connector.jdbc.dialect.db2.StructuredZonedTimestampType;
 import io.debezium.connector.jdbc.dialect.db2i.connect.ConnectDateType;
 import io.debezium.connector.jdbc.dialect.db2i.connect.ConnectTimeType;
 import io.debezium.connector.jdbc.dialect.db2i.connect.ConnectTimestampType;
@@ -127,6 +129,13 @@ public class Db2iDatabaseDialect extends GeneralDatabaseDialect {
         registerType(TimeType.INSTANCE);
         registerType(NanoTimeType.INSTANCE);
         registerType(MicroTimeType.INSTANCE);
+        registerType(new StructuredTimestampType());
+        registerType(new StructuredZonedTimestampType());
+    }
+
+    @Override
+    public int getMaxTimestampPrecision() {
+        return 12;
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -38,6 +38,8 @@ import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.ZonedTimestamp;
@@ -50,9 +52,20 @@ import io.debezium.util.Strings;
  */
 public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
 
+    private static final TemporalRange DATETIME_RANGE = new TemporalRange(
+            Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
+            Boundary.timestamp(9999, 12, 31, 23, 59, 59, 499_999_999_999L));
+
+    private static final TemporalRange TIMESTAMP_RANGE = new TemporalRange(
+            Boundary.timestamp(1970, 1, 1, 0, 0, 1, 0),
+            Boundary.timestamp(2038, 1, 19, 3, 14, 7, 499_999_999_999L));
+
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
         return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(1000, 9999))
+                .withTimestampRange(DATETIME_RANGE)
+                .withTimestampRangeForType(TIMESTAMP_RANGE, "timestamp")
                 .withDurationKinds(EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -66,7 +66,8 @@ public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
                 .withDateRange(TemporalRange.dateYears(1000, 9999))
                 .withTimestampRange(DATETIME_RANGE)
                 .withTimestampRangeForType(TIMESTAMP_RANGE, "timestamp")
-                .withDurationKinds(EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
+                .withDurationKinds(EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME))
+                .withZeroDateSupported(true);
     }
 
     private static final List<String> NO_DEFAULT_VALUE_TYPES = Arrays.asList(

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -36,7 +37,9 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.sink.field.FieldDescriptor;
+import io.debezium.time.StructuredDuration;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Strings;
 
@@ -46,6 +49,12 @@ import io.debezium.util.Strings;
  * @author Chris Cranford
  */
 public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDurationKinds(EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
+    }
 
     private static final List<String> NO_DEFAULT_VALUE_TYPES = Arrays.asList(
             "tinytext", "mediumtext", "longtext", "text", "tinyblob", "mediumblob", "longblob");

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -52,6 +52,8 @@ import io.debezium.util.Strings;
  */
 public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
 
+    // MySQL defines .499999, rather than .999999, as the fractional upper boundary
+    // for both DATETIME(6) and TIMESTAMP(6).
     private static final TemporalRange DATETIME_RANGE = new TemporalRange(
             Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
             Boundary.timestamp(9999, 12, 31, 23, 59, 59, 499_999_999_999L));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -52,15 +52,17 @@ import io.debezium.util.Strings;
  */
 public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
 
-    // MySQL defines .499999, rather than .999999, as the fractional upper boundary
-    // for both DATETIME(6) and TIMESTAMP(6).
+    // Boundaries carry the storage maximum; range checks truncate them to the
+    // target column precision after rounding. The MySQL manual documents .499999
+    // as the upper bound, but that is only the round-up-safe input limit for
+    // lower-precision conversions, not what a column can store.
     private static final TemporalRange DATETIME_RANGE = new TemporalRange(
             Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
-            Boundary.timestamp(9999, 12, 31, 23, 59, 59, 499_999_999_999L));
+            Boundary.timestamp(9999, 12, 31, 23, 59, 59, 999_999_999_999L));
 
     private static final TemporalRange TIMESTAMP_RANGE = new TemporalRange(
             Boundary.timestamp(1970, 1, 1, 0, 0, 1, 0),
-            Boundary.timestamp(2038, 1, 19, 3, 14, 7, 499_999_999_999L));
+            Boundary.timestamp(2038, 1, 19, 3, 14, 7, 999_999_999_999L));
 
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDateType.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
 
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
@@ -21,7 +22,12 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return "'" + StructuredTemporalLiteral.date(requireStruct(value)) + "'";
+        if (getDialect() == null) {
+            return "'" + StructuredTemporalLiteral.date(requireStruct(value)) + "'";
+        }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        return "'" + StructuredTemporalLiteral.date(
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema)) + "'";
     }
 
     @Override
@@ -29,6 +35,30 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(requireStruct(value)), Types.VARCHAR));
+        if (getDialect() == null) {
+            return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(requireStruct(value)), Types.VARCHAR));
+        }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema)), Types.VARCHAR));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            StructuredTemporalLiteral.date(
+                    requireStruct(value), getDialect().getTargetTemporalCapabilities().targetDateRange(column),
+                    getRangeLossHandlingMode(), targetDescription(column));
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(
+                requireStruct(value), getDialect().getTargetTemporalCapabilities().targetDateRange(column),
+                getRangeLossHandlingMode(), targetDescription(column)), Types.VARCHAR));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDateType.java
@@ -27,7 +27,8 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
         }
         final var capabilities = getDialect().getTargetTemporalCapabilities();
         return "'" + StructuredTemporalLiteral.date(
-                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema)) + "'";
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(),
+                capabilities.zeroDateSupported(), targetDescription(schema)) + "'";
     }
 
     @Override
@@ -40,15 +41,17 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
         }
         final var capabilities = getDialect().getTargetTemporalCapabilities();
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(
-                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema)), Types.VARCHAR));
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(),
+                capabilities.zeroDateSupported(), targetDescription(schema)), Types.VARCHAR));
     }
 
     @Override
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
         if (value != null) {
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
             StructuredTemporalLiteral.date(
-                    requireStruct(value), getDialect().getTargetTemporalCapabilities().targetDateRange(column),
-                    getRangeLossHandlingMode(), targetDescription(column));
+                    requireStruct(value), capabilities.targetDateRange(column), getRangeLossHandlingMode(),
+                    capabilities.zeroDateSupported(), targetDescription(column));
         }
     }
 
@@ -57,8 +60,9 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.date(
-                requireStruct(value), getDialect().getTargetTemporalCapabilities().targetDateRange(column),
-                getRangeLossHandlingMode(), targetDescription(column)), Types.VARCHAR));
+                requireStruct(value), capabilities.targetDateRange(column), getRangeLossHandlingMode(),
+                capabilities.zeroDateSupported(), targetDescription(column)), Types.VARCHAR));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
@@ -38,14 +38,13 @@ public class StructuredDurationType extends AbstractTemporalType {
             throw new org.apache.kafka.connect.errors.ConnectException(String.format(
                     "Structured duration kind '%s' cannot be mapped to MySQL TIME without semantic loss", kind.getValue()));
         }
-        final int maxPrecision = getDialect().getTargetTemporalCapabilities().maxTimePrecision();
-        final int precision = StructuredTemporalSupport.getPrecision(schema).orElse(Math.min(6, maxPrecision));
-        return getDialect().getJdbcTypeName(Types.TIME, Size.precision(Math.min(precision, maxPrecision)));
+        return getDialect().getJdbcTypeName(Types.TIME, Size.precision(getSchemaTimePrecision(schema)));
     }
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return "'" + StructuredTemporalLiteral.duration(requireStruct(value)) + "'";
+        return "'" + StructuredTemporalLiteral.duration(
+                requireStruct(value), getSchemaTimePrecision(schema), getPrecisionLossHandlingMode()) + "'";
     }
 
     @Override
@@ -53,7 +52,8 @@ public class StructuredDurationType extends AbstractTemporalType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.duration(requireStruct(value)), Types.VARCHAR));
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.duration(
+                requireStruct(value), getSchemaTimePrecision(schema), getPrecisionLossHandlingMode()), Types.VARCHAR));
     }
 
     @Override
@@ -78,5 +78,11 @@ public class StructuredDurationType extends AbstractTemporalType {
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
         return List.of(new ValueBindDescriptor(index,
                 StructuredTemporalLiteral.duration(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+    }
+
+    private int getSchemaTimePrecision(Schema schema) {
+        final int maxPrecision = getDialect().getTargetTemporalCapabilities().maxTimePrecision();
+        final int precision = StructuredTemporalSupport.getPrecision(schema).orElse(Math.min(6, maxPrecision));
+        return Math.min(precision, maxPrecision);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
@@ -64,9 +64,9 @@ public class StructuredDurationType extends AbstractTemporalType {
         final Struct struct = requireStruct(value);
         final var capabilities = getDialect().getTargetTemporalCapabilities();
         StructuredTemporalPreflightValidator.validateDuration(schema, struct, capabilities);
-        StructuredTemporalPreflightValidator.validatePrecision(column, struct, capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+        StructuredTemporalPreflightValidator.validatePrecision(column, struct, targetTimePrecision(column), getPrecisionLossHandlingMode());
         StructuredTemporalLiteral.duration(struct,
-                capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+                targetTimePrecision(column), getPrecisionLossHandlingMode());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class StructuredDurationType extends AbstractTemporalType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         validate(column, schema, value);
-        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final int precision = targetTimePrecision(column);
         return List.of(new ValueBindDescriptor(index,
                 StructuredTemporalLiteral.duration(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
     }
@@ -84,5 +84,21 @@ public class StructuredDurationType extends AbstractTemporalType {
         final int maxPrecision = getDialect().getTargetTemporalCapabilities().maxTimePrecision();
         final int precision = StructuredTemporalSupport.getPrecision(schema).orElse(Math.min(6, maxPrecision));
         return Math.min(precision, maxPrecision);
+    }
+
+    private int targetTimePrecision(ColumnDescriptor column) {
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final int precision = capabilities.targetTimePrecision(column);
+        final int columnSizeWithoutFraction = getTimeColumnSizeWithoutFraction();
+        if (precision == 0 && column.getPrecision() > columnSizeWithoutFraction && "time".equalsIgnoreCase(column.getTypeName())) {
+            // MySQL Connector/J reports fractional-second precision in COLUMN_SIZE for temporal columns,
+            // while DECIMAL_DIGITS is always zero. The fractional representation adds a decimal separator.
+            return Math.min(column.getPrecision() - columnSizeWithoutFraction - 1, capabilities.maxTimePrecision());
+        }
+        return precision;
+    }
+
+    protected int getTimeColumnSizeWithoutFraction() {
+        return 8;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
@@ -28,7 +28,7 @@ public class StructuredDurationType extends AbstractTemporalType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredDuration.SCHEMA_NAME };
+        return StructuredDuration.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredDurationType.java
@@ -9,16 +9,20 @@ import java.sql.Types;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.AbstractTemporalType;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredDuration;
 
 /**
  * MySQL implementation of {@link StructuredDuration} values.
  */
-public class StructuredDurationType extends AbstractType {
+public class StructuredDurationType extends AbstractTemporalType {
 
     public static final StructuredDurationType INSTANCE = new StructuredDurationType();
 
@@ -29,10 +33,14 @@ public class StructuredDurationType extends AbstractType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final int precision = getSourceColumnPrecision(schema)
-                .map(Integer::parseInt)
-                .orElseGet(() -> getSourceColumnSize(schema).map(Integer::parseInt).orElse(6));
-        return getDialect().getJdbcTypeName(Types.TIME, Size.precision(Math.min(precision, 6)));
+        final var kind = StructuredTemporalPreflightValidator.durationKind(schema, null);
+        if (!getDialect().getTargetTemporalCapabilities().durationKinds().contains(kind)) {
+            throw new org.apache.kafka.connect.errors.ConnectException(String.format(
+                    "Structured duration kind '%s' cannot be mapped to MySQL TIME without semantic loss", kind.getValue()));
+        }
+        final int maxPrecision = getDialect().getTargetTemporalCapabilities().maxTimePrecision();
+        final int precision = StructuredTemporalSupport.getPrecision(schema).orElse(Math.min(6, maxPrecision));
+        return getDialect().getJdbcTypeName(Types.TIME, Size.precision(Math.min(precision, maxPrecision)));
     }
 
     @Override
@@ -46,5 +54,29 @@ public class StructuredDurationType extends AbstractType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.duration(requireStruct(value)), Types.VARCHAR));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return;
+        }
+        final Struct struct = requireStruct(value);
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        StructuredTemporalPreflightValidator.validateDuration(schema, struct, capabilities);
+        StructuredTemporalPreflightValidator.validatePrecision(column, struct, capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+        StructuredTemporalLiteral.duration(struct,
+                capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        return List.of(new ValueBindDescriptor(index,
+                StructuredTemporalLiteral.duration(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -7,45 +7,67 @@ package io.debezium.connector.jdbc.dialect.mysql;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.LocalDateTime;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.time.StructuredTemporal;
 
 final class StructuredTemporalLiteral {
 
     static String date(Struct value) {
-        requireFinite(value);
+        return date(value, TemporalRange.unbounded(), TemporalRangeLossHandlingMode.FAIL, "target temporal type");
+    }
+
+    static String date(Struct value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
+                       String targetDescription) {
+        if (StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
+            return formatDate(
+                    value.getInt32(StructuredTemporal.YEAR_FIELD),
+                    value.getInt8(StructuredTemporal.MONTH_FIELD),
+                    value.getInt8(StructuredTemporal.DAY_FIELD));
+        }
+        final Boundary adjusted = StructuredTemporalSupport.adjustDate(value, range, handlingMode, targetDescription);
+        return formatDate(adjusted.year(), adjusted.month(), adjusted.day());
+    }
+
+    private static String formatDate(int year, int month, int day) {
         return String.format("%04d-%02d-%02d",
-                value.getInt32(StructuredTemporal.YEAR_FIELD),
-                value.getInt8(StructuredTemporal.MONTH_FIELD),
-                value.getInt8(StructuredTemporal.DAY_FIELD));
+                year, month, day);
     }
 
     static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
-        requireFinite(value);
-        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
-                StructuredTemporalSupport.getPicoseconds(value), precision, handlingMode);
-        if (fraction.carrySeconds() != 0) {
-            final LocalDateTime dateTime = StructuredTemporalSupport.toLocalDateTime(value)
-                    .withNano(fraction.nanoseconds())
-                    .plusSeconds(fraction.carrySeconds());
-            return formatTimestamp(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(),
-                    dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(), fraction.picoseconds(), precision);
+        return timestamp(value, precision, handlingMode, TemporalRange.unbounded(),
+                TemporalRangeLossHandlingMode.FAIL, "target temporal type");
+    }
+
+    static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode precisionHandlingMode,
+                            TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
+                            String targetDescription) {
+        if (StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
+            final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
+                    StructuredTemporalSupport.getPicoseconds(value), precision, precisionHandlingMode);
+            if (fraction.carrySeconds() == 0) {
+                return formatTimestamp(
+                        value.getInt32(StructuredTemporal.YEAR_FIELD),
+                        value.getInt8(StructuredTemporal.MONTH_FIELD),
+                        value.getInt8(StructuredTemporal.DAY_FIELD),
+                        value.getInt8(StructuredTemporal.HOUR_FIELD),
+                        value.getInt8(StructuredTemporal.MINUTE_FIELD),
+                        value.getInt8(StructuredTemporal.SECOND_FIELD),
+                        fraction.picoseconds(), precision);
+            }
         }
-        return formatTimestamp(
-                value.getInt32(StructuredTemporal.YEAR_FIELD),
-                value.getInt8(StructuredTemporal.MONTH_FIELD),
-                value.getInt8(StructuredTemporal.DAY_FIELD),
-                value.getInt8(StructuredTemporal.HOUR_FIELD),
-                value.getInt8(StructuredTemporal.MINUTE_FIELD),
-                value.getInt8(StructuredTemporal.SECOND_FIELD),
-                fraction.picoseconds(), precision);
+        final Boundary adjusted = StructuredTemporalSupport.adjustTimestamp(
+                value, precision, precisionHandlingMode, range, rangeHandlingMode, targetDescription);
+        return formatTimestamp(adjusted.year(), adjusted.month(), adjusted.day(), adjusted.hour(), adjusted.minute(),
+                adjusted.second(), adjusted.picoseconds(), precision);
     }
 
     static String duration(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
@@ -92,6 +114,15 @@ final class StructuredTemporalLiteral {
             throw new ConnectException(String.format(
                     "MySQL TIME cannot represent structured duration field '%s' without semantic loss", fieldName));
         }
+    }
+
+    private static boolean hasZeroDate(Struct value) {
+        final Integer year = value.getInt32(StructuredTemporal.YEAR_FIELD);
+        final Byte month = value.getInt8(StructuredTemporal.MONTH_FIELD);
+        final Byte day = value.getInt8(StructuredTemporal.DAY_FIELD);
+        return (year == null || year == 0)
+                && (month == null || month == 0)
+                && (day == null || day == 0);
     }
 
     private static int intValue(Struct value, String fieldName) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -87,7 +87,9 @@ final class StructuredTemporalLiteral {
         final BigDecimal maxSeconds = BigDecimal.valueOf(838L * 3_600 + 59L * 60 + 59L)
                 .add(BigDecimal.ONE.subtract(BigDecimal.ONE.movePointLeft(precision)));
         if (totalSeconds.abs().compareTo(maxSeconds) > 0) {
-            throw new ConnectException("Structured duration is outside the MySQL TIME range");
+            throw new ConnectException(String.format(
+                    "Structured duration value '%s' is outside the MySQL TIME range",
+                    StructuredTemporalSupport.toDurationString(value)));
         }
 
         final boolean negative = totalSeconds.signum() < 0;

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -5,9 +5,16 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.time.StructuredTemporal;
 
 final class StructuredTemporalLiteral {
@@ -21,30 +28,86 @@ final class StructuredTemporalLiteral {
     }
 
     static String timestamp(Struct value) {
+        return timestamp(value, 6, TemporalPrecisionLossHandlingMode.TRUNCATE);
+    }
+
+    static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
         requireFinite(value);
-        final Integer nanos = value.getInt32(StructuredTemporal.NANOS_FIELD);
-        return String.format("%04d-%02d-%02d %02d:%02d:%02d.%06d",
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
+                StructuredTemporalSupport.getPicoseconds(value), precision, handlingMode);
+        if (fraction.carrySeconds() != 0) {
+            final LocalDateTime dateTime = StructuredTemporalSupport.toLocalDateTime(value)
+                    .withNano(fraction.nanoseconds())
+                    .plusSeconds(fraction.carrySeconds());
+            return formatTimestamp(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(),
+                    dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(), fraction.picoseconds(), precision);
+        }
+        return formatTimestamp(
                 value.getInt32(StructuredTemporal.YEAR_FIELD),
                 value.getInt8(StructuredTemporal.MONTH_FIELD),
                 value.getInt8(StructuredTemporal.DAY_FIELD),
                 value.getInt8(StructuredTemporal.HOUR_FIELD),
                 value.getInt8(StructuredTemporal.MINUTE_FIELD),
                 value.getInt8(StructuredTemporal.SECOND_FIELD),
-                (nanos == null ? 0 : nanos) / 1_000);
+                fraction.picoseconds(), precision);
     }
 
     static String duration(Struct value) {
-        final int hours = value.getInt32(StructuredTemporal.HOURS_FIELD) == null ? 0 : value.getInt32(StructuredTemporal.HOURS_FIELD);
-        final int minutes = value.getInt32(StructuredTemporal.MINUTES_FIELD) == null ? 0 : value.getInt32(StructuredTemporal.MINUTES_FIELD);
-        final Long seconds = value.getInt64(StructuredTemporal.SECONDS_FIELD);
-        final int nanos = value.getInt32(StructuredTemporal.NANOS_FIELD) == null ? 0 : value.getInt32(StructuredTemporal.NANOS_FIELD);
-        final boolean negative = hours < 0 || minutes < 0 || (seconds != null && seconds < 0) || nanos < 0;
-        return String.format("%s%03d:%02d:%02d.%06d",
-                negative ? "-" : "",
-                Math.abs(hours),
-                Math.abs(minutes),
-                Math.abs(seconds == null ? 0 : seconds),
-                Math.abs(nanos) / 1_000);
+        return duration(value, 6, TemporalPrecisionLossHandlingMode.TRUNCATE);
+    }
+
+    static String duration(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
+        requireZero(value, StructuredTemporal.YEARS_FIELD);
+        requireZero(value, StructuredTemporal.MONTHS_FIELD);
+        requireZero(value, StructuredTemporal.DAYS_FIELD);
+
+        BigDecimal totalSeconds = BigDecimal.valueOf(intValue(value, StructuredTemporal.HOURS_FIELD)).multiply(BigDecimal.valueOf(3_600))
+                .add(BigDecimal.valueOf(intValue(value, StructuredTemporal.MINUTES_FIELD)).multiply(BigDecimal.valueOf(60)))
+                .add(BigDecimal.valueOf(longValue(value, StructuredTemporal.SECONDS_FIELD)))
+                .add(BigDecimal.valueOf(longValue(value, StructuredTemporal.PICOSECONDS_FIELD), 12));
+        final RoundingMode roundingMode = handlingMode == TemporalPrecisionLossHandlingMode.ROUND ? RoundingMode.HALF_UP : RoundingMode.DOWN;
+        totalSeconds = totalSeconds.setScale(precision, roundingMode);
+
+        final BigDecimal maxSeconds = BigDecimal.valueOf(838L * 3_600 + 59L * 60 + 59L)
+                .add(BigDecimal.ONE.subtract(BigDecimal.ONE.movePointLeft(precision)));
+        if (totalSeconds.abs().compareTo(maxSeconds) > 0) {
+            throw new ConnectException("Structured duration is outside the MySQL TIME range");
+        }
+
+        final boolean negative = totalSeconds.signum() < 0;
+        BigDecimal remaining = totalSeconds.abs();
+        final int hours = remaining.divideToIntegralValue(BigDecimal.valueOf(3_600)).intValueExact();
+        remaining = remaining.remainder(BigDecimal.valueOf(3_600));
+        final int minutes = remaining.divideToIntegralValue(BigDecimal.valueOf(60)).intValueExact();
+        remaining = remaining.remainder(BigDecimal.valueOf(60));
+        final int seconds = remaining.intValue();
+        final int fraction = remaining.remainder(BigDecimal.ONE).movePointRight(precision).intValue();
+
+        final String suffix = precision == 0 ? "" : "." + String.format("%0" + precision + "d", fraction);
+        return String.format("%s%03d:%02d:%02d%s", negative ? "-" : "", hours, minutes, seconds, suffix);
+    }
+
+    private static String formatTimestamp(int year, int month, int day, int hour, int minute, int second, long picoseconds, int precision) {
+        final long fraction = precision == 0 ? 0 : picoseconds / (long) Math.pow(10, 12 - precision);
+        final String suffix = precision == 0 ? "" : "." + String.format("%0" + precision + "d", fraction);
+        return String.format("%04d-%02d-%02d %02d:%02d:%02d%s", year, month, day, hour, minute, second, suffix);
+    }
+
+    private static void requireZero(Struct value, String fieldName) {
+        if (intValue(value, fieldName) != 0) {
+            throw new ConnectException(String.format(
+                    "MySQL TIME cannot represent structured duration field '%s' without semantic loss", fieldName));
+        }
+    }
+
+    private static int intValue(Struct value, String fieldName) {
+        final Integer fieldValue = value.getInt32(fieldName);
+        return fieldValue == null ? 0 : fieldValue;
+    }
+
+    private static long longValue(Struct value, String fieldName) {
+        final Long fieldValue = value.getInt64(fieldName);
+        return fieldValue == null ? 0 : fieldValue;
     }
 
     private static void requireFinite(Struct value) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -27,10 +27,6 @@ final class StructuredTemporalLiteral {
                 value.getInt8(StructuredTemporal.DAY_FIELD));
     }
 
-    static String timestamp(Struct value) {
-        return timestamp(value, 6, TemporalPrecisionLossHandlingMode.TRUNCATE);
-    }
-
     static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
         requireFinite(value);
         final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
@@ -52,14 +48,12 @@ final class StructuredTemporalLiteral {
                 fraction.picoseconds(), precision);
     }
 
-    static String duration(Struct value) {
-        return duration(value, 6, TemporalPrecisionLossHandlingMode.TRUNCATE);
-    }
-
     static String duration(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
         requireZero(value, StructuredTemporal.YEARS_FIELD);
         requireZero(value, StructuredTemporal.MONTHS_FIELD);
         requireZero(value, StructuredTemporal.DAYS_FIELD);
+        StructuredTemporalPreflightValidator.reduceFraction(
+                longValue(value, StructuredTemporal.PICOSECONDS_FIELD), precision, handlingMode);
 
         BigDecimal totalSeconds = BigDecimal.valueOf(intValue(value, StructuredTemporal.HOURS_FIELD)).multiply(BigDecimal.valueOf(3_600))
                 .add(BigDecimal.valueOf(intValue(value, StructuredTemporal.MINUTES_FIELD)).multiply(BigDecimal.valueOf(60)))

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -22,12 +22,12 @@ import io.debezium.time.StructuredTemporal;
 final class StructuredTemporalLiteral {
 
     static String date(Struct value) {
-        return date(value, TemporalRange.unbounded(), TemporalRangeLossHandlingMode.FAIL, "target temporal type");
+        return date(value, TemporalRange.unbounded(), TemporalRangeLossHandlingMode.FAIL, true, "target temporal type");
     }
 
     static String date(Struct value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
-                       String targetDescription) {
-        if (StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
+                       boolean zeroDateSupported, String targetDescription) {
+        if (zeroDateSupported && StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
             return formatDate(
                     value.getInt32(StructuredTemporal.YEAR_FIELD),
                     value.getInt8(StructuredTemporal.MONTH_FIELD),
@@ -44,13 +44,13 @@ final class StructuredTemporalLiteral {
 
     static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
         return timestamp(value, precision, handlingMode, TemporalRange.unbounded(),
-                TemporalRangeLossHandlingMode.FAIL, "target temporal type");
+                TemporalRangeLossHandlingMode.FAIL, true, "target temporal type");
     }
 
     static String timestamp(Struct value, int precision, TemporalPrecisionLossHandlingMode precisionHandlingMode,
                             TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
-                            String targetDescription) {
-        if (StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
+                            boolean zeroDateSupported, String targetDescription) {
+        if (zeroDateSupported && StructuredTemporal.isFinite(value) && hasZeroDate(value)) {
             final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
                     StructuredTemporalSupport.getPicoseconds(value), precision, precisionHandlingMode);
             if (fraction.carrySeconds() == 0) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -26,7 +26,8 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         final var capabilities = getDialect().getTargetTemporalCapabilities();
         return "'" + StructuredTemporalLiteral.timestamp(
                 requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
-                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema)) + "'";
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), capabilities.zeroDateSupported(),
+                targetDescription(schema)) + "'";
     }
 
     @Override
@@ -37,7 +38,8 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         final var capabilities = getDialect().getTargetTemporalCapabilities();
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(
                 requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
-                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema)), Types.VARCHAR));
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), capabilities.zeroDateSupported(),
+                targetDescription(schema)), Types.VARCHAR));
     }
 
     @Override
@@ -49,7 +51,8 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
                     column, requireStruct(value), precision, getPrecisionLossHandlingMode());
             StructuredTemporalLiteral.timestamp(
                     requireStruct(value), precision, getPrecisionLossHandlingMode(),
-                    capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), targetDescription(column));
+                    capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), capabilities.zeroDateSupported(),
+                    targetDescription(column));
         }
     }
 
@@ -59,11 +62,12 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
             return List.of(new ValueBindDescriptor(index, null));
         }
         validate(column, schema, value);
-        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final int precision = capabilities.targetTimestampPrecision(column);
         return List.of(new ValueBindDescriptor(index,
                 StructuredTemporalLiteral.timestamp(
                         requireStruct(value), precision, getPrecisionLossHandlingMode(),
-                        getDialect().getTargetTemporalCapabilities().targetTimestampRange(column), getRangeLossHandlingMode(),
+                        capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), capabilities.zeroDateSupported(),
                         targetDescription(column)),
                 Types.VARCHAR));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -22,7 +22,8 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return "'" + StructuredTemporalLiteral.timestamp(requireStruct(value)) + "'";
+        return "'" + StructuredTemporalLiteral.timestamp(
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()) + "'";
     }
 
     @Override
@@ -30,7 +31,8 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(requireStruct(value)), Types.VARCHAR));
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()), Types.VARCHAR));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
 
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
@@ -22,8 +23,10 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
         return "'" + StructuredTemporalLiteral.timestamp(
-                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()) + "'";
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema)) + "'";
     }
 
     @Override
@@ -31,8 +34,23 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(
-                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()), Types.VARCHAR));
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema)), Types.VARCHAR));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
+            final int precision = capabilities.targetTimestampPrecision(column);
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, requireStruct(value), precision, getPrecisionLossHandlingMode());
+            StructuredTemporalLiteral.timestamp(
+                    requireStruct(value), precision, getPrecisionLossHandlingMode(),
+                    capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), targetDescription(column));
+        }
     }
 
     @Override
@@ -43,6 +61,10 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         validate(column, schema, value);
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
         return List.of(new ValueBindDescriptor(index,
-                StructuredTemporalLiteral.timestamp(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+                StructuredTemporalLiteral.timestamp(
+                        requireStruct(value), precision, getPrecisionLossHandlingMode(),
+                        getDialect().getTargetTemporalCapabilities().targetTimestampRange(column), getRangeLossHandlingMode(),
+                        targetDescription(column)),
+                Types.VARCHAR));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
 
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
@@ -30,5 +31,16 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
             return List.of(new ValueBindDescriptor(index, null));
         }
         return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(requireStruct(value)), Types.VARCHAR));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        return List.of(new ValueBindDescriptor(index,
+                StructuredTemporalLiteral.timestamp(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -46,7 +46,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
         if (value != null) {
             final var capabilities = getDialect().getTargetTemporalCapabilities();
-            final int precision = capabilities.targetTimestampPrecision(column);
+            final int precision = targetTimestampPrecision(column);
             StructuredTemporalPreflightValidator.validatePrecision(
                     column, requireStruct(value), precision, getPrecisionLossHandlingMode());
             StructuredTemporalLiteral.timestamp(
@@ -63,12 +63,25 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         }
         validate(column, schema, value);
         final var capabilities = getDialect().getTargetTemporalCapabilities();
-        final int precision = capabilities.targetTimestampPrecision(column);
+        final int precision = targetTimestampPrecision(column);
         return List.of(new ValueBindDescriptor(index,
                 StructuredTemporalLiteral.timestamp(
                         requireStruct(value), precision, getPrecisionLossHandlingMode(),
                         capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), capabilities.zeroDateSupported(),
                         targetDescription(column)),
                 Types.VARCHAR));
+    }
+
+    private int targetTimestampPrecision(ColumnDescriptor column) {
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final int precision = capabilities.targetTimestampPrecision(column);
+        if (precision == 0 && column.getPrecision() > 19
+                && ("datetime".equalsIgnoreCase(column.getTypeName()) || "timestamp".equalsIgnoreCase(column.getTypeName()))) {
+            // MySQL Connector/J reports fractional-second precision in COLUMN_SIZE for temporal columns,
+            // while DECIMAL_DIGITS is always zero. DATETIME/TIMESTAMP use 19 characters without a fraction
+            // and one additional character for the decimal separator.
+            return Math.min(column.getPrecision() - 20, capabilities.maxTimestampPrecision());
+        }
+        return precision;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
@@ -19,7 +19,7 @@ public class StructuredZonedTimestampType extends StructuredTimestampType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ io.debezium.time.StructuredZonedTimestamp.SCHEMA_NAME };
+        return io.debezium.time.StructuredZonedTimestamp.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
@@ -5,6 +5,11 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
+import io.debezium.sink.column.ColumnDescriptor;
+
 /**
  * MySQL implementation of {@link io.debezium.time.StructuredZonedTimestamp} values.
  */
@@ -15,5 +20,14 @@ public class StructuredZonedTimestampType extends StructuredTimestampType {
     @Override
     public String[] getRegistrationKeys() {
         return new String[]{ io.debezium.time.StructuredZonedTimestamp.SCHEMA_NAME };
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        super.validate(column, schema, value);
+        if (value != null) {
+            StructuredTemporalPreflightValidator.validateZonedTimestamp(
+                    requireStruct(value), getDialect().getTargetTemporalCapabilities());
+        }
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredZonedTimestampType.java
@@ -24,10 +24,13 @@ public class StructuredZonedTimestampType extends StructuredTimestampType {
 
     @Override
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
-        super.validate(column, schema, value);
+        // MySQL cannot store a zone or an offset at all, so that failure offers the user no remedy, while the
+        // precision and range failures each name a handling mode that resolves them. Report the unrecoverable
+        // one first, consistent with the shared base type and the Db2 dialect.
         if (value != null) {
             StructuredTemporalPreflightValidator.validateZonedTimestamp(
                     requireStruct(value), getDialect().getTargetTemporalCapabilities());
         }
+        super.validate(column, schema, value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
@@ -26,6 +26,7 @@ import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 
 /**
  * A {@link DatabaseDialect} implementation for Oracle.
@@ -37,6 +38,8 @@ public class OracleDatabaseDialect extends GeneralDatabaseDialect {
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
         return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(-4711, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(-4711, 9999))
                 .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
@@ -24,6 +24,8 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
 import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
 
 /**
  * A {@link DatabaseDialect} implementation for Oracle.
@@ -31,6 +33,12 @@ import io.debezium.connector.jdbc.relational.TableDescriptor;
  * @author Chris Cranford
  */
 public class OracleDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
+    }
 
     private static final String TO_DATE = "TO_DATE(%s, 'YYYY-MM-DD')";
     private static final String TO_TIMESTAMP_FF9 = "TO_TIMESTAMP('%s', 'YYYY-MM-DD\"T\"HH24:MI:SS.FF9 TZH:TZM')";

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.jdbc.dialect.oracle;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Types;
 import java.util.List;
 import java.util.Locale;
@@ -13,7 +15,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.type.AbstractTemporalType;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -23,7 +27,7 @@ import io.debezium.time.StructuredTemporal;
 /**
  * Oracle implementation of {@link StructuredDuration} values.
  */
-public class StructuredDurationType extends AbstractType {
+public class StructuredDurationType extends AbstractTemporalType {
 
     public static final StructuredDurationType INSTANCE = new StructuredDurationType();
 
@@ -61,7 +65,8 @@ public class StructuredDurationType extends AbstractType {
         final Struct struct = requireStruct(value);
         return switch (resolveIntervalKind(schema)) {
             case YEAR_MONTH -> "TO_YMINTERVAL('" + toYearMonthLiteral(struct) + "')";
-            case DAY_SECOND -> "TO_DSINTERVAL('" + toDaySecondLiteral(struct) + "')";
+            case DAY_SECOND -> "TO_DSINTERVAL('" + toDaySecondLiteral(
+                    struct, getDaySecondPrecision(schema), TemporalPrecisionLossHandlingMode.FAIL) + "')";
             case TEXT -> "'" + StructuredTemporalSupport.toDurationString(struct) + "'";
         };
     }
@@ -74,25 +79,65 @@ public class StructuredDurationType extends AbstractType {
         return List.of(new ValueBindDescriptor(index, toBindingValue(schema, requireStruct(value)), Types.VARCHAR));
     }
 
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return;
+        }
+        final Struct struct = requireStruct(value);
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        StructuredTemporalPreflightValidator.validateDuration(schema, struct, capabilities);
+        if (resolveIntervalKind(schema) == IntervalKind.DAY_SECOND) {
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, struct, capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final Struct struct = requireStruct(value);
+        if (resolveIntervalKind(schema) == IntervalKind.DAY_SECOND) {
+            final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+            return List.of(new ValueBindDescriptor(index,
+                    toDaySecondLiteral(struct, precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+        }
+        return List.of(new ValueBindDescriptor(index, toBindingValue(schema, struct), Types.VARCHAR));
+    }
+
     private String getDaySecondTypeName(Schema schema) {
         final String dayPrecision = getSourceColumnSize(schema)
                 .filter(StructuredDurationType::isPositive)
                 .map(value -> "(" + value + ")")
                 .orElse("");
-        final int secondPrecision = getSourceColumnPrecision(schema).map(Integer::parseInt).orElse(9);
-        return "INTERVAL DAY" + dayPrecision + " TO SECOND(" + Math.min(secondPrecision, 9) + ")";
+        return "INTERVAL DAY" + dayPrecision + " TO SECOND(" + getDaySecondPrecision(schema) + ")";
     }
 
     private String toBindingValue(Schema schema, Struct value) {
         return switch (resolveIntervalKind(schema)) {
             case YEAR_MONTH -> toYearMonthLiteral(value);
-            case DAY_SECOND -> toDaySecondLiteral(value);
+            case DAY_SECOND -> toDaySecondLiteral(value, getDaySecondPrecision(schema), TemporalPrecisionLossHandlingMode.FAIL);
             case TEXT -> StructuredTemporalSupport.toDurationString(value);
         };
     }
 
+    private int getDaySecondPrecision(Schema schema) {
+        return Math.min(StructuredTemporalSupport.getPrecision(schema).orElse(9), 9);
+    }
+
     private IntervalKind resolveIntervalKind(Schema schema) {
         if (schema != null) {
+            if (getSchemaParameter(schema, StructuredTemporal.DURATION_KIND_PARAMETER_KEY).isPresent()) {
+                final StructuredDuration.Kind kind = StructuredTemporalPreflightValidator.durationKind(schema, null);
+                return switch (kind) {
+                    case YEAR_MONTH -> IntervalKind.YEAR_MONTH;
+                    case DAY_TIME, ELAPSED_TIME -> IntervalKind.DAY_SECOND;
+                    case MIXED -> IntervalKind.TEXT;
+                };
+            }
             return resolveIntervalKind(getSourceColumnType(schema).orElse(null));
         }
         return IntervalKind.TEXT;
@@ -120,21 +165,40 @@ public class StructuredDurationType extends AbstractType {
         return String.format("%s%d-%02d", negative ? "-" : "", Math.abs(years), Math.abs(months));
     }
 
-    private String toDaySecondLiteral(Struct value) {
-        final int days = intValue(value, StructuredTemporal.DAYS_FIELD);
-        final int hours = intValue(value, StructuredTemporal.HOURS_FIELD);
-        final int minutes = intValue(value, StructuredTemporal.MINUTES_FIELD);
+    private String toDaySecondLiteral(Struct value, int precision, TemporalPrecisionLossHandlingMode handlingMode) {
+        long days = Math.abs((long) intValue(value, StructuredTemporal.DAYS_FIELD));
+        long hours = Math.abs((long) intValue(value, StructuredTemporal.HOURS_FIELD));
+        long minutes = Math.abs((long) intValue(value, StructuredTemporal.MINUTES_FIELD));
         final long seconds = longValue(value, StructuredTemporal.SECONDS_FIELD);
-        final int nanos = intValue(value, StructuredTemporal.NANOS_FIELD);
-        final boolean negative = days < 0 || hours < 0 || minutes < 0 || seconds < 0 || nanos < 0;
-        final String fraction = nanos == 0 ? "" : "." + String.format("%09d", Math.abs(nanos));
+        final long picoseconds = longValue(value, StructuredTemporal.PICOSECONDS_FIELD);
+        final boolean negative = intValue(value, StructuredTemporal.DAYS_FIELD) < 0
+                || intValue(value, StructuredTemporal.HOURS_FIELD) < 0
+                || intValue(value, StructuredTemporal.MINUTES_FIELD) < 0
+                || seconds < 0
+                || picoseconds < 0;
+
+        BigDecimal adjustedSeconds = BigDecimal.valueOf(Math.abs(seconds))
+                .add(BigDecimal.valueOf(Math.abs(picoseconds), 12));
+        final RoundingMode roundingMode = handlingMode == TemporalPrecisionLossHandlingMode.ROUND ? RoundingMode.HALF_UP : RoundingMode.DOWN;
+        adjustedSeconds = adjustedSeconds.setScale(precision, roundingMode);
+
+        minutes += adjustedSeconds.divideToIntegralValue(BigDecimal.valueOf(60)).longValueExact();
+        adjustedSeconds = adjustedSeconds.remainder(BigDecimal.valueOf(60));
+        hours += minutes / 60;
+        minutes %= 60;
+        days += hours / 24;
+        hours %= 24;
+
+        final int wholeSeconds = adjustedSeconds.intValue();
+        final int fraction = adjustedSeconds.remainder(BigDecimal.ONE).movePointRight(precision).intValue();
+        final String suffix = precision == 0 ? "" : "." + String.format("%0" + precision + "d", fraction);
         return String.format("%s%d %02d:%02d:%02d%s",
                 negative ? "-" : "",
-                Math.abs(days),
-                Math.abs(hours),
-                Math.abs(minutes),
-                Math.abs(seconds),
-                fraction);
+                days,
+                hours,
+                minutes,
+                wholeSeconds,
+                suffix);
     }
 
     private int intValue(Struct value, String fieldName) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
@@ -66,7 +66,7 @@ public class StructuredDurationType extends AbstractTemporalType {
         return switch (resolveIntervalKind(schema)) {
             case YEAR_MONTH -> "TO_YMINTERVAL('" + toYearMonthLiteral(struct) + "')";
             case DAY_SECOND -> "TO_DSINTERVAL('" + toDaySecondLiteral(
-                    struct, getDaySecondPrecision(schema), TemporalPrecisionLossHandlingMode.FAIL) + "')";
+                    struct, getDaySecondPrecision(schema), getPrecisionLossHandlingMode()) + "')";
             case TEXT -> "'" + StructuredTemporalSupport.toDurationString(struct) + "'";
         };
     }
@@ -119,7 +119,7 @@ public class StructuredDurationType extends AbstractTemporalType {
     private String toBindingValue(Schema schema, Struct value) {
         return switch (resolveIntervalKind(schema)) {
             case YEAR_MONTH -> toYearMonthLiteral(value);
-            case DAY_SECOND -> toDaySecondLiteral(value, getDaySecondPrecision(schema), TemporalPrecisionLossHandlingMode.FAIL);
+            case DAY_SECOND -> toDaySecondLiteral(value, getDaySecondPrecision(schema), getPrecisionLossHandlingMode());
             case TEXT -> StructuredTemporalSupport.toDurationString(value);
         };
     }
@@ -176,6 +176,7 @@ public class StructuredDurationType extends AbstractTemporalType {
                 || intValue(value, StructuredTemporal.MINUTES_FIELD) < 0
                 || seconds < 0
                 || picoseconds < 0;
+        StructuredTemporalPreflightValidator.reduceFraction(picoseconds, precision, handlingMode);
 
         BigDecimal adjustedSeconds = BigDecimal.valueOf(Math.abs(seconds))
                 .add(BigDecimal.valueOf(Math.abs(picoseconds), 12));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredDurationType.java
@@ -39,7 +39,7 @@ public class StructuredDurationType extends AbstractTemporalType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredDuration.SCHEMA_NAME };
+        return StructuredDuration.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTimeType.java
@@ -15,6 +15,7 @@ import org.hibernate.engine.jdbc.Size;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
@@ -28,7 +29,7 @@ public class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium
     public String getTypeName(Schema schema, boolean isKey) {
         final int precision = getTimePrecision(schema);
         final DatabaseDialect dialect = getDialect();
-        if (precision > 0) {
+        if (precision >= 0) {
             return dialect.getJdbcTypeName(Types.TIMESTAMP, Size.precision(precision));
         }
         return dialect.getJdbcTypeName(Types.TIMESTAMP, Size.precision(dialect.getMaxTimePrecision()));
@@ -40,6 +41,19 @@ public class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium
             return List.of(new ValueBindDescriptor(index, null));
         }
         final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalTime(requireStruct(value)).atDate(LocalDate.EPOCH);
+        return List.of(new ValueBindDescriptor(index, localDateTime, Types.TIMESTAMP));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final LocalDateTime localDateTime = StructuredTemporalSupport
+                .toLocalTime(requireStruct(value), precision, getPrecisionLossHandlingMode())
+                .atDate(LocalDate.EPOCH);
         return List.of(new ValueBindDescriptor(index, localDateTime, Types.TIMESTAMP));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTimeType.java
@@ -13,7 +13,6 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -27,12 +26,7 @@ public class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final int precision = getTimePrecision(schema);
-        final DatabaseDialect dialect = getDialect();
-        if (precision >= 0) {
-            return dialect.getJdbcTypeName(Types.TIMESTAMP, Size.precision(precision));
-        }
-        return dialect.getJdbcTypeName(Types.TIMESTAMP, Size.precision(dialect.getMaxTimePrecision()));
+        return getDialect().getJdbcTypeName(Types.TIMESTAMP, Size.precision(getSchemaTimePrecision(schema)));
     }
 
     @Override
@@ -55,5 +49,11 @@ public class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium
                 .toLocalTime(requireStruct(value), precision, getPrecisionLossHandlingMode())
                 .atDate(LocalDate.EPOCH);
         return List.of(new ValueBindDescriptor(index, localDateTime, Types.TIMESTAMP));
+    }
+
+    @Override
+    protected int getSchemaTimePrecision(Schema schema) {
+        final int precision = getTimePrecision(schema);
+        return precision >= 0 ? precision : getDialect().getMaxTimePrecision();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredZonedTimeType.java
@@ -16,7 +16,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -31,12 +30,7 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final int precision = getTimePrecision(schema);
-        final DatabaseDialect dialect = getDialect();
-        if (precision >= 0) {
-            return dialect.getJdbcTypeName(Types.TIME_WITH_TIMEZONE, Size.precision(precision));
-        }
-        return dialect.getJdbcTypeName(Types.TIME_WITH_TIMEZONE, Size.precision(dialect.getMaxTimePrecision()));
+        return getDialect().getJdbcTypeName(Types.TIME_WITH_TIMEZONE, Size.precision(getSchemaTimePrecision(schema)));
     }
 
     @Override
@@ -65,5 +59,11 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
                 ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         final ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.EPOCH).toZonedDateTime();
         return List.of(new ValueBindDescriptor(index, zonedDateTime, Types.TIME_WITH_TIMEZONE));
+    }
+
+    @Override
+    protected int getSchemaTimePrecision(Schema schema) {
+        final int precision = getTimePrecision(schema);
+        return precision >= 0 ? precision : getDialect().getMaxTimePrecision();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/StructuredZonedTimeType.java
@@ -18,6 +18,7 @@ import org.hibernate.engine.jdbc.Size;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredTemporal;
 
@@ -32,7 +33,7 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
     public String getTypeName(Schema schema, boolean isKey) {
         final int precision = getTimePrecision(schema);
         final DatabaseDialect dialect = getDialect();
-        if (precision > 0) {
+        if (precision >= 0) {
             return dialect.getJdbcTypeName(Types.TIME_WITH_TIMEZONE, Size.precision(precision));
         }
         return dialect.getJdbcTypeName(Types.TIME_WITH_TIMEZONE, Size.precision(dialect.getMaxTimePrecision()));
@@ -46,6 +47,21 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
         final Struct struct = requireStruct(value);
         final OffsetTime offsetTime = OffsetTime.of(
                 StructuredTemporalSupport.toLocalTime(struct),
+                ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+        final ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.EPOCH).toZonedDateTime();
+        return List.of(new ValueBindDescriptor(index, zonedDateTime, Types.TIME_WITH_TIMEZONE));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final Struct struct = requireStruct(value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final OffsetTime offsetTime = OffsetTime.of(
+                StructuredTemporalSupport.toLocalTime(struct, precision, getPrecisionLossHandlingMode()),
                 ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         final ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.EPOCH).toZonedDateTime();
         return List.of(new ValueBindDescriptor(index, zonedDateTime, Types.TIME_WITH_TIMEZONE));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -29,6 +29,8 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 
@@ -38,6 +40,12 @@ import io.debezium.sink.column.ColumnDescriptor;
  * @author Chris Cranford
  */
 public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withZonedTimestampSupport(ZonedTimestampSupport.INSTANT);
+    }
 
     public static class PostgresDatabaseDialectProvider implements DatabaseDialectProvider {
         @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -30,7 +30,9 @@ import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampRangeBasis;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 
@@ -44,6 +46,9 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
         return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(-4712, 5_874_897))
+                .withTimestampRange(TemporalRange.timestampYears(-4712, 294_276))
+                .withZonedTimestampRangeBasis(ZonedTimestampRangeBasis.INSTANT)
                 .withZonedTimestampSupport(ZonedTimestampSupport.INSTANT);
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -49,7 +49,9 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
                 .withDateRange(TemporalRange.dateYears(-4712, 5_874_897))
                 .withTimestampRange(TemporalRange.timestampYears(-4712, 294_276))
                 .withZonedTimestampRangeBasis(ZonedTimestampRangeBasis.INSTANT)
-                .withZonedTimestampSupport(ZonedTimestampSupport.INSTANT);
+                .withZonedTimestampSupport(ZonedTimestampSupport.INSTANT)
+                .withDateInfinitySupported(true)
+                .withTimestampInfinitySupported(true);
     }
 
     public static class PostgresDatabaseDialectProvider implements DatabaseDialectProvider {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
@@ -75,6 +75,6 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
     }
 
     private boolean supportsInfinity() {
-        return getDialect() == null || getDialect().getTargetTemporalCapabilities().dateInfinitySupported();
+        return getDialect() != null && getDialect().getTargetTemporalCapabilities().dateInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
@@ -28,6 +28,19 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
     }
 
     @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return "'infinity'";
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return "'-infinity'";
+            }
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
         if (value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
@@ -38,5 +51,26 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
             }
         }
         return super.bind(index, schema, value);
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+            return;
+        }
+        super.validate(column, schema, value);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "-infinity", Types.VARCHAR));
+            }
+        }
+        return super.bind(index, column, schema, value);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDateType.java
@@ -29,7 +29,7 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return "'infinity'";
             }
@@ -42,7 +42,7 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -55,7 +55,7 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+        if (supportsInfinity() && value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
             return;
         }
         super.validate(column, schema, value);
@@ -63,7 +63,7 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
 
     @Override
     public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -72,5 +72,9 @@ public class StructuredDateType extends io.debezium.connector.jdbc.type.debezium
             }
         }
         return super.bind(index, column, schema, value);
+    }
+
+    private boolean supportsInfinity() {
+        return getDialect() == null || getDialect().getTargetTemporalCapabilities().dateInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
@@ -30,7 +30,7 @@ public class StructuredDurationType extends AbstractTemporalType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredDuration.SCHEMA_NAME };
+        return StructuredDuration.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
@@ -6,13 +6,16 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Types;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
-import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.type.AbstractTemporalType;
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalPreflightValidator;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredDuration;
@@ -21,7 +24,7 @@ import io.debezium.time.StructuredTemporal;
 /**
  * PostgreSQL implementation of {@link StructuredDuration} values.
  */
-public class StructuredDurationType extends AbstractType {
+public class StructuredDurationType extends AbstractTemporalType {
 
     public static final StructuredDurationType INSTANCE = new StructuredDurationType();
 
@@ -53,7 +56,34 @@ public class StructuredDurationType extends AbstractType {
         return List.of(new ValueBindDescriptor(index, toIntervalLiteral(requireStruct(value)), Types.VARCHAR));
     }
 
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return;
+        }
+        final Struct struct = requireStruct(value);
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        StructuredTemporalPreflightValidator.validateDuration(schema, struct, capabilities);
+        StructuredTemporalPreflightValidator.validatePrecision(
+                column, struct, capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        return List.of(new ValueBindDescriptor(index,
+                toIntervalLiteral(requireStruct(value), precision, getPrecisionLossHandlingMode()), Types.VARCHAR));
+    }
+
     private String toIntervalLiteral(Struct value) {
+        return toIntervalLiteral(value, null, TemporalPrecisionLossHandlingMode.FAIL);
+    }
+
+    private String toIntervalLiteral(Struct value, Integer precision, TemporalPrecisionLossHandlingMode handlingMode) {
         final StringBuilder builder = new StringBuilder();
         append(builder, value.getInt32(StructuredTemporal.YEARS_FIELD), " years");
         append(builder, value.getInt32(StructuredTemporal.MONTHS_FIELD), " months");
@@ -62,10 +92,14 @@ public class StructuredDurationType extends AbstractType {
         append(builder, value.getInt32(StructuredTemporal.MINUTES_FIELD), " minutes");
 
         final Long seconds = value.getInt64(StructuredTemporal.SECONDS_FIELD);
-        final Integer nanos = value.getInt32(StructuredTemporal.NANOS_FIELD);
-        final BigDecimal fractionalSeconds = BigDecimal.valueOf(seconds == null ? 0 : seconds)
-                .add(BigDecimal.valueOf(nanos == null ? 0 : nanos, 9))
-                .stripTrailingZeros();
+        final Long picoseconds = value.getInt64(StructuredTemporal.PICOSECONDS_FIELD);
+        BigDecimal fractionalSeconds = BigDecimal.valueOf(seconds == null ? 0 : seconds)
+                .add(BigDecimal.valueOf(picoseconds == null ? 0 : picoseconds, 12));
+        if (precision != null) {
+            final RoundingMode roundingMode = handlingMode == TemporalPrecisionLossHandlingMode.ROUND ? RoundingMode.HALF_UP : RoundingMode.DOWN;
+            fractionalSeconds = fractionalSeconds.setScale(precision, roundingMode);
+        }
+        fractionalSeconds = fractionalSeconds.stripTrailingZeros();
         if (fractionalSeconds.signum() != 0 || builder.length() == 0) {
             append(builder, fractionalSeconds.toPlainString(), " seconds");
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredDurationType.java
@@ -45,7 +45,8 @@ public class StructuredDurationType extends AbstractTemporalType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return String.format("'%s'", toIntervalLiteral(requireStruct(value)));
+        return String.format("'%s'", toIntervalLiteral(
+                requireStruct(value), getDialect().getTargetTemporalCapabilities().maxTimePrecision(), getPrecisionLossHandlingMode()));
     }
 
     @Override
@@ -80,7 +81,7 @@ public class StructuredDurationType extends AbstractTemporalType {
     }
 
     private String toIntervalLiteral(Struct value) {
-        return toIntervalLiteral(value, null, TemporalPrecisionLossHandlingMode.FAIL);
+        return toIntervalLiteral(value, null, getPrecisionLossHandlingMode());
     }
 
     private String toIntervalLiteral(Struct value, Integer precision, TemporalPrecisionLossHandlingMode handlingMode) {
@@ -96,6 +97,7 @@ public class StructuredDurationType extends AbstractTemporalType {
         BigDecimal fractionalSeconds = BigDecimal.valueOf(seconds == null ? 0 : seconds)
                 .add(BigDecimal.valueOf(picoseconds == null ? 0 : picoseconds, 12));
         if (precision != null) {
+            StructuredTemporalPreflightValidator.reduceFraction(picoseconds == null ? 0 : picoseconds, precision, handlingMode);
             final RoundingMode roundingMode = handlingMode == TemporalPrecisionLossHandlingMode.ROUND ? RoundingMode.HALF_UP : RoundingMode.DOWN;
             fractionalSeconds = fractionalSeconds.setScale(precision, roundingMode);
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
@@ -28,6 +28,19 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
     }
 
     @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return "'infinity'";
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return "'-infinity'";
+            }
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
         if (value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
@@ -38,6 +51,14 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
             }
         }
         return super.bind(index, schema, value);
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+            return;
+        }
+        super.validate(column, schema, value);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
@@ -39,4 +39,17 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         }
         return super.bind(index, schema, value);
     }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "-infinity", Types.VARCHAR));
+            }
+        }
+        return super.bind(index, column, schema, value);
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
@@ -75,6 +75,6 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
     }
 
     private boolean supportsInfinity() {
-        return getDialect() == null || getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
+        return getDialect() != null && getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTimestampType.java
@@ -29,7 +29,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return "'infinity'";
             }
@@ -42,7 +42,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -55,7 +55,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+        if (supportsInfinity() && value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
             return;
         }
         super.validate(column, schema, value);
@@ -63,7 +63,7 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -72,5 +72,9 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
             }
         }
         return super.bind(index, column, schema, value);
+    }
+
+    private boolean supportsInfinity() {
+        return getDialect() == null || getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimeType.java
@@ -27,6 +27,12 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
     }
 
     @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return getDialect().getFormattedTimeWithTimeZone(StructuredTemporalSupport.toTimetzLiteral(
+                requireStruct(value), getSchemaTimePrecision(schema), getPrecisionLossHandlingMode()));
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
@@ -52,5 +58,10 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
         return "timetz";
+    }
+
+    @Override
+    protected int getSchemaTimePrecision(Schema schema) {
+        return getDialect().getDefaultTimePrecision();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimeType.java
@@ -39,6 +39,17 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
     }
 
     @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalSupport.toTimetzLiteral(
+                requireStruct(value), precision, getPrecisionLossHandlingMode())));
+    }
+
+    @Override
     public String getTypeName(Schema schema, boolean isKey) {
         return "timetz";
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
@@ -29,7 +29,7 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return "'infinity'";
             }
@@ -42,7 +42,7 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -55,7 +55,7 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
 
     @Override
     public void validate(ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+        if (supportsInfinity() && value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
             return;
         }
         super.validate(column, schema, value);
@@ -63,7 +63,7 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
 
     @Override
     public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
-        if (value instanceof Struct struct) {
+        if (supportsInfinity() && value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
                 return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
             }
@@ -72,5 +72,9 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
             }
         }
         return super.bind(index, column, schema, value);
+    }
+
+    private boolean supportsInfinity() {
+        return getDialect() == null || getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
@@ -75,6 +75,6 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
     }
 
     private boolean supportsInfinity() {
-        return getDialect() == null || getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
+        return getDialect() != null && getDialect().getTargetTemporalCapabilities().timestampInfinitySupported();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
@@ -39,4 +39,17 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
         }
         return super.bind(index, schema, value);
     }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "infinity", Types.VARCHAR));
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return List.of(new ValueBindDescriptor(index, "-infinity", Types.VARCHAR));
+            }
+        }
+        return super.bind(index, column, schema, value);
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructuredZonedTimestampType.java
@@ -28,6 +28,19 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
     }
 
     @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            if (StructuredTemporal.isPositiveInfinity(struct)) {
+                return "'infinity'";
+            }
+            if (StructuredTemporal.isNegativeInfinity(struct)) {
+                return "'-infinity'";
+            }
+        }
+        return super.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
         if (value instanceof Struct struct) {
             if (StructuredTemporal.isPositiveInfinity(struct)) {
@@ -38,6 +51,14 @@ public class StructuredZonedTimestampType extends io.debezium.connector.jdbc.typ
             }
         }
         return super.bind(index, schema, value);
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value instanceof Struct struct && !StructuredTemporal.isFinite(struct)) {
+            return;
+        }
+        super.validate(column, schema, value);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
@@ -78,5 +78,6 @@ public class SingleStoreDatabaseDialect extends MariaDbDatabaseDialect {
         registerType(PointType.INSTANCE);
         registerType(FloatVectorType.INSTANCE);
         registerType(DoubleVectorType.INSTANCE);
+        registerType(SingleStoreStructuredDurationType.INSTANCE);
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.jdbc.dialect.singlestore;
 
+import java.util.EnumSet;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.community.dialect.SingleStoreDialect;
 import org.hibernate.dialect.Dialect;
@@ -15,11 +17,23 @@ import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectProvider;
 import io.debezium.connector.jdbc.dialect.mysql.MariaDbDatabaseDialect;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
+import io.debezium.time.StructuredDuration;
 
 /**
  * A {@link DatabaseDialect} implementation for SingleStore.
  */
 public class SingleStoreDatabaseDialect extends MariaDbDatabaseDialect {
+
+    private static final TemporalRange DATETIME_RANGE = new TemporalRange(
+            Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
+            Boundary.timestamp(9999, 12, 31, 23, 59, 59, 999_999_000_000L));
+
+    private static final TemporalRange TIMESTAMP_RANGE = new TemporalRange(
+            Boundary.timestamp(1970, 1, 1, 0, 0, 1, 0),
+            Boundary.timestamp(2038, 1, 19, 3, 14, 7, 999_999_000_000L));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SingleStoreDatabaseDialect.class);
 
@@ -43,6 +57,15 @@ public class SingleStoreDatabaseDialect extends MariaDbDatabaseDialect {
 
     private SingleStoreDatabaseDialect(JdbcSinkConnectorConfig config, SessionFactory sessionFactory) {
         super(config, sessionFactory);
+    }
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(1000, 9999))
+                .withTimestampRange(DATETIME_RANGE)
+                .withTimestampRangeForType(TIMESTAMP_RANGE, "timestamp")
+                .withDurationKinds(EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreStructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreStructuredDurationType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.singlestore;
+
+/**
+ * SingleStore implementation of structured duration values.
+ */
+public class SingleStoreStructuredDurationType extends io.debezium.connector.jdbc.dialect.mysql.StructuredDurationType {
+
+    public static final SingleStoreStructuredDurationType INSTANCE = new SingleStoreStructuredDurationType();
+
+    @Override
+    protected int getTimeColumnSizeWithoutFraction() {
+        // SingleStore reports TIME column size using its three-digit hour range.
+        return 10;
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
@@ -19,6 +19,8 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.dialect.sqlserver.connect.ConnectTimeType;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
 
 /**
  * A {@link DatabaseDialect} implementation for SQL Server.
@@ -26,6 +28,12 @@ import io.debezium.connector.jdbc.relational.TableDescriptor;
  * @author Chris Cranford
  */
 public class SqlServerDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
+    }
 
     public static class SqlServerDatabaseDialectProvider implements DatabaseDialectProvider {
         @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
@@ -20,7 +20,10 @@ import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.dialect.sqlserver.connect.ConnectTimeType;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampRangeBasis;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 
 /**
  * A {@link DatabaseDialect} implementation for SQL Server.
@@ -29,9 +32,22 @@ import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.Zoned
  */
 public class SqlServerDatabaseDialect extends GeneralDatabaseDialect {
 
+    private static final TemporalRange DATETIME_RANGE = new TemporalRange(
+            Boundary.timestamp(1753, 1, 1, 0, 0, 0, 0),
+            Boundary.timestamp(9999, 12, 31, 23, 59, 59, 997_000_000_000L));
+
+    private static final TemporalRange SMALLDATETIME_RANGE = new TemporalRange(
+            Boundary.timestamp(1900, 1, 1, 0, 0, 0, 0),
+            Boundary.timestamp(2079, 6, 6, 23, 59, 0, 0));
+
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
         return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(1, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(1, 9999))
+                .withTimestampRangeForType(DATETIME_RANGE, "datetime")
+                .withTimestampRangeForType(SMALLDATETIME_RANGE, "smalldatetime")
+                .withZonedTimestampRangeBasis(ZonedTimestampRangeBasis.LOCAL_AND_INSTANT)
                 .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTimeType.java
@@ -35,4 +35,17 @@ public class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium
         final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalTime(requireStruct(value)).atDate(LocalDate.EPOCH);
         return List.of(new ValueBindDescriptor(index, localDateTime));
     }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final LocalDateTime localDateTime = StructuredTemporalSupport
+                .toLocalTime(requireStruct(value), precision, getPrecisionLossHandlingMode())
+                .atDate(LocalDate.EPOCH);
+        return List.of(new ValueBindDescriptor(index, localDateTime));
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredZonedTimeType.java
@@ -16,7 +16,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -36,12 +35,7 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        final int precision = getTimePrecision(schema);
-        final DatabaseDialect dialect = getDialect();
-        if (precision >= 0) {
-            return dialect.getJdbcTypeName(Types.TIMESTAMP_WITH_TIMEZONE, Size.precision(precision));
-        }
-        return dialect.getJdbcTypeName(Types.TIMESTAMP_WITH_TIMEZONE, Size.precision(dialect.getMaxTimePrecision()));
+        return getDialect().getJdbcTypeName(Types.TIMESTAMP_WITH_TIMEZONE, Size.precision(getSchemaTimePrecision(schema)));
     }
 
     @Override
@@ -70,5 +64,11 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
                 ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         final OffsetDateTime offsetDateTime = offsetTime.atDate(LocalDate.EPOCH);
         return List.of(new ValueBindDescriptor(index, offsetDateTime, Types.TIMESTAMP_WITH_TIMEZONE));
+    }
+
+    @Override
+    protected int getSchemaTimePrecision(Schema schema) {
+        final int precision = getTimePrecision(schema);
+        return precision >= 0 ? precision : getDialect().getMaxTimePrecision();
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredZonedTimeType.java
@@ -38,7 +38,7 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
     public String getTypeName(Schema schema, boolean isKey) {
         final int precision = getTimePrecision(schema);
         final DatabaseDialect dialect = getDialect();
-        if (precision > 0) {
+        if (precision >= 0) {
             return dialect.getJdbcTypeName(Types.TIMESTAMP_WITH_TIMEZONE, Size.precision(precision));
         }
         return dialect.getJdbcTypeName(Types.TIMESTAMP_WITH_TIMEZONE, Size.precision(dialect.getMaxTimePrecision()));
@@ -52,6 +52,21 @@ public class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.deb
         final Struct struct = requireStruct(value);
         final OffsetTime offsetTime = OffsetTime.of(
                 StructuredTemporalSupport.toLocalTime(struct),
+                ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+        final OffsetDateTime offsetDateTime = offsetTime.atDate(LocalDate.EPOCH);
+        return List.of(new ValueBindDescriptor(index, offsetDateTime, Types.TIMESTAMP_WITH_TIMEZONE));
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final Struct struct = requireStruct(value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final OffsetTime offsetTime = OffsetTime.of(
+                StructuredTemporalSupport.toLocalTime(struct, precision, getPrecisionLossHandlingMode()),
                 ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         final OffsetDateTime offsetDateTime = offsetTime.atDate(LocalDate.EPOCH);
         return List.of(new ValueBindDescriptor(index, offsetDateTime, Types.TIMESTAMP_WITH_TIMEZONE));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
@@ -38,6 +38,7 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.time.ZonedTimestamp;
@@ -54,6 +55,12 @@ import io.debezium.util.Strings;
  * do not exist.
  */
 public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
+
+    @Override
+    public TargetTemporalCapabilities getTargetTemporalCapabilities() {
+        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withTimestampColumnPrecisionReliable(false);
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StarRocksDatabaseDialect.class);
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
@@ -59,7 +59,7 @@ public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
 
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
-        return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+        return TargetTemporalCapabilities.defaults(12, getMaxTimestampPrecision())
                 .withDateRange(TemporalRange.dateYears(0, 9999))
                 .withTimestampRange(TemporalRange.timestampYears(0, 9999))
                 .withTimestampColumnPrecisionReliable(false);
@@ -175,6 +175,8 @@ public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
         registerType(ConnectTimeType.INSTANCE);
         registerType(ZonedTimeType.INSTANCE);
         registerType(ZonedTimestampType.INSTANCE);
+        registerType(StructuredTimeType.INSTANCE);
+        registerType(StructuredZonedTimeType.INSTANCE);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
@@ -39,6 +39,7 @@ import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.time.ZonedTimestamp;
@@ -59,6 +60,8 @@ public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
     @Override
     public TargetTemporalCapabilities getTargetTemporalCapabilities() {
         return TargetTemporalCapabilities.defaults(getMaxTimePrecision(), getMaxTimestampPrecision())
+                .withDateRange(TemporalRange.dateYears(0, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(0, 9999))
                 .withTimestampColumnPrecisionReliable(false);
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredTimeType.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Stores structured local times as text because StarRocks does not provide a {@code TIME} type.
+ */
+class StructuredTimeType extends io.debezium.connector.jdbc.type.debezium.StructuredTimeType {
+
+    static final StructuredTimeType INSTANCE = new StructuredTimeType();
+
+    private static final int MAX_PRECISION = 12;
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "varchar(21)";
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return "'" + toLiteral(value) + "'";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        return bind(index, value);
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            toLiteral(value);
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        return bind(index, value);
+    }
+
+    private List<ValueBindDescriptor> bind(int index, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        return List.of(new ValueBindDescriptor(index, toLiteral(value), Types.VARCHAR));
+    }
+
+    private String toLiteral(Object value) {
+        return StructuredTemporalSupport.toTimeLiteral(requireStruct(value), MAX_PRECISION, getPrecisionLossHandlingMode());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredZonedTimeType.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Stores structured zoned times as text so StarRocks retains the original UTC offset.
+ */
+class StructuredZonedTimeType extends io.debezium.connector.jdbc.type.debezium.StructuredZonedTimeType {
+
+    static final StructuredZonedTimeType INSTANCE = new StructuredZonedTimeType();
+
+    private static final int MAX_PRECISION = 12;
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "varchar(32)";
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return "'" + toLiteral(value) + "'";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        return bind(index, value);
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            toLiteral(value);
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        return bind(index, value);
+    }
+
+    private List<ValueBindDescriptor> bind(int index, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        return List.of(new ValueBindDescriptor(index, toLiteral(value), Types.VARCHAR));
+    }
+
+    private String toLiteral(Object value) {
+        return StructuredTemporalSupport.toTimetzLiteral(requireStruct(value), MAX_PRECISION, getPrecisionLossHandlingMode());
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
@@ -40,6 +40,10 @@ public class JdbcFieldDescriptor extends FieldDescriptor {
         return jdbcType.bind(startIndex, schema, value);
     }
 
+    public List<ValueBindDescriptor> bind(int startIndex, ColumnDescriptor column, Object value, JdbcType jdbcType) {
+        return jdbcType.bind(startIndex, column, schema, value);
+    }
+
     @Override
     public String toString() {
         return "JdbcFieldDescriptor{" +

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
@@ -8,13 +8,16 @@ package io.debezium.connector.jdbc.type;
 import java.time.ZoneId;
 import java.util.TimeZone;
 
+import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 
 /**
  * An abstract base class for all temporal implementations of {@link JdbcType}.
@@ -27,6 +30,7 @@ public abstract class AbstractTemporalType extends AbstractType {
 
     private TimeZone databaseTimeZone;
     private TemporalPrecisionLossHandlingMode precisionLossHandlingMode = TemporalPrecisionLossHandlingMode.FAIL;
+    private TemporalRangeLossHandlingMode rangeLossHandlingMode = TemporalRangeLossHandlingMode.FAIL;
 
     @Override
     public void configure(SinkConnectorConfig config, DatabaseDialect dialect) {
@@ -44,6 +48,9 @@ public abstract class AbstractTemporalType extends AbstractType {
         if (config instanceof JdbcSinkConnectorConfig jdbcConfig && jdbcConfig.getTemporalPrecisionLossHandlingMode() != null) {
             precisionLossHandlingMode = jdbcConfig.getTemporalPrecisionLossHandlingMode();
         }
+        if (config instanceof JdbcSinkConnectorConfig jdbcConfig && jdbcConfig.getTemporalRangeLossHandlingMode() != null) {
+            rangeLossHandlingMode = jdbcConfig.getTemporalRangeLossHandlingMode();
+        }
     }
 
     protected TimeZone getDatabaseTimeZone() {
@@ -52,6 +59,18 @@ public abstract class AbstractTemporalType extends AbstractType {
 
     protected TemporalPrecisionLossHandlingMode getPrecisionLossHandlingMode() {
         return precisionLossHandlingMode;
+    }
+
+    protected TemporalRangeLossHandlingMode getRangeLossHandlingMode() {
+        return rangeLossHandlingMode;
+    }
+
+    protected String targetDescription(Schema schema) {
+        return String.format("target type '%s'", getTypeName(schema, false));
+    }
+
+    protected String targetDescription(ColumnDescriptor column) {
+        return String.format("target column '%s' (%s)", column.getColumnName(), column.getTypeName());
     }
 
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
@@ -11,6 +11,8 @@ import java.util.TimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.sink.SinkConnectorConfig;
 
@@ -24,6 +26,7 @@ public abstract class AbstractTemporalType extends AbstractType {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTemporalType.class);
 
     private TimeZone databaseTimeZone;
+    private TemporalPrecisionLossHandlingMode precisionLossHandlingMode = TemporalPrecisionLossHandlingMode.FAIL;
 
     @Override
     public void configure(SinkConnectorConfig config, DatabaseDialect dialect) {
@@ -37,10 +40,18 @@ public abstract class AbstractTemporalType extends AbstractType {
             LOGGER.error("Failed to resolve time zone '{}', please specify a correct time zone value", databaseTimeZone, e);
             throw e;
         }
+
+        if (config instanceof JdbcSinkConnectorConfig jdbcConfig && jdbcConfig.getTemporalPrecisionLossHandlingMode() != null) {
+            precisionLossHandlingMode = jdbcConfig.getTemporalPrecisionLossHandlingMode();
+        }
     }
 
     protected TimeZone getDatabaseTimeZone() {
         return databaseTimeZone;
+    }
+
+    protected TemporalPrecisionLossHandlingMode getPrecisionLossHandlingMode() {
+        return precisionLossHandlingMode;
     }
 
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTimeType.java
@@ -27,14 +27,20 @@ public abstract class AbstractTimeType extends AbstractTemporalType {
         // the time column's precision but instead uses the __debezium.source.column.length key
         // which differs from all other connector implementations.
         //
+        final int precision = getSchemaTimePrecision(schema);
+        final DatabaseDialect dialect = getDialect();
+        return dialect.getJdbcTypeName(Types.TIME, Size.precision(precision));
+    }
+
+    protected int getSchemaTimePrecision(Schema schema) {
         final int precision = getTimePrecision(schema);
-        DatabaseDialect dialect = getDialect();
-        // We use TIMESTAMP here even for source TIME types as Oracle will use DATE types for
-        // such columns, and it only supports second-based precision.
+        final DatabaseDialect dialect = getDialect();
+        // Use the timestamp precision bound for source TIME types because Oracle maps them to
+        // timestamp-based target columns.
         if (shouldUseSourcePrecision(precision, dialect.getDefaultTimestampPrecision())) {
-            return dialect.getJdbcTypeName(Types.TIME, Size.precision(precision));
+            return precision;
         }
-        return dialect.getJdbcTypeName(Types.TIME, Size.precision(dialect.getDefaultTimePrecision()));
+        return dialect.getDefaultTimePrecision();
     }
 
     protected int getTimePrecision(Schema schema) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTimestampType.java
@@ -22,12 +22,18 @@ public abstract class AbstractTimestampType extends AbstractTemporalType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
+        final int precision = getSchemaTimestampPrecision(schema);
+        final DatabaseDialect dialect = getDialect();
+        return dialect.getJdbcTypeName(getJdbcType(), Size.precision(precision));
+    }
+
+    protected int getSchemaTimestampPrecision(Schema schema) {
         final int precision = getTimePrecision(schema);
-        DatabaseDialect dialect = getDialect();
+        final DatabaseDialect dialect = getDialect();
         if (shouldUseSourcePrecision(precision, dialect.getMaxTimestampPrecision())) {
-            return dialect.getJdbcTypeName(getJdbcType(), Size.precision(precision));
+            return precision;
         }
-        return dialect.getJdbcTypeName(getJdbcType(), Size.precision(dialect.getDefaultTimestampPrecision()));
+        return dialect.getDefaultTimestampPrecision();
     }
 
     protected int getTimePrecision(Schema schema) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/JdbcType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/JdbcType.java
@@ -5,11 +5,15 @@
  */
 package io.debezium.connector.jdbc.type;
 
+import java.util.List;
+
 import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.type.Type;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
  * A type represents a relational column type used for query abd parameter binding.
@@ -37,4 +41,27 @@ public interface JdbcType extends Type {
      * @return the resolved type to be used in DDL statements
      */
     String getTypeName(Schema schema, boolean isKey);
+
+    /**
+     * Validates that a value can be represented by the target column without an implicit semantic loss.
+     *
+     * @param column target column descriptor, never {@code null}
+     * @param schema field schema, never {@code null}
+     * @param value value to validate, may be {@code null}
+     */
+    default void validate(ColumnDescriptor column, Schema schema, Object value) {
+    }
+
+    /**
+     * Binds a value with access to the actual target column definition.
+     *
+     * @param index parameter index to bind
+     * @param column target column descriptor, never {@code null}
+     * @param schema field schema, never {@code null}
+     * @param value value to bind, may be {@code null}
+     * @return the list of {@link ValueBindDescriptor}
+     */
+    default List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        return bind(index, schema, value);
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDateType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDateType.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractDateType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredDate;
 
@@ -29,7 +30,9 @@ public class StructuredDateType extends AbstractDateType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return getDialect().getFormattedDate(StructuredTemporalSupport.toLocalDate(requireStruct(value)));
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        return getDialect().getFormattedDate(StructuredTemporalSupport.toLocalDate(
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema)));
     }
 
     @Override
@@ -37,7 +40,33 @@ public class StructuredDateType extends AbstractDateType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        final LocalDate localDate = StructuredTemporalSupport.toLocalDate(requireStruct(value));
+        if (getDialect() == null) {
+            return List.of(new ValueBindDescriptor(index, StructuredTemporalSupport.toLocalDate(requireStruct(value))));
+        }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final LocalDate localDate = StructuredTemporalSupport.toLocalDate(
+                requireStruct(value), capabilities.targetDateRange(null), getRangeLossHandlingMode(), targetDescription(schema));
         return List.of(new ValueBindDescriptor(index, localDate));
     }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var range = getDialect().getTargetTemporalCapabilities().targetDateRange(column);
+            StructuredTemporalSupport.adjustDate(
+                    requireStruct(value), range, getRangeLossHandlingMode(), targetDescription(column));
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        final var range = getDialect().getTargetTemporalCapabilities().targetDateRange(column);
+        final LocalDate localDate = StructuredTemporalSupport.toLocalDate(
+                requireStruct(value), range, getRangeLossHandlingMode(), targetDescription(column));
+        return List.of(new ValueBindDescriptor(index, localDate));
+    }
+
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDurationType.java
@@ -50,4 +50,12 @@ public class StructuredDurationType extends AbstractType {
         }
         return List.of(new ValueBindDescriptor(index, StructuredTemporalSupport.toDurationString(requireStruct(value)), Types.VARCHAR));
     }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            StructuredTemporalPreflightValidator.validateDuration(
+                    schema, requireStruct(value), getDialect().getTargetTemporalCapabilities());
+        }
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDurationType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredDurationType.java
@@ -25,7 +25,7 @@ public class StructuredDurationType extends AbstractType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredDuration.SCHEMA_NAME };
+        return StructuredDuration.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPreflightValidator.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPreflightValidator.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.debezium;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredDuration;
+import io.debezium.time.StructuredTemporal;
+
+/**
+ * Validates structured temporal values against the actual target column before JDBC statement execution.
+ */
+public final class StructuredTemporalPreflightValidator {
+
+    public static void validatePrecision(ColumnDescriptor column, Struct value, int targetPrecision,
+                                         TemporalPrecisionLossHandlingMode handlingMode) {
+        if (value == null || !StructuredTemporal.isFinite(value)) {
+            return;
+        }
+
+        final Long picoseconds = StructuredTemporalSupport.getPicoseconds(value);
+        if (handlingMode == TemporalPrecisionLossHandlingMode.FAIL && hasDiscardedDigits(picoseconds, targetPrecision)) {
+            throw new ConnectException(String.format(
+                    "Structured temporal value for target column '%s' has non-zero fractional digits beyond precision %d; "
+                            + "set 'temporal.precision.loss.handling.mode' to 'truncate' or 'round' to allow an explicit reduction",
+                    column.getColumnName(), targetPrecision));
+        }
+    }
+
+    public static void validateDuration(Schema schema, Struct value, TargetTemporalCapabilities capabilities) {
+        final StructuredDuration.Kind kind = durationKind(schema, value);
+        validateDurationComponents(kind, value);
+        if (!capabilities.durationKinds().contains(kind)) {
+            throw new ConnectException(String.format(
+                    "Structured duration kind '%s' cannot be represented by the target dialect without semantic loss",
+                    kind.getValue()));
+        }
+    }
+
+    public static void validateZonedTimestamp(Struct value, TargetTemporalCapabilities capabilities) {
+        if (value == null || !StructuredTemporal.isFinite(value)) {
+            return;
+        }
+
+        final String zoneId = value.getString(StructuredTemporal.ZONE_ID_FIELD);
+        final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
+        if (isRegionId(zoneId) && !capabilities.zonedTimestampSupport().preservesRegion()) {
+            throw new ConnectException(String.format(
+                    "Structured zoned timestamp region '%s' cannot be preserved by the target dialect", zoneId));
+        }
+        if (offsetSeconds != null && offsetSeconds != 0 && !capabilities.zonedTimestampSupport().preservesOffset()) {
+            throw new ConnectException(String.format(
+                    "Structured zoned timestamp offset %d cannot be preserved by the target dialect", offsetSeconds));
+        }
+    }
+
+    public static boolean hasDiscardedDigits(Long picoseconds, int targetPrecision) {
+        if (picoseconds == null || targetPrecision >= 12) {
+            return false;
+        }
+        final long factor = precisionFactor(targetPrecision);
+        return Math.abs(picoseconds) % factor != 0;
+    }
+
+    public static StructuredDuration.Kind durationKind(Schema schema, Struct value) {
+        if (schema != null && schema.parameters() != null) {
+            final String kindValue = schema.parameters().get(StructuredTemporal.DURATION_KIND_PARAMETER_KEY);
+            if (kindValue != null) {
+                final StructuredDuration.Kind kind = StructuredDuration.Kind.parse(kindValue);
+                if (kind == null) {
+                    throw new ConnectException("Unknown structured duration kind '" + kindValue + "'");
+                }
+                return kind;
+            }
+        }
+
+        final boolean hasYearMonth = value != null
+                && (nonZero(value.getInt32(StructuredTemporal.YEARS_FIELD)) || nonZero(value.getInt32(StructuredTemporal.MONTHS_FIELD)));
+        final boolean hasDayTime = value != null
+                && (nonZero(value.getInt32(StructuredTemporal.DAYS_FIELD))
+                        || nonZero(value.getInt32(StructuredTemporal.HOURS_FIELD))
+                        || nonZero(value.getInt32(StructuredTemporal.MINUTES_FIELD))
+                        || nonZero(value.getInt64(StructuredTemporal.SECONDS_FIELD))
+                        || StructuredTemporalSupport.getPicoseconds(value) != 0);
+        if (hasYearMonth && hasDayTime) {
+            return StructuredDuration.Kind.MIXED;
+        }
+        if (hasYearMonth) {
+            return StructuredDuration.Kind.YEAR_MONTH;
+        }
+        if (value != null && nonZero(value.getInt32(StructuredTemporal.DAYS_FIELD))) {
+            return StructuredDuration.Kind.DAY_TIME;
+        }
+        return StructuredDuration.Kind.ELAPSED_TIME;
+    }
+
+    public static ReducedFraction reduceFraction(long picoseconds, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        if (targetPrecision >= 12) {
+            return new ReducedFraction(picoseconds, 0);
+        }
+
+        final long factor = precisionFactor(targetPrecision);
+        if (handlingMode == TemporalPrecisionLossHandlingMode.FAIL && Math.abs(picoseconds) % factor != 0) {
+            throw new ConnectException(String.format(
+                    "Structured temporal value has non-zero fractional digits beyond precision %d", targetPrecision));
+        }
+        if (handlingMode == TemporalPrecisionLossHandlingMode.ROUND) {
+            final long adjustment = picoseconds < 0 ? -factor / 2L : factor / 2L;
+            final long rounded = (picoseconds + adjustment) / factor * factor;
+            if (Math.abs(rounded) == StructuredTemporal.PICOSECONDS_PER_SECOND) {
+                return new ReducedFraction(0, rounded < 0 ? -1 : 1);
+            }
+            return new ReducedFraction(rounded, 0);
+        }
+        return new ReducedFraction(picoseconds / factor * factor, 0);
+    }
+
+    private static long precisionFactor(int targetPrecision) {
+        if (targetPrecision < 0 || targetPrecision > 12) {
+            throw new ConnectException("Target temporal precision must be between 0 and 12, but was " + targetPrecision);
+        }
+        long factor = 1;
+        for (int i = targetPrecision; i < 12; ++i) {
+            factor *= 10;
+        }
+        return factor;
+    }
+
+    private static boolean nonZero(Number value) {
+        return value != null && value.longValue() != 0;
+    }
+
+    private static void validateDurationComponents(StructuredDuration.Kind kind, Struct value) {
+        if (value == null) {
+            return;
+        }
+        final boolean hasYearMonth = nonZero(value.getInt32(StructuredTemporal.YEARS_FIELD))
+                || nonZero(value.getInt32(StructuredTemporal.MONTHS_FIELD));
+        final boolean hasDays = nonZero(value.getInt32(StructuredTemporal.DAYS_FIELD));
+        final boolean hasTime = nonZero(value.getInt32(StructuredTemporal.HOURS_FIELD))
+                || nonZero(value.getInt32(StructuredTemporal.MINUTES_FIELD))
+                || nonZero(value.getInt64(StructuredTemporal.SECONDS_FIELD))
+                || StructuredTemporalSupport.getPicoseconds(value) != 0;
+        final boolean invalid = switch (kind) {
+            case ELAPSED_TIME -> hasYearMonth || hasDays;
+            case YEAR_MONTH -> hasDays || hasTime;
+            case DAY_TIME -> hasYearMonth;
+            case MIXED -> false;
+        };
+        if (invalid) {
+            throw new ConnectException(String.format(
+                    "Structured duration components do not match schema kind '%s'", kind.getValue()));
+        }
+    }
+
+    private static boolean isRegionId(String zoneId) {
+        if (zoneId == null) {
+            return false;
+        }
+        try {
+            return !(ZoneId.of(zoneId) instanceof ZoneOffset);
+        }
+        catch (DateTimeException e) {
+            throw new ConnectException("Invalid structured zoned timestamp zone identifier '" + zoneId + "'", e);
+        }
+    }
+
+    public record ReducedFraction(long picoseconds, int carrySeconds) {
+
+        public int nanoseconds() {
+            return Math.toIntExact(picoseconds / StructuredTemporal.PICOSECONDS_PER_NANOSECOND);
+        }
+    }
+
+    private StructuredTemporalPreflightValidator() {
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
@@ -260,13 +260,14 @@ public final class StructuredTemporalSupport {
 
     private static Boundary applyRange(Boundary value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
                                        int targetPrecision, String targetDescription) {
-        if (range.contains(value)) {
+        final TemporalRange effectiveRange = range.atPrecision(targetPrecision);
+        if (effectiveRange.contains(value)) {
             return value;
         }
         if (handlingMode == TemporalRangeLossHandlingMode.SATURATE) {
-            return range.saturate(value).withPrecision(targetPrecision);
+            return effectiveRange.saturate(value).withPrecision(targetPrecision);
         }
-        throw rangeException(value, range, targetDescription);
+        throw rangeException(value, effectiveRange, targetDescription);
     }
 
     private static Boundary saturateSpecialValue(Struct value, TemporalRange range,

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
@@ -11,10 +11,13 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.OptionalInt;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.time.StructuredTemporal;
 
 public final class StructuredTemporalSupport {
@@ -33,7 +36,7 @@ public final class StructuredTemporalSupport {
                 value.getInt8(StructuredTemporal.HOUR_FIELD),
                 value.getInt8(StructuredTemporal.MINUTE_FIELD),
                 value.getInt8(StructuredTemporal.SECOND_FIELD),
-                value.getInt32(StructuredTemporal.NANOS_FIELD));
+                toNanoseconds(getPicoseconds(value)));
     }
 
     /**
@@ -46,22 +49,51 @@ public final class StructuredTemporalSupport {
         final int hour = value.getInt8(StructuredTemporal.HOUR_FIELD);
         final int minute = value.getInt8(StructuredTemporal.MINUTE_FIELD);
         final int second = value.getInt8(StructuredTemporal.SECOND_FIELD);
-        final Integer nanos = value.getInt32(StructuredTemporal.NANOS_FIELD);
+        final long picoseconds = getPicoseconds(value);
         final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
 
         final StringBuilder builder = new StringBuilder(String.format("%02d:%02d:%02d", hour, minute, second));
-        if (nanos != null && nanos > 0) {
-            // Match java.time fractional-second formatting: emit 3, 6 or 9 digits, trimming trailing zero-triples.
-            final String digits = String.format("%09d", nanos);
-            int length = 9;
-            while (length > 3 && digits.charAt(length - 1) == '0' && digits.charAt(length - 2) == '0'
-                    && digits.charAt(length - 3) == '0') {
-                length -= 3;
-            }
-            builder.append('.').append(digits, 0, length);
-        }
+        appendFraction(builder, picoseconds, 12);
         builder.append(formatOffset(offsetSeconds == null ? 0 : offsetSeconds));
         return builder.toString();
+    }
+
+    public static String toTimetzLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        requireFinite(value);
+        final int hour = value.getInt8(StructuredTemporal.HOUR_FIELD);
+        final int minute = value.getInt8(StructuredTemporal.MINUTE_FIELD);
+        final int second = value.getInt8(StructuredTemporal.SECOND_FIELD);
+        final long picoseconds = getPicoseconds(value);
+        final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
+                picoseconds, targetPrecision, handlingMode);
+
+        final int totalSeconds = hour * 3_600 + minute * 60 + second + fraction.carrySeconds();
+        if (totalSeconds < 0 || totalSeconds > 24 * 3_600) {
+            throw new ConnectException("Structured zoned time is outside the PostgreSQL timetz range after precision reduction");
+        }
+
+        final int adjustedHour = totalSeconds / 3_600;
+        final int adjustedMinute = totalSeconds % 3_600 / 60;
+        final int adjustedSecond = totalSeconds % 60;
+        final StringBuilder builder = new StringBuilder(String.format("%02d:%02d:%02d", adjustedHour, adjustedMinute, adjustedSecond));
+        appendFraction(builder, fraction.picoseconds(), targetPrecision);
+        builder.append(formatOffset(offsetSeconds == null ? 0 : offsetSeconds));
+        return builder.toString();
+    }
+
+    public static void appendFraction(StringBuilder builder, long picoseconds, int precision) {
+        if (picoseconds == 0 || precision == 0) {
+            return;
+        }
+        final String digits = String.format("%012d", Math.abs(picoseconds));
+        int length = precision;
+        while (length > 0 && digits.charAt(length - 1) == '0') {
+            --length;
+        }
+        if (length > 0) {
+            builder.append('.').append(digits, 0, length);
+        }
     }
 
     private static String formatOffset(int offsetSeconds) {
@@ -87,6 +119,69 @@ public final class StructuredTemporalSupport {
         return OffsetDateTime.of(localDateTime, offsetSeconds == null ? ZoneOffset.UTC : ZoneOffset.ofTotalSeconds(offsetSeconds));
     }
 
+    public static LocalDateTime toLocalDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        final LocalDateTime dateTime = toLocalDateTimeWithoutFraction(value);
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
+        return dateTime.withNano(fraction.nanoseconds()).plusSeconds(fraction.carrySeconds());
+    }
+
+    public static LocalTime toLocalTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        requireFinite(value);
+        final LocalTime time = LocalTime.of(
+                value.getInt8(StructuredTemporal.HOUR_FIELD),
+                value.getInt8(StructuredTemporal.MINUTE_FIELD),
+                value.getInt8(StructuredTemporal.SECOND_FIELD));
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
+        return time.withNano(fraction.nanoseconds()).plusSeconds(fraction.carrySeconds());
+    }
+
+    public static OffsetDateTime toOffsetDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
+        final OffsetDateTime dateTime = OffsetDateTime.of(
+                toLocalDateTimeWithoutFraction(value), offsetSeconds == null ? ZoneOffset.UTC : ZoneOffset.ofTotalSeconds(offsetSeconds));
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
+        return dateTime.withNano(fraction.nanoseconds()).plusSeconds(fraction.carrySeconds());
+    }
+
+    public static String toLocalDateTimeLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        final LocalDateTime dateTime = toLocalDateTimeWithoutFraction(value);
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
+        final LocalDateTime adjusted = dateTime.plusSeconds(fraction.carrySeconds());
+        final StringBuilder builder = new StringBuilder(String.format("%04d-%02d-%02d %02d:%02d:%02d",
+                adjusted.getYear(), adjusted.getMonthValue(), adjusted.getDayOfMonth(), adjusted.getHour(), adjusted.getMinute(), adjusted.getSecond()));
+        appendFraction(builder, fraction.picoseconds(), targetPrecision);
+        return builder.toString();
+    }
+
+    public static long getPicoseconds(Struct value) {
+        final Long picoseconds = value.getInt64(StructuredTemporal.PICOSECONDS_FIELD);
+        if (picoseconds == null) {
+            return 0;
+        }
+        if (picoseconds <= -StructuredTemporal.PICOSECONDS_PER_SECOND || picoseconds >= StructuredTemporal.PICOSECONDS_PER_SECOND) {
+            throw new ConnectException("Structured temporal picoseconds must have an absolute value less than one second");
+        }
+        return picoseconds;
+    }
+
+    public static OptionalInt getPrecision(Schema schema) {
+        if (schema != null && schema.parameters() != null) {
+            final String precision = schema.parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY);
+            if (precision != null) {
+                return OptionalInt.of(Integer.parseInt(precision));
+            }
+            final String sourcePrecision = schema.parameters().get("__debezium.source.column.scale");
+            if (sourcePrecision != null) {
+                return OptionalInt.of(Integer.parseInt(sourcePrecision));
+            }
+            final String sourceLength = schema.parameters().get("__debezium.source.column.length");
+            if (sourceLength != null) {
+                return OptionalInt.of(Integer.parseInt(sourceLength));
+            }
+        }
+        return OptionalInt.empty();
+    }
+
     public static void requireFinite(Struct value) {
         if (!StructuredTemporal.isFinite(value)) {
             throw new ConnectException("Non-finite structured temporal values require dialect-specific handling");
@@ -102,9 +197,9 @@ public final class StructuredTemporalSupport {
         append(builder, value.getInt32(StructuredTemporal.MINUTES_FIELD), " minutes");
 
         final Long seconds = value.getInt64(StructuredTemporal.SECONDS_FIELD);
-        final Integer nanos = value.getInt32(StructuredTemporal.NANOS_FIELD);
+        final long picoseconds = getPicoseconds(value);
         final BigDecimal fractionalSeconds = BigDecimal.valueOf(seconds == null ? 0 : seconds)
-                .add(BigDecimal.valueOf(nanos == null ? 0 : nanos, 9))
+                .add(BigDecimal.valueOf(picoseconds, 12))
                 .stripTrailingZeros();
         if (fractionalSeconds.signum() != 0 || builder.length() == 0) {
             append(builder, fractionalSeconds.toPlainString(), " seconds");
@@ -123,6 +218,21 @@ public final class StructuredTemporalSupport {
             builder.append(' ');
         }
         builder.append(value).append(suffix);
+    }
+
+    private static LocalDateTime toLocalDateTimeWithoutFraction(Struct value) {
+        requireFinite(value);
+        return LocalDateTime.of(
+                value.getInt32(StructuredTemporal.YEAR_FIELD),
+                value.getInt8(StructuredTemporal.MONTH_FIELD),
+                value.getInt8(StructuredTemporal.DAY_FIELD),
+                value.getInt8(StructuredTemporal.HOUR_FIELD),
+                value.getInt8(StructuredTemporal.MINUTE_FIELD),
+                value.getInt8(StructuredTemporal.SECOND_FIELD));
+    }
+
+    private static int toNanoseconds(long picoseconds) {
+        return Math.toIntExact(picoseconds / StructuredTemporal.PICOSECONDS_PER_NANOSECOND);
     }
 
     private StructuredTemporalSupport() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
@@ -46,6 +46,27 @@ public final class StructuredTemporalSupport {
                 toNanoseconds(getPicoseconds(value)));
     }
 
+    public static String toTimeLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        requireFinite(value);
+        final int hour = value.getInt8(StructuredTemporal.HOUR_FIELD);
+        final int minute = value.getInt8(StructuredTemporal.MINUTE_FIELD);
+        final int second = value.getInt8(StructuredTemporal.SECOND_FIELD);
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
+                getPicoseconds(value), targetPrecision, handlingMode);
+
+        final int totalSeconds = hour * 3_600 + minute * 60 + second + fraction.carrySeconds();
+        if (totalSeconds < 0 || totalSeconds > 24 * 3_600) {
+            throw new ConnectException("Structured time is outside the 24-hour clock range after precision reduction");
+        }
+
+        final int adjustedHour = totalSeconds / 3_600;
+        final int adjustedMinute = totalSeconds % 3_600 / 60;
+        final int adjustedSecond = totalSeconds % 60;
+        final StringBuilder builder = new StringBuilder(String.format("%02d:%02d:%02d", adjustedHour, adjustedMinute, adjustedSecond));
+        appendFraction(builder, fraction.picoseconds(), targetPrecision);
+        return builder.toString();
+    }
+
     /**
      * Formats a {@code StructuredZonedTime} struct into a PostgreSQL {@code timetz} literal directly from its
      * raw components, so the original offset and the end-of-day boundary hour {@code 24} are preserved. This
@@ -66,25 +87,8 @@ public final class StructuredTemporalSupport {
     }
 
     public static String toTimetzLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
-        requireFinite(value);
-        final int hour = value.getInt8(StructuredTemporal.HOUR_FIELD);
-        final int minute = value.getInt8(StructuredTemporal.MINUTE_FIELD);
-        final int second = value.getInt8(StructuredTemporal.SECOND_FIELD);
-        final long picoseconds = getPicoseconds(value);
         final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
-        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
-                picoseconds, targetPrecision, handlingMode);
-
-        final int totalSeconds = hour * 3_600 + minute * 60 + second + fraction.carrySeconds();
-        if (totalSeconds < 0 || totalSeconds > 24 * 3_600) {
-            throw new ConnectException("Structured zoned time is outside the PostgreSQL timetz range after precision reduction");
-        }
-
-        final int adjustedHour = totalSeconds / 3_600;
-        final int adjustedMinute = totalSeconds % 3_600 / 60;
-        final int adjustedSecond = totalSeconds % 60;
-        final StringBuilder builder = new StringBuilder(String.format("%02d:%02d:%02d", adjustedHour, adjustedMinute, adjustedSecond));
-        appendFraction(builder, fraction.picoseconds(), targetPrecision);
+        final StringBuilder builder = new StringBuilder(toTimeLiteral(value, targetPrecision, handlingMode));
         builder.append(formatOffset(offsetSeconds == null ? 0 : offsetSeconds));
         return builder.toString();
     }
@@ -212,6 +216,9 @@ public final class StructuredTemporalSupport {
                 value.getInt8(StructuredTemporal.MINUTE_FIELD),
                 value.getInt8(StructuredTemporal.SECOND_FIELD),
                 fraction.picoseconds());
+        if (fraction.carrySeconds() != 0 && !range.contains(timestamp)) {
+            return applyRange(timestamp, range, rangeHandlingMode, targetPrecision, targetDescription);
+        }
         timestamp = timestamp.plusSeconds(fraction.carrySeconds());
         return applyRange(timestamp, range, rangeHandlingMode, targetPrecision, targetDescription);
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalSupport.java
@@ -18,6 +18,8 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.time.StructuredTemporal;
 
 public final class StructuredTemporalSupport {
@@ -28,6 +30,11 @@ public final class StructuredTemporalSupport {
                 value.getInt32(StructuredTemporal.YEAR_FIELD),
                 value.getInt8(StructuredTemporal.MONTH_FIELD),
                 value.getInt8(StructuredTemporal.DAY_FIELD));
+    }
+
+    public static LocalDate toLocalDate(Struct value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
+                                        String targetDescription) {
+        return adjustDate(value, range, handlingMode, targetDescription).toLocalDate();
     }
 
     public static LocalTime toLocalTime(Struct value) {
@@ -120,9 +127,15 @@ public final class StructuredTemporalSupport {
     }
 
     public static LocalDateTime toLocalDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
-        final LocalDateTime dateTime = toLocalDateTimeWithoutFraction(value);
-        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
-        return dateTime.withNano(fraction.nanoseconds()).plusSeconds(fraction.carrySeconds());
+        return adjustTimestamp(value, targetPrecision, handlingMode, TemporalRange.unbounded(),
+                TemporalRangeLossHandlingMode.FAIL, "target dialect").toLocalDateTime();
+    }
+
+    public static LocalDateTime toLocalDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode precisionHandlingMode,
+                                                TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
+                                                String targetDescription) {
+        return adjustTimestamp(value, targetPrecision, precisionHandlingMode, range, rangeHandlingMode,
+                targetDescription).toLocalDateTime();
     }
 
     public static LocalTime toLocalTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
@@ -136,21 +149,71 @@ public final class StructuredTemporalSupport {
     }
 
     public static OffsetDateTime toOffsetDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
+        return toOffsetDateTime(value, targetPrecision, handlingMode, TemporalRange.unbounded(),
+                TemporalRangeLossHandlingMode.FAIL, "target dialect");
+    }
+
+    public static OffsetDateTime toOffsetDateTime(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode precisionHandlingMode,
+                                                  TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
+                                                  String targetDescription) {
         final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
-        final OffsetDateTime dateTime = OffsetDateTime.of(
-                toLocalDateTimeWithoutFraction(value), offsetSeconds == null ? ZoneOffset.UTC : ZoneOffset.ofTotalSeconds(offsetSeconds));
-        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
-        return dateTime.withNano(fraction.nanoseconds()).plusSeconds(fraction.carrySeconds());
+        final Boundary adjusted = adjustTimestamp(value, targetPrecision, precisionHandlingMode, range, rangeHandlingMode,
+                targetDescription);
+        return OffsetDateTime.of(adjusted.toLocalDateTime(),
+                offsetSeconds == null ? ZoneOffset.UTC : ZoneOffset.ofTotalSeconds(offsetSeconds));
     }
 
     public static String toLocalDateTimeLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode handlingMode) {
-        final LocalDateTime dateTime = toLocalDateTimeWithoutFraction(value);
-        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(getPicoseconds(value), targetPrecision, handlingMode);
-        final LocalDateTime adjusted = dateTime.plusSeconds(fraction.carrySeconds());
+        return toLocalDateTimeLiteral(value, targetPrecision, handlingMode, TemporalRange.unbounded(),
+                TemporalRangeLossHandlingMode.FAIL, "target dialect");
+    }
+
+    public static String toLocalDateTimeLiteral(Struct value, int targetPrecision, TemporalPrecisionLossHandlingMode precisionHandlingMode,
+                                                TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
+                                                String targetDescription) {
+        final Boundary adjusted = adjustTimestamp(value, targetPrecision, precisionHandlingMode, range, rangeHandlingMode,
+                targetDescription);
         final StringBuilder builder = new StringBuilder(String.format("%04d-%02d-%02d %02d:%02d:%02d",
-                adjusted.getYear(), adjusted.getMonthValue(), adjusted.getDayOfMonth(), adjusted.getHour(), adjusted.getMinute(), adjusted.getSecond()));
-        appendFraction(builder, fraction.picoseconds(), targetPrecision);
+                adjusted.year(), adjusted.month(), adjusted.day(), adjusted.hour(), adjusted.minute(), adjusted.second()));
+        appendFraction(builder, adjusted.picoseconds(), targetPrecision);
         return builder.toString();
+    }
+
+    public static Boundary adjustDate(Struct value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
+                                      String targetDescription) {
+        if (!StructuredTemporal.isFinite(value)) {
+            return saturateSpecialValue(value, range, handlingMode, 0, targetDescription);
+        }
+        final Boundary date = Boundary.date(
+                value.getInt32(StructuredTemporal.YEAR_FIELD),
+                value.getInt8(StructuredTemporal.MONTH_FIELD),
+                value.getInt8(StructuredTemporal.DAY_FIELD));
+        return applyRange(date, range, handlingMode, 0, targetDescription);
+    }
+
+    public static Boundary adjustTimestamp(Struct value, int targetPrecision,
+                                           TemporalPrecisionLossHandlingMode precisionHandlingMode,
+                                           TemporalRange range, TemporalRangeLossHandlingMode rangeHandlingMode,
+                                           String targetDescription) {
+        if (!StructuredTemporal.isFinite(value)) {
+            return saturateSpecialValue(value, range, rangeHandlingMode, targetPrecision, targetDescription);
+        }
+
+        final var fraction = StructuredTemporalPreflightValidator.reduceFraction(
+                getPicoseconds(value), targetPrecision, precisionHandlingMode);
+        if (fraction.picoseconds() < 0) {
+            throw new ConnectException("Structured timestamp picoseconds must not be negative");
+        }
+        Boundary timestamp = Boundary.timestamp(
+                value.getInt32(StructuredTemporal.YEAR_FIELD),
+                value.getInt8(StructuredTemporal.MONTH_FIELD),
+                value.getInt8(StructuredTemporal.DAY_FIELD),
+                value.getInt8(StructuredTemporal.HOUR_FIELD),
+                value.getInt8(StructuredTemporal.MINUTE_FIELD),
+                value.getInt8(StructuredTemporal.SECOND_FIELD),
+                fraction.picoseconds());
+        timestamp = timestamp.plusSeconds(fraction.carrySeconds());
+        return applyRange(timestamp, range, rangeHandlingMode, targetPrecision, targetDescription);
     }
 
     public static long getPicoseconds(Struct value) {
@@ -186,6 +249,41 @@ public final class StructuredTemporalSupport {
         if (!StructuredTemporal.isFinite(value)) {
             throw new ConnectException("Non-finite structured temporal values require dialect-specific handling");
         }
+    }
+
+    private static Boundary applyRange(Boundary value, TemporalRange range, TemporalRangeLossHandlingMode handlingMode,
+                                       int targetPrecision, String targetDescription) {
+        if (range.contains(value)) {
+            return value;
+        }
+        if (handlingMode == TemporalRangeLossHandlingMode.SATURATE) {
+            return range.saturate(value).withPrecision(targetPrecision);
+        }
+        throw rangeException(value, range, targetDescription);
+    }
+
+    private static Boundary saturateSpecialValue(Struct value, TemporalRange range,
+                                                 TemporalRangeLossHandlingMode handlingMode, int targetPrecision,
+                                                 String targetDescription) {
+        if (handlingMode == TemporalRangeLossHandlingMode.SATURATE) {
+            if (StructuredTemporal.isPositiveInfinity(value) && range.maximum() != null) {
+                return range.maximum().withPrecision(targetPrecision);
+            }
+            if (StructuredTemporal.isNegativeInfinity(value) && range.minimum() != null) {
+                return range.minimum().withPrecision(targetPrecision);
+            }
+        }
+        throw new ConnectException(String.format(
+                "Non-finite structured temporal value cannot be represented by %s", targetDescription));
+    }
+
+    private static ConnectException rangeException(Boundary value, TemporalRange range, String targetDescription) {
+        final String minimum = range.minimum() == null ? "unbounded" : range.minimum().toString();
+        final String maximum = range.maximum() == null ? "unbounded" : range.maximum().toString();
+        return new ConnectException(String.format(
+                "Structured temporal value '%s' is outside the range [%s, %s] supported by %s; "
+                        + "set 'temporal.range.loss.handling.mode' to 'saturate' to map it to the nearest boundary",
+                value, minimum, maximum, targetDescription));
     }
 
     public static String toDurationString(Struct value) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
@@ -25,7 +25,7 @@ public class StructuredTimeType extends AbstractTimeType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredTime.SCHEMA_NAME };
+        return StructuredTime.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractTimeType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredTime;
 
@@ -29,8 +30,11 @@ public class StructuredTimeType extends AbstractTimeType {
 
     @Override
     protected int getTimePrecision(Schema schema) {
-        final String length = getSourceColumnSize(schema).orElse("-1");
-        return getSourceColumnPrecision(schema).map(Integer::parseInt).orElseGet(() -> Integer.parseInt(length));
+        return StructuredTemporalSupport.getPrecision(schema)
+                .stream()
+                .map(precision -> Math.min(precision, getDialect().getMaxTimePrecision()))
+                .findFirst()
+                .orElse(-1);
     }
 
     @Override
@@ -50,5 +54,25 @@ public class StructuredTimeType extends AbstractTimeType {
         }
         final LocalTime localTime = StructuredTemporalSupport.toLocalTime(requireStruct(value));
         return List.of(new ValueBindDescriptor(index, localTime));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, requireStruct(value), capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        return List.of(new ValueBindDescriptor(index,
+                StructuredTemporalSupport.toLocalTime(requireStruct(value), precision, getPrecisionLossHandlingMode())));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimeType.java
@@ -44,7 +44,8 @@ public class StructuredTimeType extends AbstractTimeType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return getDialect().getFormattedTime(StructuredTemporalSupport.toLocalTime(requireStruct(value)));
+        return getDialect().getFormattedTime(StructuredTemporalSupport.toLocalTime(
+                requireStruct(value), getSchemaTimePrecision(schema), getPrecisionLossHandlingMode()));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
@@ -25,7 +25,7 @@ public class StructuredTimestampType extends AbstractTimestampType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredTimestamp.SCHEMA_NAME };
+        return StructuredTimestamp.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractTimestampType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredTimestamp;
 
@@ -29,8 +30,11 @@ public class StructuredTimestampType extends AbstractTimestampType {
 
     @Override
     protected int getTimePrecision(Schema schema) {
-        final String length = getSourceColumnSize(schema).orElse("-1");
-        return getSourceColumnPrecision(schema).map(Integer::parseInt).orElseGet(() -> Integer.parseInt(length));
+        return StructuredTemporalSupport.getPrecision(schema)
+                .stream()
+                .map(precision -> Math.min(precision, getDialect().getMaxTimestampPrecision()))
+                .findFirst()
+                .orElse(-1);
     }
 
     @Override
@@ -49,6 +53,27 @@ public class StructuredTimestampType extends AbstractTimestampType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(requireStruct(value));
+        return List.of(new ValueBindDescriptor(index, localDateTime, getJdbcType()));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, requireStruct(value), capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode());
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(
+                requireStruct(value), precision, getPrecisionLossHandlingMode());
         return List.of(new ValueBindDescriptor(index, localDateTime, getJdbcType()));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
@@ -44,7 +44,8 @@ public class StructuredTimestampType extends AbstractTimestampType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return getDialect().getFormattedDateTime(StructuredTemporalSupport.toLocalDateTime(requireStruct(value)));
+        return getDialect().getFormattedDateTime(StructuredTemporalSupport.toLocalDateTime(
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
@@ -44,8 +44,10 @@ public class StructuredTimestampType extends AbstractTimestampType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
         return getDialect().getFormattedDateTime(StructuredTemporalSupport.toLocalDateTime(
-                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()));
+                requireStruct(value), getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetTimestampRange(null), getRangeLossHandlingMode(), targetDescription(schema)));
     }
 
     @Override
@@ -53,7 +55,14 @@ public class StructuredTimestampType extends AbstractTimestampType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(requireStruct(value));
+        if (getDialect() == null) {
+            return List.of(new ValueBindDescriptor(index, StructuredTemporalSupport.toLocalDateTime(requireStruct(value)), getJdbcType()));
+        }
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final int precision = getSchemaTimestampPrecision(schema);
+        final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(
+                requireStruct(value), precision, getPrecisionLossHandlingMode(), capabilities.targetTimestampRange(null),
+                getRangeLossHandlingMode(), targetDescription(schema));
         return List.of(new ValueBindDescriptor(index, localDateTime, getJdbcType()));
     }
 
@@ -63,6 +72,9 @@ public class StructuredTimestampType extends AbstractTimestampType {
             final var capabilities = getDialect().getTargetTemporalCapabilities();
             StructuredTemporalPreflightValidator.validatePrecision(
                     column, requireStruct(value), capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode());
+            StructuredTemporalSupport.adjustTimestamp(
+                    requireStruct(value), capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode(),
+                    capabilities.targetTimestampRange(column), getRangeLossHandlingMode(), targetDescription(column));
         }
     }
 
@@ -74,7 +86,10 @@ public class StructuredTimestampType extends AbstractTimestampType {
         validate(column, schema, value);
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
         final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(
-                requireStruct(value), precision, getPrecisionLossHandlingMode());
+                requireStruct(value), precision, getPrecisionLossHandlingMode(),
+                getDialect().getTargetTemporalCapabilities().targetTimestampRange(column), getRangeLossHandlingMode(),
+                targetDescription(column));
         return List.of(new ValueBindDescriptor(index, localDateTime, getJdbcType()));
     }
+
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.type.debezium;
 
 import java.sql.Types;
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
@@ -46,6 +47,15 @@ public class StructuredZonedTimeType extends AbstractTimeType {
     }
 
     @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        final Struct struct = requireStruct(value);
+        final OffsetTime offsetTime = OffsetTime.of(
+                StructuredTemporalSupport.toLocalTime(struct, getSchemaTimePrecision(schema), getPrecisionLossHandlingMode()),
+                ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+        return getDialect().getFormattedTimeWithTimeZone(offsetTime.toString());
+    }
+
+    @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
@@ -53,7 +63,7 @@ public class StructuredZonedTimeType extends AbstractTimeType {
         final Struct struct = requireStruct(value);
         final OffsetTime offsetTime = OffsetTime.of(
                 StructuredTemporalSupport.toLocalTime(struct),
-                java.time.ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+                ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         return List.of(new ValueBindDescriptor(index, offsetTime, Types.TIME_WITH_TIMEZONE));
     }
 
@@ -76,7 +86,7 @@ public class StructuredZonedTimeType extends AbstractTimeType {
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
         final OffsetTime offsetTime = OffsetTime.of(
                 StructuredTemporalSupport.toLocalTime(struct, precision, getPrecisionLossHandlingMode()),
-                java.time.ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+                ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         return List.of(new ValueBindDescriptor(index, offsetTime, Types.TIME_WITH_TIMEZONE));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
@@ -29,7 +29,7 @@ public class StructuredZonedTimeType extends AbstractTimeType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredZonedTime.SCHEMA_NAME };
+        return StructuredZonedTime.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimeType.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.jdbc.type.AbstractTimeType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredTemporal;
 import io.debezium.time.StructuredZonedTime;
@@ -32,8 +33,11 @@ public class StructuredZonedTimeType extends AbstractTimeType {
 
     @Override
     protected int getTimePrecision(Schema schema) {
-        final String length = getSourceColumnSize(schema).orElse("-1");
-        return getSourceColumnPrecision(schema).map(Integer::parseInt).orElseGet(() -> Integer.parseInt(length));
+        return StructuredTemporalSupport.getPrecision(schema)
+                .stream()
+                .map(precision -> Math.min(precision, getDialect().getMaxTimePrecision()))
+                .findFirst()
+                .orElse(-1);
     }
 
     @Override
@@ -49,6 +53,29 @@ public class StructuredZonedTimeType extends AbstractTimeType {
         final Struct struct = requireStruct(value);
         final OffsetTime offsetTime = OffsetTime.of(
                 StructuredTemporalSupport.toLocalTime(struct),
+                java.time.ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
+        return List.of(new ValueBindDescriptor(index, offsetTime, Types.TIME_WITH_TIMEZONE));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, requireStruct(value), capabilities.targetTimePrecision(column), getPrecisionLossHandlingMode());
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final Struct struct = requireStruct(value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimePrecision(column);
+        final OffsetTime offsetTime = OffsetTime.of(
+                StructuredTemporalSupport.toLocalTime(struct, precision, getPrecisionLossHandlingMode()),
                 java.time.ZoneOffset.ofTotalSeconds(struct.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)));
         return List.of(new ValueBindDescriptor(index, offsetTime, Types.TIME_WITH_TIMEZONE));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.type.AbstractTimestampType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredZonedTimestamp;
 
@@ -35,8 +36,11 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
 
     @Override
     protected int getTimePrecision(Schema schema) {
-        final String length = getSourceColumnSize(schema).orElse("-1");
-        return getSourceColumnPrecision(schema).map(Integer::parseInt).orElseGet(() -> Integer.parseInt(length));
+        return StructuredTemporalSupport.getPrecision(schema)
+                .stream()
+                .map(precision -> Math.min(precision, getDialect().getMaxTimestampPrecision()))
+                .findFirst()
+                .orElse(-1);
     }
 
     @Override
@@ -55,6 +59,29 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(requireStruct(value));
+        return List.of(new ValueBindDescriptor(index, offsetDateTime, getJdbcType()));
+    }
+
+    @Override
+    public void validate(ColumnDescriptor column, Schema schema, Object value) {
+        if (value != null) {
+            final var struct = requireStruct(value);
+            final var capabilities = getDialect().getTargetTemporalCapabilities();
+            StructuredTemporalPreflightValidator.validateZonedTimestamp(struct, capabilities);
+            StructuredTemporalPreflightValidator.validatePrecision(
+                    column, struct, capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode());
+        }
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, ColumnDescriptor column, Schema schema, Object value) {
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null));
+        }
+        validate(column, schema, value);
+        final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(
+                requireStruct(value), precision, getPrecisionLossHandlingMode());
         return List.of(new ValueBindDescriptor(index, offsetDateTime, getJdbcType()));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
@@ -15,6 +15,7 @@ import io.debezium.connector.jdbc.type.AbstractTimestampType;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.StructuredTemporal;
 import io.debezium.time.StructuredZonedTimestamp;
 
 /**
@@ -53,8 +54,11 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
         final var struct = requireStruct(value);
         StructuredTemporalPreflightValidator.validateZonedTimestamp(
                 struct, getDialect().getTargetTemporalCapabilities());
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        final int offsetSeconds = offsetSeconds(struct);
         return getDialect().getFormattedDateTime(StructuredTemporalSupport.toOffsetDateTime(
-                struct, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()));
+                struct, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetZonedTimestampRange(null, offsetSeconds), getRangeLossHandlingMode(), targetDescription(schema)));
     }
 
     @Override
@@ -62,7 +66,15 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(requireStruct(value));
+        if (getDialect() == null) {
+            return List.of(new ValueBindDescriptor(index, StructuredTemporalSupport.toOffsetDateTime(requireStruct(value)), getJdbcType()));
+        }
+        final var struct = requireStruct(value);
+        final var capabilities = getDialect().getTargetTemporalCapabilities();
+        StructuredTemporalPreflightValidator.validateZonedTimestamp(struct, capabilities);
+        final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(
+                struct, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode(),
+                capabilities.targetZonedTimestampRange(null, offsetSeconds(struct)), getRangeLossHandlingMode(), targetDescription(schema));
         return List.of(new ValueBindDescriptor(index, offsetDateTime, getJdbcType()));
     }
 
@@ -74,6 +86,10 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
             StructuredTemporalPreflightValidator.validateZonedTimestamp(struct, capabilities);
             StructuredTemporalPreflightValidator.validatePrecision(
                     column, struct, capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode());
+            StructuredTemporalSupport.adjustTimestamp(
+                    struct, capabilities.targetTimestampPrecision(column), getPrecisionLossHandlingMode(),
+                    capabilities.targetZonedTimestampRange(column, offsetSeconds(struct)), getRangeLossHandlingMode(),
+                    targetDescription(column));
         }
     }
 
@@ -84,8 +100,16 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
         }
         validate(column, schema, value);
         final int precision = getDialect().getTargetTemporalCapabilities().targetTimestampPrecision(column);
+        final var struct = requireStruct(value);
         final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(
-                requireStruct(value), precision, getPrecisionLossHandlingMode());
+                struct, precision, getPrecisionLossHandlingMode(),
+                getDialect().getTargetTemporalCapabilities().targetZonedTimestampRange(column, offsetSeconds(struct)),
+                getRangeLossHandlingMode(), targetDescription(column));
         return List.of(new ValueBindDescriptor(index, offsetDateTime, getJdbcType()));
+    }
+
+    private static int offsetSeconds(org.apache.kafka.connect.data.Struct value) {
+        final Integer offsetSeconds = value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD);
+        return offsetSeconds == null ? 0 : offsetSeconds;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
@@ -50,7 +50,11 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
 
     @Override
     public String getDefaultValueBinding(Schema schema, Object value) {
-        return getDialect().getFormattedDateTime(StructuredTemporalSupport.toOffsetDateTime(requireStruct(value)));
+        final var struct = requireStruct(value);
+        StructuredTemporalPreflightValidator.validateZonedTimestamp(
+                struct, getDialect().getTargetTemporalCapabilities());
+        return getDialect().getFormattedDateTime(StructuredTemporalSupport.toOffsetDateTime(
+                struct, getSchemaTimestampPrecision(schema), getPrecisionLossHandlingMode()));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
@@ -27,7 +27,7 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
 
     @Override
     public String[] getRegistrationKeys() {
-        return new String[]{ StructuredZonedTimestamp.SCHEMA_NAME };
+        return StructuredZonedTimestamp.schemaNames();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.debezium;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredDuration;
+
+/**
+ * Describes the structured temporal values that a target dialect can preserve.
+ */
+public record TargetTemporalCapabilities(
+        int maxTimePrecision,
+        int maxTimestampPrecision,
+        ZonedTimestampSupport zonedTimestampSupport,
+        Set<StructuredDuration.Kind> durationKinds,
+        boolean timeColumnPrecisionReliable,
+        boolean timestampColumnPrecisionReliable) {
+
+    public TargetTemporalCapabilities {
+        durationKinds = Set.copyOf(durationKinds);
+    }
+
+    public static TargetTemporalCapabilities defaults(int maxTimePrecision, int maxTimestampPrecision) {
+        return new TargetTemporalCapabilities(
+                maxTimePrecision,
+                maxTimestampPrecision,
+                ZonedTimestampSupport.NONE,
+                EnumSet.allOf(StructuredDuration.Kind.class),
+                true,
+                true);
+    }
+
+    public TargetTemporalCapabilities withZonedTimestampSupport(ZonedTimestampSupport support) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, support, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable);
+    }
+
+    public TargetTemporalCapabilities withDurationKinds(Set<StructuredDuration.Kind> kinds) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, kinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable);
+    }
+
+    public TargetTemporalCapabilities withTimestampColumnPrecisionReliable(boolean reliable) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, reliable);
+    }
+
+    public int targetTimePrecision(ColumnDescriptor column) {
+        return targetPrecision(column, maxTimePrecision, timeColumnPrecisionReliable);
+    }
+
+    public int targetTimestampPrecision(ColumnDescriptor column) {
+        return targetPrecision(column, maxTimestampPrecision, timestampColumnPrecisionReliable);
+    }
+
+    private static int targetPrecision(ColumnDescriptor column, int maxPrecision, boolean columnPrecisionReliable) {
+        if (!columnPrecisionReliable) {
+            return maxPrecision;
+        }
+        final int columnPrecision = column.getScale();
+        return columnPrecision < 0 ? maxPrecision : Math.min(columnPrecision, maxPrecision);
+    }
+
+    public enum ZonedTimestampSupport {
+        NONE,
+        INSTANT,
+        OFFSET,
+        REGION;
+
+        public boolean preservesOffset() {
+            return this == OFFSET || this == REGION;
+        }
+
+        public boolean preservesRegion() {
+            return this == REGION;
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
@@ -6,6 +6,9 @@
 package io.debezium.connector.jdbc.type.debezium;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import io.debezium.sink.column.ColumnDescriptor;
@@ -20,10 +23,15 @@ public record TargetTemporalCapabilities(
         ZonedTimestampSupport zonedTimestampSupport,
         Set<StructuredDuration.Kind> durationKinds,
         boolean timeColumnPrecisionReliable,
-        boolean timestampColumnPrecisionReliable) {
+        boolean timestampColumnPrecisionReliable,
+        TemporalRange dateRange,
+        TemporalRange timestampRange,
+        Map<String, TemporalRange> timestampRangesByType,
+        ZonedTimestampRangeBasis zonedTimestampRangeBasis) {
 
     public TargetTemporalCapabilities {
         durationKinds = Set.copyOf(durationKinds);
+        timestampRangesByType = Map.copyOf(timestampRangesByType);
     }
 
     public static TargetTemporalCapabilities defaults(int maxTimePrecision, int maxTimestampPrecision) {
@@ -33,22 +41,57 @@ public record TargetTemporalCapabilities(
                 ZonedTimestampSupport.NONE,
                 EnumSet.allOf(StructuredDuration.Kind.class),
                 true,
-                true);
+                true,
+                TemporalRange.unbounded(),
+                TemporalRange.unbounded(),
+                Map.of(),
+                ZonedTimestampRangeBasis.LOCAL);
     }
 
     public TargetTemporalCapabilities withZonedTimestampSupport(ZonedTimestampSupport support) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, support, durationKinds,
-                timeColumnPrecisionReliable, timestampColumnPrecisionReliable);
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis);
     }
 
     public TargetTemporalCapabilities withDurationKinds(Set<StructuredDuration.Kind> kinds) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, kinds,
-                timeColumnPrecisionReliable, timestampColumnPrecisionReliable);
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis);
     }
 
     public TargetTemporalCapabilities withTimestampColumnPrecisionReliable(boolean reliable) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
-                timeColumnPrecisionReliable, reliable);
+                timeColumnPrecisionReliable, reliable, dateRange, timestampRange, timestampRangesByType,
+                zonedTimestampRangeBasis);
+    }
+
+    public TargetTemporalCapabilities withDateRange(TemporalRange range) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, range, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis);
+    }
+
+    public TargetTemporalCapabilities withTimestampRange(TemporalRange range) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, range,
+                timestampRangesByType, zonedTimestampRangeBasis);
+    }
+
+    public TargetTemporalCapabilities withTimestampRangeForType(TemporalRange range, String... typeNames) {
+        final Map<String, TemporalRange> ranges = new HashMap<>(timestampRangesByType);
+        for (String typeName : typeNames) {
+            ranges.put(normalizeTypeName(typeName), range);
+        }
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange, ranges,
+                zonedTimestampRangeBasis);
+    }
+
+    public TargetTemporalCapabilities withZonedTimestampRangeBasis(ZonedTimestampRangeBasis basis) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, basis);
     }
 
     public int targetTimePrecision(ColumnDescriptor column) {
@@ -59,12 +102,42 @@ public record TargetTemporalCapabilities(
         return targetPrecision(column, maxTimestampPrecision, timestampColumnPrecisionReliable);
     }
 
+    public TemporalRange targetDateRange(ColumnDescriptor column) {
+        return dateRange;
+    }
+
+    public TemporalRange targetTimestampRange(ColumnDescriptor column) {
+        if (column != null && column.getTypeName() != null) {
+            final TemporalRange columnTypeRange = timestampRangesByType.get(normalizeTypeName(column.getTypeName()));
+            if (columnTypeRange != null) {
+                return columnTypeRange;
+            }
+        }
+        return timestampRange;
+    }
+
+    public TemporalRange targetZonedTimestampRange(ColumnDescriptor column, int offsetSeconds) {
+        final TemporalRange range = targetTimestampRange(column);
+        return switch (zonedTimestampRangeBasis) {
+            case LOCAL -> range;
+            case INSTANT -> range.shiftSeconds(offsetSeconds);
+            case LOCAL_AND_INSTANT -> range.intersect(range.shiftSeconds(offsetSeconds));
+        };
+    }
+
     private static int targetPrecision(ColumnDescriptor column, int maxPrecision, boolean columnPrecisionReliable) {
         if (!columnPrecisionReliable) {
             return maxPrecision;
         }
         final int columnPrecision = column.getScale();
         return columnPrecision < 0 ? maxPrecision : Math.min(columnPrecision, maxPrecision);
+    }
+
+    private static String normalizeTypeName(String typeName) {
+        return typeName.toLowerCase(Locale.ROOT)
+                .replaceAll("\\([^)]*\\)", "")
+                .trim()
+                .replaceAll("\\s+", " ");
     }
 
     public enum ZonedTimestampSupport {
@@ -80,5 +153,11 @@ public record TargetTemporalCapabilities(
         public boolean preservesRegion() {
             return this == REGION;
         }
+    }
+
+    public enum ZonedTimestampRangeBasis {
+        LOCAL,
+        INSTANT,
+        LOCAL_AND_INSTANT
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TargetTemporalCapabilities.java
@@ -27,7 +27,10 @@ public record TargetTemporalCapabilities(
         TemporalRange dateRange,
         TemporalRange timestampRange,
         Map<String, TemporalRange> timestampRangesByType,
-        ZonedTimestampRangeBasis zonedTimestampRangeBasis) {
+        ZonedTimestampRangeBasis zonedTimestampRangeBasis,
+        boolean dateInfinitySupported,
+        boolean timestampInfinitySupported,
+        boolean zeroDateSupported) {
 
     public TargetTemporalCapabilities {
         durationKinds = Set.copyOf(durationKinds);
@@ -45,37 +48,44 @@ public record TargetTemporalCapabilities(
                 TemporalRange.unbounded(),
                 TemporalRange.unbounded(),
                 Map.of(),
-                ZonedTimestampRangeBasis.LOCAL);
+                ZonedTimestampRangeBasis.LOCAL,
+                false,
+                false,
+                false);
     }
 
     public TargetTemporalCapabilities withZonedTimestampSupport(ZonedTimestampSupport support) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, support, durationKinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
-                timestampRangesByType, zonedTimestampRangeBasis);
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported,
+                zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withDurationKinds(Set<StructuredDuration.Kind> kinds) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, kinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
-                timestampRangesByType, zonedTimestampRangeBasis);
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported,
+                zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withTimestampColumnPrecisionReliable(boolean reliable) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
                 timeColumnPrecisionReliable, reliable, dateRange, timestampRange, timestampRangesByType,
-                zonedTimestampRangeBasis);
+                zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported, zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withDateRange(TemporalRange range) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, range, timestampRange,
-                timestampRangesByType, zonedTimestampRangeBasis);
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported,
+                zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withTimestampRange(TemporalRange range) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, range,
-                timestampRangesByType, zonedTimestampRangeBasis);
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported,
+                zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withTimestampRangeForType(TemporalRange range, String... typeNames) {
@@ -85,13 +95,31 @@ public record TargetTemporalCapabilities(
         }
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange, ranges,
-                zonedTimestampRangeBasis);
+                zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported, zeroDateSupported);
     }
 
     public TargetTemporalCapabilities withZonedTimestampRangeBasis(ZonedTimestampRangeBasis basis) {
         return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
                 timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
-                timestampRangesByType, basis);
+                timestampRangesByType, basis, dateInfinitySupported, timestampInfinitySupported, zeroDateSupported);
+    }
+
+    public TargetTemporalCapabilities withDateInfinitySupported(boolean supported) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis, supported, timestampInfinitySupported, zeroDateSupported);
+    }
+
+    public TargetTemporalCapabilities withTimestampInfinitySupported(boolean supported) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, supported, zeroDateSupported);
+    }
+
+    public TargetTemporalCapabilities withZeroDateSupported(boolean supported) {
+        return new TargetTemporalCapabilities(maxTimePrecision, maxTimestampPrecision, zonedTimestampSupport, durationKinds,
+                timeColumnPrecisionReliable, timestampColumnPrecisionReliable, dateRange, timestampRange,
+                timestampRangesByType, zonedTimestampRangeBasis, dateInfinitySupported, timestampInfinitySupported, supported);
     }
 
     public int targetTimePrecision(ColumnDescriptor column) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TemporalRange.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TemporalRange.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.debezium;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import io.debezium.time.StructuredTemporal;
+
+/**
+ * Inclusive range of calendar-based structured temporal values supported by a target data type.
+ */
+public record TemporalRange(Boundary minimum, Boundary maximum) {
+
+    private static final TemporalRange UNBOUNDED = new TemporalRange(null, null);
+
+    public TemporalRange {
+        if (minimum != null && maximum != null && minimum.compareTo(maximum) > 0) {
+            throw new IllegalArgumentException("Temporal range minimum must not be greater than its maximum");
+        }
+    }
+
+    public static TemporalRange unbounded() {
+        return UNBOUNDED;
+    }
+
+    public static TemporalRange dateYears(int minimumYear, int maximumYear) {
+        return new TemporalRange(
+                Boundary.date(minimumYear, 1, 1),
+                Boundary.date(maximumYear, 12, 31));
+    }
+
+    public static TemporalRange timestampYears(int minimumYear, int maximumYear) {
+        return new TemporalRange(
+                Boundary.timestamp(minimumYear, 1, 1, 0, 0, 0, 0),
+                Boundary.timestamp(maximumYear, 12, 31, 23, 59, 59, StructuredTemporal.PICOSECONDS_PER_SECOND - 1));
+    }
+
+    public boolean isBounded() {
+        return minimum != null || maximum != null;
+    }
+
+    public boolean contains(Boundary value) {
+        return (minimum == null || value.compareTo(minimum) >= 0)
+                && (maximum == null || value.compareTo(maximum) <= 0);
+    }
+
+    public Boundary saturate(Boundary value) {
+        if (minimum != null && value.compareTo(minimum) < 0) {
+            return minimum;
+        }
+        if (maximum != null && value.compareTo(maximum) > 0) {
+            return maximum;
+        }
+        return value;
+    }
+
+    public TemporalRange shiftSeconds(int seconds) {
+        return new TemporalRange(
+                minimum == null ? null : minimum.plusSeconds(seconds),
+                maximum == null ? null : maximum.plusSeconds(seconds));
+    }
+
+    public TemporalRange intersect(TemporalRange other) {
+        final Boundary intersectionMinimum;
+        if (minimum == null) {
+            intersectionMinimum = other.minimum;
+        }
+        else if (other.minimum == null) {
+            intersectionMinimum = minimum;
+        }
+        else {
+            intersectionMinimum = minimum.compareTo(other.minimum) >= 0 ? minimum : other.minimum;
+        }
+
+        final Boundary intersectionMaximum;
+        if (maximum == null) {
+            intersectionMaximum = other.maximum;
+        }
+        else if (other.maximum == null) {
+            intersectionMaximum = maximum;
+        }
+        else {
+            intersectionMaximum = maximum.compareTo(other.maximum) <= 0 ? maximum : other.maximum;
+        }
+        return new TemporalRange(intersectionMinimum, intersectionMaximum);
+    }
+
+    /**
+     * Raw calendar components used to retain picosecond precision while comparing and saturating values.
+     */
+    public record Boundary(
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second,
+            long picoseconds) implements Comparable<Boundary> {
+
+        public Boundary {
+            if (picoseconds < 0 || picoseconds >= StructuredTemporal.PICOSECONDS_PER_SECOND) {
+                throw new IllegalArgumentException("Temporal boundary picoseconds must be between 0 and one second");
+            }
+        }
+
+        public static Boundary date(int year, int month, int day) {
+            return timestamp(year, month, day, 0, 0, 0, 0);
+        }
+
+        public static Boundary timestamp(int year, int month, int day, int hour, int minute, int second, long picoseconds) {
+            return new Boundary(year, month, day, hour, minute, second, picoseconds);
+        }
+
+        public Boundary plusSeconds(int secondsToAdd) {
+            if (secondsToAdd == 0) {
+                return this;
+            }
+            final LocalDateTime adjusted = LocalDateTime.of(year, month, day, hour, minute, second).plusSeconds(secondsToAdd);
+            return timestamp(adjusted.getYear(), adjusted.getMonthValue(), adjusted.getDayOfMonth(),
+                    adjusted.getHour(), adjusted.getMinute(), adjusted.getSecond(), picoseconds);
+        }
+
+        public Boundary withPrecision(int precision) {
+            if (precision >= 12) {
+                return this;
+            }
+            if (precision < 0) {
+                throw new IllegalArgumentException("Temporal precision must not be negative");
+            }
+            long factor = 1;
+            for (int i = precision; i < 12; ++i) {
+                factor *= 10;
+            }
+            return timestamp(year, month, day, hour, minute, second, picoseconds / factor * factor);
+        }
+
+        public LocalDate toLocalDate() {
+            return LocalDate.of(year, month, day);
+        }
+
+        public LocalDateTime toLocalDateTime() {
+            return LocalDateTime.of(year, month, day, hour, minute, second,
+                    Math.toIntExact(picoseconds / StructuredTemporal.PICOSECONDS_PER_NANOSECOND));
+        }
+
+        @Override
+        public int compareTo(Boundary other) {
+            int result = Integer.compare(year, other.year);
+            if (result == 0) {
+                result = Integer.compare(month, other.month);
+            }
+            if (result == 0) {
+                result = Integer.compare(day, other.day);
+            }
+            if (result == 0) {
+                result = Integer.compare(hour, other.hour);
+            }
+            if (result == 0) {
+                result = Integer.compare(minute, other.minute);
+            }
+            if (result == 0) {
+                result = Integer.compare(second, other.second);
+            }
+            if (result == 0) {
+                result = Long.compare(picoseconds, other.picoseconds);
+            }
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder builder = new StringBuilder(String.format("%04d-%02d-%02d %02d:%02d:%02d",
+                    year, month, day, hour, minute, second));
+            StructuredTemporalSupport.appendFraction(builder, picoseconds, 12);
+            return builder.toString();
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TemporalRange.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/TemporalRange.java
@@ -58,6 +58,17 @@ public record TemporalRange(Boundary minimum, Boundary maximum) {
         return value;
     }
 
+    public TemporalRange atPrecision(int precision) {
+        if (maximum == null) {
+            return this;
+        }
+        // Only the maximum is truncated: a fractional second beyond the target precision cannot be
+        // stored, so the effective upper bound is the maximum truncated to that precision. Truncating
+        // the minimum would move it downward and wrongly widen the range.
+        final Boundary truncatedMaximum = maximum.withPrecision(precision);
+        return truncatedMaximum.equals(maximum) ? this : new TemporalRange(minimum, truncatedMaximum);
+    }
+
     public TemporalRange shiftSeconds(int seconds) {
         return new TemporalRange(
                 minimum == null ? null : minimum.plusSeconds(seconds),

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/DefaultRecordWriterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/DefaultRecordWriterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.hibernate.SharedSessionContract;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
+import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.field.FieldDescriptor;
+import io.debezium.sink.spi.SinkProgressListener;
+import io.debezium.time.StructuredTimestamp;
+
+@Tag("UnitTests")
+class DefaultRecordWriterTest extends AbstractBaseJdbcSinkTest {
+
+    @Test
+    void shouldValidateAllValuesBeforeGeneratingSql() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        final var writer = new ExposedRecordWriter(
+                mock(SharedSessionContract.class), getConfig(Map.of()), dialect);
+        final var timestampSchema = StructuredTimestamp.builder(9).build();
+        final var value = StructuredTimestamp.from(timestampSchema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9);
+        final var payloadSchema = SchemaBuilder.struct().field("ts", timestampSchema).build();
+        final var payload = new Struct(payloadSchema).put("ts", value);
+        final var field = new JdbcFieldDescriptor(new FieldDescriptor(timestampSchema, "ts", false), false);
+        final var column = ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(6)
+                .build();
+        final var table = TableDescriptor.builder().tableName("target_table").column(column).build();
+        final JdbcSinkRecord record = mock(JdbcSinkRecord.class);
+
+        when(record.isDelete()).thenReturn(false);
+        when(record.filteredKey()).thenReturn(null);
+        when(record.keyFieldNames()).thenReturn(Set.of());
+        when(record.nonKeyFieldNames()).thenReturn(Set.of("ts"));
+        when(record.getPayload()).thenReturn(payload);
+        when(record.jdbcFields()).thenReturn(Map.of("ts", field));
+        when(dialect.resolveColumn(table, field)).thenReturn(column);
+        doThrow(new ConnectException("precision loss"))
+                .when(dialect).validateValue(field, column, value);
+
+        assertThatThrownBy(() -> writer.statement(table, List.of(record)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessage("precision loss");
+        verify(dialect, never()).getInsertStatement(table, record);
+    }
+
+    private static class ExposedRecordWriter extends DefaultRecordWriter {
+
+        ExposedRecordWriter(SharedSessionContract session, JdbcSinkConnectorConfig config, DatabaseDialect dialect) {
+            super(session, new QueryBinderResolver(), config, dialect, SinkProgressListener.NO_OP());
+        }
+
+        void statement(TableDescriptor table, List<JdbcSinkRecord> records) {
+            getSqlStatementInfo(table, records);
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -119,6 +119,29 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
     }
 
     @Test
+    public void testTemporalPrecisionLossHandlingMode() {
+        final JdbcSinkConnectorConfig defaultConfig = getConfig(Collections.emptyMap());
+        assertThat(defaultConfig.getTemporalPrecisionLossHandlingMode())
+                .isEqualTo(JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode.FAIL);
+
+        final JdbcSinkConnectorConfig roundConfig = getConfig(Map.of(
+                JdbcSinkConnectorConfig.TEMPORAL_PRECISION_LOSS_HANDLING_MODE, "round"));
+        assertThat(roundConfig.validateAndRecord(
+                List.of(JdbcSinkConnectorConfig.TEMPORAL_PRECISION_LOSS_HANDLING_MODE_FIELD), LOGGER::error)).isTrue();
+        assertThat(roundConfig.getTemporalPrecisionLossHandlingMode())
+                .isEqualTo(JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode.ROUND);
+    }
+
+    @Test
+    public void testInvalidTemporalPrecisionLossHandlingMode() {
+        final JdbcSinkConnectorConfig config = getConfig(Map.of(
+                JdbcSinkConnectorConfig.TEMPORAL_PRECISION_LOSS_HANDLING_MODE, "silent"));
+
+        assertThat(config.validateAndRecord(
+                List.of(JdbcSinkConnectorConfig.TEMPORAL_PRECISION_LOSS_HANDLING_MODE_FIELD), LOGGER::error)).isFalse();
+    }
+
+    @Test
     public void testNonDefaultSqlSelverIdentityTableNamesProperty() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(JdbcSinkConnectorConfig.SQLSERVER_IDENTITY_INSERT, "true");

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigTest.java
@@ -142,6 +142,29 @@ public class JdbcSinkConnectorConfigTest extends AbstractBaseJdbcSinkTest {
     }
 
     @Test
+    public void testTemporalRangeLossHandlingMode() {
+        final JdbcSinkConnectorConfig defaultConfig = getConfig(Collections.emptyMap());
+        assertThat(defaultConfig.getTemporalRangeLossHandlingMode())
+                .isEqualTo(JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode.FAIL);
+
+        final JdbcSinkConnectorConfig saturateConfig = getConfig(Map.of(
+                JdbcSinkConnectorConfig.TEMPORAL_RANGE_LOSS_HANDLING_MODE, "saturate"));
+        assertThat(saturateConfig.validateAndRecord(
+                List.of(JdbcSinkConnectorConfig.TEMPORAL_RANGE_LOSS_HANDLING_MODE_FIELD), LOGGER::error)).isTrue();
+        assertThat(saturateConfig.getTemporalRangeLossHandlingMode())
+                .isEqualTo(JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode.SATURATE);
+    }
+
+    @Test
+    public void testInvalidTemporalRangeLossHandlingMode() {
+        final JdbcSinkConnectorConfig config = getConfig(Map.of(
+                JdbcSinkConnectorConfig.TEMPORAL_RANGE_LOSS_HANDLING_MODE, "clip"));
+
+        assertThat(config.validateAndRecord(
+                List.of(JdbcSinkConnectorConfig.TEMPORAL_RANGE_LOSS_HANDLING_MODE_FIELD), LOGGER::error)).isFalse();
+    }
+
+    @Test
     public void testNonDefaultSqlSelverIdentityTableNamesProperty() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(JdbcSinkConnectorConfig.SQLSERVER_IDENTITY_INSERT, "true");

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
@@ -18,6 +18,7 @@ import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
@@ -36,6 +37,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
@@ -142,11 +144,21 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(dialect.getSchemaType(timestampSchema)).thenReturn(tsType);
         when(dialect.getSchemaType(dateSchema)).thenReturn(dateType);
 
+        final ColumnDescriptor tsColumn = column("ts_col", Types.TIMESTAMP, "timestamp");
+        final ColumnDescriptor dateColumn = column("date_col", Types.DATE, "date");
+        final TableDescriptor table = TableDescriptor.builder()
+                .tableName("t")
+                .column(tsColumn)
+                .column(dateColumn)
+                .build();
+        when(dialect.resolveColumn(table, tsField)).thenReturn(tsColumn);
+        when(dialect.resolveColumn(table, dateField)).thenReturn(dateColumn);
+
         LocalDateTime transformedTs = LocalDateTime.of(2024, 1, 15, 10, 30, 0);
-        when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))
+        when(dialect.bindValue(any(JdbcFieldDescriptor.class), any(ColumnDescriptor.class), anyInt(), any()))
                 .thenAnswer(invocation -> {
                     JdbcFieldDescriptor field = invocation.getArgument(0);
-                    Object value = invocation.getArgument(2);
+                    Object value = invocation.getArgument(3);
                     if (field.getSchema().name().equals(io.debezium.time.Timestamp.SCHEMA_NAME)) {
                         return List.of(new ValueBindDescriptor(1, transformedTs));
                     }
@@ -171,11 +183,11 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(record.getPayload()).thenReturn(payload);
         when(record.jdbcFields()).thenReturn(Map.of("ts_col", tsField, "date_col", dateField));
 
-        writer.performUnnestBatch(conn, "INSERT INTO t SELECT * FROM UNNEST(?::timestamp[],?::date[])", List.of(record));
+        writer.performUnnestBatch(conn, table, "INSERT INTO t SELECT * FROM UNNEST(?::timestamp[],?::date[])", List.of(record));
 
         // Verify dialect.bindValue was called for value transformation
-        verify(dialect).bindValue(tsField, 1, 1705312200000L);
-        verify(dialect).bindValue(dateField, 1, 19894);
+        verify(dialect).bindValue(tsField, tsColumn, 1, 1705312200000L);
+        verify(dialect).bindValue(dateField, dateColumn, 1, 19894);
 
         // Verify arrays were created and bound
         verify(conn).createArrayOf("timestamp", new Object[]{ transformedTs });
@@ -208,8 +220,12 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(geoType.getTypeName(any(), any(Boolean.class))).thenReturn("geometry");
         when(dialect.getSchemaType(geometrySchema)).thenReturn(geoType);
 
+        final ColumnDescriptor geoColumn = column("geom", Types.OTHER, "geometry");
+        final TableDescriptor table = TableDescriptor.builder().tableName("t").column(geoColumn).build();
+        when(dialect.resolveColumn(table, geoField)).thenReturn(geoColumn);
+
         // Geometry returns TWO ValueBindDescriptors (wkb bytes + srid)
-        when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))
+        when(dialect.bindValue(any(JdbcFieldDescriptor.class), any(ColumnDescriptor.class), anyInt(), any()))
                 .thenReturn(List.of(
                         new ValueBindDescriptor(1, new byte[]{ 0x01 }),
                         new ValueBindDescriptor(2, 4326)));
@@ -227,9 +243,17 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(record.getPayload()).thenReturn(payload);
         when(record.jdbcFields()).thenReturn(Map.of("geom", geoField));
 
-        assertThatThrownBy(() -> writer.performUnnestBatch(conn, "INSERT INTO t SELECT * FROM UNNEST(?::geometry[])", List.of(record)))
+        assertThatThrownBy(() -> writer.performUnnestBatch(conn, table, "INSERT INTO t SELECT * FROM UNNEST(?::geometry[])", List.of(record)))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("UNNEST does not support types that expand to multiple bind parameters")
                 .hasMessageContaining("geom");
+    }
+
+    private ColumnDescriptor column(String name, int jdbcType, String typeName) {
+        return ColumnDescriptor.builder()
+                .columnName(name)
+                .jdbcType(jdbcType)
+                .typeName(typeName)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/cockroachdb/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/cockroachdb/StructuredTemporalTypeTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.dialect.postgres.StructuredDateType;
+import io.debezium.connector.jdbc.dialect.postgres.StructuredTimestampType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredDate;
+import io.debezium.time.StructuredTimestamp;
+
+@Tag("UnitTests")
+class StructuredTemporalTypeTest {
+
+    @Test
+    @DisplayName("Should declare CockroachDB timestamp bounds without timestamp infinity support")
+    void shouldDeclareCockroachDbTemporalCapabilities() {
+        final var capabilities = cockroachCapabilities();
+
+        assertThat(capabilities.dateInfinitySupported()).isTrue();
+        assertThat(capabilities.timestampInfinitySupported()).isFalse();
+        assertThat(capabilities.timestampRange().minimum())
+                .isEqualTo(Boundary.timestamp(-4714, 11, 24, 0, 0, 0, 0));
+        assertThat(capabilities.timestampRange().maximum())
+                .isEqualTo(Boundary.timestamp(294_276, 12, 31, 23, 59, 59, 999_999_000_000L));
+    }
+
+    @Test
+    @DisplayName("Should reject CockroachDB timestamp infinity in fail mode")
+    void shouldRejectTimestampInfinity() {
+        final var schema = StructuredTimestamp.schema();
+        final var type = configuredTimestampType(TemporalRangeLossHandlingMode.FAIL);
+
+        assertThatThrownBy(() -> type.bind(1, timestampColumn(), schema, StructuredTimestamp.positiveInfinity(schema)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Non-finite structured temporal value")
+                .hasMessageContaining("ts");
+    }
+
+    @Test
+    @DisplayName("Should saturate CockroachDB timestamp infinity to its finite boundary")
+    void shouldSaturateTimestampInfinity() {
+        final var schema = StructuredTimestamp.schema();
+        final var type = configuredTimestampType(TemporalRangeLossHandlingMode.SATURATE);
+
+        assertThat(type.bind(1, timestampColumn(), schema, StructuredTimestamp.positiveInfinity(schema)).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(294_276, 12, 31, 23, 59, 59, 999_999_000));
+    }
+
+    @Test
+    @DisplayName("Should retain CockroachDB date infinity")
+    void shouldRetainDateInfinity() {
+        final var schema = StructuredDate.schema();
+        final var type = configuredDateType();
+
+        assertThat(type.bind(1, dateColumn(), schema, StructuredDate.positiveInfinity(schema)).get(0).getValue())
+                .isEqualTo("infinity");
+    }
+
+    private StructuredTimestampType configuredTimestampType(TemporalRangeLossHandlingMode rangeMode) {
+        final var type = new StructuredTimestampType();
+        type.configure(config(rangeMode), dialect());
+        return type;
+    }
+
+    private StructuredDateType configuredDateType() {
+        final var type = new StructuredDateType();
+        type.configure(config(TemporalRangeLossHandlingMode.FAIL), dialect());
+        return type;
+    }
+
+    private JdbcSinkConnectorConfig config(TemporalRangeLossHandlingMode rangeMode) {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(rangeMode);
+        return config;
+    }
+
+    private DatabaseDialect dialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        final TargetTemporalCapabilities capabilities = cockroachCapabilities();
+        when(dialect.getMaxTimestampPrecision()).thenReturn(6);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(capabilities);
+        return dialect;
+    }
+
+    private TargetTemporalCapabilities cockroachCapabilities() {
+        final CockroachDBDatabaseDialect dialect = mock(CockroachDBDatabaseDialect.class, CALLS_REAL_METHODS);
+        doReturn(6).when(dialect).getMaxTimePrecision();
+        doReturn(6).when(dialect).getMaxTimestampPrecision();
+        return dialect.getTargetTemporalCapabilities();
+    }
+
+    private ColumnDescriptor timestampColumn() {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(6)
+                .build();
+    }
+
+    private ColumnDescriptor dateColumn() {
+        return ColumnDescriptor.builder()
+                .columnName("d")
+                .jdbcType(Types.DATE)
+                .typeName("date")
+                .build();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
@@ -58,7 +58,7 @@ class StructuredTemporalTypeTest {
         final var schema = StructuredTimestamp.builder(12).build();
         final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
         final var type = new StructuredTimestampType();
-        type.configure(jdbcConfig(), db2TimestampDialect());
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.FAIL), db2TimestampDialect());
         final var column = timestampColumn(12);
 
         assertThat(type.getTypeName(schema, false)).isEqualTo("timestamp(12)");
@@ -74,11 +74,24 @@ class StructuredTemporalTypeTest {
         final var schema = StructuredTimestamp.builder(12).build();
         final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
         final var type = new StructuredTimestampType();
-        type.configure(jdbcConfig(), db2TimestampDialect());
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.FAIL), db2TimestampDialect());
 
         assertThatThrownBy(() -> type.bind(1, timestampColumn(9), schema, value))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("precision 9");
+    }
+
+    @Test
+    @DisplayName("Should apply round mode to Db2 timestamp defaults")
+    void shouldRoundDb2TimestampDefault() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.fromPicoseconds(
+                schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.ROUND), db2TimestampDialect());
+
+        assertThat(type.getDefaultValueBinding(schema, value))
+                .isEqualTo("'2026-07-17 12:13:14.123457'");
     }
 
     private DatabaseDialect db2Dialect() {
@@ -87,10 +100,10 @@ class StructuredTemporalTypeTest {
         return dialect;
     }
 
-    private JdbcSinkConnectorConfig jdbcConfig() {
+    private JdbcSinkConnectorConfig jdbcConfig(TemporalPrecisionLossHandlingMode mode) {
         final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
         when(config.useTimeZone()).thenReturn("UTC");
-        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
         return config;
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.dialect.db2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -13,15 +14,21 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.engine.jdbc.Size;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredDurationType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
+import io.debezium.time.StructuredTimestamp;
 
 @Tag("UnitTests")
 class StructuredTemporalTypeTest {
@@ -45,9 +52,63 @@ class StructuredTemporalTypeTest {
         assertThat(bindings.get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
     }
 
+    @Test
+    @DisplayName("Should bind Db2 timestamp with picosecond precision")
+    void shouldBindPicosecondTimestamp() {
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(), db2TimestampDialect());
+        final var column = timestampColumn(12);
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("timestamp(12)");
+        assertThat(type.getQueryBinding(column, schema, value)).isEqualTo("cast(? as timestamp(12))");
+        assertThat(type.getDefaultValueBinding(schema, value)).isEqualTo("'2026-07-17 12:13:14.123456789012'");
+        assertThat(type.bind(1, column, schema, value).get(0).getValue()).isEqualTo("2026-07-17 12:13:14.123456789012");
+        assertThat(type.bind(1, column, schema, value).get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
+    }
+
+    @Test
+    @DisplayName("Should reject picosecond loss for a narrower Db2 timestamp")
+    void shouldRejectPicosecondLoss() {
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(), db2TimestampDialect());
+
+        assertThatThrownBy(() -> type.bind(1, timestampColumn(9), schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 9");
+    }
+
     private DatabaseDialect db2Dialect() {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getJdbcTypeName(eq(Types.VARCHAR), any(Size.class))).thenReturn("varchar(128)");
         return dialect;
+    }
+
+    private JdbcSinkConnectorConfig jdbcConfig() {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        return config;
+    }
+
+    private DatabaseDialect db2TimestampDialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getMaxTimestampPrecision()).thenReturn(12);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 12));
+        when(dialect.getJdbcTypeName(eq(Types.TIMESTAMP), any(Size.class))).thenReturn("timestamp(12)");
+        return dialect;
+    }
+
+    private ColumnDescriptor timestampColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(precision)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2/StructuredTemporalTypeTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredDurationType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
 import io.debezium.sink.SinkConnectorConfig;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
@@ -94,6 +96,20 @@ class StructuredTemporalTypeTest {
                 .isEqualTo("'2026-07-17 12:13:14.123457'");
     }
 
+    @Test
+    @DisplayName("Should saturate Db2 timestamps without losing picosecond target precision")
+    void shouldSaturateDb2TimestampRange() {
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(
+                schema, 12_000, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(
+                TemporalPrecisionLossHandlingMode.FAIL, TemporalRangeLossHandlingMode.SATURATE), db2TimestampDialect());
+
+        assertThat(type.bind(1, timestampColumn(12), schema, value).get(0).getValue())
+                .isEqualTo("9999-12-31 23:59:59.999999999999");
+    }
+
     private DatabaseDialect db2Dialect() {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getJdbcTypeName(eq(Types.VARCHAR), any(Size.class))).thenReturn("varchar(128)");
@@ -101,9 +117,15 @@ class StructuredTemporalTypeTest {
     }
 
     private JdbcSinkConnectorConfig jdbcConfig(TemporalPrecisionLossHandlingMode mode) {
+        return jdbcConfig(mode, TemporalRangeLossHandlingMode.FAIL);
+    }
+
+    private JdbcSinkConnectorConfig jdbcConfig(TemporalPrecisionLossHandlingMode precisionMode,
+                                               TemporalRangeLossHandlingMode rangeMode) {
         final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
         when(config.useTimeZone()).thenReturn("UTC");
-        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(precisionMode);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(rangeMode);
         return config;
     }
 
@@ -111,7 +133,9 @@ class StructuredTemporalTypeTest {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getMaxTimestampPrecision()).thenReturn(12);
         when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
-        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 12));
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 12)
+                .withDateRange(TemporalRange.dateYears(1, 9999))
+                .withTimestampRange(TemporalRange.timestampYears(1, 9999)));
         when(dialect.getJdbcTypeName(eq(Types.TIMESTAMP), any(Size.class))).thenReturn("timestamp(12)");
         return dialect;
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2i/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/db2i/StructuredTemporalTypeTest.java
@@ -18,10 +18,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.dialect.db2.StructuredTimestampType;
 import io.debezium.connector.jdbc.type.debezium.StructuredDurationType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
+import io.debezium.time.StructuredTimestamp;
 
 @Tag("UnitTests")
 class StructuredTemporalTypeTest {
@@ -45,9 +51,45 @@ class StructuredTemporalTypeTest {
         assertThat(bindings.get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
     }
 
+    @Test
+    @DisplayName("Should bind Db2 iSeries timestamp with picosecond precision")
+    void shouldBindPicosecondTimestamp() {
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(), db2iTimestampDialect());
+        final var column = ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(12)
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("timestamp(12)");
+        assertThat(type.getQueryBinding(column, schema, value)).isEqualTo("cast(? as timestamp(12))");
+        assertThat(type.bind(1, column, schema, value).get(0).getValue()).isEqualTo("2026-07-17 12:13:14.123456789012");
+        assertThat(type.bind(1, column, schema, value).get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
+    }
+
     private DatabaseDialect db2iDialect() {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getJdbcTypeName(eq(Types.VARCHAR), any(Size.class))).thenReturn("varchar(128)");
+        return dialect;
+    }
+
+    private JdbcSinkConnectorConfig jdbcConfig() {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        return config;
+    }
+
+    private DatabaseDialect db2iTimestampDialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getMaxTimestampPrecision()).thenReturn(12);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 12));
+        when(dialect.getJdbcTypeName(eq(Types.TIMESTAMP), any(Size.class))).thenReturn("timestamp(12)");
         return dialect;
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.sink.SinkConnectorConfig;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDate;
@@ -156,12 +159,62 @@ class StructuredTemporalTypeTest {
                 .hasMessageContaining("precision 6");
     }
 
+    @Test
+    @DisplayName("Should saturate PostgreSQL-sized timestamps to the MySQL datetime range")
+    void shouldSaturateTimestampRange() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.from(schema, 12_000, 1, 2, 3, 4, 5, 123_456_000, 6);
+        final var type = configuredTimestampType(
+                TemporalPrecisionLossHandlingMode.FAIL, TemporalRangeLossHandlingMode.SATURATE);
+
+        assertThat(type.bind(1, timestampColumn("datetime", 6), schema, value).get(0).getValue())
+                .isEqualTo("9999-12-31 23:59:59.499999");
+        assertThat(type.getDefaultValueBinding(schema, value))
+                .isEqualTo("'9999-12-31 23:59:59.499999'");
+    }
+
+    @Test
+    @DisplayName("Should reject out-of-range MySQL timestamps in fail mode")
+    void shouldRejectTimestampRangeLoss() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.from(schema, 12_000, 1, 2, 3, 4, 5, 0, 6);
+        final var type = configuredTimestampType(
+                TemporalPrecisionLossHandlingMode.FAIL, TemporalRangeLossHandlingMode.FAIL);
+
+        assertThatThrownBy(() -> type.bind(1, timestampColumn("datetime", 6), schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("12000-01-02")
+                .hasMessageContaining("saturate");
+    }
+
+    @Test
+    @DisplayName("Should retain MySQL zero dates when range handling is enabled")
+    void shouldRetainZeroDateWithRangeHandling() {
+        final var schema = StructuredDate.schema();
+        final var value = StructuredDate.from(schema, 0, 0, 0);
+        final var type = new StructuredDateType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(TemporalRangeLossHandlingMode.SATURATE);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
+        type.configure(config, dialect);
+
+        assertThat(type.bind(1, dateColumn(), schema, value).get(0).getValue()).isEqualTo("0000-00-00");
+    }
+
     private StructuredTimestampType configuredTimestampType(TemporalPrecisionLossHandlingMode mode) {
+        return configuredTimestampType(mode, TemporalRangeLossHandlingMode.FAIL);
+    }
+
+    private StructuredTimestampType configuredTimestampType(TemporalPrecisionLossHandlingMode precisionMode,
+                                                            TemporalRangeLossHandlingMode rangeMode) {
         final var type = new StructuredTimestampType();
         final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(config.useTimeZone()).thenReturn("UTC");
-        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(precisionMode);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(rangeMode);
         when(dialect.getMaxTimestampPrecision()).thenReturn(6);
         when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
         when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
@@ -181,7 +234,12 @@ class StructuredTemporalTypeTest {
     }
 
     private TargetTemporalCapabilities mysqlCapabilities() {
+        final TemporalRange datetimeRange = new TemporalRange(
+                Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
+                Boundary.timestamp(9999, 12, 31, 23, 59, 59, 499_999_999_999L));
         return TargetTemporalCapabilities.defaults(6, 6)
+                .withDateRange(TemporalRange.dateYears(1000, 9999))
+                .withTimestampRange(datetimeRange)
                 .withDurationKinds(java.util.EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
     }
 
@@ -191,6 +249,23 @@ class StructuredTemporalTypeTest {
                 .jdbcType(Types.TIME)
                 .typeName("time")
                 .scale(precision)
+                .build();
+    }
+
+    private ColumnDescriptor timestampColumn(String typeName, int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName(typeName)
+                .scale(precision)
+                .build();
+    }
+
+    private ColumnDescriptor dateColumn() {
+        return ColumnDescriptor.builder()
+                .columnName("d")
+                .jdbcType(Types.DATE)
+                .typeName("date")
                 .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -52,13 +52,14 @@ class StructuredTemporalTypeTest {
     void shouldBindInvalidTimestampComponents() {
         final var schema = StructuredTimestamp.schema();
         final var value = StructuredTimestamp.from(schema, 2026, 2, 31, 12, 13, 14, 123_456_000);
+        final var type = configuredTimestampType(TemporalPrecisionLossHandlingMode.FAIL);
 
-        final var bindings = StructuredTimestampType.INSTANCE.bind(2, schema, value);
+        final var bindings = type.bind(2, schema, value);
 
         assertThat(bindings).hasSize(1);
         assertThat(bindings.get(0).getValue()).isEqualTo("2026-02-31 12:13:14.123456");
         assertThat(bindings.get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
-        assertThat(StructuredTimestampType.INSTANCE.getDefaultValueBinding(schema, value)).isEqualTo("'2026-02-31 12:13:14.123456'");
+        assertThat(type.getDefaultValueBinding(schema, value)).isEqualTo("'2026-02-31 12:13:14.123456'");
     }
 
     @Test
@@ -66,13 +67,14 @@ class StructuredTemporalTypeTest {
     void shouldBindStructuredDuration() {
         final var schema = StructuredDuration.schema();
         final var value = StructuredDuration.from(schema, 0, 0, 0, -838, -59, -58, -999_999_000);
+        final var type = configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL);
 
-        final var bindings = StructuredDurationType.INSTANCE.bind(3, schema, value);
+        final var bindings = type.bind(3, schema, value);
 
         assertThat(bindings).hasSize(1);
         assertThat(bindings.get(0).getValue()).isEqualTo("-838:59:58.999999");
         assertThat(bindings.get(0).getTargetSqlType()).isEqualTo(Types.VARCHAR);
-        assertThat(StructuredDurationType.INSTANCE.getDefaultValueBinding(schema, value)).isEqualTo("'-838:59:58.999999'");
+        assertThat(type.getDefaultValueBinding(schema, value)).isEqualTo("'-838:59:58.999999'");
     }
 
     @Test
@@ -131,6 +133,40 @@ class StructuredTemporalTypeTest {
                 .isEqualTo("001:02:03.123456");
         assertThat(roundType.bind(1, timeColumn(6), schema, value).get(0).getValue())
                 .isEqualTo("001:02:03.123457");
+    }
+
+    @Test
+    @DisplayName("Should apply round mode to MySQL structured temporal defaults")
+    void shouldRoundMySqlStructuredTemporalDefaults() {
+        final var timestampSchema = StructuredTimestamp.builder(9).build();
+        final var timestamp = StructuredTimestamp.from(
+                timestampSchema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9);
+        final var durationSchema = StructuredDuration.builder(9, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var duration = StructuredDuration.from(durationSchema, 0, 0, 0, 1, 2, 3, 123_456_789, 9);
+
+        assertThat(configuredTimestampType(TemporalPrecisionLossHandlingMode.ROUND)
+                .getDefaultValueBinding(timestampSchema, timestamp))
+                .isEqualTo("'2026-07-17 12:13:14.123457'");
+        assertThat(configuredDurationType(TemporalPrecisionLossHandlingMode.ROUND)
+                .getDefaultValueBinding(durationSchema, duration))
+                .isEqualTo("'001:02:03.123457'");
+        assertThatThrownBy(() -> configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL)
+                .getDefaultValueBinding(durationSchema, duration))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 6");
+    }
+
+    private StructuredTimestampType configuredTimestampType(TemporalPrecisionLossHandlingMode mode) {
+        final var type = new StructuredTimestampType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(dialect.getMaxTimestampPrecision()).thenReturn(6);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
+        type.configure(config, dialect);
+        return type;
     }
 
     private StructuredDurationType configuredDurationType(TemporalPrecisionLossHandlingMode mode) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.dialect.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -13,13 +14,18 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.engine.jdbc.Size;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDate;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTimestamp;
@@ -76,12 +82,79 @@ class StructuredTemporalTypeTest {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getJdbcTypeName(eq(Types.TIME), any(Size.class)))
                 .thenAnswer(invocation -> "time(" + ((Size) invocation.getArgument(1)).getPrecision() + ")");
-        type.configure(mock(SinkConnectorConfig.class), dialect);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
+        final SinkConnectorConfig config = mock(SinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        type.configure(config, dialect);
 
         final var schema = StructuredDuration.builder()
                 .parameter("__debezium.source.column.length", "6")
                 .build();
 
         assertThat(type.getTypeName(schema, false)).isEqualTo("time(6)");
+    }
+
+    @Test
+    @DisplayName("Should reject calendar duration kinds for MySQL time")
+    void shouldRejectCalendarDurationKinds() {
+        final var type = configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL);
+        final var yearMonthSchema = StructuredDuration.builder(0, StructuredDuration.Kind.YEAR_MONTH).build();
+
+        assertThatThrownBy(() -> type.getTypeName(yearMonthSchema, false))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("year-month")
+                .hasMessageContaining("MySQL TIME");
+
+        final var legacySchema = StructuredDuration.schema();
+        final var valueWithDays = StructuredDuration.from(legacySchema, 0, 0, 1, 2, 3, 4, 0);
+        assertThatThrownBy(() -> type.validate(timeColumn(6), legacySchema, valueWithDays))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("day-time");
+
+        final var elapsedSchema = StructuredDuration.builder(6, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var inconsistentValue = StructuredDuration.from(elapsedSchema, 0, 0, 1, 2, 3, 4, 0, 6);
+        assertThatThrownBy(() -> type.validate(timeColumn(6), elapsedSchema, inconsistentValue))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("do not match schema kind 'elapsed-time'");
+    }
+
+    @Test
+    @DisplayName("Should explicitly truncate and round MySQL duration fractions")
+    void shouldReduceMySqlDurationPrecision() {
+        final var schema = StructuredDuration.builder(9, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var value = StructuredDuration.from(schema, 0, 0, 0, 1, 2, 3, 123_456_789, 9);
+
+        final var truncateType = configuredDurationType(TemporalPrecisionLossHandlingMode.TRUNCATE);
+        final var roundType = configuredDurationType(TemporalPrecisionLossHandlingMode.ROUND);
+
+        assertThat(truncateType.bind(1, timeColumn(6), schema, value).get(0).getValue())
+                .isEqualTo("001:02:03.123456");
+        assertThat(roundType.bind(1, timeColumn(6), schema, value).get(0).getValue())
+                .isEqualTo("001:02:03.123457");
+    }
+
+    private StructuredDurationType configuredDurationType(TemporalPrecisionLossHandlingMode mode) {
+        final var type = new StructuredDurationType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
+        type.configure(config, dialect);
+        return type;
+    }
+
+    private TargetTemporalCapabilities mysqlCapabilities() {
+        return TargetTemporalCapabilities.defaults(6, 6)
+                .withDurationKinds(java.util.EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
+    }
+
+    private ColumnDescriptor timeColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("duration")
+                .jdbcType(Types.TIME)
+                .typeName("time")
+                .scale(precision)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -240,7 +240,8 @@ class StructuredTemporalTypeTest {
         return TargetTemporalCapabilities.defaults(6, 6)
                 .withDateRange(TemporalRange.dateYears(1000, 9999))
                 .withTimestampRange(datetimeRange)
-                .withDurationKinds(java.util.EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME));
+                .withDurationKinds(java.util.EnumSet.of(StructuredDuration.Kind.ELAPSED_TIME))
+                .withZeroDateSupported(true);
     }
 
     private ColumnDescriptor timeColumn(int precision) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -81,6 +81,19 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should include the structured duration value in MySQL range errors")
+    void shouldIncludeStructuredDurationValueInRangeError() {
+        final var schema = StructuredDuration.builder(6, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var value = StructuredDuration.from(schema, 0, 0, 0, 839, 0, 0, 0, 6);
+        final var type = configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL);
+
+        assertThatThrownBy(() -> type.bind(1, schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("839 hours")
+                .hasMessageContaining("MySQL TIME range");
+    }
+
+    @Test
     @DisplayName("Should use propagated source column length for structured duration precision")
     void shouldUseSourceColumnLengthForStructuredDurationPrecision() {
         final var type = new StructuredDurationType();
@@ -135,6 +148,29 @@ class StructuredTemporalTypeTest {
         assertThat(truncateType.bind(1, timeColumn(6), schema, value).get(0).getValue())
                 .isEqualTo("001:02:03.123456");
         assertThat(roundType.bind(1, timeColumn(6), schema, value).get(0).getValue())
+                .isEqualTo("001:02:03.123457");
+    }
+
+    @Test
+    @DisplayName("Should derive MySQL timestamp precision from Connector/J column size metadata")
+    void shouldDeriveTimestampPrecisionFromConnectorJColumnSize() {
+        final var schema = StructuredTimestamp.builder(9).build();
+        final var value = StructuredTimestamp.from(
+                schema, 2026, 7, 21, 12, 13, 14, 123_456_789, 9);
+        final var type = configuredTimestampType(TemporalPrecisionLossHandlingMode.ROUND);
+
+        assertThat(type.bind(1, timestampColumn("DATETIME", 26, 0), schema, value).get(0).getValue())
+                .isEqualTo("2026-07-21 12:13:14.123457");
+    }
+
+    @Test
+    @DisplayName("Should derive MySQL time precision from Connector/J column size metadata")
+    void shouldDeriveTimePrecisionFromConnectorJColumnSize() {
+        final var schema = StructuredDuration.builder(9, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var value = StructuredDuration.from(schema, 0, 0, 0, 1, 2, 3, 123_456_789, 9);
+        final var type = configuredDurationType(TemporalPrecisionLossHandlingMode.ROUND);
+
+        assertThat(type.bind(1, timeColumn(15, 0), schema, value).get(0).getValue())
                 .isEqualTo("001:02:03.123457");
     }
 
@@ -245,20 +281,30 @@ class StructuredTemporalTypeTest {
     }
 
     private ColumnDescriptor timeColumn(int precision) {
+        return timeColumn(0, precision);
+    }
+
+    private ColumnDescriptor timeColumn(int columnSize, int scale) {
         return ColumnDescriptor.builder()
                 .columnName("duration")
                 .jdbcType(Types.TIME)
                 .typeName("time")
-                .scale(precision)
+                .precision(columnSize)
+                .scale(scale)
                 .build();
     }
 
     private ColumnDescriptor timestampColumn(String typeName, int precision) {
+        return timestampColumn(typeName, 0, precision);
+    }
+
+    private ColumnDescriptor timestampColumn(String typeName, int columnSize, int scale) {
         return ColumnDescriptor.builder()
                 .columnName("ts")
                 .jdbcType(Types.TIMESTAMP)
                 .typeName(typeName)
-                .scale(precision)
+                .precision(columnSize)
+                .scale(scale)
                 .build();
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -204,9 +204,9 @@ class StructuredTemporalTypeTest {
                 TemporalPrecisionLossHandlingMode.FAIL, TemporalRangeLossHandlingMode.SATURATE);
 
         assertThat(type.bind(1, timestampColumn("datetime", 6), schema, value).get(0).getValue())
-                .isEqualTo("9999-12-31 23:59:59.499999");
+                .isEqualTo("9999-12-31 23:59:59.999999");
         assertThat(type.getDefaultValueBinding(schema, value))
-                .isEqualTo("'9999-12-31 23:59:59.499999'");
+                .isEqualTo("'9999-12-31 23:59:59.999999'");
     }
 
     @Test
@@ -272,7 +272,7 @@ class StructuredTemporalTypeTest {
     private TargetTemporalCapabilities mysqlCapabilities() {
         final TemporalRange datetimeRange = new TemporalRange(
                 Boundary.timestamp(1000, 1, 1, 0, 0, 0, 0),
-                Boundary.timestamp(9999, 12, 31, 23, 59, 59, 499_999_999_999L));
+                Boundary.timestamp(9999, 12, 31, 23, 59, 59, 999_999_999_999L));
         return TargetTemporalCapabilities.defaults(6, 6)
                 .withDateRange(TemporalRange.dateYears(1000, 9999))
                 .withTimestampRange(datetimeRange)

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalTypeTest.java
@@ -32,6 +32,7 @@ import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDate;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTimestamp;
+import io.debezium.time.StructuredZonedTimestamp;
 
 @Tag("UnitTests")
 class StructuredTemporalTypeTest {
@@ -224,6 +225,24 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should report unsupported zoned timestamp offsets before precision and range loss")
+    void shouldRejectZonedTimestampOffsetBeforePrecisionAndRange() {
+        // The value violates all three conditions at once: MySQL cannot keep the +09:00 offset, the fraction
+        // carries digits beyond precision 6, and the year is outside the datetime range. Only the offset failure
+        // is unrecoverable, so it has to be the one reported.
+        final var schema = StructuredZonedTimestamp.builder(6).build();
+        final var value = StructuredZonedTimestamp.from(schema, 12_000, 1, 2, 3, 4, 5, 123_456_789, 32_400, null, 6);
+        final var type = configuredZonedTimestampType();
+
+        assertThatThrownBy(() -> type.validate(timestampColumn("datetime", 6), schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("offset 32400")
+                .hasMessageContaining("cannot be preserved")
+                .hasMessageNotContaining("precision")
+                .hasMessageNotContaining("outside the range");
+    }
+
+    @Test
     @DisplayName("Should retain MySQL zero dates when range handling is enabled")
     void shouldRetainZeroDateWithRangeHandling() {
         final var schema = StructuredDate.schema();
@@ -251,6 +270,20 @@ class StructuredTemporalTypeTest {
         when(config.useTimeZone()).thenReturn("UTC");
         when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(precisionMode);
         when(config.getTemporalRangeLossHandlingMode()).thenReturn(rangeMode);
+        when(dialect.getMaxTimestampPrecision()).thenReturn(6);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());
+        type.configure(config, dialect);
+        return type;
+    }
+
+    private StructuredZonedTimestampType configuredZonedTimestampType() {
+        final var type = new StructuredZonedTimestampType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(TemporalRangeLossHandlingMode.FAIL);
         when(dialect.getMaxTimestampPrecision()).thenReturn(6);
         when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
         when(dialect.getTargetTemporalCapabilities()).thenReturn(mysqlCapabilities());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTemporalTypeTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.jdbc.dialect.oracle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 import java.time.LocalDate;
@@ -21,8 +23,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredTimestampType;
 import io.debezium.connector.jdbc.type.debezium.StructuredZonedTimestampType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTime;
 import io.debezium.time.StructuredTimestamp;
@@ -43,6 +50,26 @@ class StructuredTemporalTypeTest {
         assertThat(bindings).hasSize(1);
         assertThat(bindings.get(0).getValue()).isEqualTo(LocalDateTime.of(LocalDate.EPOCH, LocalTime.of(12, 13, 14, 123_456_789)));
         assertThat(bindings.get(0).getTargetSqlType()).isEqualTo(Types.TIMESTAMP);
+    }
+
+    @Test
+    @DisplayName("Should preserve Oracle binding shape after precision reduction")
+    void shouldReduceStructuredTimeAsTimestampValue() {
+        final var schema = StructuredTime.builder(9).build();
+        final var value = StructuredTime.from(schema, LocalTime.of(12, 13, 14, 123_456_789), 9);
+        final var type = new io.debezium.connector.jdbc.dialect.oracle.StructuredTimeType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.TRUNCATE);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(9, 9));
+        type.configure(config, dialect);
+
+        final var binding = type.bind(1, timeColumn(3), schema, value).get(0);
+
+        assertThat(binding.getValue())
+                .isEqualTo(LocalDateTime.of(LocalDate.EPOCH, LocalTime.of(12, 13, 14, 123_000_000)));
+        assertThat(binding.getTargetSqlType()).isEqualTo(Types.TIMESTAMP);
     }
 
     @Test
@@ -100,6 +127,20 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should map structured elapsed duration to Oracle day-second interval")
+    void shouldBindStructuredElapsedDuration() {
+        final var schema = StructuredDuration.builder(6, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var value = StructuredDuration.from(schema, 0, 0, 0, 34, 5, 6, 789_000_000, 6);
+
+        assertThat(StructuredDurationType.INSTANCE.getTypeName(schema, false))
+                .isEqualTo("INTERVAL DAY TO SECOND(6)");
+        assertThat(StructuredDurationType.INSTANCE.getQueryBinding(null, schema, value))
+                .isEqualTo("TO_DSINTERVAL(?)");
+        assertThat(StructuredDurationType.INSTANCE.bind(1, schema, value).get(0).getValue())
+                .isEqualTo("1 10:05:06.789000");
+    }
+
+    @Test
     @DisplayName("Should fail structured timestamp infinity for Oracle")
     void shouldFailStructuredTimestampInfinity() {
         final var schema = StructuredTimestamp.schema();
@@ -117,5 +158,14 @@ class StructuredTemporalTypeTest {
         assertThatThrownBy(() -> StructuredZonedTimestampType.INSTANCE.bind(4, schema, StructuredZonedTimestamp.negativeInfinity(schema)))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("Non-finite structured temporal values require dialect-specific handling");
+    }
+
+    private ColumnDescriptor timeColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("time_value")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(precision)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/StructuredTemporalTypeTest.java
@@ -141,6 +141,26 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should apply round mode to Oracle day-second defaults")
+    void shouldRoundOracleDaySecondDefault() {
+        final var schema = StructuredDuration.builder()
+                .parameter("__debezium.source.column.type", "INTERVAL DAY TO SECOND")
+                .parameter("__debezium.source.column.scale", "6")
+                .build();
+        final var value = StructuredDuration.from(schema, 0, 0, 1, 2, 3, 4, 567_890_600, 9);
+        final var type = configuredDurationType(TemporalPrecisionLossHandlingMode.ROUND);
+
+        assertThat(type.getDefaultValueBinding(schema, value))
+                .isEqualTo("TO_DSINTERVAL('1 02:03:04.567891')");
+        assertThat(type.bind(1, schema, value).get(0).getValue())
+                .isEqualTo("1 02:03:04.567891");
+        assertThatThrownBy(() -> configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL)
+                .getDefaultValueBinding(schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 6");
+    }
+
+    @Test
     @DisplayName("Should fail structured timestamp infinity for Oracle")
     void shouldFailStructuredTimestampInfinity() {
         final var schema = StructuredTimestamp.schema();
@@ -167,5 +187,16 @@ class StructuredTemporalTypeTest {
                 .typeName("timestamp")
                 .scale(precision)
                 .build();
+    }
+
+    private StructuredDurationType configuredDurationType(TemporalPrecisionLossHandlingMode mode) {
+        final var type = new StructuredDurationType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(9, 9));
+        type.configure(config, dialect);
+        return type;
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 import java.time.OffsetTime;
@@ -15,6 +17,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.time.StructuredDate;
 import io.debezium.time.StructuredDuration;
@@ -76,6 +83,25 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should explicitly reduce PostgreSQL interval fractional precision")
+    void shouldReduceStructuredDurationPrecision() {
+        final var schema = StructuredDuration.builder(9, StructuredDuration.Kind.MIXED).build();
+        final var value = StructuredDuration.from(schema, 1, 2, 3, 4, 5, 6, 789_123_456, 9);
+
+        final var truncateType = configuredDurationType(TemporalPrecisionLossHandlingMode.TRUNCATE);
+        final var roundType = configuredDurationType(TemporalPrecisionLossHandlingMode.ROUND);
+
+        assertThat(truncateType.bind(1, intervalColumn(6), schema, value).get(0).getValue())
+                .isEqualTo("1 years 2 months 3 days 4 hours 5 minutes 6.789123 seconds");
+        assertThat(roundType.bind(1, intervalColumn(6), schema, value).get(0).getValue())
+                .isEqualTo("1 years 2 months 3 days 4 hours 5 minutes 6.789123 seconds");
+
+        final var roundedValue = StructuredDuration.from(schema, 0, 0, 0, 0, 0, 6, 789_123_556, 9);
+        assertThat(roundType.bind(1, intervalColumn(6), schema, roundedValue).get(0).getValue())
+                .isEqualTo("6.789124 seconds");
+    }
+
+    @Test
     @DisplayName("Should bind structured zoned time as a PostgreSQL timetz literal")
     void shouldBindStructuredZonedTimeAsString() {
         final var schema = StructuredZonedTime.schema();
@@ -108,6 +134,26 @@ class StructuredTemporalTypeTest {
     private void assertInfinityBinding(ValueBindDescriptor binding, String expectedValue) {
         assertThat(binding.getValue()).isEqualTo(expectedValue);
         assertThat(binding.getTargetSqlType()).isEqualTo(Types.VARCHAR);
+    }
+
+    private StructuredDurationType configuredDurationType(TemporalPrecisionLossHandlingMode mode) {
+        final var type = new StructuredDurationType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 6));
+        type.configure(config, dialect);
+        return type;
+    }
+
+    private ColumnDescriptor intervalColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("interval_value")
+                .jdbcType(Types.OTHER)
+                .typeName("interval")
+                .scale(precision)
+                .build();
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
@@ -39,35 +40,38 @@ class StructuredTemporalTypeTest {
     @DisplayName("Should bind structured timestamp infinity as PostgreSQL timestamp literal")
     void shouldBindStructuredTimestampInfinity() {
         final var schema = StructuredTimestamp.schema();
+        final var type = configuredWithInfinitySupport(new StructuredTimestampType());
 
-        final var bindings = StructuredTimestampType.INSTANCE.bind(1, schema, StructuredTimestamp.positiveInfinity(schema));
+        final var bindings = type.bind(1, schema, StructuredTimestamp.positiveInfinity(schema));
 
         assertInfinityBinding(bindings.get(0), "infinity");
-        assertThat(StructuredTimestampType.INSTANCE.getQueryBinding(null, schema, null)).isEqualTo("cast(? as timestamp)");
+        assertThat(type.getQueryBinding(null, schema, null)).isEqualTo("cast(? as timestamp)");
     }
 
     @Test
     @DisplayName("Should bind structured zoned timestamp infinity as PostgreSQL timestamptz literal")
     void shouldBindStructuredZonedTimestampInfinity() {
         final var schema = StructuredZonedTimestamp.schema();
+        final var type = configuredWithInfinitySupport(new StructuredZonedTimestampType());
 
-        final var bindings = StructuredZonedTimestampType.INSTANCE.bind(2, schema, StructuredZonedTimestamp.negativeInfinity(schema));
+        final var bindings = type.bind(2, schema, StructuredZonedTimestamp.negativeInfinity(schema));
 
         assertThat(bindings).hasSize(1);
         assertInfinityBinding(bindings.get(0), "-infinity");
-        assertThat(StructuredZonedTimestampType.INSTANCE.getQueryBinding(null, schema, null)).isEqualTo("cast(? as timestamptz)");
+        assertThat(type.getQueryBinding(null, schema, null)).isEqualTo("cast(? as timestamptz)");
     }
 
     @Test
     @DisplayName("Should bind structured date infinity as PostgreSQL date literal")
     void shouldBindStructuredDateInfinity() {
         final var schema = StructuredDate.schema();
+        final var type = configuredWithInfinitySupport(new StructuredDateType());
 
-        final var bindings = StructuredDateType.INSTANCE.bind(3, schema, StructuredDate.positiveInfinity(schema));
+        final var bindings = type.bind(3, schema, StructuredDate.positiveInfinity(schema));
 
         assertThat(bindings).hasSize(1);
         assertInfinityBinding(bindings.get(0), "infinity");
-        assertThat(StructuredDateType.INSTANCE.getQueryBinding(null, schema, null)).isEqualTo("cast(? as date)");
+        assertThat(type.getQueryBinding(null, schema, null)).isEqualTo("cast(? as date)");
     }
 
     @Test
@@ -76,14 +80,38 @@ class StructuredTemporalTypeTest {
         final var timestampSchema = StructuredTimestamp.schema();
         final var zonedTimestampSchema = StructuredZonedTimestamp.schema();
         final var dateSchema = StructuredDate.schema();
+        final var timestampType = configuredWithInfinitySupport(new StructuredTimestampType());
+        final var zonedTimestampType = configuredWithInfinitySupport(new StructuredZonedTimestampType());
+        final var dateType = configuredWithInfinitySupport(new StructuredDateType());
 
-        StructuredTimestampType.INSTANCE.validate(
+        timestampType.validate(
                 temporalColumn(Types.TIMESTAMP, "timestamp"), timestampSchema, StructuredTimestamp.positiveInfinity(timestampSchema));
-        StructuredZonedTimestampType.INSTANCE.validate(
+        zonedTimestampType.validate(
                 temporalColumn(Types.TIMESTAMP_WITH_TIMEZONE, "timestamptz"), zonedTimestampSchema,
                 StructuredZonedTimestamp.negativeInfinity(zonedTimestampSchema));
-        StructuredDateType.INSTANCE.validate(
+        dateType.validate(
                 temporalColumn(Types.DATE, "date"), dateSchema, StructuredDate.positiveInfinity(dateSchema));
+    }
+
+    @Test
+    @DisplayName("Should reject structured temporal infinity without a configured dialect")
+    void shouldRejectStructuredTemporalInfinityWithoutConfiguredDialect() {
+        final var timestampSchema = StructuredTimestamp.schema();
+        final var zonedTimestampSchema = StructuredZonedTimestamp.schema();
+        final var dateSchema = StructuredDate.schema();
+
+        assertThatThrownBy(() -> new StructuredTimestampType().bind(
+                1, timestampSchema, StructuredTimestamp.positiveInfinity(timestampSchema)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Non-finite");
+        assertThatThrownBy(() -> new StructuredZonedTimestampType().bind(
+                1, zonedTimestampSchema, StructuredZonedTimestamp.positiveInfinity(zonedTimestampSchema)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Non-finite");
+        assertThatThrownBy(() -> new StructuredDateType().bind(
+                1, dateSchema, StructuredDate.positiveInfinity(dateSchema)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Non-finite");
     }
 
     @Test
@@ -188,6 +216,17 @@ class StructuredTemporalTypeTest {
         when(config.useTimeZone()).thenReturn("UTC");
         when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
         when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 6));
+        type.configure(config, dialect);
+        return type;
+    }
+
+    private <T extends JdbcType> T configuredWithInfinitySupport(T type) {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 6)
+                .withDateInfinitySupported(true)
+                .withTimestampInfinitySupported(true));
         type.configure(config, dialect);
         return type;
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
@@ -71,6 +71,22 @@ class StructuredTemporalTypeTest {
     }
 
     @Test
+    @DisplayName("Should preserve structured temporal infinity during actual column validation")
+    void shouldPreserveStructuredTemporalInfinityDuringValidation() {
+        final var timestampSchema = StructuredTimestamp.schema();
+        final var zonedTimestampSchema = StructuredZonedTimestamp.schema();
+        final var dateSchema = StructuredDate.schema();
+
+        StructuredTimestampType.INSTANCE.validate(
+                temporalColumn(Types.TIMESTAMP, "timestamp"), timestampSchema, StructuredTimestamp.positiveInfinity(timestampSchema));
+        StructuredZonedTimestampType.INSTANCE.validate(
+                temporalColumn(Types.TIMESTAMP_WITH_TIMEZONE, "timestamptz"), zonedTimestampSchema,
+                StructuredZonedTimestamp.negativeInfinity(zonedTimestampSchema));
+        StructuredDateType.INSTANCE.validate(
+                temporalColumn(Types.DATE, "date"), dateSchema, StructuredDate.positiveInfinity(dateSchema));
+    }
+
+    @Test
     @DisplayName("Should bind structured duration as PostgreSQL interval literal")
     void shouldBindStructuredDuration() {
         final var schema = StructuredDuration.schema();
@@ -182,6 +198,15 @@ class StructuredTemporalTypeTest {
                 .jdbcType(Types.OTHER)
                 .typeName("interval")
                 .scale(precision)
+                .build();
+    }
+
+    private ColumnDescriptor temporalColumn(int jdbcType, String typeName) {
+        return ColumnDescriptor.builder()
+                .columnName("temporal_value")
+                .jdbcType(jdbcType)
+                .typeName(typeName)
+                .scale(6)
                 .build();
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/StructuredTemporalTypeTest.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +15,7 @@ import java.sql.Types;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -99,6 +102,12 @@ class StructuredTemporalTypeTest {
         final var roundedValue = StructuredDuration.from(schema, 0, 0, 0, 0, 0, 6, 789_123_556, 9);
         assertThat(roundType.bind(1, intervalColumn(6), schema, roundedValue).get(0).getValue())
                 .isEqualTo("6.789124 seconds");
+        assertThat(roundType.getDefaultValueBinding(schema, roundedValue))
+                .isEqualTo("'6.789124 seconds'");
+        assertThatThrownBy(() -> configuredDurationType(TemporalPrecisionLossHandlingMode.FAIL)
+                .getDefaultValueBinding(schema, roundedValue))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 6");
     }
 
     @Test
@@ -129,6 +138,26 @@ class StructuredTemporalTypeTest {
 
         assertThat(bindings).hasSize(1);
         assertThat(bindings.get(0).getValue()).isEqualTo("24:00:00+05:30");
+    }
+
+    @Test
+    @DisplayName("Should apply round mode to PostgreSQL timetz defaults")
+    void shouldRoundStructuredZonedTimeDefault() {
+        final var schema = StructuredZonedTime.builder(9).build();
+        final var value = StructuredZonedTime.from(
+                schema, OffsetTime.of(12, 13, 14, 123_456_789, ZoneOffset.ofHours(9)), 9);
+        final var type = new StructuredZonedTimeType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.ROUND);
+        when(dialect.getDefaultTimePrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(6, 6));
+        when(dialect.getFormattedTimeWithTimeZone(anyString())).thenAnswer(invocation -> "'" + invocation.getArgument(0) + "'");
+        type.configure(config, dialect);
+
+        assertThat(type.getDefaultValueBinding(schema, value))
+                .isEqualTo("'12:13:14.123457+09:00'");
     }
 
     private void assertInfinityBinding(ValueBindDescriptor binding, String expectedValue) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/StructuredTemporalTypeTest.java
@@ -29,6 +29,7 @@ import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
 import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDate;
+import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTimestamp;
 
 @Tag("UnitTests")
@@ -81,6 +82,21 @@ class StructuredTemporalTypeTest {
                 .isEqualTo("9999-12-31 23:59:59.999999");
     }
 
+    @Test
+    @DisplayName("Should derive SingleStore time precision from column size metadata")
+    void shouldDeriveTimePrecisionFromColumnSize() {
+        final var schema = StructuredDuration.builder(6, StructuredDuration.Kind.ELAPSED_TIME).build();
+        final var value = StructuredDuration.from(schema, 0, 0, 0, 1, 2, 3, 123_456_000, 6);
+        final var type = new SingleStoreStructuredDurationType();
+        type.configure(config(TemporalRangeLossHandlingMode.FAIL), dialect());
+
+        assertThat(type.bind(1, timeColumn(17), schema, value).get(0).getValue())
+                .isEqualTo("001:02:03.123456");
+        assertThatThrownBy(() -> type.bind(1, timeColumn(10), schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 0");
+    }
+
     private StructuredDateType configuredDateType(TemporalRangeLossHandlingMode rangeMode) {
         final var type = new StructuredDateType();
         type.configure(config(rangeMode), dialect());
@@ -122,7 +138,18 @@ class StructuredTemporalTypeTest {
                 .columnName("ts")
                 .jdbcType(Types.TIMESTAMP)
                 .typeName(typeName)
-                .scale(6)
+                .precision(26)
+                .scale(0)
+                .build();
+    }
+
+    private ColumnDescriptor timeColumn(int columnSize) {
+        return ColumnDescriptor.builder()
+                .columnName("t")
+                .jdbcType(Types.TIME)
+                .typeName("time")
+                .precision(columnSize)
+                .scale(0)
                 .build();
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/StructuredTemporalTypeTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.singlestore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.dialect.mysql.StructuredDateType;
+import io.debezium.connector.jdbc.dialect.mysql.StructuredTimestampType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredDate;
+import io.debezium.time.StructuredTimestamp;
+
+@Tag("UnitTests")
+class StructuredTemporalTypeTest {
+
+    @Test
+    @DisplayName("Should declare SingleStore date and timestamp ranges")
+    void shouldDeclareSingleStoreTemporalCapabilities() {
+        final var capabilities = singleStoreCapabilities();
+
+        assertThat(capabilities.zeroDateSupported()).isFalse();
+        assertThat(capabilities.dateRange().minimum()).isEqualTo(Boundary.date(1000, 1, 1));
+        assertThat(capabilities.timestampRange().maximum())
+                .isEqualTo(Boundary.timestamp(9999, 12, 31, 23, 59, 59, 999_999_000_000L));
+        assertThat(capabilities.targetTimestampRange(timestampColumn("timestamp")).maximum())
+                .isEqualTo(Boundary.timestamp(2038, 1, 19, 3, 14, 7, 999_999_000_000L));
+    }
+
+    @Test
+    @DisplayName("Should reject SingleStore zero dates in fail mode")
+    void shouldRejectZeroDate() {
+        final var schema = StructuredDate.schema();
+        final var type = configuredDateType(TemporalRangeLossHandlingMode.FAIL);
+
+        assertThatThrownBy(() -> type.bind(1, dateColumn(), schema, StructuredDate.from(schema, 0, 0, 0)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("0000-00-00")
+                .hasMessageContaining("saturate");
+    }
+
+    @Test
+    @DisplayName("Should saturate SingleStore zero dates to the minimum finite date")
+    void shouldSaturateZeroDate() {
+        final var schema = StructuredDate.schema();
+        final var type = configuredDateType(TemporalRangeLossHandlingMode.SATURATE);
+
+        assertThat(type.bind(1, dateColumn(), schema, StructuredDate.from(schema, 0, 0, 0)).get(0).getValue())
+                .isEqualTo("1000-01-01");
+    }
+
+    @Test
+    @DisplayName("Should retain the SingleStore datetime microsecond upper boundary")
+    void shouldRetainDatetimeUpperBoundary() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.from(
+                schema, 9999, 12, 31, 23, 59, 59, 999_999_000, 6);
+        final var type = configuredTimestampType(TemporalRangeLossHandlingMode.FAIL);
+
+        assertThat(type.bind(1, timestampColumn("datetime"), schema, value).get(0).getValue())
+                .isEqualTo("9999-12-31 23:59:59.999999");
+    }
+
+    private StructuredDateType configuredDateType(TemporalRangeLossHandlingMode rangeMode) {
+        final var type = new StructuredDateType();
+        type.configure(config(rangeMode), dialect());
+        return type;
+    }
+
+    private StructuredTimestampType configuredTimestampType(TemporalRangeLossHandlingMode rangeMode) {
+        final var type = new StructuredTimestampType();
+        type.configure(config(rangeMode), dialect());
+        return type;
+    }
+
+    private JdbcSinkConnectorConfig config(TemporalRangeLossHandlingMode rangeMode) {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(rangeMode);
+        return config;
+    }
+
+    private DatabaseDialect dialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        final TargetTemporalCapabilities capabilities = singleStoreCapabilities();
+        when(dialect.getMaxTimestampPrecision()).thenReturn(6);
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(capabilities);
+        return dialect;
+    }
+
+    private TargetTemporalCapabilities singleStoreCapabilities() {
+        final SingleStoreDatabaseDialect dialect = mock(SingleStoreDatabaseDialect.class, CALLS_REAL_METHODS);
+        doReturn(6).when(dialect).getMaxTimePrecision();
+        doReturn(6).when(dialect).getMaxTimestampPrecision();
+        return dialect.getTargetTemporalCapabilities();
+    }
+
+    private ColumnDescriptor timestampColumn(String typeName) {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName(typeName)
+                .scale(6)
+                .build();
+    }
+
+    private ColumnDescriptor dateColumn() {
+        return ColumnDescriptor.builder()
+                .columnName("d")
+                .jdbcType(Types.DATE)
+                .typeName("date")
+                .build();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTemporalTypeTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.jdbc.dialect.sqlserver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 import java.time.LocalDate;
@@ -21,7 +23,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredDurationType;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTime;
 import io.debezium.time.StructuredTimestamp;
@@ -43,6 +50,25 @@ class StructuredTemporalTypeTest {
         assertThat(bindings).hasSize(1);
         assertThat(bindings.get(0).getValue()).isInstanceOf(LocalDateTime.class);
         assertThat(bindings.get(0).getValue()).isEqualTo(LocalDateTime.of(LocalDate.EPOCH, LocalTime.of(12, 13, 14, 123_456_789)));
+    }
+
+    @Test
+    @DisplayName("Should preserve SQL Server binding shape after precision reduction")
+    void shouldReduceStructuredTimeAsTimestampValue() {
+        final var schema = StructuredTime.builder(9).build();
+        final var value = StructuredTime.from(schema, LocalTime.of(12, 13, 14, 123_456_789), 9);
+        final var type = new StructuredTimeType();
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.TRUNCATE);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(TargetTemporalCapabilities.defaults(7, 7));
+        type.configure(config, dialect);
+
+        final var binding = type.bind(1, timeColumn(3), schema, value).get(0);
+
+        assertThat(binding.getValue())
+                .isEqualTo(LocalDateTime.of(LocalDate.EPOCH, LocalTime.of(12, 13, 14, 123_000_000)));
     }
 
     @Test
@@ -102,5 +128,14 @@ class StructuredTemporalTypeTest {
         assertThatThrownBy(() -> StructuredZonedTimestampType.INSTANCE.bind(3, schema, StructuredZonedTimestamp.positiveInfinity(schema)))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("Non-finite structured temporal values require dialect-specific handling");
+    }
+
+    private ColumnDescriptor timeColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("time_value")
+                .jdbcType(Types.TIME)
+                .typeName("time")
+                .scale(precision)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/StructuredTemporalTypeTest.java
@@ -25,9 +25,12 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.debezium.StructuredDurationType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredDuration;
 import io.debezium.time.StructuredTime;
@@ -77,6 +80,30 @@ class StructuredTemporalTypeTest {
         final var schema = StructuredTimestamp.schema();
 
         assertThat(StructuredTimestampType.INSTANCE.getQueryBinding(null, schema, null)).isEqualTo("cast(? as datetime2(7))");
+    }
+
+    @Test
+    @DisplayName("Should use the actual SQL Server timestamp type range when saturating")
+    void shouldSaturateActualTimestampTypeRange() {
+        final var schema = StructuredTimestamp.builder(7).build();
+        final var value = StructuredTimestamp.from(schema, 1600, 1, 1, 12, 13, 14, 0, 7);
+        final var datetimeRange = new TemporalRange(
+                Boundary.timestamp(1753, 1, 1, 0, 0, 0, 0),
+                Boundary.timestamp(9999, 12, 31, 23, 59, 59, 997_000_000_000L));
+        final var capabilities = TargetTemporalCapabilities.defaults(7, 7)
+                .withTimestampRange(TemporalRange.timestampYears(1, 9999))
+                .withTimestampRangeForType(datetimeRange, "datetime");
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(TemporalPrecisionLossHandlingMode.FAIL);
+        when(config.getTemporalRangeLossHandlingMode()).thenReturn(TemporalRangeLossHandlingMode.SATURATE);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(capabilities);
+        final var type = new StructuredTimestampType();
+        type.configure(config, dialect);
+
+        assertThat(type.bind(1, timestampColumn("datetime", 3), schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(1753, 1, 1, 0, 0));
     }
 
     @Test
@@ -135,6 +162,15 @@ class StructuredTemporalTypeTest {
                 .columnName("time_value")
                 .jdbcType(Types.TIME)
                 .typeName("time")
+                .scale(precision)
+                .build();
+    }
+
+    private ColumnDescriptor timestampColumn(String typeName, int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("timestamp_value")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName(typeName)
                 .scale(precision)
                 .build();
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredTemporalTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/starrocks/StructuredTemporalTypeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.time.StructuredTime;
+import io.debezium.time.StructuredZonedTime;
+
+@Tag("UnitTests")
+class StructuredTemporalTypeTest {
+
+    @Test
+    @DisplayName("Should preserve picosecond structured times as StarRocks strings")
+    void shouldBindStructuredTimeAsString() {
+        final var schema = StructuredTime.builder(12).build();
+        final var value = StructuredTime.fromPicoseconds(schema, 12, 13, 14, 123_456_789_012L, 12);
+
+        assertThat(StructuredTimeType.INSTANCE.getTypeName(schema, false)).isEqualTo("varchar(21)");
+        assertThat(StructuredTimeType.INSTANCE.bind(1, schema, value).get(0))
+                .satisfies(binding -> {
+                    assertThat(binding.getValue()).isEqualTo("12:13:14.123456789012");
+                    assertThat(binding.getTargetSqlType()).isEqualTo(Types.VARCHAR);
+                });
+        assertThat(StructuredTimeType.INSTANCE.getDefaultValueBinding(schema, value))
+                .isEqualTo("'12:13:14.123456789012'");
+    }
+
+    @Test
+    @DisplayName("Should preserve picoseconds and offsets for StarRocks structured zoned times")
+    void shouldBindStructuredZonedTimeAsString() {
+        final var schema = StructuredZonedTime.builder(12).build();
+        final var value = StructuredZonedTime.fromPicoseconds(
+                schema, 12, 13, 14, 123_456_789_012L, 9 * 3_600, 12);
+
+        assertThat(StructuredZonedTimeType.INSTANCE.getTypeName(schema, false)).isEqualTo("varchar(32)");
+        assertThat(StructuredZonedTimeType.INSTANCE.bind(1, schema, value).get(0))
+                .satisfies(binding -> {
+                    assertThat(binding.getValue()).isEqualTo("12:13:14.123456789012+09:00");
+                    assertThat(binding.getTargetSqlType()).isEqualTo(Types.VARCHAR);
+                });
+    }
+
+    @Test
+    @DisplayName("Should declare picosecond time storage capability for StarRocks string types")
+    void shouldDeclareStarRocksTimeCapability() {
+        final StarRocksDatabaseDialect dialect = mock(StarRocksDatabaseDialect.class, CALLS_REAL_METHODS);
+        doReturn(6).when(dialect).getMaxTimestampPrecision();
+
+        assertThat(dialect.getTargetTemporalCapabilities().maxTimePrecision()).isEqualTo(12);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
@@ -29,6 +29,7 @@ import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.vector.DoubleVector;
 import io.debezium.data.vector.FloatVector;
 import io.debezium.doc.FixFor;
+import io.debezium.time.StructuredTimestamp;
 
 /**
  * Column type mapping tests for CockroachDB.
@@ -57,6 +58,39 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
     @FixFor("debezium/dbz#1639")
     public void testShouldCoerceStringTypeToJsonbColumnType(SinkRecordFactory factory) throws Exception {
         shouldCoerceStringTypeToColumnType(factory, "jsonb", "{\"id\": 12345}", "{\"id\": 67890}");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldSaturateStructuredTimestampInfinity(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.TEMPORAL_RANGE_LOSS_HANDLING_MODE, "saturate");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final Schema schema = StructuredTimestamp.builder(6).optional().build();
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                schema,
+                StructuredTimestamp.positiveInfinity(schema),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).startsWith("294276-12-31 23:59:59.999999");
+            return null;
+        });
     }
 
     private void shouldCoerceStringTypeToColumnType(SinkRecordFactory factory, String columnType, String insertValue, String updateValue) throws Exception {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.integration.cockroachdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -91,6 +92,32 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getString("data")).startsWith("294276-12-31 23:59:59.999999");
             return null;
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldRejectStructuredTimestampRangeLoss(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final Schema schema = StructuredTimestamp.builder(6).optional().build();
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                schema,
+                StructuredTimestamp.from(schema, 300_000, 1, 1, 0, 0, 0, 0, 6),
+                getConfig(properties));
+
+        final RuntimeException exception = assertThrows(RuntimeException.class, () -> consume(record));
+        assertExceptionCauseMessage(exception, ".*outside the range.*");
     }
 
     private void shouldCoerceStringTypeToColumnType(SinkRecordFactory factory, String columnType, String insertValue, String updateValue) throws Exception {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkColumnTypeMappingIT.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.integration.db2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -63,5 +64,26 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(resultSet.next()).isTrue();
             assertThat(resultSet.getString(1)).endsWith("123456789012");
         }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void shouldRejectStructuredTimestampRangeLoss(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.from(schema, 10_000, 1, 1, 0, 0, 0, 0, 6);
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "captured_at", schema, value, getConfig(properties));
+
+        final RuntimeException exception = assertThrows(RuntimeException.class, () -> consume(record));
+        assertExceptionCauseMessage(exception, ".*outside the range.*");
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkColumnTypeMappingIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.db2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.Db2SinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+import io.debezium.time.StructuredTimestamp;
+
+@Tag("all")
+@Tag("it")
+@Tag("it-db2")
+@ExtendWith(Db2SinkDatabaseContextProvider.class)
+public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkColumnTypeMappingIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void shouldPreservePicosecondTimestamp(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_012L, 12);
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "captured_at", schema, value, getConfig(properties));
+
+        consume(record);
+
+        final String destinationTable = destinationTableName(record);
+        getSink().assertColumn(destinationTable, "captured_at", "TIMESTAMP");
+        try (Statement statement = getSink().getConnection().createStatement();
+                ResultSet resultSet = statement.executeQuery(
+                        "SELECT CAST(captured_at AS VARCHAR(32)) FROM " + destinationTable)) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).endsWith("123456789012");
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -276,4 +276,44 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             return null;
         });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldRoundStructuredTemporalsToTargetPrecision(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.TEMPORAL_PRECISION_LOSS_HANDLING_MODE, "round");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema timestampSchema = StructuredTimestamp.builder(9).optional().build();
+        final Schema durationSchema = StructuredDuration.builder(9, StructuredDuration.Kind.ELAPSED_TIME).optional().build();
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("data", "duration"),
+                List.of(timestampSchema, durationSchema),
+                List.of(
+                        StructuredTimestamp.from(timestampSchema, 2026, 7, 21, 12, 13, 14, 123_456_789, 9),
+                        StructuredDuration.from(durationSchema, 0, 0, 0, 1, 2, 3, 123_456_789, 9)),
+                getConfig(properties));
+
+        final String destinationTable = destinationTableName(record);
+        getSink().execute(String.format(
+                "CREATE TABLE %s (id int not null, data datetime(6), duration time(6), primary key(id))",
+                destinationTable));
+
+        consume(record);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo("2026-07-21 12:13:14.123457");
+            assertThat(rs.getString("duration")).isEqualTo("01:02:03.123457");
+            return null;
+        });
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkColumnTypeMappingIT.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.integration.singlestore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -75,6 +76,32 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getString("data")).isEqualTo("9999-12-31 23:59:59.999999");
             return null;
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldRejectStructuredDatetimeRangeLoss(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema schema = StructuredTimestamp.builder(6).optional().build();
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                schema,
+                StructuredTimestamp.from(schema, 10_000, 1, 1, 0, 0, 0, 0, 6),
+                getConfig(properties));
+
+        final RuntimeException exception = assertThrows(RuntimeException.class, () -> consume(record));
+        assertExceptionCauseMessage(exception, ".*outside the range.*");
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkColumnTypeMappingIT.java
@@ -30,6 +30,7 @@ import io.debezium.data.geometry.Point;
 import io.debezium.data.vector.DoubleVector;
 import io.debezium.data.vector.FloatVector;
 import io.debezium.doc.FixFor;
+import io.debezium.time.StructuredTimestamp;
 
 /**
  * Column type mappings for SingleStore.
@@ -42,6 +43,38 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     public JdbcSinkColumnTypeMappingIT(Sink sink) {
         super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldWriteStructuredDatetimeUpperBoundary(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema schema = StructuredTimestamp.builder(6).optional().build();
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                schema,
+                StructuredTimestamp.from(schema, 9999, 12, 31, 23, 59, 59, 999_999_000, 6),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("data")).isEqualTo("9999-12-31 23:59:59.999999");
+            return null;
+        });
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.integration.starrocks;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -31,6 +32,7 @@ import io.debezium.doc.FixFor;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
 import io.debezium.time.StructuredTime;
+import io.debezium.time.StructuredTimestamp;
 import io.debezium.time.StructuredZonedTime;
 
 /**
@@ -84,6 +86,32 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getString("zoned_time_data")).isEqualTo("12:13:14.123456789012+09:00");
             return null;
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldRejectStructuredTimestampRangeLoss(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema schema = StructuredTimestamp.builder(6).optional().build();
+        final JdbcKafkaSinkRecord record = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                schema,
+                StructuredTimestamp.from(schema, 10_000, 1, 1, 0, 0, 0, 0, 6),
+                getConfig(properties));
+
+        final RuntimeException exception = assertThrows(RuntimeException.class, () -> consume(record));
+        assertExceptionCauseMessage(exception, ".*outside the range.*");
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkColumnTypeMappingIT.java
@@ -30,6 +30,8 @@ import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.doc.FixFor;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
+import io.debezium.time.StructuredTime;
+import io.debezium.time.StructuredZonedTime;
 
 /**
  * Column type mappings for StarRocks, including boundary cases for byte-length string
@@ -44,6 +46,44 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     public JdbcSinkColumnTypeMappingIT(Sink sink) {
         super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2119")
+    public void testShouldWriteStructuredTimesAsPicosecondStrings(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema timeSchema = StructuredTime.builder(12).optional().build();
+        final Schema zonedTimeSchema = StructuredZonedTime.builder(12).optional().build();
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("time_data", "zoned_time_data"),
+                List.of(timeSchema, zonedTimeSchema),
+                List.of(
+                        StructuredTime.fromPicoseconds(timeSchema, 12, 13, 14, 123_456_789_012L, 12),
+                        StructuredZonedTime.fromPicoseconds(zonedTimeSchema, 12, 13, 14, 123_456_789_012L, 9 * 3_600, 12)),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "time_data", "VARCHAR", 21);
+        getSink().assertColumn(destinationTable, "zoned_time_data", "VARCHAR", 32);
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("time_data")).isEqualTo("12:13:14.123456789012");
+            assertThat(rs.getString("zoned_time_data")).isEqualTo("12:13:14.123456789012+09:00");
+            return null;
+        });
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPrecisionTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPrecisionTest.java
@@ -6,20 +6,30 @@
 package io.debezium.connector.jdbc.type.debezium;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.engine.jdbc.Size;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredTime;
 import io.debezium.time.StructuredTimestamp;
 import io.debezium.time.StructuredZonedTimestamp;
@@ -62,6 +72,18 @@ class StructuredTemporalPrecisionTest {
                 .build();
 
         assertThat(type.getTypeName(schema, false)).isEqualTo("timestamp(6)");
+    }
+
+    @Test
+    @DisplayName("Should prefer structured precision metadata over propagated source metadata")
+    void shouldPreferStructuredPrecisionMetadata() {
+        final var type = new StructuredTimestampType();
+        type.configure(config(), timestampDialect());
+        final var schema = StructuredTimestamp.builder(7)
+                .parameter("__debezium.source.column.scale", "3")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("timestamp(7)");
     }
 
     @Test
@@ -112,10 +134,144 @@ class StructuredTemporalPrecisionTest {
         assertThat(type.getTypeName(schema, false)).isEqualTo("timestamptz(3)");
     }
 
+    @Test
+    @DisplayName("Should fail only when discarded timestamp digits are non-zero")
+    void shouldFailOnlyForNonZeroDiscardedDigits() {
+        final var capabilities = TargetTemporalCapabilities.defaults(9, 9);
+        final var type = configuredTimestampType(TemporalPrecisionLossHandlingMode.FAIL, capabilities);
+        final var schema = StructuredTimestamp.builder(9).build();
+        final var column = timestampColumn(6);
+        final var exactValue = StructuredTimestamp.from(schema, 2026, 7, 17, 12, 13, 14, 123_456_000, 9);
+        final var lossyValue = StructuredTimestamp.from(schema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9);
+
+        assertThatCode(() -> type.validate(column, schema, exactValue)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> type.validate(column, schema, lossyValue))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("target column 'ts'")
+                .hasMessageContaining("precision 6");
+    }
+
+    @Test
+    @DisplayName("Should explicitly truncate and round timestamp fractions")
+    void shouldApplyConfiguredPrecisionReduction() {
+        final var capabilities = TargetTemporalCapabilities.defaults(9, 9);
+        final var schema = StructuredTimestamp.builder(9).build();
+        final var column = timestampColumn(6);
+        final var value = StructuredTimestamp.from(schema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9);
+
+        final var truncateType = configuredTimestampType(TemporalPrecisionLossHandlingMode.TRUNCATE, capabilities);
+        final var roundType = configuredTimestampType(TemporalPrecisionLossHandlingMode.ROUND, capabilities);
+
+        assertThat(truncateType.bind(1, column, schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 14, 123_456_000));
+        assertThat(roundType.bind(1, column, schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 14, 123_457_000));
+    }
+
+    @Test
+    @DisplayName("Should explicitly reduce picoseconds for nanosecond targets")
+    void shouldReducePicosecondsForNanosecondTargets() {
+        final var capabilities = TargetTemporalCapabilities.defaults(9, 9);
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var column = timestampColumn(9);
+        final var value = StructuredTimestamp.fromPicoseconds(schema, 2026, 7, 17, 12, 13, 14, 123_456_789_600L, 12);
+
+        final var failType = configuredTimestampType(TemporalPrecisionLossHandlingMode.FAIL, capabilities);
+        final var truncateType = configuredTimestampType(TemporalPrecisionLossHandlingMode.TRUNCATE, capabilities);
+        final var roundType = configuredTimestampType(TemporalPrecisionLossHandlingMode.ROUND, capabilities);
+
+        assertThatThrownBy(() -> failType.bind(1, column, schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("precision 9");
+        assertThat(truncateType.bind(1, column, schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 14, 123_456_789));
+        assertThat(roundType.bind(1, column, schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 14, 123_456_790));
+    }
+
+    @Test
+    @DisplayName("Should carry a rounded timestamp fraction into the next second")
+    void shouldCarryRoundedFraction() {
+        final var type = configuredTimestampType(
+                TemporalPrecisionLossHandlingMode.ROUND, TargetTemporalCapabilities.defaults(9, 9));
+        final var schema = StructuredTimestamp.builder(9).build();
+        final var value = StructuredTimestamp.from(schema, 2026, 7, 17, 12, 13, 14, 999_999_999, 9);
+
+        assertThat(type.bind(1, timestampColumn(6), schema, value).get(0).getValue())
+                .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 15));
+    }
+
+    @Test
+    @DisplayName("Should reject zoned timestamp metadata that the target cannot preserve")
+    void shouldRejectUnsupportedZonedTimestampMetadata() {
+        final var schema = StructuredZonedTimestamp.builder(9).build();
+        final var offsetValue = StructuredZonedTimestamp.from(
+                schema, OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 0, ZoneOffset.ofHours(9)), null, 9);
+        final var regionValue = StructuredZonedTimestamp.from(
+                schema, OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 0, ZoneOffset.ofHours(9)), "Asia/Seoul", 9);
+        final var fixedUtcValue = StructuredZonedTimestamp.from(
+                schema, OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 0, ZoneOffset.UTC), "Z", 9);
+
+        final var noZoneType = configuredZonedTimestampType(TargetTemporalCapabilities.defaults(9, 9));
+        assertThatCode(() -> noZoneType.validate(timestampColumn(9), schema, fixedUtcValue)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> noZoneType.validate(timestampColumn(9), schema, offsetValue))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("offset 32400");
+
+        final var offsetOnlyType = configuredZonedTimestampType(
+                TargetTemporalCapabilities.defaults(9, 9).withZonedTimestampSupport(ZonedTimestampSupport.OFFSET));
+        assertThatThrownBy(() -> offsetOnlyType.validate(timestampColumn(9), schema, regionValue))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("region 'Asia/Seoul'");
+    }
+
+    @Test
+    @DisplayName("Should use dialect precision when JDBC metadata is unreliable")
+    void shouldUseDialectPrecisionForUnreliableMetadata() {
+        final var capabilities = TargetTemporalCapabilities.defaults(6, 6)
+                .withTimestampColumnPrecisionReliable(false);
+
+        assertThat(capabilities.targetTimestampPrecision(timestampColumn(0))).isEqualTo(6);
+    }
+
     private SinkConnectorConfig config() {
         final SinkConnectorConfig config = mock(SinkConnectorConfig.class);
         when(config.useTimeZone()).thenReturn("UTC");
         return config;
+    }
+
+    private StructuredTimestampType configuredTimestampType(TemporalPrecisionLossHandlingMode mode, TargetTemporalCapabilities capabilities) {
+        final var type = new StructuredTimestampType();
+        type.configure(jdbcConfig(mode), temporalDialect(capabilities));
+        return type;
+    }
+
+    private StructuredZonedTimestampType configuredZonedTimestampType(TargetTemporalCapabilities capabilities) {
+        final var type = new StructuredZonedTimestampType();
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.FAIL), temporalDialect(capabilities));
+        return type;
+    }
+
+    private JdbcSinkConnectorConfig jdbcConfig(TemporalPrecisionLossHandlingMode mode) {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.getTemporalPrecisionLossHandlingMode()).thenReturn(mode);
+        return config;
+    }
+
+    private DatabaseDialect temporalDialect(TargetTemporalCapabilities capabilities) {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getTargetTemporalCapabilities()).thenReturn(capabilities);
+        return dialect;
+    }
+
+    private ColumnDescriptor timestampColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(precision)
+                .build();
     }
 
     private DatabaseDialect timestampDialect() {
@@ -131,6 +287,7 @@ class StructuredTemporalPrecisionTest {
 
     private DatabaseDialect timeDialect() {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getMaxTimePrecision()).thenReturn(9);
         when(dialect.getDefaultTimestampPrecision()).thenReturn(6);
         when(dialect.getDefaultTimePrecision()).thenReturn(6);
         when(dialect.getJdbcTypeName(eq(Types.TIME), any(Size.class)))

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPrecisionTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalPrecisionTest.java
@@ -15,23 +15,33 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Types;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.util.stream.Stream;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.engine.jdbc.Size;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampSupport;
 import io.debezium.sink.SinkConnectorConfig;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.time.StructuredTime;
 import io.debezium.time.StructuredTimestamp;
+import io.debezium.time.StructuredZonedTime;
 import io.debezium.time.StructuredZonedTimestamp;
 
 @Tag("UnitTests")
@@ -201,6 +211,41 @@ class StructuredTemporalPrecisionTest {
                 .isEqualTo(LocalDateTime.of(2026, 7, 17, 12, 13, 15));
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("structuredTemporalRoundCases")
+    @DisplayName("Should apply the round contract to every structured temporal type")
+    void shouldRoundEveryStructuredTemporalType(String name, JdbcType type, Schema schema, Struct value,
+                                                ColumnDescriptor column, Object expected) {
+        final var capabilities = TargetTemporalCapabilities.defaults(9, 9)
+                .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.ROUND), temporalDialect(capabilities));
+
+        assertThat(type.bind(1, column, schema, value).get(0).getValue()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("structuredTemporalRoundCarryCases")
+    @DisplayName("Should carry rounded fractions for every structured temporal type")
+    void shouldCarryRoundForEveryStructuredTemporalType(String name, JdbcType type, Schema schema, Struct value,
+                                                        ColumnDescriptor column, Object expected) {
+        final var capabilities = TargetTemporalCapabilities.defaults(9, 9)
+                .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.ROUND), temporalDialect(capabilities));
+
+        assertThat(type.bind(1, column, schema, value).get(0).getValue()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("structuredTemporalDefaultRoundCases")
+    @DisplayName("Should apply the round contract to structured temporal defaults")
+    void shouldRoundEveryStructuredTemporalDefault(String name, JdbcType type, Schema schema, Struct value, String expected) {
+        final var capabilities = TargetTemporalCapabilities.defaults(6, 6)
+                .withZonedTimestampSupport(ZonedTimestampSupport.OFFSET);
+        type.configure(jdbcConfig(TemporalPrecisionLossHandlingMode.ROUND), temporalDialect(capabilities));
+
+        assertThat(type.getDefaultValueBinding(schema, value)).isEqualTo(expected);
+    }
+
     @Test
     @DisplayName("Should reject zoned timestamp metadata that the target cannot preserve")
     void shouldRejectUnsupportedZonedTimestampMetadata() {
@@ -262,16 +307,14 @@ class StructuredTemporalPrecisionTest {
     private DatabaseDialect temporalDialect(TargetTemporalCapabilities capabilities) {
         final DatabaseDialect dialect = mock(DatabaseDialect.class);
         when(dialect.getTargetTemporalCapabilities()).thenReturn(capabilities);
+        when(dialect.getMaxTimePrecision()).thenReturn(capabilities.maxTimePrecision());
+        when(dialect.getMaxTimestampPrecision()).thenReturn(capabilities.maxTimestampPrecision());
+        when(dialect.getDefaultTimePrecision()).thenReturn(capabilities.maxTimePrecision());
+        when(dialect.getDefaultTimestampPrecision()).thenReturn(capabilities.maxTimestampPrecision());
+        when(dialect.getFormattedTime(any())).thenAnswer(invocation -> invocation.getArgument(0).toString());
+        when(dialect.getFormattedDateTime(any())).thenAnswer(invocation -> invocation.getArgument(0).toString());
+        when(dialect.getFormattedTimeWithTimeZone(any(String.class))).thenAnswer(invocation -> invocation.getArgument(0));
         return dialect;
-    }
-
-    private ColumnDescriptor timestampColumn(int precision) {
-        return ColumnDescriptor.builder()
-                .columnName("ts")
-                .jdbcType(Types.TIMESTAMP)
-                .typeName("timestamp")
-                .scale(precision)
-                .build();
     }
 
     private DatabaseDialect timestampDialect() {
@@ -297,5 +340,90 @@ class StructuredTemporalPrecisionTest {
 
     private Integer size(Size size) {
         return size.getPrecision();
+    }
+
+    private static Stream<Arguments> structuredTemporalRoundCases() {
+        final var timeSchema = StructuredTime.builder(9).build();
+        final var timestampSchema = StructuredTimestamp.builder(9).build();
+        final var zonedTimeSchema = StructuredZonedTime.builder(9).build();
+        final var zonedTimestampSchema = StructuredZonedTimestamp.builder(9).build();
+        final var offset = ZoneOffset.ofHours(9);
+
+        return Stream.of(
+                Arguments.of("time", new StructuredTimeType(), timeSchema,
+                        StructuredTime.from(timeSchema, LocalTime.of(12, 13, 14, 123_456_789), 9), timeColumn(6),
+                        LocalTime.of(12, 13, 14, 123_457_000)),
+                Arguments.of("timestamp", new StructuredTimestampType(), timestampSchema,
+                        StructuredTimestamp.from(timestampSchema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9), timestampColumn(6),
+                        LocalDateTime.of(2026, 7, 17, 12, 13, 14, 123_457_000)),
+                Arguments.of("zoned time", new StructuredZonedTimeType(), zonedTimeSchema,
+                        StructuredZonedTime.from(zonedTimeSchema, OffsetTime.of(12, 13, 14, 123_456_789, offset), 9), timeColumn(6),
+                        OffsetTime.of(12, 13, 14, 123_457_000, offset)),
+                Arguments.of("zoned timestamp", new StructuredZonedTimestampType(), zonedTimestampSchema,
+                        StructuredZonedTimestamp.from(zonedTimestampSchema,
+                                OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 123_456_789, offset), null, 9),
+                        timestampColumn(6), OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 123_457_000, offset)));
+    }
+
+    private static Stream<Arguments> structuredTemporalRoundCarryCases() {
+        final var timeSchema = StructuredTime.builder(9).build();
+        final var timestampSchema = StructuredTimestamp.builder(9).build();
+        final var zonedTimeSchema = StructuredZonedTime.builder(9).build();
+        final var zonedTimestampSchema = StructuredZonedTimestamp.builder(9).build();
+        final var offset = ZoneOffset.ofHours(9);
+
+        return Stream.of(
+                Arguments.of("time", new StructuredTimeType(), timeSchema,
+                        StructuredTime.from(timeSchema, LocalTime.of(23, 59, 59, 999_999_600), 9), timeColumn(6), LocalTime.MIDNIGHT),
+                Arguments.of("timestamp", new StructuredTimestampType(), timestampSchema,
+                        StructuredTimestamp.from(timestampSchema, 2026, 7, 17, 23, 59, 59, 999_999_600, 9), timestampColumn(6),
+                        LocalDateTime.of(2026, 7, 18, 0, 0)),
+                Arguments.of("zoned time", new StructuredZonedTimeType(), zonedTimeSchema,
+                        StructuredZonedTime.from(zonedTimeSchema, OffsetTime.of(23, 59, 59, 999_999_600, offset), 9), timeColumn(6),
+                        OffsetTime.of(LocalTime.MIDNIGHT, offset)),
+                Arguments.of("zoned timestamp", new StructuredZonedTimestampType(), zonedTimestampSchema,
+                        StructuredZonedTimestamp.from(zonedTimestampSchema,
+                                OffsetDateTime.of(2026, 7, 17, 23, 59, 59, 999_999_600, offset), null, 9),
+                        timestampColumn(6), OffsetDateTime.of(2026, 7, 18, 0, 0, 0, 0, offset)));
+    }
+
+    private static Stream<Arguments> structuredTemporalDefaultRoundCases() {
+        final var timeSchema = StructuredTime.builder(9).build();
+        final var timestampSchema = StructuredTimestamp.builder(9).build();
+        final var zonedTimeSchema = StructuredZonedTime.builder(9).build();
+        final var zonedTimestampSchema = StructuredZonedTimestamp.builder(9).build();
+        final var offset = ZoneOffset.ofHours(9);
+
+        return Stream.of(
+                Arguments.of("time", new StructuredTimeType(), timeSchema,
+                        StructuredTime.from(timeSchema, LocalTime.of(12, 13, 14, 123_456_789), 9), "12:13:14.123457"),
+                Arguments.of("timestamp", new StructuredTimestampType(), timestampSchema,
+                        StructuredTimestamp.from(timestampSchema, 2026, 7, 17, 12, 13, 14, 123_456_789, 9),
+                        "2026-07-17T12:13:14.123457"),
+                Arguments.of("zoned time", new StructuredZonedTimeType(), zonedTimeSchema,
+                        StructuredZonedTime.from(zonedTimeSchema, OffsetTime.of(12, 13, 14, 123_456_789, offset), 9),
+                        "12:13:14.123457+09:00"),
+                Arguments.of("zoned timestamp", new StructuredZonedTimestampType(), zonedTimestampSchema,
+                        StructuredZonedTimestamp.from(zonedTimestampSchema,
+                                OffsetDateTime.of(2026, 7, 17, 12, 13, 14, 123_456_789, offset), null, 9),
+                        "2026-07-17T12:13:14.123457+09:00"));
+    }
+
+    private static ColumnDescriptor timeColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("time_value")
+                .jdbcType(Types.TIME)
+                .typeName("time")
+                .scale(precision)
+                .build();
+    }
+
+    private static ColumnDescriptor timestampColumn(int precision) {
+        return ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("timestamp")
+                .scale(precision)
+                .build();
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalRangeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalRangeTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.debezium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Types;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalPrecisionLossHandlingMode;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.TemporalRangeLossHandlingMode;
+import io.debezium.connector.jdbc.type.debezium.TargetTemporalCapabilities.ZonedTimestampRangeBasis;
+import io.debezium.connector.jdbc.type.debezium.TemporalRange.Boundary;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.time.StructuredDate;
+import io.debezium.time.StructuredTimestamp;
+
+@Tag("UnitTests")
+class StructuredTemporalRangeTest {
+
+    private static final TemporalRange STANDARD_TIMESTAMP_RANGE = TemporalRange.timestampYears(1, 9999);
+
+    @Test
+    @DisplayName("Should reject structured timestamps outside the target range by default")
+    void shouldRejectOutOfRangeTimestamp() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var value = StructuredTimestamp.from(schema, 12_000, 1, 1, 12, 13, 14, 123_456_000, 6);
+
+        assertThatThrownBy(() -> StructuredTemporalSupport.adjustTimestamp(
+                value, 6, TemporalPrecisionLossHandlingMode.FAIL, STANDARD_TIMESTAMP_RANGE,
+                TemporalRangeLossHandlingMode.FAIL, "target column 'ts' (timestamp)"))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("12000-01-01")
+                .hasMessageContaining("temporal.range.loss.handling.mode")
+                .hasMessageContaining("target column 'ts'");
+    }
+
+    @Test
+    @DisplayName("Should saturate after fractional precision reduction")
+    void shouldSaturateAfterPrecisionReduction() {
+        final var schema = StructuredTimestamp.builder(12).build();
+        final var value = StructuredTimestamp.fromPicoseconds(
+                schema, 9999, 12, 31, 23, 59, 59, 999_999_500_000L, 12);
+
+        final Boundary adjusted = StructuredTemporalSupport.adjustTimestamp(
+                value, 6, TemporalPrecisionLossHandlingMode.ROUND, STANDARD_TIMESTAMP_RANGE,
+                TemporalRangeLossHandlingMode.SATURATE, "target type 'timestamp(6)'");
+
+        assertThat(adjusted).isEqualTo(Boundary.timestamp(
+                9999, 12, 31, 23, 59, 59, 999_999_000_000L));
+    }
+
+    @Test
+    @DisplayName("Should saturate finite dates and infinity to the nearest boundary")
+    void shouldSaturateDateAndInfinity() {
+        final TemporalRange dateRange = TemporalRange.dateYears(1, 9999);
+        final var dateSchema = StructuredDate.schema();
+        final var timestampSchema = StructuredTimestamp.schema();
+
+        assertThat(StructuredTemporalSupport.adjustDate(
+                StructuredDate.from(dateSchema, 0, 12, 31), dateRange,
+                TemporalRangeLossHandlingMode.SATURATE, "target date")).isEqualTo(dateRange.minimum());
+        assertThat(StructuredTemporalSupport.adjustTimestamp(
+                StructuredTimestamp.positiveInfinity(timestampSchema), 6, TemporalPrecisionLossHandlingMode.FAIL,
+                STANDARD_TIMESTAMP_RANGE, TemporalRangeLossHandlingMode.SATURATE, "target timestamp"))
+                .isEqualTo(STANDARD_TIMESTAMP_RANGE.maximum().withPrecision(6));
+    }
+
+    @Test
+    @DisplayName("Should resolve actual column ranges and zoned timestamp range basis")
+    void shouldResolveActualTargetRange() {
+        final TemporalRange narrowRange = new TemporalRange(
+                Boundary.timestamp(1970, 1, 1, 0, 0, 1, 0),
+                Boundary.timestamp(2038, 1, 19, 3, 14, 7, 0));
+        final var capabilities = TargetTemporalCapabilities.defaults(6, 6)
+                .withTimestampRange(STANDARD_TIMESTAMP_RANGE)
+                .withTimestampRangeForType(narrowRange, "timestamp")
+                .withZonedTimestampRangeBasis(ZonedTimestampRangeBasis.LOCAL_AND_INSTANT);
+        final var column = ColumnDescriptor.builder()
+                .columnName("ts")
+                .jdbcType(Types.TIMESTAMP)
+                .typeName("TIMESTAMP(6)")
+                .scale(6)
+                .build();
+
+        assertThat(capabilities.targetTimestampRange(column)).isEqualTo(narrowRange);
+        assertThat(capabilities.targetZonedTimestampRange(null, 14 * 3_600).minimum())
+                .isEqualTo(Boundary.timestamp(1, 1, 1, 14, 0, 0, 0));
+        assertThat(capabilities.targetZonedTimestampRange(null, 14 * 3_600).maximum())
+                .isEqualTo(STANDARD_TIMESTAMP_RANGE.maximum());
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalRangeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/debezium/StructuredTemporalRangeTest.java
@@ -59,6 +59,32 @@ class StructuredTemporalRangeTest {
     }
 
     @Test
+    @DisplayName("Should apply range boundaries truncated to the target precision")
+    void shouldApplyRangeAtTargetPrecision() {
+        final var schema = StructuredTimestamp.builder(6).build();
+        final var maxAtMicros = StructuredTimestamp.from(schema, 9999, 12, 31, 23, 59, 59, 999_999_000, 6);
+
+        assertThat(StructuredTemporalSupport.adjustTimestamp(
+                maxAtMicros, 6, TemporalPrecisionLossHandlingMode.FAIL, STANDARD_TIMESTAMP_RANGE,
+                TemporalRangeLossHandlingMode.FAIL, "target type 'datetime(6)'"))
+                .isEqualTo(Boundary.timestamp(9999, 12, 31, 23, 59, 59, 999_999_000_000L));
+
+        assertThat(StructuredTemporalSupport.adjustTimestamp(
+                StructuredTimestamp.from(schema, 9999, 12, 31, 23, 59, 59, 0, 6), 0,
+                TemporalPrecisionLossHandlingMode.ROUND, STANDARD_TIMESTAMP_RANGE,
+                TemporalRangeLossHandlingMode.FAIL, "target type 'datetime'"))
+                .isEqualTo(Boundary.timestamp(9999, 12, 31, 23, 59, 59, 0));
+
+        // rounding the fraction up at precision 0 overflows past the truncated maximum
+        assertThatThrownBy(() -> StructuredTemporalSupport.adjustTimestamp(
+                maxAtMicros, 0, TemporalPrecisionLossHandlingMode.ROUND, STANDARD_TIMESTAMP_RANGE,
+                TemporalRangeLossHandlingMode.FAIL, "target type 'datetime'"))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("10000-01-01 00:00:00")
+                .hasMessageContaining("23:59:59]");
+    }
+
+    @Test
     @DisplayName("Should saturate finite dates and infinity to the nearest boundary")
     void shouldSaturateDateAndInfinity() {
         final TemporalRange dateRange = TemporalRange.dateYears(1, 9999);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -150,17 +150,17 @@ public class OracleValueConverters extends JdbcValueConverters {
             case OracleTypes.TIMESTAMPTZ:
             case OracleTypes.TIMESTAMPLTZ:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTimestamp.builder();
+                    return StructuredZonedTimestamp.builder(getTimePrecision(column));
                 }
                 return ZonedTimestamp.builder();
             case OracleTypes.INTERVALDS:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredDuration.builder();
+                    return StructuredDuration.builder(getTimePrecision(column), StructuredDuration.Kind.DAY_TIME);
                 }
                 return intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING ? Interval.builder() : MicroDuration.builder();
             case OracleTypes.INTERVALYM:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredDuration.builder();
+                    return StructuredDuration.builder(0, StructuredDuration.Kind.YEAR_MONTH);
                 }
                 return intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING ? Interval.builder() : MicroDuration.builder();
             case Types.STRUCT:

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
@@ -701,7 +701,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
 
         Struct after = (Struct) ((Struct) record.value()).get("after");
 
-        assertThat(after.schema().field("VAL_TS_PRECISION9").schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(after.schema().field("VAL_TS_PRECISION9").schema().name()).isEqualTo(StructuredTimestamp.schemaName(9));
         Struct timestamp = after.getStruct("VAL_TS_PRECISION9");
         assertThat(timestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(timestamp.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(2018);
@@ -712,7 +712,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
         assertThat(timestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 56);
         assertThat(timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(125_456_789_000L);
 
-        assertThat(after.schema().field("VAL_TSTZ").schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(after.schema().field("VAL_TSTZ").schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(6));
         Struct zonedTimestamp = after.getStruct("VAL_TSTZ");
         assertThat(zonedTimestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(zonedTimestamp.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(2018);
@@ -724,12 +724,14 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
         assertThat(zonedTimestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(7_891_000_000L);
         assertThat(zonedTimestamp.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(-39_600);
 
-        assertThat(after.schema().field("VAL_INT_YTM").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(after.schema().field("VAL_INT_YTM").schema().name())
+                .isEqualTo(StructuredDuration.schemaName(0, StructuredDuration.Kind.YEAR_MONTH));
         Struct yearMonth = after.getStruct("VAL_INT_YTM");
         assertThat(yearMonth.getInt32(StructuredTemporal.YEARS_FIELD)).isEqualTo(-3);
         assertThat(yearMonth.getInt32(StructuredTemporal.MONTHS_FIELD)).isEqualTo(-6);
 
-        assertThat(after.schema().field("VAL_INT_DTS").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(after.schema().field("VAL_INT_DTS").schema().name())
+                .isEqualTo(StructuredDuration.schemaName(2, StructuredDuration.Kind.DAY_TIME));
         Struct daySecond = after.getStruct("VAL_INT_DTS");
         assertThat(daySecond.getInt32(StructuredTemporal.DAYS_FIELD)).isEqualTo(-1);
         assertThat(daySecond.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-2);
@@ -768,7 +770,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
 
             final Struct after = (Struct) ((Struct) record.value()).get("after");
 
-            assertThat(after.schema().field("VAL_TS_PRECISION9_EDGE").schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+            assertThat(after.schema().field("VAL_TS_PRECISION9_EDGE").schema().name()).isEqualTo(StructuredTimestamp.schemaName(9));
             final Struct timestamp = after.getStruct("VAL_TS_PRECISION9_EDGE");
             assertThat(timestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
             assertThat(timestamp.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
@@ -779,7 +781,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
             assertThat(timestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
             assertThat(timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
 
-            assertThat(after.schema().field("VAL_TSTZ_EDGE").schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+            assertThat(after.schema().field("VAL_TSTZ_EDGE").schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(6));
             final Struct zonedTimestamp = after.getStruct("VAL_TSTZ_EDGE");
             assertThat(zonedTimestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
             assertThat(zonedTimestamp.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
@@ -791,12 +793,14 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
             assertThat(zonedTimestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
             assertThat(zonedTimestamp.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(50_400);
 
-            assertThat(after.schema().field("VAL_INT_YTM_EDGE").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+            assertThat(after.schema().field("VAL_INT_YTM_EDGE").schema().name())
+                    .isEqualTo(StructuredDuration.schemaName(0, StructuredDuration.Kind.YEAR_MONTH));
             final Struct yearMonth = after.getStruct("VAL_INT_YTM_EDGE");
             assertThat(yearMonth.getInt32(StructuredTemporal.YEARS_FIELD)).isEqualTo(-123);
             assertThat(yearMonth.getInt32(StructuredTemporal.MONTHS_FIELD)).isEqualTo(-11);
 
-            assertThat(after.schema().field("VAL_INT_DTS_EDGE").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+            assertThat(after.schema().field("VAL_INT_DTS_EDGE").schema().name())
+                    .isEqualTo(StructuredDuration.schemaName(9, StructuredDuration.Kind.DAY_TIME));
             final Struct daySecond = after.getStruct("VAL_INT_DTS_EDGE");
             assertThat(daySecond.getInt32(StructuredTemporal.DAYS_FIELD)).isEqualTo(-999);
             assertThat(daySecond.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-23);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
@@ -710,7 +710,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
         assertThat(timestamp.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 12);
         assertThat(timestamp.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 34);
         assertThat(timestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 56);
-        assertThat(timestamp.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(125_456_789);
+        assertThat(timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(125_456_789_000L);
 
         assertThat(after.schema().field("VAL_TSTZ").schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
         Struct zonedTimestamp = after.getStruct("VAL_TSTZ");
@@ -721,7 +721,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
         assertThat(zonedTimestamp.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 1);
         assertThat(zonedTimestamp.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 34);
         assertThat(zonedTimestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 56);
-        assertThat(zonedTimestamp.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(7_891_000);
+        assertThat(zonedTimestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(7_891_000_000L);
         assertThat(zonedTimestamp.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(-39_600);
 
         assertThat(after.schema().field("VAL_INT_YTM").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
@@ -735,7 +735,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
         assertThat(daySecond.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-2);
         assertThat(daySecond.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-3);
         assertThat(daySecond.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-4L);
-        assertThat(daySecond.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-560_000_000);
+        assertThat(daySecond.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-560_000_000_000L);
     }
 
     @Test
@@ -777,7 +777,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
             assertThat(timestamp.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
             assertThat(timestamp.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
             assertThat(timestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-            assertThat(timestamp.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_999);
+            assertThat(timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
 
             assertThat(after.schema().field("VAL_TSTZ_EDGE").schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
             final Struct zonedTimestamp = after.getStruct("VAL_TSTZ_EDGE");
@@ -788,7 +788,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
             assertThat(zonedTimestamp.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
             assertThat(zonedTimestamp.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
             assertThat(zonedTimestamp.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-            assertThat(zonedTimestamp.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_999);
+            assertThat(zonedTimestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
             assertThat(zonedTimestamp.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(50_400);
 
             assertThat(after.schema().field("VAL_INT_YTM_EDGE").schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
@@ -802,7 +802,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractAsyncEngineCon
             assertThat(daySecond.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-23);
             assertThat(daySecond.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-59);
             assertThat(daySecond.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-59L);
-            assertThat(daySecond.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-999_999_999);
+            assertThat(daySecond.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-999_999_999_000L);
         }
         finally {
             stopConnector();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
@@ -180,7 +180,7 @@ public class OracleValueConvertersTest {
         final Struct result = (Struct) convertersStructured.converter(column, field)
                 .convert(new TIMESTAMP(LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_999)));
 
-        assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.schemaName(9));
         assertThat(field.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9");
         assertThat(result.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(9);
@@ -208,7 +208,7 @@ public class OracleValueConvertersTest {
         final Struct result = (Struct) convertersStructured.converter(column, field)
                 .convert(new TIMESTAMPTZ(OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_999, ZoneOffset.ofHours(14))));
 
-        assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(9));
         assertThat(field.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9");
         assertThat(result.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(9);
@@ -236,7 +236,7 @@ public class OracleValueConvertersTest {
         final Struct yearMonth = (Struct) convertersStructured.converter(yearMonthColumn, yearMonthField)
                 .convert(new INTERVALYM("-123-11"));
 
-        assertThat(yearMonthField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(yearMonthField.schema().name()).isEqualTo(StructuredDuration.schemaName(0, StructuredDuration.Kind.YEAR_MONTH));
         assertThat(yearMonthField.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "0")
                 .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.YEAR_MONTH.getValue());
@@ -256,7 +256,7 @@ public class OracleValueConvertersTest {
         final Struct daySecond = (Struct) convertersStructured.converter(daySecondColumn, daySecondField)
                 .convert(new INTERVALDS("-999 23:59:59.999999999"));
 
-        assertThat(daySecondField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
+        assertThat(daySecondField.schema().name()).isEqualTo(StructuredDuration.schemaName(9, StructuredDuration.Kind.DAY_TIME));
         assertThat(daySecondField.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9")
                 .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.DAY_TIME.getValue());

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
@@ -181,7 +181,8 @@ public class OracleValueConvertersTest {
                 .convert(new TIMESTAMP(LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_999)));
 
         assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
-        assertThat(field.schema().parameters()).isNullOrEmpty();
+        assertThat(field.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9");
         assertThat(result.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(9);
         assertThat(result.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(result.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
@@ -190,7 +191,7 @@ public class OracleValueConvertersTest {
         assertThat(result.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(result.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(result.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(result.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_999);
+        assertThat(result.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
     }
 
     @Test
@@ -208,7 +209,8 @@ public class OracleValueConvertersTest {
                 .convert(new TIMESTAMPTZ(OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_999, ZoneOffset.ofHours(14))));
 
         assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
-        assertThat(field.schema().parameters()).isNullOrEmpty();
+        assertThat(field.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9");
         assertThat(result.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(9);
         assertThat(result.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(result.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
@@ -217,7 +219,7 @@ public class OracleValueConvertersTest {
         assertThat(result.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(result.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(result.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(result.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_999);
+        assertThat(result.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_999_000L);
         assertThat(result.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(50_400);
     }
 
@@ -235,7 +237,9 @@ public class OracleValueConvertersTest {
                 .convert(new INTERVALYM("-123-11"));
 
         assertThat(yearMonthField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
-        assertThat(yearMonthField.schema().parameters()).isNullOrEmpty();
+        assertThat(yearMonthField.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "0")
+                .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.YEAR_MONTH.getValue());
         assertThat(yearMonth.getInt32(StructuredTemporal.YEARS_FIELD)).isEqualTo(-123);
         assertThat(yearMonth.getInt32(StructuredTemporal.MONTHS_FIELD)).isEqualTo(-11);
         assertThat(yearMonth.getInt32(StructuredTemporal.DAYS_FIELD)).isZero();
@@ -253,13 +257,15 @@ public class OracleValueConvertersTest {
                 .convert(new INTERVALDS("-999 23:59:59.999999999"));
 
         assertThat(daySecondField.schema().name()).isEqualTo(StructuredDuration.SCHEMA_NAME);
-        assertThat(daySecondField.schema().parameters()).isNullOrEmpty();
+        assertThat(daySecondField.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "9")
+                .containsEntry(StructuredTemporal.DURATION_KIND_PARAMETER_KEY, StructuredDuration.Kind.DAY_TIME.getValue());
         assertThat(daySecond.getInt32(StructuredTemporal.PRECISION_FIELD)).isEqualTo(9);
         assertThat(daySecond.getInt32(StructuredTemporal.DAYS_FIELD)).isEqualTo(-999);
         assertThat(daySecond.getInt32(StructuredTemporal.HOURS_FIELD)).isEqualTo(-23);
         assertThat(daySecond.getInt32(StructuredTemporal.MINUTES_FIELD)).isEqualTo(-59);
         assertThat(daySecond.getInt64(StructuredTemporal.SECONDS_FIELD)).isEqualTo(-59L);
-        assertThat(daySecond.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(-999_999_999);
+        assertThat(daySecond.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(-999_999_999_000L);
     }
 
     private Field fieldFor(Column column) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -229,19 +229,19 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 return column.length() > 1 ? Bits.builder(column.length()) : SchemaBuilder.bool();
             case PgOid.INTERVAL:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredDuration.builder();
+                    return StructuredDuration.builder(getTimePrecision(column), StructuredDuration.Kind.MIXED);
                 }
                 return intervalMode == IntervalHandlingMode.STRING ? Interval.builder() : MicroDuration.builder();
             case PgOid.TIMESTAMPTZ:
                 // JDBC reports this as "timestamp" even though it's with tz, so we can't use the base class...
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTimestamp.builder();
+                    return StructuredZonedTimestamp.builder(getTimePrecision(column));
                 }
                 return ZonedTimestamp.builder();
             case PgOid.TIMETZ:
                 // JDBC reports this as "time" but this contains TZ information
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTime.builder();
+                    return StructuredZonedTime.builder(getTimePrecision(column));
                 }
                 return ZonedTime.builder();
             case PgOid.OID:
@@ -323,14 +323,14 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 return SchemaBuilder.array(temporalPrecisionMode.getTimeBuilder(getTimePrecision(column)).optional().build());
             case PgOid.TIMETZ_ARRAY:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return SchemaBuilder.array(StructuredZonedTime.builder().optional().build());
+                    return SchemaBuilder.array(StructuredZonedTime.builder(getTimePrecision(column)).optional().build());
                 }
                 return SchemaBuilder.array(ZonedTime.builder().optional().build());
             case PgOid.TIMESTAMP_ARRAY:
                 return SchemaBuilder.array(temporalPrecisionMode.getTimestampBuilder(getTimePrecision(column)).optional().build());
             case PgOid.TIMESTAMPTZ_ARRAY:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return SchemaBuilder.array(StructuredZonedTimestamp.builder().optional().build());
+                    return SchemaBuilder.array(StructuredZonedTimestamp.builder(getTimePrecision(column)).optional().build());
                 }
                 return SchemaBuilder.array(ZonedTimestamp.builder().optional().build());
             case PgOid.BYTEA_ARRAY:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
@@ -455,7 +455,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(StructuredDate.SCHEMA_NAME, after.schema().field("c_date").schema().name());
         assertStructuredSpecialValue(after.getStruct("c_date"), StructuredTemporal.POSITIVE_INFINITY);
 
-        assertEquals(StructuredTimestamp.SCHEMA_NAME, after.schema().field("c_timestamp6").schema().name());
+        assertEquals(StructuredTimestamp.schemaName(6), after.schema().field("c_timestamp6").schema().name());
         assertEquals("6", after.schema().field("c_timestamp6").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         Struct timestamp = after.getStruct("c_timestamp6");
         assertNull(timestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD));
@@ -467,11 +467,11 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(999_999_000_000L, timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
-        assertEquals(StructuredZonedTimestamp.SCHEMA_NAME, after.schema().field("c_timestamptz").schema().name());
+        assertEquals(StructuredZonedTimestamp.schemaName(6), after.schema().field("c_timestamptz").schema().name());
         assertEquals("6", after.schema().field("c_timestamptz").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         assertStructuredSpecialValue(after.getStruct("c_timestamptz"), StructuredTemporal.POSITIVE_INFINITY);
 
-        assertEquals(StructuredZonedTime.SCHEMA_NAME, after.schema().field("c_time").schema().name());
+        assertEquals(StructuredZonedTime.schemaName(6), after.schema().field("c_time").schema().name());
         assertEquals("6", after.schema().field("c_time").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         Struct zonedTime = after.getStruct("c_time");
         // '04:05:11 PST' (-08): STRUCTURED mode preserves the raw clock and the original offset (no UTC shift).
@@ -480,14 +480,14 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 11, zonedTime.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(-8 * 3600, zonedTime.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD));
 
-        assertEquals(StructuredTime.SCHEMA_NAME, after.schema().field("c_time_whtz").schema().name());
+        assertEquals(StructuredTime.schemaName(6), after.schema().field("c_time_whtz").schema().name());
         Struct time = after.getStruct("c_time_whtz");
         assertEquals((byte) 4, time.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 5, time.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 11, time.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(789_000_000_000L, time.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
-        assertEquals(StructuredDuration.SCHEMA_NAME, after.schema().field("c_interval").schema().name());
+        assertEquals(StructuredDuration.schemaName(6, StructuredDuration.Kind.MIXED), after.schema().field("c_interval").schema().name());
         assertEquals("6", after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         assertEquals(StructuredDuration.Kind.MIXED.getValue(),
                 after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.DURATION_KIND_PARAMETER_KEY));
@@ -579,7 +579,8 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(StructuredDate.SCHEMA_NAME, after.schema().field("c_date").schema().name());
         assertStructuredSpecialValue(after.getStruct("c_date"), StructuredTemporal.POSITIVE_INFINITY);
 
-        assertEquals(StructuredTimestamp.SCHEMA_NAME, after.schema().field("c_timestamp6").schema().name());
+        assertEquals(StructuredTimestamp.schemaName(6), after.schema().field("c_timestamp6").schema().name());
+        assertEquals("6", after.schema().field("c_timestamp6").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         final Struct timestamp = after.getStruct("c_timestamp6");
         assertNull(timestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD));
         assertEquals(294276, timestamp.getInt32(StructuredTemporal.YEAR_FIELD));
@@ -590,10 +591,12 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(999_999_000_000L, timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
-        assertEquals(StructuredZonedTimestamp.SCHEMA_NAME, after.schema().field("c_timestamptz").schema().name());
+        assertEquals(StructuredZonedTimestamp.schemaName(6), after.schema().field("c_timestamptz").schema().name());
+        assertEquals("6", after.schema().field("c_timestamptz").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         assertStructuredSpecialValue(after.getStruct("c_timestamptz"), StructuredTemporal.POSITIVE_INFINITY);
 
-        assertEquals(StructuredZonedTime.SCHEMA_NAME, after.schema().field("c_time").schema().name());
+        assertEquals(StructuredZonedTime.schemaName(6), after.schema().field("c_time").schema().name());
+        assertEquals("6", after.schema().field("c_time").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         final Struct zonedTime = after.getStruct("c_time");
         // '04:05:11 PST' (-08): STRUCTURED mode preserves the raw clock and the original offset (no UTC shift).
         assertEquals((byte) 4, zonedTime.getInt8(StructuredTemporal.HOUR_FIELD));
@@ -601,14 +604,17 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 11, zonedTime.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(-8 * 3600, zonedTime.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD));
 
-        assertEquals(StructuredTime.SCHEMA_NAME, after.schema().field("c_time_whtz").schema().name());
+        assertEquals(StructuredTime.schemaName(6), after.schema().field("c_time_whtz").schema().name());
         final Struct time = after.getStruct("c_time_whtz");
         assertEquals((byte) 4, time.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 5, time.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 11, time.getInt8(StructuredTemporal.SECOND_FIELD));
         assertEquals(789_000_000_000L, time.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
-        assertEquals(StructuredDuration.SCHEMA_NAME, after.schema().field("c_interval").schema().name());
+        assertEquals(StructuredDuration.schemaName(6, StructuredDuration.Kind.MIXED), after.schema().field("c_interval").schema().name());
+        assertEquals("6", after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
+        assertEquals(StructuredDuration.Kind.MIXED.getValue(),
+                after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.DURATION_KIND_PARAMETER_KEY));
         final Struct interval = after.getStruct("c_interval");
         assertEquals(1, interval.getInt32(StructuredTemporal.YEARS_FIELD));
         assertEquals(2, interval.getInt32(StructuredTemporal.MONTHS_FIELD));
@@ -648,7 +654,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         // 24:00:00+05:30 -> raw clock preserved (hour 24) with the original +05:30 offset.
         final Struct boundary = getAfter(read.get(0));
         assertEquals(31, boundary.get("c_id"));
-        assertEquals(StructuredZonedTime.SCHEMA_NAME, boundary.schema().field("c_time").schema().name());
+        assertEquals(StructuredZonedTime.schemaName(6), boundary.schema().field("c_time").schema().name());
         final Struct boundaryTime = boundary.getStruct("c_time");
         assertEquals((byte) 24, boundaryTime.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 0, boundaryTime.getInt8(StructuredTemporal.MINUTE_FIELD));

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresTemporalPrecisionHandlingIT.java
@@ -456,6 +456,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertStructuredSpecialValue(after.getStruct("c_date"), StructuredTemporal.POSITIVE_INFINITY);
 
         assertEquals(StructuredTimestamp.SCHEMA_NAME, after.schema().field("c_timestamp6").schema().name());
+        assertEquals("6", after.schema().field("c_timestamp6").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         Struct timestamp = after.getStruct("c_timestamp6");
         assertNull(timestamp.getString(StructuredTemporal.SPECIAL_VALUE_FIELD));
         assertEquals(294276, timestamp.getInt32(StructuredTemporal.YEAR_FIELD));
@@ -464,12 +465,14 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 23, timestamp.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(999_999_000, timestamp.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(999_999_000_000L, timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         assertEquals(StructuredZonedTimestamp.SCHEMA_NAME, after.schema().field("c_timestamptz").schema().name());
+        assertEquals("6", after.schema().field("c_timestamptz").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         assertStructuredSpecialValue(after.getStruct("c_timestamptz"), StructuredTemporal.POSITIVE_INFINITY);
 
         assertEquals(StructuredZonedTime.SCHEMA_NAME, after.schema().field("c_time").schema().name());
+        assertEquals("6", after.schema().field("c_time").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
         Struct zonedTime = after.getStruct("c_time");
         // '04:05:11 PST' (-08): STRUCTURED mode preserves the raw clock and the original offset (no UTC shift).
         assertEquals((byte) 4, zonedTime.getInt8(StructuredTemporal.HOUR_FIELD));
@@ -482,9 +485,12 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 4, time.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 5, time.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 11, time.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(789_000_000, time.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(789_000_000_000L, time.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         assertEquals(StructuredDuration.SCHEMA_NAME, after.schema().field("c_interval").schema().name());
+        assertEquals("6", after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.PRECISION_PARAMETER_KEY));
+        assertEquals(StructuredDuration.Kind.MIXED.getValue(),
+                after.schema().field("c_interval").schema().parameters().get(StructuredTemporal.DURATION_KIND_PARAMETER_KEY));
         Struct interval = after.getStruct("c_interval");
         assertEquals(1, interval.getInt32(StructuredTemporal.YEARS_FIELD));
         assertEquals(2, interval.getInt32(StructuredTemporal.MONTHS_FIELD));
@@ -492,7 +498,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(4, interval.getInt32(StructuredTemporal.HOURS_FIELD));
         assertEquals(5, interval.getInt32(StructuredTemporal.MINUTES_FIELD));
         assertEquals(6L, interval.getInt64(StructuredTemporal.SECONDS_FIELD));
-        assertEquals(789_000_000, interval.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(789_000_000_000L, interval.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         TestHelper.execute(
                 """
@@ -582,7 +588,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 23, timestamp.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 59, timestamp.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(999_999_000, timestamp.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(999_999_000_000L, timestamp.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         assertEquals(StructuredZonedTimestamp.SCHEMA_NAME, after.schema().field("c_timestamptz").schema().name());
         assertStructuredSpecialValue(after.getStruct("c_timestamptz"), StructuredTemporal.POSITIVE_INFINITY);
@@ -600,7 +606,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 4, time.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 5, time.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 11, time.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(789_000_000, time.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(789_000_000_000L, time.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         assertEquals(StructuredDuration.SCHEMA_NAME, after.schema().field("c_interval").schema().name());
         final Struct interval = after.getStruct("c_interval");
@@ -610,7 +616,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals(4, interval.getInt32(StructuredTemporal.HOURS_FIELD));
         assertEquals(5, interval.getInt32(StructuredTemporal.MINUTES_FIELD));
         assertEquals(6L, interval.getInt64(StructuredTemporal.SECONDS_FIELD));
-        assertEquals(789_000_000, interval.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(789_000_000_000L, interval.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
 
         stopConnector();
     }
@@ -647,7 +653,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 24, boundaryTime.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 0, boundaryTime.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 0, boundaryTime.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(0, boundaryTime.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(0, boundaryTime.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
         assertEquals(5 * 3600 + 30 * 60, boundaryTime.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD));
 
         // 13:51:30.123789+02:00 -> sub-second precision and the positive offset are both preserved.
@@ -657,7 +663,7 @@ public class PostgresTemporalPrecisionHandlingIT extends AbstractAsyncEngineConn
         assertEquals((byte) 13, fractionalTime.getInt8(StructuredTemporal.HOUR_FIELD));
         assertEquals((byte) 51, fractionalTime.getInt8(StructuredTemporal.MINUTE_FIELD));
         assertEquals((byte) 30, fractionalTime.getInt8(StructuredTemporal.SECOND_FIELD));
-        assertEquals(123_789_000, fractionalTime.getInt32(StructuredTemporal.NANOS_FIELD));
+        assertEquals(123_789_000_000L, fractionalTime.getInt64(StructuredTemporal.PICOSECONDS_FIELD));
         assertEquals(2 * 3600, fractionalTime.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD));
 
         stopConnector();

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
@@ -113,7 +113,7 @@ public class SqlServerValueConverters extends JdbcValueConverters {
                 return SpecialValueDecimal.builder(decimalMode, column.length(), column.scale().get());
             case microsoft.sql.Types.DATETIMEOFFSET:
                 if (temporalPrecisionMode == TemporalPrecisionMode.STRUCTURED) {
-                    return StructuredZonedTimestamp.builder();
+                    return StructuredZonedTimestamp.builder(getTimePrecision(column));
                 }
                 return ZonedTimestamp.builder();
             default:

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/AbstractSqlServerDatatypesTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/AbstractSqlServerDatatypesTest.java
@@ -185,39 +185,43 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractAsyncEngine
                             .toInstant())));
 
     private static final Schema STRUCTURED_DATE_SCHEMA = StructuredDate.builder().optional().build();
-    private static final Schema STRUCTURED_TIME_SCHEMA = StructuredTime.builder().optional().build();
-    private static final Schema STRUCTURED_TIMESTAMP_SCHEMA = StructuredTimestamp.builder().optional().build();
-    private static final Schema STRUCTURED_ZONED_TIMESTAMP_SCHEMA = StructuredZonedTimestamp.builder().optional().build();
+    private static final Schema STRUCTURED_TIME_2_SCHEMA = StructuredTime.builder(2).optional().build();
+    private static final Schema STRUCTURED_TIME_4_SCHEMA = StructuredTime.builder(4).optional().build();
+    private static final Schema STRUCTURED_TIME_7_SCHEMA = StructuredTime.builder(7).optional().build();
+    private static final Schema STRUCTURED_TIMESTAMP_0_SCHEMA = StructuredTimestamp.builder(0).optional().build();
+    private static final Schema STRUCTURED_TIMESTAMP_3_SCHEMA = StructuredTimestamp.builder(3).optional().build();
+    private static final Schema STRUCTURED_TIMESTAMP_7_SCHEMA = StructuredTimestamp.builder(7).optional().build();
+    private static final Schema STRUCTURED_ZONED_TIMESTAMP_7_SCHEMA = StructuredZonedTimestamp.builder(7).optional().build();
 
     private static final List<SchemaAndValueField> EXPECTED_DATE_TIME_AS_STRUCTURED = Arrays.asList(
             new SchemaAndValueField("val_date", STRUCTURED_DATE_SCHEMA,
                     StructuredDate.from(STRUCTURED_DATE_SCHEMA, LocalDate.of(2018, 7, 13))),
-            new SchemaAndValueField("val_time_p2", STRUCTURED_TIME_SCHEMA,
-                    StructuredTime.from(STRUCTURED_TIME_SCHEMA, LocalTime.of(10, 23, 45, 680_000_000), 2)),
-            new SchemaAndValueField("val_time", STRUCTURED_TIME_SCHEMA,
-                    StructuredTime.from(STRUCTURED_TIME_SCHEMA, LocalTime.of(10, 23, 45, 678_900_000), 4)),
-            new SchemaAndValueField("val_time_p7", STRUCTURED_TIME_SCHEMA,
-                    StructuredTime.from(STRUCTURED_TIME_SCHEMA, LocalTime.of(10, 23, 45, 678_901_200), 7)),
-            new SchemaAndValueField("val_datetime2", STRUCTURED_TIMESTAMP_SCHEMA,
-                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_SCHEMA, LocalDateTime.of(2018, 7, 13, 11, 23, 45, 340_000_000), 7)),
-            new SchemaAndValueField("val_datetimeoffset", STRUCTURED_ZONED_TIMESTAMP_SCHEMA,
-                    StructuredZonedTimestamp.from(STRUCTURED_ZONED_TIMESTAMP_SCHEMA, 2018, 7, 13, 12, 23, 45, 456_000_000, 39_600, null, 7)),
-            new SchemaAndValueField("val_datetime", STRUCTURED_TIMESTAMP_SCHEMA,
-                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_SCHEMA, LocalDateTime.of(2018, 7, 13, 13, 23, 45, 780_000_000), 3)),
-            new SchemaAndValueField("val_smalldatetime", STRUCTURED_TIMESTAMP_SCHEMA,
-                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_SCHEMA, LocalDateTime.of(2018, 7, 13, 14, 24, 0), 0)));
+            new SchemaAndValueField("val_time_p2", STRUCTURED_TIME_2_SCHEMA,
+                    StructuredTime.from(STRUCTURED_TIME_2_SCHEMA, LocalTime.of(10, 23, 45, 680_000_000), 2)),
+            new SchemaAndValueField("val_time", STRUCTURED_TIME_4_SCHEMA,
+                    StructuredTime.from(STRUCTURED_TIME_4_SCHEMA, LocalTime.of(10, 23, 45, 678_900_000), 4)),
+            new SchemaAndValueField("val_time_p7", STRUCTURED_TIME_7_SCHEMA,
+                    StructuredTime.from(STRUCTURED_TIME_7_SCHEMA, LocalTime.of(10, 23, 45, 678_901_200), 7)),
+            new SchemaAndValueField("val_datetime2", STRUCTURED_TIMESTAMP_7_SCHEMA,
+                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_7_SCHEMA, LocalDateTime.of(2018, 7, 13, 11, 23, 45, 340_000_000), 7)),
+            new SchemaAndValueField("val_datetimeoffset", STRUCTURED_ZONED_TIMESTAMP_7_SCHEMA,
+                    StructuredZonedTimestamp.from(STRUCTURED_ZONED_TIMESTAMP_7_SCHEMA, 2018, 7, 13, 12, 23, 45, 456_000_000, 39_600, null, 7)),
+            new SchemaAndValueField("val_datetime", STRUCTURED_TIMESTAMP_3_SCHEMA,
+                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_3_SCHEMA, LocalDateTime.of(2018, 7, 13, 13, 23, 45, 780_000_000), 3)),
+            new SchemaAndValueField("val_smalldatetime", STRUCTURED_TIMESTAMP_0_SCHEMA,
+                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_0_SCHEMA, LocalDateTime.of(2018, 7, 13, 14, 24, 0), 0)));
 
     private static final List<SchemaAndValueField> EXPECTED_DATE_TIME_EDGE_AS_STRUCTURED = Arrays.asList(
             new SchemaAndValueField("val_date_min", STRUCTURED_DATE_SCHEMA,
                     StructuredDate.from(STRUCTURED_DATE_SCHEMA, LocalDate.of(1, 1, 1))),
             new SchemaAndValueField("val_date_max", STRUCTURED_DATE_SCHEMA,
                     StructuredDate.from(STRUCTURED_DATE_SCHEMA, LocalDate.of(9999, 12, 31))),
-            new SchemaAndValueField("val_time_p7_edge", STRUCTURED_TIME_SCHEMA,
-                    StructuredTime.from(STRUCTURED_TIME_SCHEMA, LocalTime.of(23, 59, 59, 999_999_900), 7)),
-            new SchemaAndValueField("val_datetime2_edge", STRUCTURED_TIMESTAMP_SCHEMA,
-                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_SCHEMA, LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_900), 7)),
-            new SchemaAndValueField("val_datetimeoffset_edge", STRUCTURED_ZONED_TIMESTAMP_SCHEMA,
-                    StructuredZonedTimestamp.from(STRUCTURED_ZONED_TIMESTAMP_SCHEMA, 9999, 12, 31, 23, 59, 59, 999_999_900, 50_400, null, 7)));
+            new SchemaAndValueField("val_time_p7_edge", STRUCTURED_TIME_7_SCHEMA,
+                    StructuredTime.from(STRUCTURED_TIME_7_SCHEMA, LocalTime.of(23, 59, 59, 999_999_900), 7)),
+            new SchemaAndValueField("val_datetime2_edge", STRUCTURED_TIMESTAMP_7_SCHEMA,
+                    StructuredTimestamp.from(STRUCTURED_TIMESTAMP_7_SCHEMA, LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_900), 7)),
+            new SchemaAndValueField("val_datetimeoffset_edge", STRUCTURED_ZONED_TIMESTAMP_7_SCHEMA,
+                    StructuredZonedTimestamp.from(STRUCTURED_ZONED_TIMESTAMP_7_SCHEMA, 9999, 12, 31, 23, 59, 59, 999_999_900, 50_400, null, 7)));
 
     private static final List<SchemaAndValueField> EXPECTED_XML = Arrays.asList(
             new SchemaAndValueField("val_xml", Schema.OPTIONAL_STRING_SCHEMA, "<a>b</a>"));

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerValueConvertersTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerValueConvertersTest.java
@@ -67,10 +67,12 @@ class SqlServerValueConvertersTest {
                 .convert(LocalTime.of(23, 59, 59, 999_999_900));
 
         assertThat(field.schema().name()).isEqualTo(StructuredTime.SCHEMA_NAME);
+        assertThat(field.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_900);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_900_000L);
     }
 
     @Test
@@ -82,6 +84,8 @@ class SqlServerValueConvertersTest {
                 .convert(LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_900));
 
         assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(value.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
         assertThat(value.getInt8(StructuredTemporal.MONTH_FIELD)).isEqualTo((byte) 12);
@@ -89,7 +93,7 @@ class SqlServerValueConvertersTest {
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_900);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_900_000L);
     }
 
     @Test
@@ -102,6 +106,8 @@ class SqlServerValueConvertersTest {
                 .convert(DateTimeOffset.valueOf(Timestamp.from(timestamp.toInstant()), 14 * 60));
 
         assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().parameters())
+                .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
         assertThat(value.getInt32(StructuredTemporal.YEAR_FIELD)).isEqualTo(9999);
         assertThat(value.getInt8(StructuredTemporal.MONTH_FIELD)).isEqualTo((byte) 12);
@@ -109,7 +115,7 @@ class SqlServerValueConvertersTest {
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
         assertThat(value.getInt8(StructuredTemporal.MINUTE_FIELD)).isEqualTo((byte) 59);
         assertThat(value.getInt8(StructuredTemporal.SECOND_FIELD)).isEqualTo((byte) 59);
-        assertThat(value.getInt32(StructuredTemporal.NANOS_FIELD)).isEqualTo(999_999_900);
+        assertThat(value.getInt64(StructuredTemporal.PICOSECONDS_FIELD)).isEqualTo(999_999_900_000L);
         assertThat(value.getInt32(StructuredTemporal.OFFSET_SECONDS_FIELD)).isEqualTo(50_400);
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerValueConvertersTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerValueConvertersTest.java
@@ -66,7 +66,7 @@ class SqlServerValueConvertersTest {
         final Struct value = (Struct) converters.converter(column, field)
                 .convert(LocalTime.of(23, 59, 59, 999_999_900));
 
-        assertThat(field.schema().name()).isEqualTo(StructuredTime.SCHEMA_NAME);
+        assertThat(field.schema().name()).isEqualTo(StructuredTime.schemaName(7));
         assertThat(field.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getInt8(StructuredTemporal.HOUR_FIELD)).isEqualTo((byte) 23);
@@ -83,7 +83,7 @@ class SqlServerValueConvertersTest {
         final Struct value = (Struct) converters.converter(column, field)
                 .convert(LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_900));
 
-        assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().name()).isEqualTo(StructuredTimestamp.schemaName(7));
         assertThat(field.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();
@@ -105,7 +105,7 @@ class SqlServerValueConvertersTest {
         final Struct value = (Struct) converters.converter(column, field)
                 .convert(DateTimeOffset.valueOf(Timestamp.from(timestamp.toInstant()), 14 * 60));
 
-        assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.SCHEMA_NAME);
+        assertThat(field.schema().name()).isEqualTo(StructuredZonedTimestamp.schemaName(7));
         assertThat(field.schema().parameters())
                 .containsEntry(StructuredTemporal.PRECISION_PARAMETER_KEY, "7");
         assertThat(value.getString(StructuredTemporal.SPECIAL_VALUE_FIELD)).isNull();

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1904,7 +1904,8 @@ Represents timestamp values in UTC format, according to the ISO 8601 standard, f
 .`time.precision.mode=structured`
 Set the `time.precision.mode` property to `structured` to configure the connector to represent temporal values as Kafka Connect structs with separate calendar and clock components.
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
-Structured temporal values that have fractional seconds include an optional `precision` field that records the source column's fractional second precision.
+Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
+The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 .Mappings when `time.precision.mode` is `structured`
@@ -1922,19 +1923,19 @@ Contains `year`, `month`, and `day` fields.
 |`STRUCT`
 |`io.debezium.time.StructuredTime` +
  +
-Contains `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`TIMESTAMP`
 |`STRUCT`
 |`io.debezium.time.StructuredTimestamp` +
  +
-Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields. Timestamp precision up to 12 digits is preserved.
 
 |`TIMESTAMP WITH TIME ZONE`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTimestamp` +
  +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1906,6 +1906,7 @@ Set the `time.precision.mode` property to `structured` to configure the connecto
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
 Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
 The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
+To keep Avro named-record definitions with different metadata distinct, structured temporal schema names include their precision.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 .Mappings when `time.precision.mode` is `structured`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -660,9 +660,12 @@ For `io.debezium.time.StructuredZonedTimestamp`, the connector rejects a value i
 ====
 
 When a source connector uses `time.precision.mode=structured`, the `io.debezium.time.precision` schema parameter describes the source fractional-second precision.
+To keep Avro named-record definitions with different precision metadata distinct, the logical schema name includes a `Precision<P>` suffix, for example, `io.debezium.time.StructuredTimestampPrecision6`.
+If a source connector adds column-specific metadata, such as propagated source types or column comments, it also adds a source-column qualifier to prevent that metadata from redefining the same Avro named record.
 Structured temporal values store the fractional second in the `picoseconds` `INT64` field as a fixed picosecond value whose absolute magnitude is less than one second; duration values can be signed.
 This representation preserves source precisions up to 12 digits without relying on the nanosecond limit of Java temporal types.
 For `io.debezium.time.StructuredDuration`, the `io.debezium.time.duration.kind` schema parameter also identifies whether the source value represents elapsed time, a year-month interval, a day-time interval, or a mixed interval.
+Duration logical schema names also include the duration kind, for example, `io.debezium.time.StructuredDurationPrecision9DAY_TIME`.
 When it creates a target column, the JDBC sink uses the logical precision and duration metadata before the `__debezium.source.column.*` propagation parameters to determine the target type and precision.
 When it writes to an existing column, the connector instead validates the value against the actual target column metadata.
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -73,6 +73,10 @@ The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debez
 SingleStore supports a subset of WKT geospatial values.
 The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.
 
+For structured temporal values, SingleStore `DATE` and `DATETIME(6)` columns accept years from 1000 through 9999, while `TIMESTAMP(6)` columns use the narrower range from `1970-01-01 00:00:01.000000` through `2038-01-19 03:14:07.999999`.
+The connector applies xref:jdbc-property-temporal-range-loss-handling-mode[`temporal.range.loss.handling.mode`] before writing values outside these ranges.
+Because the default SingleStore data conversion compatibility level rejects zero dates, the connector also treats structured zero dates as out of range; use `saturate` to map them to the minimum finite target value.
+
 // Type: concept
 // Title: Using StarRocks as a sink target
 // ModuleID: debezium-jdbc-connector-using-starrocks-as-a-sink-target
@@ -99,6 +103,8 @@ StarRocks applies `ALTER TABLE` schema changes asynchronously; writes that arriv
 StarRocks has no `TIME` data type.
 The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.MicroTime`, and `io.debezium.time.NanoTime` logical values, and Kafka Connect `Time` values, to `VARCHAR` columns as `HH:mm:ss.ffffff` formatted strings.
 MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
+Structured `io.debezium.time.StructuredTime` values map to `VARCHAR(21)`, and `io.debezium.time.StructuredZonedTime` values map to `VARCHAR(32)`.
+These string mappings preserve up to 12 fractional-second digits, and the zoned mapping also preserves the original UTC offset.
 `io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
 StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
 Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
@@ -674,6 +680,8 @@ By default, the connector rejects an out-of-range value.
 You can use xref:jdbc-property-temporal-range-loss-handling-mode[`temporal.range.loss.handling.mode`] to map it to the nearest target boundary instead.
 When both precision and range reduction are necessary, the connector applies the precision policy first and then checks the resulting value against the target range.
 PostgreSQL positive and negative infinity values remain unchanged because PostgreSQL can represent them directly.
+CockroachDB preserves `DATE` infinity, but its timestamp types convert infinity to a finite boundary.
+The connector therefore treats structured timestamp infinity as a range loss for CockroachDB: `fail` rejects it, while `saturate` maps it to `-4714-11-24 00:00:00` or `294276-12-31 23:59:59.999999`.
 
 Db2 and Db2 iSeries timestamp targets support fractional-second precision up to 12 digits.
 For structured timestamp values, the connector binds the picosecond value as text and applies a server-side `TIMESTAMP(p)` cast, avoiding the nine-digit precision limit of standard JDBC temporal values.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -659,11 +659,12 @@ If the database does not support time with time zones, the mapping resolves to i
 For `io.debezium.time.StructuredZonedTimestamp`, the connector rejects a value if its non-zero offset or named region would be lost by the target database.
 ====
 
-When a source connector uses `temporal.precision.mode=structured`, the `io.debezium.time.precision` schema parameter describes the source fractional-second precision.
+When a source connector uses `time.precision.mode=structured`, the `io.debezium.time.precision` schema parameter describes the source fractional-second precision.
 Structured temporal values store the fractional second in the `picoseconds` `INT64` field as a fixed picosecond value whose absolute magnitude is less than one second; duration values can be signed.
 This representation preserves source precisions up to 12 digits without relying on the nanosecond limit of Java temporal types.
 For `io.debezium.time.StructuredDuration`, the `io.debezium.time.duration.kind` schema parameter also identifies whether the source value represents elapsed time, a year-month interval, a day-time interval, or a mixed interval.
-The JDBC sink uses this metadata before the `__debezium.source.column.*` propagation parameters when it creates a target column and validates values against an existing target column.
+When it creates a target column, the JDBC sink uses the logical precision and duration metadata before the `__debezium.source.column.*` propagation parameters to determine the target type and precision.
+When it writes to an existing column, the connector instead validates the value against the actual target column metadata.
 
 Before the connector generates or executes a DML statement, it verifies that the target column can represent each structured temporal value without an implicit loss of meaning.
 For example, a MySQL `TIME` target accepts only elapsed-time durations, so the connector rejects structured durations that include year, month, or day semantics.
@@ -671,6 +672,7 @@ The connector also rejects a structured zoned timestamp if the target cannot pre
 
 By default, the connector rejects fractional-second values only if the target precision would discard non-zero digits.
 You can use xref:jdbc-property-temporal-precision-loss-handling-mode[`temporal.precision.loss.handling.mode`] to explicitly truncate or round such values instead.
+Rounding chooses the nearest value, with halfway values rounded away from zero, and can carry into the next or previous second and date.
 The same policy applies when the connector renders structured temporal schema default values in generated DDL.
 
 The connector also verifies that structured date and timestamp values are within the range of the target data type.
@@ -680,8 +682,47 @@ By default, the connector rejects an out-of-range value.
 You can use xref:jdbc-property-temporal-range-loss-handling-mode[`temporal.range.loss.handling.mode`] to map it to the nearest target boundary instead.
 When both precision and range reduction are necessary, the connector applies the precision policy first and then checks the resulting value against the target range.
 PostgreSQL positive and negative infinity values remain unchanged because PostgreSQL can represent them directly.
+For a target that cannot represent infinity, `fail` rejects the value and `saturate` maps it to the corresponding finite boundary.
 CockroachDB preserves `DATE` infinity, but its timestamp types convert infinity to a finite boundary.
 The connector therefore treats structured timestamp infinity as a range loss for CockroachDB: `fail` rejects it, while `saturate` maps it to `-4714-11-24 00:00:00` or `294276-12-31 23:59:59.999999`.
+
+.Structured temporal target capabilities
+[cols="18%a,42%a,40%a",options="header"]
+|===
+|Target |Date and timestamp range |Other behavior
+
+|Db2 and Db2 iSeries
+|`DATE` and `TIMESTAMP` values use years 1 through 9999.
+|Timestamp precision up to 12 digits is preserved by text binding and a server-side cast.
+
+|MySQL
+|`DATE` and `DATETIME(6)` use years 1000 through 9999. The upper `DATETIME(6)` boundary is `9999-12-31 23:59:59.499999`. An existing `TIMESTAMP(6)` column uses `1970-01-01 00:00:01.000000` through `2038-01-19 03:14:07.499999`.
+|All-zero structured dates and timestamps are passed through when the target SQL mode permits them. `StructuredDuration` accepts only elapsed-time values.
+
+|PostgreSQL
+|The connector uses the PostgreSQL finite `DATE` and `TIMESTAMP` ranges.
+|Positive and negative infinity are preserved. Zoned timestamps support instant semantics; values with a non-zero offset or named region identifier are rejected to prevent metadata loss.
+
+|CockroachDB
+|`DATE` uses the PostgreSQL-compatible range. Timestamp values use `-4714-11-24 00:00:00` through `294276-12-31 23:59:59.999999`.
+|`DATE` infinity is preserved. Timestamp infinity is handled by xref:jdbc-property-temporal-range-loss-handling-mode[`temporal.range.loss.handling.mode`].
+
+|Oracle
+|`DATE` and timestamp values use years -4711 through 9999.
+|Timestamp precision is limited to 9 digits. Offsets are preserved, but named region identifiers are rejected.
+
+|SQL Server
+|`date` and `datetime2` values use years 1 through 9999. Existing `datetime` and `smalldatetime` columns use their narrower native ranges.
+|Timestamp precision is limited to 7 digits. Zoned timestamp validation checks both the local value and its instant; offsets are preserved, but named region identifiers are rejected.
+
+|SingleStore
+|`DATE` and `DATETIME(6)` use years 1000 through 9999. `TIMESTAMP(6)` uses `1970-01-01 00:00:01.000000` through `2038-01-19 03:14:07.999999`.
+|All-zero structured dates and timestamps are handled as range loss. `StructuredDuration` accepts only elapsed-time values.
+
+|StarRocks
+|`DATE` and `DATETIME` values use years 0 through 9999. `DATETIME` preserves up to 6 fractional digits.
+|`StructuredTime` and `StructuredZonedTime` use string-backed columns that preserve up to 12 fractional digits; the zoned form also preserves its offset.
+|===
 
 Db2 and Db2 iSeries timestamp targets support fractional-second precision up to 12 digits.
 For structured timestamp values, the connector binds the picosecond value as text and applies a server-side `TIMESTAMP(p)` cast, avoiding the nine-digit precision limit of standard JDBC temporal values.
@@ -1858,7 +1899,7 @@ The following options are available:
 
 `fail`:: Rejects the value if reducing its precision would discard non-zero fractional digits.
 `truncate`:: Discards fractional digits that exceed the target column precision.
-`round`:: Rounds the value to the target column precision.
+`round`:: Rounds the value to the nearest target column precision, with halfway values rounded away from zero. Rounding can carry into the next or previous second and date.
 
 |[[jdbc-property-temporal-range-loss-handling-mode]]<<jdbc-property-temporal-range-loss-handling-mode, `+temporal.range.loss.handling.mode+`>>
 |`fail`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -667,6 +667,14 @@ By default, the connector rejects fractional-second values only if the target pr
 You can use xref:jdbc-property-temporal-precision-loss-handling-mode[`temporal.precision.loss.handling.mode`] to explicitly truncate or round such values instead.
 The same policy applies when the connector renders structured temporal schema default values in generated DDL.
 
+The connector also verifies that structured date and timestamp values are within the range of the target data type.
+The supported range depends on the target dialect and, for an existing column, its actual data type.
+For example, MySQL `TIMESTAMP` and SQL Server `datetime` have narrower ranges than the default timestamp types that those dialects create.
+By default, the connector rejects an out-of-range value.
+You can use xref:jdbc-property-temporal-range-loss-handling-mode[`temporal.range.loss.handling.mode`] to map it to the nearest target boundary instead.
+When both precision and range reduction are necessary, the connector applies the precision policy first and then checks the resulting value against the target range.
+PostgreSQL positive and negative infinity values remain unchanged because PostgreSQL can represent them directly.
+
 Db2 and Db2 iSeries timestamp targets support fractional-second precision up to 12 digits.
 For structured timestamp values, the connector binds the picosecond value as text and applies a server-side `TIMESTAMP(p)` cast, avoiding the nine-digit precision limit of standard JDBC temporal values.
 
@@ -1843,6 +1851,14 @@ The following options are available:
 `fail`:: Rejects the value if reducing its precision would discard non-zero fractional digits.
 `truncate`:: Discards fractional digits that exceed the target column precision.
 `round`:: Rounds the value to the target column precision.
+
+|[[jdbc-property-temporal-range-loss-handling-mode]]<<jdbc-property-temporal-range-loss-handling-mode, `+temporal.range.loss.handling.mode+`>>
+|`fail`
+|Specifies how the connector handles a structured date or timestamp value that is outside the range of the target column.
+The following options are available:
+
+`fail`:: Rejects the value.
+`saturate`:: Maps a value below or above the supported range to the nearest target boundary. Different source values can therefore be stored as the same target value.
 
 |[[jdbc-property-delete-enabled]]<<jdbc-property-delete-enabled, `+delete.enabled+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -665,6 +665,7 @@ The connector also rejects a structured zoned timestamp if the target cannot pre
 
 By default, the connector rejects fractional-second values only if the target precision would discard non-zero digits.
 You can use xref:jdbc-property-temporal-precision-loss-handling-mode[`temporal.precision.loss.handling.mode`] to explicitly truncate or round such values instead.
+The same policy applies when the connector renders structured temporal schema default values in generated DDL.
 
 Db2 and Db2 iSeries timestamp targets support fractional-second precision up to 12 digits.
 For structured timestamp values, the connector binds the picosecond value as text and applies a server-side `TIMESTAMP(p)` cast, avoiding the nine-digit precision limit of standard JDBC temporal values.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -649,8 +649,25 @@ As a workaround, if you need a BOOLEAN data type for an Oracle 23 sink, add the 
 
 [IMPORTANT]
 ====
-If the database does not support time or timestamps with time zones, the mapping resolves to its equivalent without timezones.
+If the database does not support time with time zones, the mapping resolves to its equivalent without a time zone.
+For `io.debezium.time.StructuredZonedTimestamp`, the connector rejects a value if its non-zero offset or named region would be lost by the target database.
 ====
+
+When a source connector uses `temporal.precision.mode=structured`, the `io.debezium.time.precision` schema parameter describes the source fractional-second precision.
+Structured temporal values store the fractional second in the `picoseconds` `INT64` field as a fixed picosecond value whose absolute magnitude is less than one second; duration values can be signed.
+This representation preserves source precisions up to 12 digits without relying on the nanosecond limit of Java temporal types.
+For `io.debezium.time.StructuredDuration`, the `io.debezium.time.duration.kind` schema parameter also identifies whether the source value represents elapsed time, a year-month interval, a day-time interval, or a mixed interval.
+The JDBC sink uses this metadata before the `__debezium.source.column.*` propagation parameters when it creates a target column and validates values against an existing target column.
+
+Before the connector generates or executes a DML statement, it verifies that the target column can represent each structured temporal value without an implicit loss of meaning.
+For example, a MySQL `TIME` target accepts only elapsed-time durations, so the connector rejects structured durations that include year, month, or day semantics.
+The connector also rejects a structured zoned timestamp if the target cannot preserve its non-zero offset or region identifier.
+
+By default, the connector rejects fractional-second values only if the target precision would discard non-zero digits.
+You can use xref:jdbc-property-temporal-precision-loss-handling-mode[`temporal.precision.loss.handling.mode`] to explicitly truncate or round such values instead.
+
+Db2 and Db2 iSeries timestamp targets support fractional-second precision up to 12 digits.
+For structured timestamp values, the connector binds the picosecond value as text and applies a server-side `TIMESTAMP(p)` cast, avoiding the nine-digit precision limit of standard JDBC temporal values.
 
 
 
@@ -1816,6 +1833,15 @@ Use with caution where strong data consistency is required.
 |[[jdbc-property-use-time-zone]]<<jdbc-property-use-time-zone, `+use.time.zone+`>>
 |`UTC`
 |Specifies the timezone used when inserting JDBC temporal values.
+
+|[[jdbc-property-temporal-precision-loss-handling-mode]]<<jdbc-property-temporal-precision-loss-handling-mode, `+temporal.precision.loss.handling.mode+`>>
+|`fail`
+|Specifies how the connector handles a structured temporal value when its fractional-second precision exceeds the precision of the target column.
+The following options are available:
+
+`fail`:: Rejects the value if reducing its precision would discard non-zero fractional digits.
+`truncate`:: Discards fractional digits that exceed the target column precision.
+`round`:: Rounds the value to the target column precision.
 
 |[[jdbc-property-delete-enabled]]<<jdbc-property-delete-enabled, `+delete.enabled+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2495,6 +2495,7 @@ This mode avoids flattening high-precision temporal values into a single epoch-b
 Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
 The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
 For an interval, the `io.debezium.time.duration.kind` schema parameter is `day-time` for `INTERVAL DAY TO SECOND` and `year-month` for `INTERVAL YEAR TO MONTH`.
+To keep Avro named-record definitions with different metadata distinct, structured temporal schema names include their precision and, for durations, their duration kind.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [cols="25%a,20%a,55%a",options="header"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2492,7 +2492,9 @@ Represents the timestamp value in UTC format, according to the ISO 8601 standard
 
 When the `time.precision.mode` configuration property is set to `structured`, the connector maps temporal values to Kafka Connect structs with separate calendar and clock components.
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
-Structured temporal values that have fractional seconds include an optional `precision` field that records the source column's fractional second precision.
+Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
+The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
+For an interval, the `io.debezium.time.duration.kind` schema parameter is `day-time` for `INTERVAL DAY TO SECOND` and `year-month` for `INTERVAL YEAR TO MONTH`.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [cols="25%a,20%a,55%a",options="header"]
@@ -2503,37 +2505,37 @@ The {prodname} JDBC sink connector can consume these structured temporal schemas
 |`STRUCT`
 |`io.debezium.time.StructuredTimestamp` +
  +
-Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`INTERVAL DAY[(M)] TO SECOND`
 |`STRUCT`
 |`io.debezium.time.StructuredDuration` +
  +
-Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `nanos`, and optional `precision` fields.
+Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `picoseconds`, and optional `precision` fields. The duration kind is `day-time`.
 
 |`INTERVAL YEAR[(M)] TO MONTH`
 |`STRUCT`
 |`io.debezium.time.StructuredDuration` +
  +
-Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `nanos`, and optional `precision` fields.
+Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `picoseconds`, and optional `precision` fields. The duration kind is `year-month`.
 
 |`TIMESTAMP(0 - 9)`
 |`STRUCT`
 |`io.debezium.time.StructuredTimestamp` +
  +
-Contains calendar and clock component fields with nanosecond precision and optional `precision`.
+Contains calendar and clock component fields, including `picoseconds`, with source precision up to 9 digits and optional `precision`.
 
 |`TIMESTAMP WITH TIME ZONE`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTimestamp` +
  +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`.
 
 |`TIMESTAMP WITH LOCAL TIME ZONE`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTimestamp` +
  +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2004,7 +2004,9 @@ If the source schema may contain values outside the representable range, use `ti
 Set the `time.precision.mode` property to `structured` to configure the connector to represent temporal values as Kafka Connect structs with separate calendar and clock components.
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
 PostgreSQL `infinity` and `-infinity` values are represented by the `specialValue` field instead of by finite sentinel timestamps.
-Structured temporal values that have fractional seconds include an optional `precision` field that records the source column's fractional second precision.
+Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
+The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
+For an `INTERVAL` column, the `io.debezium.time.duration.kind` schema parameter is `mixed` because PostgreSQL intervals can combine year-month and day-time components.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [NOTE]
@@ -2032,31 +2034,31 @@ Contains `year`, `month`, and `day` fields. PostgreSQL `infinity` and `-infinity
 |`STRUCT`
 |`io.debezium.time.StructuredTime` +
  +
-Contains `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`TIMESTAMP([P])`
 |`STRUCT`
 |`io.debezium.time.StructuredTimestamp` +
  +
-Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `nanos`, and optional `precision` fields. PostgreSQL `infinity` and `-infinity` values are represented as `specialValue`.
+Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields. PostgreSQL `infinity` and `-infinity` values are represented as `specialValue`.
 
 |`TIMETZ`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTime` +
  +
-Contains clock component fields, an `offsetSeconds` field, and an optional `precision` field.
+Contains clock component fields, `picoseconds`, `offsetSeconds`, and optional `precision` fields.
 
 |`TIMESTAMPTZ`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTimestamp` +
  +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`. PostgreSQL `infinity` and `-infinity` values are represented as `specialValue`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`. PostgreSQL `infinity` and `-infinity` values are represented as `specialValue`.
 
 |`INTERVAL`
 |`STRUCT`
 |`io.debezium.time.StructuredDuration` +
  +
-Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `nanos`, and optional `precision` fields.
+Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `picoseconds`, and optional `precision` fields. The duration kind is `mixed`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2007,6 +2007,7 @@ PostgreSQL `infinity` and `-infinity` values are represented by the `specialValu
 Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
 The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
 For an `INTERVAL` column, the `io.debezium.time.duration.kind` schema parameter is `mixed` because PostgreSQL intervals can combine year-month and day-time components.
+To keep Avro named-record definitions with different metadata distinct, structured temporal schema names include their precision and, for durations, their duration kind.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [NOTE]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1863,7 +1863,8 @@ Represents timestamp values in UTC format, according to the ISO 8601 standard, f
 
 When the `time.precision.mode` configuration property is set to `structured`, the connector maps temporal values to Kafka Connect structs with separate calendar and clock components.
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
-Structured temporal values that have fractional seconds include an optional `precision` field that records the source column's fractional second precision.
+Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
+The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [cols="30%a,25%a,45%a",options="header"]
@@ -1882,19 +1883,19 @@ Contains `year`, `month`, and `day` fields.
 |`STRUCT`
 |`io.debezium.time.StructuredTime` +
  +
-Contains `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`DATETIME`, `SMALLDATETIME`, `DATETIME2`
 |`STRUCT`
 |`io.debezium.time.StructuredTimestamp` +
  +
-Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`DATETIMEOFFSET`
 |`STRUCT`
 |`io.debezium.time.StructuredZonedTimestamp` +
  +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1865,6 +1865,7 @@ When the `time.precision.mode` configuration property is set to `structured`, th
 This mode avoids flattening high-precision temporal values into a single epoch-based integer.
 Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
 The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
+To keep Avro named-record definitions with different metadata distinct, structured temporal schema names include their precision.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 
 [cols="30%a,25%a,45%a",options="header"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2078,7 +2078,9 @@ Use `time.precision.mode=microseconds` (or `isostring`) to avoid the limitation.
 time.precision.mode=structured::
 The {connector-name} connector represents temporal values as Kafka Connect structs with separate calendar and clock components.
 This mode can preserve zero and invalid temporal components without converting them to epoch-based numeric values.
-Structured temporal values that have fractional seconds include an optional `precision` field that records the source column's fractional second precision.
+Structured temporal values store fractional seconds in an optional `picoseconds` `INT64` field.
+The optional `precision` value field and the `io.debezium.time.precision` schema parameter record the source column's fractional-second precision.
+For a `TIME` column, the `io.debezium.time.duration.kind` schema parameter is `elapsed-time`.
 The {prodname} JDBC sink connector can consume these structured temporal schemas directly and maps them according to the target database dialect.
 +
 .Mappings when `time.precision.mode=structured`
@@ -2094,17 +2096,17 @@ Contains `year`, `month`, and `day` fields.
 |`TIME[(M)]`
 |`STRUCT`
 a|`io.debezium.time.StructuredDuration` +
-Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `nanos`, and optional `precision` fields.
+Contains signed `years`, `months`, `days`, `hours`, `minutes`, `seconds`, `picoseconds`, and optional `precision` fields. The duration kind is `elapsed-time`.
 
 |`DATETIME[(M)]`
 |`STRUCT`
 a|`io.debezium.time.StructuredTimestamp` +
-Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `nanos`, and optional `precision` fields.
+Contains `year`, `month`, `day`, `hour`, `minute`, `second`, `picoseconds`, and optional `precision` fields.
 
 |`TIMESTAMP[(M)]`
 |`STRUCT`
 a|`io.debezium.time.StructuredZonedTimestamp` +
-Contains calendar and clock component fields, `offsetSeconds`, optional `zoneId`, and optional `precision`.
+Contains calendar and clock component fields, `picoseconds`, `offsetSeconds`, optional `zoneId`, and optional `precision`.
 
 |===
 end::temporal-data-types[]


### PR DESCRIPTION
Follow-up to #7554.

## Summary

- Represent structured fractional seconds as picoseconds and add precision and duration-kind schema metadata.
- Validate target precision, duration semantics, zoned timestamp metadata, and temporal ranges before JDBC writes, with explicit `truncate`, `round`, `fail`, and `saturate` policies.
- Model target support for date and timestamp infinity and zero dates, so PostgreSQL and MySQL special values are preserved only by compatible targets.
- Add explicit CockroachDB and SingleStore temporal bounds, including CockroachDB finite timestamp handling and SingleStore `DATE`, `DATETIME`, and `TIMESTAMP` limits.
- Preserve StarRocks `StructuredTime` and `StructuredZonedTime` values through p12 and retain the original offset by using string-backed target columns.
- Preserve Db2 and Db2i timestamp precision through p12 using text binding and a server-side cast.

## Testing

- Focused source converter and structured temporal tests, including the CockroachDB, SingleStore, and StarRocks dialect tests.
- Full JDBC unit and architecture tests (378 tests).
- Formatting, checkstyle, compilation, and verification for all changed modules.
- Added integration coverage for CockroachDB, SingleStore, StarRocks, and Db2. CockroachDB passed locally; StarRocks container startup timed out, while the SingleStore and Db2 images have no arm64 manifest, so those tests are left to CI.
