### PR TITLE
debezium/dbz#2255 Fix BoundedConcurrentHashMap eviction on put-heavy workloads

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -325,6 +325,7 @@ Ivan Kovbas
 Ivan Lorenz
 Ivan Luzyanin
 Ivan San Jose
+Ivan Senyk
 Ivan Trusov
 Ivan Vucina
 Jackey Zhang

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/core/BoundedConcurrentHashMapPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/core/BoundedConcurrentHashMapPerf.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.core;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.debezium.util.BoundedConcurrentHashMap;
+import io.debezium.util.BoundedConcurrentHashMap.Eviction;
+
+/**
+ * Measures {@link BoundedConcurrentHashMap#put(Object, Object)} on existing keys, the hot path of
+ * write-through dedup caches such as the OpenLineage SMT. The key set fits well within the map
+ * capacity, so every operation is a hit. A batch of {@code putCount} puts is timed as a whole:
+ * doubling {@code putCount} should roughly double the time, so a superlinear growth between the
+ * two data points exposes a per-operation cost that increases with the number of operations.
+ */
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode({ Mode.SingleShotTime })
+public class BoundedConcurrentHashMapPerf {
+
+    private static final int CAPACITY = 64;
+    private static final int KEY_COUNT = 32;
+
+    @Param({ "100000", "400000" })
+    private int putCount;
+
+    @Param({ "LRU", "LIRS" })
+    private Eviction eviction;
+
+    private BoundedConcurrentHashMap<Integer, Integer> map;
+
+    @Setup(Level.Iteration)
+    public void prepare() {
+        map = new BoundedConcurrentHashMap<>(CAPACITY, 16, eviction);
+        for (int i = 0; i < KEY_COUNT; i++) {
+            map.put(i, i);
+        }
+    }
+
+    @Benchmark
+    public void putExistingKeys(Blackhole blackhole) {
+        for (int i = 0; i < putCount; i++) {
+            blackhole.consume(map.put(i % KEY_COUNT, i));
+        }
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/BoundedConcurrentHashMap.java
+++ b/debezium-util/src/main/java/io/debezium/util/BoundedConcurrentHashMap.java
@@ -34,6 +34,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -422,6 +423,11 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
         private static final long serialVersionUID = -7645068174197717838L;
 
         private final ConcurrentLinkedQueue<HashEntry<K, V>> accessQueue;
+        /**
+         * ConcurrentLinkedQueue.size() is O(n); the hot paths below would turn
+         * quadratic on put-heavy workloads without a constant-time counter.
+         */
+        private final AtomicInteger accessQueueSize = new AtomicInteger();
         private final Segment<K, V> segment;
         private final int maxBatchQueueSize;
         private final int trimDownSize;
@@ -446,6 +452,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
             }
             evictedCopy.addAll(evicted);
             accessQueue.clear();
+            accessQueueSize.set(0);
             evicted.clear();
             return evictedCopy;
         }
@@ -470,7 +477,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
         @Override
         public boolean onEntryHit(HashEntry<K, V> e) {
             accessQueue.add(e);
-            return accessQueue.size() >= maxBatchQueueSize * batchThresholdFactor;
+            return accessQueueSize.incrementAndGet() >= maxBatchQueueSize * batchThresholdFactor;
         }
 
         /*
@@ -478,7 +485,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
          */
         @Override
         public boolean thresholdExpired() {
-            return accessQueue.size() >= maxBatchQueueSize;
+            return accessQueueSize.get() >= maxBatchQueueSize;
         }
 
         @Override
@@ -486,7 +493,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
             remove(e);
             // we could have multiple instances of e in accessQueue; remove them all
             while (accessQueue.remove(e)) {
-                continue;
+                accessQueueSize.decrementAndGet();
             }
         }
 
@@ -494,6 +501,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
         public void clear() {
             super.clear();
             accessQueue.clear();
+            accessQueueSize.set(0);
         }
 
         @Override
