### PR TITLE
debezium/dbz#2296 Fix regression with archive log mode wait

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
@@ -119,20 +119,17 @@ public class LogFileCollector {
      * @throws SQLException if there is a database failure during the collection
      */
     public boolean isScnInArchiveLogs(Scn scn) throws SQLException {
-        try {
-            final List<LogFile> allLogs = getLogs(scn).logFiles();
-            final Map<Integer, List<LogFile>> threadLogs = allLogs.stream()
-                    .collect(Collectors.groupingBy(LogFile::getThread));
+        final Map<Integer, List<LogFile>> threadLogs = getLogsForOffsetScn(scn).stream()
+                .filter(LogFile::isArchive)
+                .collect(Collectors.groupingBy(LogFile::getThread));
 
-            return threadLogs.entrySet().stream()
-                    .allMatch(e -> e.getValue().stream()
-                            .filter(LogFile::isCurrent)
-                            .allMatch(log -> log.getFirstScn().compareTo(scn) > 0));
-        }
-        catch (LogFileNotFoundException e) {
-            // It is safe to ignore this because we used consistency checks
+        if (threadLogs.isEmpty()) {
             return false;
         }
+
+        return threadLogs.values().stream()
+                .allMatch(logs -> logs.stream()
+                        .anyMatch(log -> log.isScnInLogFileRange(scn)));
     }
 
     @VisibleForTesting

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -2671,11 +2671,13 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
-    @FixFor({ "DBZ-3712", "DBZ-4879" })
+    @FixFor({ "DBZ-3712", "DBZ-4879", "debezium/dbz#2296" })
     @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER, reason = "Tests archive log support for LogMiner only")
     public void shouldStartWithArchiveLogOnlyModeAndStreamWhenRecordsBecomeAvailable() throws Exception {
         TestHelper.dropTable(connection, "dbz3712");
         try {
+            final LogInterceptor logInterceptor = TestHelper.getAbstractEventProcessorLogInterceptor();
+
             connection.execute("CREATE TABLE dbz3712 (id number(9,0), data varchar2(50))");
             TestHelper.streamTable(connection, "dbz3712");
 
@@ -2694,10 +2696,16 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
             waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
             assertNoRecordsToConsume();
 
+            Awaitility.await().atMost(Duration.ofMinutes(1))
+                    .until(() -> logInterceptor.containsMessage("is not yet in archive logs, waiting for log switch."));
+
             // We will insert a new record but this record won't be emitted right away and will
             // require that a log switch happen so that it can be emitted.
             connection.execute("INSERT INTO dbz3712 (id,data) values (1, 'Test')");
             waitForLogSwitchOrForceOneAfterTimeout();
+
+            Awaitility.await().atMost(Duration.ofMinutes(1))
+                    .until(() -> logInterceptor.containsMessage("is now available in archive logs, log mining session resumed."));
 
             // We should now be able to consume a record
             SourceRecords records = consumeRecordsByTopic(1);


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2296

## Description
Fixes a regression introduced in 3.4.3/3.5.0 with Oracle archive log only mode not waiting and advancing too early.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
