### PR TITLE
debezium/dbz#2236 Add signal id and data collection attribution to incremental snapshot watermark metadata

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -160,6 +160,7 @@ Collin Van Dyck
 Connor Szczepaniak
 Conor Gallagher
 Cory Harper
+Cuong Dang
 Cyprien Etienne
 Cyril Scetbon
 Daan Gerits

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -90,6 +90,14 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     private boolean schemaVerificationPassed;
 
+    /**
+     * The id of the signal that most recently added data collections to this context. When a further
+     * signal arrives while a snapshot is running, this field is overwritten although collections queued
+     * by earlier signals are still pending — so it only identifies the latest request (that is what the
+     * notifications report). For per-chunk attribution the canonical value is the requesting signal's id
+     * carried by each collection, {@link DataCollection#getCorrelationId()}, which is what the watermark
+     * metadata uses.
+     */
     private String correlationId;
 
     /**
@@ -217,7 +225,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
         LOGGER.trace("Adding data collections names {} to snapshot", dataCollectionIds);
         final List<DataCollection<T>> newDataCollectionIds = dataCollectionIds.stream()
-                .map(buildDataCollection(additionalCondition, surrogateKey))
+                .map(buildDataCollection(additionalCondition, surrogateKey, correlationId))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
@@ -226,7 +234,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         return newDataCollectionIds;
     }
 
-    private Function<String, Optional<DataCollection<T>>> buildDataCollection(List<AdditionalCondition> additionalCondition, String surrogateKey) {
+    private Function<String, Optional<DataCollection<T>>> buildDataCollection(List<AdditionalCondition> additionalCondition, String surrogateKey,
+                                                                              String correlationId) {
         return expandedCollectionName -> {
             String filter = additionalCondition.stream()
                     .filter(condition -> condition.getDataCollection().matcher(expandedCollectionName).matches())
@@ -235,7 +244,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                     .orElse("");
             try {
                 TableId parsedTable = TableId.parse(expandedCollectionName, useCatalogBeforeSchema);
-                return Optional.of(new DataCollection<T>((T) parsedTable, filter, surrogateKey));
+                return Optional.of(new DataCollection<T>((T) parsedTable, filter, surrogateKey, correlationId));
             }
             catch (Exception e) {
                 LOGGER.warn("Unable to parse table identifier from {}. Skipping it.", expandedCollectionName);
@@ -395,6 +404,10 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
         public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
                 + "_surrogate_key";
+
+        public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
+                + "_correlation_id";
+
         private final ObjectMapper mapper = new ObjectMapper();
         private final TypeReference<List<LinkedHashMap<String, String>>> mapperTypeRef = new TypeReference<>() {
         };
@@ -465,6 +478,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, context.getPredicateBasedTableIdForId((TableId) x.getId()).toString());
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID, x.getCorrelationId().orElse(null));
                             return map;
                         })
                         .collect(Collectors.toList());
@@ -482,7 +496,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 return dataCollections.stream()
                         .map(x -> new DataCollection<>((T) context.getPredicateBasedTableIdForString(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID)),
                                 Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)).orElse(""),
-                                Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY)).orElse("")))
+                                Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY)).orElse(""),
+                                x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID)))
                         .collect(Collectors.toList());
             }
             catch (JsonProcessingException e) {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
@@ -24,17 +24,29 @@ public class DataCollection<T> {
 
     private final String surrogateKey;
 
+    /**
+     * The id of the signal that requested snapshotting of this data collection, if any.
+     * Kept per data collection because collections requested by different signals can be
+     * queued in the same incremental snapshot context.
+     */
+    private final String correlationId;
+
     public DataCollection(T id) {
-        this(id, "", "");
+        this(id, "", "", null);
     }
 
     public DataCollection(T id, String additionalCondition, String surrogateKey) {
+        this(id, additionalCondition, surrogateKey, null);
+    }
+
+    public DataCollection(T id, String additionalCondition, String surrogateKey, String correlationId) {
         Objects.requireNonNull(additionalCondition);
         Objects.requireNonNull(surrogateKey);
 
         this.id = id;
         this.additionalCondition = additionalCondition;
         this.surrogateKey = surrogateKey;
+        this.correlationId = correlationId;
     }
 
     public T getId() {
@@ -49,6 +61,10 @@ public class DataCollection<T> {
 
     public Optional<String> getSurrogateKey() {
         return Strings.isNullOrEmpty(surrogateKey) ? Optional.empty() : Optional.of(surrogateKey);
+    }
+
+    public Optional<String> getCorrelationId() {
+        return Strings.isNullOrEmpty(correlationId) ? Optional.empty() : Optional.of(correlationId);
     }
 
     @Override
@@ -74,6 +90,7 @@ public class DataCollection<T> {
                 "id=" + id +
                 ", additionalCondition=" + additionalCondition +
                 ", surrogateKey=" + surrogateKey +
+                ", correlationId=" + correlationId +
                 '}';
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
@@ -148,7 +148,16 @@ public class SignalBasedIncrementalSnapshotChangeEventSource<P extends Partition
 
     private void insertOpenWindow(String signalTableName) throws SQLException {
         String signalWindowStatement = "INSERT INTO " + signalTableName + " VALUES (?, ?, ?)";
-        signalMetadata = new SignalMetadata(Instant.now(), null);
+        // Attribution is captured here and reused for the close, because the data collection queue
+        // may already have advanced to the next collection by the time the close is emitted.
+        final DataCollection<T> currentDataCollection = context.currentDataCollectionId();
+        String correlationId = null;
+        String dataCollectionId = null;
+        if (currentDataCollection != null) {
+            correlationId = currentDataCollection.getCorrelationId().orElse(null);
+            dataCollectionId = currentDataCollection.getId().identifier();
+        }
+        signalMetadata = new SignalMetadata(Instant.now(), null, correlationId, dataCollectionId);
         jdbcConnection.prepareUpdate(signalWindowStatement, x -> {
             LOGGER.trace("Emitting open window for chunk = '{}' to signal table '{}'", context.currentChunkId(), signalTableName);
             x.setString(1, context.currentChunkId() + "-open");
@@ -177,6 +186,6 @@ public class SignalBasedIncrementalSnapshotChangeEventSource<P extends Partition
             return new DeleteWindowCloser<>(jdbcConnection, signalTable, this);
         }
 
-        return new InsertWindowCloser(jdbcConnection, signalTable, new SignalMetadata(signalMetadata.getOpenWindowTimestamp(), Instant.now()));
+        return new InsertWindowCloser(jdbcConnection, signalTable, signalMetadata.withCloseWindowTimestamp(Instant.now()));
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalMetadata.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalMetadata.java
@@ -5,7 +5,18 @@
  */
 package io.debezium.pipeline.source.snapshot.incremental;
 
+import java.io.IOException;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import io.debezium.DebeziumException;
 
 /**
  * Signal metadata for the incremental snapshotting
@@ -13,19 +24,67 @@ import java.time.Instant;
  * @author Anisha Mohanty
  */
 public class SignalMetadata {
+
+    /**
+     * Writes the metadata JSON with a space after {@code :} and {@code ,}, matching the format
+     * emitted by previous versions, with Jackson handling the escaping of field values.
+     */
+    private static final ObjectWriter WRITER = new ObjectMapper().writer(new LegacySpacingPrettyPrinter());
+
     private final Instant openWindowTimestamp;
     private final Instant closeWindowTimestamp;
 
+    /**
+     * The id of the signal that requested the snapshot of the data collection this window belongs to,
+     * so downstream consumers of the watermark events can attribute a window to the snapshot request
+     * that caused it. May be {@code null} for snapshots resumed from offsets written by older versions.
+     */
+    private final String correlationId;
+
+    /**
+     * The fully-qualified identifier of the data collection this window's chunk belongs to.
+     */
+    private final String dataCollectionId;
+
     public SignalMetadata(Instant openWindowTimestamp, Instant closeWindowTimestamp) {
+        this(openWindowTimestamp, closeWindowTimestamp, null, null);
+    }
+
+    public SignalMetadata(Instant openWindowTimestamp, Instant closeWindowTimestamp, String correlationId, String dataCollectionId) {
         this.openWindowTimestamp = openWindowTimestamp;
         this.closeWindowTimestamp = closeWindowTimestamp;
+        this.correlationId = correlationId;
+        this.dataCollectionId = dataCollectionId;
+    }
+
+    /**
+     * Returns a copy of this metadata with the given close-window timestamp, carrying every other field forward.
+     */
+    public SignalMetadata withCloseWindowTimestamp(Instant closeWindowTimestamp) {
+        return new SignalMetadata(openWindowTimestamp, closeWindowTimestamp, correlationId, dataCollectionId);
     }
 
     public String metadataString() {
-        if (closeWindowTimestamp == null) {
-            return String.format("{\"openWindowTimestamp\": \"%s\"}", openWindowTimestamp);
+        final Map<String, String> fields = new LinkedHashMap<>();
+        if (openWindowTimestamp != null) {
+            fields.put("openWindowTimestamp", openWindowTimestamp.toString());
         }
-        return String.format("{\"openWindowTimestamp\": \"%s\", \"closeWindowTimestamp\": \"%s\"}", openWindowTimestamp, closeWindowTimestamp);
+        if (closeWindowTimestamp != null) {
+            fields.put("closeWindowTimestamp", closeWindowTimestamp.toString());
+        }
+        if (correlationId != null) {
+            fields.put("correlationId", correlationId);
+        }
+        if (dataCollectionId != null) {
+            fields.put("dataCollectionId", dataCollectionId);
+        }
+        try {
+            return WRITER.writeValueAsString(fields);
+        }
+        catch (JsonProcessingException e) {
+            // Not reachable for a flat map of non-null strings; declared because the exception is checked
+            throw new DebeziumException("Cannot serialize signal metadata", e);
+        }
     }
 
     public Instant getOpenWindowTimestamp() {
@@ -34,5 +93,26 @@ public class SignalMetadata {
 
     public Instant getCloseWindowTimestamp() {
         return closeWindowTimestamp;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public String getDataCollectionId() {
+        return dataCollectionId;
+    }
+
+    private static class LegacySpacingPrettyPrinter extends MinimalPrettyPrinter {
+
+        @Override
+        public void writeObjectFieldValueSeparator(JsonGenerator generator) throws IOException {
+            generator.writeRaw(": ");
+        }
+
+        @Override
+        public void writeObjectEntrySeparator(JsonGenerator generator) throws IOException {
+            generator.writeRaw(", ");
+        }
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSourceTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.signal.actions.snapshotting.CloseIncrementalSnapshotWindow;
+import io.debezium.pipeline.signal.actions.snapshotting.OpenIncrementalSnapshotWindow;
+import io.debezium.relational.ColumnFilterMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.TableId;
+
+/**
+ * Verifies that the open/close watermark rows written to the signal table carry the id of the
+ * signal that requested the snapshot and the data collection the chunk belongs to.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SignalBasedIncrementalSnapshotChangeEventSourceTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JdbcConnection jdbcConnection;
+    private List<Map<Integer, String>> signalInserts;
+    private SignalBasedIncrementalSnapshotChangeEventSource<TestPartition, TableId> source;
+    private SignalBasedIncrementalSnapshotContext<TableId> context;
+
+    interface TestPartition extends io.debezium.pipeline.spi.Partition {
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        jdbcConnection = mock(JdbcConnection.class);
+        signalInserts = new ArrayList<>();
+        when(jdbcConnection.quotedTableIdString(any())).thenReturn("debezium.signal");
+        when(jdbcConnection.prepareUpdate(anyString(), any(JdbcConnection.StatementPreparer.class))).thenAnswer(invocation -> {
+            final Map<Integer, String> row = new HashMap<>();
+            final PreparedStatement statement = mock(PreparedStatement.class);
+            doAnswer(setter -> row.put(setter.getArgument(0), setter.getArgument(1)))
+                    .when(statement).setString(anyInt(), any());
+            invocation.getArgument(1, JdbcConnection.StatementPreparer.class).accept(statement);
+            signalInserts.add(row);
+            return jdbcConnection;
+        });
+
+        source = new SignalBasedIncrementalSnapshotChangeEventSource<>(config(), jdbcConnection, null, null, null, null, null, null);
+        context = new SignalBasedIncrementalSnapshotContext<>();
+        source.context = context;
+    }
+
+    private RelationalDatabaseConnectorConfig config() {
+        final Configuration configuration = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                .build();
+        return new RelationalDatabaseConnectorConfig(configuration, null, null, 0, ColumnFilterMode.CATALOG, true) {
+            @Override
+            protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+                return null;
+            }
+
+            @Override
+            public String getContextName() {
+                return null;
+            }
+
+            @Override
+            public String getConnectorName() {
+                return null;
+            }
+
+            @Override
+            public EnumeratedValue getSnapshotMode() {
+                return null;
+            }
+
+            @Override
+            public Optional<EnumeratedValue> getSnapshotLockingMode() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @Test
+    public void shouldAttributeWatermarksToSignalAndDataCollection() throws Exception {
+        context.addDataCollectionNamesToSnapshot("signal-1", List.of("public.a"), List.of(), "");
+        context.addDataCollectionNamesToSnapshot("signal-2", List.of("public.b"), List.of(), "");
+
+        context.startNewChunk();
+        source.emitWindowOpen(null, null);
+
+        assertThat(signalInserts).hasSize(1);
+        assertThat(signalInserts.get(0).get(1)).isEqualTo(context.currentChunkId() + "-open");
+        assertThat(signalInserts.get(0).get(2)).isEqualTo(OpenIncrementalSnapshotWindow.NAME);
+        JsonNode metadata = mapper.readTree(signalInserts.get(0).get(3));
+        assertThat(metadata.get("correlationId").asText()).isEqualTo("signal-1");
+        assertThat(metadata.get("dataCollectionId").asText()).isEqualTo("public.a");
+
+        // The queue advances to the next data collection before the close of the current data
+        // collection's last chunk is emitted; the close must keep the attribution captured at open.
+        final String chunkId = context.currentChunkId();
+        context.nextDataCollection();
+        source.emitWindowClose(null, null);
+
+        assertThat(signalInserts).hasSize(2);
+        assertThat(signalInserts.get(1).get(1)).isEqualTo(chunkId + "-close");
+        assertThat(signalInserts.get(1).get(2)).isEqualTo(CloseIncrementalSnapshotWindow.NAME);
+        metadata = mapper.readTree(signalInserts.get(1).get(3));
+        assertThat(metadata.get("correlationId").asText()).isEqualTo("signal-1");
+        assertThat(metadata.get("dataCollectionId").asText()).isEqualTo("public.a");
+        assertThat(metadata.get("openWindowTimestamp").asText()).isEqualTo(mapper.readTree(signalInserts.get(0).get(3)).get("openWindowTimestamp").asText());
+
+        // The next chunk belongs to the next data collection, requested by the other signal.
+        context.startNewChunk();
+        source.emitWindowOpen(null, null);
+
+        assertThat(signalInserts).hasSize(3);
+        metadata = mapper.readTree(signalInserts.get(2).get(3));
+        assertThat(metadata.get("correlationId").asText()).isEqualTo("signal-2");
+        assertThat(metadata.get("dataCollectionId").asText()).isEqualTo("public.b");
+    }
+
+    @Test
+    public void shouldEmitWatermarksWithoutAttributionWhenCorrelationIdIsUnknown() throws Exception {
+        // Snapshots resumed from offsets written by older versions have no per-collection correlation id.
+        context.addDataCollectionNamesToSnapshot(null, List.of("public.a"), List.of(), "");
+
+        context.startNewChunk();
+        source.emitWindowOpen(null, null);
+
+        final JsonNode metadata = mapper.readTree(signalInserts.get(0).get(3));
+        assertThat(metadata.has("correlationId")).isFalse();
+        assertThat(metadata.get("dataCollectionId").asText()).isEqualTo("public.a");
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotContextTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotContextTest.java
@@ -50,6 +50,29 @@ public class SignalBasedIncrementalSnapshotContextTest {
     }
 
     @Test
+    public void shouldLoadOffsetsWrittenWithPerCollectionCorrelationId() {
+        final Map<String, Object> offsets = Map.of(
+                "incremental_snapshot_collections",
+                "[{\"incremental_snapshot_collections_id\":\"public.a\","
+                        + "\"incremental_snapshot_collections_additional_condition\":null,"
+                        + "\"incremental_snapshot_collections_surrogate_key\":null,"
+                        + "\"incremental_snapshot_collections_correlation_id\":\"signal-1\"},"
+                        + "{\"incremental_snapshot_collections_id\":\"public.b\","
+                        + "\"incremental_snapshot_collections_additional_condition\":null,"
+                        + "\"incremental_snapshot_collections_surrogate_key\":null,"
+                        + "\"incremental_snapshot_collections_correlation_id\":\"signal-2\"}]");
+
+        final IncrementalSnapshotContext<TableId> restored = SignalBasedIncrementalSnapshotContext.load(offsets);
+
+        assertThat(restored.getDataCollections())
+                .extracting(DataCollection::getCorrelationId)
+                .containsExactly(Optional.of("signal-1"), Optional.of("signal-2"));
+        assertThat(restored.getDataCollections())
+                .extracting(dataCollection -> dataCollection.getId().identifier())
+                .containsExactly("public.a", "public.b");
+    }
+
+    @Test
     public void shouldLoadOffsetsWrittenWithoutPerCollectionCorrelationId() {
         final Map<String, Object> offsets = Map.of(
                 "incremental_snapshot_collections",

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotContextTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotContextTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+
+public class SignalBasedIncrementalSnapshotContextTest {
+
+    @Test
+    public void shouldTagDataCollectionsWithTheRequestingSignalId() {
+        final SignalBasedIncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+
+        context.addDataCollectionNamesToSnapshot("signal-1", List.of("public.a", "public.b"), List.of(), "");
+        context.addDataCollectionNamesToSnapshot("signal-2", List.of("public.c"), List.of(), "");
+
+        assertThat(context.getDataCollections())
+                .extracting(DataCollection::getCorrelationId)
+                .containsExactly(Optional.of("signal-1"), Optional.of("signal-1"), Optional.of("signal-2"));
+        assertThat(context.getCorrelationId()).isEqualTo("signal-2");
+    }
+
+    @Test
+    public void shouldRoundTripPerCollectionCorrelationIdThroughOffsets() {
+        final SignalBasedIncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        context.addDataCollectionNamesToSnapshot("signal-1", List.of("public.a"), List.of(), "");
+        context.addDataCollectionNamesToSnapshot("signal-2", List.of("public.b"), List.of(), "");
+
+        final Map<String, Object> offsets = context.store(new HashMap<>());
+        final IncrementalSnapshotContext<TableId> restored = SignalBasedIncrementalSnapshotContext.load(offsets);
+
+        assertThat(restored.getDataCollections())
+                .extracting(DataCollection::getCorrelationId)
+                .containsExactly(Optional.of("signal-1"), Optional.of("signal-2"));
+        assertThat(restored.getDataCollections())
+                .extracting(dataCollection -> dataCollection.getId().identifier())
+                .containsExactly("public.a", "public.b");
+        assertThat(restored.getCorrelationId()).isEqualTo("signal-2");
+    }
+
+    @Test
+    public void shouldLoadOffsetsWrittenWithoutPerCollectionCorrelationId() {
+        final Map<String, Object> offsets = Map.of(
+                "incremental_snapshot_collections",
+                "[{\"incremental_snapshot_collections_id\":\"public.a\","
+                        + "\"incremental_snapshot_collections_additional_condition\":null,"
+                        + "\"incremental_snapshot_collections_surrogate_key\":null}]");
+
+        final IncrementalSnapshotContext<TableId> restored = SignalBasedIncrementalSnapshotContext.load(offsets);
+
+        assertThat(restored.getDataCollections())
+                .extracting(DataCollection::getCorrelationId)
+                .containsExactly(Optional.empty());
+        assertThat(restored.getDataCollections())
+                .extracting(dataCollection -> dataCollection.getId().identifier())
+                .containsExactly("public.a");
+    }
+}

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalMetadataTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalMetadataTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SignalMetadataTest {
+
+    private static final Instant OPEN = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant CLOSE = Instant.parse("2026-01-01T00:00:05Z");
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldKeepLegacyFormatWhenNoAttributionIsSet() {
+        assertThat(new SignalMetadata(OPEN, null).metadataString())
+                .isEqualTo("{\"openWindowTimestamp\": \"2026-01-01T00:00:00Z\"}");
+        assertThat(new SignalMetadata(OPEN, CLOSE).metadataString())
+                .isEqualTo("{\"openWindowTimestamp\": \"2026-01-01T00:00:00Z\", \"closeWindowTimestamp\": \"2026-01-01T00:00:05Z\"}");
+    }
+
+    @Test
+    public void shouldEmitCorrelationIdAndDataCollectionId() throws Exception {
+        final SignalMetadata metadata = new SignalMetadata(OPEN, CLOSE, "signal-1", "public.my_table");
+
+        final JsonNode json = mapper.readTree(metadata.metadataString());
+        assertThat(json.get("openWindowTimestamp").asText()).isEqualTo("2026-01-01T00:00:00Z");
+        assertThat(json.get("closeWindowTimestamp").asText()).isEqualTo("2026-01-01T00:00:05Z");
+        assertThat(json.get("correlationId").asText()).isEqualTo("signal-1");
+        assertThat(json.get("dataCollectionId").asText()).isEqualTo("public.my_table");
+    }
+
+    @Test
+    public void shouldOmitAbsentFields() throws Exception {
+        final SignalMetadata metadata = new SignalMetadata(OPEN, null, null, "public.my_table");
+
+        final JsonNode json = mapper.readTree(metadata.metadataString());
+        assertThat(json.has("closeWindowTimestamp")).isFalse();
+        assertThat(json.has("correlationId")).isFalse();
+        assertThat(json.get("dataCollectionId").asText()).isEqualTo("public.my_table");
+    }
+
+    @Test
+    public void shouldEscapeJsonSpecialCharacters() throws Exception {
+        final SignalMetadata metadata = new SignalMetadata(OPEN, null, "id-with-\"quote\"", "schema.table\\odd");
+
+        final JsonNode json = mapper.readTree(metadata.metadataString());
+        assertThat(json.get("correlationId").asText()).isEqualTo("id-with-\"quote\"");
+        assertThat(json.get("dataCollectionId").asText()).isEqualTo("schema.table\\odd");
+    }
+
+    @Test
+    public void shouldEscapeControlCharacters() throws Exception {
+        final SignalMetadata metadata = new SignalMetadata(OPEN, null, "id\nwith\tcontrols\r", "schema.table\fodd\b");
+
+        final JsonNode json = mapper.readTree(metadata.metadataString());
+        assertThat(json.get("correlationId").asText()).isEqualTo("id\nwith\tcontrols\r");
+        assertThat(json.get("dataCollectionId").asText()).isEqualTo("schema.table\fodd\b");
+    }
+
+    @Test
+    public void shouldCopyAllFieldsWhenClosingWindow() {
+        final SignalMetadata closed = new SignalMetadata(OPEN, null, "signal-1", "public.my_table").withCloseWindowTimestamp(CLOSE);
+
+        assertThat(closed.getOpenWindowTimestamp()).isEqualTo(OPEN);
+        assertThat(closed.getCloseWindowTimestamp()).isEqualTo(CLOSE);
+        assertThat(closed.getCorrelationId()).isEqualTo("signal-1");
+        assertThat(closed.getDataCollectionId()).isEqualTo("public.my_table");
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotContext.java
@@ -58,6 +58,10 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
             + "_additional_condition";
+
+    public static final String DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID = DATA_COLLECTIONS_TO_SNAPSHOT_KEY
+            + "_correlation_id";
+
     public static final String EVENT_PRIMARY_KEY = INCREMENTAL_SNAPSHOT_KEY + "_primary_key";
     public static final String TABLE_MAXIMUM_KEY = INCREMENTAL_SNAPSHOT_KEY + "_maximum_key";
 
@@ -95,6 +99,13 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
 
     private boolean schemaVerificationPassed;
 
+    /**
+     * The id of the signal that most recently added data collections to this context. When a further
+     * signal arrives while a snapshot is running, this field is overwritten although collections queued
+     * by earlier signals are still pending — so it only identifies the latest request (that is what the
+     * notifications report). For per-chunk attribution the canonical value is the requesting signal's id
+     * carried by each collection, {@link DataCollection#getCorrelationId()}.
+     */
     private String correlationId;
 
     /**
@@ -197,6 +208,7 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
                         map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, x.getId().toString());
                         map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION,
                                 x.getAdditionalCondition().isEmpty() ? null : x.getAdditionalCondition().orElse(null));
+                        map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID, x.getCorrelationId().orElse(null));
                         return map;
                     })
                     .collect(Collectors.toList());
@@ -214,7 +226,8 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
                     .map(x -> new DataCollection<T>(
                             (T) CollectionId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID)),
                             stripWrappingParentheses(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)),
-                            ""))
+                            "",
+                            x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_CORRELATION_ID)))
                     .filter(x -> x.getId() != null)
                     .collect(Collectors.toList());
             return dataCollectionsList;
@@ -265,7 +278,7 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
                                                                     String surrogateKey) {
         LOGGER.trace("Adding data collections names {} to snapshot", dataCollectionIds);
         final List<DataCollection<T>> newDataCollectionIds = dataCollectionIds.stream()
-                .map(buildDataCollection(additionalCondition, surrogateKey))
+                .map(buildDataCollection(additionalCondition, surrogateKey, correlationId))
                 .filter(x -> x.getId() != null) // Remove collections with incorrectly formatted name
                 .collect(Collectors.toList());
         addTablesIdsToSnapshot(newDataCollectionIds);
@@ -273,14 +286,14 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
         return newDataCollectionIds;
     }
 
-    private Function<String, DataCollection<T>> buildDataCollection(List<AdditionalCondition> additionalCondition, String surrogateKey) {
+    private Function<String, DataCollection<T>> buildDataCollection(List<AdditionalCondition> additionalCondition, String surrogateKey, String correlationId) {
         return expandedCollectionName -> {
             String filter = additionalCondition.stream()
                     .filter(condition -> condition.getDataCollection().matcher(expandedCollectionName).matches())
                     .map(AdditionalCondition::getFilter)
                     .findFirst()
                     .orElse("");
-            return new DataCollection<T>((T) CollectionId.parse(expandedCollectionName), filter, surrogateKey);
+            return new DataCollection<T>((T) CollectionId.parse(expandedCollectionName), filter, surrogateKey, correlationId);
         };
     }
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -385,4 +385,5 @@ Paul_Kim,Sundong Kim
 TimurRakhmatullin86,Timur Rakhmatullin
 lekhrocks,Lekhraj Kumar
 zach-all,Zach All
+cuong-dang,Cuong Dang
 regi-c,Regi Çallmori


### PR DESCRIPTION
Fixes debezium/dbz#2236

## Description

Incremental snapshot watermark rows (`snapshot-window-open` / `snapshot-window-close`) currently carry only a per-chunk UUID and the open/close timestamps, so external tooling consuming the signal table's CDC events cannot attribute a window to the `execute-snapshot` signal that requested it or to the data collection being chunked — particularly when one signal lists several collections, or a second signal arrives while a snapshot is running.

This PR threads that attribution through to the watermark metadata:

* `DataCollection` now carries the `correlationId` of the signal that requested it, assigned in `addDataCollectionNamesToSnapshot` and round-tripped through the offsets. Tracking it per collection (rather than only on the context) keeps attribution correct when collections queued by different signals are pending in the same context.
* The watermark `SignalMetadata` JSON gains two fields: `correlationId` (the requesting signal's id) and `dataCollectionId` (the fully-qualified identifier of the collection the chunk belongs to). Both are captured at window-open and carried to the matching close, since the collection queue may already have advanced by the time the close is emitted.
* `SignalMetadata` serialization uses Jackson (correct escaping for arbitrary signal ids and identifiers) with a custom printer that keeps the emitted format byte-identical to previous versions — pinned by test.

Backward compatibility:

* The `data` column of watermark rows is write-only metadata; nothing on the connector side parses it (`OpenIncrementalSnapshotWindow`/`CloseIncrementalSnapshotWindow` key off the `id` column only), and the legacy field layout is unchanged.
* Offsets written by older versions deserialize with a null per-collection correlation id; the new offset key is ignored on downgrade.
* The pre-existing context-level `correlationId` (read by the notification service) is kept as-is; its overwrite-on-latest-signal behavior and its relationship to the per-collection value are now documented on the field.
* The `INSERT_DELETE` watermarking strategy is unaffected (its close deletes the open row and writes no metadata; open rows carry attribution under both strategies).

Unit tests cover the metadata format and escaping, the offset round-trip (including legacy offsets without the new key), and open/close attribution across collections queued by different signals.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`