### PR TITLE
debezium/dbz#2260 Treat nonzero TINYINT(1) values as true in TinyIntOneToBooleanConverter

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/TinyIntOneToBooleanConverter.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/converters/TinyIntOneToBooleanConverter.java
@@ -79,11 +79,12 @@ public class TinyIntOneToBooleanConverter implements CustomConverter<SchemaBuild
                 return x;
             }
             else if (x instanceof Number) {
-                return ((Number) x).intValue() > 0;
+                // MySQL considers any nonzero value true, e.g. "SELECT -1 IS TRUE" returns 1
+                return ((Number) x).intValue() != 0;
             }
             else if (x instanceof String) {
                 try {
-                    return Integer.parseInt((String) x);
+                    return Integer.parseInt((String) x) != 0;
                 }
                 catch (NumberFormatException e) {
                     return Boolean.parseBoolean((String) x);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogTinyIntIT.java
@@ -111,6 +111,34 @@ public abstract class BinlogTinyIntIT<C extends SourceConnector> extends Abstrac
     }
 
     @Test
+    @FixFor("debezium/dbz#2260")
+    public void shouldHandleNegativeTinyIntOneAsTrue() throws SQLException, InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("DBZ1773"))
+                .with(BinlogConnectorConfig.CUSTOM_CONVERTERS, "boolean")
+                .with("boolean.type", TinyIntOneToBooleanConverter.class.getName())
+                .with("boolean.selector", ".*DBZ1773.b")
+                .build();
+
+        // Start the connector ...
+        start(getConnectorClass(), config);
+
+        consumeInitial();
+
+        assertBooleanChangeRecord();
+
+        // MySQL considers any nonzero value true, e.g. "SELECT -1 IS TRUE" returns 1
+        try (Connection conn = getTestDatabaseConnection(DATABASE.getDatabaseName()).connection()) {
+            conn.createStatement().execute("INSERT INTO DBZ1773 VALUES (DEFAULT, 100, 5, 50, -1)");
+        }
+        assertBooleanChangeRecord();
+
+        stopConnector();
+    }
+
+    @Test
     @FixFor("DBZ-2085")
     public void shouldDefaultValueForTinyIntOneAsBoolean() throws SQLException, InterruptedException {
         // Use the DB configuration to define the connector's configuration ...

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/TinyIntOneToBooleanConverterTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/converters/TinyIntOneToBooleanConverterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.OptionalInt;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+
+/**
+ * Unit tests for {@link TinyIntOneToBooleanConverter}, covering the value conversion
+ * dispatch — in particular that any nonzero value converts to {@code true}, matching
+ * MySQL semantics where {@code SELECT -1 IS TRUE} returns 1.
+ *
+ * @author minleejae
+ */
+class TinyIntOneToBooleanConverterTest {
+
+    private static final String DATA_COLLECTION = "appdb.users";
+
+    @Test
+    void zeroConvertsToFalse() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert((short) 0)).isEqualTo(false);
+    }
+
+    @Test
+    void positiveValuesConvertToTrue() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert((short) 1)).isEqualTo(true);
+        assertThat(reg.converter.convert((short) 2)).isEqualTo(true);
+        assertThat(reg.converter.convert((short) 127)).isEqualTo(true);
+    }
+
+    @Test
+    void negativeValuesConvertToTrue() {
+        // MySQL considers any nonzero value true: SELECT -1 IS TRUE returns 1, and the
+        // default BOOLEAN conversion (JdbcValueConverters#convertBoolean) agrees.
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert((short) -1)).isEqualTo(true);
+        assertThat(reg.converter.convert((short) -128)).isEqualTo(true);
+    }
+
+    @Test
+    void booleanInputPassesThrough() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert(Boolean.TRUE)).isEqualTo(true);
+        assertThat(reg.converter.convert(Boolean.FALSE)).isEqualTo(false);
+    }
+
+    @Test
+    void numericStringsConvertToBoolean() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert("0")).isEqualTo(false);
+        assertThat(reg.converter.convert("1")).isEqualTo(true);
+        assertThat(reg.converter.convert("-1")).isEqualTo(true);
+    }
+
+    @Test
+    void nonNumericStringsFallBackToBooleanParsing() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert("true")).isEqualTo(true);
+        assertThat(reg.converter.convert("false")).isEqualTo(false);
+    }
+
+    @Test
+    void nullConvertsToNullForOptionalColumn() {
+        final Registration reg = registerOn(newConfigured(), tinyIntOneColumn("b"));
+        assertThat(reg.converter.convert(null)).isNull();
+    }
+
+    private static TinyIntOneToBooleanConverter newConfigured() {
+        final TinyIntOneToBooleanConverter converter = new TinyIntOneToBooleanConverter();
+        converter.configure(new Properties());
+        return converter;
+    }
+
+    private static RelationalColumn tinyIntOneColumn(String name) {
+        final RelationalColumn col = Mockito.mock(RelationalColumn.class);
+        Mockito.when(col.name()).thenReturn(name);
+        Mockito.when(col.dataCollection()).thenReturn(DATA_COLLECTION);
+        Mockito.when(col.typeName()).thenReturn("TINYINT");
+        Mockito.when(col.length()).thenReturn(OptionalInt.of(1));
+        Mockito.when(col.isOptional()).thenReturn(true);
+        return col;
+    }
+
+    private static Registration registerOn(TinyIntOneToBooleanConverter converter, RelationalColumn column) {
+        final AtomicReference<SchemaBuilder> schemaRef = new AtomicReference<>();
+        final AtomicReference<CustomConverter.Converter> convRef = new AtomicReference<>();
+        converter.converterFor(column, (schema, conv) -> {
+            schemaRef.set(schema);
+            convRef.set(conv);
+        });
+        assertThat(schemaRef.get()).as("converter did not register a schema for column %s", column.name()).isNotNull();
+        return new Registration(schemaRef.get().build(), convRef.get());
+    }
+
+    private record Registration(Schema schema, CustomConverter.Converter converter) {
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2260

## Description

`TinyIntOneToBooleanConverter` converted numeric values with `intValue() > 0`, so negative values stored in a `TINYINT(1)` column converted to `false`. MySQL treats any nonzero value as true (`SELECT -1 IS TRUE` returns `1`), as does Debezium's default BOOLEAN conversion (`JdbcValueConverters#convertBoolean`), so the same stored value produced opposite results depending on the conversion path.

- Number branch: convert with `!= 0` instead of `> 0`.
- String branch: `return Integer.parseInt((String) x);` returned the parsed `Integer` itself under the registered BOOL schema — apply the same `!= 0` comparison.

Verified with a new unit test (`TinyIntOneToBooleanConverterTest`) and a new integration test (`BinlogTinyIntIT#shouldHandleNegativeTinyIntOneAsTrue`, inserting `-1` during streaming); MySQL 8.2 and MariaDB 11.4.3 `TinyIntIT` suites pass.
