### PR TITLE
debezium/dbz#2246 Fix double negation in Predicates.excludesLiterals(String, Function)

### DIFF
--- a/debezium-util/src/main/java/io/debezium/function/Predicates.java
+++ b/debezium-util/src/main/java/io/debezium/function/Predicates.java
@@ -166,7 +166,7 @@ public class Predicates {
      * Same as {@link #excludesLiterals(String, Function, boolean)} without trimming
      */
     public static <T> Predicate<T> excludesLiterals(String literals, Function<T, String> conversion) {
-        return excludesLiterals(literals, conversion, false).negate();
+        return excludesLiterals(literals, conversion, false);
     }
 
     /**

--- a/debezium-util/src/test/java/io/debezium/function/PredicatesTest.java
+++ b/debezium-util/src/test/java/io/debezium/function/PredicatesTest.java
@@ -12,6 +12,8 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import io.debezium.doc.FixFor;
+
 /**
  * @author Randall Hauch
  */
@@ -87,6 +89,17 @@ public class PredicatesTest {
         assertThat(p.test(uuid3)).isTrue();
         assertThat(p.test(uuid4)).isFalse();
 
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2246")
+    public void shouldExcludeMatchingLiteralsWithConversion() {
+        Predicate<Integer> p = Predicates.excludesLiterals("1,2,3", (i) -> i.toString());
+        assertThat(p.test(1)).isFalse();
+        assertThat(p.test(2)).isFalse();
+        assertThat(p.test(3)).isFalse();
+        assertThat(p.test(0)).isTrue();
+        assertThat(p.test(4)).isTrue();
     }
 
 }


### PR DESCRIPTION
The two-argument `Predicates.excludesLiterals(String, Function)` overload delegates to
`excludesLiterals(literals, conversion, false).negate()`. Since the three-argument form already
returns an *excludes* predicate (`includesLiterals(...).negate()`), the extra `.negate()` here
produces `includesLiterals(...).negate().negate()` — i.e. an **includes** predicate returned from a
method named `excludesLiterals`, contradicting both its Javadoc ("Generate a predicate that ...
does *not* match ...") and every sibling overload.

Fix: drop the extra `.negate()` so the two-arg overload actually excludes the listed literals.

### Before / after
For `excludesLiterals("1,2,3", i -> i.toString())`:

| input | current (buggy) | expected / fixed |
|---|---|---|
| 1, 2, 3 | `true` (matches) | `false` (excluded) |
| 0, 4 | `false` | `true` |

Added `PredicatesTest.shouldExcludeMatchingLiteralsWithConversion` (`@FixFor("debezium/dbz#2246")`)
covering both excluded and passed-through values.

Closes debezium/dbz#2246