@@ -939,6 +947,12 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
         private final ConcurrentLinkedQueue<LIRSHashEntry<K, V>> accessQueue;
 
         /**
+         * ConcurrentLinkedQueue.size() is O(n); the hot paths below would turn
+         * quadratic on put-heavy workloads without a constant-time counter.
+         */
+        private final AtomicInteger accessQueueSize = new AtomicInteger();
+
+        /**
          * The maxBatchQueueSize
          * <p/>
          * See "BP-Wrapper: a system framework making any replacement algorithms (almost) lock
@@ -1015,6 +1029,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
             }
             finally {
                 accessQueue.clear();
+                accessQueueSize.set(0);
             }
             return evicted;
         }
@@ -1068,7 +1083,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
         @Override
         public boolean onEntryHit(HashEntry<K, V> e) {
             accessQueue.add((LIRSHashEntry<K, V>) e);
-            return accessQueue.size() >= maxBatchQueueSize * batchThresholdFactor;
+            return accessQueueSize.incrementAndGet() >= maxBatchQueueSize * batchThresholdFactor;
         }
 
         /*
@@ -1076,7 +1091,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
          */
         @Override
         public boolean thresholdExpired() {
-            return accessQueue.size() >= maxBatchQueueSize;
+            return accessQueueSize.get() >= maxBatchQueueSize;
         }
 
         @Override
@@ -1085,12 +1100,14 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
             ((LIRSHashEntry<K, V>) e).remove();
             // we could have multiple instances of e in accessQueue; remove them all
             while (accessQueue.remove(e)) {
+                accessQueueSize.decrementAndGet();
             }
         }
 
         @Override
         public void clear() {
             accessQueue.clear();
+            accessQueueSize.set(0);
         }
 
         @Override
@@ -1402,7 +1419,9 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
                     oldValue = e.value;
                     if (!onlyIfAbsent) {
                         e.value = value;
-                        eviction.onEntryHit(e);
+                        if (eviction.onEntryHit(e)) {
+                            evicted = attemptEviction(true);
+                        }
                     }
                 }
                 else {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -387,3 +387,4 @@ lekhrocks,Lekhraj Kumar
 zach-all,Zach All
 cuong-dang,Cuong Dang
 regi-c,Regi Çallmori
+MrIvv,Ivan Senyk


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2255

`BoundedConcurrentHashMap` combines two defects into quadratic per-record cost on put-heavy workloads:

1. **`Segment.put()` on an existing key ignores the `onEntryHit` return value** — the check-and-evict contract is honored at the other three call sites (`get()` at 1292, both `replace()` overloads at 1347/1372) but not in the put hit path (1405), so a put-only caller (e.g. a dedup cache probed with unconditional `put`, like the OpenLineage SMT) grows the access queue without bound and the batch drain never triggers.
2. **`LRU`/`LIRS` threshold checks call `ConcurrentLinkedQueue.size()`** — an O(n) traversal per the Javadoc — on every hit.

Production evidence, reproduction steps and thread dump are in the linked issue: throughput decayed from ~90k to ~12.5k records/min over 18 hours with one conversion thread at ~96% CPU inside `ConcurrentLinkedQueue.size()`.

The fix:
- honors the `onEntryHit` return value in the put hit path, mirroring the exact form already used by both `replace()` overloads (`attemptEviction(true)` under the held segment lock; the evicted set flows into the existing out-of-lock `notifyEvictionListener`)
- tracks the access queue size with an `AtomicInteger` in both `LRU` and `LIRS` (increment on add, decrement on remove, reset on `execute()`/`clear()`). The counter may drift by a unit in rare races, which only delays the batch threshold slightly — the thresholds are approximate by design and the original racy `size()` snapshot had the same property.

No observable semantic change: same eviction policy, same thresholds, same listener notifications. Verified in a production-like rollout with the OpenLineage SMT active: the degradation signature is gone and the rate is stable over time.