### PR TITLE
[docs] Document the sinkless changefeed delivery mode for the CockroachDB connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -53,7 +53,9 @@ The enriched format includes both schema metadata and the full before and after 
 2. **Intermediate Kafka to {prodname} to Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer; routes each event to the correct table based on the topic name; transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields); and produces them to the final output Kafka topics.
 
 By using this architecture the connector can use the native, highly-available changefeed infrastructure of CockroachDB to reliably capture data and provide it to downstream consumers in the standard {prodname} event format.
-The two-stage architecture describes the default `kafka` delivery mode; for an alternative that streams the changefeed over the connector's SQL connection, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
+The two-stage architecture that is described in the preceding paragraphs applies to the default `kafka` delivery mode.
+As an alternative, you can configure the connector to stream the changefeed over the connector's SQL connection.
+For more information, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
 By default, the connector consolidates all configured tables into a single changefeed.
 By consolidating data in a single changefeed job, the connector conforms to the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended limit] on the number of changefeeds per CockroachDB cluster (approximately 80 at the time of writing).
 To improve throughput and prevent performance coupling, CockroachDB link:https://www.cockroachlabs.com/docs/stable/changefeed-best-practices[best practices] advise against using a single changefeed to monitor a large number of tables.
@@ -62,19 +64,24 @@ In environments with large table counts, consider setting xref:cockroachdb-prope
 [[cockroachdb-changefeed-delivery-modes]]
 === Changefeed delivery modes
 
-The xref:cockroachdb-property-sink-type[`cockroachdb.changefeed.sink.type`] property determines how the connector receives changefeed events:
+By default, the CockroachDB connector uses a two-stage flow in which CockroachDB first writes changefeed events to an intermediate Kafka cluster. 
+The connector then consumes those events, converts them to the standard {prodname} envelope, and republishes them to the final Kafka topics. 
+As an alternative to this standard flow, you can set the connector's xref:cockroachdb-property-sink-type[`cockroachdb.changefeed.sink.type`] property to `sinkless` so that the connector ingests change events directly  from the database via a dedicated SQL connection.
+It then emits the change event records to the configured Kafka topics as in the default flow. 
+The following descriptions provide details about the available `cockroachdb.changefeed.sink.type` settings: 
 
 `kafka` (default)::
 The connector creates a changefeed with an `INTO 'kafka://...'` clause, and CockroachDB pushes change events to per-table topics on an intermediate Kafka cluster.
 The connector runs its own consumer to read the events back.
-The intermediate topics durably buffer change events independently of the connector, so the connector can be offline for an extended period and resume from the buffered events.
-The xref:cockroachdb-property-sink-uri[`cockroachdb.changefeed.sink.uri`] property is required.
+Intermediate topics store change events independently of the connector. 
+As a result, the connector can remain offline for an extended period and then resume processing from the stored events when it reconnects.
+To use this property, you must set the xref:cockroachdb-property-sink-uri[cockroachdb.changefeed.sink.uri] property.
 
 `sinkless`::
-The connector creates a link:https://www.cockroachlabs.com/docs/stable/changefeed-examples#create-a-sinkless-changefeed[sinkless changefeed] with no `INTO` clause, and streams change events directly over a dedicated SQL connection.
+The connector creates a https://www.cockroachlabs.com/docs/stable/changefeed-examples#create-a-sinkless-changefeed[sinkless changefeed] with no `INTO` clause, and streams change events directly from the database over a dedicated SQL connection.
 There is no intermediate Kafka cluster, no changefeed job, and no separate changefeed consumer to secure.
 The `cockroachdb.changefeed.sink.uri` property is not used.
-Because there is no intermediate buffer, resuming after connector downtime depends on the CockroachDB link:https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection window] (`gc.ttlseconds`).
+Because there is no intermediate buffer, resuming after connector downtime depends on the CockroachDB https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection window (`gc.ttlseconds`)].
 If the connector is offline for longer than the garbage collection window, a new snapshot is required.
 
 The change events that the connector produces are identical in both modes; only the ingestion path differs.
