### PR TITLE
debezium/dbz#806 Support the Lettuce client in debezium-storage-redis

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -47,6 +47,7 @@
 
         <!-- Redis -->
         <version.jedis>6.0.0</version.jedis>
+        <version.lettuce>6.7.1.RELEASE</version.lettuce>
 
         <!-- S3 -->
         <version.s3>2.53.1</version.s3>
@@ -575,6 +576,11 @@
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
                 <version>${version.jedis}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.lettuce</groupId>
+                <artifactId>lettuce-core</artifactId>
+                <version>${version.lettuce}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.rocketmq</groupId>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -47,6 +47,7 @@
 
         <!-- Redis -->
         <version.jedis>6.0.0</version.jedis>
+        <version.lettuce>6.7.1.RELEASE</version.lettuce>
 
         <!-- S3 -->
         <version.s3>2.26.30</version.s3>
@@ -575,6 +576,11 @@
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
                 <version>${version.jedis}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.lettuce</groupId>
+                <artifactId>lettuce-core</artifactId>
+                <version>${version.lettuce}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.rocketmq</groupId>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -62,6 +62,18 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
         </dependency>
+        <!--
+            Provided rather than compile so that the default (Jedis) deployments neither pull in Lettuce
+            transitively nor carry it, Netty and Reactor in the distribution archive: that chain is about
+            6.9 MB of the 11 MB the archive would otherwise hold, and Jedis users never load a class of it.
+            Users who set redis.client.library=lettuce add lettuce-core to the runtime classpath themselves;
+            RedisConnection fails with an actionable message when it is missing.
+        -->
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>jedis</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -62,9 +62,15 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
         </dependency>
