### PR TITLE
debezium/dbz#2252 Validate custom metric tag keys

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -24,6 +24,9 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -1059,10 +1062,10 @@ public abstract class CommonConnectorConfig {
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
-            .withValidation(Field::isListOfMap)
-            .withDescription("The custom metric tags will accept key-value pairs to customize the MBean object name "
-                    + "which should be appended the end of regular name, each key would represent a tag for the MBean object name, "
-                    + "and the corresponding value would be the value of that tag the key is. For example: k1=v1,k2=v2");
+            .withValidation(Field::isListOfMap, CommonConnectorConfig::validateCustomMetricTags)
+            .withDescription("A comma-separated list of key-value pairs that are appended to the MBean object name. "
+                    + "Keys must be valid JMX ObjectName property keys. "
+                    + "For example: k1=v1,k2=v2");
 
     public static final Field INCREMENTAL_SNAPSHOT_WATERMARKING_STRATEGY = Field.create("incremental.snapshot.watermarking.strategy")
             .withDisplayName("Incremental snapshot watermarking strategy")
@@ -1991,6 +1994,38 @@ public abstract class CommonConnectorConfig {
         }
 
         return result;
+    }
+
+    /**
+     * Validates that every {@code custom.metric.tags} entry can be turned into a legal JMX
+     * {@link ObjectName} property. Values do not need JMX syntax validation because they are sanitized before MBean
+     * registration. Without this check an invalid key passes {@link Field#isListOfMap} but crashes the connector at
+     * startup with a {@link MalformedObjectNameException}.
+     */
+    private static int validateCustomMetricTags(Configuration config, Field field, ValidationOutput problems) {
+        String rawValue = config.getString(field);
+        if (Strings.isNullOrBlank(rawValue)) {
+            return 0;
+        }
+
+        int errors = 0;
+        List<String> entries = Strings.listOf(rawValue, x -> x.split(","), String::trim);
+        for (String entry : entries) {
+            List<String> keyValue = Strings.listOf(entry, x -> x.split("="), String::trim);
+            if (keyValue.size() == 2) {
+                String key = keyValue.get(0);
+                try {
+                    // Values are sanitized before MBean registration, so only the key needs JMX syntax validation.
+                    new ObjectName("debezium:" + key + "=value");
+                }
+                catch (MalformedObjectNameException e) {
+                    problems.accept(field, rawValue, "The custom metric tag key '" + key
+                            + "' is not a valid JMX ObjectName property key");
+                    ++errors;
+                }
+            }
+        }
+        return errors;
     }
 
     public WatermarkStrategy getIncrementalSnapshotWatermarkingStrategy() {

--- a/debezium-connector-common/src/test/java/io/debezium/config/CustomMetricTagsValidationTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/config/CustomMetricTagsValidationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CustomMetricTagsValidationTest {
+
+    private List<String> validationProblems(String rawValue) {
+        Configuration.Builder builder = Configuration.create();
+        if (rawValue != null) {
+            builder.with(CommonConnectorConfig.CUSTOM_METRIC_TAGS, rawValue);
+        }
+
+        List<String> problems = new ArrayList<>();
+        CommonConnectorConfig.CUSTOM_METRIC_TAGS.validate(builder.build(),
+                (field, value, message) -> problems.add(message));
+        return problems;
+    }
+
+    @Test
+    void shouldRejectKeysWithInvalidJmxSyntax() {
+        assertThat(validationProblems("region:eu=prod")).anySatisfy(
+                message -> assertThat(message).contains("not a valid JMX ObjectName"));
+        assertThat(validationProblems("a*b=v")).anySatisfy(
+                message -> assertThat(message).contains("not a valid JMX ObjectName"));
+        assertThat(validationProblems("a?b=v")).anySatisfy(
+                message -> assertThat(message).contains("not a valid JMX ObjectName"));
+    }
+
+    @Test
+    void shouldAcceptWellFormedTagsAndSanitizableValues() {
+        assertThat(validationProblems("region=eu,team=data")).isEmpty();
+        assertThat(validationProblems("region=eu:west")).isEmpty();
+        assertThat(validationProblems("database=salesdb-streaming,table=inventory")).isEmpty();
+    }
+
+    @Test
+    void shouldAcceptBlankOrUnsetTags() {
+        assertThat(validationProblems("")).isEmpty();
+        assertThat(validationProblems(null)).isEmpty();
+    }
+
+    @Test
+    void shouldRejectStructurallyMalformedTags() {
+        assertThat(validationProblems("foo")).isNotEmpty();
+        assertThat(validationProblems("k1=a=b")).isNotEmpty();
+    }
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-mbean-name.adoc
@@ -55,6 +55,9 @@ To prevent monitoring disruptions that result from MBean name changes, you can c
 You configure custom metrics by adding the `custom.metric.tags` property to the connector configuration.
 The property accepts key-value pairs in which each key represents a tag for the MBean object name, and the corresponding value represents the value of that tag.
 For example: `k1=v1,k2=v2`.
+Tag keys must be valid JMX `ObjectName` property keys.
+The comma separates entries, and the equals sign separates each key from its value; therefore, neither can occur in a key.
+Keys also cannot contain JMX-reserved characters such as `:`, `*`, or `?`.
 {prodname} appends the specified tags to the MBean name of the connector.
 
 After you configure the `custom.metric.tags` property for a connector, you can configure the observability stack to retrieve metrics associated with the specified tags.


### PR DESCRIPTION
Reject JMX-invalid custom metric tag keys during configuration validation

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2252

## Description
Validates custom metric tag keys during configuration to prevent invalid JMX MBean names at connector startup.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