@@ -1218,8 +1225,10 @@ When the connector restarts from a stored offset, it uses the stored resolved ti
 |[[cockroachdb-property-sink-type]]<<cockroachdb-property-sink-type, `+cockroachdb.changefeed.sink.type+`>>
 |`kafka`
 |The changefeed delivery mode.
-Set `kafka` to have CockroachDB push changefeed events to an intermediate Kafka cluster that the connector consumes.
-Set `sinkless` to have the connector stream changefeed events directly over a dedicated SQL connection, with no intermediate Kafka cluster.
+Set one of the following options:
+`kafka`:: CockroachDB pushes changefeed events to an intermediate Kafka cluster that the connector consumes.
+`sinkless`:: The connector streams changefeed events directly from the database over a dedicated SQL connection, with no intermediate Kafka cluster.
+
 For more information, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
 
 |[[cockroachdb-property-kafka-sink-config]]<<cockroachdb-property-kafka-sink-config, `+cockroachdb.changefeed.kafka.sink.config+`>>
@@ -1508,7 +1517,10 @@ curl -X PUT -H "Content-Type: application/json" \
 [[cockroachdb-limitations]]
 == Limitations
 
-Changefeed sink types:: The connector supports two changefeed delivery modes: the default `kafka` mode, which uses an intermediate Kafka sink, and the `sinkless` mode, which streams change events over the connector's SQL connection.
+Changefeed sink types:: 
+The connector supports two changefeed delivery modes.
+Configure the connector to use the default `kafka` mode if you want CockroachDB to push changefeed events to an intermediate Kafka sink and have the connector consume events from that sink. 
+Or configure the `sinkless` mode if you want the database to stream change events directly to {prodname} over the connector's SQL connection.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).
 
 Before state in updates:: By default, CockroachDB changefeeds do not include the previous row state.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1425,7 +1425,13 @@ Because CockroachDB is a distributed database, the cluster automatically handles
 If the entire cluster becomes unavailable, the changefeed stops producing events.
 After the cluster recovers, the connector resumes processing from the last stored offset.
 
