### PR TITLE
debezium/dbz#2238 Avoid NullPointerException resolving unsupported array column types

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -487,19 +487,21 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
             return type;
         }
 
-        switch (schema.name()) {
-            case SparseDoubleVector.LOGICAL_NAME, FloatVector.LOGICAL_NAME, DoubleVector.LOGICAL_NAME ->
-                throw new ConnectException(
-                        String.format(
-                                "Dialect does not support schema type %s. Please use the VectorToJsonConverter transform in " +
-                                        "your connector configuration to ingest data of this type.",
-                                schema.name()));
-            default -> throw new ConnectException(
-                    String.format(
-                            "Failed to resolve column type for schema: %s (%s)",
-                            schema.type(),
-                            schema.name()));
+        if (!Objects.isNull(schema.name())) {
+            switch (schema.name()) {
+                case SparseDoubleVector.LOGICAL_NAME, FloatVector.LOGICAL_NAME, DoubleVector.LOGICAL_NAME ->
+                    throw new ConnectException(
+                            String.format(
+                                    "Dialect does not support schema type %s. Please use the VectorToJsonConverter transform in " +
+                                            "your connector configuration to ingest data of this type.",
+                                    schema.name()));
+            }
         }
+        throw new ConnectException(
+                String.format(
+                        "Failed to resolve column type for schema: %s (%s)",
+                        schema.type(),
+                        schema.name()));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -6,9 +6,11 @@
 package io.debezium.connector.jdbc.integration.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -275,5 +277,40 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getString(4)).isEqualTo("-838:59:58.999999");
             return null;
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2238")
+    public void testShouldFailWithClearErrorForUnsupportedArrayColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                arraySchema,
+                List.of(1, 2, 3),
+                config);
+
+        // MySQL has no native array type. An array schema carries no logical name, which previously
+        // tripped the String switch in GeneralDatabaseDialect#getSchemaType with a NullPointerException;
+        // the sink must instead surface the intended, actionable resolution error.
+        assertThatThrownBy(() -> {
+            consume(createRecord);
+            consume(Collections.emptyList());
+        })
+                .rootCause()
+                .hasMessageContaining("Failed to resolve column type for schema: ARRAY");
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2238

## Description

When a PostgreSQL array column (`int[]`, `text[]`, …) is streamed to a JDBC sink whose dialect does not register an `ARRAY` type (e.g. MySQL), `GeneralDatabaseDialect#getSchemaType` fails with an opaque `NullPointerException` instead of the clear error it was designed to raise.

A Connect `ARRAY` schema has no logical name, so `schema.name()` is `null`. After the type-registry lookups miss (`ARRAY` is registered only by `PostgresDatabaseDialect`), the method reaches `switch (schema.name())`, which the compiler implements via `schema.name().hashCode()` — throwing an NPE before the `default` branch that raises `ConnectException("Failed to resolve column type ...")`.

This change guards the switch against a `null` schema name so unsupported, unnamed schemas fall through to the intended clear `ConnectException`. Behavior for named schemas (including the vector types) is unchanged.

Added a regression test (`JdbcSinkColumnTypeMappingIT#testShouldFailWithClearErrorForUnsupportedArrayColumnType`, MySQL sink) that feeds an array-typed field and asserts the clear error message; it fails with the NPE before the fix and passes after.

> Note: this PR only converts the crash into a clear error. Whether the JDBC sink should additionally map arrays to a portable type (e.g. `JSON`) on array-less dialects is an open design question — happy to follow up separately based on maintainer preference.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
