### PR TITLE
debezium/dbz#67 Retry MongoDB task start when resume token validation fails with a connection failure

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mongodb;
 
 import static java.util.Comparator.comparing;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +17,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.mongodb.MongoException;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.ThreadSafe;
@@ -306,8 +310,9 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
         return super.withMaskedSensitiveOptions(config).withMasked(MongoDbConnectorConfig.CONNECTION_STRING.name());
     }
 
-    private void validate(MongoDbConnectorConfig connectorConfig, MongoDbConnection mongoDbConnection, Offsets<MongoDbPartition, MongoDbOffsetContext> previousOffsets,
-                          Snapshotter snapshotter) {
+    // Package-private for testing.
+    void validate(MongoDbConnectorConfig connectorConfig, MongoDbConnection mongoDbConnection, Offsets<MongoDbPartition, MongoDbOffsetContext> previousOffsets,
+                  Snapshotter snapshotter) {
 
         for (Map.Entry<MongoDbPartition, MongoDbOffsetContext> previousOffset : previousOffsets) {
 
@@ -332,7 +337,18 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
             }
 
             if (connectorConfig.isLogPositionCheckEnabled()) {
-                boolean logPositionAvailable = mongoDbConnection.validateLogPosition(offset, taskContext);
+                boolean logPositionAvailable;
+                try {
+                    logPositionAvailable = mongoDbConnection.validateLogPosition(offset, taskContext);
+                }
+                catch (DebeziumException e) {
+                    // A communication failure (an invalid resume token instead returns false) must be retriable so
+                    // the task restarts and reconnects, consistent with the streaming path, rather than failing.
+                    if (isCommunicationFailure(e)) {
+                        throw new RetriableException("Failed to validate the resume token because of a connection failure; will retry", e);
+                    }
+                    throw e;
+                }
 
                 if (!logPositionAvailable) {
                     LOGGER.warn("Last recorded offset is no longer available on the server.");
@@ -354,6 +370,16 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
                 }
             }
         }
+    }
+
+    // Uses the same exception types the streaming MongoDbErrorHandler treats as retriable.
+    private static boolean isCommunicationFailure(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof IOException || cause instanceof MongoException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void validateGuardrailLimits(MongoDbConnectorConfig connectorConfig, MongoDbConnection connection) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -22,7 +22,9 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoSecurityException;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.ThreadSafe;
@@ -372,14 +374,29 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
         }
     }
 
-    // Uses the same exception types the streaming MongoDbErrorHandler treats as retriable.
+    // Mirrors the exception types the streaming MongoDbErrorHandler treats as retriable, but excludes
+    // authentication/authorization failures: those are permanent misconfigurations that would otherwise spin on
+    // every restart until retries are exhausted (cf. debezium/dbz#2139).
     private static boolean isCommunicationFailure(Throwable throwable) {
+        boolean communicationFailure = false;
         for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (isAuthenticationFailure(cause)) {
+                return false;
+            }
             if (cause instanceof IOException || cause instanceof MongoException) {
-                return true;
+                communicationFailure = true;
             }
         }
-        return false;
+        return communicationFailure;
+    }
+
+    private static boolean isAuthenticationFailure(Throwable throwable) {
+        if (throwable instanceof MongoSecurityException) {
+            return true;
+        }
+        // 18 = AuthenticationFailed, 13 = Unauthorized
+        return throwable instanceof MongoCommandException commandException
+                && (commandException.getErrorCode() == 18 || commandException.getErrorCode() == 13);
     }
 
     private void validateGuardrailLimits(MongoDbConnectorConfig connectorConfig, MongoDbConnection connection) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTaskTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTaskTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.apache.kafka.connect.errors.RetriableException;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.MongoException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.mongodb.connection.MongoDbConnection;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.spi.snapshot.Snapshotter;
