### PR TITLE
debezium/dbz#2291 Fix MySQL DDL parser with `sql_mode` as ANSI_QUOTES

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
@@ -41,6 +41,7 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection.DatabaseLocales;
+import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.binlog.metrics.BinlogSnapshotChangeEventSourceMetrics;
 import io.debezium.data.Envelope;
 import io.debezium.function.BlockingConsumer;
@@ -315,6 +316,8 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         if (!snapshottingTask.isOnDemand()) {
             // Record default charset
             addSchemaEvent(snapshotContext, "", connection.setStatementFor(connection.readCharsetSystemVariables()));
+            // Set sql_mode directly so DDL parser knows whether ANSI_QUOTES is active
+            databaseSchema.setSystemVariables(BinlogSystemVariables.BinlogScope.GLOBAL, connection.readSqlModeSystemVariable());
         }
 
         for (TableId tableId : capturedSchemaTables) {

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/jdbc/BinlogConnectorConnection.java
@@ -47,6 +47,7 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
 
     private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
     private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
+    private static final String SQL_SHOW_SYSTEM_VARIABLES_SQL_MODE = "SHOW VARIABLES WHERE Variable_name = 'sql_mode'";
     private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
     private static final String QUOTED_CHARACTER = "`";
     public static final String MASTER_STATUS_STATEMENT = "SHOW MASTER STATUS";
@@ -246,6 +247,16 @@ public abstract class BinlogConnectorConnection extends JdbcConnection {
         // Read the system variables from the MySQL instance and get the current database name ...
         LOGGER.debug("Reading charset-related system variables before parsing DDL history.");
         return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET);
+    }
+
+    /**
+     * Read the sql_mode system variable from the server.
+     *
+     * @return a map containing the sql_mode variable; never null
+     */
+    public Map<String, String> readSqlModeSystemVariable() {
+        LOGGER.debug("Reading sql_mode system variable before parsing DDL history.");
+        return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES_SQL_MODE);
     }
 
     /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
@@ -14,6 +14,10 @@ import java.util.regex.Pattern;
  * but MySQL's default mode allows double quotes for strings. This normalizer
  * transforms DDL before parsing to support both modes.
  *
+ * When the server is running with {@code sql_mode=ANSI_QUOTES}, double-quoted
+ * text represents identifiers and must not be converted. In that case, callers
+ * should pass {@code ansiQuotesMode=true} to skip the conversion.
+ *
  * Also adds backticks around reserved keywords when used as identifiers.
  *
  * @author Debezium Authors
