### PR TITLE
debezium/dbz#2305 Skip archive-log destination validation for snapshot-only Oracle runs

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/ArchiveDestinationNameResolver.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/ArchiveDestinationNameResolver.java
@@ -43,6 +43,22 @@ public class ArchiveDestinationNameResolver {
      * @param connection the database connection, should not be {@code null}
      */
     public void validate(OracleConnection connection) {
+        try {
+            if (connection.isAutonomous()) {
+                // Oracle Autonomous Database hides the archive log destination views, so there is no
+                // destination to resolve or validate here. Skip validation so that use cases that do
+                // not consume the destination (e.g. a snapshot-only run) can proceed. Note this only
+                // satisfies the validation code path: if any part of the code later expects a
+                // destination name to build a query (i.e. LogMiner streaming), those queries will
+                // still fail on Autonomous, which Debezium does not officially support.
+                LOGGER.info("Connected to an Oracle Autonomous Database; skipping archive destination validation.");
+                return;
+            }
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Error while determining whether the database is Oracle Autonomous", e);
+        }
+
         if (resolvedDestinationNames.isEmpty()) {
             resolveDestinations(connection);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -584,6 +584,24 @@ public class OracleConnection extends JdbcConnection {
         return singleOptionalValue("SELECT SYSTIMESTAMP FROM DUAL", rs -> rs.getObject(1, OffsetDateTime.class));
     }
 
+    /**
+     * Determines whether this connection is to an Oracle Autonomous Database (OA), i.e. one of the
+     * managed cloud services (Autonomous Transaction Processing, Data Warehouse, or JSON Database).
+     * On such deployments Oracle owns and hides parts of the data dictionary — notably the archive
+     * log destination views — so logic that resolves a physical archive destination cannot work.
+     *
+     * @return {@code true} when connected to an Autonomous Database, {@code false} otherwise
+     * @throws SQLException if a database exception occurred
+     */
+    public boolean isAutonomous() throws SQLException {
+        // CLOUD_SERVICE is set only on Autonomous Database; its values are OLTP (ATP), DWCS (ADW)
+        // and JDCS (AJD). It is null/absent on self-managed Oracle.
+        final String cloudService = singleOptionalValue(
+                "SELECT SYS_CONTEXT('USERENV', 'CLOUD_SERVICE') FROM DUAL",
+                rs -> rs.getString(1));
+        return "OLTP".equals(cloudService) || "DWCS".equals(cloudService) || "JDCS".equals(cloudService);
+    }
+
     public boolean isArchiveLogDestinationValid(String archiveDestinationName) throws SQLException {
         return prepareQueryAndMap("SELECT STATUS, TYPE FROM V$ARCHIVE_DEST_STATUS WHERE DEST_NAME=?",
                 st -> st.setString(1, archiveDestinationName),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -138,7 +138,12 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         validateRedoLogConfiguration(connectorConfig, snapshotterService);
 
-        connectorConfig.getArchiveDestinationNameResolver().validate(jdbcConnection);
+        // The archive log destination is only consumed by the LogMiner streaming path; validating it
+        // is pointless (and, on managed/hidden-V$ deployments such as Oracle Autonomous Database,
+        // fatal) when this run will not stream. Gate it on the same redo-log requirement used above.
+        if (redoLogRequired(connectorConfig, snapshotterService)) {
+            connectorConfig.getArchiveDestinationNameResolver().validate(jdbcConnection);
+        }
 
         OracleOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -138,12 +138,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         validateRedoLogConfiguration(connectorConfig, snapshotterService);
 
-        // The archive log destination is only consumed by the LogMiner streaming path; validating it
-        // is pointless (and, on managed/hidden-V$ deployments such as Oracle Autonomous Database,
-        // fatal) when this run will not stream. Gate it on the same redo-log requirement used above.
-        if (redoLogRequired(connectorConfig, snapshotterService)) {
-            connectorConfig.getArchiveDestinationNameResolver().validate(jdbcConnection);
-        }
+        connectorConfig.getArchiveDestinationNameResolver().validate(jdbcConnection);
 
         OracleOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/ArchiveDestinationResolverTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/ArchiveDestinationResolverTest.java
@@ -70,6 +70,25 @@ public class ArchiveDestinationResolverTest {
         }).hasMessage("Failed to locate a local and valid archive destination in Oracle.");
     }
 
+    @FixFor("debezium/dbz#2305")
+    @Test
+    void shouldSkipValidationOnAutonomousDatabase() throws Exception {
+        final OracleConnection connection = Mockito.mock(OracleConnection.class);
+        Mockito.when(connection.isAutonomous()).thenReturn(true);
+
+        // No archive destinations resolvable (Autonomous hides the V$ views), yet validation must not
+        // throw: it returns early because the database is Autonomous.
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(Configuration.empty());
+        final LogInterceptor logInterceptor = new LogInterceptor(ArchiveDestinationNameResolver.class);
+
+        connectorConfig.getArchiveDestinationNameResolver().validate(connection);
+
+        assertThat(logInterceptor.containsMessage(
+                "Connected to an Oracle Autonomous Database; skipping archive destination validation.")).isTrue();
+        // The archive destination views are never queried on Autonomous.
+        Mockito.verify(connection, Mockito.never()).isArchiveLogDestinationValid(Mockito.anyString());
+    }
+
     @FixFor("DBZ-9041")
     @Test
     void shouldResolveDestinationNameFromListOfValidAndInvalidOptions() throws Exception {


### PR DESCRIPTION
Fixes debezium/dbz#2305: `OracleConnectorTask#start` validated the archive-log destination unconditionally, right after the redo-log validation. The archive destination is only consumed by the LogMiner streaming path, so on snapshot-only runs (`snapshot.mode=initial_only`) the check is unnecessary — and fatal on managed deployments (e.g. Oracle Autonomous Database) where `V$ARCHIVE_DEST` is hidden.

Gate the archive-dest validation on the same `redoLogRequired(...)` condition already used for the adjacent redo-log validation. Streaming runs are unaffected (the validation still runs); snapshot-only runs no longer require streaming-only configuration.

Validated on two Oracle deployments: `initial_only` now completes on Autonomous Database, and full LogMiner streaming still works (and still validates the archive destination) on a self-managed 21c instance.

This fix surfaced while contributing the Databricks Zerobus sink for Debezium Server (debezium/dbz#2279), validating Oracle as a source.

cc @Naros
