### PR TITLE
Support Mariadb 12.3 InnoDB Binlog

### DIFF
--- a/.github/actions/build-debezium-mariadb/action.yml
+++ b/.github/actions/build-debezium-mariadb/action.yml
@@ -12,7 +12,7 @@ inputs:
   version-mariadb-server:
     description: "The MariaDB server version to use"
     required: false
-    default: "11.4.3"
+    default: "11.4"
   profile:
     description: "The MariaDB build profile to use"
     required: false

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -18,12 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl' ]
-        version-mariadb-server: [ "11.4.3", "11.7" ]
+        version-mariadb-server: [ "11.4.3", "11.8.8", "12.3.2" ]
         exclude:
           - profile: "mariadb-ci-gtids"
-            version-mariadb-server: "11.7"
+            version-mariadb-server: "11.8.8"
           - profile: "mariadb-ci-ssl"
-            version-mariadb-server: "11.7"
+            version-mariadb-server: "11.8.8"
+          - profile: "mariadb-ci-gtids"
+            version-mariadb-server: "12.3.2"
+          - profile: "mariadb-ci-ssl"
+            version-mariadb-server: "12.3.2"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: ${{ inputs.max-parallel }}
       fail-fast: false
       matrix:
-        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl' ]
+        profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl', 'mariadb-innodb-binlog' ]
         version-mariadb-server: [ "11.4", "11.8", "12.3" ]
         exclude:
           - profile: "mariadb-ci-gtids"
@@ -28,6 +28,10 @@ jobs:
             version-mariadb-server: "12.3"
           - profile: "mariadb-ci-ssl"
             version-mariadb-server: "12.3"
+          - profile: "mariadb-innodb-binlog"
+            version-mariadb-server: "11.4"
+          - profile: "mariadb-innodb-binlog"
+            version-mariadb-server: "11.8"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/connector-mariadb-workflow.yml
+++ b/.github/workflows/connector-mariadb-workflow.yml
@@ -18,16 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         profile: [ 'mariadb-ci', 'mariadb-ci-gtids', 'mariadb-ci-ssl' ]
-        version-mariadb-server: [ "11.4.3", "11.8.8", "12.3.2" ]
+        version-mariadb-server: [ "11.4", "11.8", "12.3" ]
         exclude:
           - profile: "mariadb-ci-gtids"
-            version-mariadb-server: "11.8.8"
+            version-mariadb-server: "11.8"
           - profile: "mariadb-ci-ssl"
-            version-mariadb-server: "11.8.8"
+            version-mariadb-server: "11.8"
           - profile: "mariadb-ci-gtids"
-            version-mariadb-server: "12.3.2"
+            version-mariadb-server: "12.3"
           - profile: "mariadb-ci-ssl"
-            version-mariadb-server: "12.3.2"
+            version-mariadb-server: "12.3"
     name: MariaDB ${{ matrix.version-mariadb-server }} - ${{ matrix.profile }}
     runs-on: ubuntu-latest
 

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -193,6 +193,7 @@
         -->
         <mariadb.server.image.source>quay.io/debezium/official-mariadb</mariadb.server.image.source>
         <version.mariadb.server>11.4.3</version.mariadb.server>
+        <version.mariadb.server.innodb>12.3.2</version.mariadb.server.innodb>
         <mariadb.user>mysqluser</mariadb.user>
         <mariadb.password>mysqlpw</mariadb.password>
         <mariadb.replica.user>mysqlreplica</mariadb.replica.user>
@@ -202,6 +203,7 @@
         <mariadb.gtid.port>3306</mariadb.gtid.port>
         <mariadb.gtid.replica.port>3306</mariadb.gtid.replica.port>
         <mariadb.ssl.port>3306</mariadb.ssl.port>
+        <mariadb.innodb.port>3306</mariadb.innodb.port>
         <mariadb.replica.port>3306</mariadb.replica.port> <!-- by default use primary as 'replica' -->
         <mariadb.init.timeout>60000</mariadb.init.timeout> <!-- 60 seconds -->
         <mariadb.replica.fileset.path>${project.basedir}/src/test/docker/init-replica</mariadb.replica.fileset.path>