+
+/**
+ * Unit tests for {@link MongoDbConnectorTask#validate} focused on how resume-token validation failures are
+ * classified. A communication failure while checking the resume token must surface as a
+ * {@link RetriableException} so the task restarts and reconnects instead of failing permanently.
+ */
+class MongoDbConnectorTaskTest {
+
+    private Offsets<MongoDbPartition, MongoDbOffsetContext> offsetsWithExistingResumeToken() {
+        MongoDbOffsetContext offset = mock(MongoDbOffsetContext.class);
+        when(offset.isInitialSnapshotRunning()).thenReturn(false);
+        return Offsets.of(mock(MongoDbPartition.class), offset);
+    }
+
+    private MongoDbConnectorConfig configWithLogPositionCheckEnabled() {
+        MongoDbConnectorConfig config = mock(MongoDbConnectorConfig.class);
+        when(config.isLogPositionCheckEnabled()).thenReturn(true);
+        return config;
+    }
+
+    private MongoDbConnection connectionFailingWith(Throwable failure) {
+        MongoDbConnection connection = mock(MongoDbConnection.class);
+        when(connection.validateLogPosition(any(), any())).thenThrow(failure);
+        return connection;
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldRetryWhenResumeTokenValidationFailsWithMongoCommunicationError() {
+        // The connection error handler wraps communication failures as a DebeziumException with the original
+        // MongoException as the cause; this must become retriable.
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream", new MongoException("connection refused")));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isInstanceOf(RetriableException.class)
+                .hasCauseInstanceOf(DebeziumException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldRetryWhenResumeTokenValidationFailsWithIoError() {
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream", new IOException("socket closed")));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isInstanceOf(RetriableException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenResumeTokenIsValid() {
+        MongoDbConnection connection = mock(MongoDbConnection.class);
+        when(connection.validateLogPosition(any(), any())).thenReturn(true);
+
+        assertThatNoException().isThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenResumeTokenValidationFailsWithNonCommunicationError() {
+        DebeziumException nonRetriable = new DebeziumException("misconfiguration", new IllegalStateException("bad state"));
+        MongoDbConnection connection = connectionFailingWith(nonRetriable);
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isSameAs(nonRetriable);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotValidateWhenLogPositionCheckDisabled() {
+        MongoDbConnectorConfig config = mock(MongoDbConnectorConfig.class);
+        when(config.isLogPositionCheckEnabled()).thenReturn(false);
+        MongoDbConnection connection = mock(MongoDbConnection.class);
+
+        assertThatNoException().isThrownBy(() -> new MongoDbConnectorTask().validate(
+                config, connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)));
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTaskTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTaskTest.java
@@ -14,9 +14,16 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 
 import org.apache.kafka.connect.errors.RetriableException;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.junit.jupiter.api.Test;
 
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
+import com.mongodb.MongoSecurityException;
+import com.mongodb.ServerAddress;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.mongodb.connection.MongoDbConnection;
@@ -93,6 +100,65 @@ class MongoDbConnectorTaskTest {
         assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
                 configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
                 .isSameAs(nonRetriable);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenResumeTokenValidationFailsWithAuthenticationError() {
+        // MongoSecurityException is a MongoException subtype, so the auth exclusion, not the blanket rule, must win.
+        MongoSecurityException authFailure = new MongoSecurityException(
+                MongoCredential.createCredential("user", "admin", "secret".toCharArray()), "Exception authenticating");
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream", authFailure));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isInstanceOf(DebeziumException.class)
+                .isNotInstanceOf(RetriableException.class)
+                .hasCause(authFailure);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenResumeTokenValidationFailsWithUnauthorizedError() {
+        MongoCommandException unauthorized = new MongoCommandException(
+                new BsonDocument("code", new BsonInt32(13)).append("errmsg", new BsonString("not authorized")),
+                new ServerAddress());
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream", unauthorized));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isNotInstanceOf(RetriableException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenResumeTokenValidationFailsWithAuthenticationFailedCode() {
+        MongoCommandException authenticationFailed = new MongoCommandException(
+                new BsonDocument("code", new BsonInt32(18)).append("errmsg", new BsonString("Authentication failed")),
+                new ServerAddress());
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream", authenticationFailed));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isNotInstanceOf(RetriableException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#67")
+    void shouldNotRetryWhenAuthenticationFailureIsWrappedBehindCommunicationError() {
+        // An auth failure deeper in the cause chain must veto the retry even behind a retriable wrapper.
+        MongoSecurityException authFailure = new MongoSecurityException(
+                MongoCredential.createCredential("user", "admin", "secret".toCharArray()), "Exception authenticating");
+        MongoDbConnection connection = connectionFailingWith(
+                new DebeziumException("Error while attempting to Checking change stream",
+                        new MongoException("connection reset", authFailure)));
+
+        assertThatThrownBy(() -> new MongoDbConnectorTask().validate(
+                configWithLogPositionCheckEnabled(), connection, offsetsWithExistingResumeToken(), mock(Snapshotter.class)))
+                .isNotInstanceOf(RetriableException.class);
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#67

## Description

When a running MongoDB connector task restarts while the server is temporarily unreachable, the connector fails permanently instead of retrying.

On start, `MongoDbConnectorTask.validate()` checks the stored resume token via `MongoDbConnection.validateLogPosition()` → `isValidResumeToken()` → `execute()`. That path uses the `eventSourcingErrorHandler`, which rethrows any communication failure as a `DebeziumException`. `BaseSourceTask.startIfNeededAndPossible()` only catches `RetriableException`, so the `DebeziumException` escapes and the task is killed.

The streaming path recovers from the very same failure: `MongoDbErrorHandler` classifies `IOException`/`MongoException` as communication exceptions and wraps them as `RetriableException`, so the coordinator reconnects. Only the start-time validation was inconsistent, which is a regression from the 2.6 snapshot-mode alignment.

### Fix

Wrap a communication failure raised while checking the resume token as a `RetriableException`, so the task restarts and reconnects during polling — the same treatment the streaming path already gives it. `BaseSourceTask.start()` catches it and transitions to `RESTARTING`.

A genuinely invalid resume token does **not** reach this branch: `isValidResumeToken()` catches `MongoCommandException`/`MongoChangeStreamException` internally and returns `false`, driving the existing snapshot-on-data-error logic. The other fail-fast configuration/data errors thrown by `validate()` (e.g. "offset no longer available") are outside the wrapped call and remain non-retriable.

### Notes / scope

- Communication failures are classified with the same exception set the streaming `MongoDbErrorHandler` uses (`IOException`, `MongoException`). This means, as on the streaming path today, all `MongoException`s (including auth errors) are treated as retriable — this restores consistency rather than introducing a new behavior.
- The change is localized to the validate boundary; the shared `eventSourcingErrorHandler` and `BaseSourceTask` are intentionally left untouched to avoid connector-wide impact.
- `validateGuardrailLimits()` reaches the server through the same handler and has the same permanent-failure characteristic; that is a separate path and is left for a follow-up rather than widened into this change.

### Tests

Added `MongoDbConnectorTaskTest` covering the classification at the validate boundary (deterministic, no container):
- resume-token validation failing with a `MongoException` cause → `RetriableException`
- failing with an `IOException` cause → `RetriableException`
- failing with a non-communication cause → original `DebeziumException` propagates unchanged
- valid resume token → no exception
- log position check disabled → validation skipped

A full replica-set integration test (start with an offset, stop the server, assert the task retries) reproduces the runtime scenario but is heavy and flaky; since the fix is a pure exception-classification decision, the unit tests exercise it precisely.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
