### PR TITLE
DBZ-1876 Reduce TypeRegistry and SqlTypeMapper WARN log volume

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -135,6 +135,12 @@ public class TypeRegistry {
     private int ltreeArrayOid = Integer.MIN_VALUE;
     private int tsVectorOid = Integer.MIN_VALUE;
 
+    /**
+     * Tracks whether the one-time summary WARN about schema-qualified type name re-mapping has already
+     * been emitted for this registry instance. See dbz#1876.
+     */
+    private boolean typeCollisionWarned = false;
+
     public TypeRegistry(PostgresConnection connection) {
         this(connection, Collections.emptySet());
     }
@@ -180,7 +186,13 @@ public class TypeRegistry {
             }
             PostgresType currentType = nameToType.get(qualifiedName);
             if (!currentType.equals(type)) {
-                LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
+                LOGGER.debug("Type [oid:{}, name:{}] is already mapped", type.getOid(), qualifiedName);
+                if (!typeCollisionWarned) {
+                    typeCollisionWarned = true;
+                    LOGGER.warn(
+                            "Type name re-mapped: Type [oid:{}, name:{}] is already mapped (existing oid:{}); further occurrences for this registry instance will be logged at DEBUG level.",
+                            type.getOid(), qualifiedName, currentType.getOid());
+                }
             }
         }
 
