### PR TITLE
debezium/dbz#2244 Bound retries when a JDBC storage operation keeps failing

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/RetriableConnection.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/RetriableConnection.java
@@ -113,6 +113,7 @@ public class RetriableConnection implements AutoCloseable {
     private synchronized <T> T executeWithRetry(ConnectionFunction<T> func, ConnectionConsumer consumer, String name, boolean rollback)
             throws SQLException {
         int attempt = 1;
+        DelayStrategy delayStrategy = DelayStrategy.constant(waitRetryDelay);
         while (true) {
             if (!isOpen()) {
                 LOGGER.debug("Trying to reconnect (attempt {}).", attempt);
@@ -127,7 +128,6 @@ public class RetriableConnection implements AutoCloseable {
                     }
                     attempt++;
                     LOGGER.debug("Waiting for reconnect for {} ms.", waitRetryDelay);
-                    DelayStrategy delayStrategy = DelayStrategy.constant(waitRetryDelay);
                     delayStrategy.sleepWhen(true);
                     continue;
                 }
@@ -163,7 +163,6 @@ public class RetriableConnection implements AutoCloseable {
                 }
                 attempt++;
                 LOGGER.debug("Waiting for retry for {} ms.", waitRetryDelay);
-                DelayStrategy delayStrategy = DelayStrategy.constant(waitRetryDelay);
                 delayStrategy.sleepWhen(true);
             }
         }

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/RetriableConnection.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/RetriableConnection.java
@@ -153,6 +153,18 @@ public class RetriableConnection implements AutoCloseable {
                     }
                 }
                 close();
+                // The connection may be healthy while the operation itself keeps failing (e.g. a
+                // constraint violation or a value that does not fit the target column). Without
+                // bounding the retries here the loop would reconnect and re-run the same failing
+                // operation forever, so honor maxRetryCount and the retry delay as the reconnect
+                // branch above does.
+                if (attempt >= maxRetryCount) {
+                    throw e;
+                }
+                attempt++;
+                LOGGER.debug("Waiting for retry for {} ms.", waitRetryDelay);
+                DelayStrategy delayStrategy = DelayStrategy.constant(waitRetryDelay);
+                delayStrategy.sleepWhen(true);
             }
         }
     }

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/RetriableConnectionTest.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/RetriableConnectionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.debezium.doc.FixFor;
+import io.debezium.storage.jdbc.RetriableConnection.ConnectionConsumer;
+
+public class RetriableConnectionTest {
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    @FixFor("debezium/dbz#2244")
+    public void shouldStopRetryingFailingOperationAfterMaxRetries() throws IOException, SQLException {
+        File dbFile = File.createTempFile("retriable-", ".db");
+        dbFile.deleteOnExit();
+        String url = "jdbc:sqlite:" + dbFile.getAbsolutePath();
+        int maxRetryCount = 3;
+
+        try (RetriableConnection connection = new RetriableConnection(url, "user", "pass", Duration.ofMillis(1), maxRetryCount)) {
+            AtomicInteger calls = new AtomicInteger();
+            // The connection itself stays healthy (reconnection always succeeds); only the
+            // operation keeps failing. Before the fix this reconnected and re-ran the failing
+            // operation forever. It must now give up after maxRetryCount attempts and rethrow.
+            ConnectionConsumer alwaysFailing = conn -> {
+                calls.incrementAndGet();
+                throw new SQLException("persistent operation failure");
+            };
+
+            assertThatThrownBy(() -> connection.executeWithRetry(alwaysFailing, "always-failing", false))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("persistent operation failure");
+
+            assertThat(calls.get()).isEqualTo(maxRetryCount);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2244

### Problem

`io.debezium.storage.jdbc.RetriableConnection#executeWithRetry(...)` bounds its retries only
on the **reconnection** path — that branch increments `attempt` and rethrows once
`attempt >= maxRetryCount`. The **operation-failure** path does not:

```java
catch (SQLException e) {
    LOGGER.warn("Attempt {} to call '{}' failed.", attempt, name, e);
    if (rollback) { ... conn.rollback(); ... }
    close();                 // conn = null
}
// loops: attempt never incremented, maxRetryCount never checked, no delay
```

When the operation itself keeps throwing a `SQLException` on a healthy database (e.g. a
value that does not fit the target column, a constraint/type error, or a syntax error from a
misconfigured custom `table.ddl` / insert), `close()` sets `conn = null`, the next iteration
reconnects successfully, re-runs the identical operation, throws again, and repeats
**forever** — a tight busy-loop with no back-off that masks the error and hangs the affected
thread. Reachable from `JdbcSchemaHistory.storeRecord` / `recoverRecords` and
`JdbcOffsetBackingStore.save`.

### Change

Honor `max.retries` and `wait.retry.delay` on the operation-failure path too, mirroring the
existing reconnection branch: after closing the connection, rethrow the `SQLException` once
the attempts are exhausted, otherwise increment the counter, wait `wait.retry.delay`, and
retry. A persistent failure now surfaces as a thrown `SQLException` instead of an infinite
hang, while genuinely transient failures still succeed on a later attempt as before.

### Tests

- New `RetriableConnectionTest.shouldStopRetryingFailingOperationAfterMaxRetries` uses a real
  SQLite database and an operation that always throws `SQLException`; it asserts the call
  rethrows after exactly `maxRetryCount` invocations (with `@Timeout(SEPARATE_THREAD)` so a
  regression fails fast instead of hanging). It fails against the previous behaviour (infinite
  loop) and passes with the fix.
- `mvn -pl debezium-storage/debezium-storage-jdbc -am install`: `RetriableConnectionTest`
  passes and the reactor builds successfully.

### Author checklist
- [x] Change targets a single, self-contained fix
- [x] New unit test covering the fix
- [x] Commit is DCO signed-off
