### PR TITLE
debezium/dbz#2333 Unwrap SpecialValueDecimal when binding query column values

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -55,7 +55,6 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Field;
-import io.debezium.data.SpecialValueDecimal;
 import io.debezium.pipeline.source.snapshot.incremental.ChunkQueryBuilder;
 import io.debezium.pipeline.source.snapshot.incremental.DefaultChunkQueryBuilder;
 import io.debezium.relational.Attribute;
@@ -1795,9 +1794,6 @@ public class JdbcConnection implements AutoCloseable {
      * Sets value on {@link PreparedStatement} and set explicit SQL type for it if necessary
      */
     public void setQueryColumnValue(PreparedStatement statement, Column column, int pos, Object value) throws SQLException {
-        if (value instanceof SpecialValueDecimal specialValueDecimal) {
-            value = specialValueDecimal.getDecimalValue().orElse(null);
-        }
         statement.setObject(pos, value);
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -55,6 +55,7 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Field;
+import io.debezium.data.SpecialValueDecimal;
 import io.debezium.pipeline.source.snapshot.incremental.ChunkQueryBuilder;
 import io.debezium.pipeline.source.snapshot.incremental.DefaultChunkQueryBuilder;
 import io.debezium.relational.Attribute;
@@ -1794,6 +1795,9 @@ public class JdbcConnection implements AutoCloseable {
      * Sets value on {@link PreparedStatement} and set explicit SQL type for it if necessary
      */
     public void setQueryColumnValue(PreparedStatement statement, Column column, int pos, Object value) throws SQLException {
+        if (value instanceof SpecialValueDecimal specialValueDecimal) {
+            value = specialValueDecimal.getDecimalValue().orElse(null);
+        }
         statement.setObject(pos, value);
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -12,6 +12,7 @@ import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationS
 import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationService.TableScanCompletionStatus.UNKNOWN_SCHEMA;
 import static io.debezium.util.Loggings.maybeRedactSensitiveData;
 
+import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.ValueWrapper;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
@@ -781,7 +783,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         return Threads.timer(clock, RelationalSnapshotChangeEventSource.LOG_INTERVAL);
     }
 
-    @SuppressWarnings("unchecked")
     private Object[] keyFromRow(Object[] row) {
         if (row == null) {
             return null;
@@ -789,11 +790,24 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         final List<Column> keyColumns = chunkQueryBuilder.getQueryColumns(context, currentTable);
         final Object[] key = new Object[keyColumns.size()];
         for (int i = 0; i < keyColumns.size(); i++) {
-            final Object fieldValue = row[keyColumns.get(i).position() - 1];
-            key[i] = fieldValue instanceof ValueWrapper<?> ? ((ValueWrapper<Object>) fieldValue).getWrappedValue()
-                    : fieldValue;
+            key[i] = unwrapKeyValue(row[keyColumns.get(i).position() - 1]);
         }
         return key;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Object unwrapKeyValue(Object fieldValue) {
+        if (fieldValue instanceof SpecialValueDecimal specialValueDecimal) {
+            final Optional<BigDecimal> decimalValue = specialValueDecimal.getDecimalValue();
+            if (decimalValue.isPresent()) {
+                return decimalValue.get();
+            }
+            // NaN and the infinities have no BigDecimal form: getWrappedValue() would degrade them to null,
+            // which the chunk query cannot bind. Their double form stays bindable and PostgreSQL orders it
+            // consistently with the numeric column (NaN above everything).
+            return specialValueDecimal.toDouble();
+        }
+        return fieldValue instanceof ValueWrapper<?> ? ((ValueWrapper<Object>) fieldValue).getWrappedValue() : fieldValue;
     }
 
     protected void setContext(IncrementalSnapshotContext<T> context) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -431,7 +431,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
         final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
                 expectedRecordCount,
                 x -> true,
-                k -> specialAwareKey(Double.parseDouble(k.getString("pk"))),
+                k -> specialAwareKey(k.getString("pk")),
                 record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 "test_server.s1.anumeric",
                 null);
@@ -443,17 +443,17 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
         assertThat(dbChanges).contains(entry(Integer.MAX_VALUE, 102));
     }
 
-    private int specialAwareKey(double pk) {
-        if (Double.isNaN(pk)) {
-            return Integer.MAX_VALUE;
+    private int specialAwareKey(String pk) {
+        switch (pk) {
+            case "NAN":
+                return Integer.MAX_VALUE;
+            case "POSITIVE_INFINITY":
+                return Integer.MAX_VALUE - 1;
+            case "NEGATIVE_INFINITY":
+                return Integer.MIN_VALUE;
+            default:
+                return Integer.parseInt(pk);
         }
-        if (pk == Double.POSITIVE_INFINITY) {
-            return Integer.MAX_VALUE - 1;
-        }
-        if (pk == Double.NEGATIVE_INFINITY) {
-            return Integer.MIN_VALUE;
-        }
-        return (int) pk;
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -402,6 +402,61 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     }
 
     @Test
+    @FixFor("debezium/dbz#2333")
+    public void insertsNumericPkWithSpecialValues() throws Exception {
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            for (int i = 1; i <= 18; i++) {
+                connection.executeWithoutCommitting(
+                        String.format("INSERT INTO s1.anumeric (pk, aa) VALUES (%d, %d)", i, i));
+            }
+            connection.executeWithoutCommitting(
+                    "INSERT INTO s1.anumeric (pk, aa) VALUES ('-Infinity'::numeric, 100)",
+                    "INSERT INTO s1.anumeric (pk, aa) VALUES ('Infinity'::numeric, 101)",
+                    "INSERT INTO s1.anumeric (pk, aa) VALUES ('NaN'::numeric, 102)");
+            connection.commit();
+        }
+        // String mode keeps the emitted keys JSON-safe: the test harness round-trips every record
+        // through the JSON converter, which cannot represent NaN or the infinities as float64. The
+        // boundary extraction under test is unaffected: chunk reads produce SpecialValueDecimal
+        // regardless of the emission mode.
+        startConnector(x -> x.with(PostgresConnectorConfig.DECIMAL_HANDLING_MODE, "string"));
+
+        sendAdHocSnapshotSignal("s1.anumeric");
+
+        // 21 rows with chunk size 10: the ascending key order is -Infinity, 1..18, Infinity, NaN, so the
+        // second chunk ends exactly on Infinity (bound as the next chunk's lower bound) and NaN is the
+        // maximum key, bound into every chunk query.
+        final int expectedRecordCount = 21;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(
+                expectedRecordCount,
+                x -> true,
+                k -> specialAwareKey(Double.parseDouble(k.getString("pk"))),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
+                "test_server.s1.anumeric",
+                null);
+        for (int i = 1; i <= 18; i++) {
+            assertThat(dbChanges).contains(entry(i, i));
+        }
+        assertThat(dbChanges).contains(entry(Integer.MIN_VALUE, 100));
+        assertThat(dbChanges).contains(entry(Integer.MAX_VALUE - 1, 101));
+        assertThat(dbChanges).contains(entry(Integer.MAX_VALUE, 102));
+    }
+
+    private int specialAwareKey(double pk) {
+        if (Double.isNaN(pk)) {
+            return Integer.MAX_VALUE;
+        }
+        if (pk == Double.POSITIVE_INFINITY) {
+            return Integer.MAX_VALUE - 1;
+        }
+        if (pk == Double.NEGATIVE_INFINITY) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) pk;
+    }
+
+    @Test
     @FixFor("DBZ-5240")
     @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Primary keys on partitioned tables are supported only on Postgres 11+")
     public void snapshotPartitionedTable() throws Exception {


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2333

An incremental snapshot of a table whose `NUMERIC` key holds one of PostgreSQL's special values (`NaN`, `Infinity`, `-Infinity`) silently loses data. `keyFromRow()` unwraps `ValueWrapper` boundary values via `getWrappedValue()`, which returns `null` for the special values since they have no `BigDecimal` form; `bindBoundaryParams()` then silently skips the null, the chunk query matches nothing, and the snapshot completes early without errors. Since PostgreSQL orders `NaN` above every other numeric, a single `NaN` row immediately becomes the snapshot's `maximumKey` — which is bound into every chunk query — so one such row is enough to lose everything past the first chunk.

This PR:
- handles the special values where the chunk boundaries are extracted (`keyFromRow()`): ordinary values keep their exact `BigDecimal` form, `NaN`/`±Infinity` fall back to their double form (`SpecialValueDecimal.toDouble()`), which drivers bind as `float8` and PostgreSQL compares against `numeric` with the same ordering semantics;
- reverts the previous bind-time unwrap in `JdbcConnection.setQueryColumnValue()`: the ordinary-value case it addressed is already covered on main by `keyFromRow()`'s `ValueWrapper` unwrap (the symptom I originally reported came from custom chunk-reading code in #7362, and will be fixed there);
- adds `IncrementalSnapshotIT.insertsNumericPkWithSpecialValues`, sized so that with the test chunk size of 10 the `Infinity` row lands exactly on a chunk boundary and `NaN` is the maximum key bound into every chunk query.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
