### PR TITLE
debezium/dbz#2248 Close MySQL connection after initialization failure

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
@@ -364,6 +365,29 @@ public class JdbcConnection implements AutoCloseable {
         this.conn = null;
         this.queryTimeout = (int) config.getQueryTimeout().toSeconds();
         this.likeWildcardCharacters = getLikeWildcardCharacters();
+    }
+
+    /**
+     * Executes initialization that may establish a JDBC connection and closes the connection if initialization fails.
+     * Any exception raised while closing the connection is added to the initialization failure as a suppressed exception.
+     *
+     * @param initializer the initialization to execute
+     * @return the value produced by the initializer
+     * @param <T> the type of value produced by the initializer
+     */
+    protected final <T> T initializeAndCloseOnFailure(Supplier<T> initializer) {
+        try {
+            return initializer.get();
+        }
+        catch (RuntimeException | Error initializationException) {
+            try {
+                close();
+            }
+            catch (Exception resourceReleasingException) {
+                initializationException.addSuppressed(resourceReleasingException);
+            }
+            throw initializationException;
+        }
     }
 
     /**

--- a/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.jdbc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -30,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -88,6 +91,52 @@ class JdbcConnectionTest {
             driverManager.verify(() -> DriverManager.getConnection(
                     eq("jdbc:driver://db-host$01.example.com:5432;databaseName=db$name-dev_01#test@mock+v1!"),
                     eq(new Properties())));
+        }
+    }
+
+    @Test
+    public void shouldCloseConnectionWhenInitializationFails() throws SQLException {
+        final Connection jdbcConnection = Mockito.mock(Connection.class);
+        final TestJdbcConnection connection = new TestJdbcConnection(config -> jdbcConnection);
+        final RuntimeException initializationException = new RuntimeException("Initialization failed");
+        connection.connect();
+
+        final RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> connection.initialize(() -> {
+                    throw initializationException;
+                }));
+
+        assertSame(initializationException, thrown);
+        Mockito.verify(jdbcConnection).close();
+    }
+
+    @Test
+    public void shouldSuppressCloseFailureWhenInitializationFails() throws SQLException {
+        final Connection jdbcConnection = Mockito.mock(Connection.class);
+        final TestJdbcConnection connection = new TestJdbcConnection(config -> jdbcConnection);
+        final RuntimeException initializationException = new RuntimeException("Initialization failed");
+        final SQLException resourceReleasingException = new SQLException("Close failed");
+        Mockito.doThrow(resourceReleasingException).when(jdbcConnection).close();
+        connection.connect();
+
+        final RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> connection.initialize(() -> {
+                    throw initializationException;
+                }));
+
+        assertSame(initializationException, thrown);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertSame(resourceReleasingException, thrown.getSuppressed()[0]);
+    }
+
+    private static class TestJdbcConnection extends JdbcConnection {
+
+        private TestJdbcConnection(ConnectionFactory connectionFactory) {
+            super(JdbcConfiguration.empty(), connectionFactory, "\"", "\"");
+        }
+
+        private <T> T initialize(Supplier<T> initializer) {
+            return initializeAndCloseOnFailure(initializer);
         }
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
@@ -33,18 +33,7 @@ public class MySqlConnection extends BinlogConnectorConnection {
     public MySqlConnection(MySqlConnectionConfiguration connectionConfig, BinlogFieldReader fieldReader) {
         super(connectionConfig, fieldReader);
 
-        try {
-            this.binaryLogStatusStatement = resolveBinaryLogStatusStatement();
-        }
-        catch (RuntimeException initializationException) {
-            try {
-                close();
-            }
-            catch (Exception resourceReleasingException) {
-                initializationException.addSuppressed(resourceReleasingException);
-            }
-            throw initializationException;
-        }
+        this.binaryLogStatusStatement = initializeAndCloseOnFailure(this::resolveBinaryLogStatusStatement);
     }
 
     public static boolean isNetworkError(SQLException e) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/jdbc/MySqlConnection.java
@@ -33,7 +33,18 @@ public class MySqlConnection extends BinlogConnectorConnection {
     public MySqlConnection(MySqlConnectionConfiguration connectionConfig, BinlogFieldReader fieldReader) {
         super(connectionConfig, fieldReader);
 
-        this.binaryLogStatusStatement = resolveBinaryLogStatusStatement();
+        try {
+            this.binaryLogStatusStatement = resolveBinaryLogStatusStatement();
+        }
+        catch (RuntimeException initializationException) {
+            try {
+                close();
+            }
+            catch (Exception resourceReleasingException) {
+                initializationException.addSuppressed(resourceReleasingException);
+            }
+            throw initializationException;
+        }
     }
 
     public static boolean isNetworkError(SQLException e) {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectionTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectionTest.java
@@ -6,12 +6,23 @@
 package io.debezium.connector.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import org.junit.jupiter.api.Test;
 
+import io.debezium.DebeziumException;
+import io.debezium.connector.binlog.jdbc.BinlogFieldReader;
 import io.debezium.connector.mysql.jdbc.MySqlConnection;
+import io.debezium.connector.mysql.jdbc.MySqlConnectionConfiguration;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /**
  * Unit test for MySqlConnection network error detection.
@@ -47,5 +58,30 @@ public class MySqlConnectionTest {
     @Test
     public void shouldHandleEmptySQLStateGracefully() {
         assertThat(MySqlConnection.isNetworkError(new SQLException("Error with empty SQLState", ""))).isFalse();
+    }
+
+    @Test
+    public void shouldCloseJdbcConnectionWhenConstructionFails() throws SQLException {
+        final MySqlConnectionConfiguration connectionConfig = mock(MySqlConnectionConfiguration.class);
+        final Connection jdbcConnection = mock(Connection.class);
+        final Statement statement = mock(Statement.class);
+        final ResultSet resultSet = mock(ResultSet.class);
+        final SQLException permissionError = new SQLException("Access denied", "42000");
+
+        when(connectionConfig.config()).thenReturn(JdbcConfiguration.empty());
+        when(connectionConfig.factory()).thenReturn(config -> jdbcConnection);
+        when(jdbcConnection.createStatement()).thenReturn(statement);
+        when(jdbcConnection.isClosed()).thenReturn(false);
+        when(statement.getConnection()).thenReturn(jdbcConnection);
+        when(statement.executeQuery(MySqlConnection.BINARY_LOG_STATUS_STATEMENT)).thenThrow(permissionError);
+        when(statement.executeQuery("SELECT VERSION()")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("8.4.0");
+
+        assertThatThrownBy(() -> new MySqlConnection(connectionConfig, mock(BinlogFieldReader.class)))
+                .isInstanceOf(DebeziumException.class)
+                .hasCause(permissionError);
+
+        verify(jdbcConnection).close();
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -117,9 +117,10 @@ public class PostgresConnection extends JdbcConnection {
         }
         else {
             this.typeRegistry = typeRegistry;
-
-            final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
-            this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
+            this.defaultValueConverter = initializeAndCloseOnFailure(() -> {
+                final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
+                return new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
+            });
         }
     }
 
@@ -162,8 +163,10 @@ public class PostgresConnection extends JdbcConnection {
         }
         else {
             this.typeRegistry = typeRegistry;
-            final PostgresValueConverter valueConverter = PostgresValueConverter.of(config, this.getDatabaseCharset(), typeRegistry);
-            this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
+            this.defaultValueConverter = initializeAndCloseOnFailure(() -> {
+                final PostgresValueConverter valueConverter = PostgresValueConverter.of(config, this.getDatabaseCharset(), typeRegistry);
+                return new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
+            });
         }
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2248

## Description

Closes the JDBC connection when MySqlConnection initialization fails after a physical connection has been established. The original initialization exception is preserved, with any cleanup failure added as suppressed.

Adds regression coverage for the MySQL 8.4 permission failure path.

## Testing

- `./mvnw -pl debezium-connector-mysql test -DskipITs`
- `./mvnw clean install -pl debezium-connector-mysql -am -DskipITs`