### PR TITLE
debezium/dbz#984 Route non-retriable record failures to the errant record reporter in the JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -250,15 +250,7 @@ public class DefaultRecordWriter implements RecordWriter {
     }
 
     private boolean isRetriable(Throwable throwable) {
-        if (throwable == null) {
-            return false;
-        }
-        for (Class<? extends Exception> e : dialect.getCommunicationExceptions()) {
-            if (e.isAssignableFrom(throwable.getClass())) {
-                return true;
-            }
-        }
-        return isRetriable(throwable.getCause());
+        return dialect.isCommunicationException(throwable);
     }
 
     // Retries the callable operation based on the configured retry settings.

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -28,6 +28,7 @@ import io.debezium.connector.common.DebeziumTaskState;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.dlq.ErrorReporter;
+import io.debezium.dlq.ErrorReporters;
 import io.debezium.metadata.CollectionId;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
@@ -60,6 +61,11 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
 
     final Map<CollectionId, Buffer> upsertBufferByTable = new LinkedHashMap<>();
     final Map<CollectionId, Buffer> deleteBufferByTable = new LinkedHashMap<>();
+
+    public JdbcChangeEventSink(JdbcSinkConnectorConfig config, StatelessSession session, DatabaseDialect dialect, RecordWriter recordWriter,
+                               ConnectorContext connectorContext, SinkProgressListener progressListener) {
+        this(config, session, dialect, recordWriter, connectorContext, progressListener, ErrorReporters.nop());
+    }
 
     public JdbcChangeEventSink(JdbcSinkConnectorConfig config, StatelessSession session, DatabaseDialect dialect, RecordWriter recordWriter,
                                ConnectorContext connectorContext, SinkProgressListener progressListener, ErrorReporter errorReporter) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -302,19 +302,7 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
 
     @Override
     protected boolean isRetriableWriteException(RuntimeException exception) {
-        return isCommunicationException(exception);
-    }
-
-    private boolean isCommunicationException(Throwable throwable) {
-        if (throwable == null) {
-            return false;
-        }
-        for (Class<? extends Exception> communicationException : dialect.getCommunicationExceptions()) {
-            if (communicationException.isAssignableFrom(throwable.getClass())) {
-                return true;
-            }
-        }
-        return isCommunicationException(throwable.getCause());
+        return dialect.isCommunicationException(exception);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.common.DebeziumTaskState;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.dlq.ErrorReporter;
 import io.debezium.metadata.CollectionId;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
@@ -61,8 +62,8 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
     final Map<CollectionId, Buffer> deleteBufferByTable = new LinkedHashMap<>();
 
     public JdbcChangeEventSink(JdbcSinkConnectorConfig config, StatelessSession session, DatabaseDialect dialect, RecordWriter recordWriter,
-                               ConnectorContext connectorContext, SinkProgressListener progressListener) {
-        super(config);
+                               ConnectorContext connectorContext, SinkProgressListener progressListener, ErrorReporter errorReporter) {
+        super(config, errorReporter);
         this.config = config;
         this.dialect = dialect;
         this.session = session;
@@ -292,6 +293,23 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
                         LOGGER.debug("Could not emit OpenLineage event for collection '{}'", collectionId, e);
                     }
                 });
+    }
+
+    @Override
+    protected boolean isRetriableWriteException(RuntimeException exception) {
+        return isCommunicationException(exception);
+    }
+
+    private boolean isCommunicationException(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Exception> communicationException : dialect.getCommunicationExceptions()) {
+            if (communicationException.isAssignableFrom(throwable.getClass())) {
+                return true;
+            }
+        }
+        return isCommunicationException(throwable.getCause());
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcChangeEventSink.java
@@ -296,6 +296,11 @@ public class JdbcChangeEventSink extends AbstractChangeEventSink implements Chan
     }
 
     @Override
+    protected void recordReported(DebeziumSinkRecord record, RuntimeException cause) {
+        progressListener.errantRecordsReported(1);
+    }
+
+    @Override
     protected boolean isRetriableWriteException(RuntimeException exception) {
         return isCommunicationException(exception);
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -43,6 +43,7 @@ import io.debezium.connector.common.UUIDUtils;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectResolver;
 import io.debezium.connector.jdbc.metrics.JdbcSinkConnectorMetrics;
+import io.debezium.dlq.ErrorReporters;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.openlineage.dataset.DatasetDataExtractor;
@@ -155,7 +156,8 @@ public class JdbcSinkConnectorTask extends SinkTask {
             // Instantiate the appropriate RecordWriter based on dialect and configuration
             RecordWriter recordWriter = createRecordWriter(session, queryBinderResolver, config, dialect, metrics);
 
-            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics);
+            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics,
+                    ErrorReporters.fromContext(context));
             DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING);
         }
         finally {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -43,6 +43,7 @@ import io.debezium.connector.common.UUIDUtils;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.dialect.DatabaseDialectResolver;
 import io.debezium.connector.jdbc.metrics.JdbcSinkConnectorMetrics;
+import io.debezium.dlq.ErrorReporter;
 import io.debezium.dlq.ErrorReporters;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
@@ -156,8 +157,9 @@ public class JdbcSinkConnectorTask extends SinkTask {
             // Instantiate the appropriate RecordWriter based on dialect and configuration
             RecordWriter recordWriter = createRecordWriter(session, queryBinderResolver, config, dialect, metrics);
 
-            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics,
-                    ErrorReporters.fromContext(context));
+            final ErrorReporter errorReporter = ErrorReporters.fromContext(context);
+            ErrorReporters.validateConfiguration(errorReporter, props);
+            changeEventSink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, metrics, errorReporter);
             DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RUNNING);
         }
         finally {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -422,4 +422,24 @@ public interface DatabaseDialect {
      */
     Set<Class<? extends Exception>> getCommunicationExceptions();
 
+    /**
+     * Returns whether the given failure, or any failure in its cause chain, is one of the
+     * dialect's {@link #getCommunicationExceptions() communication exceptions} and is therefore
+     * considered transient and retriable.
+     *
+     * @param throwable the failure to inspect; may be null
+     * @return true if the failure is a communication problem with the database
+     */
+    default boolean isCommunicationException(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Exception> communicationException : getCommunicationExceptions()) {
+            if (communicationException.isAssignableFrom(throwable.getClass())) {
+                return true;
+            }
+        }
+        return isCommunicationException(throwable.getCause());
+    }
+
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
@@ -38,6 +38,7 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     private final AtomicLong totalNumberOfDeletes = new AtomicLong();
     private final AtomicLong totalNumberOfTruncates = new AtomicLong();
     private final AtomicLong totalNumberOfFilteredEvents = new AtomicLong();
+    private final AtomicLong totalNumberOfErrantRecords = new AtomicLong();
     private final AtomicLong totalNumberOfTablesCreated = new AtomicLong();
     private final AtomicLong totalNumberOfTablesAltered = new AtomicLong();
 
@@ -80,6 +81,11 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     }
 
     @Override
