### PR TITLE
debezium/dbz#2330 Pin the exported snapshot on pooled connections for parallel PostgreSQL snapshots

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -838,7 +838,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                                                               SnapshotReceiver<P> snapshotReceiver, Table table, boolean firstTable, boolean lastTable, int tableOrder,
                                                               int tableCount, String selectStatement, OptionalLong rowCount, Set<TableId> rowCountTablesKeySet,
                                                               Queue<JdbcConnection> connectionPool, Queue<O> offsets) {
-        return createPooledResourceCallable(connectionPool, offsets,
+        return createPooledResourceCallable(snapshotContext, connectionPool, offsets,
                 (connection, offset) -> {
                     LoggingContext.PreviousContext previousLoggingContext = LoggingContext.forConnector(
                             connectorConfig.getContextName(), connectorConfig.getLogicalName(), null, "snapshot", snapshotContext.partition);
@@ -863,7 +863,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                                                                      SnapshotReceiver<P> snapshotReceiver, SnapshotChunk chunk,
                                                                      Map<TableId, TableChunkProgress> progressMap, SnapshotProgress snapshotProgress,
                                                                      Queue<JdbcConnection> connectionPool, Queue<O> offsets) {
-        return createPooledResourceCallable(connectionPool, offsets,
+        return createPooledResourceCallable(snapshotContext, connectionPool, offsets,
                 (connection, offset) -> {
                     LoggingContext.PreviousContext previousLoggingContext = LoggingContext.forConnector(
                             connectorConfig.getContextName(), connectorConfig.getLogicalName(), null, "snapshot", snapshotContext.partition);
@@ -1406,7 +1406,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
      * @return a Callable wrapping the resource management
      */
     @SuppressWarnings("SameParameterValue")
-    private Callable<Void> createPooledResourceCallable(Queue<JdbcConnection> connectionPool,
+    private Callable<Void> createPooledResourceCallable(RelationalSnapshotContext<P, O> snapshotContext,
+                                                        Queue<JdbcConnection> connectionPool,
                                                         Queue<O> offsetPool,
                                                         PooledWork<O> work,
                                                         Runnable errorHandler) {
@@ -1417,6 +1418,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 LOGGER.warn("Snapshot pool connection is no longer valid, attempting reconnect. Snapshot consistency for subsequent tables may be affected.");
                 connection.reconnect();
                 initializePooledConnection(connection);
+                // Re-apply the connector-specific pin (e.g. Oracle PDB, PostgreSQL exported snapshot) that
+                // createConnectionPool applies at pool creation, so a reconnected connection is not left with
+                // only the isolation level copied by initializePooledConnection.
+                connectionPoolConnectionCreated(snapshotContext, connection);
             }
             try {
                 work.execute(connection, offset);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -21,6 +21,7 @@ import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
@@ -106,6 +107,26 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         if (snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot() && startingSlotInfo == null) {
             setSnapshotTransactionIsolationLevel(snapshotContext.onDemand);
         }
+    }
+
+    @Override
+    protected void connectionPoolConnectionCreated(RelationalSnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext,
+                                                   JdbcConnection connection)
+            throws SQLException {
+        // The exported-snapshot pin that connectionCreated() sets on the main connection is not shared by the
+        // extra connections created when snapshot.max.threads > 1. Without importing the same exported snapshot
+        // here, each of those connections reads under its own MVCC snapshot, so a parallel snapshot is not
+        // consistent across connections. Import the exported snapshot on every pooled connection, under the same
+        // conditions the main connection uses to set it.
+        if (slotCreatedInfo == null
+                || snapshotContext.onDemand
+                || !snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot()
+                || startingSlotInfo != null) {
+            return;
+        }
+        // SET TRANSACTION SNAPSHOT must be the first statement of a fresh transaction.
+        connection.rollback();
+        connection.executeWithoutCommitting(snapshotTransactionIsolationLevelStatement(slotCreatedInfo, snapshotContext.onDemand));
     }
 
     @Override


### PR DESCRIPTION
Fixes debezium/dbz#2330

### What

When `snapshot.max.threads > 1`, the PostgreSQL connector's initial snapshot uses a pool of extra connections. The exported snapshot from the replication slot (`SET TRANSACTION SNAPSHOT '<name>'`) is applied only on the main connection in `connectionCreated`; the pooled connections created in `createConnectionPool` copy only the isolation level (`initializePooledConnection`), not the exported snapshot. So each pooled connection reads under its own MVCC snapshot, and a parallel snapshot is **not consistent across connections** — a row committed concurrently after the slot's snapshot was taken can appear in the output of a table read by a pooled connection while being absent from tables read by the main one.

### Fix

Override `connectionPoolConnectionCreated` in `PostgresSnapshotChangeEventSource` to import the exported snapshot on each pooled connection, guarded by exactly the conditions under which the main connection sets it (`slotCreatedInfo != null && !onDemand && shouldStreamEventsStartingFromSnapshot() && startingSlotInfo == null`). It `rollback()`s first so `SET TRANSACTION SNAPSHOT` runs as the first statement of a fresh transaction, and reuses the existing `snapshotTransactionIsolationLevelStatement(...)`. On-demand/blocking snapshots, pre-existing slots, and catch-up streaming are skipped, matching the main connection.

Raised during the DDD-59 review (debezium/debezium-design-documents#60) — @Naros suggested fixing this independently of the DDD and backporting to 3.6.

### Testing

I have not added a test yet because there isn't an existing one to re-enable (the `@Disabled` tests in `RecordsSnapshotParallelProducerIT` assert per-record snapshot ordering, which is nondeterministic under parallel threads for unrelated reasons and wouldn't be fixed by this). I'd like to add a new IT (e.g. `PostgresParallelSnapshotConsistencyIT`) that runs an initial-snapshot-with-streaming with `snapshot.max.threads > 1` and more tables than threads, commits a change from a separate session between slot establishment and the pooled reads, and asserts no table's snapshot reflects that concurrent change. Before writing it — does that approach look right to you, or would you prefer a lighter `LogInterceptor` test asserting the `SET TRANSACTION SNAPSHOT` is issued on the pooled connections?

Backport candidate for 3.6.