@@ -336,6 +338,60 @@
                                             </fileSet>
                                             <fileSet>
                                                 <directory>${project.basedir}/src/test/docker/init-ssl</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <image>
+                            <!-- A Docker image using MariaDB 12.3 with InnoDB-based binary log. -->
+                            <name>debezium/mariadb-server-innodb-binlog-test-database</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <MARIADB_ROOT_PASSWORD>debezium-rocks</MARIADB_ROOT_PASSWORD>
+                                    <MARIADB_DATABASE>mysql</MARIADB_DATABASE>
+                                    <MARIADB_USER>${mariadb.user}</MARIADB_USER>
+                                    <MARIADB_PASSWORD>${mariadb.password}</MARIADB_PASSWORD>
+                                    <TZ>UTC</TZ>
+                                </env>
+                                <ports>
+                                    <port>${mariadb.innodb.port}:3306</port>
+                                </ports>
+                                <log>
+                                    <prefix>mariadb-innodb-binlog</prefix>
+                                    <enabled>true</enabled>
+                                    <color>cyan</color>
+                                </log>
+                                <wait>
+                                    <log>(MariaDB) init process done. Ready for start up.(?s)(.*)(mariadbd): ready for connections.</log>
+                                    <time>${mariadb.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>mariadb:12.3</from>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server-innodb-binlog</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init</directory>
                                                 <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
                                             </fileSet>
                                         </fileSets>
@@ -600,13 +656,14 @@
             <properties>
                 <!-- Run multiple images at the same time, but use different ports for all MariaDB servers -->
                 <docker.dbs>
-                    debezium/mariadb-server-test-database,debezium/mariadb-server-gtids-test-database,debezium/mariadb-server-gtids-test-database-replica,debezium/mariadb-server-test-database-ssl
+                    debezium/mariadb-server-test-database,debezium/mariadb-server-innodb-binlog-test-database,debezium/mariadb-server-gtids-test-database,debezium/mariadb-server-gtids-test-database-replica,debezium/mariadb-server-test-database-ssl
                 </docker.dbs>
                 <mariadb.port>4301</mariadb.port>
                 <mariadb.gtid.port>4302</mariadb.gtid.port>
                 <mariadb.gtid.replica.port>4303</mariadb.gtid.replica.port>
                 <mariadb.percona.port>4304</mariadb.percona.port>
                 <mariadb.ssl.port>4305</mariadb.ssl.port>
+                <mariadb.innodb.port>4306</mariadb.innodb.port>
             </properties>
             <build>
                 <plugins>
@@ -846,6 +903,37 @@
                             <systemPropertyVariables>
                                 <database.port>${mariadb.ssl.port}</database.port>
                                 <database.replica.port>${mariadb.ssl.port}</database.replica.port>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Use the Docker image for MariaDB 12.3+ with InnoDB-based binary log.
+        To use, specify "-Dmariadb-innodb-binlog" or -Pmariadb-innodb-binlog on the Maven command line.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>mariadb-innodb-binlog</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>mariadb-innodb-binlog</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Docker properties -->
+                <docker.dbs>debezium/mariadb-server-innodb-binlog-test-database</docker.dbs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <database.port>${mariadb.innodb.port}</database.port>
+                                <database.replica.port>${mariadb.innodb.port}</database.replica.port>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -934,6 +934,7 @@
                             <systemPropertyVariables>
                                 <database.port>${mariadb.innodb.port}</database.port>
                                 <database.replica.port>${mariadb.innodb.port}</database.replica.port>
+                                <database.innodb.binlog>true</database.innodb.binlog>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -103,7 +103,7 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -376,7 +376,7 @@
                                 </wait>
                             </run>
                             <build>
-                                <from>mariadb:12.3</from>
+                                <from>${mariadb.server.image.source}:${version.mariadb.server.innodb}</from>
                                 <runCmds>
                                     <run>${docker.initimage}</run>
                                 </runCmds>

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -192,8 +192,8 @@
         Specify the properties for the various Docker containers.
         -->
         <mariadb.server.image.source>quay.io/debezium/official-mariadb</mariadb.server.image.source>
-        <version.mariadb.server>11.4.3</version.mariadb.server>
-        <version.mariadb.server.innodb>12.3.2</version.mariadb.server.innodb>
+        <version.mariadb.server>11.4</version.mariadb.server>
+        <version.mariadb.server.innodb>12.3</version.mariadb.server.innodb>
         <mariadb.user>mysqluser</mariadb.user>
         <mariadb.password>mysqlpw</mariadb.password>
         <mariadb.replica.user>mysqlreplica</mariadb.replica.user>

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbStreamingChangeEventSource.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbStreamingChangeEventSource.java
@@ -109,6 +109,14 @@ public class MariaDbStreamingChangeEventSource extends BinlogStreamingChangeEven
         }
         setGtidChanged(gtid);
 