+    public void errantRecordsReported(long count) {
+        totalNumberOfErrantRecords.addAndGet(count);
+    }
+
+    @Override
     public void tableCreated() {
         totalNumberOfTablesCreated.incrementAndGet();
     }
@@ -107,6 +113,11 @@ public class JdbcSinkConnectorMetrics implements JdbcSinkConnectorMetricsMXBean,
     @Override
     public long getTotalNumberOfFilteredEvents() {
         return totalNumberOfFilteredEvents.get();
+    }
+
+    @Override
+    public long getTotalNumberOfErrantRecords() {
+        return totalNumberOfErrantRecords.get();
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsMXBean.java
@@ -50,6 +50,12 @@ public interface JdbcSinkConnectorMetricsMXBean {
     long getTotalNumberOfFilteredEvents();
 
     /**
+     * Returns the total number of records that were routed to the errant record reporter
+     * (dead letter queue) instead of being written to the target database.
+     */
+    long getTotalNumberOfErrantRecords();
+
+    /**
      * @return the total number of tables the sink created in the target database; only increases
      *         when {@code schema.evolution} is enabled
      */

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -14,15 +15,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLRecoverableException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.StatelessSession;
 import org.hibernate.dialect.DatabaseVersion;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -32,6 +37,7 @@ import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.util.DebeziumSinkRecordFactory;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.dlq.ErrorReporters;
+import io.debezium.doc.FixFor;
 import io.debezium.metadata.CollectionId;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.sink.spi.SinkProgressListener;
@@ -81,6 +87,34 @@ class JdbcChangeEventSinkTest {
 
         verify(progressListener).written(1);
         verifyNoMoreInteractions(progressListener);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#984")
+    void isRetriableWriteExceptionShouldMatchDialectCommunicationExceptionsAcrossCauseChain() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of());
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        final StatelessSession session = mock(StatelessSession.class);
+        final DefaultRecordWriter recordWriter = mock(DefaultRecordWriter.class);
+        final ConnectorContext connectorContext = new ConnectorContext("jdbc-sink", "jdbc", "0", "test", UUID.randomUUID(), Map.of());
+
+        when(dialect.getVersion()).thenReturn(DatabaseVersion.make(1));
+        when(dialect.getCommunicationExceptions()).thenReturn(Set.of(SQLRecoverableException.class));
+
+        final JdbcChangeEventSink sink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext,
+                mock(SinkProgressListener.class), ErrorReporters.nop());
+
+        // A communication failure buried in the cause chain (e.g. after exhausted flush retries) must be retriable
+        assertThat(sink.isRetriableWriteException(
+                new ConnectException("Exceeded max retries",
+                        new RuntimeException(new SQLRecoverableException("connection reset")))))
+                .isTrue();
+
+        // A data-caused failure (e.g. constraint violation) must not be classified as retriable
+        assertThat(sink.isRetriableWriteException(
+                new ConnectException("Failed to flush",
+                        new SQLIntegrityConstraintViolationException("duplicate key"))))
+                .isFalse();
     }
 
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
@@ -100,6 +100,7 @@ class JdbcChangeEventSinkTest {
 
         when(dialect.getVersion()).thenReturn(DatabaseVersion.make(1));
         when(dialect.getCommunicationExceptions()).thenReturn(Set.of(SQLRecoverableException.class));
+        doCallRealMethod().when(dialect).isCommunicationException(any());
 
         final JdbcChangeEventSink sink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext,
                 mock(SinkProgressListener.class), ErrorReporters.nop());

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcChangeEventSinkTest.java
@@ -31,6 +31,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.util.DebeziumSinkRecordFactory;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.dlq.ErrorReporters;
 import io.debezium.metadata.CollectionId;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.sink.spi.SinkProgressListener;
@@ -74,7 +75,7 @@ class JdbcChangeEventSinkTest {
             return null;
         }).when(recordWriter).write(any(TableDescriptor.class), any());
 
-        final JdbcChangeEventSink sink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, progressListener);
+        final JdbcChangeEventSink sink = new JdbcChangeEventSink(config, session, dialect, recordWriter, connectorContext, progressListener, ErrorReporters.nop());
         sink.execute(List.of(RECORD_FACTORY.createRecord("database.schema.table", config).getOriginalKafkaRecord()));
         sink.forceFlush();
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
@@ -237,4 +237,11 @@ public abstract class AbstractJdbcSinkTest extends AbstractBaseJdbcSinkTest {
         return -1;
     }
 
