### PR TITLE
debezium/dbz#2338 Compare Durations with > 0 in Temporals.max/min

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/time/Temporals.java
+++ b/debezium-connector-common/src/main/java/io/debezium/time/Temporals.java
@@ -20,7 +20,7 @@ public class Temporals {
      * returned.
      */
     public static Duration max(Duration d1, Duration d2) {
-        return d1.compareTo(d2) == 1 ? d1 : d2;
+        return d1.compareTo(d2) > 0 ? d1 : d2;
     }
 
     /**
@@ -29,6 +29,6 @@ public class Temporals {
      * returned.
      */
     public static Duration min(Duration d1, Duration d2) {
-        return d1.compareTo(d2) == 1 ? d2 : d1;
+        return d1.compareTo(d2) > 0 ? d2 : d1;
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/time/TemporalsTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/time/TemporalsTest.java
@@ -39,4 +39,22 @@ public class TemporalsTest {
         assertThat(Temporals.max(oneMilli, oneMillionNanos)).isEqualTo(oneMilli);
         assertThat(Temporals.max(oneMilli, oneMillionNanos)).isEqualTo(oneMillionNanos);
     }
+
+    @Test
+    public void maxAndMinHandleSubSecondDurationsWithSameWholeSeconds() {
+        // Duration.compareTo returns the nanos difference (not a normalized 1) when the whole-second
+        // counts are equal, so comparing against == 1 gets both max and min backwards here.
+        Duration fiveHundredMillis = Duration.ofMillis(500);
+        Duration twoHundredMillis = Duration.ofMillis(200);
+        assertThat(Temporals.max(fiveHundredMillis, twoHundredMillis)).isEqualTo(fiveHundredMillis);
+        assertThat(Temporals.min(fiveHundredMillis, twoHundredMillis)).isEqualTo(twoHundredMillis);
+    }
+
+    @Test
+    public void minCapsValueJustAboveTheLimit() {
+        // Mirrors ChangeEventQueue capping poll.interval.ms at 5000ms: values 5001-5999 share the
+        // same whole seconds as 5000, so the cap leaked before comparing against > 0.
+        assertThat(Temporals.min(Duration.ofMillis(5001), Duration.ofMillis(5000)))
+                .isEqualTo(Duration.ofMillis(5000));
+    }
 }


### PR DESCRIPTION
### What

`Temporals.max`/`min` decide the order with `d1.compareTo(d2) == 1`. `Comparable.compareTo` is only contracted to return a negative/zero/positive int, not a normalized `-1/0/1`, and `Duration.compareTo` returns the raw nanosecond difference when the two durations share the same whole-second count. So `== 1` is false in that case and both methods return the wrong operand:

```
Temporals.max(500ms, 200ms) -> 200ms   (should be 500ms)
Temporals.min(500ms, 200ms) -> 500ms   (should be 200ms)
```

The production caller is `ChangeEventQueue.poll()`, which uses `Temporals.min(pollInterval, 5000ms)` to enforce the documented `poll.interval.ms` cap (the config validator only warns; it doesn't clamp). For `poll.interval.ms` values in 5001–5999 ms — same whole seconds as 5000 — the cap silently leaks and the connector waits longer than its documented ceiling.

### Fix

Compare with `> 0` per the `Comparable` contract.

### Test

Added `maxAndMinHandleSubSecondDurationsWithSameWholeSeconds` and `minCapsValueJustAboveTheLimit` to `TemporalsTest`. Both fail on the current code (max returns `0.2S`, the cap returns `5.001S`) and pass with the fix. Pure logic, no DB/container. The existing tests didn't catch it because they only compare durations whose whole seconds differ — the one case where `compareTo` happens to return `1`.

Closes debezium/dbz#2338