+        // Ensure eventTimestamp is populated from this event before calling handleTransactionBegin.
+        // With the new InnoDB-based binlog (MariaDB 12.3+), there may be no prior FORMAT_DESCRIPTION
+        // or ROTATE events to have set eventTimestamp via onEvent(), since event listeners are called
+        // in registration order and handleEvent runs before onEvent.
+        if (eventTimestamp == null) {
+            setEventTimestamp(event, event.getHeader().getTimestamp());
+        }
+
         // With compatibility mode 4, this event equates to a new transaction.
         handleTransactionBegin(partition, offsetContext, event, null);
     }

--- a/debezium-connector-mariadb/src/test/docker/server-innodb-binlog/my.cnf
+++ b/debezium-connector-mariadb/src/test/docker/server-innodb-binlog/my.cnf
@@ -1,0 +1,25 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/8.2/en/server-configuration-defaults.html
+
+# --------------------------------------------------------------------------------------------
+# This section specifies MariaDB 12.3+ InnoDB-based binary log configuration
+# --------------------------------------------------------------------------------------------
+[mariadb]
+skip-host-cache
+skip-name-resolve
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# Enable the InnoDB-based binary log (MariaDB 12.3+).
+# log_bin must be specified without a value when binlog_storage_engine=innodb.
+# This format requires GTID-based replication; filename/offset positioning is not supported.
+server-id                     = 112233
+log_bin
+binlog_storage_engine         = innodb
+binlog_format                 = row
+binlog_row_image              = full
+log_slave_updates             = on
+log_bin_compress              = off
+default_authentication_plugin = mysql_native_password

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ConnectionIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ConnectionIT.java
@@ -32,7 +32,7 @@ public class ConnectionIT extends BinlogConnectionIT<MariaDbConnector> implement
 
             assertThatThrownBy(() -> conn.execute("SELECT SLEEP(10)"))
                     .isInstanceOf(SQLTimeoutException.class)
-                    .hasMessageContaining("Query execution was interrupted (max_statement_time exceeded)");
+                    .hasMessageContaining("Query was interrupted");
 
         }
     }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ConnectionIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ConnectionIT.java
@@ -32,7 +32,7 @@ public class ConnectionIT extends BinlogConnectionIT<MariaDbConnector> implement
 
             assertThatThrownBy(() -> conn.execute("SELECT SLEEP(10)"))
                     .isInstanceOf(SQLTimeoutException.class)
-                    .hasMessageContaining("Query was interrupted");
+                    .hasMessageContaining("was interrupted");
 
         }
     }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbCommon.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbCommon.java
@@ -47,4 +47,8 @@ public interface MariaDbCommon extends BinlogConnectorTest<MariaDbConnector> {
     default boolean isMariaDb() {
         return true;
     }
+
+    default boolean isInnoDbBinlogEnabled() {
+        return Boolean.getBoolean("database.innodb.binlog");
+    }
 }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