+        <!--
+            Optional so that the default (Jedis) deployments do not pull in Lettuce and its Netty/Reactor
+            transitive dependencies. Users who set redis.client.library=lettuce must add lettuce-core to
+            the runtime classpath themselves.
+        -->
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.util.Strings;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.LettuceFutures;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCommandTimeoutException;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.SslOptions;
+import io.lettuce.core.SslVerifyMode;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.sync.RedisCommands;
+
+/**
+ * A {@link RedisClient} implementation backed by the <a href="https://github.com/redis/lettuce">Lettuce</a>
+ * driver, used for single (standalone) Redis instances.
+ * <p>
+ * Lettuce fixes the key/value codec per connection, whereas the {@link RedisClient} contract mixes
+ * {@code String}-based commands with a single {@code byte[]}-based {@link #hset(byte[], byte[], byte[])}.
+ * This client deliberately uses a <em>single</em> UTF-8 string connection and decodes the {@code hset}
+ * arguments, rather than adding a second byte-array connection.
+ * <p>
+ * A second connection would break {@link #waitReplicas(int, long)}: Redis evaluates {@code WAIT} against
+ * the write offset of the <em>calling</em> connection, so a {@code WAIT} issued on a different connection
+ * than the preceding write reports success without ever covering that write. Since {@code hset} is the
+ * only {@code byte[]} command and {@link WaitReplicasRedisClient} pairs it with {@code WAIT}, both must
+ * travel over the same connection.
+ * <p>
+ * Decoding the {@code hset} arguments as UTF-8 introduces no new assumption: {@link #hgetAll(String)}
+ * already returns {@code Map<String, String>} for every {@link RedisClient} implementation, so callers
+ * such as {@code RedisOffsetBackingStore} already round-trip these values through {@code String}.
+ * <p>
+ * This class is <em>not</em> safe for concurrent use by multiple threads: {@link #xadd(List)} toggles
+ * auto-flushing, which is a property of the whole connection, so a concurrent command issued on the same
+ * client would sit in the buffer until the batch completes. Each store creates its own client instance.
+ * <p>
+ * {@code lettuce-core} is a provided dependency of this module and is not bundled in the distribution
+ * archive, so this class is the only place that references Lettuce types, including the connection setup
+ * in {@link #create(RedisConnection, String)}.
+ */
+public class LettuceClient implements RedisClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LettuceClient.class);
+
+    private static final String LOADING_MESSAGE = "LOADING";
+
+    /**
+     * Shutdown quiet period; the Lettuce default of 2 seconds would needlessly delay connector shutdown.
+     */
+    private static final Duration SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(2);
+
+    private final io.lettuce.core.RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+    private final RedisCommands<String, String> commands;
+    private final long commandTimeoutMs;
+
+    public LettuceClient(io.lettuce.core.RedisClient client,
+                         StatefulRedisConnection<String, String> connection,
+                         long commandTimeoutMs) {
+        this.client = client;
+        this.connection = connection;
+        this.commands = connection.sync();
+        this.commandTimeoutMs = commandTimeoutMs;
+    }
+
+    /**
+     * Connects to the standalone Redis instance described by the given connection settings.
+     *
+     * @param conn the connection settings; cluster mode must already have been rejected by the caller
+     * @param clientName the name to report through {@code CLIENT SETNAME}
+     * @return a connected client
+     * @throws RedisClientConnectionException if the connection could not be established
+     */
+    static RedisClient create(RedisConnection conn, String clientName) {
+        // Lettuce standalone connects to a single node; if multiple addresses are provided, use the first.
+        String firstAddress = conn.address.split(",")[0].trim();
+        if (conn.address.contains(",")) {
+            LOGGER.warn("Multiple Redis addresses provided but Lettuce cluster mode is not supported; using the first address: {}", firstAddress);
+        }
+        int separatorIndex = firstAddress.lastIndexOf(':');
+        String host = firstAddress.substring(0, separatorIndex);
+        int port = Integer.parseInt(firstAddress.substring(separatorIndex + 1));
+
+        // RedisURI.timeout is Lettuce's *command* timeout, which is the counterpart of the Jedis socket
+        // timeout; the connect timeout is configured separately through SocketOptions below.
+        RedisURI.Builder uriBuilder = RedisURI.builder()
+                .withHost(host)
+                .withPort(port)
+                .withDatabase(conn.dbIndex)
+                .withTimeout(Duration.ofMillis(conn.socketTimeout))
+                .withSsl(conn.sslEnabled);
+
+        if (conn.sslEnabled) {
+            // Mirror the Jedis behaviour: full hostname verification when enabled, otherwise CA-only verification.
+            uriBuilder.withVerifyPeer(conn.hostnameVerificationEnabled ? SslVerifyMode.FULL : SslVerifyMode.CA);
+        }
+
+        if (!Strings.isNullOrEmpty(conn.user) && !Strings.isNullOrEmpty(conn.password)) {
+            uriBuilder.withAuthentication(conn.user, conn.password.toCharArray());
+        }
+        else if (!Strings.isNullOrEmpty(conn.password)) {
+            uriBuilder.withPassword(conn.password.toCharArray());
+        }
+
+        ClientOptions.Builder optionsBuilder = ClientOptions.builder()
+                .socketOptions(SocketOptions.builder().connectTimeout(Duration.ofMillis(conn.connectionTimeout)).build());
+
+        if (conn.sslEnabled && (!Strings.isNullOrEmpty(conn.truststorePath) || !Strings.isNullOrEmpty(conn.keystorePath))) {
+            // Lettuce derives the store type (JKS/PKCS12) from the file itself, so the *.type properties are not applied here.
+            SslOptions.Builder sslBuilder = SslOptions.builder();
+            if (!Strings.isNullOrEmpty(conn.truststorePath)) {
+                sslBuilder.truststore(new File(conn.truststorePath), conn.truststorePassword);
+            }
+            if (!Strings.isNullOrEmpty(conn.keystorePath)) {
+                char[] ksPassword = !Strings.isNullOrEmpty(conn.keystorePassword) ? conn.keystorePassword.toCharArray() : null;
+                sslBuilder.keystore(new File(conn.keystorePath), ksPassword);
+            }
+            optionsBuilder.sslOptions(sslBuilder.build());
+        }
+
+        io.lettuce.core.RedisClient lettuceClient = io.lettuce.core.RedisClient.create(uriBuilder.build());
+        lettuceClient.setOptions(optionsBuilder.build());
+
+        try {
+            StatefulRedisConnection<String, String> connection = lettuceClient.connect();
+
+            // make sure that the client is connected
+            connection.sync().ping();
+
+            try {
+                connection.sync().clientSetname(clientName);
+            }
+            catch (RedisException e) {
+                LOGGER.warn("Failed to set client name", e);
+            }
+
+            return new LettuceClient(lettuceClient, connection, conn.socketTimeout);
+        }
+        catch (RedisException e) {
+            lettuceClient.shutdown(SHUTDOWN_QUIET_PERIOD, SHUTDOWN_TIMEOUT);
+            throw new RedisClientConnectionException(e);
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        tryErrors(() -> {
+            connection.close();
+            client.shutdown(SHUTDOWN_QUIET_PERIOD, SHUTDOWN_TIMEOUT);
+        });
+    }
+
+    @Override
+    public String xadd(String key, Map<String, String> hash) {
+        return tryErrors(() -> commands.xadd(key, hash));
+    }
+
+    @Override
+    public List<String> xadd(List<SimpleEntry<String, Map<String, String>>> hashes) {
+        RedisAsyncCommands<String, String> async = connection.async();
+        try {
+            // Make sure the connection is still alive before pipelining
+            // to reduce the chance of ending up with duplicate records
+            commands.ping();
+            async.setAutoFlushCommands(false);
+            List<RedisFuture<String>> futures = new ArrayList<>(hashes.size());
+            for (SimpleEntry<String, Map<String, String>> hash : hashes) {
+                futures.add(async.xadd(hash.getKey(), hash.getValue()));
+            }
+            // Write all buffered commands to the transport in a single batch
+            async.flushCommands();
+
+            long batchTimeoutMs = batchTimeoutMs(commandTimeoutMs, hashes.size());
+
+            // awaitAll neither cancels the futures nor throws on timeout, and futures produced by the async
+            // API carry no timeout of their own, so reading them back after a timeout would block forever.
+            if (!LettuceFutures.awaitAll(batchTimeoutMs, TimeUnit.MILLISECONDS, futures.toArray(new RedisFuture[0]))) {
+                throw new RedisCommandTimeoutException(
+                        "Pipelined XADD of " + hashes.size() + " entries did not complete within " + batchTimeoutMs + " ms");
+            }
+
+            List<String> ids = new ArrayList<>(futures.size());
+            for (RedisFuture<String> future : futures) {
+                ids.add(future.get());
+            }
+            return ids;
+        }
+        catch (RedisCommandExecutionException e) {
+            // When Redis is starting, an error with this message is returned. We will retry communicating
+            // with the target DB as once Redis is available, this message will be gone.
+            // awaitAll unwraps command failures, so they surface here rather than as an ExecutionException.
+            if (e.getMessage() != null && e.getMessage().contains(LOADING_MESSAGE)) {
+                LOGGER.error("Redis is starting", e);
+                return Collections.emptyList();
+            }
+            LOGGER.error("Unexpected error during pipelined xadd", e);
+            throw new DebeziumException(e);
+        }
+        catch (RedisException e) {
+            throw new RedisClientConnectionException(e);
+        }
+        catch (ExecutionException e) {
+            LOGGER.error("Unexpected error during pipelined xadd", e);
+            throw new DebeziumException(e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DebeziumException(e);
+        }
+        finally {
+            async.setAutoFlushCommands(true);
+        }
+    }
+
+    @Override
+    public List<Map<String, String>> xrange(String key) {
+        return tryErrors(() -> commands.xrange(key, Range.unbounded())
+                .stream()
+                .map(StreamMessage::getBody)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public long xlen(String key) {
+        return tryErrors(() -> commands.xlen(key));
+    }
+
+    @Override
+    public Map<String, String> hgetAll(String key) {
+        return tryErrors(() -> commands.hgetall(key));
+    }
+
+    @Override
+    public long hset(byte[] key, byte[] field, byte[] value) {
+        // Issued on the same connection as WAIT on purpose; see the class javadoc.
+        // Lettuce returns Boolean (true when a new field was created); the contract expects the
+        // number of added fields, matching Jedis semantics.
+        return tryErrors(() -> Boolean.TRUE.equals(commands.hset(utf8(key), utf8(field), utf8(value))) ? 1L : 0L);
+    }
+
+    /**
+     * {@code awaitAll} spends a single budget across the whole batch, whereas the Jedis socket timeout that
+     * {@code commandTimeoutMs} comes from applies to each response read. Scaling by the batch size keeps the
+     * two drivers comparable; without it a batch of more than a handful of entries would time out well
+     * before Jedis would have.
+     *
+     * @param commandTimeoutMs the per-command timeout, i.e. {@code redis.socket.timeout.ms}
+     * @param batchSize the number of pipelined commands
+     * @return the budget for the whole batch, never smaller than a single command's timeout
+     */
+    static long batchTimeoutMs(long commandTimeoutMs, int batchSize) {
+        // Math.max keeps a pathological configuration from overflowing into a negative (immediately
+        // exhausted) budget, and also covers the empty batch.
+        return Math.max(commandTimeoutMs, commandTimeoutMs * Math.max(1, batchSize));
+    }
+
+    private static String utf8(byte[] bytes) {
+        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public long waitReplicas(int replicas, long timeout) {
+        // Must run on the connection that issued the preceding write; see the class javadoc.
+        return tryErrors(() -> commands.waitForReplication(replicas, timeout));
+    }
+
+    @Override
+    public String info(String section) {
+        return tryErrors(() -> commands.info(section));
+    }
+
+    @Override
+    public String clientList() {
+        return tryErrors(() -> commands.clientList());
+    }
+
+    @Override
+    public String toString() {
+        return "LettuceClient [client=" + client + "]";
+    }
+
+    private void tryErrors(Runnable runnable) {
+        tryErrors(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    private <R> R tryErrors(Supplier<R> supplier) {
+        try {
+            return supplier.get();
+        }
+        catch (RedisCommandExecutionException e) {
+            // Errors returned by the server (WRONGTYPE, NOAUTH, OOM, ...) are not connection failures and
+            // must not trigger the reconnect paths that RedisClientConnectionException drives. JedisClient
+            // draws the same line: it maps JedisConnectionException only and lets JedisDataException through.
+            throw e;
+        }
+        catch (RedisException e) {
+            // Covers RedisConnectionException, RedisCommandTimeoutException and the plain RedisException
+            // that Lettuce raises when dispatching on a closed connection.
+            throw new RedisClientConnectionException(e);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.storage.redis;
 
+import java.io.File;
+import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,14 +21,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.Strings;
+import io.lettuce.core.ClientOptions;
 import io.lettuce.core.LettuceFutures;
 import io.lettuce.core.Range;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCommandTimeoutException;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisFuture;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.SslOptions;
+import io.lettuce.core.SslVerifyMode;
 import io.lettuce.core.StreamMessage;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.ByteArrayCodec;
 
 /**
  * A {@link RedisClient} implementation backed by the <a href="https://github.com/redis/lettuce">Lettuce</a>
@@ -36,12 +47,21 @@ import io.lettuce.core.api.sync.RedisCommands;
  * {@code String}-based commands with a single {@code byte[]}-based {@link #hset(byte[], byte[], byte[])}.
  * For that reason this client holds two connections: a UTF-8 string connection for the stream/hash read
  * commands and a byte-array connection dedicated to {@code hset}.
+ * <p>
+ * {@code lettuce-core} is an optional dependency of this module, so this class is the only place that
+ * references Lettuce types, including the connection setup in {@link #create(RedisConnection, String)}.
  */
 public class LettuceClient implements RedisClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LettuceClient.class);
 
     private static final String LOADING_MESSAGE = "LOADING";
+
+    /**
+     * Shutdown quiet period; the Lettuce default of 2 seconds would needlessly delay connector shutdown.
+     */
+    private static final Duration SHUTDOWN_QUIET_PERIOD = Duration.ZERO;
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(2);
 
     private final io.lettuce.core.RedisClient client;
     private final StatefulRedisConnection<String, String> stringConnection;
@@ -62,6 +82,86 @@ public class LettuceClient implements RedisClient {
         this.commandTimeoutMs = commandTimeoutMs;
     }
 
+    /**
+     * Connects to the standalone Redis instance described by the given connection settings.
+     *
+     * @param conn the connection settings; cluster mode must already have been rejected by the caller
+     * @param clientName the name to report through {@code CLIENT SETNAME}
+     * @return a connected client
+     * @throws RedisClientConnectionException if the connection could not be established
+     */
+    static RedisClient create(RedisConnection conn, String clientName) {
+        // Lettuce standalone connects to a single node; if multiple addresses are provided, use the first.
+        String firstAddress = conn.address.split(",")[0].trim();
+        if (conn.address.contains(",")) {
+            LOGGER.warn("Multiple Redis addresses provided but Lettuce cluster mode is not supported; using the first address: {}", firstAddress);
+        }
+        int separatorIndex = firstAddress.lastIndexOf(':');
+        String host = firstAddress.substring(0, separatorIndex);
+        int port = Integer.parseInt(firstAddress.substring(separatorIndex + 1));
+
+        // RedisURI.timeout is Lettuce's *command* timeout, which is the counterpart of the Jedis socket
+        // timeout; the connect timeout is configured separately through SocketOptions below.
+        RedisURI.Builder uriBuilder = RedisURI.builder()
+                .withHost(host)
+                .withPort(port)
+                .withDatabase(conn.dbIndex)
+                .withTimeout(Duration.ofMillis(conn.socketTimeout))
+                .withSsl(conn.sslEnabled);
+
+        if (conn.sslEnabled) {
+            // Mirror the Jedis behaviour: full hostname verification when enabled, otherwise CA-only verification.
+            uriBuilder.withVerifyPeer(conn.hostnameVerificationEnabled ? SslVerifyMode.FULL : SslVerifyMode.CA);
+        }
+
+        if (!Strings.isNullOrEmpty(conn.user) && !Strings.isNullOrEmpty(conn.password)) {
+            uriBuilder.withAuthentication(conn.user, conn.password.toCharArray());
+        }
+        else if (!Strings.isNullOrEmpty(conn.password)) {
+            uriBuilder.withPassword(conn.password.toCharArray());
+        }
+
+        ClientOptions.Builder optionsBuilder = ClientOptions.builder()
+                .socketOptions(SocketOptions.builder().connectTimeout(Duration.ofMillis(conn.connectionTimeout)).build());
+
+        if (conn.sslEnabled && (!Strings.isNullOrEmpty(conn.truststorePath) || !Strings.isNullOrEmpty(conn.keystorePath))) {
+            // Lettuce derives the store type (JKS/PKCS12) from the file itself, so the *.type properties are not applied here.
+            SslOptions.Builder sslBuilder = SslOptions.builder();
+            if (!Strings.isNullOrEmpty(conn.truststorePath)) {
+                sslBuilder.truststore(new File(conn.truststorePath), conn.truststorePassword);
+            }
+            if (!Strings.isNullOrEmpty(conn.keystorePath)) {
+                char[] ksPassword = !Strings.isNullOrEmpty(conn.keystorePassword) ? conn.keystorePassword.toCharArray() : null;
+                sslBuilder.keystore(new File(conn.keystorePath), ksPassword);
+            }
+            optionsBuilder.sslOptions(sslBuilder.build());
+        }
+
+        io.lettuce.core.RedisClient lettuceClient = io.lettuce.core.RedisClient.create(uriBuilder.build());
+        lettuceClient.setOptions(optionsBuilder.build());
+
+        try {
+            StatefulRedisConnection<String, String> stringConnection = lettuceClient.connect();
+            StatefulRedisConnection<byte[], byte[]> byteConnection = lettuceClient.connect(ByteArrayCodec.INSTANCE);
+
+            // make sure that the client is connected
+            stringConnection.sync().ping();
+
+            try {
+                stringConnection.sync().clientSetname(clientName);
+            }
+            catch (RedisException e) {
+                LOGGER.warn("Failed to set client name", e);
+            }
+
+            return new LettuceClient(lettuceClient, stringConnection, byteConnection, conn.socketTimeout);
+        }
+        catch (RedisException e) {
+            lettuceClient.shutdown(SHUTDOWN_QUIET_PERIOD, SHUTDOWN_TIMEOUT);
+            throw new RedisClientConnectionException(e);
+        }
+    }
+
     @Override
     public void disconnect() {
         close();
@@ -72,7 +172,7 @@ public class LettuceClient implements RedisClient {
         tryErrors(() -> {
             stringConnection.close();
             byteConnection.close();
-            client.shutdown();
+            client.shutdown(SHUTDOWN_QUIET_PERIOD, SHUTDOWN_TIMEOUT);
         });
     }
 
@@ -83,48 +183,56 @@ public class LettuceClient implements RedisClient {
 
     @Override
     public List<String> xadd(List<SimpleEntry<String, Map<String, String>>> hashes) {
-        return tryErrors(() -> {
-            RedisAsyncCommands<String, String> async = stringConnection.async();
-            try {
-                // Make sure the connection is still alive before pipelining
-                // to reduce the chance of ending up with duplicate records
-                commands.ping();
-                async.setAutoFlushCommands(false);
-                List<RedisFuture<String>> futures = new ArrayList<>(hashes.size());
-                for (SimpleEntry<String, Map<String, String>> hash : hashes) {
-                    futures.add(async.xadd(hash.getKey(), hash.getValue()));
-                }
-                // Write all buffered commands to the transport in a single batch
-                async.flushCommands();
-                LettuceFutures.awaitAll(commandTimeoutMs, TimeUnit.MILLISECONDS, futures.toArray(new RedisFuture[0]));
+        RedisAsyncCommands<String, String> async = stringConnection.async();
+        try {
+            // Make sure the connection is still alive before pipelining
+            // to reduce the chance of ending up with duplicate records
+            commands.ping();
+            async.setAutoFlushCommands(false);
+            List<RedisFuture<String>> futures = new ArrayList<>(hashes.size());
+            for (SimpleEntry<String, Map<String, String>> hash : hashes) {
+                futures.add(async.xadd(hash.getKey(), hash.getValue()));
+            }
+            // Write all buffered commands to the transport in a single batch
+            async.flushCommands();
 
-                List<String> ids = new ArrayList<>(futures.size());
-                for (RedisFuture<String> future : futures) {
-                    ids.add(future.get());
-                }
-                return ids;
+            // awaitAll neither cancels the futures nor throws on timeout, and futures produced by the async
+            // API carry no timeout of their own, so reading them back after a timeout would block forever.
+            if (!LettuceFutures.awaitAll(commandTimeoutMs, TimeUnit.MILLISECONDS, futures.toArray(new RedisFuture[0]))) {
+                throw new RedisCommandTimeoutException("Pipelined XADD of " + hashes.size() + " entries did not complete within " + commandTimeoutMs + " ms");
             }
-            catch (ExecutionException ee) {
-                Throwable cause = ee.getCause();
-                // When Redis is starting, an error with this message is returned.
-                // We will retry communicating with the target DB as once Redis is available, this message will be gone.
-                if (cause != null && cause.getMessage() != null && cause.getMessage().contains(LOADING_MESSAGE)) {
-                    LOGGER.error("Redis is starting", cause);
-                }
-                else {
-                    LOGGER.error("Unexpected error during pipelined xadd", ee);
-                    throw new DebeziumException(ee);
-                }
+
+            List<String> ids = new ArrayList<>(futures.size());
+            for (RedisFuture<String> future : futures) {
+                ids.add(future.get());
             }
-            catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new DebeziumException(ie);
+            return ids;
+        }
+        catch (RedisCommandExecutionException e) {
+            // When Redis is starting, an error with this message is returned. We will retry communicating
+            // with the target DB as once Redis is available, this message will be gone.
+            // awaitAll unwraps command failures, so they surface here rather than as an ExecutionException.
+            if (e.getMessage() != null && e.getMessage().contains(LOADING_MESSAGE)) {
+                LOGGER.error("Redis is starting", e);
+                return Collections.emptyList();
             }
-            finally {
-                async.setAutoFlushCommands(true);
-            }
-            return Collections.emptyList();
-        });
+            LOGGER.error("Unexpected error during pipelined xadd", e);
+            throw new DebeziumException(e);
+        }
+        catch (RedisException e) {
+            throw new RedisClientConnectionException(e);
+        }
+        catch (ExecutionException e) {
+            LOGGER.error("Unexpected error during pipelined xadd", e);
+            throw new DebeziumException(e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DebeziumException(e);
+        }
+        finally {
+            async.setAutoFlushCommands(true);
+        }
     }
 
     @Override
@@ -183,7 +291,15 @@ public class LettuceClient implements RedisClient {
         try {
             return supplier.get();
         }
+        catch (RedisCommandExecutionException e) {
+            // Errors returned by the server (WRONGTYPE, NOAUTH, OOM, ...) are not connection failures and
+            // must not trigger the reconnect paths that RedisClientConnectionException drives. JedisClient
+            // draws the same line: it maps JedisConnectionException only and lets JedisDataException through.
+            throw e;
+        }
         catch (RedisException e) {
+            // Covers RedisConnectionException, RedisCommandTimeoutException and the plain RedisException
+            // that Lettuce raises when dispatching on a closed connection.
             throw new RedisClientConnectionException(e);
         }
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/LettuceClient.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.lettuce.core.LettuceFutures;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.sync.RedisCommands;
+
+/**
+ * A {@link RedisClient} implementation backed by the <a href="https://github.com/redis/lettuce">Lettuce</a>
+ * driver, used for single (standalone) Redis instances.
+ * <p>
+ * Lettuce fixes the key/value codec per connection, whereas the {@link RedisClient} contract mixes
+ * {@code String}-based commands with a single {@code byte[]}-based {@link #hset(byte[], byte[], byte[])}.
+ * For that reason this client holds two connections: a UTF-8 string connection for the stream/hash read
+ * commands and a byte-array connection dedicated to {@code hset}.
+ */
+public class LettuceClient implements RedisClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LettuceClient.class);
+
+    private static final String LOADING_MESSAGE = "LOADING";
+
+    private final io.lettuce.core.RedisClient client;
+    private final StatefulRedisConnection<String, String> stringConnection;
+    private final StatefulRedisConnection<byte[], byte[]> byteConnection;
+    private final RedisCommands<String, String> commands;
+    private final RedisCommands<byte[], byte[]> byteCommands;
+    private final long commandTimeoutMs;
+
+    public LettuceClient(io.lettuce.core.RedisClient client,
+                         StatefulRedisConnection<String, String> stringConnection,
+                         StatefulRedisConnection<byte[], byte[]> byteConnection,
+                         long commandTimeoutMs) {
+        this.client = client;
+        this.stringConnection = stringConnection;
+        this.byteConnection = byteConnection;
+        this.commands = stringConnection.sync();
+        this.byteCommands = byteConnection.sync();
+        this.commandTimeoutMs = commandTimeoutMs;
+    }
+
+    @Override
+    public void disconnect() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        tryErrors(() -> {
+            stringConnection.close();
+            byteConnection.close();
+            client.shutdown();
+        });
+    }
+
+    @Override
+    public String xadd(String key, Map<String, String> hash) {
+        return tryErrors(() -> commands.xadd(key, hash));
+    }
+
+    @Override
+    public List<String> xadd(List<SimpleEntry<String, Map<String, String>>> hashes) {
+        return tryErrors(() -> {
+            RedisAsyncCommands<String, String> async = stringConnection.async();
+            try {
+                // Make sure the connection is still alive before pipelining
+                // to reduce the chance of ending up with duplicate records
+                commands.ping();
+                async.setAutoFlushCommands(false);
+                List<RedisFuture<String>> futures = new ArrayList<>(hashes.size());
+                for (SimpleEntry<String, Map<String, String>> hash : hashes) {
+                    futures.add(async.xadd(hash.getKey(), hash.getValue()));
+                }
+                // Write all buffered commands to the transport in a single batch
+                async.flushCommands();
+                LettuceFutures.awaitAll(commandTimeoutMs, TimeUnit.MILLISECONDS, futures.toArray(new RedisFuture[0]));
+
+                List<String> ids = new ArrayList<>(futures.size());
+                for (RedisFuture<String> future : futures) {
+                    ids.add(future.get());
+                }
+                return ids;
+            }
+            catch (ExecutionException ee) {
+                Throwable cause = ee.getCause();
+                // When Redis is starting, an error with this message is returned.
+                // We will retry communicating with the target DB as once Redis is available, this message will be gone.
+                if (cause != null && cause.getMessage() != null && cause.getMessage().contains(LOADING_MESSAGE)) {
+                    LOGGER.error("Redis is starting", cause);
+                }
+                else {
+                    LOGGER.error("Unexpected error during pipelined xadd", ee);
+                    throw new DebeziumException(ee);
+                }
+            }
+            catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new DebeziumException(ie);
+            }
+            finally {
+                async.setAutoFlushCommands(true);
+            }
+            return Collections.emptyList();
+        });
+    }
+
+    @Override
+    public List<Map<String, String>> xrange(String key) {
+        return tryErrors(() -> commands.xrange(key, Range.unbounded())
+                .stream()
+                .map(StreamMessage::getBody)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public long xlen(String key) {
+        return tryErrors(() -> commands.xlen(key));
+    }
+
+    @Override
+    public Map<String, String> hgetAll(String key) {
+        return tryErrors(() -> commands.hgetall(key));
+    }
+
+    @Override
+    public long hset(byte[] key, byte[] field, byte[] value) {
+        // Lettuce returns Boolean (true when a new field was created); the contract expects the
+        // number of added fields, matching Jedis semantics.
+        return tryErrors(() -> Boolean.TRUE.equals(byteCommands.hset(key, field, value)) ? 1L : 0L);
+    }
+
+    @Override
+    public long waitReplicas(int replicas, long timeout) {
+        return tryErrors(() -> commands.waitForReplication(replicas, timeout));
+    }
+
+    @Override
+    public String info(String section) {
+        return tryErrors(() -> commands.info(section));
+    }
+
+    @Override
+    public String clientList() {
+        return tryErrors(() -> commands.clientList());
+    }
+
+    @Override
+    public String toString() {
+        return "LettuceClient [client=" + client + "]";
+    }
+
+    private void tryErrors(Runnable runnable) {
+        tryErrors(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    private <R> R tryErrors(Supplier<R> supplier) {
+        try {
+            return supplier.get();
+        }
+        catch (RedisException e) {
+            throw new RedisClientConnectionException(e);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisClientLibrary.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisClientLibrary.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import io.debezium.config.EnumeratedValue;
+
+/**
+ * The Redis driver library used to communicate with Redis.
+ */
+public enum RedisClientLibrary implements EnumeratedValue {
+
+    /**
+     * Use the Jedis driver. Supports both single instance and cluster mode.
+     */
+    JEDIS("jedis"),
+
+    /**
+     * Use the Lettuce driver. Supports single instance mode only and requires
+     * {@code io.lettuce:lettuce-core} on the classpath.
+     */
+    LETTUCE("lettuce");
+
+    private final String value;
+
+    RedisClientLibrary(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Determine the library matching the given value.
+     *
+     * @param value the configuration property value; may be null
+     * @return the matching library, or null if no match was found
+     */
+    public static RedisClientLibrary parse(String value) {
+        if (value == null) {
+            return null;
+        }
+        for (RedisClientLibrary option : values()) {
+            if (option.getValue().equalsIgnoreCase(value.trim())) {
+                return option;
+            }
+        }
+        return null;
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -131,6 +131,12 @@ public class RedisCommonConfig {
             .withDescription("Enable Redis Cluster mode; when true, a JedisCluster client will be created. Single or comma-separated host:port addresses are accepted.")
             .withDefault(DEFAULT_CLUSTER_ENABLED);
 
+    // Client driver library selection
+    private static final Field PROP_CLIENT_LIBRARY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "client.library")
+            .withDescription("The Redis client driver library to use; the 'lettuce' driver supports single instance mode only "
+                    + "and requires io.lettuce:lettuce-core on the classpath.")
+            .withEnum(RedisClientLibrary.class, RedisClientLibrary.JEDIS);
+
     private String address;
     private int dbIndex;
     private String user;
@@ -158,6 +164,7 @@ public class RedisCommonConfig {
     private long waitRetryDelay;
 
     private boolean clusterEnabled;
+    private RedisClientLibrary clientLibrary;
 
     public RedisCommonConfig() {
         // Intentionally blank
@@ -183,7 +190,7 @@ public class RedisCommonConfig {
                 PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
                 PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY,
                 PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY,
-                PROP_CLUSTER_ENABLED);
+                PROP_CLUSTER_ENABLED, PROP_CLIENT_LIBRARY);
     }
 
     protected void init(Configuration config) {
@@ -214,6 +221,8 @@ public class RedisCommonConfig {
         waitRetryDelay = config.getLong(PROP_WAIT_RETRY_DELAY);
 
         clusterEnabled = config.getBoolean(PROP_CLUSTER_ENABLED);
+
+        clientLibrary = RedisClientLibrary.parse(config.getString(PROP_CLIENT_LIBRARY));
     }
 
     public String getPassword() {
@@ -306,5 +315,9 @@ public class RedisCommonConfig {
 
     public boolean isClusterEnabled() {
         return clusterEnabled;
+    }
+
+    public RedisClientLibrary getClientLibrary() {
+        return clientLibrary;
     }
 }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -132,23 +132,10 @@ public class RedisCommonConfig {
             .withDefault(DEFAULT_CLUSTER_ENABLED);
 
     // Client driver library selection
-    public static final String CLIENT_LIBRARY_JEDIS = "jedis";
-    public static final String CLIENT_LIBRARY_LETTUCE = "lettuce";
-    private static final String DEFAULT_CLIENT_LIBRARY = CLIENT_LIBRARY_JEDIS;
     private static final Field PROP_CLIENT_LIBRARY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "client.library")
-            .withDescription("The Redis client driver library to use: 'jedis' (default) or 'lettuce'.")
-            .withAllowedValues(Collect.unmodifiableSet(CLIENT_LIBRARY_JEDIS, CLIENT_LIBRARY_LETTUCE))
-            .withValidation(RedisCommonConfig::validateClientLibrary)
-            .withDefault(DEFAULT_CLIENT_LIBRARY);
-
-    private static int validateClientLibrary(Configuration config, Field field, Field.ValidationOutput problems) {
-        String value = config.getString(field);
-        if (value != null && !CLIENT_LIBRARY_JEDIS.equalsIgnoreCase(value) && !CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(value)) {
-            problems.accept(field, value, "Value must be one of " + CLIENT_LIBRARY_JEDIS + ", " + CLIENT_LIBRARY_LETTUCE);
-            return 1;
-        }
-        return 0;
-    }
+            .withDescription("The Redis client driver library to use; the 'lettuce' driver supports single instance mode only "
+                    + "and requires io.lettuce:lettuce-core on the classpath.")
+            .withEnum(RedisClientLibrary.class, RedisClientLibrary.JEDIS);
 
     private String address;
     private int dbIndex;
@@ -177,7 +164,7 @@ public class RedisCommonConfig {
     private long waitRetryDelay;
 
     private boolean clusterEnabled;
-    private String clientLibrary;
+    private RedisClientLibrary clientLibrary;
 
     public RedisCommonConfig() {
         // Intentionally blank
@@ -235,7 +222,7 @@ public class RedisCommonConfig {
 
         clusterEnabled = config.getBoolean(PROP_CLUSTER_ENABLED);
 
-        clientLibrary = config.getString(PROP_CLIENT_LIBRARY);
+        clientLibrary = RedisClientLibrary.parse(config.getString(PROP_CLIENT_LIBRARY));
     }
 
     public String getPassword() {
@@ -330,11 +317,7 @@ public class RedisCommonConfig {
         return clusterEnabled;
     }
 
-    public String getClientLibrary() {
+    public RedisClientLibrary getClientLibrary() {
         return clientLibrary;
-    }
-
-    public boolean isLettuceEnabled() {
-        return CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(clientLibrary);
     }
 }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -131,6 +131,25 @@ public class RedisCommonConfig {
             .withDescription("Enable Redis Cluster mode; when true, a JedisCluster client will be created. Single or comma-separated host:port addresses are accepted.")
             .withDefault(DEFAULT_CLUSTER_ENABLED);
 
+    // Client driver library selection
+    public static final String CLIENT_LIBRARY_JEDIS = "jedis";
+    public static final String CLIENT_LIBRARY_LETTUCE = "lettuce";
+    private static final String DEFAULT_CLIENT_LIBRARY = CLIENT_LIBRARY_JEDIS;
+    private static final Field PROP_CLIENT_LIBRARY = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "client.library")
+            .withDescription("The Redis client driver library to use: 'jedis' (default) or 'lettuce'.")
+            .withAllowedValues(Collect.unmodifiableSet(CLIENT_LIBRARY_JEDIS, CLIENT_LIBRARY_LETTUCE))
+            .withValidation(RedisCommonConfig::validateClientLibrary)
+            .withDefault(DEFAULT_CLIENT_LIBRARY);
+
+    private static int validateClientLibrary(Configuration config, Field field, Field.ValidationOutput problems) {
+        String value = config.getString(field);
+        if (value != null && !CLIENT_LIBRARY_JEDIS.equalsIgnoreCase(value) && !CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(value)) {
+            problems.accept(field, value, "Value must be one of " + CLIENT_LIBRARY_JEDIS + ", " + CLIENT_LIBRARY_LETTUCE);
+            return 1;
+        }
+        return 0;
+    }
+
     private String address;
     private int dbIndex;
     private String user;
@@ -158,6 +177,7 @@ public class RedisCommonConfig {
     private long waitRetryDelay;
 
     private boolean clusterEnabled;
+    private String clientLibrary;
 
     public RedisCommonConfig() {
         // Intentionally blank
@@ -183,7 +203,7 @@ public class RedisCommonConfig {
                 PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
                 PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY,
                 PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY,
-                PROP_CLUSTER_ENABLED);
+                PROP_CLUSTER_ENABLED, PROP_CLIENT_LIBRARY);
     }
 
     protected void init(Configuration config) {
@@ -214,6 +234,8 @@ public class RedisCommonConfig {
         waitRetryDelay = config.getLong(PROP_WAIT_RETRY_DELAY);
 
         clusterEnabled = config.getBoolean(PROP_CLUSTER_ENABLED);
+
+        clientLibrary = config.getString(PROP_CLIENT_LIBRARY);
     }
 
     public String getPassword() {
@@ -306,5 +328,13 @@ public class RedisCommonConfig {
 
     public boolean isClusterEnabled() {
         return clusterEnabled;
+    }
+
+    public String getClientLibrary() {
+        return clientLibrary;
+    }
+
+    public boolean isLettuceEnabled() {
+        return CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(clientLibrary);
     }
 }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -36,22 +36,27 @@ public class RedisConnection {
     public static final String DEBEZIUM_OFFSETS_CLIENT_NAME = "debezium:offsets";
     public static final String DEBEZIUM_SCHEMA_HISTORY = "debezium:schema_history";
     private static final String HOST_PORT_ERROR = "Invalid host:port format in '<...>.redis.address' property.";
+    private static final String LETTUCE_DRIVER_CLASS = "io.lettuce.core.RedisClient";
+    private static final String LETTUCE_DRIVER_ARTIFACT = "io.lettuce:lettuce-core";
 
-    private final String address;
-    private final int dbIndex;
-    private final String user;
-    private final String password;
-    private final int connectionTimeout;
-    private final int socketTimeout;
-    private final boolean sslEnabled;
-    private final boolean hostnameVerificationEnabled;
-    private final boolean clusterEnabled;
-    private final String truststorePath;
-    private final String truststorePassword;
-    private final String truststoreType;
-    private final String keystorePath;
-    private final String keystorePassword;
-    private final String keystoreType;
+    // Package private so that the driver-specific client factories in this package can read the
+    // connection settings without this class having to reference their (possibly absent) driver types.
+    final String address;
+    final int dbIndex;
+    final String user;
+    final String password;
+    final int connectionTimeout;
+    final int socketTimeout;
+    final boolean sslEnabled;
+    final boolean hostnameVerificationEnabled;
+    final boolean clusterEnabled;
+    final RedisClientLibrary clientLibrary;
+    final String truststorePath;
+    final String truststorePassword;
+    final String truststoreType;
+    final String keystorePath;
+    final String keystorePassword;
+    final String keystoreType;
 
     /**
      *
@@ -108,6 +113,14 @@ public class RedisConnection {
     public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
                            boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
                            String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled) {
+        this(address, dbIndex, user, password, connectionTimeout, socketTimeout, sslEnabled, hostnameVerificationEnabled,
+                truststorePath, truststorePassword, truststoreType, keystorePath, keystorePassword, keystoreType, clusterEnabled,
+                RedisClientLibrary.JEDIS);
+    }
+
+    public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
+                           boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
+                           String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled, RedisClientLibrary clientLibrary) {
         validateHostPort(address);
 
         this.address = address;
@@ -119,6 +132,7 @@ public class RedisConnection {
         this.sslEnabled = sslEnabled;
         this.hostnameVerificationEnabled = hostnameVerificationEnabled;
         this.clusterEnabled = clusterEnabled;
+        this.clientLibrary = clientLibrary;
         this.truststorePath = truststorePath;
         this.truststorePassword = truststorePassword;
         this.truststoreType = truststoreType;
@@ -149,7 +163,8 @@ public class RedisConnection {
                 config.getKeystorePath(),
                 config.getKeystorePassword(),
                 config.getKeystoreType(),
-                config.isClusterEnabled());
+                config.isClusterEnabled(),
+                config.getClientLibrary());
     }
 
     /**
@@ -167,6 +182,53 @@ public class RedisConnection {
             throw new DebeziumException("Redis client wait timeout should be positive");
         }
 
+        // Use config-driven driver selection; when 'lettuce' is requested, a Lettuce-backed client is created.
+        if (RedisClientLibrary.LETTUCE == this.clientLibrary) {
+            return createLettuceClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
+        }
+        return createJedisClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
+    }
+
+    /**
+     * Creates a Lettuce-backed client. {@code lettuce-core} is a provided dependency of this module, so
+     * every Lettuce type stays inside {@link LettuceClient}; this method must not reference any of them
+     * directly, otherwise loading this class would fail when the driver is absent.
+     */
+    private RedisClient createLettuceClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
+        if (this.clusterEnabled) {
+            throw new DebeziumException(
+                    "The Lettuce client does not yet support Redis Cluster mode; use the Jedis client (redis.client.library=jedis) for cluster mode.");
+        }
+
+        requireLettuceDriver(getClass().getClassLoader());
+
+        RedisClient lettuce = LettuceClient.create(this, clientName);
+        // Use WAIT wrapper only for standalone
+        RedisClient redisClient = waitEnabled ? new WaitReplicasRedisClient(lettuce, 1, waitTimeout, waitRetry, waitRetryDelay) : lettuce;
+        LOGGER.info("Using Redis client '{}'", redisClient);
+        return redisClient;
+    }
+
+    /**
+     * Fails fast with an actionable message when the Lettuce driver was requested but is not on the
+     * classpath, instead of letting a {@link NoClassDefFoundError} escape from deep inside
+     * {@link LettuceClient}. The distribution archive deliberately does not bundle the driver.
+     *
+     * <p>Package private, and taking the class loader as an argument, so that a test can supply one that
+     * hides the driver.
+     */
+    static void requireLettuceDriver(ClassLoader classLoader) {
+        try {
+            Class.forName(LETTUCE_DRIVER_CLASS, false, classLoader);
+        }
+        catch (ClassNotFoundException e) {
+            throw new DebeziumException("redis.client.library=lettuce requires '" + LETTUCE_DRIVER_ARTIFACT
+                    + "' on the runtime classpath, which the Debezium distribution does not bundle. Add it together with its "
+                    + "Netty and Reactor dependencies, or set redis.client.library=jedis.", e);
+        }
+    }
+
+    private RedisClient createJedisClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
         // Use config-driven cluster mode; when enabled, a JedisCluster client is created.
         boolean isCluster = this.clusterEnabled;
 

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -6,6 +6,7 @@
 package io.debezium.storage.redis;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLParameters;
@@ -15,6 +16,11 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.util.Strings;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisClientConfig.Builder;
@@ -46,6 +52,7 @@ public class RedisConnection {
     private final boolean sslEnabled;
     private final boolean hostnameVerificationEnabled;
     private final boolean clusterEnabled;
+    private final String clientLibrary;
     private final String truststorePath;
     private final String truststorePassword;
     private final String truststoreType;
@@ -108,6 +115,14 @@ public class RedisConnection {
     public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
                            boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
                            String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled) {
+        this(address, dbIndex, user, password, connectionTimeout, socketTimeout, sslEnabled, hostnameVerificationEnabled,
+                truststorePath, truststorePassword, truststoreType, keystorePath, keystorePassword, keystoreType, clusterEnabled,
+                RedisCommonConfig.CLIENT_LIBRARY_JEDIS);
+    }
+
+    public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
+                           boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
+                           String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled, String clientLibrary) {
         validateHostPort(address);
 
         this.address = address;
@@ -119,6 +134,7 @@ public class RedisConnection {
         this.sslEnabled = sslEnabled;
         this.hostnameVerificationEnabled = hostnameVerificationEnabled;
         this.clusterEnabled = clusterEnabled;
+        this.clientLibrary = clientLibrary;
         this.truststorePath = truststorePath;
         this.truststorePassword = truststorePassword;
         this.truststoreType = truststoreType;
@@ -149,7 +165,8 @@ public class RedisConnection {
                 config.getKeystorePath(),
                 config.getKeystorePassword(),
                 config.getKeystoreType(),
-                config.isClusterEnabled());
+                config.isClusterEnabled(),
+                config.getClientLibrary());
     }
 
     /**
@@ -167,6 +184,14 @@ public class RedisConnection {
             throw new DebeziumException("Redis client wait timeout should be positive");
         }
 
+        // Use config-driven driver selection; when 'lettuce' is requested, a Lettuce-backed client is created.
+        if (RedisCommonConfig.CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(this.clientLibrary)) {
+            return createLettuceClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
+        }
+        return createJedisClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
+    }
+
+    private RedisClient createJedisClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
         // Use config-driven cluster mode; when enabled, a JedisCluster client is created.
         boolean isCluster = this.clusterEnabled;
 
@@ -255,6 +280,82 @@ public class RedisConnection {
             }
         }
         catch (JedisConnectionException e) {
+            throw new RedisClientConnectionException(e);
+        }
+    }
+
+    private RedisClient createLettuceClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
+        if (this.clusterEnabled) {
+            throw new DebeziumException(
+                    "The Lettuce client does not yet support Redis Cluster mode; use the Jedis client (redis.client.library=jedis) for cluster mode.");
+        }
+
+        // Lettuce standalone connects to a single node; if multiple addresses are provided, use the first.
+        String firstAddress = this.address.split(",")[0].trim();
+        if (this.address.contains(",")) {
+            LOGGER.warn("Multiple Redis addresses provided but Lettuce cluster mode is not supported; using the first address: {}", firstAddress);
+        }
+        int separatorIndex = firstAddress.lastIndexOf(':');
+        String host = firstAddress.substring(0, separatorIndex);
+        int port = Integer.parseInt(firstAddress.substring(separatorIndex + 1));
+
+        RedisURI.Builder uriBuilder = RedisURI.builder()
+                .withHost(host)
+                .withPort(port)
+                .withDatabase(this.dbIndex)
+                .withTimeout(Duration.ofMillis(this.connectionTimeout))
+                .withSsl(this.sslEnabled);
+
+        if (this.sslEnabled) {
+            // Mirror the Jedis behaviour: full hostname verification when enabled, otherwise CA-only verification.
+            uriBuilder.withVerifyPeer(hostnameVerificationEnabled ? io.lettuce.core.SslVerifyMode.FULL : io.lettuce.core.SslVerifyMode.CA);
+        }
+
+        if (!Strings.isNullOrEmpty(this.user) && !Strings.isNullOrEmpty(this.password)) {
+            uriBuilder.withAuthentication(this.user, this.password.toCharArray());
+        }
+        else if (!Strings.isNullOrEmpty(this.password)) {
+            uriBuilder.withPassword(this.password.toCharArray());
+        }
+
+        io.lettuce.core.RedisClient lettuceClient = io.lettuce.core.RedisClient.create(uriBuilder.build());
+
+        boolean configureSslOptions = this.sslEnabled && (!Strings.isNullOrEmpty(this.truststorePath) || !Strings.isNullOrEmpty(this.keystorePath));
+        if (configureSslOptions) {
+            // Lettuce derives the store type (JKS/PKCS12) from the file itself, so the *.type properties are not applied here.
+            io.lettuce.core.SslOptions.Builder sslBuilder = io.lettuce.core.SslOptions.builder();
+            if (!Strings.isNullOrEmpty(this.truststorePath)) {
+                sslBuilder.truststore(new File(this.truststorePath), this.truststorePassword);
+            }
+            if (!Strings.isNullOrEmpty(this.keystorePath)) {
+                char[] ksPassword = !Strings.isNullOrEmpty(this.keystorePassword) ? this.keystorePassword.toCharArray() : null;
+                sslBuilder.keystore(new File(this.keystorePath), ksPassword);
+            }
+            lettuceClient.setOptions(ClientOptions.builder().sslOptions(sslBuilder.build()).build());
+        }
+
+        try {
+            StatefulRedisConnection<String, String> stringConnection = lettuceClient.connect();
+            StatefulRedisConnection<byte[], byte[]> byteConnection = lettuceClient.connect(ByteArrayCodec.INSTANCE);
+
+            // make sure that the client is connected
+            stringConnection.sync().ping();
+
+            try {
+                stringConnection.sync().clientSetname(clientName);
+            }
+            catch (RedisException e) {
+                LOGGER.warn("Failed to set client name", e);
+            }
+
+            RedisClient lettuce = new LettuceClient(lettuceClient, stringConnection, byteConnection, this.socketTimeout);
+            // Use WAIT wrapper only for standalone
+            RedisClient redisClient = waitEnabled ? new WaitReplicasRedisClient(lettuce, 1, waitTimeout, waitRetry, waitRetryDelay) : lettuce;
+            LOGGER.info("Using Redis client '{}'", redisClient);
+            return redisClient;
+        }
+        catch (RedisException e) {
+            lettuceClient.shutdown();
             throw new RedisClientConnectionException(e);
         }
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -6,7 +6,6 @@
 package io.debezium.storage.redis;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLParameters;
@@ -16,11 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.util.Strings;
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.RedisException;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.codec.ByteArrayCodec;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisClientConfig.Builder;
@@ -43,22 +37,24 @@ public class RedisConnection {
     public static final String DEBEZIUM_SCHEMA_HISTORY = "debezium:schema_history";
     private static final String HOST_PORT_ERROR = "Invalid host:port format in '<...>.redis.address' property.";
 
-    private final String address;
-    private final int dbIndex;
-    private final String user;
-    private final String password;
-    private final int connectionTimeout;
-    private final int socketTimeout;
-    private final boolean sslEnabled;
-    private final boolean hostnameVerificationEnabled;
-    private final boolean clusterEnabled;
-    private final String clientLibrary;
-    private final String truststorePath;
-    private final String truststorePassword;
-    private final String truststoreType;
-    private final String keystorePath;
-    private final String keystorePassword;
-    private final String keystoreType;
+    // Package private so that the driver-specific client factories in this package can read the
+    // connection settings without this class having to reference their (optional) driver types.
+    final String address;
+    final int dbIndex;
+    final String user;
+    final String password;
+    final int connectionTimeout;
+    final int socketTimeout;
+    final boolean sslEnabled;
+    final boolean hostnameVerificationEnabled;
+    final boolean clusterEnabled;
+    final RedisClientLibrary clientLibrary;
+    final String truststorePath;
+    final String truststorePassword;
+    final String truststoreType;
+    final String keystorePath;
+    final String keystorePassword;
+    final String keystoreType;
 
     /**
      *
@@ -117,12 +113,12 @@ public class RedisConnection {
                            String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled) {
         this(address, dbIndex, user, password, connectionTimeout, socketTimeout, sslEnabled, hostnameVerificationEnabled,
                 truststorePath, truststorePassword, truststoreType, keystorePath, keystorePassword, keystoreType, clusterEnabled,
-                RedisCommonConfig.CLIENT_LIBRARY_JEDIS);
+                RedisClientLibrary.JEDIS);
     }
 
     public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
                            boolean hostnameVerificationEnabled, String truststorePath, String truststorePassword, String truststoreType,
-                           String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled, String clientLibrary) {
+                           String keystorePath, String keystorePassword, String keystoreType, boolean clusterEnabled, RedisClientLibrary clientLibrary) {
         validateHostPort(address);
 
         this.address = address;
@@ -185,10 +181,35 @@ public class RedisConnection {
         }
 
         // Use config-driven driver selection; when 'lettuce' is requested, a Lettuce-backed client is created.
-        if (RedisCommonConfig.CLIENT_LIBRARY_LETTUCE.equalsIgnoreCase(this.clientLibrary)) {
+        if (RedisClientLibrary.LETTUCE == this.clientLibrary) {
             return createLettuceClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
         }
         return createJedisClient(clientName, waitEnabled, waitTimeout, waitRetry, waitRetryDelay);
+    }
+
+    /**
+     * Creates a Lettuce-backed client. {@code lettuce-core} is an optional dependency of this module, so
+     * every Lettuce type stays inside {@link LettuceClient}; this method must not reference any of them
+     * directly, otherwise loading this class would fail when the driver is absent.
+     */
+    private RedisClient createLettuceClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
+        if (this.clusterEnabled) {
+            throw new DebeziumException(
+                    "The Lettuce client does not yet support Redis Cluster mode; use the Jedis client (redis.client.library=jedis) for cluster mode.");
+        }
+
+        try {
+            Class.forName("io.lettuce.core.RedisClient", false, getClass().getClassLoader());
+        }
+        catch (ClassNotFoundException e) {
+            throw new DebeziumException("redis.client.library=lettuce requires the optional 'io.lettuce:lettuce-core' dependency on the classpath", e);
+        }
+
+        RedisClient lettuce = LettuceClient.create(this, clientName);
+        // Use WAIT wrapper only for standalone
+        RedisClient redisClient = waitEnabled ? new WaitReplicasRedisClient(lettuce, 1, waitTimeout, waitRetry, waitRetryDelay) : lettuce;
+        LOGGER.info("Using Redis client '{}'", redisClient);
+        return redisClient;
     }
 
     private RedisClient createJedisClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
@@ -280,82 +301,6 @@ public class RedisConnection {
             }
         }
         catch (JedisConnectionException e) {
-            throw new RedisClientConnectionException(e);
-        }
-    }
-
-    private RedisClient createLettuceClient(String clientName, boolean waitEnabled, long waitTimeout, boolean waitRetry, long waitRetryDelay) {
-        if (this.clusterEnabled) {
-            throw new DebeziumException(
-                    "The Lettuce client does not yet support Redis Cluster mode; use the Jedis client (redis.client.library=jedis) for cluster mode.");
-        }
-
-        // Lettuce standalone connects to a single node; if multiple addresses are provided, use the first.
-        String firstAddress = this.address.split(",")[0].trim();
-        if (this.address.contains(",")) {
-            LOGGER.warn("Multiple Redis addresses provided but Lettuce cluster mode is not supported; using the first address: {}", firstAddress);
-        }
-        int separatorIndex = firstAddress.lastIndexOf(':');
-        String host = firstAddress.substring(0, separatorIndex);
-        int port = Integer.parseInt(firstAddress.substring(separatorIndex + 1));
-
-        RedisURI.Builder uriBuilder = RedisURI.builder()
-                .withHost(host)
-                .withPort(port)
-                .withDatabase(this.dbIndex)
-                .withTimeout(Duration.ofMillis(this.connectionTimeout))
-                .withSsl(this.sslEnabled);
-
-        if (this.sslEnabled) {
-            // Mirror the Jedis behaviour: full hostname verification when enabled, otherwise CA-only verification.
-            uriBuilder.withVerifyPeer(hostnameVerificationEnabled ? io.lettuce.core.SslVerifyMode.FULL : io.lettuce.core.SslVerifyMode.CA);
-        }
-
-        if (!Strings.isNullOrEmpty(this.user) && !Strings.isNullOrEmpty(this.password)) {
-            uriBuilder.withAuthentication(this.user, this.password.toCharArray());
-        }
-        else if (!Strings.isNullOrEmpty(this.password)) {
-            uriBuilder.withPassword(this.password.toCharArray());
-        }
-
-        io.lettuce.core.RedisClient lettuceClient = io.lettuce.core.RedisClient.create(uriBuilder.build());
-
-        boolean configureSslOptions = this.sslEnabled && (!Strings.isNullOrEmpty(this.truststorePath) || !Strings.isNullOrEmpty(this.keystorePath));
-        if (configureSslOptions) {
-            // Lettuce derives the store type (JKS/PKCS12) from the file itself, so the *.type properties are not applied here.
-            io.lettuce.core.SslOptions.Builder sslBuilder = io.lettuce.core.SslOptions.builder();
-            if (!Strings.isNullOrEmpty(this.truststorePath)) {
-                sslBuilder.truststore(new File(this.truststorePath), this.truststorePassword);
-            }
-            if (!Strings.isNullOrEmpty(this.keystorePath)) {
-                char[] ksPassword = !Strings.isNullOrEmpty(this.keystorePassword) ? this.keystorePassword.toCharArray() : null;
-                sslBuilder.keystore(new File(this.keystorePath), ksPassword);
-            }
-            lettuceClient.setOptions(ClientOptions.builder().sslOptions(sslBuilder.build()).build());
-        }
-
-        try {
-            StatefulRedisConnection<String, String> stringConnection = lettuceClient.connect();
-            StatefulRedisConnection<byte[], byte[]> byteConnection = lettuceClient.connect(ByteArrayCodec.INSTANCE);
-
-            // make sure that the client is connected
-            stringConnection.sync().ping();
-
-            try {
-                stringConnection.sync().clientSetname(clientName);
-            }
-            catch (RedisException e) {
-                LOGGER.warn("Failed to set client name", e);
-            }
-
-            RedisClient lettuce = new LettuceClient(lettuceClient, stringConnection, byteConnection, this.socketTimeout);
-            // Use WAIT wrapper only for standalone
-            RedisClient redisClient = waitEnabled ? new WaitReplicasRedisClient(lettuce, 1, waitTimeout, waitRetry, waitRetryDelay) : lettuce;
-            LOGGER.info("Using Redis client '{}'", redisClient);
-            return redisClient;
-        }
-        catch (RedisException e) {
-            lettuceClient.shutdown();
             throw new RedisClientConnectionException(e);
         }
     }

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.config.Configuration;
+import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
+
+/**
+ * Integration tests for {@link LettuceClient} against a single (standalone) Redis instance.
+ */
+@Testcontainers
+class LettuceClientIT {
+
+    private static final String REDIS_CONTAINER_IMAGE = "redis:5.0.3-alpine";
+    private static final String PROP_PREFIX = "offset.storage.redis.";
+    private static final String CLIENT_NAME = RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME;
+
+    @Container
+    public GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse(REDIS_CONTAINER_IMAGE))
+            .withExposedPorts(6379);
+
+    private RedisClient client;
+
+    @BeforeEach
+    public void setUp() {
+        redis.start();
+        Map<String, String> props = new HashMap<>();
+        props.put(PROP_PREFIX + "address", redis.getHost() + ":" + redis.getFirstMappedPort());
+        props.put(PROP_PREFIX + "client.library", RedisClientLibrary.LETTUCE.getValue());
+        RedisOffsetBackingStoreConfig config = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        client = RedisConnection.getInstance(config).getRedisClient(CLIENT_NAME, false, 0, false, 0);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+        if (redis != null) {
+            redis.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Lettuce client should be selected when redis.client.library=lettuce")
+    public void shouldCreateLettuceClient() {
+        assertTrue(client instanceof LettuceClient, "Expected a LettuceClient instance but got " + client);
+    }
+
+    @Test
+    @DisplayName("xadd/xrange/xlen round-trip on a stream")
+    public void shouldWriteAndReadStream() {
+        String key = "test:stream";
+        Map<String, String> entry = new HashMap<>();
+        entry.put("field", "value");
+
+        String id = client.xadd(key, entry);
+        assertNotNull(id, "XADD should return a stream entry id");
+        assertEquals(1L, client.xlen(key));
+
+        List<Map<String, String>> range = client.xrange(key);
+        assertEquals(1, range.size());
+        assertEquals("value", range.get(0).get("field"));
+    }
+
+    @Test
+    @DisplayName("pipelined xadd writes all entries")
+    public void shouldWritePipelinedStream() {
+        String key = "test:stream:pipeline";
+        List<SimpleEntry<String, Map<String, String>>> hashes = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            hashes.add(new SimpleEntry<>(key, Map.of("i", String.valueOf(i))));
+        }
+
+        List<String> ids = client.xadd(hashes);
+        assertEquals(3, ids.size());
+        assertEquals(3L, client.xlen(key));
+    }
+
+    @Test
+    @DisplayName("hset/hgetAll round-trip on a hash")
+    public void shouldWriteAndReadHash() {
+        String key = "test:hash";
+        client.hset(key.getBytes(), "field".getBytes(), "value".getBytes());
+
+        Map<String, String> hash = client.hgetAll(key);
+        assertEquals("value", hash.get("field"));
+    }
+
+    @Test
+    @DisplayName("hset reports 1 for a new field and 0 for an update, matching the Jedis contract")
+    public void shouldReportWhetherTheFieldWasCreated() {
+        // RedisOffsetBackingStore.save() returns this value straight to Kafka Connect, and Lettuce natively
+        // answers with a Boolean, so the mapping to the Jedis-shaped count is worth pinning down.
+        String key = "test:hash:created";
+        assertEquals(1L, client.hset(key.getBytes(), "field".getBytes(), "value".getBytes()));
+        assertEquals(0L, client.hset(key.getBytes(), "field".getBytes(), "other".getBytes()));
+
+        assertEquals("other", client.hgetAll(key).get("field"));
+    }
+
+    @Test
+    @DisplayName("hset round-trips non-ASCII payloads through the string codec")
+    public void shouldRoundTripNonAsciiHashValues() {
+        // The client holds a single StringCodec connection so that writes and WAIT share it, which means the
+        // byte[] arguments of hset are decoded as UTF-8. hgetAll already returns Strings for every client
+        // implementation, so this only makes the existing round-trip explicit.
+        String key = "test:hash:utf8";
+        String value = "\uc624\ud504\uc14b-\u30c6\u30b9\u30c8-\u00e9\u00e0";
+        client.hset(key.getBytes(StandardCharsets.UTF_8), "field".getBytes(StandardCharsets.UTF_8),
+                value.getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(value, client.hgetAll(key).get("field"));
+    }
+
+    @Test
+    @DisplayName("info and clientList are supported")
+    public void shouldReturnServerMetadata() {
+        assertNotNull(client.info("server"));
+        assertTrue(client.clientList().contains(CLIENT_NAME), "CLIENT LIST should report the configured client name");
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
@@ -48,7 +48,7 @@ class LettuceClientIT {
         redis.start();
         Map<String, String> props = new HashMap<>();
         props.put(PROP_PREFIX + "address", redis.getHost() + ":" + redis.getFirstMappedPort());
-        props.put(PROP_PREFIX + "client.library", RedisCommonConfig.CLIENT_LIBRARY_LETTUCE);
+        props.put(PROP_PREFIX + "client.library", RedisClientLibrary.LETTUCE.getValue());
         RedisOffsetBackingStoreConfig config = new RedisOffsetBackingStoreConfig(Configuration.from(props));
         client = RedisConnection.getInstance(config).getRedisClient(CLIENT_NAME, false, 0, false, 0);
     }

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.config.Configuration;
+import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
+
+/**
+ * Integration tests for {@link LettuceClient} against a single (standalone) Redis instance.
+ */
+@Testcontainers
+class LettuceClientIT {
+
+    private static final String REDIS_CONTAINER_IMAGE = "redis:5.0.3-alpine";
+    private static final String PROP_PREFIX = "offset.storage.redis.";
+    private static final String CLIENT_NAME = RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME;
+
+    @Container
+    public GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse(REDIS_CONTAINER_IMAGE))
+            .withExposedPorts(6379);
+
+    private RedisClient client;
+
+    @BeforeEach
+    public void setUp() {
+        redis.start();
+        Map<String, String> props = new HashMap<>();
+        props.put(PROP_PREFIX + "address", redis.getHost() + ":" + redis.getFirstMappedPort());
+        props.put(PROP_PREFIX + "client.library", RedisCommonConfig.CLIENT_LIBRARY_LETTUCE);
+        RedisOffsetBackingStoreConfig config = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        client = RedisConnection.getInstance(config).getRedisClient(CLIENT_NAME, false, 0, false, 0);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+        if (redis != null) {
+            redis.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Lettuce client should be selected when redis.client.library=lettuce")
+    public void shouldCreateLettuceClient() {
+        assertTrue(client instanceof LettuceClient, "Expected a LettuceClient instance but got " + client);
+    }
+
+    @Test
+    @DisplayName("xadd/xrange/xlen round-trip on a stream")
+    public void shouldWriteAndReadStream() {
+        String key = "test:stream";
+        Map<String, String> entry = new HashMap<>();
+        entry.put("field", "value");
+
+        String id = client.xadd(key, entry);
+        assertNotNull(id, "XADD should return a stream entry id");
+        assertEquals(1L, client.xlen(key));
+
+        List<Map<String, String>> range = client.xrange(key);
+        assertEquals(1, range.size());
+        assertEquals("value", range.get(0).get("field"));
+    }
+
+    @Test
+    @DisplayName("pipelined xadd writes all entries")
+    public void shouldWritePipelinedStream() {
+        String key = "test:stream:pipeline";
+        List<SimpleEntry<String, Map<String, String>>> hashes = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            hashes.add(new SimpleEntry<>(key, Map.of("i", String.valueOf(i))));
+        }
+
+        List<String> ids = client.xadd(hashes);
+        assertEquals(3, ids.size());
+        assertEquals(3L, client.xlen(key));
+    }
+
+    @Test
+    @DisplayName("hset/hgetAll round-trip on a hash")
+    public void shouldWriteAndReadHash() {
+        String key = "test:hash";
+        client.hset(key.getBytes(), "field".getBytes(), "value".getBytes());
+
+        Map<String, String> hash = client.hgetAll(key);
+        assertEquals("value", hash.get("field"));
+    }
+
+    @Test
+    @DisplayName("info and clientList are supported")
+    public void shouldReturnServerMetadata() {
+        assertNotNull(client.info("server"));
+        assertTrue(client.clientList().contains(CLIENT_NAME), "CLIENT LIST should report the configured client name");
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceClientTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
+
+/**
+ * Unit tests for the parts of the Lettuce client that need no running Redis.
+ */
+class LettuceClientTest {
+
+    private static final String PROP_PREFIX = "offset.storage.redis.";
+
+    @Test
+    @DisplayName("the pipelined batch budget scales with the batch size, matching the per-response Jedis timeout")
+    public void batchTimeoutShouldScaleWithTheBatchSize() {
+        assertEquals(2000L, LettuceClient.batchTimeoutMs(2000L, 1));
+        assertEquals(20_000L, LettuceClient.batchTimeoutMs(2000L, 10));
+        assertEquals(2_000_000L, LettuceClient.batchTimeoutMs(2000L, 1000));
+    }
+
+    @Test
+    @DisplayName("an empty batch still gets a usable budget")
+    public void batchTimeoutShouldFallBackToASingleCommandTimeout() {
+        assertEquals(2000L, LettuceClient.batchTimeoutMs(2000L, 0));
+    }
+
+    @Test
+    @DisplayName("a batch large enough to overflow the budget falls back instead of going negative")
+    public void batchTimeoutShouldNotOverflowIntoANegativeBudget() {
+        // A negative budget would make awaitAll give up immediately, turning a configuration mistake into
+        // an instant failure of every batch.
+        long overflowing = LettuceClient.batchTimeoutMs(Long.MAX_VALUE / 2, 1000);
+        assertTrue(overflowing > 0, "expected a positive budget but got " + overflowing);
+    }
+
+    @Test
+    @DisplayName("cluster mode is rejected before any connection attempt")
+    public void shouldRejectClusterModeUpFront() {
+        Map<String, String> props = new HashMap<>();
+        // Deliberately unreachable: the rejection must happen before the client tries to connect.
+        props.put(PROP_PREFIX + "address", "127.0.0.1:1,127.0.0.1:2,127.0.0.1:3");
+        props.put(PROP_PREFIX + "cluster.enabled", "true");
+        props.put(PROP_PREFIX + "client.library", RedisClientLibrary.LETTUCE.getValue());
+        RedisOffsetBackingStoreConfig config = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+
+        DebeziumException thrown = assertThrows(DebeziumException.class,
+                () -> RedisConnection.getInstance(config)
+                        .getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, false, 0, false, 0));
+
+        assertTrue(thrown.getMessage().contains("Cluster"),
+                "the error should name cluster mode as the unsupported feature, but was: " + thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("a missing Lettuce driver is reported with an actionable message, not a NoClassDefFoundError")
+    public void shouldRejectAMissingLettuceDriver() {
+        // The distribution archive no longer bundles lettuce-core, so this is the message a user sees when
+        // they flip redis.client.library=lettuce without adding the driver themselves.
+        DebeziumException thrown = assertThrows(DebeziumException.class,
+                () -> RedisConnection.requireLettuceDriver(new DriverHidingClassLoader()));
+
+        assertTrue(thrown.getMessage().contains("io.lettuce:lettuce-core"),
+                "expected the artifact coordinates in the message but got: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("redis.client.library=jedis"),
+                "expected the fallback to be suggested but got: " + thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("the driver check passes when lettuce-core is on the classpath")
+    public void shouldAcceptAPresentLettuceDriver() {
+        RedisConnection.requireLettuceDriver(getClass().getClassLoader());
+    }
+
+    /**
+     * Stands in for a deployment that selected the Lettuce client without putting the driver on the
+     * classpath. Everything else resolves normally so that only the driver lookup is exercised.
+     */
+    private static final class DriverHidingClassLoader extends ClassLoader {
+
+        private DriverHidingClassLoader() {
+            super(LettuceClientTest.class.getClassLoader());
+        }
+
+        @Override
+        public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("io.lettuce.")) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceOptionalDependencyTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceOptionalDependencyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code lettuce-core} is a provided dependency that the distribution archive does not bundle, so classes
+ * that are loaded on the default (Jedis) path must not carry any reference to a Lettuce type. A stray
+ * import would only surface at runtime, as a {@link NoClassDefFoundError} in a deployment that never asked
+ * for Lettuce, so it is checked here instead.
+ */
+public class LettuceOptionalDependencyTest {
+
+    private static final String LETTUCE_PACKAGE = "io/lettuce/";
+
+    @Test
+    public void classesOnTheDefaultPathMustNotReferenceLettuce() throws IOException {
+        for (Class<?> clazz : new Class<?>[]{ RedisConnection.class, RedisCommonConfig.class, RedisClientLibrary.class, JedisClient.class }) {
+            assertFalse(referencesLettuce(clazz), clazz.getSimpleName() + " must not reference any io.lettuce type; "
+                    + "keep Lettuce usage inside LettuceClient so that Jedis deployments never need the driver");
+        }
+    }
+
+    @Test
+    public void lettuceClientItselfDoesReferenceLettuce() throws IOException {
+        // Guards the check above against silently passing because the scan itself is broken.
+        assertTrue(referencesLettuce(LettuceClient.class), "LettuceClient is expected to reference io.lettuce types");
+    }
+
+    private boolean referencesLettuce(Class<?> clazz) throws IOException {
+        String resource = clazz.getName().replace('.', '/') + ".class";
+        try (InputStream in = clazz.getClassLoader().getResourceAsStream(resource)) {
+            assertNotNull(in, "Could not read the compiled class file for " + clazz.getName());
+            // Class names appear verbatim in the constant pool, which is what the JVM resolves against.
+            return new String(in.readAllBytes(), StandardCharsets.ISO_8859_1).contains(LETTUCE_PACKAGE);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceOptionalDependencyTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceOptionalDependencyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code lettuce-core} is an optional dependency, so classes that are loaded on the default (Jedis) path
+ * must not carry any reference to a Lettuce type. A stray import would only surface at runtime, as a
+ * {@link NoClassDefFoundError} in a deployment that never asked for Lettuce, so it is checked here instead.
+ */
+public class LettuceOptionalDependencyTest {
+
+    private static final String LETTUCE_PACKAGE = "io/lettuce/";
+
+    @Test
+    public void classesOnTheDefaultPathMustNotReferenceLettuce() throws IOException {
+        for (Class<?> clazz : new Class<?>[]{ RedisConnection.class, RedisCommonConfig.class, RedisClientLibrary.class, JedisClient.class }) {
+            assertFalse(referencesLettuce(clazz), clazz.getSimpleName() + " must not reference any io.lettuce type; "
+                    + "keep Lettuce usage inside LettuceClient so the optional dependency stays optional");
+        }
+    }
+
+    @Test
+    public void lettuceClientItselfDoesReferenceLettuce() throws IOException {
+        // Guards the check above against silently passing because the scan itself is broken.
+        assertTrue(referencesLettuce(LettuceClient.class), "LettuceClient is expected to reference io.lettuce types");
+    }
+
+    private boolean referencesLettuce(Class<?> clazz) throws IOException {
+        String resource = clazz.getName().replace('.', '/') + ".class";
+        try (InputStream in = clazz.getClassLoader().getResourceAsStream(resource)) {
+            assertNotNull(in, "Could not read the compiled class file for " + clazz.getName());
+            // Class names appear verbatim in the constant pool, which is what the JVM resolves against.
+            return new String(in.readAllBytes(), StandardCharsets.ISO_8859_1).contains(LETTUCE_PACKAGE);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceWaitReplicasIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/LettuceWaitReplicasIT.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.config.Configuration;
+import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
+
+/**
+ * Verifies that {@code WAIT} actually covers the write it is paired with, for every supported client
+ * library. Each test runs against both Jedis and Lettuce with identical assertions, so the suite doubles as
+ * the behavioural parity check between the two drivers.
+ * <p>
+ * Redis evaluates {@code WAIT} against {@code c->woff}, the replication offset recorded for the
+ * <em>calling</em> connection after its own most recent command. An implementation that sends the write
+ * over one connection and the {@code WAIT} over another therefore has the {@code WAIT} judge the offset as
+ * it stood <em>before</em> that write: it reports success for the preceding state and never covers the
+ * write it was paired with, silently weakening the guarantee {@code wait.enabled=true} is meant to buy.
+ * <p>
+ * Detecting that lag needs the preceding offset to be acknowledged while the write under test is not, so
+ * the tests write once, wait for the replica to catch up, freeze the replica so that it can no longer send
+ * {@code REPLCONF ACK}, and only then perform the write they measure. A correct implementation blocks for
+ * the whole wait timeout; one that splits the two commands across connections returns immediately.
+ */
+@Testcontainers
+class LettuceWaitReplicasIT {
+
+    private static final String REDIS_CONTAINER_IMAGE = "redis:5.0.3-alpine";
+    private static final String PROP_PREFIX = "offset.storage.redis.";
+    private static final String MASTER_ALIAS = "redis-master";
+
+    /**
+     * Must stay below the socket timeout: that value is the Jedis socket read timeout and the Lettuce
+     * command timeout alike, and a {@code WAIT} that blocks longer than it trips the driver before the
+     * server replies. The defaults (1000 ms wait, 2000 ms socket) leave the same headroom.
+     */
+    private static final long WAIT_TIMEOUT_MS = 1000L;
+    private static final long SOCKET_TIMEOUT_MS = 3000L;
+
+    /**
+     * WAIT blocks for the whole timeout, so a correct implementation cannot come back much earlier than
+     * this. A broken one returns in single-digit milliseconds, so the exact bound is not delicate.
+     */
+    private static final long BLOCKED_THRESHOLD_MS = WAIT_TIMEOUT_MS * 3 / 4;
+
+    private Network network;
+    private GenericContainer<?> master;
+    private GenericContainer<?> replica;
+    private RedisClient client;
+
+    @BeforeEach
+    public void setUp() {
+        network = Network.newNetwork();
+
+        master = new GenericContainer<>(DockerImageName.parse(REDIS_CONTAINER_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(MASTER_ALIAS)
+                .withExposedPorts(6379);
+        master.start();
+
+        replica = new GenericContainer<>(DockerImageName.parse(REDIS_CONTAINER_IMAGE))
+                .withNetwork(network)
+                .withCommand("redis-server", "--replicaof", MASTER_ALIAS, "6379")
+                .withExposedPorts(6379);
+        replica.start();
+
+        awaitReplicaOnline();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+        unpauseReplica();
+        if (replica != null) {
+            replica.stop();
+            replica = null;
+        }
+        if (master != null) {
+            master.stop();
+            master = null;
+        }
+        if (network != null) {
+            network.close();
+            network = null;
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(RedisClientLibrary.class)
+    public void hsetShouldBlockWhileTheReplicaCannotAcknowledge(RedisClientLibrary library) {
+        client = newClient(library, WAIT_TIMEOUT_MS);
+
+        // A healthy replica acknowledges quickly, so the same call is fast before the replica is frozen.
+        long healthy = timeOf(() -> client.hset("dbz:offsets".getBytes(), "warmup".getBytes(), "v".getBytes()));
+        assertTrue(healthy < BLOCKED_THRESHOLD_MS,
+                "with a healthy replica hset should not block for the wait timeout, but took " + healthy + " ms");
+
+        // The replica must have acknowledged everything written so far, otherwise a WAIT that lags by one
+        // write still blocks on the backlog and the split-connection defect stays invisible.
+        awaitReplicaCaughtUp();
+        pauseReplica();
+
+        long frozen = timeOf(() -> client.hset("dbz:offsets".getBytes(), "field".getBytes(), "value".getBytes()));
+        assertTrue(frozen >= BLOCKED_THRESHOLD_MS,
+                "hset returned after " + frozen + " ms; WAIT did not cover the write, which means it was issued "
+                        + "on a different connection than the HSET");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(RedisClientLibrary.class)
+    public void xaddShouldBlockWhileTheReplicaCannotAcknowledge(RedisClientLibrary library) {
+        client = newClient(library, WAIT_TIMEOUT_MS);
+
+        pauseReplica();
+
+        long frozen = timeOf(() -> client.xadd("dbz:stream", Map.of("field", "value")));
+        assertTrue(frozen >= BLOCKED_THRESHOLD_MS,
+                "xadd returned after " + frozen + " ms; WAIT did not cover the write");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(RedisClientLibrary.class)
+    public void pipelinedXaddShouldBlockWhileTheReplicaCannotAcknowledge(RedisClientLibrary library) {
+        // The batched overload is the one the stream change consumer uses, and Lettuce sends it through the
+        // async view of the connection while WAIT goes through the sync view. Both views share the single
+        // connection, which is exactly what this asserts.
+        client = newClient(library, WAIT_TIMEOUT_MS);
+
+        List<SimpleEntry<String, Map<String, String>>> batch = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            batch.add(new SimpleEntry<>("dbz:stream:batch", Map.of("i", String.valueOf(i))));
+        }
+
+        pauseReplica();
+
+        long frozen = timeOf(() -> client.xadd(batch));
+        assertTrue(frozen >= BLOCKED_THRESHOLD_MS,
+                "pipelined xadd returned after " + frozen + " ms; WAIT did not cover the batch");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(RedisClientLibrary.class)
+    public void shouldOpenASingleConnection(RedisClientLibrary library) {
+        client = newClient(library, WAIT_TIMEOUT_MS);
+
+        // A second connection is what breaks WAIT above; CLIENT LIST makes the regression visible directly.
+        // Counting by client name would miss it, because an extra connection need not carry the name, so
+        // every client connection is counted and only the replication link (flags=S) is excluded.
+        long connections = client.clientList().lines()
+                .filter(line -> !line.isBlank())
+                .filter(line -> !line.contains("flags=S"))
+                .count();
+        assertEquals(1L, connections,
+                "expected a single connection, otherwise writes and WAIT can end up on different connections, but CLIENT LIST was:\n"
+                        + client.clientList());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(RedisClientLibrary.class)
+    public void waitTimeoutAboveTheSocketTimeoutShouldSurfaceAsAConnectionFailure(RedisClientLibrary library) {
+        // Both drivers derive their read/command timeout from redis.socket.timeout, so a WAIT that is allowed
+        // to block longer than that trips the driver before the server answers. Pinned here so the shared
+        // constraint stays visible, and so the two libraries are known to behave the same way.
+        client = newClient(library, SOCKET_TIMEOUT_MS * 2);
+
+        pauseReplica();
+
+        assertThrows(RedisClientConnectionException.class,
+                () -> client.hset("dbz:offsets".getBytes(), "field".getBytes(), "value".getBytes()));
+    }
+
+    private RedisClient newClient(RedisClientLibrary library, long waitTimeoutMs) {
+        Map<String, String> props = new HashMap<>();
+        props.put(PROP_PREFIX + "address", master.getHost() + ":" + master.getFirstMappedPort());
+        props.put(PROP_PREFIX + "client.library", library.getValue());
+        props.put(PROP_PREFIX + "socket.timeout.ms", String.valueOf(SOCKET_TIMEOUT_MS));
+        RedisOffsetBackingStoreConfig config = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+
+        return RedisConnection.getInstance(config)
+                .getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, true, waitTimeoutMs, false, 0);
+    }
+
+    private long timeOf(Runnable action) {
+        long start = System.nanoTime();
+        action.run();
+        return Duration.ofNanos(System.nanoTime() - start).toMillis();
+    }
+
+    private void awaitReplicaOnline() {
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (System.currentTimeMillis() < deadline) {
+            if (execInMaster("redis-cli", "info", "replication").contains("state=online")) {
+                return;
+            }
+            sleep(250);
+        }
+        throw new IllegalStateException("The replica did not come online: " + execInMaster("redis-cli", "info", "replication"));
+    }
+
+    private void awaitReplicaCaughtUp() {
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (System.currentTimeMillis() < deadline) {
+            String info = execInMaster("redis-cli", "info", "replication");
+            long masterOffset = parseLong(info, "master_repl_offset:");
+            long replicaOffset = parseLong(info, "offset=");
+            if (masterOffset >= 0 && masterOffset == replicaOffset) {
+                return;
+            }
+            sleep(100);
+        }
+        throw new IllegalStateException("The replica never caught up: " + execInMaster("redis-cli", "info", "replication"));
+    }
+
+    private static long parseLong(String info, String token) {
+        int start = info.indexOf(token);
+        if (start < 0) {
+            return -1;
+        }
+        start += token.length();
+        int end = start;
+        while (end < info.length() && Character.isDigit(info.charAt(end))) {
+            end++;
+        }
+        return end == start ? -1 : Long.parseLong(info.substring(start, end));
+    }
+
+    private void pauseReplica() {
+        DockerClientFactory.instance().client().pauseContainerCmd(replica.getContainerId()).exec();
+        // The master keeps counting the replica as connected; it simply stops receiving REPLCONF ACK.
+    }
+
+    private void unpauseReplica() {
+        if (replica == null || !replica.isRunning()) {
+            return;
+        }
+        try {
+            DockerClientFactory.instance().client().unpauseContainerCmd(replica.getContainerId()).exec();
+        }
+        catch (RuntimeException e) {
+            // Already running; nothing to undo.
+        }
+    }
+
+    private String execInMaster(String... command) {
+        try {
+            return master.execInContainer(command).getStdout();
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Failed to run " + String.join(" ", command) + " in the master container", e);
+        }
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
@@ -5,7 +5,9 @@
  */
 package io.debezium.storage.redis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -13,11 +15,12 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
 
 /**
- * Unit tests for verifying Redis Cluster enablement flag handling via configuration.
+ * Unit tests for verifying Redis Cluster enablement and client library selection via configuration.
  */
 public class RedisOffsetBackingStoreConfigTest {
 
@@ -38,5 +41,32 @@ public class RedisOffsetBackingStoreConfigTest {
         props.put(PREFIX + "redis.cluster.enabled", "true");
         RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
         assertTrue(cfg.isClusterEnabled(), "Cluster mode should be enabled when property is set to true");
+    }
+
+    @Test
+    public void clientLibraryDefaultsToJedis() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        assertEquals(RedisClientLibrary.JEDIS, cfg.getClientLibrary(), "Client library should default to jedis");
+    }
+
+    @Test
+    public void clientLibraryCanBeSetToLettuce() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        props.put(PREFIX + "redis.client.library", RedisClientLibrary.LETTUCE.getValue());
+        RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        assertEquals(RedisClientLibrary.LETTUCE, cfg.getClientLibrary(), "Client library should be lettuce");
+    }
+
+    @Test
+    public void invalidClientLibraryIsRejected() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        props.put(PREFIX + "redis.client.library", "invalid");
+        assertThrows(DebeziumException.class,
+                () -> new RedisOffsetBackingStoreConfig(Configuration.from(props)),
+                "An unsupported client library value should be rejected during validation");
     }
 }

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
@@ -5,7 +5,9 @@
  */
 package io.debezium.storage.redis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -13,11 +15,12 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.storage.redis.offset.RedisOffsetBackingStoreConfig;
 
 /**
- * Unit tests for verifying Redis Cluster enablement flag handling via configuration.
+ * Unit tests for verifying Redis Cluster enablement and client library selection via configuration.
  */
 public class RedisOffsetBackingStoreConfigTest {
 
@@ -38,5 +41,34 @@ public class RedisOffsetBackingStoreConfigTest {
         props.put(PREFIX + "redis.cluster.enabled", "true");
         RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
         assertTrue(cfg.isClusterEnabled(), "Cluster mode should be enabled when property is set to true");
+    }
+
+    @Test
+    public void clientLibraryDefaultsToJedis() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        assertEquals(RedisCommonConfig.CLIENT_LIBRARY_JEDIS, cfg.getClientLibrary(), "Client library should default to jedis");
+        assertFalse(cfg.isLettuceEnabled(), "Lettuce should be disabled by default");
+    }
+
+    @Test
+    public void clientLibraryCanBeSetToLettuce() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        props.put(PREFIX + "redis.client.library", RedisCommonConfig.CLIENT_LIBRARY_LETTUCE);
+        RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
+        assertEquals(RedisCommonConfig.CLIENT_LIBRARY_LETTUCE, cfg.getClientLibrary(), "Client library should be lettuce");
+        assertTrue(cfg.isLettuceEnabled(), "Lettuce should be enabled when property is set to lettuce");
+    }
+
+    @Test
+    public void invalidClientLibraryIsRejected() {
+        Map<String, String> props = new HashMap<>();
+        props.put(PREFIX + "redis.address", "localhost:6379");
+        props.put(PREFIX + "redis.client.library", "invalid");
+        assertThrows(DebeziumException.class,
+                () -> new RedisOffsetBackingStoreConfig(Configuration.from(props)),
+                "An unsupported client library value should be rejected during validation");
     }
 }

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/RedisOffsetBackingStoreConfigTest.java
@@ -48,18 +48,16 @@ public class RedisOffsetBackingStoreConfigTest {
         Map<String, String> props = new HashMap<>();
         props.put(PREFIX + "redis.address", "localhost:6379");
         RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
-        assertEquals(RedisCommonConfig.CLIENT_LIBRARY_JEDIS, cfg.getClientLibrary(), "Client library should default to jedis");
-        assertFalse(cfg.isLettuceEnabled(), "Lettuce should be disabled by default");
+        assertEquals(RedisClientLibrary.JEDIS, cfg.getClientLibrary(), "Client library should default to jedis");
     }
 
     @Test
     public void clientLibraryCanBeSetToLettuce() {
         Map<String, String> props = new HashMap<>();
         props.put(PREFIX + "redis.address", "localhost:6379");
-        props.put(PREFIX + "redis.client.library", RedisCommonConfig.CLIENT_LIBRARY_LETTUCE);
+        props.put(PREFIX + "redis.client.library", RedisClientLibrary.LETTUCE.getValue());
         RedisOffsetBackingStoreConfig cfg = new RedisOffsetBackingStoreConfig(Configuration.from(props));
-        assertEquals(RedisCommonConfig.CLIENT_LIBRARY_LETTUCE, cfg.getClientLibrary(), "Client library should be lettuce");
-        assertTrue(cfg.isLettuceEnabled(), "Lettuce should be enabled when property is set to lettuce");
+        assertEquals(RedisClientLibrary.LETTUCE, cfg.getClientLibrary(), "Client library should be lettuce");
     }
 
     @Test

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
@@ -39,6 +39,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.debezium.config.Configuration;
 import io.debezium.storage.redis.RedisClient;
 import io.debezium.storage.redis.RedisClientConnectionException;
+import io.debezium.storage.redis.RedisClientLibrary;
 import io.debezium.storage.redis.RedisConnection;
 import io.debezium.util.Testing;
 
@@ -91,14 +92,17 @@ class RedisOffsetBackingStoreIT {
     }
 
     /**
-     * Provides test parameters for cluster enabled/disabled scenarios.
+     * Provides test parameters for every supported combination of cluster mode and client library.
+     * Lettuce appears for the single instance only: it rejects cluster mode outright, which
+     * {@code LettuceClientTest} covers without needing a cluster.
      *
-     * @return Stream of Arguments containing cluster enabled flag
+     * @return Stream of Arguments containing the cluster enabled flag and the client library
      */
-    static Stream<Arguments> clusterScenarios() {
+    static Stream<Arguments> clientScenarios() {
         return Stream.of(
-                Arguments.of(false),
-                Arguments.of(true));
+                Arguments.of(false, RedisClientLibrary.JEDIS),
+                Arguments.of(true, RedisClientLibrary.JEDIS),
+                Arguments.of(false, RedisClientLibrary.LETTUCE));
     }
 
     @AfterEach
@@ -116,10 +120,10 @@ class RedisOffsetBackingStoreIT {
     }
 
     @ParameterizedTest
-    @MethodSource("clusterScenarios")
+    @MethodSource("clientScenarios")
     @DisplayName("Test Redis connection with cluster mode")
-    public void testRedisConnection(boolean clusterEnabled) throws InterruptedException {
-        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled);
+    public void testRedisConnection(boolean clusterEnabled, RedisClientLibrary library) throws InterruptedException {
+        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled, library);
         RedisClient client = redisOffsetBackingStore.getRedisClient();
 
         // For cluster mode, clientList is not supported, so we skip this assertion
@@ -133,11 +137,11 @@ class RedisOffsetBackingStoreIT {
     }
 
     @ParameterizedTest
-    @MethodSource("clusterScenarios")
+    @MethodSource("clientScenarios")
     @Timeout(5) // Ensure we don't stuck in endless retry loop
     @DisplayName("Test load with retry mechanism")
-    public void testLoadWithRetry(boolean clusterEnabled) throws InterruptedException {
-        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled);
+    public void testLoadWithRetry(boolean clusterEnabled, RedisClientLibrary library) throws InterruptedException {
+        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled, library);
         RedisClient client = redisOffsetBackingStore.getRedisClient();
 
         RedisClient mockClient = Mockito.spy(client);
@@ -156,11 +160,11 @@ class RedisOffsetBackingStoreIT {
     }
 
     @ParameterizedTest
-    @MethodSource("clusterScenarios")
+    @MethodSource("clientScenarios")
     @Timeout(5) // Ensure we don't stuck in endless retry loop
     @DisplayName("Test save with retry mechanism")
-    public void testSaveWithRetry(boolean clusterEnabled) throws InterruptedException {
-        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled);
+    public void testSaveWithRetry(boolean clusterEnabled, RedisClientLibrary library) throws InterruptedException {
+        RedisOffsetBackingStore redisOffsetBackingStore = getRedisOffsetBackingStore(clusterEnabled, library);
         RedisClient client = redisOffsetBackingStore.getRedisClient();
 
         // Load test key-value pair to redis to able to test save()
@@ -190,15 +194,15 @@ class RedisOffsetBackingStoreIT {
         return Arrays.stream(client.clientList().split(NEW_LINE)).filter(entry -> entry.contains(name)).count();
     }
 
-    private RedisOffsetBackingStore getRedisOffsetBackingStore(boolean clusterEnabled) {
-        RedisOffsetBackingStoreConfig config = getRedisOffsetBackingStoreConfig(clusterEnabled);
+    private RedisOffsetBackingStore getRedisOffsetBackingStore(boolean clusterEnabled, RedisClientLibrary library) {
+        RedisOffsetBackingStoreConfig config = getRedisOffsetBackingStoreConfig(clusterEnabled, library);
         RedisOffsetBackingStore redisOffsetBackingStore = new RedisOffsetBackingStore();
         redisOffsetBackingStore.configure(config);
         redisOffsetBackingStore.startNoLoad();
         return redisOffsetBackingStore;
     }
 
-    private RedisOffsetBackingStoreConfig getRedisOffsetBackingStoreConfig(boolean clusterEnabled) {
+    private RedisOffsetBackingStoreConfig getRedisOffsetBackingStoreConfig(boolean clusterEnabled, RedisClientLibrary library) {
         Map<String, String> dummyConfig = new HashMap<>();
 
         if (clusterEnabled) {
@@ -214,6 +218,7 @@ class RedisOffsetBackingStoreIT {
         }
 
         dummyConfig.put(PROP_PREFIX + "cluster.enabled", String.valueOf(clusterEnabled));
+        dummyConfig.put(PROP_PREFIX + "client.library", library.getValue());
         return new RedisOffsetBackingStoreConfig(Configuration.from(dummyConfig));
     }
 

--- a/documentation/modules/ROOT/pages/configuration/storage.adoc
+++ b/documentation/modules/ROOT/pages/configuration/storage.adoc
@@ -488,7 +488,15 @@ INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_inse
 
 == Redis
 
-{prodname} can use a https://redis.io/docs/latest/develop/clients/jedis/[Jedis client] to store data in a Redis cache.
+{prodname} can use a https://redis.io/docs/latest/develop/clients/jedis/[Jedis client] (default) or a https://github.com/redis/lettuce[Lettuce client] to store data in a Redis cache.
+To select the client driver, set the `redis.client.library` property to `jedis` or `lettuce`.
+
+The Lettuce driver is not part of a {prodname} distribution, because deployments that use the default Jedis driver would otherwise carry Lettuce and its Netty and Reactor dependencies without ever loading them.
+If you set `redis.client.library` to `lettuce`, add the `io.lettuce:lettuce-core` artifact and its dependencies to the runtime classpath yourself; otherwise the connector fails at startup with an error that names the missing artifact.
+Also be aware of the following differences from the Jedis driver:
+
+* Redis Cluster mode is not supported. For cluster mode, use the Jedis driver.
+* The `redis.ssl.truststore.type` and `redis.ssl.keystore.type` properties are ignored, because Lettuce determines the store type from the store file itself.
 
 {prodname} can use either a single Redis instance or use https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/[Redis Cluster mode]:
 
@@ -604,6 +612,12 @@ If a data packet is not transferred with the specified interval, {prodname} clos
 |If you configure {prodname} Server to store offsets in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route offset data to Redis nodes.
 
+|[[offset-storage-redis-client-library]]<<offset-storage-redis-client-library, `offset.storage.redis.client.library`>>
+|jedis
+|Specifies the Redis client driver library that {prodname} uses to store offset data.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
+
 |===
 
 === Internal schema history store
@@ -710,6 +724,12 @@ If a data packet is not transferred with the specified interval, {prodname} clos
 |false
 |If you configure {prodname} Server to store schema history in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route history data to Redis nodes.
+
+|[[schema-history-internal-redis-client-library]]<<schema-history-internal-redis-client-library, `schema.history.internal.storage.redis.client.library`>>
+|jedis
+|Specifies the Redis client driver library that {prodname} uses to store schema history data.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |===
 

--- a/documentation/modules/ROOT/pages/configuration/storage.adoc
+++ b/documentation/modules/ROOT/pages/configuration/storage.adoc
@@ -488,7 +488,9 @@ INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_inse
 
 == Redis
 
-{prodname} can use a https://redis.io/docs/latest/develop/clients/jedis/[Jedis client] to store data in a Redis cache.
+{prodname} can use a https://redis.io/docs/latest/develop/clients/jedis/[Jedis client] (default) or a https://github.com/redis/lettuce[Lettuce client] to store data in a Redis cache.
+To select the client driver, set the `redis.client.library` property to `jedis` or `lettuce`.
+The Lettuce client supports single instance mode only; for Redis Cluster mode, use the Jedis client.
 
 {prodname} can use either a single Redis instance or use https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/[Redis Cluster mode]:
 
@@ -604,6 +606,12 @@ If a data packet is not transferred with the specified interval, {prodname} clos
 |If you configure {prodname} Server to store offsets in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route offset data to Redis nodes.
 
+|[[offset-storage-redis-client-library]]<<offset-storage-redis-client-library, `offset.storage.redis.client.library`>>
+|jedis
+|Specifies the Redis client driver library that {prodname} uses to store offset data.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only.
+
 |===
 
 === Internal schema history store
@@ -710,6 +718,12 @@ If a data packet is not transferred with the specified interval, {prodname} clos
 |false
 |If you configure {prodname} Server to store schema history in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route history data to Redis nodes.
+
+|[[schema-history-internal-redis-client-library]]<<schema-history-internal-redis-client-library, `schema.history.internal.storage.redis.client.library`>>
+|jedis
+|Specifies the Redis client driver library that {prodname} uses to store schema history data.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only.
 
 |===
 

--- a/documentation/modules/ROOT/pages/configuration/storage.adoc
+++ b/documentation/modules/ROOT/pages/configuration/storage.adoc
@@ -490,7 +490,12 @@ INSERT INTO %s(id, history_data, history_data_seq, record_insert_ts, record_inse
 
 {prodname} can use a https://redis.io/docs/latest/develop/clients/jedis/[Jedis client] (default) or a https://github.com/redis/lettuce[Lettuce client] to store data in a Redis cache.
 To select the client driver, set the `redis.client.library` property to `jedis` or `lettuce`.
-The Lettuce client supports single instance mode only; for Redis Cluster mode, use the Jedis client.
+
+The Lettuce driver is an optional dependency, so it is not part of a default {prodname} deployment.
+To use it, add the `io.lettuce:lettuce-core` artifact to the runtime classpath and be aware of the following differences from the Jedis driver:
+
+* Redis Cluster mode is not supported. For cluster mode, use the Jedis driver.
+* The `redis.ssl.truststore.type` and `redis.ssl.keystore.type` properties are ignored, because Lettuce determines the store type from the store file itself.
 
 {prodname} can use either a single Redis instance or use https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/[Redis Cluster mode]:
 
@@ -610,7 +615,7 @@ Set the value to `true` to configure {prodname} to use a https://redis.io/docs/l
 |jedis
 |Specifies the Redis client driver library that {prodname} uses to store offset data.
 Set the value to `jedis` (default) or `lettuce`.
-The `lettuce` driver supports single instance mode only.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |===
 
@@ -723,7 +728,7 @@ Set the value to `true` to configure {prodname} to use a https://redis.io/docs/l
 |jedis
 |Specifies the Redis client driver library that {prodname} uses to store schema history data.
 Set the value to `jedis` (default) or `lettuce`.
-The `lettuce` driver supports single instance mode only.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |===
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -301,6 +301,13 @@ For more information see Redis https://redis.io/commands/wait/[WAIT] command.
 |If you configure {prodname} Server to store offsets in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route offset data to Redis nodes.
 
+|[[debezium-source-offset-redis-client-library]]<<debezium-source-offset-redis-client-library, `debezium.source.offset.storage.redis.client.library`>>
+|`jedis`
+|If using Redis to store offsets, specifies the Redis client driver library to use.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only, and is not bundled in a {prodname} distribution.
+Add the `io.lettuce:lettuce-core` artifact and its dependencies to the runtime classpath yourself.
+
 |[[debezium-source-database-history-class]]<<debezium-source-database-history-class, `debezium.source.schema.history.internal`>>
 |`io.debezium.storage.kafka.history.KafkaSchemaHistory`
 |Some of the connectors (e.g MySQL, SQL Server, Db2, Oracle) track the database schema evolution over time and stores this data in a database schema history.
@@ -406,6 +413,13 @@ For more information see Redis https://redis.io/commands/wait/[WAIT] command.
 |`false`
 |If you configure {prodname} Server to store schema history in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route history data to Redis nodes.
+
+|[[debezium-source-database-history-redis-client-library]]<<debezium-source-database-history-redis-client-library, `debezium.source.schema.history.internal.redis.client.library`>>
+|`jedis`
+|If using Redis to store schema history, specifies the Redis client driver library to use.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only, and is not bundled in a {prodname} distribution.
+Add the `io.lettuce:lettuce-core` artifact and its dependencies to the runtime classpath yourself.
 
 |[[schema-history-internal-rocketmq-topic]]<<schema-history-internal-rocketmq-topic, `debezium.source.schema.history.internal.rocketmq.topic`>>
 |
@@ -1332,6 +1346,13 @@ By default it is `0` (disabled).
 |`false`
 |Specifies whether {prodname} uses Redis Cluster mode for sink operations.
 Set the value to `true` to configure {prodname} to use a  https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to connect to Redis.
+
+|[[redis-client-library]]<<redis-client-library, `debezium.sink.redis.client.library`>>
+|`jedis`
+|Specifies the Redis client driver library that {prodname} uses for sink operations.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only, and is not bundled in a {prodname} distribution.
+Add the `io.lettuce:lettuce-core` artifact and its dependencies to the runtime classpath yourself.
 
 |===
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -301,6 +301,12 @@ For more information see Redis https://redis.io/commands/wait/[WAIT] command.
 |If you configure {prodname} Server to store offsets in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route offset data to Redis nodes.
 
+|[[debezium-source-offset-redis-client-library]]<<debezium-source-offset-redis-client-library, `debezium.source.offset.storage.redis.client.library`>>
+|`jedis`
+|If using Redis to store offsets, specifies the Redis client driver library to use.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only.
+
 |[[debezium-source-database-history-class]]<<debezium-source-database-history-class, `debezium.source.schema.history.internal`>>
 |`io.debezium.storage.kafka.history.KafkaSchemaHistory`
 |Some of the connectors (e.g MySQL, SQL Server, Db2, Oracle) track the database schema evolution over time and stores this data in a database schema history.
@@ -406,6 +412,12 @@ For more information see Redis https://redis.io/commands/wait/[WAIT] command.
 |`false`
 |If you configure {prodname} Server to store schema history in Redis, set this property to specify whether to use Redis Cluster mode.
 Set the value to `true` to configure {prodname} to use a https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to route history data to Redis nodes.
+
+|[[debezium-source-database-history-redis-client-library]]<<debezium-source-database-history-redis-client-library, `debezium.source.schema.history.internal.redis.client.library`>>
+|`jedis`
+|If using Redis to store schema history, specifies the Redis client driver library to use.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only.
 
 |[[schema-history-internal-rocketmq-topic]]<<schema-history-internal-rocketmq-topic, `debezium.source.schema.history.internal.rocketmq.topic`>>
 |
@@ -1332,6 +1344,12 @@ By default it is `0` (disabled).
 |`false`
 |Specifies whether {prodname} uses Redis Cluster mode for sink operations.
 Set the value to `true` to configure {prodname} to use a  https://redis.io/docs/latest/develop/clients/jedis/connect/#connect-to-a-redis-cluster[JedisCluster client] to connect to Redis.
+
+|[[redis-client-library]]<<redis-client-library, `debezium.sink.redis.client.library`>>
+|`jedis`
+|Specifies the Redis client driver library that {prodname} uses for sink operations.
+Set the value to `jedis` (default) or `lettuce`.
+The `lettuce` driver supports single instance mode only.
 
 |===
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -305,7 +305,7 @@ Set the value to `true` to configure {prodname} to use a https://redis.io/docs/l
 |`jedis`
 |If using Redis to store offsets, specifies the Redis client driver library to use.
 Set the value to `jedis` (default) or `lettuce`.
-The `lettuce` driver supports single instance mode only.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |[[debezium-source-database-history-class]]<<debezium-source-database-history-class, `debezium.source.schema.history.internal`>>
 |`io.debezium.storage.kafka.history.KafkaSchemaHistory`
@@ -417,7 +417,7 @@ Set the value to `true` to configure {prodname} to use a https://redis.io/docs/l
 |`jedis`
 |If using Redis to store schema history, specifies the Redis client driver library to use.
 Set the value to `jedis` (default) or `lettuce`.
-The `lettuce` driver supports single instance mode only.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |[[schema-history-internal-rocketmq-topic]]<<schema-history-internal-rocketmq-topic, `debezium.source.schema.history.internal.rocketmq.topic`>>
 |
@@ -1349,7 +1349,7 @@ Set the value to `true` to configure {prodname} to use a  https://redis.io/docs/
 |`jedis`
 |Specifies the Redis client driver library that {prodname} uses for sink operations.
 Set the value to `jedis` (default) or `lettuce`.
-The `lettuce` driver supports single instance mode only.
+The `lettuce` driver supports single instance mode only and requires the optional `io.lettuce:lettuce-core` artifact on the runtime classpath.
 
 |===
 


### PR DESCRIPTION
Fixes debezium/dbz#806

## Description

The Redis storage module is currently Jedis-only. This adds a config-driven choice of driver through a new `redis.client.library` property (`jedis` | `lettuce`), so that users who already run Lettuce — Spring Boot applications, typically — do not have to bring Jedis along as well.

Both the offset store and the schema history obtain their client from the single `RedisConnection.getRedisClient(...)` factory, so the selection is made in one place and reaches the Debezium Server Redis sink without further changes (`RedisStreamChangeConsumerConfig` extends `RedisCommonConfig` and the consumer goes through the same factory).

**Default behaviour is unchanged.** Without the new property, everything resolves to Jedis exactly as before.

### Lettuce is a `provided` dependency

`io.lettuce:lettuce-core` is declared with `<scope>provided</scope>`. At compile scope it pulls in nine Netty artifacts plus `reactor-core`, which every Jedis user would then carry — the opposite of what this feature is for. Measured on the distribution archive, that chain is about 6.9 MB of the 11 MB the archive would otherwise hold.

`provided` rather than `optional` so that the chain is kept out of the distribution archive as well, not only out of downstream Maven consumers' transitive dependencies. Users who set `redis.client.library=lettuce` add `lettuce-core` (with its Netty and Reactor dependencies) to the runtime classpath themselves.

To make that safe, all Lettuce types are confined to `LettuceClient`, including the connection setup. `RedisConnection` probes for the driver first and reports a configuration error naming the artifact, rather than failing later with `NoClassDefFoundError`. `LettuceOptionalDependencyTest` asserts the isolation by scanning the compiled constant pool of the default-path classes, so a stray import cannot creep back in unnoticed.

I would appreciate a maintainer opinion on this trade-off — see the inline comment on `pom.xml`. If you would rather have the driver bundled, it is a one-line change and nothing else in the PR depends on it.

### Known limitations of the Lettuce driver

| | Jedis | Lettuce |
|---|---|---|
| Single instance | yes | yes |
| Cluster mode | yes | **no** — fails fast with a message pointing at `redis.client.library=jedis` |
| `redis.ssl.truststore.type` / `redis.ssl.keystore.type` | applied | **ignored** — Lettuce derives the store type from the file |

Both are documented alongside the property.

### Implementation notes

**Single connection.** `RedisClient` mixes `String`-based commands with a single `byte[]`-based `hset`, while Lettuce fixes the codec per connection. The obvious shape — a UTF-8 connection plus a second byte-array connection dedicated to `hset` — turns out to break `wait.enabled`: Redis evaluates `WAIT` against the write offset of the *calling* connection, so a `WAIT` issued on a different connection than the preceding `HSET` judges the offset as it stood before that write and reports success without ever covering it. `LettuceClient` therefore holds a single UTF-8 string connection and decodes the `hset` arguments. That adds no new assumption, because `hgetAll` already returns `Map<String, String>` for every `RedisClient` implementation.

**Pipelined `xadd` budget.** `LettuceFutures.awaitAll` spends a single timeout across the whole batch, whereas the Jedis socket timeout applies to each response read, so the batch budget is scaled by the batch size to keep the two drivers comparable. `awaitAll` neither cancels the futures nor throws on timeout, so its return value is checked and turned into a timeout exception instead of blocking on `get()`.

**Failure semantics.** Care was taken to keep them identical to `JedisClient`, since the retry and reconnect loops in `RedisOffsetBackingStore` and `RedisSchemaHistory` are driven by whether a failure is reported as `RedisClientConnectionException`. Server-side command errors (`RedisCommandExecutionException`) are let through unwrapped, as `JedisClient` does with `JedisDataException`. The inline comments call out the specific places.

### Testing

- `RedisOffsetBackingStoreConfigTest` — default, explicit `lettuce`, and rejection of an unknown value.
- `LettuceOptionalDependencyTest` — no Lettuce reference on the default code path.
- `LettuceClientTest` — batch timeout scaling (including overflow and empty batch), cluster mode rejected before any connection attempt, and the missing-driver error path via a class loader that hides `io.lettuce`.
- `LettuceClientIT` — `xadd` / pipelined `xadd` / `xrange` / `xlen` / `hset` / `hgetAll` / `info` / `clientList` round-trip against a Testcontainers Redis, plus the `hset` return value (1 for a new field, 0 for an update) and a non-ASCII `hset` round-trip.
- `LettuceWaitReplicasIT` — master plus a replica that is frozen with `docker pause` so it can no longer send `REPLCONF ACK`; asserts that `hset`, `xadd` and pipelined `xadd` block for the wait timeout, that exactly one connection is open, and that a wait timeout above the socket timeout surfaces as `RedisClientConnectionException`. Parameterised over both `RedisClientLibrary` values, so it doubles as the behavioural parity check between Jedis and Lettuce.
- `RedisOffsetBackingStoreIT` — now parameterised over `(cluster, library)`, so the existing connection / load-retry / save-retry scenarios also run against Lettuce.
- Manually verified with `lettuce-core`, Netty and Reactor stripped from the classpath that the Jedis path is unaffected and that requesting Lettuce yields the actionable error rather than `NoClassDefFoundError`.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
