### PR TITLE
debezium/dbz#2240 Fix StarRocks test stability

### DIFF
--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkInsertModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkInsertModeTest.java
@@ -24,6 +24,8 @@ import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.SchemaEvolutionMode;
 import io.debezium.connector.jdbc.junit.TestHelper;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.junit.jupiter.SinkType;
+import io.debezium.connector.jdbc.junit.jupiter.e2e.SkipWhenSink;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.doc.FixFor;
 import io.debezium.sink.SinkConnectorConfig.PrimaryKeyMode;
@@ -264,6 +266,7 @@ public abstract class AbstractJdbcSinkInsertModeTest extends AbstractJdbcSinkTes
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @SkipWhenSink(value = SinkType.STARROCKS, reason = "StarRocks duplicate-key tables do not support UPDATE")
     public void testInsertModeUpdateWithNoPrimaryKey(SinkRecordFactory factory) {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
@@ -190,6 +190,9 @@ public abstract class AbstractJdbcSinkTest extends AbstractBaseJdbcSinkTest {
         List<SinkRecord> kafkaRecords = records.stream().map(JdbcKafkaSinkRecord::getOriginalKafkaRecord).toList();
         sinkTask.put(kafkaRecords);
         sinkTask.preCommit(Map.of());
+        if (sinkTask instanceof JdbcSinkConnectorTask jdbcTask && jdbcTask.getLastProcessingException() != null) {
+            throw new RuntimeException("JDBC sink threw an exception processing the data", jdbcTask.getLastProcessingException());
+        }
     }
 
     protected String destinationTableName(JdbcKafkaSinkRecord record) {


### PR DESCRIPTION
Fixes debezium/dbz#2240

## Description
When running the StarRocks dialect with SCES enabled or disabled, the test failed with SCES enabled. This manifests two core problems that need to be fixed:

* The test that failed should be skipped for Starrocks, using keyless tables with the `UPDATE` mode.
* The `AbstractJdbcSinkTest` class silently swallows exceptions when consuming changes, which can make tests appear to pass when they have triggered a failure with SCES disabled.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