@@ -86,6 +86,12 @@ public class MariaDbConnectorIT extends BinlogConnectorIT<MariaDbConnector, Mari
 
     @Override
     protected void assertBinlogPosition(long offsetPosition, long beforeInsertsPosition) {
+        // With the InnoDB-based binary log (MariaDB 12.3+), event header positions are
+        // reported as 0 and are not meaningful; GTID positions should be used instead.
+        // Skip the position assertion in this case.
+        if (offsetPosition == 0) {
+            return;
+        }
         assertThat(offsetPosition).isGreaterThanOrEqualTo(beforeInsertsPosition);
     }
 

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbConnectorIT.java
@@ -88,8 +88,8 @@ public class MariaDbConnectorIT extends BinlogConnectorIT<MariaDbConnector, Mari
     protected void assertBinlogPosition(long offsetPosition, long beforeInsertsPosition) {
         // With the InnoDB-based binary log (MariaDB 12.3+), event header positions are
         // reported as 0 and are not meaningful; GTID positions should be used instead.
-        // Skip the position assertion in this case.
-        if (offsetPosition == 0) {
+        // Skip the position assertion when the InnoDB-based binary log is enabled.
+        if (isInnoDbBinlogEnabled()) {
             return;
         }
         assertThat(offsetPosition).isGreaterThanOrEqualTo(beforeInsertsPosition);

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -329,6 +329,14 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-binlog]
 
+// Type: procedure
+// ModuleID: enabling-innodb-binlog-for-debezium
+// Title: Enabling the InnoDB-based binary log for {prodname}
+[[enable-innodb-binlog]]
+=== Enabling the InnoDB-based binary log
+
+include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-innodb-binlog]
+
 [id="binlog-configuration-properties-mariadb-connector"]
 ==== Descriptions of MariaDB binlog configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -329,6 +329,7 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-binlog]
 
+idef::community[]
 // Type: procedure
 // ModuleID: enabling-innodb-binlog-for-debezium
 // Title: Enabling the InnoDB-based binary log for {prodname}
@@ -336,7 +337,7 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 === Enabling the InnoDB-based binary log
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-innodb-binlog]
-
+endif::community[]
 [id="binlog-configuration-properties-mariadb-connector"]
 ==== Descriptions of MariaDB binlog configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/mariadb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mariadb.adoc
@@ -329,7 +329,7 @@ include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloff
 
 include::{partialsdir}/modules/all-connectors/shared-mariadb-mysql.adoc[leveloffset=+1,tags=enabling-binlog]
 
-idef::community[]
+ifdef::community[]
 // Type: procedure
 // ModuleID: enabling-innodb-binlog-for-debezium
 // Title: Enabling the InnoDB-based binary log for {prodname}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2418,6 +2418,8 @@ Details are in the following sections:
 
 * xref:creating-a-{context}-user-for-a-debezium-connector[]
 * xref:enabling-the-{context}-binlog-for-debezium[]
+* xref:enabling-innodb-binlog-for-debezium[]
+
 * xref:enabling-{context}-gtids-for-debezium[]
 * xref:configuring-{context}-session-timeouts-for-debezium[]
 * xref:enabling-query-log-events-for-debezium-{context}-connectors[]
@@ -2616,17 +2618,22 @@ tag::binlog-config-props[]
 |`log_bin`
 |The value of `log_bin` is the base name of the sequence of binlog files.
 ifdef::MARIADB[]
+ifdef::community[]
 When using the link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
-on MariaDB 12.3+, this option must be specified without a value.
+If the MariaDB server uses link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB to store the binary log], add an empty `log_bin` property to the MariaDB configuration.
+That is, list the property in the configuration, but do not specify a value.
+endif::community[]
 endif::MARIADB[]
 
 ifdef::MARIADB[]
+ifdef::community[]
 |`binlog_storage_engine`
 |Specifies the storage engine that manages the binary log.
 Set the value to `innodb` to enable the https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
 feature in MariaDB 12.3 and later.
 When set to `innodb`, the `log_bin` option must be specified with no value, and replication must use GTID-based positioning.
 If you do not set this property, the database uses the default value, `file`, and stores log data in standard flat file format.
+endif::community[]
 endif::MARIADB[]
 
 |`binlog_format`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2552,21 +2552,22 @@ endif::community[]
 end::enabling-binlog[]
 
 
-ifdef::MARIADB[]
 === Enabling the InnoDB-based binary log (MariaDB 12.3 and later)
 
-From MariaDB 12.3, the binary log can be optionally stored in InnoDB-managed, page-structured files.
-When enabled, this feature eliminates the traditional two-phase commit (2PC) protocol between the
-binary log and InnoDB, providing improved commit latency and simplified crash recovery.
 
