### PR TITLE
debezium/dbz#2012: Redesign direct mode around  __$command_id

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
@@ -24,10 +24,12 @@ public class SourceInfo extends BaseSourceInfo {
     public static final String CHANGE_LSN_KEY = "change_lsn";
     public static final String COMMIT_LSN_KEY = "commit_lsn";
     public static final String EVENT_SERIAL_NO_KEY = "event_serial_no";
+    public static final String COMMAND_ID_KEY = "command_id";
 
     private Lsn changeLsn;
     private Lsn commitLsn;
     private Long eventSerialNo;
+    private Integer commandId;
     private Instant sourceTime;
     private TableId tableId;
 
@@ -68,6 +70,14 @@ public class SourceInfo extends BaseSourceInfo {
         this.eventSerialNo = eventSerialNo;
     }
 
+    public Integer getCommandId() {
+        return commandId;
+    }
+
+    public void setCommandId(Integer commandId) {
+        this.commandId = commandId;
+    }
+
     /**
      * @param instant a time at which the transaction commit was executed
      */
@@ -93,6 +103,7 @@ public class SourceInfo extends BaseSourceInfo {
                 ", changeLsn=" + changeLsn +
                 ", commitLsn=" + commitLsn +
                 ", eventSerialNo=" + eventSerialNo +
+                ", commandId=" + commandId +
                 ", snapshot=" + snapshotRecord +
                 ", sourceTime=" + sourceTime +
                 "]";

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -44,7 +44,9 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
     private static final int COL_ROW_LSN = 2;
     private static final int COL_OPERATION = 3;
     private static final int COL_UPDATE_MASK = 4;
-    private static final int COL_DATA = 5;
+    private static final int COL_COMMAND_ID = 5;
+    private static final int COL_DATA_FUNCTION_MODE = 5;
+    private static final int COL_DATA_DIRECT_MODE = 6;
 
     private ResultSetMapper<Object[]> resultSetMapper;
     private final int columnDataOffset;
@@ -52,14 +54,20 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
     private final Lsn fromLsn;
     private final Lsn toLsn;
     private final int maxRowsPerResultSet;
+    private final boolean directMode;
+    private final TxLogPosition resumeFromPosition;
 
-    public SqlServerChangeTablePointer(SqlServerChangeTable changeTable, SqlServerConnection connection, Lsn fromLsn, Lsn toLsn, int maxRowsPerResultSet) {
-        super(changeTable, COL_DATA, maxRowsPerResultSet);
+    public SqlServerChangeTablePointer(SqlServerChangeTable changeTable, SqlServerConnection connection, Lsn fromLsn, Lsn toLsn,
+                                       TxLogPosition resumeFromPosition, int maxRowsPerResultSet,
+                                       SqlServerConnectorConfig.DataQueryMode dataQueryMode) {
+        super(changeTable, dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT ? COL_DATA_DIRECT_MODE : COL_DATA_FUNCTION_MODE, maxRowsPerResultSet);
+        this.directMode = dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         // Store references to these because we can't get them from our superclass
-        this.columnDataOffset = COL_DATA;
+        this.columnDataOffset = this.directMode ? COL_DATA_DIRECT_MODE : COL_DATA_FUNCTION_MODE;
         this.connection = connection;
         this.fromLsn = fromLsn;
         this.toLsn = toLsn;
+        this.resumeFromPosition = resumeFromPosition;
         this.maxRowsPerResultSet = maxRowsPerResultSet;
     }
 
@@ -78,11 +86,12 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
 
     @Override
     protected TxLogPosition getNextChangePosition(ResultSet resultSet) throws SQLException {
-        return isCompleted() ? TxLogPosition.NULL
+        return isCompleted() ? (directMode ? TxLogPosition.NULL : TxLogPosition.NULL_LEGACY)
                 : TxLogPosition.valueOf(
                         Lsn.valueOf(resultSet.getBytes(COL_COMMIT_LSN)),
                         Lsn.valueOf(resultSet.getBytes(COL_ROW_LSN)),
-                        resultSet.getInt(COL_OPERATION));
+                        resultSet.getInt(COL_OPERATION),
+                        directMode ? resultSet.getInt(COL_COMMAND_ID) : null);
     }
 
     /**
@@ -97,13 +106,30 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
 
     @Override
     protected ResultSet getNextResultSet(TxLogPosition lastPositionSeen) throws SQLException {
-        if (lastPositionSeen == null || lastPositionSeen.equals(TxLogPosition.NULL)) {
-            return connection.getChangesForTable(getChangeTable(), fromLsn, toLsn, maxRowsPerResultSet);
+        if (!directMode) {
+            if (lastPositionSeen == null || lastPositionSeen.equals(TxLogPosition.NULL_LEGACY)) {
+                return connection.getChangesForTable(getChangeTable(), fromLsn, toLsn, maxRowsPerResultSet);
+            }
+            else {
+                return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(), lastPositionSeen.getOperation(),
+                        toLsn, maxRowsPerResultSet);
+            }
         }
-        else {
-            return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(), lastPositionSeen.getOperation(),
-                    toLsn, maxRowsPerResultSet);
+
+        // next page in a running connector
+        if (lastPositionSeen != null && !lastPositionSeen.equals(TxLogPosition.NULL)) {
+            return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(),
+                    lastPositionSeen.getOperation(), lastPositionSeen.getCommandId(), toLsn, maxRowsPerResultSet);
         }
+
+        // restarted connector which has not seen any position yet
+        if (resumeFromPosition != null && fromLsn.equals(resumeFromPosition.getCommitLsn())) {
+            return connection.getChangesForTable(getChangeTable(), fromLsn, resumeFromPosition.getInTxLsn(), 0,
+                    resumeFromPosition.getCommandId(), toLsn, maxRowsPerResultSet);
+        }
+
+        // running connector with new range.
+        return connection.getChangesForTable(getChangeTable(), fromLsn, Lsn.ZERO, 0, -1, toLsn, maxRowsPerResultSet);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -44,7 +44,9 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
     private static final int COL_ROW_LSN = 2;
     private static final int COL_OPERATION = 3;
     private static final int COL_UPDATE_MASK = 4;
-    private static final int COL_DATA = 5;
+    private static final int COL_COMMAND_ID = 5;
+    private static final int COL_DATA_FUNCTION_MODE = 5;
+    private static final int COL_DATA_DIRECT_MODE = 6;
 
     private ResultSetMapper<Object[]> resultSetMapper;
     private final int columnDataOffset;
@@ -52,14 +54,20 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
     private final Lsn fromLsn;
     private final Lsn toLsn;
     private final int maxRowsPerResultSet;
+    private final boolean directMode;
+    private final TxLogPosition resumeFromPosition;
 
-    public SqlServerChangeTablePointer(SqlServerChangeTable changeTable, SqlServerConnection connection, Lsn fromLsn, Lsn toLsn, int maxRowsPerResultSet) {
-        super(changeTable, COL_DATA, maxRowsPerResultSet);
+    public SqlServerChangeTablePointer(SqlServerChangeTable changeTable, SqlServerConnection connection, Lsn fromLsn, Lsn toLsn,
+                                       TxLogPosition resumeFromPosition, int maxRowsPerResultSet,
+                                       SqlServerConnectorConfig.DataQueryMode dataQueryMode) {
+        super(changeTable, dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT ? COL_DATA_DIRECT_MODE : COL_DATA_FUNCTION_MODE, maxRowsPerResultSet);
+        this.directMode = dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         // Store references to these because we can't get them from our superclass
-        this.columnDataOffset = COL_DATA;
+        this.columnDataOffset = this.directMode ? COL_DATA_DIRECT_MODE : COL_DATA_FUNCTION_MODE;
         this.connection = connection;
         this.fromLsn = fromLsn;
         this.toLsn = toLsn;
+        this.resumeFromPosition = resumeFromPosition;
         this.maxRowsPerResultSet = maxRowsPerResultSet;
     }
 
@@ -82,7 +90,8 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
                 : TxLogPosition.valueOf(
                         Lsn.valueOf(resultSet.getBytes(COL_COMMIT_LSN)),
                         Lsn.valueOf(resultSet.getBytes(COL_ROW_LSN)),
-                        resultSet.getInt(COL_OPERATION));
+                        resultSet.getInt(COL_OPERATION),
+                        directMode ? resultSet.getInt(COL_COMMAND_ID) : null);
     }
 
     /**
@@ -97,13 +106,30 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
 
     @Override
     protected ResultSet getNextResultSet(TxLogPosition lastPositionSeen) throws SQLException {
-        if (lastPositionSeen == null || lastPositionSeen.equals(TxLogPosition.NULL)) {
-            return connection.getChangesForTable(getChangeTable(), fromLsn, toLsn, maxRowsPerResultSet);
+        if (!directMode) {
+            if (lastPositionSeen == null || lastPositionSeen.equals(TxLogPosition.NULL)) {
+                return connection.getChangesForTable(getChangeTable(), fromLsn, toLsn, maxRowsPerResultSet);
+            }
+            else {
+                return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(), lastPositionSeen.getOperation(),
+                        toLsn, maxRowsPerResultSet);
+            }
         }
-        else {
-            return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(), lastPositionSeen.getOperation(),
-                    toLsn, maxRowsPerResultSet);
+
+        // next page in a running connector
+        if (lastPositionSeen != null && !lastPositionSeen.equals(TxLogPosition.NULL)) {
+            return connection.getChangesForTable(getChangeTable(), lastPositionSeen.getCommitLsn(), lastPositionSeen.getInTxLsn(),
+                    lastPositionSeen.getOperation(), lastPositionSeen.getCommandId(), toLsn, maxRowsPerResultSet);
         }
+
+        // restarted connector which has not seen any position yet.
+        if (resumeFromPosition != null && resumeFromPosition.getCommandId() != null) {
+            return connection.getChangesForTable(getChangeTable(), fromLsn, resumeFromPosition.getInTxLsn(), 0,
+                    resumeFromPosition.getCommandId(), toLsn, maxRowsPerResultSet);
+        }
+
+        // No command id to resume on, so repeat the transaction from its start.
+        return connection.getChangesForTable(getChangeTable(), fromLsn, toLsn, maxRowsPerResultSet);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -85,10 +85,10 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String LSN_TIMESTAMP_SELECT_STATEMENT_JOIN = "TODATETIMEOFFSET(ltm.tran_begin_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))";
     private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT = "SELECT [__$start_lsn], [__$seqval], [__$operation], [__$update_mask], #, "
             + LSN_TIMESTAMP_SELECT_STATEMENT;
-    private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT = "SELECT cdc_data.[__$start_lsn], cdc_data.[__$seqval], cdc_data.[__$operation], cdc_data.[__$update_mask], #, "
+    private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT = "SELECT cdc_data.[__$start_lsn], cdc_data.[__$seqval], cdc_data.[__$operation], cdc_data.[__$update_mask], cdc_data.[__$command_id], #, "
             + LSN_TIMESTAMP_SELECT_STATEMENT_JOIN;
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION = "FROM #db.cdc.#function(?, ?, N'all update old')";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table AS cdc_data LEFT JOIN #db.cdc.lsn_time_mapping ltm ON ltm.start_lsn = cdc_data.[__$start_lsn]";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table AS cdc_data WITH (NOLOCK) LEFT JOIN #db.cdc.lsn_time_mapping ltm ON ltm.start_lsn = cdc_data.[__$start_lsn]";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY cdc_data.[__$start_lsn] ASC, cdc_data.[__$command_id] ASC, cdc_data.[__$seqval] ASC, cdc_data.[__$operation] ASC";
     private static final String GET_CDC_JOB_INFO = "{call sys.sp_cdc_help_jobs}";
@@ -211,10 +211,16 @@ public class SqlServerConnection extends JdbcConnection {
         }
 
         if (isDirectMode) {
-            where.add("(([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] = ? AND [cdc_data].[__$operation] > ?) " +
-                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] > ?) " +
+            // The seqval condition is a safeguard. Every command id observed so far maps to exactly one
+            // seqval but that is not documented and the branch keeps the keyset correct if it ever stops holding.
+            where.add("(([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] = ? AND [cdc_data].[__$seqval] = ? AND [cdc_data].[__$operation] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] = ? AND [cdc_data].[__$seqval] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] > ?) " +
                     "OR ([cdc_data].[__$start_lsn] > ?))");
             where.add("[cdc_data].[__$start_lsn] <= ?");
+            // This branch is added for performance. Bounding the seek on both sides keeps it a range seek on the change table's
+            // clustered index instead of a full table scan from the lower bound.
+            where.add("[cdc_data].[__$start_lsn] >= ?");
         }
         else {
             where.add("(([__$start_lsn] = ? AND [__$seqval] = ? AND [__$operation] > ?) " +
@@ -420,12 +426,13 @@ public class SqlServerConnection extends JdbcConnection {
      * @param intervalFromLsn - closed lower bound of interval of changes to be provided
      * @param seqvalFromLsn - in-transaction sequence value to start after, pass {@link Lsn#ZERO} to fetch all sequence values
      * @param operationFrom - operation number to start after, pass 0 to fetch all operations
+     * @param commandIdFrom - in-transaction command id to start after. Only used in {@code direct} mode;
      * @param intervalToLsn  - closed upper bound of interval  of changes to be provided
      * @param maxRows - the max number of rows to return, pass 0 for no limit
      * @throws SQLException
      */
     public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn seqvalFromLsn, int operationFrom,
-                                        Lsn intervalToLsn, int maxRows)
+                                        Integer commandIdFrom, Lsn intervalToLsn, int maxRows)
             throws SQLException {
         String databaseName = changeTable.getSourceTableId().catalog();
         String capturedColumns = changeTable.getCapturedColumns().stream().map(this::quoteIdentifier)
@@ -448,8 +455,8 @@ public class SqlServerConnection extends JdbcConnection {
         // If the table was added in the middle of queried buffer we need
         // to adjust from to the first LSN available
         final Lsn fromLsn = getFromLsn(changeTable, intervalFromLsn);
-        LOGGER.trace("Getting {} changes for table {} in range [{}-{}-{}, {}]", maxRows > 0 ? "top " + maxRows : "", changeTable, fromLsn, seqvalFromLsn, operationFrom,
-                intervalToLsn);
+        LOGGER.trace("Getting {} changes for table {} in range [{}-{}-{}-{}, {}]", maxRows > 0 ? "top " + maxRows : "", changeTable, fromLsn, commandIdFrom,
+                seqvalFromLsn, operationFrom, intervalToLsn);
 
         PreparedStatement statement = connection().prepareStatement(query);
         statement.closeOnCompletion();
@@ -462,24 +469,49 @@ public class SqlServerConnection extends JdbcConnection {
         if (config.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.FUNCTION) {
             statement.setBytes(paramIndex++, fromLsn.getBinary());
             statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setInt(paramIndex++, operationFrom);
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, intervalToLsn.getBinary());
         }
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
-        statement.setInt(paramIndex++, operationFrom);
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+        else {
+            if (commandIdFrom == null) {
+                throw new IllegalStateException("command_id must not be null in direct mode");
+            }
+
+            // (start_lsn = ? AND command_id = ? AND seqval = ? AND operation > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandIdFrom);
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setInt(paramIndex++, operationFrom);
+            // OR (start_lsn = ? AND command_id = ? AND seqval > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandIdFrom);
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            // OR (start_lsn = ? AND command_id > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandIdFrom);
+            // OR (start_lsn > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            // AND start_lsn <= ? AND start_lsn >= ?
+            statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+        }
 
         return statement.executeQuery();
     }
 
-    public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn intervalToLsn, int maxRows) throws SQLException {
-        return getChangesForTable(changeTable, intervalFromLsn, Lsn.ZERO, 0, intervalToLsn, maxRows);
+    public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn seqvalFromLsn, int operationFrom,
+                                        Lsn intervalToLsn, int maxRows)
+            throws SQLException {
+        return getChangesForTable(changeTable, intervalFromLsn, seqvalFromLsn, operationFrom, null, intervalToLsn, maxRows);
     }
 
