### PR TITLE
DBZ-2325 Preserve pending incremental snapshot across boot-time snapshot

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -287,6 +287,11 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
 
     public static PostgresOffsetContext initialContext(PostgresConnectorConfig connectorConfig, PostgresConnection jdbcConnection, Clock clock, Lsn lastCommitLsn,
                                                        Lsn lastCompletelyProcessedLsn) {
+        return initialContext(connectorConfig, jdbcConnection, clock, lastCommitLsn, lastCompletelyProcessedLsn, null);
+    }
+
+    public static PostgresOffsetContext initialContext(PostgresConnectorConfig connectorConfig, PostgresConnection jdbcConnection, Clock clock, Lsn lastCommitLsn,
+                                                       Lsn lastCompletelyProcessedLsn, IncrementalSnapshotContext<TableId> incrementalSnapshotContext) {
         try {
             LOGGER.info("Creating initial offset context");
             final Lsn lsn = Lsn.valueOf(jdbcConnection.currentXLogLocation());
@@ -304,9 +309,11 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
                     false,
                     false,
                     new TransactionContext(),
-                    connectorConfig.isReadOnlyConnection()
-                            ? new PostgresReadOnlyIncrementalSnapshotContext<>()
-                            : new SignalBasedIncrementalSnapshotContext<>(false));
+                    incrementalSnapshotContext != null
+                            ? incrementalSnapshotContext
+                            : (connectorConfig.isReadOnlyConnection()
+                                    ? new PostgresReadOnlyIncrementalSnapshotContext<>()
+                                    : new SignalBasedIncrementalSnapshotContext<>(false)));
         }
         catch (SQLException e) {
             throw new ConnectException("Database processing error", e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -25,6 +25,7 @@ import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.Table;
@@ -153,16 +154,22 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             throws Exception {
         PostgresOffsetContext offset = ctx.offset;
         if (offset == null) {
+            // A fresh context would silently drop a pending incremental snapshot restored from the offsets.
+            @SuppressWarnings("unchecked")
+            final IncrementalSnapshotContext<TableId> carriedIncrementalContext = previousOffset != null
+                    ? (IncrementalSnapshotContext<TableId>) previousOffset.getIncrementalSnapshotContext()
+                    : null;
             if (previousOffset != null && !snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot()) {
                 // The connect framework, not the connector, manages triggering committing offset state so the
                 // replication stream may not have flushed the latest offset state during catch up streaming.
                 // The previousOffset variable is shared between the catch up streaming and snapshot phases and
                 // has the latest known offset state.
                 offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock(),
-                        previousOffset.lastCommitLsn(), previousOffset.lastCompletelyProcessedLsn());
+                        previousOffset.lastCommitLsn(), previousOffset.lastCompletelyProcessedLsn(), carriedIncrementalContext);
             }
             else {
-                offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock());
+                offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock(),
+                        null, null, carriedIncrementalContext);
             }
             ctx.offset = offset;
         }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2325

When a boot-time snapshot runs on a connector restart (`snapshot.mode=always` or `configuration_based` with data/schema enabled), `determineSnapshotOffset` builds a fresh offset context whose incremental snapshot context is empty, discarding the pending incremental snapshot restored from the offsets. The skipped-snapshot path is unaffected because it hands `previousOffset` to streaming unchanged.

This change extends the existing carry-over (the two LSNs gated by `shouldStreamEventsStartingFromSnapshot`) to the incremental snapshot context: `initialContext` gains an overload accepting the restored context, and `determineSnapshotOffset` passes it in both branches. First-boot behavior is unchanged (`previousOffset == null` keeps creating a fresh context as today); no SPI or offset format changes.

Field-tested on a production-like fleet: connector killed (SIGKILL) at 30% of an incremental snapshot with persistent offsets, restarted with `configuration_based`; the pending table resumed from the exact stored chunk position and completed. Without the fix the queue is silently lost and the snapshot never resumes.

The MySQL/MariaDB family has the same structural pattern (`MySqlOffsetContext.initial`); happy to follow up with an equivalent change there if this approach is accepted.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
