### PR TITLE
debezium/dbz#2297 Retry Parial Failures of a Snapshot.

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -653,6 +653,7 @@ public abstract class CommonConnectorConfig {
     public static final int DEFAULT_MAX_RETRIES = ErrorHandler.RETRIES_UNLIMITED;
     public static final String ERRORS_MAX_RETRIES = "errors.max.retries";
     private final int maxRetriesOnError;
+    private final int maxSnapshotRetriesOnError;
 
     public static final Field TOPIC_PREFIX = Field.create(ConfigurationNames.TOPIC_PREFIX_PROPERTY_NAME)
             .withDisplayName("Topic prefix")
@@ -1064,6 +1065,16 @@ public abstract class CommonConnectorConfig {
             .withValidation(Field::isInteger)
             .withDescription(
                     "The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).");
+    public static final Field MAX_SNAPSHOT_RETRIES_ON_ERROR = Field.create("snapshot.errors.max.retries")
+            .withDisplayName("The maximum number of retries for failing parts of a snapshot")
+            .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDefault(0)
+            .withValidation(Field::isNonNegativeInteger)
+            .withDescription(
+                    "The maximum number of retries on errors before failing in case a part (chunk/table) of the snapshot failed. (0 = disabled, > 0 = num of retries).");
 
     public static final Field CUSTOM_METRIC_TAGS = Field.create("custom.metric.tags")
             .withDisplayName("Customize metric tags")
@@ -1651,6 +1662,7 @@ public abstract class CommonConnectorConfig {
         this.enabledNotificationChannels = config.getList(NOTIFICATION_ENABLED_CHANNELS);
         this.skipMessagesWithoutChange = config.getBoolean(SKIP_MESSAGES_WITHOUT_CHANGE);
         this.maxRetriesOnError = config.getInteger(MAX_RETRIES_ON_ERROR);
+        this.maxSnapshotRetriesOnError = config.getInteger(MAX_SNAPSHOT_RETRIES_ON_ERROR);
         this.customMetricTags = createCustomMetricTags(config);
         this.incrementalSnapshotWatermarkingStrategy = WatermarkStrategy.parse(config.getString(INCREMENTAL_SNAPSHOT_WATERMARKING_STRATEGY));
         this.snapshotLockingModeCustomName = config.getString(SNAPSHOT_LOCKING_MODE_CUSTOM_NAME, "");
@@ -2324,6 +2336,10 @@ public abstract class CommonConnectorConfig {
 
     public int getMaxRetriesOnError() {
         return maxRetriesOnError;
+    }
+
+    public int getMaxSnapshotRetriesOnError() {
+        return maxSnapshotRetriesOnError;
     }
 
     public String getTaskId() {

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -838,7 +838,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                                                               SnapshotReceiver<P> snapshotReceiver, Table table, boolean firstTable, boolean lastTable, int tableOrder,
                                                               int tableCount, String selectStatement, OptionalLong rowCount, Set<TableId> rowCountTablesKeySet,
                                                               Queue<JdbcConnection> connectionPool, Queue<O> offsets) {
-        return createPooledResourceCallable(connectionPool, offsets,
+        int maxSnapshotRetriesOnError = connectorConfig.getMaxSnapshotRetriesOnError();
+        return createPooledResourceCallable(connectionPool, maxSnapshotRetriesOnError, offsets,
                 (connection, offset) -> {
                     LoggingContext.PreviousContext previousLoggingContext = LoggingContext.forConnector(
                             connectorConfig.getContextName(), connectorConfig.getLogicalName(), null, "snapshot", snapshotContext.partition);
@@ -863,7 +864,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                                                                      SnapshotReceiver<P> snapshotReceiver, SnapshotChunk chunk,
                                                                      Map<TableId, TableChunkProgress> progressMap, SnapshotProgress snapshotProgress,
                                                                      Queue<JdbcConnection> connectionPool, Queue<O> offsets) {
-        return createPooledResourceCallable(connectionPool, offsets,
+        int maxSnapshotRetriesOnError = connectorConfig.getMaxSnapshotRetriesOnError();
+        return createPooledResourceCallable(connectionPool, maxSnapshotRetriesOnError, offsets,
                 (connection, offset) -> {
                     LoggingContext.PreviousContext previousLoggingContext = LoggingContext.forConnector(
                             connectorConfig.getContextName(), connectorConfig.getLogicalName(), null, "snapshot", snapshotContext.partition);
@@ -1409,26 +1411,42 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
      * @return a Callable wrapping the resource management
      */
     @SuppressWarnings("SameParameterValue")
-    private Callable<Void> createPooledResourceCallable(Queue<JdbcConnection> connectionPool,
-                                                        Queue<O> offsetPool,
-                                                        PooledWork<O> work,
-                                                        Runnable errorHandler) {
+    Callable<Void> createPooledResourceCallable(Queue<JdbcConnection> connectionPool,
+                                                int maxSnapshotRetriesOnError,
+                                                Queue<O> offsetPool,
+                                                PooledWork<O> work,
+                                                Runnable errorHandler) {
         return () -> {
             final JdbcConnection connection = connectionPool.poll();
             final O offset = offsetPool.poll();
-            if (!connection.isValid()) {
-                LOGGER.warn("Snapshot pool connection is no longer valid, attempting reconnect. Snapshot consistency for subsequent tables may be affected.");
-                connection.reconnect();
-                initializePooledConnection(connection);
-            }
+            int retry = 0;
             try {
-                work.execute(connection, offset);
-            }
-            catch (Exception e) {
-                if (errorHandler != null) {
-                    errorHandler.run();
+                while (true) {
+                    try {
+                        if (!connection.isValid()) {
+                            LOGGER.warn(
+                                    "Snapshot pool connection is no longer valid, attempting reconnect. Snapshot consistency for subsequent queries may be affected.");
+                            connection.reconnect();
+                            initializePooledConnection(connection);
+                        }
+                        work.execute(connection, offset);
+                        break;
+                    }
+                    catch (Exception e) {
+                        if (errorHandler != null) {
+                            errorHandler.run();
+                        }
+                        if (retry < maxSnapshotRetriesOnError) {
+                            retry++;
+                            LOGGER.warn("Snapshot query failed with error!", e);
+                            LOGGER.warn("Retrying with retry #{}/{}.", retry, maxSnapshotRetriesOnError);
+                        }
+                        else {
+                            LOGGER.error("Snapshot query failed with error!", e);
+                            throw e;
+                        }
+                    }
                 }
-                throw e;
             }
             finally {
                 offsetPool.add(offset);

--- a/debezium-connector-common/src/test/java/io/debezium/relational/RelationalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/RelationalSnapshotChangeEventSourceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.RelationalSnapshotChangeEventSource.PooledWork;
+
+/**
+ * Unit tests for {@link RelationalSnapshotChangeEventSource}.
+ *
+ * <p>These focus on the per-chunk/table retry loop in
+ * {@link RelationalSnapshotChangeEventSource#createPooledResourceCallable} that backs the
+ * {@code snapshot.errors.max.retries} option. Both {@code createDataEventsForTableCallable} (legacy full-table
+ * snapshot) and {@code createDataEventsForChunkedTableCallable} (chunked snapshot) run their work through this same
+ * method.
+ *
+ * @author Hagar Yasser
+ */
+class RelationalSnapshotChangeEventSourceTest {
+
+    @Test
+    void shouldSucceedWithoutRetryWhenWorkSucceedsFirstTime() throws Exception {
+        final AtomicInteger attempts = new AtomicInteger();
+        final PooledWork<OffsetContext> work = (connection, offset) -> attempts.incrementAndGet();
+
+        callableFor(work, 3).call();
+
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRetryFailingWorkThenSucceedWithinMaxRetries() throws Exception {
+        final int failuresBeforeSuccess = 2;
+        final AtomicInteger attempts = new AtomicInteger();
+        final PooledWork<OffsetContext> work = (connection, offset) -> {
+            if (attempts.incrementAndGet() <= failuresBeforeSuccess) {
+                throw new RuntimeException("injected snapshot failure #" + attempts.get());
+            }
+        };
+
+        // maxRetries (3) > failuresBeforeSuccess (2), so the chunk eventually succeeds
+        callableFor(work, 3).call();
+
+        // two failed attempts followed by a successful one
+        assertThat(attempts.get()).isEqualTo(failuresBeforeSuccess + 1);
+    }
+
+    @Test
+    void shouldSucceedWhenLastAllowedRetrySucceeds() throws Exception {
+        final int maxRetries = 2;
+        final AtomicInteger attempts = new AtomicInteger();
+        // fails on the initial attempt and the first retry, succeeds on the second (last allowed) retry
+        final PooledWork<OffsetContext> work = (connection, offset) -> {
+            if (attempts.incrementAndGet() <= maxRetries) {
+                throw new RuntimeException("injected snapshot failure #" + attempts.get());
+            }
+        };
+
+        callableFor(work, maxRetries).call();
+
+        assertThat(attempts.get()).isEqualTo(maxRetries + 1);
+    }
+
+    @Test
+    void shouldFailAfterExhaustingMaxRetries() {
+        final int maxRetries = 3;
+        final AtomicInteger attempts = new AtomicInteger();
+        final RuntimeException failure = new RuntimeException("always fails");
+        final PooledWork<OffsetContext> work = (connection, offset) -> {
+            attempts.incrementAndGet();
+            throw failure;
+        };
+
+        // the original exception from the final attempt is rethrown
+        assertThatThrownBy(() -> callableFor(work, maxRetries).call()).isSameAs(failure);
+
+        // one initial attempt plus maxRetries retries
+        assertThat(attempts.get()).isEqualTo(maxRetries + 1);
+    }
+
+    @Test
+    void shouldNotRetryWhenRetriesDisabled() {
+        final AtomicInteger attempts = new AtomicInteger();
+        final PooledWork<OffsetContext> work = (connection, offset) -> {
+            attempts.incrementAndGet();
+            throw new RuntimeException("injected snapshot failure");
+        };
+
+        // snapshot.errors.max.retries defaults to 0 (disabled)
+        assertThatThrownBy(() -> callableFor(work, 0).call()).isInstanceOf(RuntimeException.class);
+
+        // only the initial attempt, no retries
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    private Callable<Void> callableFor(PooledWork<OffsetContext> work, int maxRetries) throws SQLException {
+        final Queue<JdbcConnection> connectionPool = new ConcurrentLinkedQueue<>();
+        connectionPool.add(validConnection());
+        final Queue<OffsetContext> offsetPool = new ConcurrentLinkedQueue<>();
+        offsetPool.add(mock(OffsetContext.class));
+        return source().createPooledResourceCallable(connectionPool, maxRetries, offsetPool, work, null);
+    }
+
+    private RelationalSnapshotChangeEventSource<Partition, OffsetContext> source() {
+        return mock(RelationalSnapshotChangeEventSource.class, CALLS_REAL_METHODS);
+    }
+
+    private JdbcConnection validConnection() throws SQLException {
+        final JdbcConnection connection = mock(JdbcConnection.class);
+        // keep the connection valid so the retry loop re-runs the work in place rather than reconnecting
+        when(connection.isValid()).thenReturn(true);
+        return connection;
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2297

## Description
<!-- Briefly describe your changes here. -->
This PR is an implementation of the suggested fix for debezium/dbz#2297.
Note: 

1. I wanted to implement an integration test for this where I could inject an implementation for JdbcConnection but I am not sure how to do that in the simplest way possible.
2. The retries relaxes the constraint for consistency across snapshot chunks or tables. This was built over the suggestion to reduce the load (imposed on the DB by long running transactions using a relatively old snapshot id) with the tradeoff of accepting eventual consistency through the synced tables after cdc streaming starts. If the partial retries introduced by this PR is disabled the snapshots should guarantee consistency (keeping in mind [PR#7473](https://github.com/debezium/debezium/pull/7473) may have introduced a corner case where consistency is not guaranteed by default based on my understanding). 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ ] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