-    public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn intervalToLsn) throws SQLException {
-        return getChangesForTable(changeTable, intervalFromLsn, intervalToLsn, 0);
+    public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn intervalToLsn, int maxRows) throws SQLException {
+        return getChangesForTable(changeTable, intervalFromLsn, Lsn.ZERO, 0, null, intervalToLsn, maxRows);
     }
 
     private Lsn getFromLsn(SqlServerChangeTable changeTable, Lsn intervalFromLsn) throws SQLException {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -85,10 +85,10 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String LSN_TIMESTAMP_SELECT_STATEMENT_JOIN = "TODATETIMEOFFSET(ltm.tran_begin_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))";
     private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT = "SELECT [__$start_lsn], [__$seqval], [__$operation], [__$update_mask], #, "
             + LSN_TIMESTAMP_SELECT_STATEMENT;
-    private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT = "SELECT cdc_data.[__$start_lsn], cdc_data.[__$seqval], cdc_data.[__$operation], cdc_data.[__$update_mask], #, "
+    private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT = "SELECT cdc_data.[__$start_lsn], cdc_data.[__$seqval], cdc_data.[__$operation], cdc_data.[__$update_mask], cdc_data.[__$command_id], #, "
             + LSN_TIMESTAMP_SELECT_STATEMENT_JOIN;
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION = "FROM #db.cdc.#function(?, ?, N'all update old')";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table AS cdc_data LEFT JOIN #db.cdc.lsn_time_mapping ltm ON ltm.start_lsn = cdc_data.[__$start_lsn]";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table AS cdc_data WITH (NOLOCK) LEFT JOIN #db.cdc.lsn_time_mapping ltm ON ltm.start_lsn = cdc_data.[__$start_lsn]";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY cdc_data.[__$start_lsn] ASC, cdc_data.[__$command_id] ASC, cdc_data.[__$seqval] ASC, cdc_data.[__$operation] ASC";
     private static final String GET_CDC_JOB_INFO = "{call sys.sp_cdc_help_jobs}";
@@ -96,6 +96,7 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String CDC_JOB_INFO_JOB_TYPE_CAPTURE_VALUE = "capture";
     private static final String CDC_JOB_INFO_POLLING_INTERVAL_COLUMN_NAME = "pollinginterval";
     private static final long DEFAULT_CDC_POLLING_INTERVAL_SECONDS = 5;
+    private static final int COMMAND_ID_BEFORE_FIRST = -1;
     private static final String GET_START_LSN_FOR_LAST_BATCH_SCANNED = "SELECT TOP 1 start_lsn from sys.dm_cdc_log_scan_sessions ORDER BY session_id DESC";
     private static final String START_LSN_INDICATING_EMPTY_BATCH = "00000000:00000000:0000\u0000";
 
@@ -195,8 +196,8 @@ public class SqlServerConnection extends JdbcConnection {
         this.optionRecompile = optionRecompile;
     }
 
-    private String buildGetAllChangesForTableQuery(SqlServerConnectorConfig.DataQueryMode dataQueryMode,
-                                                   Set<Envelope.Operation> skippedOperations) {
+    static String buildGetAllChangesForTableQuery(SqlServerConnectorConfig.DataQueryMode dataQueryMode,
+                                                  Set<Envelope.Operation> skippedOperations) {
         boolean isDirectMode = dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         String result;
         List<String> where = new LinkedList<>();
@@ -211,10 +212,17 @@ public class SqlServerConnection extends JdbcConnection {
         }
 
         if (isDirectMode) {
-            where.add("(([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] = ? AND [cdc_data].[__$operation] > ?) " +
-                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] > ?) " +
+
+            // The seqval condition is a safeguard. Every command id observed so far maps to exactly one
+            // seqval but that is not documented and the branch keeps the keyset correct if it ever stops holding.
+            where.add("(([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] = ? AND [cdc_data].[__$seqval] = ? AND [cdc_data].[__$operation] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] = ? AND [cdc_data].[__$seqval] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$command_id] > ?) " +
                     "OR ([cdc_data].[__$start_lsn] > ?))");
             where.add("[cdc_data].[__$start_lsn] <= ?");
+            // This branch is added for performance. Bounding the seek on both sides keeps it a range seek on the change table's
+            // clustered index instead of a full table scan from the lower bound.
+            where.add("[cdc_data].[__$start_lsn] >= ?");
         }
         else {
             where.add("(([__$start_lsn] = ? AND [__$seqval] = ? AND [__$operation] > ?) " +
@@ -261,7 +269,7 @@ public class SqlServerConnection extends JdbcConnection {
         return result;
     }
 
-    private boolean hasSkippedOperations(Set<Envelope.Operation> skippedOperations) {
+    private static boolean hasSkippedOperations(Set<Envelope.Operation> skippedOperations) {
         if (!skippedOperations.isEmpty()) {
             for (Envelope.Operation operation : skippedOperations) {
                 switch (operation) {
@@ -420,12 +428,14 @@ public class SqlServerConnection extends JdbcConnection {
      * @param intervalFromLsn - closed lower bound of interval of changes to be provided
      * @param seqvalFromLsn - in-transaction sequence value to start after, pass {@link Lsn#ZERO} to fetch all sequence values
      * @param operationFrom - operation number to start after, pass 0 to fetch all operations
+     * @param commandIdFrom - in-transaction command id to start after, pass null to fetch from the beginning of the
+     *            transaction. Only used in {@code direct} mode;
      * @param intervalToLsn  - closed upper bound of interval  of changes to be provided
      * @param maxRows - the max number of rows to return, pass 0 for no limit
      * @throws SQLException
      */
     public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn seqvalFromLsn, int operationFrom,
-                                        Lsn intervalToLsn, int maxRows)
+                                        Integer commandIdFrom, Lsn intervalToLsn, int maxRows)
             throws SQLException {
         String databaseName = changeTable.getSourceTableId().catalog();
         String capturedColumns = changeTable.getCapturedColumns().stream().map(this::quoteIdentifier)
@@ -448,8 +458,8 @@ public class SqlServerConnection extends JdbcConnection {
         // If the table was added in the middle of queried buffer we need
         // to adjust from to the first LSN available
         final Lsn fromLsn = getFromLsn(changeTable, intervalFromLsn);
-        LOGGER.trace("Getting {} changes for table {} in range [{}-{}-{}, {}]", maxRows > 0 ? "top " + maxRows : "", changeTable, fromLsn, seqvalFromLsn, operationFrom,
-                intervalToLsn);
+        LOGGER.trace("Getting {} changes for table {} in range [{}-{}-{}-{}, {}]", maxRows > 0 ? "top " + maxRows : "", changeTable, fromLsn, commandIdFrom,
+                seqvalFromLsn, operationFrom, intervalToLsn);
 
         PreparedStatement statement = connection().prepareStatement(query);
         statement.closeOnCompletion();
@@ -462,20 +472,47 @@ public class SqlServerConnection extends JdbcConnection {
         if (config.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.FUNCTION) {
             statement.setBytes(paramIndex++, fromLsn.getBinary());
             statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setInt(paramIndex++, operationFrom);
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setBytes(paramIndex++, intervalToLsn.getBinary());
         }
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
-        statement.setInt(paramIndex++, operationFrom);
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
-        statement.setBytes(paramIndex++, fromLsn.getBinary());
-        statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+        else {
+            final int commandId = commandIdFrom == null ? COMMAND_ID_BEFORE_FIRST : commandIdFrom;
+
+            // (start_lsn = ? AND command_id = ? AND seqval = ? AND operation > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandId);
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            statement.setInt(paramIndex++, operationFrom);
+            // OR (start_lsn = ? AND command_id = ? AND seqval > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandId);
+            statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
+            // OR (start_lsn = ? AND command_id > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            statement.setInt(paramIndex++, commandId);
+            // OR (start_lsn > ?)
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+            // AND start_lsn <= ? AND start_lsn >= ?
+            statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+        }
 
         return statement.executeQuery();
     }
 
+    public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn seqvalFromLsn, int operationFrom,
+                                        Lsn intervalToLsn, int maxRows)
+            throws SQLException {
+        return getChangesForTable(changeTable, intervalFromLsn, seqvalFromLsn, operationFrom, null, intervalToLsn, maxRows);
+    }
+
     public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn intervalToLsn, int maxRows) throws SQLException {
-        return getChangesForTable(changeTable, intervalFromLsn, Lsn.ZERO, 0, intervalToLsn, maxRows);
+        return getChangesForTable(changeTable, intervalFromLsn, Lsn.ZERO, 0, null, intervalToLsn, maxRows);
     }
 
     public ResultSet getChangesForTable(SqlServerChangeTable changeTable, Lsn intervalFromLsn, Lsn intervalToLsn) throws SQLException {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -196,8 +196,8 @@ public class SqlServerConnection extends JdbcConnection {
         this.optionRecompile = optionRecompile;
     }
 
-    static String buildGetAllChangesForTableQuery(SqlServerConnectorConfig.DataQueryMode dataQueryMode,
-                                                  Set<Envelope.Operation> skippedOperations) {
+    private String buildGetAllChangesForTableQuery(SqlServerConnectorConfig.DataQueryMode dataQueryMode,
+                                                   Set<Envelope.Operation> skippedOperations) {
         boolean isDirectMode = dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         String result;
         List<String> where = new LinkedList<>();
@@ -269,7 +269,7 @@ public class SqlServerConnection extends JdbcConnection {
         return result;
     }
 
-    private static boolean hasSkippedOperations(Set<Envelope.Operation> skippedOperations) {
+    private boolean hasSkippedOperations(Set<Envelope.Operation> skippedOperations) {
         if (!skippedOperations.isEmpty()) {
             for (Envelope.Operation operation : skippedOperations) {
                 switch (operation) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -39,6 +39,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
 
         sourceInfo.setCommitLsn(position.getCommitLsn());
         sourceInfo.setChangeLsn(position.getInTxLsn());
+        sourceInfo.setCommandId(position.getCommandId());
         sourceInfoSchema = sourceInfo.schema();
 
         if (this.snapshotCompleted) {
@@ -69,6 +70,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
         offset.put(SourceInfo.CHANGE_LSN_KEY,
                 sourceInfo.getChangeLsn() == null ? null : sourceInfo.getChangeLsn().toString());
         offset.put(SourceInfo.EVENT_SERIAL_NO_KEY, eventSerialNo);
+        offset.put(SourceInfo.COMMAND_ID_KEY, sourceInfo.getCommandId());
         return sourceInfo.isSnapshot() ? offset : incrementalSnapshotContext.store(transactionContext.store(offset));
     }
 
@@ -78,7 +80,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
     }
 
     public TxLogPosition getChangePosition() {
-        return TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn());
+        return TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn(), 0, sourceInfo.getCommandId());
     }
 
     public long getEventSerialNo() {
@@ -94,6 +96,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
         }
         sourceInfo.setCommitLsn(position.getCommitLsn());
         sourceInfo.setChangeLsn(position.getInTxLsn());
+        sourceInfo.setCommandId(position.getCommandId());
         sourceInfo.setEventSerialNo(eventSerialNo);
     }
 
@@ -115,6 +118,10 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
             final SnapshotType snapshot = loadSnapshot(offset).orElse(null);
             final boolean snapshotCompleted = loadSnapshotCompleted(offset);
+            // A committed offset comes back as a Long, so casting straight to Integer fails
+            // the task on restart.
+            final Number storedCommandId = (Number) offset.get(SourceInfo.COMMAND_ID_KEY);
+            final Integer commandId = storedCommandId == null ? null : storedCommandId.intValue();
 
             // only introduced in 0.10.Beta1, so it might be not present when upgrading from earlier versions
             Long eventSerialNo = ((Long) offset.get(SourceInfo.EVENT_SERIAL_NO_KEY));
@@ -122,7 +129,9 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
                 eventSerialNo = Long.valueOf(0);
             }
 
-            return new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(commitLsn, changeLsn), snapshot, snapshotCompleted, eventSerialNo,
+            return new SqlServerOffsetContext(connectorConfig,
+                    TxLogPosition.valueOf(commitLsn, changeLsn, 0, commandId),
+                    snapshot, snapshotCompleted, eventSerialNo,
                     TransactionContext.load(offset), SqlServerIncrementalSnapshotContext.load(offset));
         }
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -39,6 +39,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
 
         sourceInfo.setCommitLsn(position.getCommitLsn());
         sourceInfo.setChangeLsn(position.getInTxLsn());
+        sourceInfo.setCommandId(position.getCommandId());
         sourceInfoSchema = sourceInfo.schema();
 
         if (this.snapshotCompleted) {
@@ -69,6 +70,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
         offset.put(SourceInfo.CHANGE_LSN_KEY,
                 sourceInfo.getChangeLsn() == null ? null : sourceInfo.getChangeLsn().toString());
         offset.put(SourceInfo.EVENT_SERIAL_NO_KEY, eventSerialNo);
+        offset.put(SourceInfo.COMMAND_ID_KEY, sourceInfo.getCommandId());
         return sourceInfo.isSnapshot() ? offset : incrementalSnapshotContext.store(transactionContext.store(offset));
     }
 
@@ -78,7 +80,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
     }
 
     public TxLogPosition getChangePosition() {
-        return TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn());
+        return TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn(), 0, sourceInfo.getCommandId());
     }
 
     public long getEventSerialNo() {
@@ -86,7 +88,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
     }
 
     public void setChangePosition(TxLogPosition position, int eventCount) {
-        if (getChangePosition().equals(position)) {
+        if (shouldUpdateEventSerialNo(position)) {
             eventSerialNo += eventCount;
         }
         else {
@@ -94,6 +96,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
         }
         sourceInfo.setCommitLsn(position.getCommitLsn());
         sourceInfo.setChangeLsn(position.getInTxLsn());
+        sourceInfo.setCommandId(position.getCommandId());
         sourceInfo.setEventSerialNo(eventSerialNo);
     }
 
@@ -115,6 +118,10 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
             final SnapshotType snapshot = loadSnapshot(offset).orElse(null);
             final boolean snapshotCompleted = loadSnapshotCompleted(offset);
+            // A committed offset comes back as a Long, so casting straight to Integer fails
+            // the task on restart.
+            final Number storedCommandId = (Number) offset.get(SourceInfo.COMMAND_ID_KEY);
+            final Integer commandId = storedCommandId == null ? null : storedCommandId.intValue();
 
             // only introduced in 0.10.Beta1, so it might be not present when upgrading from earlier versions
             Long eventSerialNo = ((Long) offset.get(SourceInfo.EVENT_SERIAL_NO_KEY));
@@ -122,7 +129,9 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
                 eventSerialNo = Long.valueOf(0);
             }
 
-            return new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(commitLsn, changeLsn), snapshot, snapshotCompleted, eventSerialNo,
+            return new SqlServerOffsetContext(connectorConfig,
+                    TxLogPosition.valueOf(commitLsn, changeLsn, 0, commandId),
+                    snapshot, snapshotCompleted, eventSerialNo,
                     TransactionContext.load(offset), SqlServerIncrementalSnapshotContext.load(offset));
         }
     }
@@ -155,5 +164,20 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
 
     public Instant getSourceTime() {
         return sourceInfo.timestamp();
+    }
+
+    private boolean shouldUpdateEventSerialNo(TxLogPosition position) {
+        // On mode switch from direct to function, commandId would be not-null in sourceInfo and null in the position
+        // On mode switch from function to direct, commandId would be null in sourceInfo and not-null in the position
+        if ((position.getCommandId() == null && sourceInfo.getCommandId() != null)
+                || position.getCommandId() != null && sourceInfo.getCommandId() == null) {
+            return false;
+        }
+
+        // for adjacent insert/delete coming from same operation, command_id will be different so its skipped from event_serial_no increment check
+        TxLogPosition lastPosition = TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn(), null);
+        TxLogPosition currentPosition = TxLogPosition.valueOf(position.getCommitLsn(), position.getInTxLsn(), null);
+
+        return lastPosition.equals(currentPosition);
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -155,9 +155,10 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
             return;
         }
 
+        boolean directMode = connectorConfig.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         ctx.offset = new SqlServerOffsetContext(
                 connectorConfig,
-                TxLogPosition.valueOf(jdbcConnection.getMaxLsn(ctx.partition.getDatabaseName())),
+                TxLogPosition.valueOf(jdbcConnection.getMaxLsn(ctx.partition.getDatabaseName()), directMode ? -1 : null),
                 null,
                 false);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -98,6 +98,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     private final Duration endTransactionTimerDelay;
     private final SnapshotterService snapshotterService;
     private final SqlServerConnectorConfig connectorConfig;
+    private final boolean directMode;
 
     private final ElapsedTimeStrategy pauseBetweenCommits;
     private final Map<SqlServerPartition, SqlServerStreamingExecutionContext> streamingExecutionContexts;
@@ -128,6 +129,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
         this.endTransactionTimerDelay = metadataConnection.getCdcCapturePollingInterval()
                 .multipliedBy(INTERVAL_BETWEEN_TRANSACTION_END_CHECKS_BASED_ON_CDC_CAPTURE_POLL_FACTOR);
         this.snapshotterService = snapshotterService;
+        this.directMode = connectorConfig.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT;
         final Duration intervalBetweenCommitsBasedOnPoll = this.pollInterval.multipliedBy(INTERVAL_BETWEEN_COMMITS_BASED_ON_POLL_FACTOR);
         this.pauseBetweenCommits = ElapsedTimeStrategy.constant(clock,
                 DEFAULT_INTERVAL_BETWEEN_COMMITS.compareTo(intervalBetweenCommitsBasedOnPoll) > 0
@@ -140,12 +142,28 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
     @Override
     public void init(SqlServerOffsetContext offsetContext) {
-        this.effectiveOffset = offsetContext == null ? new SqlServerOffsetContext(connectorConfig, TxLogPosition.NULL, null, false) : offsetContext;
+        this.effectiveOffset = offsetContext == null
+                ? new SqlServerOffsetContext(connectorConfig, directMode ? TxLogPosition.NULL : TxLogPosition.NULL_LEGACY, null, false)
+                : offsetContext;
     }
 
     @Override
     public void execute(ChangeEventSourceContext context, SqlServerPartition partition, SqlServerOffsetContext offsetContext) throws InterruptedException {
         throw new UnsupportedOperationException("Currently unsupported by the SQL Server connector");
+    }
+
+    private TxLogPosition resumePosition(TxLogPosition position) {
+        final boolean commandIdExists = position.getCommandId() != null;
+
+        // direct and function mode orders change events differently hence a mode change contains a risk of data loss.
+        // To prevent data loss, we re-read the last transaction in full if the mode changes.
+        if ((directMode && commandIdExists) || (!directMode && !commandIdExists)) {
+            return position;
+        }
+
+        LOGGER.info("Offset {} and query mode {} indicates a change in mode, so the last transaction is streamed again", position,
+                connectorConfig.getDataQueryMode());
+        return TxLogPosition.valueOf(position.getCommitLsn(), directMode ? -1 : null);
     }
 
     @Override
@@ -171,14 +189,16 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                             // otherwise we might skip an incomplete transaction after restart
                             offsetContext.isSnapshotCompleted()));
 
+            TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
+
             if (!streamingExecutionContexts.containsKey(partition)) {
                 streamingExecutionContexts.put(partition, streamingExecutionContext);
                 LOGGER.info("Last position recorded in offsets is {}[{}]", offsetContext.getChangePosition(), offsetContext.getEventSerialNo());
+                lastProcessedPositionOnStart = resumePosition(lastProcessedPositionOnStart);
             }
 
             final Queue<SqlServerChangeTable> schemaChangeCheckpoints = streamingExecutionContext.getSchemaChangeCheckpoints();
             final AtomicReference<SqlServerChangeTable[]> tablesSlot = streamingExecutionContext.getTablesSlot();
-            final TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
             final long lastProcessedEventSerialNoOnStart = offsetContext.getEventSerialNo();
             final AtomicBoolean changesStoppedBeingMonotonic = streamingExecutionContext.getChangesStoppedBeingMonotonic();
             final int maxTransactionsPerIteration = connectorConfig.getMaxTransactionsPerIteration();
@@ -262,7 +282,8 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     changeTables = new SqlServerChangeTablePointer[tables.length];
 
                     for (int i = 0; i < tables.length; i++) {
-                        changeTables[i] = new SqlServerChangeTablePointer(tables[i], dataConnection, fromLsn, toLsn, connectorConfig.getStreamingFetchSize());
+                        changeTables[i] = new SqlServerChangeTablePointer(tables[i], dataConnection, fromLsn, toLsn, lastProcessedPositionOnStart,
+                                connectorConfig.getStreamingFetchSize(), connectorConfig.getDataQueryMode());
                         changeTables[i].next();
                     }
 
@@ -369,11 +390,11 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                                                 connectorConfig));
                         tableWithSmallestLsn.next();
                     }
