### PR TITLE
debezium/dbz#2263 Fix AsyncEmbeddedEngine default pool stuck at one thread

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OpenLineageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OpenLineageIT.java
@@ -269,6 +269,7 @@ public class OpenLineageIT extends AbstractAsyncEngineConnectorTest {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.INITIAL.getValue())
                 .with("schema.history.internal.kafka.bootstrap.servers", "test-kafka:9092")
+                .with("record.processing.threads", "1")
                 .with("openlineage.integration.enabled", true)
                 .with("openlineage.integration.config.file.path", getClass().getClassLoader().getResource("openlineage/openlineage.yml").getPath())
                 .with("openlineage.integration.job.description", "This connector does cdc for products")

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -165,7 +165,12 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         taskService = Executors.newFixedThreadPool(this.config.getInteger(ConnectorConfig.TASKS_MAX_CONFIG, () -> 1));
         final String processingThreads = this.config.getString(AsyncEmbeddedEngine.RECORD_PROCESSING_THREADS);
         if (processingThreads == null || processingThreads.isBlank()) {
-            recordService = new ThreadPoolExecutor(0, AsyncEngineConfig.AVAILABLE_CORES, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue());
+            // With an unbounded work queue a ThreadPoolExecutor never grows past its core size,
+            // so the core must be the target parallelism; idle threads time out instead.
+            final ThreadPoolExecutor defaultRecordService = new ThreadPoolExecutor(AsyncEngineConfig.AVAILABLE_CORES, AsyncEngineConfig.AVAILABLE_CORES,
+                    60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+            defaultRecordService.allowCoreThreadTimeOut(true);
+            recordService = defaultRecordService;
         }
         else {
             recordService = Executors.newFixedThreadPool(computeRecordThreads(processingThreads));

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEngineConfig.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEngineConfig.java
@@ -29,8 +29,8 @@ public interface AsyncEngineConfig extends EmbeddedEngineConfig {
      */
     Field RECORD_PROCESSING_THREADS = Field.create("record.processing.threads")
             .withDescription("The number of threads to be used for processing CDC records. If you want to use all available threads, you can use "
-                    + "'AVAILABLE_CORES' placeholder. If the number of threads is not specified, the threads will be created as needed, using "
-                    + "Java 'Executors.newCachedThreadPool()' executor service.")
+                    + "'AVAILABLE_CORES' placeholder. If the number of threads is not specified, a thread pool sized to all available cores is used, "
+                    + "with idle threads terminated after 60 seconds.")
             .withDefault(""); // We need to set some non-null value to avoid Kafka config validation failures.
 
     /**


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2263

When `record.processing.threads` is unset (the default), the record-processing pool was built as `ThreadPoolExecutor(0, AVAILABLE_CORES, 60s, LinkedBlockingQueue)`. Per the `ThreadPoolExecutor` Javadoc ("Queuing"), with an unbounded queue the pool never grows past `corePoolSize` — so `corePoolSize=0` pinned it at a single thread and `ParallelSmtAndConvertBatchProcessor` effectively ran single-threaded, while the field's documentation promises `newCachedThreadPool` semantics ("threads created as needed"). Full analysis and a production thread dump in the issue.

The fix sets `corePoolSize = maximumPoolSize = AVAILABLE_CORES` (with an unbounded queue the core size is the only lever that controls parallelism) and `allowCoreThreadTimeOut(true)` to keep the at-rest footprint of the original `corePoolSize=0` — idle threads still exit after 60s. The explicit-property branch is untouched.

As noted in the issue: we deliberately avoided a literal `Executors.newCachedThreadPool()` (unbounded thread growth under burst via `SynchronousQueue`); if you prefer matching the field doc literally, happy to adapt.

Related: debezium/dbz#2255 / #7703 (merged), debezium/dbz#2262 / #7708 — independent findings from the same production investigation.