+    protected int getTotalRecordsReported() {
+        if (sinkTask instanceof JdbcSinkConnectorTask jdbcTask && jdbcTask.getChangeEventSink() != null) {
+            return jdbcTask.getChangeEventSink().getTotalRecordsReported();
+        }
+        return -1;
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractJdbcSinkTest extends AbstractBaseJdbcSinkTest {
         try {
             sinkTask = (SinkTask) sinkConnector.taskClass().getConstructor().newInstance();
             // Initialize sink task with a mock context
-            sinkTask.initialize(new JdbcSinkTaskTestContext(properties));
+            sinkTask.initialize(createTaskContext(properties));
             sinkTask.start(properties);
         }
         catch (Exception e) {
@@ -159,6 +159,14 @@ public abstract class AbstractJdbcSinkTest extends AbstractBaseJdbcSinkTest {
             sinkConnector = null;
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Creates the mock sink task context used to initialize the sink task; subclasses may override
+     * to customize the context, e.g. to provide an errant record reporter.
+     */
+    protected JdbcSinkTaskTestContext createTaskContext(Map<String, String> properties) {
+        return new JdbcSinkTaskTestContext(properties);
     }
 
     /**

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
@@ -8,11 +8,15 @@ package io.debezium.connector.jdbc.integration.mysql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,6 +108,57 @@ public class JdbcSinkDlqIT extends AbstractJdbcSinkTest {
             return null;
         });
         assertThat(reportedRecords).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#984")
+    public void testShouldNotReportTransientFailuresAfterRetriesAreExhausted(SinkRecordFactory factory) throws SQLException {
+        final String tableName = randomTableName();
+        final Connection connection = getSink().getConnection();
+
+        try (Statement st = connection.createStatement()) {
+            st.execute("CREATE TABLE `" + tableName + "` (`id` bigint(20) NOT NULL, `content` varchar(200) DEFAULT NULL, PRIMARY KEY (`id`))");
+            st.execute("INSERT INTO " + tableName + " (`id`, `content`) VALUES (1, 'c1')");
+        }
+
+        connection.setAutoCommit(false);
+        try (Statement st = connection.createStatement()) {
+            st.execute("START TRANSACTION");
+            // Acquire a shared lock on id=1 so that the sink update hits the lock wait timeout.
+            st.execute("SELECT * FROM " + tableName + " WHERE id=1 LOCK IN SHARE MODE;");
+
+            final Map<String, String> properties = getDefaultSinkConfig();
+            properties.put(JdbcSinkConnectorConfig.ENABLE_SHARED_CHANGE_EVENT_SINK_FIELD.name(), "true");
+            properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+            properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_VALUE.getValue());
+            properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+            properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+            properties.put(JdbcSinkConnectorConfig.CONNECTION_URL, getSink().getJdbcUrl(Map.of("sessionVariables", "innodb_lock_wait_timeout=5")));
+            properties.put(JdbcSinkConnectorConfig.COLLECTION_NAME_FORMAT, tableName);
+            properties.put(JdbcSinkConnectorConfig.FLUSH_MAX_RETRIES, "1");
+            properties.put(JdbcSinkConnectorConfig.FLUSH_RETRY_DELAY_MS, "1000");
+            startSinkConnector(properties);
+            assertSinkConnectorIsRunning();
+
+            final String topicName = topicName("server1", "schema", tableName);
+            final JdbcSinkConnectorConfig config = getConfig(properties);
+            final JdbcKafkaSinkRecord updateRecord = factory.updateRecordWithSchemaValue(
+                    topicName, (byte) 1, "content", Schema.OPTIONAL_STRING_SCHEMA, "c11", config);
+
+            // A transient (lock wait timeout) failure must fail the task after retries are
+            // exhausted; it must never be routed to the errant record reporter.
+            assertThatThrownBy(() -> {
+                consume(updateRecord);
+                consume(List.of());
+            }).isInstanceOf(RuntimeException.class);
+
+            assertThat(reportedRecords).isEmpty();
+        }
+        finally {
+            connection.close();
+            stopSinkConnector();
+        }
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkTaskTestContext;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.MySqlSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+
+/**
+ * JDBC sink tests for routing non-retriable record failures to the errant record reporter (DLQ)
+ * when the shared change event sink framework is enabled.
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-mysql")
+@ExtendWith(MySqlSinkDatabaseContextProvider.class)
+public class JdbcSinkDlqIT extends AbstractJdbcSinkTest {
+
+    private final List<SinkRecord> reportedRecords = new ArrayList<>();
+
+    public JdbcSinkDlqIT(Sink sink) {
+        super(sink);
+    }
+
+    @BeforeEach
+    void resetReportedRecords() {
+        reportedRecords.clear();
+    }
+
+    @Override
+    protected JdbcSinkTaskTestContext createTaskContext(Map<String, String> properties) {
+        return new JdbcSinkTaskTestContext(properties) {
+            @Override
+            public ErrantRecordReporter errantRecordReporter() {
+                return (record, error) -> {
+                    reportedRecords.add(record);
+                    return CompletableFuture.completedFuture(null);
+                };
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#984")
+    public void testShouldReportConstraintViolatingRecordAndContinue(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.ENABLE_SHARED_CHANGE_EVENT_SINK_FIELD.name(), "true");
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.INSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord record = factory.createRecord(topicName, (byte) 1, config);
+        final String destinationTable = destinationTableName(record);
+
+        consume(record);
+
+        // The same key violates the primary key constraint in insert mode; the record must be
+        // routed to the errant record reporter and the task must remain healthy.
+        consume(factory.createRecord(topicName, (byte) 1, config));
+
+        assertThat(reportedRecords).hasSize(1);
+
+        // A subsequent healthy record must still be written.
+        consume(factory.createRecord(topicName, (byte) 2, config));
+
+        getSink().assertRows(destinationTable, rs -> {
+            int rows = 1;
+            while (rs.next()) {
+                rows++;
+            }
+            assertThat(rows).isEqualTo(2);
+            return null;
+        });
+        assertThat(reportedRecords).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#984")
+    public void testShouldFailTaskWithoutSharedChangeEventSink(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.ENABLE_SHARED_CHANGE_EVENT_SINK_FIELD.name(), "false");
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.INSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        consume(factory.createRecord(topicName, (byte) 1, config));
+
+        // Without the shared change event sink framework, the legacy path fails the task
+        // regardless of the errant record reporter being available.
+        assertThatThrownBy(() -> consume(factory.createRecord(topicName, (byte) 1, config)))
+                .isInstanceOf(RuntimeException.class);
+        assertThat(reportedRecords).isEmpty();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkDlqIT.java
@@ -108,6 +108,7 @@ public class JdbcSinkDlqIT extends AbstractJdbcSinkTest {
             return null;
         });
         assertThat(reportedRecords).hasSize(1);
+        assertThat(getTotalRecordsReported()).isEqualTo(1);
     }
 
     @ParameterizedTest
@@ -154,6 +155,7 @@ public class JdbcSinkDlqIT extends AbstractJdbcSinkTest {
             }).isInstanceOf(RuntimeException.class);
 
             assertThat(reportedRecords).isEmpty();
+            assertThat(getTotalRecordsReported()).isZero();
         }
         finally {
             connection.close();

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetricsTest.java
@@ -58,6 +58,16 @@ class JdbcSinkConnectorMetricsTest {
     }
 
     @Test
+    void shouldCountErrantRecords() {
+        final JdbcSinkConnectorMetrics metrics = new JdbcSinkConnectorMetrics("my-sink", "0");
+
+        metrics.errantRecordsReported(1);
+        metrics.errantRecordsReported(2);
+
+        assertThat(metrics.getTotalNumberOfErrantRecords()).isEqualTo(3);
+    }
+
+    @Test
     void shouldRegisterAndUnregisterMBeanUnderDebeziumJdbcDomain() throws Exception {
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         final ObjectName objectName = new ObjectName("debezium.jdbc:type=connector-metrics,context=sink,server=my-sink,task=0");

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTask.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -28,17 +27,16 @@ import org.slf4j.LoggerFactory;
 import com.mongodb.client.MongoClient;
 import com.mongodb.internal.VisibleForTesting;
 
-import io.debezium.bindings.kafka.KafkaDebeziumSinkRecord;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.DebeziumTaskState;
 import io.debezium.connector.common.UUIDUtils;
 import io.debezium.connector.mongodb.connection.MongoDbConnectionContext;
 import io.debezium.dlq.ErrorReporter;
+import io.debezium.dlq.ErrorReporters;
 import io.debezium.openlineage.ConnectorContext;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.openlineage.dataset.DatasetDataExtractor;
 import io.debezium.openlineage.dataset.DatasetMetadata;
-import io.debezium.sink.DebeziumSinkRecord;
 
 public class MongoDbSinkConnectorTask extends SinkTask {
     static final Logger LOGGER = LoggerFactory.getLogger(MongoDbSinkConnectorTask.class);
@@ -75,7 +73,7 @@ public class MongoDbSinkConnectorTask extends SinkTask {
                     getMaskedConfigurationMap(props));
 
             DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.INITIAL);
-            mongoSink = new MongoDbChangeEventSink(sinkConfig, client, createErrorReporter(), connectorContext);
+            mongoSink = new MongoDbChangeEventSink(sinkConfig, client, ErrorReporters.fromContext(context), connectorContext);
         }
         catch (RuntimeException taskStartingException) {
             // noinspection EmptyTryBlock
@@ -147,37 +145,12 @@ public class MongoDbSinkConnectorTask extends SinkTask {
         }
     }
 
-    private ErrorReporter createErrorReporter() {
-        ErrorReporter result = nopErrorReporter();
-        if (context != null) {
-            try {
-                ErrantRecordReporter errantRecordReporter = context.errantRecordReporter();
-                if (errantRecordReporter != null) {
-                    result = (DebeziumSinkRecord record, Exception e) -> {
-                        if (record instanceof KafkaDebeziumSinkRecord kafkaRecord) {
-                            errantRecordReporter.report(kafkaRecord.getOriginalKafkaRecord(), e);
-                        }
-                    };
-                }
-                else {
-                    LOGGER.info("Errant record reporter not configured.");
-                }
-            }
-            catch (NoClassDefFoundError | NoSuchMethodError e) {
-                // Will occur in Connect runtimes earlier than 2.6
-                LOGGER.info("Kafka versions prior to 2.6 do not support the errant record reporter.");
-            }
-        }
-        return result;
-    }
-
     private Map<String, String> getMaskedConfigurationMap(Map<String, String> props) {
         return Configuration.from(props).withMaskedPasswords().asMap();
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.AccessModifier.PRIVATE)
     static ErrorReporter nopErrorReporter() {
-        return (record, e) -> {
-            /* do nothing */ };
+        return ErrorReporters.nop();
     }
 }

--- a/debezium-sink/src/main/java/io/debezium/dlq/ErrorReporters.java
+++ b/debezium-sink/src/main/java/io/debezium/dlq/ErrorReporters.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.dlq;
 
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
@@ -20,6 +23,10 @@ import io.debezium.sink.DebeziumSinkRecord;
 public final class ErrorReporters {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorReporters.class);
+
+    private static final String ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
+    private static final String ERRORS_DLQ_TOPIC_NAME_CONFIG = "errors.deadletterqueue.topic.name";
+    private static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
 
     private static final ErrorReporter NOP = (record, e) -> {
     };
@@ -72,5 +79,34 @@ public final class ErrorReporters {
      */
     public static boolean isEnabled(ErrorReporter reporter) {
         return reporter != null && reporter != NOP;
+    }
+
+    /**
+     * Validates the standard Kafka Connect error handling options of the connector configuration.
+     * <p>
+     * A dead letter queue topic combined with {@code errors.tolerance=none} is rejected, because
+     * records can never be routed to the dead letter queue with that combination. A tolerance of
+     * {@code all} without any configured error reporter is only logged as a warning, because it is
+     * a legitimate way to skip records that fail in the converter or transformation stages.
+     *
+     * @param reporter the reporter obtained from {@link #fromContext(SinkTaskContext)}
+     * @param connectorProps the connector configuration properties
+     * @throws ConnectException if the configuration is contradictory
+     */
+    public static void validateConfiguration(ErrorReporter reporter, Map<String, String> connectorProps) {
+        final String tolerance = connectorProps.getOrDefault(ERRORS_TOLERANCE_CONFIG, "none").trim();
+        final String dlqTopic = connectorProps.getOrDefault(ERRORS_DLQ_TOPIC_NAME_CONFIG, "").trim();
+        final boolean toleranceAll = "all".equalsIgnoreCase(tolerance);
+
+        if (!dlqTopic.isEmpty() && !toleranceAll) {
+            throw new ConnectException(String.format(
+                    "'%s' is configured but '%s' is '%s'; records can never be routed to the dead letter queue. "
+                            + "Set '%s' to 'all' or remove the dead letter queue configuration.",
+                    ERRORS_DLQ_TOPIC_NAME_CONFIG, ERRORS_TOLERANCE_CONFIG, tolerance, ERRORS_TOLERANCE_CONFIG));
+        }
+        if (toleranceAll && !isEnabled(reporter)) {
+            LOGGER.warn("'{}' is 'all' but neither '{}' nor '{}' is configured; records that fail to be written will still stop the task.",
+                    ERRORS_TOLERANCE_CONFIG, ERRORS_DLQ_TOPIC_NAME_CONFIG, ERRORS_LOG_ENABLE_CONFIG);
+        }
     }
 }

--- a/debezium-sink/src/main/java/io/debezium/dlq/ErrorReporters.java
+++ b/debezium-sink/src/main/java/io/debezium/dlq/ErrorReporters.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.dlq;
+
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.bindings.kafka.KafkaDebeziumSinkRecord;
+import io.debezium.sink.DebeziumSinkRecord;
+
+/**
+ * Factory methods for {@link ErrorReporter} instances backed by the Kafka Connect
+ * errant record reporter (KIP-610).
+ */
+public final class ErrorReporters {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorReporters.class);
+
+    private static final ErrorReporter NOP = (record, e) -> {
+    };
+
+    private ErrorReporters() {
+    }
+
+    /**
+     * Creates an {@link ErrorReporter} backed by the errant record reporter of the supplied sink task
+     * context. Falls back to a no-op reporter when the runtime does not provide one, either because
+     * error reporting is not configured for the connector or because the Connect runtime predates
+     * Kafka 2.6.
+     *
+     * @param context the sink task context; may be null
+     * @return the error reporter; never null
+     */
+    public static ErrorReporter fromContext(SinkTaskContext context) {
+        ErrorReporter result = nop();
+        if (context != null) {
+            try {
+                ErrantRecordReporter errantRecordReporter = context.errantRecordReporter();
+                if (errantRecordReporter != null) {
+                    result = (DebeziumSinkRecord record, Exception e) -> {
+                        if (record instanceof KafkaDebeziumSinkRecord kafkaRecord) {
+                            errantRecordReporter.report(kafkaRecord.getOriginalKafkaRecord(), e);
+                        }
+                    };
+                }
+                else {
+                    LOGGER.info("Errant record reporter not configured.");
+                }
+            }
+            catch (NoClassDefFoundError | NoSuchMethodError e) {
+                // Will occur in Connect runtimes earlier than 2.6
+                LOGGER.info("Kafka versions prior to 2.6 do not support the errant record reporter.");
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the no-op reporter that silently discards all reported records.
+     */
+    public static ErrorReporter nop() {
+        return NOP;
+    }
+
+    /**
+     * Returns whether the supplied reporter routes records anywhere, i.e. is not the no-op reporter.
+     */
+    public static boolean isEnabled(ErrorReporter reporter) {
+        return reporter != null && reporter != NOP;
+    }
+}

--- a/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
@@ -41,6 +41,7 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
     private final Buffer buffer;
     private int batchCount;
     private int totalRecordsWritten;
+    private int totalRecordsReported;
 
     protected AbstractChangeEventSink(SinkConnectorConfig config) {
         this(config, ErrorReporters.nop());
@@ -133,6 +134,10 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
         return totalRecordsWritten;
     }
 
+    public int getTotalRecordsReported() {
+        return totalRecordsReported;
+    }
+
     protected void writeBatch(Batch batch) {
         batchCount++;
         totalRecordsWritten += batch.size();
@@ -177,7 +182,16 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
         LOGGER.warn("Reporting failed record from topic '{}' partition '{}' offset '{}' to the errant record reporter",
                 record.topicName(), record.partition(), record.offset(), cause);
         totalRecordsWritten--;
+        totalRecordsReported++;
         errorReporter.report(record, cause);
+        recordReported(record, cause);
+    }
+
+    /**
+     * Invoked after a record has been routed to the errant record reporter; subclasses may
+     * override this method, for example, to update connector metrics.
+     */
+    protected void recordReported(DebeziumSinkRecord record, RuntimeException cause) {
     }
 
     /**

--- a/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/AbstractChangeEventSink.java
@@ -13,8 +13,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.bindings.kafka.KafkaDebeziumSinkRecord;
+import io.debezium.dlq.ErrorReporter;
+import io.debezium.dlq.ErrorReporters;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.batch.Batch;
+import io.debezium.sink.batch.BatchRecord;
 import io.debezium.sink.batch.Buffer;
 import io.debezium.sink.batch.DeduplicatingBuffer;
 import io.debezium.sink.batch.PassthroughBuffer;
@@ -34,12 +37,18 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
     private static final String DETECT_SCHEMA_CHANGE_RECORD_MSG = "Schema change records are not supported by Debezium sink connectors. Please adjust `topics` or `topics.regex` to exclude schema change topic.";
 
     protected final SinkConnectorConfig config;
+    private final ErrorReporter errorReporter;
     private final Buffer buffer;
     private int batchCount;
     private int totalRecordsWritten;
 
     protected AbstractChangeEventSink(SinkConnectorConfig config) {
+        this(config, ErrorReporters.nop());
+    }
+
+    protected AbstractChangeEventSink(SinkConnectorConfig config, ErrorReporter errorReporter) {
         this.config = config;
+        this.errorReporter = errorReporter != null ? errorReporter : ErrorReporters.nop();
         boolean keyed = !SinkConnectorConfig.PrimaryKeyMode.NONE.equals(config.getPrimaryKeyMode());
         if (SinkConnectorConfig.KeyedMessageBatchMode.PASSTHROUGH.equals(config.getKeyedMessageBatchMode())) {
             buffer = new PassthroughBuffer(config, keyed);
@@ -127,7 +136,58 @@ public abstract class AbstractChangeEventSink implements ChangeEventSink {
     protected void writeBatch(Batch batch) {
         batchCount++;
         totalRecordsWritten += batch.size();
-        doWriteBatch(batch);
+        try {
+            doWriteBatch(batch);
+        }
+        catch (RuntimeException e) {
+            if (!ErrorReporters.isEnabled(errorReporter) || isRetriableWriteException(e)) {
+                throw e;
+            }
+            reportFailedRecords(batch, e);
+        }
+    }
+
+    /**
+     * Retries the records of a failed batch one at a time to isolate the failing ones and routes
+     * only those to the errant record reporter, so a single bad record does not fail the task and
+     * does not discard the healthy records written alongside it.
+     */
+    private void reportFailedRecords(Batch batch, RuntimeException cause) {
+        if (batch.size() == 1) {
+            reportRecord(batch.get(0), cause);
+            return;
+        }
+        LOGGER.warn("Batch of {} records failed to be written; retrying records individually to isolate the failing ones",
+                batch.size(), cause);
+        for (BatchRecord batchRecord : batch) {
+            try {
+                doWriteBatch(new Batch(List.of(batchRecord)));
+            }
+            catch (RuntimeException e) {
+                if (isRetriableWriteException(e)) {
+                    throw e;
+                }
+                reportRecord(batchRecord, e);
+            }
+        }
+    }
+
+    private void reportRecord(BatchRecord batchRecord, RuntimeException cause) {
+        DebeziumSinkRecord record = batchRecord.record();
+        LOGGER.warn("Reporting failed record from topic '{}' partition '{}' offset '{}' to the errant record reporter",
+                record.topicName(), record.partition(), record.offset(), cause);
+        totalRecordsWritten--;
+        errorReporter.report(record, cause);
+    }
+
+    /**
+     * Returns whether the given write failure is transient (e.g. caused by a communication problem
+     * with the target system) and should be propagated so existing retry mechanisms apply, instead
+     * of being routed to the errant record reporter. Defaults to {@code false}; subclasses should
+     * override this based on the failure semantics of their target system.
+     */
+    protected boolean isRetriableWriteException(RuntimeException exception) {
+        return false;
     }
 
     protected abstract void doWriteBatch(Batch batch);

--- a/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
@@ -22,7 +22,8 @@ public interface SinkProgressListener {
      * Invoked when records are routed to the errant record reporter (dead letter queue)
      * instead of being written to the target system.
      */
-    void errantRecordsReported(long count);
+    default void errantRecordsReported(long count) {
+    }
 
     void tableCreated();
 
@@ -45,10 +46,6 @@ public interface SinkProgressListener {
 
             @Override
             public void filtered() {
-            }
-
-            @Override
-            public void errantRecordsReported(long count) {
             }
 
             @Override

--- a/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
+++ b/debezium-sink/src/main/java/io/debezium/sink/spi/SinkProgressListener.java
@@ -18,6 +18,12 @@ public interface SinkProgressListener {
 
     void filtered();
 
+    /**
+     * Invoked when records are routed to the errant record reporter (dead letter queue)
+     * instead of being written to the target system.
+     */
+    void errantRecordsReported(long count);
+
     void tableCreated();
 
     void tableAltered();
@@ -39,6 +45,10 @@ public interface SinkProgressListener {
 
             @Override
             public void filtered() {
+            }
+
+            @Override
+            public void errantRecordsReported(long count) {
             }
 
             @Override

--- a/debezium-sink/src/test/java/io/debezium/dlq/ErrorReportersTest.java
+++ b/debezium-sink/src/test/java/io/debezium/dlq/ErrorReportersTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.dlq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.bindings.kafka.KafkaDebeziumSinkRecord;
+import io.debezium.doc.FixFor;
+
+class ErrorReportersTest {
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void nopReporterShouldBeDisabled() {
+        assertThat(ErrorReporters.isEnabled(ErrorReporters.nop())).isFalse();
+        assertThat(ErrorReporters.isEnabled(null)).isFalse();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void fromNullContextShouldReturnNop() {
+        assertThat(ErrorReporters.isEnabled(ErrorReporters.fromContext(null))).isFalse();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void fromContextWithoutReporterShouldReturnNop() {
+        ErrorReporter reporter = ErrorReporters.fromContext(new TestSinkTaskContext(null));
+
+        assertThat(ErrorReporters.isEnabled(reporter)).isFalse();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void fromContextWithReporterShouldRouteOriginalKafkaRecord() {
+        List<SinkRecord> reported = new ArrayList<>();
+        ErrantRecordReporter errantRecordReporter = (record, error) -> {
+            reported.add(record);
+            return CompletableFuture.completedFuture(null);
+        };
+        ErrorReporter reporter = ErrorReporters.fromContext(new TestSinkTaskContext(errantRecordReporter));
+
+        assertThat(ErrorReporters.isEnabled(reporter)).isTrue();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT8_SCHEMA)
+                .build();
+        Struct value = new Struct(valueSchema).put("id", (byte) 1);
+        SinkRecord kafkaRecord = new SinkRecord("topic", 0, null, null, valueSchema, value, 42);
+        reporter.report(new KafkaDebeziumSinkRecord(kafkaRecord, null), new RuntimeException("boom"));
+
+        assertThat(reported).hasSize(1);
+        assertThat(reported.get(0).kafkaOffset()).isEqualTo(42);
+    }
+
+    private static class TestSinkTaskContext implements SinkTaskContext {
+
+        private final ErrantRecordReporter reporter;
+
+        TestSinkTaskContext(ErrantRecordReporter reporter) {
+            this.reporter = reporter;
+        }
+
+        @Override
+        public Map<String, String> configs() {
+            return Map.of();
+        }
+
+        @Override
+        public void offset(Map<TopicPartition, Long> offsets) {
+        }
+
+        @Override
+        public void offset(TopicPartition tp, long offset) {
+        }
+
+        @Override
+        public void timeout(long timeoutMs) {
+        }
+
+        @Override
+        public Set<TopicPartition> assignment() {
+            return Set.of();
+        }
+
+        @Override
+        public void pause(TopicPartition... partitions) {
+        }
+
+        @Override
+        public void resume(TopicPartition... partitions) {
+        }
+
+        @Override
+        public void requestCommit() {
+        }
+
+        @Override
+        public ErrantRecordReporter errantRecordReporter() {
+            return reporter;
+        }
+
+        @Override
+        public PluginMetrics pluginMetrics() {
+            return null;
+        }
+    }
+
+}

--- a/debezium-sink/src/test/java/io/debezium/dlq/ErrorReportersTest.java
+++ b/debezium-sink/src/test/java/io/debezium/dlq/ErrorReportersTest.java
@@ -6,6 +6,7 @@
 package io.debezium.dlq;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -70,6 +72,57 @@ class ErrorReportersTest {
 
         assertThat(reported).hasSize(1);
         assertThat(reported.get(0).kafkaOffset()).isEqualTo(42);
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void validateShouldRejectDlqTopicWithoutToleranceAll() {
+        Map<String, String> props = Map.of(
+                "errors.deadletterqueue.topic.name", "dlq-topic");
+
+        assertThatThrownBy(() -> ErrorReporters.validateConfiguration(ErrorReporters.nop(), props))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("errors.deadletterqueue.topic.name")
+                .hasMessageContaining("Set 'errors.tolerance' to 'all'");
+
+        Map<String, String> explicitNone = Map.of(
+                "errors.tolerance", "none",
+                "errors.deadletterqueue.topic.name", "dlq-topic");
+
+        assertThatThrownBy(() -> ErrorReporters.validateConfiguration(ErrorReporters.nop(), explicitNone))
+                .isInstanceOf(ConnectException.class);
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void validateShouldAcceptDlqTopicWithToleranceAll() {
+        Map<String, String> props = Map.of(
+                "errors.tolerance", "all",
+                "errors.deadletterqueue.topic.name", "dlq-topic");
+
+        ErrorReporters.validateConfiguration((record, e) -> {
+        }, props);
+
+        Map<String, String> upperCase = Map.of(
+                "errors.tolerance", "ALL",
+                "errors.deadletterqueue.topic.name", "dlq-topic");
+
+        ErrorReporters.validateConfiguration((record, e) -> {
+        }, upperCase);
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void validateShouldOnlyWarnWhenToleranceAllHasNoReporter() {
+        // errors.tolerance=all without a DLQ topic or error log is a legitimate way to skip
+        // converter/transformation stage failures, so it must not fail the startup.
+        ErrorReporters.validateConfiguration(ErrorReporters.nop(), Map.of("errors.tolerance", "all"));
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void validateShouldAcceptDefaultErrorHandlingConfiguration() {
+        ErrorReporters.validateConfiguration(ErrorReporters.nop(), Map.of());
     }
 
     private static class TestSinkTaskContext implements SinkTaskContext {

--- a/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
+++ b/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
@@ -48,6 +48,7 @@ class AbstractChangeEventSinkDlqTest {
         assertThat(name(reported.get(0))).isEqualTo("b");
         assertThat(sink.writtenRecordNames).containsExactly("a", "c");
         assertThat(sink.getTotalRecordsWritten()).isEqualTo(2);
+        assertThat(sink.getTotalRecordsReported()).isEqualTo(1);
     }
 
     @FixFor("debezium/dbz#984")

--- a/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
+++ b/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
@@ -86,6 +86,22 @@ class AbstractChangeEventSinkDlqTest {
 
     @FixFor("debezium/dbz#984")
     @Test
+    void throwingReporterShouldPropagateAndStopUnroll() {
+        // When errors.tolerance=none the Kafka Connect errant record reporter throws on report();
+        // the failure must propagate so the task fails as it would without a reporter.
+        ErrorReporter throwingReporter = (record, e) -> {
+            throw new RuntimeException("tolerance is none");
+        };
+        FailingChangeEventSink sink = new FailingChangeEventSink(throwingReporter, named("b"), false);
+
+        assertThatThrownBy(() -> sink.writeBatch(batchOf("a", "b", "c")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("tolerance is none");
+        assertThat(sink.writtenRecordNames).containsExactly("a");
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
     void writeBatchWithReporterShouldNotInterceptSuccessfulBatches() {
         FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, record -> false, false);
 

--- a/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
+++ b/debezium-sink/src/test/java/io/debezium/sink/AbstractChangeEventSinkDlqTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.bindings.kafka.KafkaDebeziumSinkRecord;
+import io.debezium.dlq.ErrorReporter;
+import io.debezium.doc.FixFor;
+import io.debezium.metadata.CollectionId;
+import io.debezium.sink.batch.Batch;
+import io.debezium.sink.batch.BatchRecord;
+
+class AbstractChangeEventSinkDlqTest {
+
+    private final List<DebeziumSinkRecord> reported = new ArrayList<>();
+    private final ErrorReporter recordingReporter = (record, e) -> reported.add(record);
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void writeBatchWithoutReporterShouldPropagateFailure() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(null, record -> true, false);
+
+        assertThatThrownBy(() -> sink.writeBatch(batchOf("a", "b")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("write failed");
+        assertThat(reported).isEmpty();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void writeBatchShouldIsolateAndReportOnlyFailingRecords() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, named("b"), false);
+
+        sink.writeBatch(batchOf("a", "b", "c"));
+
+        assertThat(reported).hasSize(1);
+        assertThat(name(reported.get(0))).isEqualTo("b");
+        assertThat(sink.writtenRecordNames).containsExactly("a", "c");
+        assertThat(sink.getTotalRecordsWritten()).isEqualTo(2);
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void writeBatchShouldReportSingleRecordBatchWithoutReplay() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, named("a"), false);
+
+        sink.writeBatch(batchOf("a"));
+
+        assertThat(reported).hasSize(1);
+        assertThat(sink.writeAttempts).isEqualTo(1);
+        assertThat(sink.getTotalRecordsWritten()).isZero();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void writeBatchShouldPropagateRetriableFailuresInsteadOfReporting() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, record -> true, true);
+
+        assertThatThrownBy(() -> sink.writeBatch(batchOf("a", "b")))
+                .isInstanceOf(RuntimeException.class);
+        assertThat(reported).isEmpty();
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void unrollShouldPropagateRetriableFailureMidway() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, named("b"), false);
+        sink.retriableAfterFirstFailure = true;
+
+        assertThatThrownBy(() -> sink.writeBatch(batchOf("a", "b", "c")))
+                .isInstanceOf(RuntimeException.class);
+        assertThat(reported).isEmpty();
+        assertThat(sink.writtenRecordNames).containsExactly("a");
+    }
+
+    @FixFor("debezium/dbz#984")
+    @Test
+    void writeBatchWithReporterShouldNotInterceptSuccessfulBatches() {
+        FailingChangeEventSink sink = new FailingChangeEventSink(recordingReporter, record -> false, false);
+
+        sink.writeBatch(batchOf("a", "b"));
+
+        assertThat(reported).isEmpty();
+        assertThat(sink.writtenRecordNames).containsExactly("a", "b");
+        assertThat(sink.writeAttempts).isEqualTo(1);
+    }
+
+    private static Predicate<DebeziumSinkRecord> named(String name) {
+        return record -> name.equals(name(record));
+    }
+
+    private static String name(DebeziumSinkRecord record) {
+        return record.getPayload().getString("name");
+    }
+
+    private static Batch batchOf(String... names) {
+        List<BatchRecord> records = new ArrayList<>();
+        byte id = 1;
+        for (String name : names) {
+            KafkaDebeziumSinkRecord record = TestSinkRecords.flat("topic", id++, name);
+            records.add(new BatchRecord(new CollectionId("topic"), record));
+        }
+        return new Batch(records);
+    }
+
+    private static class FailingChangeEventSink extends AbstractChangeEventSink {
+
+        final List<String> writtenRecordNames = new ArrayList<>();
+        int writeAttempts;
+        boolean retriableAfterFirstFailure;
+
+        private final Predicate<DebeziumSinkRecord> failOn;
+        private final boolean retriable;
+        private boolean failed;
+
+        FailingChangeEventSink(ErrorReporter errorReporter, Predicate<DebeziumSinkRecord> failOn, boolean retriable) {
+            super(new TestSinkConnectorConfig(), errorReporter);
+            this.failOn = failOn;
+            this.retriable = retriable;
+        }
+
+        @Override
+        protected void doWriteBatch(Batch batch) {
+            writeAttempts++;
+            for (BatchRecord batchRecord : batch) {
+                if (failOn.test(batchRecord.record())) {
+                    boolean asRetriable = retriable || (retriableAfterFirstFailure && failed);
+                    failed = true;
+                    throw asRetriable ? new TestRetriableException() : new RuntimeException("write failed");
+                }
+            }
+            batch.forEach(batchRecord -> writtenRecordNames.add(name(batchRecord.record())));
+        }
+
+        @Override
+        protected boolean isRetriableWriteException(RuntimeException exception) {
+            return exception instanceof TestRetriableException;
+        }
+
+        @Override
+        public CollectionId getCollectionId(String collectionName) {
+            return new CollectionId(collectionName);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class TestRetriableException extends RuntimeException {
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -421,6 +421,8 @@ Whether a failing record stops the task or is routed to a dead letter queue is c
 
 When `errors.tolerance` is set to `none` (the default), or when no dead letter queue topic is configured, failing records stop the connector task, and the behavior of the connector is unchanged.
 
+Because a dead letter queue topic can never receive records while `errors.tolerance` is set to `none`, the connector rejects that combination and fails to start with a message that describes how to correct the configuration.
+
 [NOTE]
 ====
 When `errors.tolerance` is set to `all`, every non-transient write failure is routed to the reporter, including failures that are caused by the environment rather than by the record itself, for example, a schema evolution statement that fails because the connector lacks the required database privileges.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1675,6 +1675,11 @@ The following table describes the available metrics.
 |`long`
 |The number of records that the connector skipped without applying them, for example because the table name could not be resolved, deletes or truncates are disabled, or the record is a schema-change event.
 
+|`TotalNumberOfErrantRecords`
+|`long`
+|The total number of records that the connector routed to the errant record reporter (dead letter queue) instead of writing them to the target database.
+For more information, see xref:jdbc-error-handling-and-dead-letter-queues[Error handling and dead letter queues].
+
 |`TotalNumberOfTablesCreated`
 |`long`
 |The total number of tables that the connector created in the target database. This metric increases only when xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -398,6 +398,29 @@ You can customize the Agroal connection pool by setting properties in the `hiber
 In the preceding example, the setting of the hibernate.agroal.idleValidation property configures the connection pool to perform idle timeout tests every 300 seconds.
 After you apply the configuration, the connection pool begins to assess unused connections every five minutes.
 
+[[jdbc-error-handling-and-dead-letter-queues]]
+=== Error handling and dead letter queues
+
+When the connector fails to write a record to the target database for a reason that is not transient, for example, because the record violates a constraint, by default the failure stops the connector task.
+
+When the shared change event sink framework is enabled (`internal.enable.sces` is set to `true`), the connector can instead route the failing records to the errant record reporter that the Kafka Connect runtime provides (link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-610%3A+Error+Reporting+in+Sink+Connectors[KIP-610]).
+When a batch fails with a non-transient error, the connector retries the records in the batch one at a time to isolate the failing records, routes only those records to the reporter, and continues to process the remaining records.
+Transient failures, such as failures that result from communication problems with the database, are not routed to the reporter; the connector retries them, based on the values of the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] properties.
+
+Whether a failing record stops the task or is routed to a dead letter queue is controlled entirely by the standard Kafka Connect error handling options of the sink connector configuration:
+
+.Example dead letter queue configuration
+[source,json]
+----
+{
+  "errors.tolerance": "all",
+  "errors.deadletterqueue.topic.name": "dlq-topic",
+  "errors.deadletterqueue.context.headers.enable": "true"
+}
+----
+
+When `errors.tolerance` is set to `none` (the default), or when no dead letter queue topic is configured, failing records stop the connector task, and the behavior of the connector is unchanged.
+
 [[jdbc-changing-how-table-names-are-resolved]]
 === Changing how table names are resolved
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -421,6 +421,16 @@ Whether a failing record stops the task or is routed to a dead letter queue is c
 
 When `errors.tolerance` is set to `none` (the default), or when no dead letter queue topic is configured, failing records stop the connector task, and the behavior of the connector is unchanged.
 
+[NOTE]
+====
+When `errors.tolerance` is set to `all`, every non-transient write failure is routed to the reporter, including failures that are caused by the environment rather than by the record itself, for example, a schema evolution statement that fails because the connector lacks the required database privileges.
+Monitor the dead letter queue so that systemic failures do not silently divert large numbers of records.
+
+Because the connector provides at-least-once delivery, records that were already written can be delivered again after a restart.
+In `insert` mode, redelivered records fail with constraint violations, and the connector routes them to the dead letter queue.
+To avoid this, prefer the idempotent `upsert` mode when you enable a dead letter queue.
+====
+
 [[jdbc-changing-how-table-names-are-resolved]]
 === Changing how table names are resolved
 


### PR DESCRIPTION
Fixes debezium/dbz#984

## Description

When a record fails to be written for a non-transient reason (e.g. a constraint violation), the JDBC sink task currently stops even if the user configured `errors.tolerance=all` with a dead letter queue — the Connect framework only covers converter/SMT stage errors, and `put()`-stage failures require the connector to integrate the errant record reporter (KIP-610) explicitly.

This PR integrates the errant record reporter at the **shared sink connector framework** level (`debezium-sink`), so the JDBC sink (and any sink that adopts `AbstractChangeEventSink`) can route failing records to the DLQ and keep processing.

## Design

* **Shared reporter acquisition** — the acquisition logic (incl. the pre-Kafka-2.6 fallback) that previously lived in `MongoDbSinkConnectorTask` moves to a new `io.debezium.dlq.ErrorReporters` factory; the MongoDB sink task is refactored to use it with identical behavior.
* **Framework tolerance hook** — `AbstractChangeEventSink#writeBatch` catches non-retriable write failures and retries the batch **one record at a time** to isolate the failing records, routing only those to the reporter ("unroll and retry", following the approach of other JDBC-targeting sink connectors). This is safe because `DefaultRecordWriter#write(Batch)` executes the whole batch in a single transaction, so a failed batch leaves nothing committed.
* **Transient failures are never routed** — a new `isRetriableWriteException` template hook lets connectors classify failures; the JDBC sink delegates to the dialect's communication exception check, which is now shared between the existing flush retry logic and DLQ routing via a `DatabaseDialect#isCommunicationException` default method. Communication failures keep propagating so `flush.max.retries` semantics are unchanged.
* **No new configuration** — behavior is driven entirely by the standard `errors.tolerance` / `errors.deadletterqueue.*` sink options. With `errors.tolerance=none` (default) or no DLQ topic, the connector behaves exactly as before.
* **Fail-fast validation** — a dead letter queue topic combined with `errors.tolerance=none` can never receive records, so the connector now rejects that combination at startup with an actionable error message (`ErrorReporters#validateConfiguration`). `errors.tolerance=all` without any error reporter remains a startup warning only, because it is a legitimate way to skip converter/transformation stage failures.
* **Scope** — the integration applies to the shared change event sink path (`internal.enable.sces=true`), in line with the sink framework unification (debezium/dbz#1185); the legacy path is intentionally not wired. Once the MongoDB sink adopts `AbstractChangeEventSink`, it inherits this behavior through the same hook (`recordReported` extension point is already in place) — see debezium/dbz#1190.
* **Observability** — records routed to the reporter are counted via a new `SinkProgressListener#errantRecordsReported` callback and exposed as the `TotalNumberOfErrantRecords` attribute on the existing `debezium.jdbc:type=connector-metrics,context=sink` MBean.

## Testing

* Unit: `ErrorReportersTest` (acquisition, fail-fast validation combinations), `AbstractChangeEventSinkDlqTest` (isolation, single-record batches, retriable propagation at batch level and mid-unroll, throwing reporter/`tolerance=none`, no-reporter behavior unchanged, counters), `JdbcChangeEventSinkTest` (cause-chain classification), `JdbcSinkConnectorMetricsTest`.
* Integration (`JdbcSinkDlqIT`, MySQL): constraint-violating record is reported while the task stays healthy and subsequent records are written; **a lock-wait-timeout (transient) failure is never reported** and fails the task after retries as before; with `internal.enable.sces=false` behavior is unchanged. `JdbcSinkRetryIT` passes unchanged.
* Manually verified end-to-end on a real Kafka Connect runtime: the failing record lands on the configured DLQ topic with full `__connect.errors.*` context headers, the task stays `RUNNING`, and healthy records continue to flow.

## Documentation

* New "Error handling and dead letter queues" section in `jdbc.adoc`, including the fail-fast validation and two operational caveats: environment-caused non-transient failures are also routed when `errors.tolerance=all` (monitor the DLQ), and at-least-once redelivery can route already-written records to the DLQ in `insert` mode (prefer `upsert`).
* `TotalNumberOfErrantRecords` added to the metrics table.