-                    streamingExecutionContext.setLastProcessedPosition(TxLogPosition.valueOf(toLsn));
+                    streamingExecutionContext.setLastProcessedPosition(TxLogPosition.valueOf(toLsn, directMode ? -1 : null));
                     // Terminate the transaction otherwise CDC could not be disabled for tables
                     dataConnection.rollback();
                     if (!anyData) {
-                        offsetContext.setChangePosition(TxLogPosition.valueOf(toLsn), 0);
+                        offsetContext.setChangePosition(TxLogPosition.valueOf(toLsn, directMode ? -1 : null), 0);
                         dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                     }
                 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -143,6 +143,21 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
         throw new UnsupportedOperationException("Currently unsupported by the SQL Server connector");
     }
 
+    private TxLogPosition resumePosition(TxLogPosition position) {
+        final boolean directMode = connectorConfig.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT;
+        final boolean commandIdExists = position.getCommandId() != null;
+
+        // direct and function mode orders change events differently hence a mode change contains a risk of data loss.
+        // To prevent data loss, we re-read the last transaction in full if the mode changes.
+        if ((directMode && commandIdExists) || (!directMode && !commandIdExists)) {
+            return position;
+        }
+
+        LOGGER.info("Offset {} and query mode {} indicates a change in mode, so the last transaction is streamed again", position,
+                connectorConfig.getDataQueryMode());
+        return TxLogPosition.valueOf(position.getCommitLsn());
+    }
+
     @Override
     public boolean executeIteration(ChangeEventSourceContext context, SqlServerPartition partition, SqlServerOffsetContext offsetContext) {
 
@@ -166,14 +181,16 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                             // otherwise we might skip an incomplete transaction after restart
                             offsetContext.isSnapshotCompleted()));
 