-The connector includes retry logic with configurable parameters (`connection.max.retries`, `connection.retry.delay.ms`) for handling transient connection failures, including CockroachDB-specific errors like serialization failures (SQL state 40001) and connection errors (SQL state 08xxx).
+The connector automatically retries transient connection failures.
+The xref:cockroachdb-property-connection-max-retries[`connection.max.retries`] and xref:cockroachdb-property-connection-retry-delay[`connection.retry.delay.ms`] properties control the number of attempts and the delay between them.
+The connector treats the following SQL states as transient:
+
+* The entire connection exception class (SQL state `08xxx`), which includes the `08001` errors that the driver reports when a connection is refused or a host is unreachable.
+* Node shutdown (SQL state `57P01`), which CockroachDB reports while a node drains during a rolling restart.
+* The retryable transaction states `40001` (serialization failure), `40003` (statement completion unknown), and `40P01` (deadlock detected).
 
 [id="cockroachdb-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1426,12 +1426,12 @@ If the entire cluster becomes unavailable, the changefeed stops producing events
 After the cluster recovers, the connector resumes processing from the last stored offset.
 
 The connector automatically retries transient connection failures.
-The xref:cockroachdb-property-connection-max-retries[`connection.max.retries`] and xref:cockroachdb-property-connection-retry-delay[`connection.retry.delay.ms`] properties control the number of attempts and the delay between them.
-The connector treats the following SQL states as transient:
+The xref:cockroachdb-property-connection-max-retries[`connection.max.retries`] and xref:cockroachdb-property-connection-retry-delay[`connection.retry.delay.ms`] properties control the number of retry attempts and the delay interval between attempts.
+The connector treats the following SQL states as transient, retriable errors:
 
-* The entire connection exception class (SQL state `08xxx`), which includes the `08001` errors that the driver reports when a connection is refused or a host is unreachable.
-* Node shutdown (SQL state `57P01`), which CockroachDB reports while a node drains during a rolling restart.
-* The retryable transaction states `40001` (serialization failure), `40003` (statement completion unknown), and `40P01` (deadlock detected).
+* Connection exceptions (SQL state class `08xxx`), including `08001` errors that occur when a connection is refused or a host is unreachable.
+* Node shutdown conditions (SQL state `57P01`) that occur while CockroachDB drains a node during a rolling restart.
+* Retriable transaction conditions, including serialization failures (`40001`), statement completion unknown conditions (`40003`), and deadlocks (`40P01`).
 
 [id="cockroachdb-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -1222,6 +1222,12 @@ Set `kafka` to have CockroachDB push changefeed events to an intermediate Kafka 
 Set `sinkless` to have the connector stream changefeed events directly over a dedicated SQL connection, with no intermediate Kafka cluster.
 For more information, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
 
+|[[cockroachdb-property-kafka-sink-config]]<<cockroachdb-property-kafka-sink-config, `+cockroachdb.changefeed.kafka.sink.config+`>>
+|No default
+|A JSON value for the CockroachDB `kafka_sink_config` changefeed option, which tunes how the changefeed batches and flushes writes to the intermediate Kafka sink.
+For example, `{"Flush": {"Messages": 100, "Frequency": "500ms"}}` bounds delivery latency to 500 milliseconds.
+The connector validates the value as JSON and applies it only when `cockroachdb.changefeed.sink.type` is set to `kafka`.
+
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
 |String that the connector prefixes to intermediate changefeed topic names.

--- a/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cockroachdb.adoc
@@ -52,11 +52,32 @@ The enriched format includes both schema metadata and the full before and after 
 
 2. **Intermediate Kafka to {prodname} to Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer; routes each event to the correct table based on the topic name; transforms the enriched changefeed events into the standard {prodname} envelope format (with `before`, `after`, `source`, and `op` fields); and produces them to the final output Kafka topics.
 
-By using this architecture the connector can leverage the native, highly-available changefeed infrastructure of CockroachDB to reliably capture data and provide it to downstream consumers in the standard {prodname} event format.
+By using this architecture the connector can use the native, highly-available changefeed infrastructure of CockroachDB to reliably capture data and provide it to downstream consumers in the standard {prodname} event format.
+The two-stage architecture describes the default `kafka` delivery mode; for an alternative that streams the changefeed over the connector's SQL connection, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
 By default, the connector consolidates all configured tables into a single changefeed.
 By consolidating data in a single changefeed job, the connector conforms to the link:https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations[recommended limit] on the number of changefeeds per CockroachDB cluster (approximately 80 at the time of writing).
 To improve throughput and prevent performance coupling, CockroachDB link:https://www.cockroachlabs.com/docs/stable/changefeed-best-practices[best practices] advise against using a single changefeed to monitor a large number of tables.
 In environments with large table counts, consider setting xref:cockroachdb-property-max-tables-per-changefeed[`cockroachdb.changefeed.max.tables.per.changefeed`] to split the tables across several changefeeds, or running multiple connector instances so that each connector captures a related subset of the tables.
+
+[[cockroachdb-changefeed-delivery-modes]]
+=== Changefeed delivery modes
+
+The xref:cockroachdb-property-sink-type[`cockroachdb.changefeed.sink.type`] property determines how the connector receives changefeed events:
+
+`kafka` (default)::
+The connector creates a changefeed with an `INTO 'kafka://...'` clause, and CockroachDB pushes change events to per-table topics on an intermediate Kafka cluster.
+The connector runs its own consumer to read the events back.
+The intermediate topics durably buffer change events independently of the connector, so the connector can be offline for an extended period and resume from the buffered events.
+The xref:cockroachdb-property-sink-uri[`cockroachdb.changefeed.sink.uri`] property is required.
+
+`sinkless`::
+The connector creates a link:https://www.cockroachlabs.com/docs/stable/changefeed-examples#create-a-sinkless-changefeed[sinkless changefeed] with no `INTO` clause, and streams change events directly over a dedicated SQL connection.
+There is no intermediate Kafka cluster, no changefeed job, and no separate changefeed consumer to secure.
+The `cockroachdb.changefeed.sink.uri` property is not used.
+Because there is no intermediate buffer, resuming after connector downtime depends on the CockroachDB link:https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds[garbage collection window] (`gc.ttlseconds`).
+If the connector is offline for longer than the garbage collection window, a new snapshot is required.
+
+The change events that the connector produces are identical in both modes; only the ingestion path differs.
 
 [[cockroachdb-snapshots]]
 === Snapshots
@@ -384,7 +405,7 @@ The following JSON represents this key structure:
     "fields": [
       {
         "type": "string",
-        "optional": false,
+        "optional": true,
         "field": "id"
       }
     ]
@@ -1079,7 +1100,8 @@ Only alphanumeric characters, hyphens, dots, and underscores must be used in the
 |No default
 |The URI for the intermediate Kafka cluster where CockroachDB publishes changefeed events.
 Format: `kafka://host:port`.
-This is a required property.
+This property is required when `cockroachdb.changefeed.sink.type` is set to `kafka`.
+It is not used when the delivery mode is `sinkless`.
 
 |===
 
@@ -1195,8 +1217,10 @@ When the connector restarts from a stored offset, it uses the stored resolved ti
 
 |[[cockroachdb-property-sink-type]]<<cockroachdb-property-sink-type, `+cockroachdb.changefeed.sink.type+`>>
 |`kafka`
-|The type of sink for changefeed events.
-Currently supported: `kafka`.
+|The changefeed delivery mode.
+Set `kafka` to have CockroachDB push changefeed events to an intermediate Kafka cluster that the connector consumes.
+Set `sinkless` to have the connector stream changefeed events directly over a dedicated SQL connection, with no intermediate Kafka cluster.
+For more information, see xref:cockroachdb-changefeed-delivery-modes[Changefeed delivery modes].
 
 |[[cockroachdb-property-sink-topic-prefix]]<<cockroachdb-property-sink-topic-prefix, `+cockroachdb.changefeed.sink.topic.prefix+`>>
 |_empty_
@@ -1478,7 +1502,7 @@ curl -X PUT -H "Content-Type: application/json" \
 [[cockroachdb-limitations]]
 == Limitations
 
-Kafka sink only:: The connector currently only supports Kafka as the intermediate changefeed sink.
+Changefeed sink types:: The connector supports two changefeed delivery modes: the default `kafka` mode, which uses an intermediate Kafka sink, and the `sinkless` mode, which streams change events over the connector's SQL connection.
 Support for webhook, Pub/Sub, and cloud storage sinks is planned (see link:https://github.com/debezium/dbz/issues/1632[debezium/dbz#1632]).
 
 Before state in updates:: By default, CockroachDB changefeeds do not include the previous row state.


### PR DESCRIPTION
Documents the sinkless changefeed delivery mode added by debezium/debezium-connector-cockroachdb#58 (https://github.com/debezium/dbz/issues/2024).

Problem

The CockroachDB connector page describes only the kafka delivery mode. The connector now also supports a sinkless mode that streams the changefeed over the connector's SQL connection with no intermediate Kafka cluster, and the limitations section still states that Kafka is the only supported sink. The change event key example also shows the key field as required, but the connector emits key fields as optional.

Change

Add a Changefeed delivery modes section describing both modes, including the durability tradeoff for sinkless resume, which is bounded by the CockroachDB garbage collection window. Update the cockroachdb.changefeed.sink.type and cockroachdb.changefeed.sink.uri property descriptions and the limitations entry. Correct the key example field to optional true and replace one instance of leverage.

Verification

The delivery mode content matches the merged connector behavior, which is exercised by CockroachDBSinklessIT, CockroachDBEmbeddedSinklessIT, and the crdb-to-sinkless and crdb-to-crdb-embedded example pipelines. Both external CockroachDB documentation links and their anchors were checked.