@@ -48,13 +52,28 @@ public class DdlNormalizer {
     /**
      * Normalizes MySQL DDL by converting double-quoted strings to single-quoted strings
      * while preserving backtick-quoted identifiers, and adding backticks around reserved
-     * keywords when used as identifiers.
+     * keywords when used as identifiers. Assumes the server is NOT in ANSI_QUOTES mode.
      *
      * @param ddlContent The DDL statement to normalize
      * @return Normalized DDL with double-quoted strings converted to single quotes
      *         and reserved keywords backtick-quoted, or the original input if null or empty
      */
     public static String normalize(String ddlContent) {
+        return normalize(ddlContent, false);
+    }
+
+    /**
+     * Normalizes MySQL DDL by adding backticks around reserved keywords when used as
+     * identifiers. When {@code ansiQuotesMode} is false, also converts double-quoted
+     * strings to single-quoted strings (for servers using the default sql_mode where
+     * double quotes delimit string literals). When {@code ansiQuotesMode} is true,
+     * double-quoted text is left as-is because it represents identifiers.
+     *
+     * @param ddlContent The DDL statement to normalize
+     * @param ansiQuotesMode true if the server's sql_mode includes ANSI_QUOTES
+     * @return Normalized DDL, or the original input if null or empty
+     */
+    public static String normalize(String ddlContent, boolean ansiQuotesMode) {
         if (ddlContent == null || ddlContent.isEmpty()) {
             return ddlContent;
         }
@@ -66,6 +85,9 @@ public class DdlNormalizer {
         while (matcher.find()) {
             normalized.append(addBackticksToReservedKeywords(ddlContent.substring(lastEnd, matcher.start())));
             if (isComment(matcher) || isSingleQuotedString(matcher) || isBacktickIdentifier(matcher)) {
+                preserveOriginal(matcher, normalized);
+            }
+            else if (ansiQuotesMode) {
                 preserveOriginal(matcher, normalized);
             }
             else {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -10,6 +10,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -25,6 +26,8 @@ import io.debezium.antlr.AntlrDdlParser;
 import io.debezium.antlr.AntlrDdlParserListener;
 import io.debezium.antlr.DataTypeResolver;
 import io.debezium.antlr.DataTypeResolver.DataTypeEntry;
+import io.debezium.antlr.mysql.SqlMode;
+import io.debezium.antlr.mysql.SqlModes;
 import io.debezium.connector.binlog.charset.BinlogCharsetRegistry;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.mysql.antlr.listener.MySqlAntlrDdlParserListener;
@@ -126,9 +129,17 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
 
     @Override
     public DdlChanges parse(String ddlContent, Tables databaseTables) {
-        // Normalize double-quoted strings to support MySQL default mode in ANSI_QUOTES parser
-        String normalizedDdl = DdlNormalizer.normalize(ddlContent);
+        String normalizedDdl = DdlNormalizer.normalize(ddlContent, isAnsiQuotesMode());
         return super.parse(normalizedDdl, databaseTables);
+    }
+
+    private boolean isAnsiQuotesMode() {
+        String sqlMode = systemVariables.getVariable("sql_mode");
+        if (sqlMode == null || sqlMode.isEmpty()) {
+            return false;
+        }
+        Set<SqlMode> modes = SqlModes.sqlModeFromString(sqlMode);
+        return modes.contains(SqlMode.AnsiQuotes);
     }
 
     @Override

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -247,4 +247,102 @@ public class MySqlAntlrDdlParserTest
             this.ddlChanges = changesListener;
         }
     }
+
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void shouldParseCreateTableWithAnsiQuotesMode() {
+        parser.parse("SET sql_mode='ANSI_QUOTES'", tables);
+        String ddl = "CREATE TABLE \"customers\" (\n" +
+                "  \"id\" int NOT NULL AUTO_INCREMENT,\n" +
+                "  \"first_name\" varchar(255) NOT NULL,\n" +
+                "  \"last_name\" varchar(255) NOT NULL,\n" +
+                "  \"email\" varchar(255) NOT NULL,\n" +
+                "  PRIMARY KEY (\"id\"),\n" +
+                "  UNIQUE KEY \"email\" (\"email\")\n" +
+                ") ENGINE=InnoDB AUTO_INCREMENT=1005 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        Table table = tables.forTable(null, null, "customers");
+        assertThat(table).isNotNull();
+        assertThat(table.columns()).hasSize(4);
+        assertThat(table.columnWithName("id")).isNotNull();
+        assertThat(table.columnWithName("first_name")).isNotNull();
+        assertThat(table.columnWithName("last_name")).isNotNull();
+        assertThat(table.columnWithName("email")).isNotNull();
+        assertThat(table.primaryKeyColumnNames()).containsExactly("id");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void shouldParseAlterTableWithAnsiQuotesMode() {
+        parser.parse("SET sql_mode='ANSI_QUOTES'", tables);
+        parser.parse("CREATE TABLE \"customers\" (\n" +
+                "  \"id\" int NOT NULL AUTO_INCREMENT,\n" +
+                "  \"first_name\" varchar(255) NOT NULL,\n" +
+                "  PRIMARY KEY (\"id\")\n" +
+                ") ENGINE=InnoDB", tables);
+        parser.parse("ALTER TABLE \"customers\" ADD COLUMN \"middle_name\" varchar(255) NULL", tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        Table table = tables.forTable(null, null, "customers");
+        assertThat(table).isNotNull();
+        assertThat(table.columns()).hasSize(3);
+        assertThat(table.columnWithName("middle_name")).isNotNull();
+        assertThat(table.columnWithName("middle_name").isOptional()).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void shouldParseCreateTableWithAnsiQuotesModeAndFullSqlMode() {
+        parser.parse("SET sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE," +
+                "ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ANSI_QUOTES'", tables);
+        String ddl = "CREATE TABLE \"addresses\" (\n" +
+                "  \"id\" int NOT NULL AUTO_INCREMENT,\n" +
+                "  \"customer_id\" int NOT NULL,\n" +
+                "  \"street\" varchar(255) NOT NULL,\n" +
+                "  \"city\" varchar(255) NOT NULL,\n" +
+                "  \"state\" varchar(255) NOT NULL,\n" +
+                "  \"zip\" varchar(255) NOT NULL,\n" +
+                "  \"type\" enum('SHIPPING','BILLING','LIVING') NOT NULL,\n" +
+                "  PRIMARY KEY (\"id\"),\n" +
+                "  KEY \"address_customer\" (\"customer_id\"),\n" +
+                "  CONSTRAINT \"addresses_ibfk_1\" FOREIGN KEY (\"customer_id\") REFERENCES \"customers\" (\"id\")\n" +
+                ") ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        Table table = tables.forTable(null, null, "addresses");
+        assertThat(table).isNotNull();
+        assertThat(table.columns()).hasSize(7);
+        assertThat(table.columnWithName("type")).isNotNull();
+        assertThat(table.columnWithName("type").typeName()).isEqualTo("ENUM");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void shouldParseCreateTableWithDefaultModeDoubleQuotedStrings() {
+        String ddl = "CREATE TABLE t (\n" +
+                "  col1 ENUM(\"a\", \"b\", \"c\"),\n" +
+                "  col2 VARCHAR(10) DEFAULT \"test\"\n" +
+                ")";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        Table table = tables.forTable(null, null, "t");
+        assertThat(table).isNotNull();
+        assertThat(table.columns()).hasSize(2);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void shouldParseSchemaQualifiedAlterTableWithAnsiQuotesMode() {
+        parser.parse("SET sql_mode='ANSI_QUOTES'", tables);
+        parser.parse("CREATE TABLE \"customers\" (\n" +
+                "  \"id\" int NOT NULL AUTO_INCREMENT,\n" +
+                "  PRIMARY KEY (\"id\")\n" +
+                ") ENGINE=InnoDB", tables);
+        parser.parse("ALTER TABLE inventory.\"customers\" ADD COLUMN \"middle_name\" varchar(255) NULL", tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+    }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
@@ -335,4 +335,63 @@ public class DdlNormalizerTest {
         String expected = "CREATE TABLE `RANK` (c VARCHAR(20) DEFAULT 'FROM RANK', `RANK` INT COMMENT 'RANK: n')";
         assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
     }
+
+    @DisplayName("Given ANSI_QUOTES mode and double-quoted identifiers When normalize Then identifiers are preserved")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testAnsiQuotesModePreservesDoubleQuotedIdentifiers() {
+        String input = "CREATE TABLE \"customers\" (\"id\" int NOT NULL AUTO_INCREMENT, PRIMARY KEY (\"id\"))";
+        assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(input);
+    }
+
+    @DisplayName("Given ANSI_QUOTES mode and full CREATE TABLE with double-quoted identifiers When normalize Then identifiers are preserved")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testAnsiQuotesModeFullCreateTable() {
+        String input = "CREATE TABLE \"addresses\" (\n" +
+                "  \"id\" int NOT NULL AUTO_INCREMENT,\n" +
+                "  \"customer_id\" int NOT NULL,\n" +
+                "  \"street\" varchar(255) NOT NULL,\n" +
+                "  \"city\" varchar(255) NOT NULL,\n" +
+                "  \"type\" enum('SHIPPING','BILLING','LIVING') NOT NULL,\n" +
+                "  PRIMARY KEY (\"id\"),\n" +
+                "  KEY \"address_customer\" (\"customer_id\"),\n" +
+                "  CONSTRAINT \"addresses_ibfk_1\" FOREIGN KEY (\"customer_id\") REFERENCES \"customers\" (\"id\")\n" +
+                ") ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
+        assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(input);
+    }
+
+    @DisplayName("Given ANSI_QUOTES mode and ALTER TABLE with double-quoted identifiers When normalize Then identifiers are preserved")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testAnsiQuotesModeAlterTable() {
+        String input = "ALTER TABLE inventory.\"customers\" ADD COLUMN \"middle_name\" varchar(255) NULL";
+        assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(input);
+    }
+
+    @DisplayName("Given ANSI_QUOTES mode with single-quoted strings When normalize Then strings are preserved")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testAnsiQuotesModeSingleQuotedStrings() {
+        String input = "CREATE TABLE \"t\" (\"col\" VARCHAR(10) DEFAULT 'hello')";
+        assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(input);
+    }
+
+    @DisplayName("Given default mode (not ANSI_QUOTES) When normalize Then double-quoted strings are still converted")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testDefaultModeStillConvertsDoubleQuotes() {
+        String input = "CREATE TABLE t (col ENUM(\"a\", \"b\", \"c\"))";
+        String expected = "CREATE TABLE t (col ENUM('a', 'b', 'c'))";
+        assertThat(DdlNormalizer.normalize(input, false)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given ANSI_QUOTES mode with reserved keywords When normalize Then keywords still get backticks")
+    @Test
+    @FixFor("debezium/dbz#2291")
+    public void testAnsiQuotesModeReservedKeywordsStillBackticked() {
+        String input = "CREATE TABLE RANK (\"id\" INT, \"name\" VARCHAR(50))";
+        String expected = "CREATE TABLE `RANK` (\"id\" INT, \"name\" VARCHAR(50))";
+        assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2291

## Description
Fix MySQL DDL Parser to retain double quotes when `ANSI_QUOTES` is set as `sql_mode`

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
