### PR TITLE
debezium/dbz#2294 Use unique schema history per test

### DIFF
--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkIT.java
@@ -242,7 +242,7 @@ public abstract class AbstractJdbcSinkIT extends AbstractBaseJdbcSinkTest {
                 sourceConfig.with("database.include.list", "test");
                 sourceConfig.with("table.include.list", "test." + tableName);
                 sourceConfig.with("schema.history.internal.kafka.bootstrap.servers", source.getKafka().getNetworkBootstrapServers());
-                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-mysql");
+                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-" + source.getSourceConnectorName());
                 sourceConfig.with("schema.history.internal.store.only.captured.tables.ddl", "true");
                 if (TestHelper.isConnectionTimeZoneUsed()) {
                     sourceConfig.with("driver.connectionTimeZone", TestHelper.getSourceTimeZone());
@@ -271,7 +271,7 @@ public abstract class AbstractJdbcSinkIT extends AbstractBaseJdbcSinkTest {
                 sourceConfig.with("database.names", "testDB");
                 sourceConfig.with("driver.encrypt", "false");
                 sourceConfig.with("schema.history.internal.kafka.bootstrap.servers", source.getKafka().getNetworkBootstrapServers());
-                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-sqlserver");
+                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-" + source.getSourceConnectorName());
                 sourceConfig.with("schema.history.internal.store.only.captured.tables.ddl", "true");
                 sourceConfig.with("table.include.list", "dbo." + tableName);
                 if (source.getOptions().isColumnTypePropagated()) {
@@ -288,7 +288,7 @@ public abstract class AbstractJdbcSinkIT extends AbstractBaseJdbcSinkTest {
                 sourceConfig.with("table.include.list", "debezium." + tableName);
                 sourceConfig.with("log.mining.strategy", "online_catalog");
                 sourceConfig.with("schema.history.internal.kafka.bootstrap.servers", source.getKafka().getNetworkBootstrapServers());
-                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-oracle");
+                sourceConfig.with("schema.history.internal.kafka.topic", "schema-history-" + source.getSourceConnectorName());
                 sourceConfig.with("schema.history.internal.store.only.captured.tables.ddl", "true");
                 if (source.getOptions().isColumnTypePropagated()) {
                     sourceConfig.with("column.propagate.source.type", "debezium.*");


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2294

## Description
Lately, we've noticed that SQL Server JDBC tests seem flaky and aren't starting within the 120-second allotment. This PR is testing whether or not this could be related to the fact that the schema history topic is reused across all tests, and perhaps schema history recovery is compounding startup times.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