-.Important considerations
+tag::enabling-innodb-binlog[]
+ifdef::community[]
+In MariaDB versions 12.3 and later, you can configure the database to store the binary log in InnoDB-managed, page-structured files (`.ibb`), instead of traditional flat files.
+If you configure the database to store the binary log in InnoDB files, it does not enforce the two-phase commit (2PC) protocol between the
+binary log and InnoDB, resulting in improved commit latency and simplified crash recovery.
 
-* Replication must use GTID-based positioning. Filename and offset-based positions are not available.
-* This feature is mutually exclusive with the traditional file-based binlog. The server writes only the InnoDB-based format.
-* Galera Cluster is not supported when InnoDB-based binary logs are in use.
+When the database uses InnoDB to store the binary log, the following considerations apply:
+
+* This feature is mutually exclusive with the traditional file-based binlog.
+The server uses the InnoDB-based format to store all entries.
+* Galera Cluster is not supported.
 * Semi-synchronous replication is not supported.
 * The `sync_binlog` option is no longer required and is effectively ignored.
-* The {prodname} {connector-name} connector supports this feature from version {debezium-version}.
 
 .Prerequisites
 
@@ -2585,10 +2586,10 @@ binlog_format=ROW
 binlog_row_image=FULL
 ----
 +
-The `log_bin` option must be specified without a value. The `binlog_storage_engine=innodb`
-setting enables the InnoDB-based binary log.
+The `log_bin` property must be present in the configuration, but it cannot contain a value.
+The `binlog_storage_engine=innodb` setting enables the database to use InnoDB to store the binary log.
 
-. Verify the binlog format by connecting to the server and running:
+. Verify the binlog format by connecting to the server and running the following SQL command:
 +
 [source,sql]
 ----
@@ -2597,10 +2598,10 @@ SHOW BINARY LOGS;
 +
 Files are named with an `.ibb` extension (for example, `binlog-000000.ibb`).
 
-For additional information about the InnoDB-based binary log, see the
-link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[MariaDB documentation].
+For more information about the InnoDB-based binary log, see the https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[MariaDB documentation].
 
-endif::MARIADB[]
+endif::community[]
+end::enabling-innodb-binlog[]
 
 
 tag::binlog-config-props[]
@@ -2621,11 +2622,11 @@ endif::MARIADB[]
 
 ifdef::MARIADB[]
 |`binlog_storage_engine`
-|Controls which storage engine manages the binary log. Set to `innodb` to enable the
-link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
-feature in MariaDB 12.3 and later. When set to `innodb`, the `log_bin` option must be specified
-without a value, and replication must use GTID-based positioning.
-If unset, the default value is `file`, which uses the traditional file-based binary log.
+|Specifies the storage engine that manages the binary log.
+Set the value to `innodb` to enable the https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
+feature in MariaDB 12.3 and later.
+When set to `innodb`, the `log_bin` option must be specified with no value, and replication must use GTID-based positioning.
+If you do not set this property, the database uses the default value, `file`, and stores log data in standard flat file format.
 endif::MARIADB[]
 
 |`binlog_format`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2418,7 +2418,9 @@ Details are in the following sections:
 
 * xref:creating-a-{context}-user-for-a-debezium-connector[]
 * xref:enabling-the-{context}-binlog-for-debezium[]
+ifdef::community[]
 * xref:enabling-innodb-binlog-for-debezium[]
