### PR TITLE
dbz#2247 Bump apicurio version and default kafka version (#7702)

### DIFF
--- a/debezium-connector-common/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/VerifyRecord.java
@@ -70,7 +70,7 @@ public class VerifyRecord {
         void assertEquals(String pathToField, Object actualValue, Object expectedValue);
     }
 
-    private static final String APICURIO_URL = "http://localhost:8080/apis/registry/v2";
+    private static final String APICURIO_URL = "http://localhost:8080";
 
     private static final JsonConverter keyJsonConverter = new JsonConverter();
     private static final JsonConverter valueJsonConverter = new JsonConverter();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJdbcConfigurationTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleJdbcConfigurationTest.java
@@ -161,24 +161,6 @@ public class OracleJdbcConfigurationTest {
 
     @Test
     @FixFor("debezium/dbz#2257")
-    public void shouldResolveDualConnectionFactoryForDownstreamCaptureMode() {
-        final Configuration config = Configuration.create()
-                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
-                .with(OracleConnectorConfig.CAPTURE_MODE, "downstream")
-                .with(OracleConnectorConfig.HOSTNAME, "primary")
-                .with(OracleConnectorConfig.DATABASE_NAME, "primarydb")
-                .with(OracleConnectorConfig.SECONDARY_HOSTNAME, "secondary")
-                .with(OracleConnectorConfig.SECONDARY_DATABASE, "secondarydb")
-                .build();
-
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        final OracleConnectionFactory factory = OracleConnectionFactoryProvider.create(connectorConfig);
-        assertThat(factory).isInstanceOf(DualOracleConnectionFactory.class);
-        assertThat(providerLogInterceptor.containsMessage("Using DUAL connection factory - Streams from Downstream Mining Instance")).isTrue();
-    }
-
-    @Test
-    @FixFor("debezium/dbz#2257")
     public void shouldResolveSecondaryPortBasedOnPrimaryPort() {
         final Configuration config = Configuration.create()
                 .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -19,8 +19,8 @@
     <version.strimzi>0.40.0</version.strimzi>
     <version.strimzi.kafka>${version.kafka}</version.strimzi.kafka>
     <version.assertj>3.27.7</version.assertj>
-    <version.apicurio>2.4.1.Final</version.apicurio>
-    <version.apicurio.model>1.1.0</version.apicurio.model>
+    <version.apicurio>3.2.5</version.apicurio>
+    <version.apicurio.model>3.2.5</version.apicurio.model>
     <version.fixture5>0.1.0</version.fixture5>
     <version.debezium.jdbc.tests>2.6.0.Beta1</version.debezium.jdbc.tests>
 
@@ -352,7 +352,7 @@
 
     <dependency>
       <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-operator-api-model</artifactId>
+      <artifactId>apicurio-registry-operator-model</artifactId>
       <version>${version.apicurio.model}</version>
       <exclusions>
         <exclusion>

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
@@ -60,15 +60,18 @@ public final class ConfigProperties {
 
     // Strimzi configuration
     public static final String STRIMZI_OPERATOR_CHANNEL = System.getProperty("test.strimzi.operator.channel", "stable");
-    public static final String STRIMZI_OPERATOR_VERSION = System.getProperty("test.strimzi.operator.version", "0.45.0");
+    public static final String STRIMZI_OPERATOR_VERSION = System.getProperty("test.strimzi.operator.version", "0.51.0");
     public static final boolean STRIMZI_OPERATOR_CONNECTORS = booleanProperty("test.strimzi.operator.connectors", true);
-    public static final String STRIMZI_VERSION_KAFKA = System.getProperty("test.strimzi.version.kafka", "3.1.0");
-    public static final boolean FORCE_KRAFT = booleanProperty("test.force.kraft", false);
+    public static final String STRIMZI_VERSION_KAFKA = System.getProperty("test.strimzi.version.kafka", "4.1.0");
+    public static final boolean FORCE_KRAFT = booleanProperty("test.force.kraft", true);
 
     // Apicurio Registry configuration
-    public static final String APICURIO_LOG_LEVEL = System.getProperty("test.apicurio.log.level", "INFO");
-    public static final String APICURIO_OPERATOR_CHANNEL = System.getProperty("test.apicurio.operator.channel", "2.x");
-    public static final String APICURIO_OPERATOR_VERSION = System.getProperty("test.apicurio.operator.version", "1.1.3-v2.6.4.final");
+    public static final String VERSION_APICURIO = System.getProperty("version.apicurio", "3.2.5");
+    public static final String APICURIO_OPERATOR_NAME = System.getProperty("test.apicurio.operator.name", "apicurio-registry-3");
+    public static final String APICURIO_OPERATOR_CHANNEL = System.getProperty("test.apicurio.operator.channel", "3.x");
+    public static final String APICURIO_OPERATOR_VERSION = System.getProperty("test.apicurio.operator.version", VERSION_APICURIO);
+    public static final String APICURIO_STARTING_CSV = System.getProperty("test.apicurio.operator.starting.csv",
+            "apicurio-registry-3.v" + APICURIO_OPERATOR_VERSION);
     public static final boolean APICURIO_TLS_ENABLED = booleanProperty("test.apicurio.tls.enabled", false);
 
     // MySql Configuration

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/WaitConditions.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/WaitConditions.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistryStatus;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Status;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
@@ -84,7 +84,7 @@ public class WaitConditions {
      * @param resource dc resource
      * @return true when resource is deleted
      */
-    public static <T extends ApicurioRegistryStatus> boolean apicurioResourceDeleted(CustomResource<?, T> resource) {
+    public static <T extends ApicurioRegistry3Status> boolean apicurioResourceDeleted(CustomResource<?, T> resource) {
         T status = resource.getStatus();
         return status == null;
     }

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/operatorutil/OpenshiftOperatorEnum.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/operatorutil/OpenshiftOperatorEnum.java
@@ -17,7 +17,7 @@ public enum OpenshiftOperatorEnum {
             "apicurio-registry-operator",
             ConfigProperties.APICURIO_OPERATOR_CHANNEL,
             ConfigProperties.OCP_PROJECT_REGISTRY + "-opgroup",
-            "apicurio-registry-operator.v" + ConfigProperties.APICURIO_OPERATOR_VERSION),
+            ConfigProperties.APICURIO_STARTING_CSV),
     STRIMZI(PRODUCT_BUILD ? "AMQ Streams" : "Strimzi",
             PRODUCT_BUILD ? "amq-streams" : "strimzi",
             ConfigProperties.STRIMZI_OPERATOR_CHANNEL,

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/operatorutil/OperatorUtil.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/operatorutil/OperatorUtil.java
@@ -47,6 +47,8 @@ public class OperatorUtil {
         }
         else {
             sb = ApicurioSubscriptionBuilder.base().withConfig(PRODUCT_BUILD);
+            startingCSV = operatorEnum.getStartingCSV();
+            sb.withStartingCSV(startingCSV);
         }
 
         sb.withChannel(operatorEnum.getSubscriptionUpdateChannel())

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/OcpApicurioController.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/OcpApicurioController.java
@@ -16,8 +16,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistry;
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistryList;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3List;
 import io.debezium.testing.system.tools.OpenShiftUtils;
 import io.debezium.testing.system.tools.WaitConditions;
 import io.fabric8.kubernetes.api.model.Service;
@@ -37,16 +37,18 @@ import okhttp3.OkHttpClient;
 public class OcpApicurioController implements RegistryController {
     private static final Logger LOGGER = LoggerFactory.getLogger(OcpApicurioController.class);
 
-    public static final String APICURIO_NAME_LBL = "apicur.io/name";
+    public static final String APICURIO_INSTANCE_LBL = "app.kubernetes.io/instance";
+    public static final String APICURIO_COMPONENT_LBL = "app.kubernetes.io/component";
+    public static final String APICURIO_COMPONENT_APP = "app";
 
     protected final OpenShiftClient ocp;
     protected final OkHttpClient http;
     protected final String project;
     protected final String name;
     protected final OpenShiftUtils ocpUtils;
-    protected ApicurioRegistry registry;
+    protected ApicurioRegistry3 registry;
 
-    public OcpApicurioController(ApicurioRegistry registry, OpenShiftClient ocp, OkHttpClient http) {
+    public OcpApicurioController(ApicurioRegistry3 registry, OpenShiftClient ocp, OkHttpClient http) {
         this.registry = registry;
         this.ocp = ocp;
         this.http = http;
@@ -55,8 +57,8 @@ public class OcpApicurioController implements RegistryController {
         this.ocpUtils = new OpenShiftUtils(ocp);
     }
 
-    protected NonNamespaceOperation<ApicurioRegistry, ApicurioRegistryList, Resource<ApicurioRegistry>> registryOperation() {
-        return ocp.resources(ApicurioRegistry.class, ApicurioRegistryList.class).inNamespace(project);
+    protected NonNamespaceOperation<ApicurioRegistry3, ApicurioRegistry3List, Resource<ApicurioRegistry3>> registryOperation() {
+        return ocp.resources(ApicurioRegistry3.class, ApicurioRegistry3List.class).inNamespace(project);
     }
 
     protected String getPublicRegistryAddress() {
@@ -69,11 +71,17 @@ public class OcpApicurioController implements RegistryController {
     }
 
     private List<Route> getRoutes() {
-        return ocp.routes().inNamespace(project).withLabel(APICURIO_NAME_LBL, name).list().getItems();
+        return ocp.routes().inNamespace(project)
+                .withLabel(APICURIO_INSTANCE_LBL, name)
+                .withLabel(APICURIO_COMPONENT_LBL, APICURIO_COMPONENT_APP)
+                .list().getItems();
     }
 
     protected Service getRegistryService() {
-        List<Service> items = ocp.services().inNamespace(project).withLabel(APICURIO_NAME_LBL, name).list().getItems();
+        List<Service> items = ocp.services().inNamespace(project)
+                .withLabel(APICURIO_INSTANCE_LBL, name)
+                .withLabel(APICURIO_COMPONENT_LBL, APICURIO_COMPONENT_APP)
+                .list().getItems();
         if (items.isEmpty()) {
             throw new IllegalStateException("No service for registry '" + registry.getMetadata().getName() + "'");
         }
@@ -88,12 +96,12 @@ public class OcpApicurioController implements RegistryController {
 
     @Override
     public String getRegistryApiAddress() {
-        return getRegistryAddress() + "/apis/registry/v2";
+        return getRegistryAddress();
     }
 
     @Override
     public String getPublicRegistryApiAddress() {
-        return "http://" + getPublicRegistryAddress() + "/apis/registry/v2";
+        return "http://" + getPublicRegistryAddress();
     }
 
     @Override
@@ -114,7 +122,10 @@ public class OcpApicurioController implements RegistryController {
     }
 
     private List<Deployment> getRegistryDeployments(String name) {
-        return ocp.apps().deployments().inNamespace(project).withLabel("app", name).list().getItems();
+        return ocp.apps().deployments().inNamespace(project)
+                .withLabel(APICURIO_INSTANCE_LBL, name)
+                .withLabel(APICURIO_COMPONENT_LBL, APICURIO_COMPONENT_APP)
+                .list().getItems();
     }
 
     @Override

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/OcpApicurioDeployer.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/OcpApicurioDeployer.java
@@ -8,8 +8,8 @@ package io.debezium.testing.system.tools.registry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistry;
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistryList;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3List;
 import io.debezium.testing.system.tools.AbstractOcpDeployer;
 import io.debezium.testing.system.tools.registry.builders.FabricApicurioBuilder;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -38,7 +38,7 @@ public class OcpApicurioDeployer extends AbstractOcpDeployer<OcpApicurioControll
     public OcpApicurioController deploy() throws InterruptedException {
         LOGGER.info("Deploying Apicurio Registry to '" + project + "'");
 
-        ApicurioRegistry registry = fabricBuilder.build();
+        ApicurioRegistry3 registry = fabricBuilder.build();
         registry = registryOperation().createOrReplace(registry);
 
         OcpApicurioController controller = getController(registry);
@@ -47,11 +47,11 @@ public class OcpApicurioDeployer extends AbstractOcpDeployer<OcpApicurioControll
         return controller;
     }
 
-    protected OcpApicurioController getController(ApicurioRegistry registry) {
+    protected OcpApicurioController getController(ApicurioRegistry3 registry) {
         return new OcpApicurioController(registry, ocp, http);
     }
 
-    protected NonNamespaceOperation<ApicurioRegistry, ApicurioRegistryList, Resource<ApicurioRegistry>> registryOperation() {
-        return ocp.resources(ApicurioRegistry.class, ApicurioRegistryList.class).inNamespace(project);
+    protected NonNamespaceOperation<ApicurioRegistry3, ApicurioRegistry3List, Resource<ApicurioRegistry3>> registryOperation() {
+        return ocp.resources(ApicurioRegistry3.class, ApicurioRegistry3List.class).inNamespace(project);
     }
 }

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/builders/ApicurioSubscriptionBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/builders/ApicurioSubscriptionBuilder.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.testing.system.tools.registry.builders;
 
+import io.debezium.testing.system.tools.ConfigProperties;
 import io.debezium.testing.system.tools.fabric8.FabricBuilderWrapper;
 import io.debezium.testing.system.tools.fabric8.OperatorSubscriptionBuilder;
 import io.debezium.testing.system.tools.operatorutil.OpenshiftOperatorEnum;
@@ -20,9 +21,6 @@ import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionSpecBuild
  */
 public class ApicurioSubscriptionBuilder extends FabricBuilderWrapper<ApicurioSubscriptionBuilder, SubscriptionBuilder, Subscription>
         implements OperatorSubscriptionBuilder {
-
-    private static final String APICURIO_OPERATOR_NAME = "apicurio-registry";
-    private static final String SERVICE_REGISTRY_OPERATOR_NAME = "service-registry-operator";
 
     protected ApicurioSubscriptionBuilder(SubscriptionBuilder builder) {
         super(builder);
@@ -48,7 +46,7 @@ public class ApicurioSubscriptionBuilder extends FabricBuilderWrapper<ApicurioSu
                 .withName(OpenshiftOperatorEnum.APICURIO.getDeploymentNamePrefix())
                 .build())
                 .withSpec(new SubscriptionSpecBuilder()
-                        .withName(SERVICE_REGISTRY_OPERATOR_NAME)
+                        .withName(ConfigProperties.APICURIO_OPERATOR_NAME)
                         .withSource(SubscriptionConstants.REDHAT_OPERATORS_SOURCE)
                         .withSourceNamespace(SubscriptionConstants.OPENSHIFT_MARKETPLACE_SOURCE_NAMESPACE)
                         .withInstallPlanApproval(SubscriptionConstants.INSTALL_PLAN_APPROVAL)
@@ -66,7 +64,7 @@ public class ApicurioSubscriptionBuilder extends FabricBuilderWrapper<ApicurioSu
                 .withName(OpenshiftOperatorEnum.APICURIO.getDeploymentNamePrefix())
                 .build())
                 .withSpec(new SubscriptionSpecBuilder()
-                        .withName(APICURIO_OPERATOR_NAME)
+                        .withName(ConfigProperties.APICURIO_OPERATOR_NAME)
                         .withSource(SubscriptionConstants.COMMUNITY_OPERATORS_SOURCE)
                         .withSourceNamespace(SubscriptionConstants.OPENSHIFT_MARKETPLACE_SOURCE_NAMESPACE)
                         .withInstallPlanApproval(SubscriptionConstants.INSTALL_PLAN_APPROVAL)

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/builders/FabricApicurioBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/registry/builders/FabricApicurioBuilder.java
@@ -9,37 +9,30 @@ import static io.debezium.testing.system.tools.ConfigProperties.APICURIO_TLS_ENA
 import static io.debezium.testing.system.tools.kafka.builders.FabricKafkaConnectBuilder.KAFKA_CERT_SECRET;
 import static io.debezium.testing.system.tools.kafka.builders.FabricKafkaConnectBuilder.KAFKA_CLIENT_CERT_SECRET;
 
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistry;
-import io.apicurio.registry.operator.api.v1.model.ApicurioRegistryBuilder;
-import io.apicurio.registry.operator.api.v1.model.apicurioregistryspec.configuration.kafkasql.Security;
-import io.apicurio.registry.operator.api.v1.model.apicurioregistryspec.configuration.kafkasql.SecurityBuilder;
-import io.apicurio.registry.operator.api.v1.model.apicurioregistryspec.configuration.kafkasql.security.TlsBuilder;
-import io.debezium.testing.system.tools.ConfigProperties;
-import io.debezium.testing.system.tools.fabric8.FabricBuilderWrapper;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.KafkaSqlTLSSpec;
+import io.apicurio.registry.operator.api.v1.spec.SecretKeyRef;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 
-public class FabricApicurioBuilder
-        extends FabricBuilderWrapper<FabricApicurioBuilder, ApicurioRegistryBuilder, ApicurioRegistry> {
+public class FabricApicurioBuilder {
 
-    private static final String DEFAULT_PERSISTENCE_TYPE = "kafkasql";
+    private final ApicurioRegistry3 registry;
 
-    protected FabricApicurioBuilder(ApicurioRegistryBuilder builder) {
-        super(builder);
+    protected FabricApicurioBuilder(ApicurioRegistry3 registry) {
+        this.registry = registry;
     }
 
-    @Override
-    public ApicurioRegistry build() {
-        return builder.build();
+    public ApicurioRegistry3 build() {
+        return registry;
     }
 
     private static FabricApicurioBuilder base() {
-        ApicurioRegistryBuilder builder = new ApicurioRegistryBuilder()
-                .withNewMetadata()
-                .withName("debezium-registry")
-                .endMetadata()
-                .withNewSpec()
-                .endSpec();
-
-        return new FabricApicurioBuilder(builder);
+        ApicurioRegistry3 registry = new ApicurioRegistry3();
+        ObjectMeta metadata = new ObjectMeta();
+        metadata.setName("debezium-registry");
+        registry.setMetadata(metadata);
+        return new FabricApicurioBuilder(registry);
     }
 
     public static FabricApicurioBuilder baseKafkaSql(String bootstrap) {
@@ -47,41 +40,28 @@ public class FabricApicurioBuilder
     }
 
     public FabricApicurioBuilder withKafkaSqlConfiguration(String bootstrap) {
-        builder.editSpec()
-                .withNewConfiguration()
-                .withLogLevel(ConfigProperties.APICURIO_LOG_LEVEL)
-                .withPersistence(DEFAULT_PERSISTENCE_TYPE)
-                .withNewKafkasql()
-                .withBootstrapServers(bootstrap)
-                .endKafkasql()
-                .endConfiguration()
-                .endSpec();
+        registry.withSpec().withApp().withStorage().setType(StorageType.KAFKASQL);
+        registry.withSpec().withApp().withStorage().withKafkasql().setBootstrapServers(bootstrap);
 
         if (APICURIO_TLS_ENABLED) {
             withTls();
         }
 
-        return self();
+        return this;
     }
 
     public FabricApicurioBuilder withTls() {
-        builder.editSpec()
-                .editConfiguration()
-                .editKafkasql()
-                .withSecurity(getTlsSpec())
-                .endKafkasql()
-                .endConfiguration()
-                .endSpec();
-        return self();
-    }
-
-    private Security getTlsSpec() {
-        return new SecurityBuilder()
-                .withTls(
-                        new TlsBuilder()
-                                .withKeystoreSecretName(KAFKA_CLIENT_CERT_SECRET)
-                                .withTruststoreSecretName(KAFKA_CERT_SECRET)
-                                .build())
+        KafkaSqlTLSSpec tlsSpec = KafkaSqlTLSSpec.builder()
+                .keystoreSecretRef(SecretKeyRef.builder()
+                        .name(KAFKA_CLIENT_CERT_SECRET)
+                        .build())
+                .truststoreSecretRef(SecretKeyRef.builder()
+                        .name(KAFKA_CERT_SECRET)
+                        .build())
                 .build();
+
+        registry.withSpec().withApp().withStorage().withKafkasql().setTls(tlsSpec);
+
+        return this;
     }
 }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioTestResourceLifeCycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioTestResourceLifeCycleManager.java
@@ -39,6 +39,6 @@ public class ApicurioTestResourceLifeCycleManager implements QuarkusTestResource
     }
 
     public static String getApicurioUrl() {
-        return "http://" + container.getHost() + ":" + container.getMappedPort(APICURIO_PORT) + "/apis/registry/v2";
+        return "http://" + container.getHost() + ":" + container.getMappedPort(APICURIO_PORT);
     }
 }

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
@@ -312,7 +312,7 @@ public class ApicurioRegistryTestIT {
     private String getApicurioUrl() {
         final String host = apicurioContainer.getContainerInfo().getConfig().getHostName();
         final int port = apicurioContainer.getExposedPorts().get(0);
-        final String apicurioUrl = "http://" + host + ":" + port + "/apis/registry/v2";
+        final String apicurioUrl = "http://" + host + ":" + port;
         return apicurioUrl;
     }
 


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2247

## Description
Backport to 3.6
Update apicurio and kafka/strimzi default versions to be aligned with the latest change in the code.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
