### PR TITLE
debezium/dbz#2262 Fix OpenLineage SMT dedup emission and per-record cache writes

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/openlineage/OpenLineage.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/openlineage/OpenLineage.java
@@ -66,22 +66,27 @@ public class OpenLineage<R extends ConnectRecord<R>> implements Transformation<R
             return record;
         }
 
-        if (recentlySeenTopics.put(record.topic(), true) == null || recentlySeenSchemas.put(record.valueSchema(), true) == null) {
+        final boolean newTopic = recentlySeenTopics.get(record.topic()) == null;
+        final boolean newSchema = recentlySeenSchemas.get(record.valueSchema()) == null;
 
-            if (recentlySeenSchemas.put(record.valueSchema(), true) == null) {
+        if (newTopic) {
+            recentlySeenTopics.put(record.topic(), true);
+        }
+        if (newSchema) {
+            recentlySeenSchemas.put(record.valueSchema(), true);
+        }
 
-                List<DatasetMetadata.FieldDefinition> fieldDefinitions = datasetDataExtractor.extract(record);
+        if (newTopic || newSchema) {
 
-                ConnectorContext connectorContext = ConnectorContext.from(record.headers());
-                DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING,
-                        List.of(new DatasetMetadata(record.topic(), OUTPUT, STREAM_DATASET_TYPE, KAFKA, fieldDefinitions)));
+            List<DatasetMetadata.FieldDefinition> fieldDefinitions = datasetDataExtractor.extract(record);
 
-                lastEmissionTime = ZonedDateTime.now();
-            }
+            ConnectorContext connectorContext = ConnectorContext.from(record.headers());
+            DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING,
+                    List.of(new DatasetMetadata(record.topic(), OUTPUT, STREAM_DATASET_TYPE, KAFKA, fieldDefinitions)));
+
+            lastEmissionTime = ZonedDateTime.now();
 
             LOGGER.debug("Emitting running event for output dataset {}", record.topic());
-
-            return record;
         }
 
         return record;


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2262

Two nested defects in the `OpenLineage` SMT dedup logic (full analysis with truth table in the issue):

1. **Schema changes on known topics were never emitted**: the nested `recentlySeenSchemas.put(...) == null` probe re-checked a cache the outer `||` condition had just written, consuming the novelty it was supposed to detect.
2. **Every record wrote to both dedup caches**: `Segment.put` takes the segment lock unconditionally while `get` is lock-free, so the steady-state hot path paid two lock acquisitions per record for probes that a read satisfies.

The fix computes novelty with read-only `get`s first, writes each cache only on miss, and emits on `newTopic || newSchema`. Steady state becomes two lock-free reads, zero writes. The check-then-act is not atomic: for best-effort lineage dedup the worst case is a duplicate emission under concurrency (never a missed one) — same property as the original code.

One open question in the issue: whether case "new topic, known schema" should announce the topic as its own dataset (this PR's behavior, matching the intent suggested by the original `||`) or per-schema dedup is intended — happy to adapt the condition if the latter.

Related: #7703 / debezium/dbz#2255 (BoundedConcurrentHashMap eviction fix — this SMT's put-per-record pattern was the caller that exposed it in production).