### PR TITLE
debezium/dbz#2275 Close connection on non-transient connection errors…

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -16,6 +16,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -288,6 +289,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                         context.maximumKey(maximumKey);
                     }
                     catch (SQLException e) {
+                        if (e instanceof SQLNonTransientConnectionException) {
+                            closeJdbcConnection();
+                        }
                         LOGGER.error("Failed to read maximum key for table {}", currentTableId, e);
                         notificationService.incrementalSnapshotNotificationService().notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned,
                                 SQL_EXCEPTION);
@@ -337,6 +341,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                     }
                 }
                 catch (SQLException e) {
+                    if (e instanceof SQLNonTransientConnectionException) {
+                        closeJdbcConnection();
+                    }
                     notificationService.incrementalSnapshotNotificationService().notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned,
                             SQL_EXCEPTION);
                     nextDataCollection(partition, offsetContext);
@@ -346,6 +353,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             LOGGER.trace("Window close emitted");
         }
         catch (SQLException e) {
+            if (e instanceof SQLNonTransientConnectionException) {
+                closeJdbcConnection();
+            }
             warnAndSkip(partition, offsetContext,
                     SQL_EXCEPTION,
                     "SQL error while executing incremental snapshot for table '%s', skipping and continuing streaming"
@@ -394,6 +404,16 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             return true;
         }
         return false;
+    }
+
+    private void closeJdbcConnection() {
+        try {
+            LOGGER.info("Connection is being closed after Not recoverable SQL exception");
+            jdbcConnection.close();
+        }
+        catch (SQLException ex) {
+            LOGGER.error("Failed to close JDBC connection", ex);
+        }
     }
 
     private void warnAndSkip(P partition, OffsetContext offsetContext, TableScanCompletionStatus status, String formattedReason, Throwable t) {

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSourceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.ColumnFilterMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.TableId;
+
+/**
+ * Verifies how {@link AbstractIncrementalSnapshotChangeEventSource#readChunk} reacts when reading a
+ * chunk fails with a JDBC error. A non-transient connection error (the server closed the connection)
+ * must lead to the stale connection being discarded so that a fresh one is opened on the next chunk
+ * read, rather than the connector getting stuck retrying a broken connection.
+ */
+@ExtendWith(MockitoExtension.class)
+public class AbstractIncrementalSnapshotChangeEventSourceTest {
+
+    interface TestPartition extends Partition {
+    }
+
+    private JdbcConnection jdbcConnection;
+    private OffsetContext offsetContext;
+    private SignalBasedIncrementalSnapshotChangeEventSource<TestPartition, TableId> source;
+    private SnapshotProgressListener<TestPartition> progressListener;
+    private NotificationService<TestPartition, OffsetContext> notificationService;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        jdbcConnection = mock(JdbcConnection.class);
+        progressListener = mock(SnapshotProgressListener.class);
+        notificationService = mock(NotificationService.class, RETURNS_DEEP_STUBS);
+        source = new SignalBasedIncrementalSnapshotChangeEventSource<>(config(), jdbcConnection, null, null, null, progressListener, null,
+                notificationService);
+
+        // A snapshot with a single pending data collection so that readChunk proceeds past its
+        // guard clauses and starts reading a chunk.
+        SignalBasedIncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
+        context.addDataCollectionNamesToSnapshot("signal-1", List.of("public.a"), List.of(), "");
+
+        offsetContext = mock(OffsetContext.class);
+        doReturn(context).when(offsetContext).getIncrementalSnapshotContext();
+    }
+
+    @Test
+    @FixFor("dbz#2275")
+    public void shouldCloseConnectionWhenChunkReadFailsWithNonTransientConnectionError() throws Exception {
+        // The server has closed the connection: the first JDBC call while reading the chunk fails
+        // with a non-transient connection error.
+        when(jdbcConnection.commit()).thenThrow(new SQLNonTransientConnectionException("connection closed by server"));
+
+        source.readChunk(null, offsetContext);
+
+        // The dead connection must be closed so it is re-opened on the next chunk read.
+        verify(jdbcConnection).close();
+    }
+
+    @Test
+    @FixFor("dbz#2275")
+    public void shouldNotCloseConnectionWhenChunkReadFailsWithOtherSqlError() throws Exception {
+        // A generic (potentially transient) SQL error is not a broken connection and must not cause
+        // the connection to be discarded.
+        when(jdbcConnection.commit()).thenThrow(new SQLException("transient failure"));
+
+        source.readChunk(null, offsetContext);
+
+        verify(jdbcConnection, never()).close();
+    }
+
+    private RelationalDatabaseConnectorConfig config() {
+        final Configuration configuration = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal")
+                .with(RelationalDatabaseConnectorConfig.TOPIC_PREFIX, "core")
+                .build();
+        return new RelationalDatabaseConnectorConfig(configuration, null, null, 0, ColumnFilterMode.CATALOG, true) {
+            @Override
+            protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+                return null;
+            }
+
+            @Override
+            public String getContextName() {
+                return null;
+            }
+
+            @Override
+            public String getConnectorName() {
+                return null;
+            }
+
+            @Override
+            public EnumeratedValue getSnapshotMode() {
+                return null;
+            }
+
+            @Override
+            public Optional<EnumeratedValue> getSnapshotLockingMode() {
+                return Optional.empty();
+            }
+        };
+    }
+}


### PR DESCRIPTION
When the database closes the connection on its end, the JDBC driver throws a SQLNonTransientException during an incremental snapshot. This exception indicates that retry of the same operation would fail unless the cause of the SQLException is corrected. In such cases, we should close the connection and clear its prepared statement cache so that the connection is reinitialized on the next retry.

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2275

## Description
<!-- Briefly describe your changes here. -->

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