+            TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
+
             if (!streamingExecutionContexts.containsKey(partition)) {
                 streamingExecutionContexts.put(partition, streamingExecutionContext);
                 LOGGER.info("Last position recorded in offsets is {}[{}]", offsetContext.getChangePosition(), offsetContext.getEventSerialNo());
+                lastProcessedPositionOnStart = resumePosition(lastProcessedPositionOnStart);
             }
 
             final Queue<SqlServerChangeTable> schemaChangeCheckpoints = streamingExecutionContext.getSchemaChangeCheckpoints();
             final AtomicReference<SqlServerChangeTable[]> tablesSlot = streamingExecutionContext.getTablesSlot();
-            final TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
             final long lastProcessedEventSerialNoOnStart = offsetContext.getEventSerialNo();
             final AtomicBoolean changesStoppedBeingMonotonic = streamingExecutionContext.getChangesStoppedBeingMonotonic();
             final int maxTransactionsPerIteration = connectorConfig.getMaxTransactionsPerIteration();
@@ -257,7 +274,8 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     changeTables = new SqlServerChangeTablePointer[tables.length];
 
                     for (int i = 0; i < tables.length; i++) {
-                        changeTables[i] = new SqlServerChangeTablePointer(tables[i], dataConnection, fromLsn, toLsn, connectorConfig.getStreamingFetchSize());
+                        changeTables[i] = new SqlServerChangeTablePointer(tables[i], dataConnection, fromLsn, toLsn, lastProcessedPositionOnStart,
+                                connectorConfig.getStreamingFetchSize(), connectorConfig.getDataQueryMode());
                         changeTables[i].next();
                     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -12,21 +12,26 @@ import io.debezium.connector.Nullable;
  * and sequence number of the change in the given transaction.
  * The sequence number is monotonically increasing in transaction but it is not guaranteed across multiple
  * transactions so the combination is necessary to get total order.
+ * <p>
+ * The command id is only available when the change table is read directly
+ * ({@code data.query.mode=direct}). In function mode it is therefore always {@code null}
  *
  * @author Jiri Pechanec
  *
  */
 public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
 
-    public static final TxLogPosition NULL = new TxLogPosition(null, null, 0);
+    public static final TxLogPosition NULL = new TxLogPosition(null, null, 0, null);
     private final Lsn commitLsn;
     private final Lsn inTxLsn;
     private int operation;
+    private final Integer commandId;
 
-    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn, int operation) {
+    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn, int operation, Integer commandId) {
         this.commitLsn = commitLsn;
         this.inTxLsn = inTxLsn;
         this.operation = operation;
+        this.commandId = commandId;
     }
 
     public Lsn getCommitLsn() {
@@ -41,9 +46,13 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         return operation;
     }
 
+    public Integer getCommandId() {
+        return commandId;
+    }
+
     @Override
     public String toString() {
-        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + "," + operation + ")";
+        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + "," + operation + "," + commandId + ")";
     }
 
     @Override
@@ -51,6 +60,7 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((commitLsn == null) ? 0 : commitLsn.hashCode());
+        result = prime * result + ((commandId == null) ? 0 : commandId.hashCode());
         result = prime * result + ((inTxLsn == null) ? 0 : inTxLsn.hashCode());
         result = prime * result + operation;
         return result;
@@ -76,6 +86,16 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         else if (!commitLsn.equals(other.commitLsn)) {
             return false;
         }
+
+        if (commandId == null) {
+            if (other.commandId != null) {
+                return false;
+            }
+        }
+        else if (!commandId.equals(other.commandId)) {
+            return false;
+        }
+
         if (inTxLsn == null) {
             if (other.inTxLsn != null) {
                 return false;
@@ -89,24 +109,39 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
 
     @Override
     public int compareTo(TxLogPosition o) {
-        final int comparison = commitLsn.compareTo(o.getCommitLsn());
-        return comparison == 0 ? inTxLsn.compareTo(o.inTxLsn) : comparison;
+        int comparison = commitLsn.compareTo(o.getCommitLsn());
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        if (commandId != null && o.getCommandId() != null) {
+            comparison = commandId.compareTo(o.getCommandId());
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return inTxLsn.compareTo(o.inTxLsn);
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation) {
-        return commitLsn == null && inTxLsn == null ? NULL
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation, Integer commandId) {
+        return commitLsn == null && inTxLsn == null && commandId == null ? NULL
                 : new TxLogPosition(
                         commitLsn == null ? Lsn.NULL : commitLsn,
                         inTxLsn == null ? Lsn.NULL : inTxLsn,
-                        operation);
+                        operation,
+                        commandId);
+    }
+
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation) {
+        return valueOf(commitLsn, inTxLsn, operation, null);
     }
 
     public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn) {
-        return valueOf(commitLsn, inTxLsn, 0);
+        return valueOf(commitLsn, inTxLsn, 0, null);
     }
 
     public static TxLogPosition valueOf(Lsn commitLsn) {
-        return valueOf(commitLsn, Lsn.NULL, 0);
+        return valueOf(commitLsn, Lsn.NULL, 0, null);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -12,21 +12,34 @@ import io.debezium.connector.Nullable;
  * and sequence number of the change in the given transaction.
  * The sequence number is monotonically increasing in transaction but it is not guaranteed across multiple
  * transactions so the combination is necessary to get total order.
+ * <p>
+ * The command id is only available when the change table is read directly
+ * ({@code data.query.mode=direct}). In function mode it is therefore always {@code null}
  *
  * @author Jiri Pechanec
  *
  */
 public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
 
-    public static final TxLogPosition NULL = new TxLogPosition(null, null, 0);
+    public static final TxLogPosition NULL_LEGACY = new TxLogPosition(null, null, 0);
+    public static final TxLogPosition NULL = new TxLogPosition(null, null, 0, -1);
     private final Lsn commitLsn;
     private final Lsn inTxLsn;
     private int operation;
+    private final Integer commandId;
 
     private TxLogPosition(Lsn commitLsn, Lsn inTxLsn, int operation) {
         this.commitLsn = commitLsn;
         this.inTxLsn = inTxLsn;
         this.operation = operation;
+        this.commandId = null;
+    }
+
+    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn, int operation, Integer commandId) {
+        this.commitLsn = commitLsn;
+        this.inTxLsn = inTxLsn;
+        this.operation = operation;
+        this.commandId = commandId;
     }
 
     public Lsn getCommitLsn() {
@@ -41,9 +54,13 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         return operation;
     }
 
+    public Integer getCommandId() {
+        return commandId;
+    }
+
     @Override
     public String toString() {
-        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + "," + operation + ")";
+        return this == NULL_LEGACY ? "NULL" : commitLsn + "(" + inTxLsn + "," + operation + "," + commandId + ")";
     }
 
     @Override
@@ -51,8 +68,8 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((commitLsn == null) ? 0 : commitLsn.hashCode());
+        result = prime * result + ((commandId == null) ? 0 : commandId.hashCode());
         result = prime * result + ((inTxLsn == null) ? 0 : inTxLsn.hashCode());
-        result = prime * result + operation;
         return result;
     }
 
@@ -76,6 +93,16 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         else if (!commitLsn.equals(other.commitLsn)) {
             return false;
         }