+endif::community[]
 
 * xref:enabling-{context}-gtids-for-debezium[]
 * xref:configuring-{context}-session-timeouts-for-debezium[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2552,6 +2552,57 @@ endif::community[]
 end::enabling-binlog[]
 
 
+ifdef::MARIADB[]
+=== Enabling the InnoDB-based binary log (MariaDB 12.3 and later)
+
+From MariaDB 12.3, the binary log can be optionally stored in InnoDB-managed, page-structured files.
+When enabled, this feature eliminates the traditional two-phase commit (2PC) protocol between the
+binary log and InnoDB, providing improved commit latency and simplified crash recovery.
+
+.Important considerations
+
+* Replication must use GTID-based positioning. Filename and offset-based positions are not available.
+* This feature is mutually exclusive with the traditional file-based binlog. The server writes only the InnoDB-based format.
+* Galera Cluster is not supported when InnoDB-based binary logs are in use.
+* Semi-synchronous replication is not supported.
+* The `sync_binlog` option is no longer required and is effectively ignored.
+* The {prodname} {connector-name} connector supports this feature from version {debezium-version}.
+
+.Prerequisites
+
+* MariaDB version 12.3 or later.
+* GTID-based replication is enabled.
+
+.Procedure
+
+. Add the following options to your MariaDB configuration file:
++
+[source,properties]
+----
+log_bin
+binlog_storage_engine=innodb
+binlog_format=ROW
+binlog_row_image=FULL
+----
++
+The `log_bin` option must be specified without a value. The `binlog_storage_engine=innodb`
+setting enables the InnoDB-based binary log.
+
+. Verify the binlog format by connecting to the server and running:
++
+[source,sql]
+----
+SHOW BINARY LOGS;
+----
++
+Files are named with an `.ibb` extension (for example, `binlog-000000.ibb`).
+
+For additional information about the InnoDB-based binary log, see the
+link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[MariaDB documentation].
+
+endif::MARIADB[]
+
+
 tag::binlog-config-props[]
 .Descriptions of {connector-name} binlog configuration properties
 [cols="1,4",options="header",subs="+attributes"]
@@ -2563,6 +2614,19 @@ tag::binlog-config-props[]
 
 |`log_bin`
 |The value of `log_bin` is the base name of the sequence of binlog files.
+ifdef::MARIADB[]
+When using the link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
+on MariaDB 12.3+, this option must be specified without a value.
+endif::MARIADB[]
+
+ifdef::MARIADB[]
+|`binlog_storage_engine`
+|Controls which storage engine manages the binary log. Set to `innodb` to enable the
+link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
+feature in MariaDB 12.3 and later. When set to `innodb`, the `log_bin` option must be specified
+without a value, and replication must use GTID-based positioning.
+If unset, the default value is `file`, which uses the traditional file-based binary log.
+endif::MARIADB[]
 
 |`binlog_format`
 |The `binlog-format` must be set to `ROW` or `row`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -2562,8 +2562,7 @@ end::enabling-binlog[]
 tag::enabling-innodb-binlog[]
 ifdef::community[]
 In MariaDB versions 12.3 and later, you can configure the database to store the binary log in InnoDB-managed, page-structured files (`.ibb`), instead of traditional flat files.
-If you configure the database to store the binary log in InnoDB files, it does not enforce the two-phase commit (2PC) protocol between the
-binary log and InnoDB, resulting in improved commit latency and simplified crash recovery.
+If you configure the database to store the binary log in InnoDB files, it does not enforce the two-phase commit (2PC) protocol between the binary log and InnoDB, resulting in improved commit latency and simplified crash recovery.
 
 When the database uses InnoDB to store the binary log, the following considerations apply:
 
@@ -2621,7 +2620,6 @@ tag::binlog-config-props[]
 |The value of `log_bin` is the base name of the sequence of binlog files.
 ifdef::MARIADB[]
 ifdef::community[]
-When using the link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB-based binary log]
 If the MariaDB server uses link:https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/innodb-based-binary-log/[InnoDB to store the binary log], add an empty `log_bin` property to the MariaDB configuration.
 That is, list the property in the configuration, but do not specify a value.
 endif::community[]


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2259

## Description
Adds support for Mariadb 12.3's innodb binlog

An integration test profile `mariadb-innodb-binlog` was added, which is currently using the docker hub mariadb 12.3, as there isn't yet one in https://quay.io/repository/debezium/official-mariadb.

Test can be run with `mvn verify -Pmariadb-innodb-binlog`

It is entirely possible/probable that more changes need to be made, but the new integration test profile passed after slight modifications to accommodate slight changes that caused a couple failures. 

Docs updated to explain how to use it

Deepseek Flash V4 was used to diagnose the issue and apply all changes, with my supervision.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
