### PR TITLE
debezium/dbz#2254 Apply reserved-keyword quoting only outside comments and string literals

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
@@ -61,21 +61,21 @@ public class DdlNormalizer {
 
         Matcher matcher = QUOTED_LITERAL_PATTERN.matcher(ddlContent);
         StringBuilder normalized = new StringBuilder(ddlContent.length());
+        int lastEnd = 0;
 
         while (matcher.find()) {
+            normalized.append(addBackticksToReservedKeywords(ddlContent.substring(lastEnd, matcher.start())));
             if (isComment(matcher) || isSingleQuotedString(matcher) || isBacktickIdentifier(matcher)) {
                 preserveOriginal(matcher, normalized);
             }
             else {
                 convertToSingleQuoted(matcher, normalized);
             }
+            lastEnd = matcher.end();
         }
-        matcher.appendTail(normalized);
+        normalized.append(addBackticksToReservedKeywords(ddlContent.substring(lastEnd)));
 
-        String result = normalized.toString();
-        result = addBackticksToReservedKeywords(result);
-
-        return result;
+        return normalized.toString();
     }
 
     private static boolean isComment(Matcher matcher) {
@@ -91,7 +91,7 @@ public class DdlNormalizer {
     }
 
     private static void preserveOriginal(Matcher matcher, StringBuilder result) {
-        matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(0)));
+        result.append(matcher.group(0));
     }
 
     /**
@@ -99,12 +99,14 @@ public class DdlNormalizer {
      */
     private static void convertToSingleQuoted(Matcher matcher, StringBuilder result) {
         String escapedContent = matcher.group(DOUBLE_QUOTED_STRING_GROUP).replace("'", "''");
-        matcher.appendReplacement(result, "'" + Matcher.quoteReplacement(escapedContent) + "'");
+        result.append("'").append(escapedContent).append("'");
     }
 
     /**
      * Adds backticks around reserved keywords when used as identifiers (not as keywords).
      * Targets specific contexts: table names, column names, aliases, labels.
+     * Only ever invoked on the plain SQL segments between comments, string literals and
+     * quoted identifiers, so their content is never rewritten.
      */
     private static String addBackticksToReservedKeywords(String ddl) {
         String result = ddl;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
@@ -285,4 +285,54 @@ public class DdlNormalizerTest {
         String expected = "CREATE TABLE `RANK` (id INT, `DENSE_RANK` VARCHAR(10))";
         assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
     }
+
+    @DisplayName("Given reserved keyword pattern inside single-quoted default value When normalize Then string content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordInsideSingleQuotedDefault() {
+        String input = "CREATE TABLE t (c VARCHAR(20) DEFAULT 'FROM RANK')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given reserved keyword pattern inside single-quoted comment When normalize Then string content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordInsideSingleQuotedComment() {
+        String input = "CREATE TABLE t (c INT COMMENT 'RANK INT is a reserved word')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given reserved keyword label pattern inside single-quoted comment When normalize Then string content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordLabelInsideSingleQuotedComment() {
+        String input = "CREATE TABLE t (c INT COMMENT 'RANK: top 10')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given reserved keyword pattern inside double-quoted string When normalize Then converted content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordInsideDoubleQuotedString() {
+        String input = "CREATE TABLE t (c VARCHAR(20) DEFAULT \"FROM RANK\")";
+        String expected = "CREATE TABLE t (c VARCHAR(20) DEFAULT 'FROM RANK')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given reserved keyword pattern inside SQL comment When normalize Then comment content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordInsideSqlComment() {
+        String input = "-- example: CREATE TABLE RANK ...\nCREATE TABLE t (c INT)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given reserved keyword identifier next to string literals When normalize Then only the identifier gets backticks")
+    @Test
+    @FixFor("debezium/dbz#2254")
+    public void testReservedKeywordIdentifierNextToStrings() {
+        String input = "CREATE TABLE RANK (c VARCHAR(20) DEFAULT 'FROM RANK', RANK INT COMMENT 'RANK: n')";
+        String expected = "CREATE TABLE `RANK` (c VARCHAR(20) DEFAULT 'FROM RANK', `RANK` INT COMMENT 'RANK: n')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2254

## Description
`DdlNormalizer.addBackticksToReservedKeywords()` used to run three context-blind
`replaceAll` calls over the entire normalized statement, injecting backticks into
single-quoted string literals (column `DEFAULT` values, `COMMENT`s) and SQL comments
whose content happened to match the reserved-keyword heuristics, e.g.:

CREATE TABLE t (c VARCHAR(20) DEFAULT 'FROM RANK')
-> CREATE TABLE t (c VARCHAR(20) DEFAULT 'FROM RANK')

The corrupted statement is still valid SQL, so the connector silently records
literal values that differ from the actual database schema (schema history topic,
schema change events).

This change folds the reserved-keyword quoting into the existing
`QUOTED_LITERAL_PATTERN` matcher loop, applying it only to the plain SQL segments
between comments, string literals and quoted identifiers, and drops the global
second pass. Same class of defect as dbz#2237 (#7682), which fixed the
quote-conversion pass but did not cover this one.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`