+
+        if (commandId == null) {
+            if (other.commandId != null) {
+                return false;
+            }
+        }
+        else if (!commandId.equals(other.commandId)) {
+            return false;
+        }
+
         if (inTxLsn == null) {
             if (other.inTxLsn != null) {
                 return false;
@@ -89,24 +116,43 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
 
     @Override
     public int compareTo(TxLogPosition o) {
-        final int comparison = commitLsn.compareTo(o.getCommitLsn());
-        return comparison == 0 ? inTxLsn.compareTo(o.inTxLsn) : comparison;
+        int comparison = commitLsn.compareTo(o.getCommitLsn());
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        if (commandId != null && o.getCommandId() != null) {
+            comparison = commandId.compareTo(o.getCommandId());
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return inTxLsn.compareTo(o.inTxLsn);
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation) {
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, int operation, Integer commandId) {
+        if (commandId == null) {
+            return commitLsn == null && inTxLsn == null ? NULL_LEGACY
+                    : new TxLogPosition(
+                            commitLsn == null ? Lsn.NULL : commitLsn,
+                            inTxLsn == null ? Lsn.NULL : inTxLsn,
+                            operation);
+        }
+
         return commitLsn == null && inTxLsn == null ? NULL
                 : new TxLogPosition(
                         commitLsn == null ? Lsn.NULL : commitLsn,
                         inTxLsn == null ? Lsn.NULL : inTxLsn,
-                        operation);
+                        operation,
+                        commandId);
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn) {
-        return valueOf(commitLsn, inTxLsn, 0);
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn, Integer commandId) {
+        return valueOf(commitLsn, inTxLsn, 0, commandId);
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn) {
-        return valueOf(commitLsn, Lsn.NULL, 0);
+    public static TxLogPosition valueOf(Lsn commitLsn, Integer commandId) {
+        return valueOf(commitLsn, Lsn.NULL, 0, commandId);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -219,11 +219,12 @@ public class SnapshotIT extends AbstractAsyncEngineConnectorTest {
             final Struct value1 = (Struct) record1.value();
             assertRecord(key1, expectedKey1);
             assertRecord((Struct) value1.get("after"), expectedRow1);
-            assertThat(record1.sourceOffset()).hasSize(3);
+            assertThat(record1.sourceOffset()).hasSize(4);
 
             assertTrue(record1.sourceOffset().containsKey("change_lsn"));
             assertTrue(record1.sourceOffset().containsKey("commit_lsn"));
             assertTrue(record1.sourceOffset().containsKey("event_serial_no"));
+            assertTrue(record1.sourceOffset().containsKey("command_id"));
             assertNull(value1.get("before"));
         }
     }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.SnapshotRecord;
+import io.debezium.doc.FixFor;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaFactory;
 
@@ -67,6 +68,15 @@ public class SourceInfoTest {
     @Test
     void eventSerialNoIsPresent() {
         assertThat(source.struct().getInt64(SourceInfo.EVENT_SERIAL_NO_KEY)).isEqualTo(30L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void commandIdIsRecordedButNotExposedInTheSourceBlock() {
+        source.setCommandId(6);
+
+        assertThat(source.getCommandId()).isEqualTo(6);
+        assertThat(source.struct().schema().field(SourceInfo.COMMAND_ID_KEY)).isNull();
     }
 
     @Test

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -714,6 +714,7 @@ public class SqlServerConnectionIT {
                 Properties configProps = new Properties();
                 configProps.setProperty(SqlServerConnectorConfig.SNAPSHOT_MODE_PROPERTY_NAME, SqlServerConnectorConfig.SnapshotMode.WHEN_NEEDED.getValue());
                 SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(Configuration.from(configProps));
+                boolean directMode = connectorConfig.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT;
 
                 // Query min LSN
                 final String[] minLsn = { null };
@@ -727,7 +728,7 @@ public class SqlServerConnectionIT {
 
                 boolean validated = connection.validateLogPosition(
                         new SqlServerPartition("server1", "testDB1"),
-                        new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(Lsn.valueOf(minLsn[0])), SnapshotType.INITIAL, true),
+                        new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(Lsn.valueOf(minLsn[0]), directMode ? -1 : null), SnapshotType.INITIAL, true),
                         connectorConfig);
 
                 Testing.print("Valid log position: " + validated);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -914,7 +914,7 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
                         final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE_1, tableName);
                         final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE_1);
                         final List<Integer> ids = new ArrayList<>();
-                        try (ResultSet rs = connection.getChangesForTable(ct, minLsn, maxLsn)) {
+                        try (ResultSet rs = connection.getChangesForTable(ct, minLsn, Lsn.ZERO, 0, -1, maxLsn, 0)) {
                             while (rs.next()) {
                                 ids.add(rs.getInt("id"));
                             }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -635,7 +635,9 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
         assertRecord(insertValueB.getStruct("after"), expectedInsertRowB);
         assertRecord(insertkeyB, expectedInsertKeyB);
         assertNull(insertValueB.get("before"));
-        assertThat(insertValueB.getStruct("source").getInt64("event_serial_no")).isEqualTo(2L);
+        // The delete and the insert of this primary key update share a commit LSN and a sequence value but
+        // carry different command ids hence event_serial_no stays 1L.
+        assertThat(insertValueB.getStruct("source").getInt64("event_serial_no")).isEqualTo(1L);
 
         stopConnector();
     }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.DataQueryMode;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.util.Testing;
+
+/**
+ * Integration tests for the two values of {@code data.query.mode}, and for the interaction between
+ * {@code direct} mode and {@code streaming.fetch.size} after dbz#2012 fix.
+ * <p>
+ * SQL Server records a deferred update as a physical delete followed by an insert.
+ * It is the one case where the two query modes see the same change differently:
+ * <ul>
+ * <li>{@code function} mode keeps each row's delete and insert together.</li>
+ * <li>{@code direct} mode records all deletes before its inserts.</li>
+ * </ul>
+ * The record ordering differs between the modes and hence record ordering is not asserted.
+ */
+public class SqlServerDataQueryModeIT extends AbstractAsyncEngineConnectorTest {
+    private static final String ID = "id";
+    private static final String ORDERS = "orders";
+    private static final String SHIPMENTS = "shipments";
+    private static final int DEFERRED_FROM = 1;
+    private static final int DEFERRED_COUNT = 5;
+    private static final int PLAIN_FROM = 6;
+    private static final int PLAIN_COUNT = 3;
+    private static final int PK_FROM = 9;
+    private static final int PK_COUNT = 2;
+    private static final int PK_SHIFT = 100;
+    private static final int ORDERS_SEED_ROWS = 10;
+    private static final int SHIPMENTS_SEED_ROWS = 5;
+    private static final int DEFERRED_RECORDS = 2 * DEFERRED_COUNT;
+
+    // A primary key move produces a delete and an insert per row; the plain update produces one record.
+    private static final int ALL_SHAPES_RECORDS = DEFERRED_RECORDS + PLAIN_COUNT + 2 * PK_COUNT;
+
+    private static final String DEFERRED_UPDATE = "UPDATE dbo.orders SET order_ref = order_ref + '_v2' WHERE id BETWEEN 1 AND 5;";
+    private static final String PLAIN_UPDATE = "UPDATE dbo.orders SET status = 'PROCESSED' WHERE id BETWEEN 6 AND 8;";
+    private static final String PRIMARY_KEY_MOVE = "UPDATE dbo.orders SET id = id + " + PK_SHIFT + " WHERE id BETWEEN 9 AND 10;";
+    private static final String SHIPMENTS_DEFERRED_UPDATE = "UPDATE dbo.shipments SET tracking_ref = tracking_ref + '_v2' WHERE id BETWEEN 1 AND 5;";
+
+    private static final String ORDERS_DDL = "CREATE TABLE dbo.orders (id INT NOT NULL PRIMARY KEY, order_ref VARCHAR(50) NOT NULL, status VARCHAR(20) NOT NULL);" +
+            "CREATE UNIQUE NONCLUSTERED INDEX UX_orders_order_ref ON dbo.orders(order_ref);";
+    private static final String ORDERS_SEED = "INSERT INTO dbo.orders VALUES " +
+            "(1,'REF-1','NEW'),(2,'REF-2','NEW'),(3,'REF-3','NEW'),(4,'REF-4','NEW'),(5,'REF-5','NEW')," +
+            "(6,'REF-6','NEW'),(7,'REF-7','NEW'),(8,'REF-8','NEW')," +
+            "(9,'REF-9','NEW'),(10,'REF-10','NEW');";
+
+    private static final String SHIPMENTS_DDL = "CREATE TABLE dbo.shipments (id INT NOT NULL PRIMARY KEY, tracking_ref VARCHAR(50) NOT NULL, carrier VARCHAR(20) NOT NULL, "
+            + "CONSTRAINT UQ_shipments_tracking_ref UNIQUE(tracking_ref));";
+    private static final String SHIPMENTS_SEED = "INSERT INTO dbo.shipments VALUES (1,'TRK-1','ACME'),(2,'TRK-2','ACME'),(3,'TRK-3','ACME'),(4,'TRK-4','ACME'),(5,'TRK-5','ACME');";
+
+    private SqlServerConnection connection;
+
+    static Stream<Arguments> modeSwitches() {
+        return Stream.of(
+                Arguments.of(DataQueryMode.FUNCTION, DataQueryMode.DIRECT),
+                Arguments.of(DataQueryMode.DIRECT, DataQueryMode.FUNCTION));
+    }
+
+    @BeforeEach
+    public void before() throws SQLException, InterruptedException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+        createAndEnableCdc(ORDERS_DDL, ORDERS_SEED, ORDERS);
+    }
+
+    @AfterEach
+    public void after() throws SQLException {
+        stopConnector();
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest(name = "streaming.fetch.size = {0}")
+    @ValueSource(ints = { 3, 5, 7, 12, 0 })
+    @FixFor("dbz#2012")
+    void shouldNotLoseDeferredUpdateAtAnyFetchBoundary(int fetchSize) throws Exception {
+        start(SqlServerConnector.class, config(DataQueryMode.DIRECT, "dbo.orders", fetchSize));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(DEFERRED_RECORDS));
+
+        assertThat(byOperation.get(Operation.DELETE)).hasSize(DEFERRED_COUNT);
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT);
+        assertDeferredUpdate(byOperation, "REF-", "order_ref");
+    }
+
+    @ParameterizedTest(name = "data.query.mode = {0}")
+    @EnumSource(DataQueryMode.class)
+    @FixFor("dbz#2012")
+    void shouldDeliverEveryChangeInBothQueryModes(DataQueryMode mode) throws Exception {
+        start(SqlServerConnector.class, config(mode, "dbo.orders", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        executeInOneTransaction(DEFERRED_UPDATE, PLAIN_UPDATE, PRIMARY_KEY_MOVE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(ALL_SHAPES_RECORDS));
+
+        assertThat(byOperation.get(Operation.DELETE)).hasSize(DEFERRED_COUNT + PK_COUNT);
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT + PK_COUNT);
+        assertThat(byOperation.get(Operation.UPDATE)).hasSize(PLAIN_COUNT);
+
+        assertDeferredUpdate(byOperation, "REF-", "order_ref");
+        assertPlainUpdate(byOperation);
+        assertPrimaryKeyMove(byOperation);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldOrderChangesFromTwoTablesByCommandId() throws Exception {
+        createAndEnableCdc(SHIPMENTS_DDL, SHIPMENTS_SEED, SHIPMENTS);
+
+        start(SqlServerConnector.class, config(DataQueryMode.DIRECT, "dbo.orders,dbo.shipments", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS + SHIPMENTS_SEED_ROWS);
+
+        executeInOneTransaction(DEFERRED_UPDATE, SHIPMENTS_DEFERRED_UPDATE);
+
+        SourceRecords consumed = consumeRecordsByTopic(2 * DEFERRED_RECORDS);
+
+        assertDeferredUpdate(groupByOperation(consumed.recordsForTopic(topicName(ORDERS))), "REF-", "order_ref");
+        assertDeferredUpdate(groupByOperation(consumed.recordsForTopic(topicName(SHIPMENTS))), "TRK-", "tracking_ref");
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("modeSwitches")
+    @FixFor("dbz#2012")
+    void shouldReReadLastTransactionOnModeSwitch(DataQueryMode from, DataQueryMode to) throws Exception {
+        start(SqlServerConnector.class, config(from, "dbo.orders", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+        List<SourceRecord> records = consumeOrders(DEFERRED_RECORDS);
+
+        assertThat(records).hasSize(DEFERRED_RECORDS);
+
+        stopConnector();
+
+        start(SqlServerConnector.class, config(to, "dbo.orders", 3));
+        assertConnectorIsRunning();
+
+        // The whole transaction is read again from its start, so all of it arrives a second time.
+        assertDeferredUpdate(groupByOperation(consumeOrders(DEFERRED_RECORDS)), "REF-", "order_ref");
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldResumeCorrectlyWhenOperationsAreSkipped() throws Exception {
+        Configuration config = config(DataQueryMode.DIRECT, "dbo.orders", 3)
+                .edit()
+                .with(SqlServerConnectorConfig.SKIPPED_OPERATIONS, "d")
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(DEFERRED_COUNT));
+
+        assertThat(byOperation.get(Operation.DELETE)).isEmpty();
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT);
+        for (int id = DEFERRED_FROM; id < DEFERRED_FROM + DEFERRED_COUNT; id++) {
+            assertThat(after(byOperation.get(Operation.CREATE).get(id)).getString("order_ref"))
+                    .isEqualTo("REF-" + id + "_v2");
+        }
+    }
+
+    private void assertDeferredUpdate(Map<Operation, Map<Integer, SourceRecord>> byOperation, String prefix, String column) {
+        for (int id = DEFERRED_FROM; id < DEFERRED_FROM + DEFERRED_COUNT; id++) {
+            SourceRecord delete = byOperation.get(Operation.DELETE).get(id);
+            SourceRecord insert = byOperation.get(Operation.CREATE).get(id);
+
+            assertThat(delete).isNotNull();
+            assertThat(insert).isNotNull();
+            VerifyRecord.isValidDelete(delete, ID, id);
+            VerifyRecord.isValidInsert(insert, ID, id);
+            assertThat(before(delete).getString(column)).isEqualTo(prefix + id);
+            assertThat(after(insert).getString(column)).isEqualTo(prefix + id + "_v2");
+        }
+    }
+
+    private void assertPlainUpdate(Map<Operation, Map<Integer, SourceRecord>> byOperation) {
+        for (int id = PLAIN_FROM; id < PLAIN_FROM + PLAIN_COUNT; id++) {
+            SourceRecord update = byOperation.get(Operation.UPDATE).get(id);
+
+            VerifyRecord.isValidUpdate(update, ID, id);
+            assertThat(before(update).getString("status")).isEqualTo("NEW");
+            assertThat(after(update).getString("status")).isEqualTo("PROCESSED");
+        }
+    }
+
+    private void assertPrimaryKeyMove(Map<Operation, Map<Integer, SourceRecord>> byOperation) {
+        for (int id = PK_FROM; id < PK_FROM + PK_COUNT; id++) {
+            SourceRecord delete = byOperation.get(Operation.DELETE).get(id);
+            SourceRecord insert = byOperation.get(Operation.CREATE).get(id + PK_SHIFT);
+
+            VerifyRecord.isValidDelete(delete, ID, id);
+            VerifyRecord.isValidInsert(insert, ID, id + PK_SHIFT);
+        }
+    }
+
+    private Map<Operation, Map<Integer, SourceRecord>> groupByOperation(List<SourceRecord> records) {
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = new EnumMap<>(Operation.class);
+        for (Operation operation : Operation.values()) {
+            byOperation.put(operation, new HashMap<>());
+        }
+        if (records == null) {
+            return byOperation;
+        }
+        for (SourceRecord record : records) {
+            Struct value = (Struct) record.value();
+            if (value != null) {
+                Operation operation = Operation.forCode(value.getString(Envelope.FieldName.OPERATION));
+                byOperation.get(operation).put(((Struct) record.key()).getInt32(ID), record);
+            }
+        }
+        return byOperation;
+    }
+
+    private void createAndEnableCdc(String ddl, String seedInserts, String tableName) throws SQLException, InterruptedException {
+        connection.execute(ddl, seedInserts);
+        TestHelper.enableTableCdc(connection, tableName);
+        Thread.sleep(Duration.ofSeconds(TestHelper.waitTimeForLsnTimeMapping()).toMillis());
+    }
+
+    private void executeInOneTransaction(String... statements) throws SQLException {
+        connection.setAutoCommit(false);
+        for (String statement : statements) {
+            connection.executeWithoutCommitting(statement);
+        }
+        connection.connection().commit();
+        connection.setAutoCommit(true);
+    }
+
+    private Configuration config(DataQueryMode mode, String tableIncludeList, int fetchSize) {
+        return TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.DATA_QUERY_MODE, mode)
+                .with(SqlServerConnectorConfig.STREAMING_FETCH_SIZE, fetchSize)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
+                .with(SqlServerConnectorConfig.TOMBSTONES_ON_DELETE, false)
+                .build();
+    }
+
+    private List<SourceRecord> consumeOrders(int count) throws InterruptedException {
+        return consumeRecordsByTopic(count).recordsForTopic(topicName(ORDERS));
+    }
+
+    private String topicName(String tableName) {
+        return TestHelper.TEST_SERVER_NAME + "." + TestHelper.TEST_DATABASE_1 + ".dbo." + tableName;
+    }
+
+    private Struct before(SourceRecord record) {
+        return (Struct) ((Struct) record.value()).get(Envelope.FieldName.BEFORE);
+    }
+
+    private Struct after(SourceRecord record) {
+        return (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
@@ -226,10 +226,12 @@ public class SqlServerDataQueryModeIT extends AbstractAsyncEngineConnectorTest {
     private void assertPlainUpdate(Map<Operation, Map<Integer, SourceRecord>> byOperation) {
         for (int id = PLAIN_FROM; id < PLAIN_FROM + PLAIN_COUNT; id++) {
             SourceRecord update = byOperation.get(Operation.UPDATE).get(id);
+            Struct source = (Struct) update.value();
 
             VerifyRecord.isValidUpdate(update, ID, id);
             assertThat(before(update).getString("status")).isEqualTo("NEW");
             assertThat(after(update).getString("status")).isEqualTo("PROCESSED");
+            assertThat(source.getStruct("source").getInt64("event_serial_no")).isEqualTo(2L);
         }
     }
 
@@ -240,6 +242,8 @@ public class SqlServerDataQueryModeIT extends AbstractAsyncEngineConnectorTest {
 
             VerifyRecord.isValidDelete(delete, ID, id);
             VerifyRecord.isValidInsert(insert, ID, id + PK_SHIFT);
+            assertThat(((Struct) delete.value()).getStruct("source").getInt64("event_serial_no")).isEqualTo(1L);
+            assertThat(((Struct) insert.value()).getStruct("source").getInt64("event_serial_no")).isEqualTo(1L);
         }
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerDataQueryModeIT.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.DataQueryMode;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.util.Testing;
+
+/**
+ * Integration tests for the two values of {@code data.query.mode}, and for the interaction between
+ * {@code direct} mode and {@code streaming.fetch.size} after dbz#2012 fix.
+ * <p>
+ * SQL Server records a deferred update as a physical delete followed by an insert.
+ * It is the one case where the two query modes see the same change differently:
+ * <ul>
+ * <li>{@code function} mode keeps each row's delete and insert together.</li>
+ * <li>{@code direct} mode records all deletes before its inserts.</li>
+ * </ul>
+ * The record ordering differs between the modes and hence record ordering is not asserted.
+ */
+public class SqlServerDataQueryModeIT extends AbstractAsyncEngineConnectorTest {
+    private static final String ID = "id";
+    private static final String ORDERS = "orders";
+    private static final String SHIPMENTS = "shipments";
+    private static final int DEFERRED_FROM = 1;
+    private static final int DEFERRED_COUNT = 5;
+    private static final int PLAIN_FROM = 6;
+    private static final int PLAIN_COUNT = 3;
+    private static final int PK_FROM = 9;
+    private static final int PK_COUNT = 2;
+    private static final int PK_SHIFT = 100;
+    private static final int ORDERS_SEED_ROWS = 10;
+    private static final int SHIPMENTS_SEED_ROWS = 5;
+    private static final int DEFERRED_RECORDS = 2 * DEFERRED_COUNT;
+
+    // A primary key move produces a delete and an insert per row; the plain update produces one record.
+    private static final int ALL_SHAPES_RECORDS = DEFERRED_RECORDS + PLAIN_COUNT + 2 * PK_COUNT;
+
+    private static final String DEFERRED_UPDATE = "UPDATE dbo.orders SET order_ref = order_ref + '_v2' WHERE id BETWEEN 1 AND 5;";
+    private static final String PLAIN_UPDATE = "UPDATE dbo.orders SET status = 'PROCESSED' WHERE id BETWEEN 6 AND 8;";
+    private static final String PRIMARY_KEY_MOVE = "UPDATE dbo.orders SET id = id + " + PK_SHIFT + " WHERE id BETWEEN 9 AND 10;";
+    private static final String SHIPMENTS_DEFERRED_UPDATE = "UPDATE dbo.shipments SET tracking_ref = tracking_ref + '_v2' WHERE id BETWEEN 1 AND 5;";
+
+    private static final String ORDERS_DDL = "CREATE TABLE dbo.orders (id INT NOT NULL PRIMARY KEY, order_ref VARCHAR(50) NOT NULL, status VARCHAR(20) NOT NULL);" +
+            "CREATE UNIQUE NONCLUSTERED INDEX UX_orders_order_ref ON dbo.orders(order_ref);";
+    private static final String ORDERS_SEED = "INSERT INTO dbo.orders VALUES " +
+            "(1,'REF-1','NEW'),(2,'REF-2','NEW'),(3,'REF-3','NEW'),(4,'REF-4','NEW'),(5,'REF-5','NEW')," +
+            "(6,'REF-6','NEW'),(7,'REF-7','NEW'),(8,'REF-8','NEW')," +
+            "(9,'REF-9','NEW'),(10,'REF-10','NEW');";
+
+    private static final String SHIPMENTS_DDL = "CREATE TABLE dbo.shipments (id INT NOT NULL PRIMARY KEY, tracking_ref VARCHAR(50) NOT NULL, carrier VARCHAR(20) NOT NULL, "
+            + "CONSTRAINT UQ_shipments_tracking_ref UNIQUE(tracking_ref));";
+    private static final String SHIPMENTS_SEED = "INSERT INTO dbo.shipments VALUES (1,'TRK-1','ACME'),(2,'TRK-2','ACME'),(3,'TRK-3','ACME'),(4,'TRK-4','ACME'),(5,'TRK-5','ACME');";
+
+    private SqlServerConnection connection;
+
+    static Stream<Arguments> modeSwitches() {
+        return Stream.of(
+                Arguments.of(DataQueryMode.FUNCTION, DataQueryMode.DIRECT),
+                Arguments.of(DataQueryMode.DIRECT, DataQueryMode.FUNCTION));
+    }
+
+    @BeforeEach
+    public void before() throws SQLException, InterruptedException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+        createAndEnableCdc(ORDERS_DDL, ORDERS_SEED, ORDERS);
+    }
+
+    @AfterEach
+    public void after() throws SQLException {
+        stopConnector();
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest(name = "streaming.fetch.size = {0}")
+    @ValueSource(ints = { 3, 5, 7, 12, 0 })
+    @FixFor("dbz#2012")
+    void shouldNotLoseDeferredUpdateAtAnyFetchBoundary(int fetchSize) throws Exception {
+        start(SqlServerConnector.class, config(DataQueryMode.DIRECT, "dbo.orders", fetchSize));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(DEFERRED_RECORDS));
+
+        assertThat(byOperation.get(Operation.DELETE)).hasSize(DEFERRED_COUNT);
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT);
+        assertDeferredUpdate(byOperation, "REF-", "order_ref");
+    }
+
+    @ParameterizedTest(name = "data.query.mode = {0}")
+    @EnumSource(DataQueryMode.class)
+    @FixFor("dbz#2012")
+    void shouldDeliverEveryChangeInBothQueryModes(DataQueryMode mode) throws Exception {
+        start(SqlServerConnector.class, config(mode, "dbo.orders", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        executeInOneTransaction(DEFERRED_UPDATE, PLAIN_UPDATE, PRIMARY_KEY_MOVE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(ALL_SHAPES_RECORDS));
+
+        assertThat(byOperation.get(Operation.DELETE)).hasSize(DEFERRED_COUNT + PK_COUNT);
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT + PK_COUNT);
+        assertThat(byOperation.get(Operation.UPDATE)).hasSize(PLAIN_COUNT);
+
+        assertDeferredUpdate(byOperation, "REF-", "order_ref");
+        assertPlainUpdate(byOperation);
+        assertPrimaryKeyMove(byOperation);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldOrderChangesFromTwoTablesByCommandId() throws Exception {
+        createAndEnableCdc(SHIPMENTS_DDL, SHIPMENTS_SEED, SHIPMENTS);
+
+        start(SqlServerConnector.class, config(DataQueryMode.DIRECT, "dbo.orders,dbo.shipments", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS + SHIPMENTS_SEED_ROWS);
+
+        executeInOneTransaction(DEFERRED_UPDATE, SHIPMENTS_DEFERRED_UPDATE);
+
+        SourceRecords consumed = consumeRecordsByTopic(2 * DEFERRED_RECORDS);
+
+        assertDeferredUpdate(groupByOperation(consumed.recordsForTopic(topicName(ORDERS))), "REF-", "order_ref");
+        assertDeferredUpdate(groupByOperation(consumed.recordsForTopic(topicName(SHIPMENTS))), "TRK-", "tracking_ref");
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("modeSwitches")
+    @FixFor("dbz#2012")
+    void shouldReReadLastTransactionOnModeSwitch(DataQueryMode from, DataQueryMode to) throws Exception {
+        start(SqlServerConnector.class, config(from, "dbo.orders", 3));
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+        List<SourceRecord> records = consumeOrders(DEFERRED_RECORDS);
+
+        assertThat(records).hasSize(DEFERRED_RECORDS);
+
+        stopConnector();
+
+        start(SqlServerConnector.class, config(to, "dbo.orders", 3));
+        assertConnectorIsRunning();
+
+        // The whole transaction is read again from its start, so all of it arrives a second time.
+        assertDeferredUpdate(groupByOperation(consumeOrders(DEFERRED_RECORDS)), "REF-", "order_ref");
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldResumeCorrectlyWhenOperationsAreSkipped() throws Exception {
+        Configuration config = config(DataQueryMode.DIRECT, "dbo.orders", 3)
+                .edit()
+                .with(SqlServerConnectorConfig.SKIPPED_OPERATIONS, "d")
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        consumeRecordsByTopic(ORDERS_SEED_ROWS);
+
+        connection.execute(DEFERRED_UPDATE);
+
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = groupByOperation(consumeOrders(DEFERRED_COUNT));
+
+        assertThat(byOperation.get(Operation.DELETE)).isEmpty();
+        assertThat(byOperation.get(Operation.CREATE)).hasSize(DEFERRED_COUNT);
+        for (int id = DEFERRED_FROM; id < DEFERRED_FROM + DEFERRED_COUNT; id++) {
+            assertThat(after(byOperation.get(Operation.CREATE).get(id)).getString("order_ref"))
+                    .isEqualTo("REF-" + id + "_v2");
+        }
+    }
+
+    private void assertDeferredUpdate(Map<Operation, Map<Integer, SourceRecord>> byOperation, String prefix, String column) {
+        for (int id = DEFERRED_FROM; id < DEFERRED_FROM + DEFERRED_COUNT; id++) {
+            SourceRecord delete = byOperation.get(Operation.DELETE).get(id);
+            SourceRecord insert = byOperation.get(Operation.CREATE).get(id);
+
+            assertThat(delete).isNotNull();
+            assertThat(insert).isNotNull();
+            VerifyRecord.isValidDelete(delete, ID, id);
+            VerifyRecord.isValidInsert(insert, ID, id);
+            assertThat(before(delete).getString(column)).isEqualTo(prefix + id);
+            assertThat(after(insert).getString(column)).isEqualTo(prefix + id + "_v2");
+        }
+    }
+
+    private void assertPlainUpdate(Map<Operation, Map<Integer, SourceRecord>> byOperation) {
+        for (int id = PLAIN_FROM; id < PLAIN_FROM + PLAIN_COUNT; id++) {
+            SourceRecord update = byOperation.get(Operation.UPDATE).get(id);
+            Struct source = (Struct) update.value();
+
+            VerifyRecord.isValidUpdate(update, ID, id);
+            assertThat(before(update).getString("status")).isEqualTo("NEW");
+            assertThat(after(update).getString("status")).isEqualTo("PROCESSED");
+            assertThat(source.getStruct("source").getInt64("event_serial_no")).isEqualTo(2L);
+        }
+    }
+
+    private void assertPrimaryKeyMove(Map<Operation, Map<Integer, SourceRecord>> byOperation) {
+        for (int id = PK_FROM; id < PK_FROM + PK_COUNT; id++) {
+            SourceRecord delete = byOperation.get(Operation.DELETE).get(id);
+            SourceRecord insert = byOperation.get(Operation.CREATE).get(id + PK_SHIFT);
+
+            VerifyRecord.isValidDelete(delete, ID, id);
+            VerifyRecord.isValidInsert(insert, ID, id + PK_SHIFT);
+            assertThat(((Struct) delete.value()).getStruct("source").getInt64("event_serial_no")).isEqualTo(1L);
+            assertThat(((Struct) insert.value()).getStruct("source").getInt64("event_serial_no")).isEqualTo(1L);
+        }
+    }
+
+    private Map<Operation, Map<Integer, SourceRecord>> groupByOperation(List<SourceRecord> records) {
+        Map<Operation, Map<Integer, SourceRecord>> byOperation = new EnumMap<>(Operation.class);
+        for (Operation operation : Operation.values()) {
+            byOperation.put(operation, new HashMap<>());
+        }
+        if (records == null) {
+            return byOperation;
+        }
+        for (SourceRecord record : records) {
+            Struct value = (Struct) record.value();
+            if (value != null) {
+                Operation operation = Operation.forCode(value.getString(Envelope.FieldName.OPERATION));
+                byOperation.get(operation).put(((Struct) record.key()).getInt32(ID), record);
+            }
+        }
+        return byOperation;
+    }
+
+    private void createAndEnableCdc(String ddl, String seedInserts, String tableName) throws SQLException, InterruptedException {
+        connection.execute(ddl, seedInserts);
+        TestHelper.enableTableCdc(connection, tableName);
+        Thread.sleep(Duration.ofSeconds(TestHelper.waitTimeForLsnTimeMapping()).toMillis());
+    }
+
+    private void executeInOneTransaction(String... statements) throws SQLException {
+        connection.setAutoCommit(false);
+        for (String statement : statements) {
+            connection.executeWithoutCommitting(statement);
+        }
+        connection.connection().commit();
+        connection.setAutoCommit(true);
+    }
+
+    private Configuration config(DataQueryMode mode, String tableIncludeList, int fetchSize) {
+        return TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.DATA_QUERY_MODE, mode)
+                .with(SqlServerConnectorConfig.STREAMING_FETCH_SIZE, fetchSize)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
+                .with(SqlServerConnectorConfig.TOMBSTONES_ON_DELETE, false)
+                .build();
+    }
+
+    private List<SourceRecord> consumeOrders(int count) throws InterruptedException {
+        return consumeRecordsByTopic(count).recordsForTopic(topicName(ORDERS));
+    }
+
+    private String topicName(String tableName) {
+        return TestHelper.TEST_SERVER_NAME + "." + TestHelper.TEST_DATABASE_1 + ".dbo." + tableName;
+    }
+
+    private Struct before(SourceRecord record) {
+        return (Struct) ((Struct) record.value()).get(Envelope.FieldName.BEFORE);
+    }
+
+    private Struct after(SourceRecord record) {
+        return (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerOffsetContextTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerOffsetContextTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for how {@code __$command_id} is written to and read back from the connector's offsets.
+ * <p>
+ * The value is only recorded by direct mode, so an offset may legitimately arrive without it - written by
+ * an older version, or written while the connector was running in function mode. Loading such an offset
+ * has to keep working.
+ */
+public class SqlServerOffsetContextTest {
+
+    private static final String COMMIT_LSN = "00000a24:000018a8:0015";
+    private static final String CHANGE_LSN = "00000a24:000018a8:0003";
+
+    private SqlServerConnectorConfig connectorConfig;
+
+    @BeforeEach
+    public void beforeEach() {
+        connectorConfig = new SqlServerConnectorConfig(
+                Configuration.create()
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                        .build());
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldRoundTripCommandIdThroughTheOffset() {
+        SqlServerOffsetContext offsetContext = offsetContextWithCommandId(7);
+
+        assertThat(offsetContext.getOffset().get(SourceInfo.COMMAND_ID_KEY)).isEqualTo(7);
+
+        SqlServerOffsetContext loaded = new SqlServerOffsetContext.Loader(connectorConfig).load(offsetContext.getOffset());
+
+        assertThat(loaded.getChangePosition().getCommandId()).isEqualTo(7);
+        assertThat(loaded.getChangePosition().getCommitLsn()).isEqualTo(Lsn.valueOf(COMMIT_LSN));
+        assertThat(loaded.getChangePosition().getInTxLsn()).isEqualTo(Lsn.valueOf(CHANGE_LSN));
+
+        offsetContext.setChangePosition(
+                TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 2, 6), 1);
+
+        assertThat(offsetContext.getChangePosition().getCommandId()).isEqualTo(6);
+        assertThat(offsetContext.getOffset().get(SourceInfo.COMMAND_ID_KEY)).isEqualTo(6);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldLeaveCommandIdUnknownWhenAbsentFromOffset() {
+        Map<String, Object> legacyOffset = baseOffset();
+        assertThat(legacyOffset).doesNotContainKey(SourceInfo.COMMAND_ID_KEY);
+
+        SqlServerOffsetContext loaded = new SqlServerOffsetContext.Loader(connectorConfig).load(legacyOffset);
+
+        assertThat(loaded.getChangePosition().getCommandId()).isNull();
+        assertThat(loaded.getChangePosition().getCommitLsn()).isEqualTo(Lsn.valueOf(COMMIT_LSN));
+        assertThat(loaded.getChangePosition().getInTxLsn()).isEqualTo(Lsn.valueOf(CHANGE_LSN));
+        assertThat(loaded.getEventSerialNo()).isEqualTo(2L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldLoadCommandIdWhateverNumericTypeTheOffsetStoreReturns() {
+        Map<String, Object> withInteger = baseOffset();
+        withInteger.put(SourceInfo.COMMAND_ID_KEY, Integer.valueOf(9));
+
+        Map<String, Object> withLong = baseOffset();
+        withLong.put(SourceInfo.COMMAND_ID_KEY, Long.valueOf(9L));
+
+        SqlServerOffsetContext.Loader loader = new SqlServerOffsetContext.Loader(connectorConfig);
+
+        assertThat(loader.load(withInteger).getChangePosition().getCommandId()).isEqualTo(9);
+        assertThat(loader.load(withLong).getChangePosition().getCommandId()).isEqualTo(9);
+    }
+
+    private SqlServerOffsetContext offsetContextWithCommandId(int commandId) {
+        return new SqlServerOffsetContext(
+                connectorConfig,
+                TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 0, commandId),
+                null,
+                false);
+    }
+
+    private Map<String, Object> baseOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(SourceInfo.COMMIT_LSN_KEY, COMMIT_LSN);
+        offset.put(SourceInfo.CHANGE_LSN_KEY, CHANGE_LSN);
+        offset.put(SourceInfo.EVENT_SERIAL_NO_KEY, Long.valueOf(2));
+        return offset;
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerOffsetContextTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerOffsetContextTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for how {@code __$command_id} is written to and read back from the connector's offsets.
+ * <p>
+ * The value is only recorded by direct mode, so an offset may legitimately arrive without it - written by
+ * an older version, or written while the connector was running in function mode. Loading such an offset
+ * has to keep working.
+ */
+public class SqlServerOffsetContextTest {
+
+    private static final String COMMIT_LSN = "00000a24:000018a8:0015";
+    private static final String CHANGE_LSN = "00000a24:000018a8:0003";
+    private static final String OTHER_CHANGE_LSN = "00000a24:000018a8:0007";
+
+    private SqlServerConnectorConfig connectorConfig;
+
+    @BeforeEach
+    public void beforeEach() {
+        connectorConfig = new SqlServerConnectorConfig(
+                Configuration.create()
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                        .build());
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldRoundTripCommandIdThroughTheOffset() {
+        SqlServerOffsetContext offsetContext = offsetContextWithCommandId(7);
+
+        assertThat(offsetContext.getOffset().get(SourceInfo.COMMAND_ID_KEY)).isEqualTo(7);
+
+        SqlServerOffsetContext loaded = new SqlServerOffsetContext.Loader(connectorConfig).load(offsetContext.getOffset());
+
+        assertThat(loaded.getChangePosition().getCommandId()).isEqualTo(7);
+        assertThat(loaded.getChangePosition().getCommitLsn()).isEqualTo(Lsn.valueOf(COMMIT_LSN));
+        assertThat(loaded.getChangePosition().getInTxLsn()).isEqualTo(Lsn.valueOf(CHANGE_LSN));
+
+        offsetContext.setChangePosition(
+                TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 2, 6), 1);
+
+        assertThat(offsetContext.getChangePosition().getCommandId()).isEqualTo(6);
+        assertThat(offsetContext.getOffset().get(SourceInfo.COMMAND_ID_KEY)).isEqualTo(6);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldLeaveCommandIdUnknownWhenAbsentFromOffset() {
+        Map<String, Object> legacyOffset = baseOffset();
+        assertThat(legacyOffset).doesNotContainKey(SourceInfo.COMMAND_ID_KEY);
+
+        SqlServerOffsetContext loaded = new SqlServerOffsetContext.Loader(connectorConfig).load(legacyOffset);
+
+        assertThat(loaded.getChangePosition().getCommandId()).isNull();
+        assertThat(loaded.getChangePosition().getCommitLsn()).isEqualTo(Lsn.valueOf(COMMIT_LSN));
+        assertThat(loaded.getChangePosition().getInTxLsn()).isEqualTo(Lsn.valueOf(CHANGE_LSN));
+        assertThat(loaded.getEventSerialNo()).isEqualTo(2L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldLoadCommandIdWhateverNumericTypeTheOffsetStoreReturns() {
+        Map<String, Object> withInteger = baseOffset();
+        withInteger.put(SourceInfo.COMMAND_ID_KEY, Integer.valueOf(9));
+
+        Map<String, Object> withLong = baseOffset();
+        withLong.put(SourceInfo.COMMAND_ID_KEY, Long.valueOf(9L));
+
+        SqlServerOffsetContext.Loader loader = new SqlServerOffsetContext.Loader(connectorConfig);
+
+        assertThat(loader.load(withInteger).getChangePosition().getCommandId()).isEqualTo(9);
+        assertThat(loader.load(withLong).getChangePosition().getCommandId()).isEqualTo(9);
+    }
+
+    // event_serial_no logic (setChangePosition / shouldUpdateEventSerialNo). The starting serial is 1.
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldIncrementEventSerialNoWhenTheChangeStaysAtTheSamePosition() {
+        SqlServerOffsetContext offset = offsetContextWithCommandId(7);
+
+        // same commit + change lsn, same command id -> another event at the same log position -> increment
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 4, 7), 1);
+
+        assertThat(offset.getEventSerialNo()).isEqualTo(2L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldResetEventSerialNoWhenTheChangeMovesToANewPosition() {
+        SqlServerOffsetContext offset = offsetContextWithCommandId(7);
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 4, 7), 1); // -> 2
+
+        // different change lsn -> new position -> reset to the event count
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(OTHER_CHANGE_LSN), 2, 8), 1);
+
+        assertThat(offset.getEventSerialNo()).isEqualTo(1L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldResetEventSerialNoOnAModeSwitchEvenAtTheSamePosition() {
+        SqlServerOffsetContext offset = offsetContextWithCommandId(7); // direct: command id present
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 4, 7), 1); // -> 2
+
+        // same commit + change lsn, but command id now absent (switch to function) -> reset, not increment
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 4, null), 1);
+
+        assertThat(offset.getEventSerialNo()).isEqualTo(1L);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldTreatSamePositionWithDifferentCommandIdAsTheSamePositionForSerial() {
+        SqlServerOffsetContext offset = offsetContextWithCommandId(1);
+
+        // same commit + change lsn, different (both non-null) command id -> command id is ignored in the
+        // position comparison, so it counts as the same log position -> increment
+        offset.setChangePosition(TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 2, 2), 1);
+
+        assertThat(offset.getEventSerialNo()).isEqualTo(2L);
+    }
+
+    private SqlServerOffsetContext offsetContextWithCommandId(int commandId) {
+        return new SqlServerOffsetContext(
+                connectorConfig,
+                TxLogPosition.valueOf(Lsn.valueOf(COMMIT_LSN), Lsn.valueOf(CHANGE_LSN), 0, commandId),
+                null,
+                false);
+    }
+
+    private Map<String, Object> baseOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(SourceInfo.COMMIT_LSN_KEY, COMMIT_LSN);
+        offset.put(SourceInfo.CHANGE_LSN_KEY, CHANGE_LSN);
+        offset.put(SourceInfo.EVENT_SERIAL_NO_KEY, Long.valueOf(2));
+        return offset;
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
@@ -151,7 +151,7 @@ public class TransactionMetadataIT extends AbstractAsyncEngineConnectorTest {
                             final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE_1, tableName);
                             final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE_1);
                             final AtomicReference<Boolean> found = new AtomicReference<>(false);
-                            try (ResultSet rs = connection.getChangesForTable(ct, minLsn, maxLsn)) {
+                            try (ResultSet rs = connection.getChangesForTable(ct, minLsn, Lsn.ZERO, 0, -1, maxLsn, 0)) {
                                 while (rs.next()) {
                                     if (rs.getInt("id") == -1) {
                                         found.set(true);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TxLogPositionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TxLogPositionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the ordering of {@link TxLogPosition}, in particular for the {@code __$command_id} term
+ * that direct mode resumes on.
+ */
+public class TxLogPositionTest {
+
+    private static final Lsn TX_1 = Lsn.valueOf("00000a24:000018a8:0015");
+
+    private static final Lsn SEQVAL_LOW = Lsn.valueOf("00000a24:000018a8:0003");
+    private static final Lsn SEQVAL_HIGH = Lsn.valueOf("00000a24:000018a8:0007");
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldOrderByCommandIdBeforeSequenceValue() {
+        TxLogPosition lastDelete = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 1, 5);
+        TxLogPosition firstInsert = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 2, 6);
+
+        assertThat(lastDelete).isLessThan(firstInsert);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldFallBackToSequenceValueWhenOnlyOneSideKnowsItsCommandId() {
+        TxLogPosition fromChangeTable = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1, 6);
+        TxLogPosition fromLegacyOffset = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 0, null);
+
+        assertThat(fromChangeTable).isLessThan(fromLegacyOffset);
+        assertThat(fromLegacyOffset).isGreaterThan(fromChangeTable);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldPreserveFunctionModeOrderingWhenCommandIdIsAbsent() {
+        TxLogPosition lower = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1, null);
+        TxLogPosition higher = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 2, null);
+
+        assertThat(lower).isLessThan(higher);
+        assertThat(higher).isGreaterThan(lower);
+
+        assertThat(lower.getCommandId()).isNull();
+        assertThat(higher.getCommandId()).isNull();
+        assertThat(TxLogPosition.valueOf(TX_1, (Integer) null).getCommandId()).isNull();
+        assertThat(TxLogPosition.NULL_LEGACY.getCommandId()).isNull();
+    }
+
+    @Test
+    void shouldTreatBeforeAndAfterImagesOfAnUpdateAsTheSamePosition() {
+        TxLogPosition updateBefore = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 3, 7);
+        TxLogPosition updateAfter = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 4, 7);
+
+        assertThat(updateBefore).isEqualByComparingTo(updateAfter);
+        assertThat(updateBefore).isEqualTo(updateAfter);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldDistinguishPositionsThatDifferOnlyByCommandId() {
+        TxLogPosition delete = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1, 1);
+        TxLogPosition insert = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 2, 6);
+
+        assertThat(delete).isNotEqualTo(insert);
+        assertThat(delete).isLessThan(insert);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldAssertCommandIdBasedOnMode() {
+        // NULL is the direct-mode empty position (command_id -1); NULL_LEGACY is the function-mode one (null).
+        assertThat(TxLogPosition.NULL.getCommandId()).isEqualTo(-1);
+        assertThat(TxLogPosition.NULL_LEGACY.getCommandId()).isNull();
+        assertThat(TxLogPosition.NULL).isNotEqualTo(TxLogPosition.NULL_LEGACY);
+    }
+
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TxLogPositionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TxLogPositionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the ordering of {@link TxLogPosition}, in particular for the {@code __$command_id} term
+ * that direct mode resumes on.
+ */
+public class TxLogPositionTest {
+
+    private static final Lsn TX_1 = Lsn.valueOf("00000a24:000018a8:0015");
+
+    private static final Lsn SEQVAL_LOW = Lsn.valueOf("00000a24:000018a8:0003");
+    private static final Lsn SEQVAL_HIGH = Lsn.valueOf("00000a24:000018a8:0007");
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldOrderByCommandIdBeforeSequenceValue() {
+        TxLogPosition lastDelete = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 1, 5);
+        TxLogPosition firstInsert = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 2, 6);
+
+        assertThat(lastDelete).isLessThan(firstInsert);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldFallBackToSequenceValueWhenOnlyOneSideKnowsItsCommandId() {
+        TxLogPosition fromChangeTable = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1, 6);
+        TxLogPosition fromLegacyOffset = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 0);
+
+        assertThat(fromChangeTable).isLessThan(fromLegacyOffset);
+        assertThat(fromLegacyOffset).isGreaterThan(fromChangeTable);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldPreserveFunctionModeOrderingWhenCommandIdIsAbsent() {
+        TxLogPosition lower = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1);
+        TxLogPosition higher = TxLogPosition.valueOf(TX_1, SEQVAL_HIGH, 2);
+
+        assertThat(lower).isLessThan(higher);
+        assertThat(higher).isGreaterThan(lower);
+
+        assertThat(lower.getCommandId()).isNull();
+        assertThat(higher.getCommandId()).isNull();
+        assertThat(TxLogPosition.valueOf(TX_1).getCommandId()).isNull();
+        assertThat(TxLogPosition.NULL.getCommandId()).isNull();
+    }
+
+    @Test
+    void shouldTreatBeforeAndAfterImagesOfAnUpdateAsTheSamePosition() {
+        TxLogPosition updateBefore = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 3, 7);
+        TxLogPosition updateAfter = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 4, 7);
+
+        assertThat(updateBefore).isEqualByComparingTo(updateAfter);
+        assertThat(updateBefore).isEqualTo(updateAfter);
+    }
+
+    @Test
+    @FixFor("dbz#2012")
+    void shouldDistinguishPositionsThatDifferOnlyByCommandId() {
+        TxLogPosition delete = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 1, 1);
+        TxLogPosition insert = TxLogPosition.valueOf(TX_1, SEQVAL_LOW, 2, 6);
+
+        assertThat(delete).isNotEqualTo(insert);
+        assertThat(delete).isLessThan(insert);
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -667,7 +667,7 @@ public class TestHelper {
                                     final Lsn minLsn = connection.getMinLsn(TEST_DATABASE_1, ctTableName);
                                     final Lsn maxLsn = connection.getMaxLsn(TEST_DATABASE_1);
                                     final CdcRecordFoundBlockingResultSetConsumer consumer = new CdcRecordFoundBlockingResultSetConsumer(handler);
-                                    try (ResultSet resultSet = connection.getChangesForTable(ct, minLsn, maxLsn)) {
+                                    try (ResultSet resultSet = connection.getChangesForTable(ct, minLsn, Lsn.ZERO, 0, -1, maxLsn, 0)) {
                                         consumer.accept(resultSet);
                                     }
                                     return consumer.isFound();
@@ -723,7 +723,7 @@ public class TestHelper {
                                     final Lsn minLsn = connection.getMinLsn(TEST_DATABASE_1, ctTableName);
                                     final Lsn maxLsn = connection.getMaxLsn(TEST_DATABASE_1);
                                     final CdcRecordFoundBlockingResultSetConsumer consumer = new CdcRecordFoundBlockingResultSetConsumer(handler);
-                                    try (ResultSet resultSet = connection.getChangesForTable(ct, minLsn, maxLsn)) {
+                                    try (ResultSet resultSet = connection.getChangesForTable(ct, minLsn, Lsn.ZERO, 0, -1, maxLsn, 0)) {
                                         consumer.accept(resultSet);
                                     }
                                     return consumer.isFound();

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1406,11 +1406,11 @@ The source metadata includes:
 * Name of the table that contains the new row
 * Server log offsets
 +
-The `event_serial_no` field differentiates events that have the same commit and change LSN.
-Typical situations for when this field has a value other than `1`:
+The `event_serial_no` field differentiates events that carry the same position in the transaction log. In `function` mode a position is the commit LSN and the change LSN. In `direct` mode it also includes `__$command_id`. Typical situations for when this field has a value other than `1`:
 +
 * _update_ events have the value set to `2` because the update generates two events in the CDC change table of SQL Server (link:https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[see the source documentation for details]). The first event contains the old values and the second contains contains new values. The connector uses values in the first event to create the second event. The connector drops the first event.
-* When a primary key is updated SQL Server emits two events. A _delete_ event for the removal of the record with the old primary key value and a _create_ event for the addition of the record with the new primary key. Both operations share the same commit and change LSN and their event numbers are `1` and `2`, respectively.
+* When a primary key is updated SQL Server emits two events. A _delete_ event for the removal of the record with the old primary key value and a _create_ event for the addition of the record with the new primary key.
+If both operations carry the same commit and change LSNs, their event numbers are `1` and `2`, respectively; otherwise both events have the number `1`.
 
 `op`::
 Mandatory string that describes the type of operation.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1384,12 +1384,13 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * Name of the table that contains the new row
 * Server log offsets
 
-The `event_serial_no` field differentiates events that have the same commit and change LSN. Typical situations for when this field has a value other than `1`:
+The `event_serial_no` field differentiates events that carry the same position in the transaction log. In `function` mode a position is the commit LSN and the change LSN. In `direct` mode it also includes `__$command_id`. Typical situations for when this field has a value other than `1`:
 
 * _update_ events have the value set to `2` because the update generates two events in the CDC change table of SQL Server (link:https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[see the source documentation for details]). The first event contains the old values and the second contains contains new values. The connector uses values in the first event to create the second event. The connector drops the first event.
 
 * When a primary key is updated SQL Server emits two events. A _delete_ event for the removal of the record with the old primary key value and a _create_ event for the addition of the record with the new primary key.
-Both operations share the same commit and change LSN and their event numbers are `1` and `2`, respectively.
+In `direct` mode the two operations carry different `__$command_id` values, so they are separate positions and each event has the event number `1`.
+In `function` mode the command id is not available. If both operations carry the same commit and change LSNs, their event numbers are `1` and `2`, respectively; otherwise both events have the number `1`.
 
 |4
 |`op`


### PR DESCRIPTION
Fixes debezium/dbz#2012

In `data.query.mode=direct` the connector reads the change table sorted by `__$command_id` but did not use it on the WHERE clause, which loses data on a deferred update. This PR introduces `__$command_id` into the query, into TxLogPosition, and into the connector offsets so paging and restarts resume on the same key the rows are ordered by.                       
`function` mode is unchanged. The command id is not added to the emitted record, so the record schema and its registered version stay the same and consumers are unaffected by the upgrade.       

### Testing
- Unit test: Added where applicable
- Integration test: Added test which cover mode switch, different streaming.fetch.size and deferred updates case. Existing ITs should be sufficient to cover other common flows.
- Manual test: ITs performed manually + upgrade/downgrade from the change with both function/direct modes + sanity test 
- Performance test : not done.

                                                                         