@@ -248,7 +260,7 @@ public class TypeRegistry {
         if (r == null) {
             r = resolveUnknownType(oid);
             if (r == null) {
-                LOGGER.warn("Unknown OID {} requested", oid);
+                LOGGER.debug("Unknown OID {} requested", oid);
                 r = PostgresType.UNKNOWN;
             }
         }
@@ -356,7 +368,7 @@ public class TypeRegistry {
                 : cleanParts[0];
         r = resolveUnknownType(cleanName);
         if (r == null) {
-            LOGGER.warn("Unknown type named {} requested", name);
+            LOGGER.debug("Unknown type named {} requested", name);
             r = PostgresType.UNKNOWN;
         }
         return r;
@@ -711,7 +723,7 @@ public class TypeRegistry {
                     return getTypeInfo(connection).getSQLType(typeName);
                 }
                 catch (Exception e) {
-                    LOGGER.warn("Failed to obtain SQL type information for type {} via custom statement, falling back to TypeInfo#getSQLType()", typeName, e);
+                    LOGGER.debug("Failed to obtain SQL type information for type {} via custom statement, falling back to TypeInfo#getSQLType()", typeName, e);
                     return getTypeInfo(connection).getSQLType(typeName);
                 }
             }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryWarnIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryWarnIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.util.Testing;
+
+public class TypeRegistryWarnIT implements Testing {
+
+    @Test
+    void shouldNotEmitWarnOnUnknownOidLookup() throws SQLException {
+        try (PostgresConnection connection = TestHelper.create()) {
+            final var logInterceptor = LogInterceptor.forClass(TypeRegistry.class);
+            final var registry = new TypeRegistry(connection);
+            logInterceptor.clear();
+
+            registry.get(999999);
+
+            assertThat(logInterceptor.containsWarnMessage("Unknown OID")).isFalse();
+        }
+    }
+
+    @Test
+    void shouldNotEmitWarnForRepeatedUnknownOidLookups() throws SQLException {
+        try (PostgresConnection connection = TestHelper.create()) {
+            final var logInterceptor = LogInterceptor.forClass(TypeRegistry.class);
+            final var registry = new TypeRegistry(connection);
+            logInterceptor.clear();
+
+            registry.get(999999);
+            registry.get(888888);
+            registry.get(777777);
+
+            assertThat(logInterceptor.countOccurrences("Unknown OID")).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void shouldNotEmitWarnOnUnknownTypeNameLookup() throws SQLException {
+        try (PostgresConnection connection = TestHelper.create()) {
+            final var logInterceptor = LogInterceptor.forClass(TypeRegistry.class);
+            final var registry = new TypeRegistry(connection);
+            logInterceptor.clear();
+
+            registry.get("nonexistent_type_name");
+
+            assertThat(logInterceptor.containsWarnMessage("Unknown type named")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1876

## Reduce TypeRegistry / SqlTypeMapper WARN log volume in multi-schema deployments

### Problem

In PostgreSQL deployments with many schemas (multi-tenant, schema-per-tenant, or databases with heavy use of composite types from `CREATE TABLE`), the PostgreSQL connector emits a high volume of WARN-level log lines from `io.debezium.connector.postgresql.TypeRegistry` and its nested `SqlTypeMapper` at startup and during streaming. Reported volumes reach ~17,000 WARN lines per connector startup on managed platforms such as MSK Connect, where per-class log-level overrides are not available, drowning out genuine warnings.

Four log sites contribute to the volume:

1. `TypeRegistry.addType()` — emits a WARN for every schema-qualified type name that gets re-mapped (same `schema.typeName` observed again with a different resolved type, e.g., during rapid DROP/CREATE churn). This is typically not actionable at WARN level: `oidToType` still maps every OID correctly, and name-based lookups continue to follow the existing “first one wins” alias semantics for well-known unqualified names (`hstore`, `geometry`, etc.).
2. `TypeRegistry.get(int oid)` — emits a WARN every time the streaming decoder hands the registry an OID that is not in the pre-loaded cache (e.g., types created after `prime()`, extension types, types resolved after a DROP/RECREATE cycle).
3. `TypeRegistry.get(String name)` — same pattern for name-based lookups that miss the cache.
4. `SqlTypeMapper.getSqlType()` — emits a WARN when the custom-statement resolution path throws and falls back to `TypeInfo#getSQLType()`, which can be hit repeatedly in multi-schema deployments depending on catalog state and driver behavior.

In observed multi-schema/tenant scenarios, these log events are expected and typically not actionable at WARN level.

### Solution

The change is a logging-only fix; no behavior is altered.

- `addType()` collision: per-type message demoted to `LOGGER.debug`. A single `LOGGER.warn` summary is emitted the first time a collision is detected for a given `TypeRegistry` instance, gated by a private `typeCollisionWarned` flag. This preserves the signal for operators while suppressing the per-type flood, matching the direction indicated by the maintainer in the issue thread.
- `get(int oid)` miss: `LOGGER.warn` → `LOGGER.debug`.
- `get(String name)` miss: `LOGGER.warn` → `LOGGER.debug`.
- `SqlTypeMapper.getSqlType()` exception catch-block: `LOGGER.warn` → `LOGGER.debug` (exception path only; behavior unchanged).

### Files changed

- `debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java`
- `debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TypeRegistryWarnIT.java`

### Testing

`TypeRegistryWarnIT` was added as a lightweight integration test that constructs a `TypeRegistry` directly against a PostgreSQL container (no full connector startup) and uses Debezium's `LogInterceptor` to assert the absence of WARN-level messages. Three tests cover the streaming-side miss paths:

- `shouldNotEmitWarnOnUnknownOidLookup` — single `get(int)` miss.
- `shouldNotEmitWarnForRepeatedUnknownOidLookups` — repeated `get(int)` misses, asserts zero WARNs after N lookups.
- `shouldNotEmitWarnOnUnknownTypeNameLookup` — `get(String)` miss.

The fourth test from the initial draft, `shouldNotEmitWarnOnDuplicateTypeNameMapping`, was removed before submission. Cross-schema duplicate names no longer collide because `nameToType` is keyed by schema-qualified name (`schema_a.mytype` vs `schema_b.mytype`). The remaining realistic trigger for the `addType()` re-mapping branch is DROP/CREATE churn that causes the same schema-qualified name to be observed again with a different OID. Simulating that deterministically in a hermetic test tends to be brittle (timing-dependent and/or reliant on catalog behavior), so coverage of the one-time summary WARN is left to code review and manual verification, while the high-volume streaming miss paths are verified by `TypeRegistryWarnIT`.

The `SqlTypeMapper.getSqlType()` exception-path demotion is intentionally not covered by a dedicated test. The branch only fires when the custom-statement path throws or the underlying `TypeInfo#getSQLType()` call fails, neither of which can be provoked reliably in a real-container integration test without either mocking the JDBC layer (inconsistent with the test style used here, which exercises real PostgreSQL) or corrupting a system catalog (destructive and non-portable). The change is a pure log-level demotion with no behavioral effect, so the cost/benefit of a brittle mock-based test does not justify its inclusion.

### Backward compatibility

Operators who relied on the previous per-type WARN lines for diagnostics can recover the full signal by setting the `io.debezium.connector.postgresql.TypeRegistry` logger to `DEBUG`. The one-time summary WARN preserves the high-level indication that schema-qualified type name re-mapping was encountered.

### Related

- dbz#1876
- dbz#9455 (schema-filtered type loading, complementary optimization)
- dbz#5182 (ascending OID order)