### PR TITLE
debezium/dbz#2345 Consolidate retry utilities around RetryingSupplier

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -3466,7 +3466,7 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
             assertConnectorIsRunning();
             scenario.run();
 
-            final String message = "Failed with retriable exception, will retry later; attempt #1 out of 1";
+            final String message = "Callable failed with exception, will try and auto heal (if configured); attempt #1 out of 1";
             Awaitility.await()
                     .alias("Checking for maximum restart messages1")
                     .pollInterval(100, TimeUnit.MILLISECONDS)

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -1293,7 +1293,8 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         private final SourceRecordCommitter committer;
 
         PollRecords(final EngineSourceTask task, final RecordProcessor processor, final AtomicReference<State> engineState) {
-            super(Configuration.from(task.context().config()).getInteger(EmbeddedEngineConfig.ERRORS_MAX_RETRIES));
+            super(Configuration.from(task.context().config()).getInteger(EmbeddedEngineConfig.ERRORS_MAX_RETRIES),
+                    Configuration.from(task.context().config()).getString(CommonConnectorConfig.CUSTOM_RETRIABLE_EXCEPTION));
             this.task = task;
             this.processor = processor;
             this.engineState = engineState;

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
@@ -29,9 +29,15 @@ public abstract class RetryingCallable<V> implements Callable<V> {
     private static final Logger LOGGER = LoggerFactory.getLogger(RetryingCallable.class);
 
     private final int retries;
+    private final String customRetriableMessagePattern;
 
     public RetryingCallable(final int retries) {
+        this(retries, null);
+    }
+
+    public RetryingCallable(final int retries, final String customRetriableMessagePattern) {
         this.retries = retries;
+        this.customRetriableMessagePattern = customRetriableMessagePattern;
     }
 
     public abstract V doCall() throws Exception;
@@ -43,6 +49,7 @@ public abstract class RetryingCallable<V> implements Callable<V> {
                 .retries(retries)
                 .doGet(this::doCall)
                 .retriableExceptions(RetriableException.class)
+                .customRetriableMessagePattern(customRetriableMessagePattern)
                 .delayStrategy(delayStrategy())
                 .name("Callable")
                 .logger(LOGGER)

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
@@ -50,6 +50,11 @@ public abstract class RetryingCallable<V> implements Callable<V> {
                 .doGet(this::doCall)
                 .retriableExceptions(RetriableException.class)
                 .customRetriableMessagePattern(customRetriableMessagePattern)
+                // A terminal failure can wrap a retriable one on purpose (ErrorHandler wraps a
+                // retriable whose connector-side retries are exhausted in a ConnectException, which
+                // ChangeEventQueue raises from poll() to stop the task): examining the thrown
+                // exception alone preserves that contract.
+                .walkCauseChain(false)
                 .delayStrategy(delayStrategy())
                 .name("Callable")
                 .logger(LOGGER)

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
@@ -8,6 +8,8 @@ package io.debezium.embedded.async;
 import java.util.concurrent.Callable;
 
 import org.apache.kafka.connect.errors.RetriableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.util.DelayStrategy;
 import io.debezium.util.RetryingSupplier;
@@ -23,6 +25,8 @@ import io.debezium.util.RetryingSupplier;
  * @author vjuranek
  */
 public abstract class RetryingCallable<V> implements Callable<V> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingCallable.class);
 
     private final int retries;
 
@@ -41,6 +45,7 @@ public abstract class RetryingCallable<V> implements Callable<V> {
                 .retriableExceptions(RetriableException.class)
                 .delayStrategy(delayStrategy())
                 .name("Callable")
+                .logger(LOGGER)
                 .build()
                 .get();
     }

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/RetryingCallable.java
@@ -8,21 +8,21 @@ package io.debezium.embedded.async;
 import java.util.concurrent.Callable;
 
 import org.apache.kafka.connect.errors.RetriableException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.util.DelayStrategy;
+import io.debezium.util.RetryingSupplier;
 
 /**
  * Extension to {@link Callable}, which allows to re-try the action if exception is thrown during the execution.
  * The action is re-tried {@code retries} number of times.
  * The delay between retries is defined by {@link DelayStrategy}, which needs to be provided by the implementing class.
+ * The action is re-tried when a {@link RetriableException} is thrown, either directly or as any exception in the
+ * cause chain of the thrown exception. The retry loop is implemented by {@link RetryingSupplier}, to which this
+ * class delegates.
  *
  * @author vjuranek
  */
 public abstract class RetryingCallable<V> implements Callable<V> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingCallable.class);
 
     private final int retries;
 
@@ -35,35 +35,13 @@ public abstract class RetryingCallable<V> implements Callable<V> {
     public abstract DelayStrategy delayStrategy();
 
     public V call() throws Exception {
-        final DelayStrategy delayStrategy = delayStrategy();
-        // 0 retries means retries are disabled,
-        // -1 means infinite retries; int range is not infinite, but in this case probably a sufficient approximation.
-        // We start from `retries` as the last call attempt is done out of the retry loop and this last call either
-        // succeeds or throws an exception which is propagated further. I.e. the actual number of calls is `retries+1`,
-        // meaning one ordinary call and #`retries` is it fails.
-        int attempts = retries;
-        while (attempts != 0) {
-            try {
-                return doCall();
-            }
-            catch (RetriableException e) {
-                attempts--;
-                String retriesExplained = retries == -1 ? "infinity" : String.valueOf(retries);
-                LOGGER.info("Failed with retriable exception, will retry later; attempt #{} out of {}",
-                        retries - attempts,
-                        retriesExplained,
-                        e);
-                delayStrategy.sleepWhen(true);
-                // DelayStrategy catches interrupted exception during the sleep and just set back interrupted status.
-                // We need to re-throw the InterruptedException to avoid unwanted cycles in the retry loop, e.g. when
-                // executor service running this callable shuts down. Without re-throwing the exception it would
-                // result into cycling in the retry loop without any sleep in DelayStrategy until the running thread is
-                // killed by the executor service.
-                if (Thread.currentThread().isInterrupted()) {
-                    throw new InterruptedException("Callable was interrupted while sleeping in DelayStrategy");
-                }
-            }
-        }
-        return doCall();
+        return RetryingSupplier.<V, Exception> builder()
+                .retries(retries)
+                .doGet(this::doCall)
+                .retriableExceptions(RetriableException.class)
+                .delayStrategy(delayStrategy())
+                .name("Callable")
+                .build()
+                .get();
     }
 }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/RetryingCallableTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/RetryingCallableTest.java
@@ -46,21 +46,21 @@ public class RetryingCallableTest {
     void shouldExecuteNeverFailing() throws InterruptedException, ExecutionException {
         final LogInterceptor interceptor = new LogInterceptor(RetryingCallable.class);
         Assertions.assertThat(execService.submit(new NeverFailing(0)).get()).isEqualTo(1);
-        assertThat(interceptor.containsMessage("Failed with retriable exception")).isFalse();
+        assertThat(interceptor.containsMessage("failed with exception, will try and auto heal")).isFalse();
     }
 
     @Test
     void shouldNotRetryWhenCallableDoesNotFail() throws InterruptedException, ExecutionException {
         final LogInterceptor interceptor = new LogInterceptor(RetryingCallable.class);
         Assertions.assertThat(execService.submit(new NeverFailing(10)).get()).isEqualTo(1);
-        assertThat(interceptor.containsMessage("Failed with retriable exception")).isFalse();
+        assertThat(interceptor.containsMessage("failed with exception, will try and auto heal")).isFalse();
     }
 
     @Test
     void shouldIgnoreInfiniteRetryWhenCallableDoesNotFail() throws InterruptedException, ExecutionException {
         final LogInterceptor interceptor = new LogInterceptor(RetryingCallable.class);
         Assertions.assertThat(execService.submit(new NeverFailing(EmbeddedEngineConfig.DEFAULT_ERROR_MAX_RETRIES)).get()).isEqualTo(1);
-        assertThat(interceptor.containsMessage("Failed with retriable exception")).isFalse();
+        assertThat(interceptor.containsMessage("failed with exception, will try and auto heal")).isFalse();
     }
 
     @Test
@@ -78,7 +78,7 @@ public class RetryingCallableTest {
 
         // Callable should fail 2 times and 3rh time it should succeed.
         assertThat(failing.calls).isEqualTo(3);
-        assertThat(interceptor.countOccurrences("Failed with retriable exception")).isEqualTo(2);
+        assertThat(interceptor.countOccurrences("failed with exception, will try and auto heal")).isEqualTo(2);
     }
 
     @Test
@@ -98,7 +98,7 @@ public class RetryingCallableTest {
         assertThat(failing.calls).isEqualTo(6);
         // But we should see only 5 exception as the call was retried 5 times and on the 6th call failed, which is
         // not logged but thrown up to the stack.
-        assertThat(interceptor.countOccurrences("Failed with retriable exception")).isEqualTo(5);
+        assertThat(interceptor.countOccurrences("failed with exception, will try and auto heal")).isEqualTo(5);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class RetryingCallableTest {
         // Should be called only 1 time.
         assertThat(failing.calls).isEqualTo(1);
         // And there shouldn't be any call in retry loop.
-        assertThat(interceptor.containsMessage("Failed with retriable exception")).isFalse();
+        assertThat(interceptor.containsMessage("failed with exception, will try and auto heal")).isFalse();
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RetryingCallableTest {
 
         // Wait between the calls is 100 ms, so we should have at least 5 calls during 3 seconds sleep.
         assertThat(failing.calls).isGreaterThan(5);
-        assertThat(interceptor.countOccurrences("Failed with retriable exception")).isGreaterThan(5);
+        assertThat(interceptor.countOccurrences("failed with exception, will try and auto heal")).isGreaterThan(5);
     }
 
     private static class NeverFailing extends RetryingCallable<Integer> {

--- a/debezium-util/src/main/java/io/debezium/function/ThrowingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/function/ThrowingSupplier.java
@@ -5,6 +5,12 @@
  */
 package io.debezium.function;
 
+/**
+ * A variant of {@link java.util.function.Supplier} whose {@code get()} method can throw a checked exception.
+ *
+ * @param <V> the type of the supplied value
+ * @param <E> the checked exception type the supplier is allowed to throw
+ */
 @FunctionalInterface
 public interface ThrowingSupplier<V, E extends Exception> {
 

--- a/debezium-util/src/main/java/io/debezium/function/ThrowingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/function/ThrowingSupplier.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.function;
+
+@FunctionalInterface
+public interface ThrowingSupplier<V, E extends Exception> {
+
+    V get() throws E, InterruptedException;
+
+}

--- a/debezium-util/src/main/java/io/debezium/util/DelayStrategy.java
+++ b/debezium-util/src/main/java/io/debezium/util/DelayStrategy.java
@@ -6,6 +6,7 @@
 package io.debezium.util;
 
 import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -180,6 +181,62 @@ public interface DelayStrategy {
 
             private boolean maxDelayedReached() {
                 return bounded && previousDelay >= maxDelayInMilliseconds;
+            }
+        };
+    }
+
+    /**
+     * Create a delay strategy that applies an exponentially-increasing delay where each sleep is randomized within
+     * {@code +/- jitterFactor} of the current delay, so that concurrent retry loops hitting the same resource do
+     * not wake up in lockstep. The exponential progression is computed on the un-jittered delay and stays at the
+     * maximum once reached. As soon as the criteria is not met, the delay resets to the initial value.
+     *
+     * @param initialDelay the initial delay; must be positive
+     * @param maxDelay the maximum delay; must be no less than the initial delay
+     * @param backOffMultiplier the factor by which the delay increases each pass; must be at least 1
+     * @param jitterFactor the fraction of the current delay used as randomization range; must be in [0, 1)
+     * @return the strategy
+     */
+    static DelayStrategy exponentialWithJitter(Duration initialDelay, Duration maxDelay, double backOffMultiplier, double jitterFactor) {
+        final long initialDelayInMilliseconds = initialDelay.toMillis();
+        final long maxDelayInMilliseconds = maxDelay.toMillis();
+        if (backOffMultiplier < 1.0) {
+            throw new IllegalArgumentException("Backoff multiplier must be at least 1");
+        }
+        if (initialDelayInMilliseconds <= 0) {
+            throw new IllegalArgumentException("Initial delay must be positive");
+        }
+        if (initialDelayInMilliseconds > maxDelayInMilliseconds) {
+            throw new IllegalArgumentException("Maximum delay must be no less than initial delay");
+        }
+        if (jitterFactor < 0.0 || jitterFactor >= 1.0) {
+            throw new IllegalArgumentException("Jitter factor must be in [0, 1)");
+        }
+        return new DelayStrategy() {
+            private long previousDelay = 0;
+
+            @Override
+            public boolean sleepWhen(boolean criteria) {
+                if (!criteria) {
+                    previousDelay = 0;
+                    return false;
+                }
+                if (previousDelay == 0) {
+                    previousDelay = initialDelayInMilliseconds;
+                }
+                else {
+                    previousDelay = Math.min((long) (previousDelay * backOffMultiplier), maxDelayInMilliseconds);
+                }
+                final long jitter = (long) (previousDelay * jitterFactor);
+                final long sleepMs = previousDelay - jitter
+                        + (jitter > 0 ? ThreadLocalRandom.current().nextLong(2 * jitter + 1) : 0);
+                try {
+                    Thread.sleep(sleepMs);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return true;
             }
         };
     }

--- a/debezium-util/src/main/java/io/debezium/util/DelayStrategy.java
+++ b/debezium-util/src/main/java/io/debezium/util/DelayStrategy.java
@@ -193,15 +193,15 @@ public interface DelayStrategy {
      *
      * @param initialDelay the initial delay; must be positive
      * @param maxDelay the maximum delay; must be no less than the initial delay
-     * @param backOffMultiplier the factor by which the delay increases each pass; must be at least 1
+     * @param backOffMultiplier the factor by which the delay increases each pass; must be greater than 1
      * @param jitterFactor the fraction of the current delay used as randomization range; must be in [0, 1)
      * @return the strategy
      */
     static DelayStrategy exponentialWithJitter(Duration initialDelay, Duration maxDelay, double backOffMultiplier, double jitterFactor) {
         final long initialDelayInMilliseconds = initialDelay.toMillis();
         final long maxDelayInMilliseconds = maxDelay.toMillis();
-        if (backOffMultiplier < 1.0) {
-            throw new IllegalArgumentException("Backoff multiplier must be at least 1");
+        if (backOffMultiplier <= 1.0) {
+            throw new IllegalArgumentException("Backoff multiplier must be greater than 1");
         }
         if (initialDelayInMilliseconds <= 0) {
             throw new IllegalArgumentException("Initial delay must be positive");

--- a/debezium-util/src/main/java/io/debezium/util/RetryingRunnable.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingRunnable.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.function.ThrowingRunnable;
 
 /**
@@ -24,6 +27,8 @@ import io.debezium.function.ThrowingRunnable;
  */
 public class RetryingRunnable<E extends Exception> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingRunnable.class);
+
     private final RetryingSupplier<Void, E> delegate;
 
     private RetryingRunnable(Builder<E> b) {
@@ -37,6 +42,7 @@ public class RetryingRunnable<E extends Exception> {
                 .delayStrategy(b.delayStrategy)
                 .retriableExceptions(b.retriableExceptions)
                 .name("Runnable")
+                .logger(LOGGER)
                 .build();
     }
 

--- a/debezium-util/src/main/java/io/debezium/util/RetryingRunnable.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingRunnable.java
@@ -9,40 +9,35 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.debezium.function.ThrowingRunnable;
 
 /**
  * Allows to re-try a runnable action if exception is thrown during the execution.
  * The action is re-tried {@code retries} number of times.
- * The delay between retries is defined by {@link DelayStrategy}, which needs to be provided by the implementing class.
- * Optionally, an auto-heal action can be provided, which is executed before each retry.
+ * The delay between attempts is defined by {@link DelayStrategy}.
+ * Optionally, an auto-heal action can be provided, which is executed before each retry: when it succeeds the action
+ * is retried immediately, when it fails (or when no auto-heal is configured) the delay strategy is applied.
  * Optionally, a list of retriable exception types can be provided: if the list is empty, the action is retried for
  * all exceptions, otherwise it is retried only for exceptions which are instances of one of the supplied types
  * (i.e. the supplied type or any of its descendants). A non-retriable exception is propagated immediately.
- * Inspired by: io.debezium.embedded.async.RetryingCallable.
+ * The retry loop is implemented by {@link RetryingSupplier}, to which this class delegates.
  */
 public class RetryingRunnable<E extends Exception> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingRunnable.class);
+    private final RetryingSupplier<Void, E> delegate;
 
-    private final ThrowingRunnable<E> NO_OP_HEAL = () -> {
-    };
-    private final int retries;
-    private final ThrowingRunnable<E> doRun;
-    private final ThrowingRunnable<E> doAutoHeal;
-    private final DelayStrategy delayStrategy;
-    private final List<Class<? extends Exception>> retriableExceptions;
-
-    // package-private / private: construction goes through the builder
     private RetryingRunnable(Builder<E> b) {
-        this.retries = b.retries;
-        this.doRun = b.doRun;
-        this.doAutoHeal = b.doAutoHeal == null ? NO_OP_HEAL : b.doAutoHeal;
-        this.delayStrategy = b.delayStrategy;
-        this.retriableExceptions = b.retriableExceptions;
+        this.delegate = RetryingSupplier.<Void, E> builder()
+                .retries(b.retries)
+                .doGet(() -> {
+                    b.doRun.run();
+                    return null;
+                })
+                .doAutoHeal(b.doAutoHeal)
+                .delayStrategy(b.delayStrategy)
+                .retriableExceptions(b.retriableExceptions)
+                .name("Runnable")
+                .build();
     }
 
     public static <E extends Exception> Builder<E> builder() {
@@ -50,125 +45,19 @@ public class RetryingRunnable<E extends Exception> {
     }
 
     public void runWrapped(Function<Throwable, E> exceptionWrapper) throws E {
-        try {
-            run();
-        }
-        catch (InterruptedException ex) {
-            throw exceptionWrapper.apply(ex);
-        }
+        delegate.getWrapped(exceptionWrapper);
     }
 
     public void run() throws E, InterruptedException {
-        // 0 retries means retries are disabled,
-        // -1 means infinite retries; int range is not infinite, but in this case probably a sufficient approximation.
-        // We start from `retries` as the last call attempt is done out of the retry loop and this last call either
-        // succeeds or throws an exception which is propagated further. I.e. the actual number of calls is `retries+1`,
-        // meaning one ordinary call and #`retries` is it fails.
-        int attempts = retries;
-        while (attempts != 0) {
-            try {
-                doRun.run();
-                return;
-            }
-            catch (InterruptedException ex) {
-                throw ex;
-            }
-            catch (Exception ex) {
-                // This must be E or a RuntimeException
-                if (!isRetriable(ex)) {
-                    // Not in the retriable list: propagate immediately without auto heal or delay.
-                    throwAsEOrRuntime(ex);
-                }
-                attempts--;
-                String retriesExplained = retries == -1 ? "infinity" : String.valueOf(retries);
-                LOGGER.info("Runnable failed with exception, will try and auto heal (if configured); attempt #{} out of {}",
-                        retries - attempts,
-                        retriesExplained,
-                        ex);
-
-                if (doAutoHeal == NO_OP_HEAL) {
-                    executeDelayStrategy();
-                }
-                else {
-                    // Auto heal
-                    try {
-                        doAutoHeal.run();
-                    }
-                    catch (InterruptedException exAutoHeal) {
-                        throw exAutoHeal;
-                    }
-                    catch (Exception exAutoHeal) {
-                        // Again, this must be E or a RuntimeException
-                        LOGGER.info("Auto heal failed with exception, will retry later; attempt #{} out of {}",
-                                retries - attempts,
-                                retriesExplained,
-                                exAutoHeal);
-                        executeDelayStrategy();
-                    }
-                }
-
-            }
-        }
-        doRun.run();
+        delegate.get();
     }
 
-    private void executeDelayStrategy() throws InterruptedException {
-        delayStrategy.sleepWhen(true);
-        if (Thread.currentThread().isInterrupted()) {
-            throw new InterruptedException("Runnable was interrupted while sleeping in DelayStrategy");
-        }
-    }
-
-    /**
-     * Returns {@code true} if the given exception should be retried. When no retriable exception types were
-     * configured (empty list), every exception is retriable. Otherwise the exception is retriable only if it is
-     * an instance of one of the configured types (or a descendant thereof).
-     */
-    private boolean isRetriable(Exception ex) {
-        if (retriableExceptions.isEmpty()) {
-            return true;
-        }
-        Throwable current = ex;
-        Throwable slow = ex; // Floyd's cycle guard
-        boolean advanceSlow = false;
-        while (current != null) {
-            for (Class<? extends Exception> retriable : retriableExceptions) {
-                if (retriable.isInstance(current)) {
-                    return true;
-                }
-            }
-            current = current.getCause();
-            if (advanceSlow) {
-                slow = slow.getCause();
-                if (current == slow) {
-                    break; // cycle detected
-                }
-            }
-            advanceSlow = !advanceSlow;
-        }
-        return false;
-    }
-
-    /**
-     * Re-throws the given exception. Inside {@link #run()} a caught {@link Exception} must be either {@code E} or a
-     * {@link RuntimeException}, so this cast is safe; it lets us propagate a non-retriable exception while keeping
-     * the checked {@code throws E} contract.
-     */
-    @SuppressWarnings("unchecked")
-    private void throwAsEOrRuntime(Exception ex) throws E {
-        if (ex instanceof RuntimeException) {
-            throw (RuntimeException) ex;
-        }
-        throw (E) ex;
-    }
-
-    // ---- Builder ----
     public static final class Builder<E extends Exception> {
         private int retries = 0;
         private ThrowingRunnable<E> doRun;
         private ThrowingRunnable<E> doAutoHeal;
-        private DelayStrategy delayStrategy = DelayStrategy.none(); // default: no delay
-        private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>(); // default: retry all
+        private DelayStrategy delayStrategy = DelayStrategy.none();
+        private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>();
 
         private Builder() {
         }
@@ -222,7 +111,6 @@ public class RetryingRunnable<E extends Exception> {
             if (doRun == null) {
                 throw new IllegalStateException("doRun must be provided");
             }
-            // delayStrategy / doAutoHeal / retriableExceptions have sensible defaults above
             return new RetryingRunnable<>(this);
         }
     }

--- a/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
@@ -37,6 +37,7 @@ public class RetryingSupplier<V, E extends Exception> {
     private final DelayStrategy delayStrategy;
     private final List<Class<? extends Exception>> retriableExceptions;
     private final String customRetriableMessagePattern;
+    private final boolean walkCauseChain;
     private final String name;
     private final Logger logger;
 
@@ -47,6 +48,7 @@ public class RetryingSupplier<V, E extends Exception> {
         this.delayStrategy = b.delayStrategy;
         this.retriableExceptions = b.retriableExceptions;
         this.customRetriableMessagePattern = b.customRetriableMessagePattern;
+        this.walkCauseChain = b.walkCauseChain;
         this.name = b.name;
         this.logger = b.logger;
     }
@@ -156,6 +158,9 @@ public class RetryingSupplier<V, E extends Exception> {
                     && current.getMessage().matches(customRetriableMessagePattern)) {
                 return true;
             }
+            if (!walkCauseChain) {
+                return false;
+            }
             current = current.getCause();
             if (advanceSlow) {
                 slow = slow.getCause();
@@ -188,6 +193,7 @@ public class RetryingSupplier<V, E extends Exception> {
         private DelayStrategy delayStrategy = DelayStrategy.none();
         private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>();
         private String customRetriableMessagePattern;
+        private boolean walkCauseChain = true;
         private String name = "Operation";
         private Logger logger = LOGGER;
 
@@ -243,13 +249,26 @@ public class RetryingSupplier<V, E extends Exception> {
         }
 
         /**
-         * Sets a regular expression matched against the messages of the thrown exception and its causes;
-         * a match classifies the exception as retriable even when its type does not. This mirrors the
-         * semantics of the internal {@code custom.retriable.exception} connector option. A {@code null}
-         * pattern (the default) disables the message-based classification.
+         * Sets a regular expression matched against the messages of the thrown exception and, subject to
+         * {@link #walkCauseChain(boolean)}, its causes; a match classifies the exception as retriable even
+         * when its type does not. This mirrors the semantics of the internal
+         * {@code custom.retriable.exception} connector option. A {@code null} pattern (the default)
+         * disables the message-based classification.
          */
         public Builder<V, E> customRetriableMessagePattern(String customRetriableMessagePattern) {
             this.customRetriableMessagePattern = customRetriableMessagePattern;
+            return this;
+        }
+
+        /**
+         * Whether the retriability classification walks the exception cause chain (the default) or
+         * examines the thrown exception alone. Callers whose failure contract distinguishes a
+         * retriable exception from a terminal one that merely wraps it, such as the engine polling
+         * loop where {@code ChangeEventQueue} raises a {@code ConnectException} to stop the task,
+         * should disable the walk to keep that distinction.
+         */
+        public Builder<V, E> walkCauseChain(boolean walkCauseChain) {
+            this.walkCauseChain = walkCauseChain;
             return this;
         }
 

--- a/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
@@ -36,6 +36,7 @@ public class RetryingSupplier<V, E extends Exception> {
     private final ThrowingRunnable<E> doAutoHeal;
     private final DelayStrategy delayStrategy;
     private final List<Class<? extends Exception>> retriableExceptions;
+    private final String customRetriableMessagePattern;
     private final String name;
     private final Logger logger;
 
@@ -45,6 +46,7 @@ public class RetryingSupplier<V, E extends Exception> {
         this.doAutoHeal = b.doAutoHeal;
         this.delayStrategy = b.delayStrategy;
         this.retriableExceptions = b.retriableExceptions;
+        this.customRetriableMessagePattern = b.customRetriableMessagePattern;
         this.name = b.name;
         this.logger = b.logger;
     }
@@ -150,6 +152,10 @@ public class RetryingSupplier<V, E extends Exception> {
                     return true;
                 }
             }
+            if (customRetriableMessagePattern != null && current.getMessage() != null
+                    && current.getMessage().matches(customRetriableMessagePattern)) {
+                return true;
+            }
             current = current.getCause();
             if (advanceSlow) {
                 slow = slow.getCause();
@@ -181,6 +187,7 @@ public class RetryingSupplier<V, E extends Exception> {
         private ThrowingRunnable<E> doAutoHeal;
         private DelayStrategy delayStrategy = DelayStrategy.none();
         private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>();
+        private String customRetriableMessagePattern;
         private String name = "Operation";
         private Logger logger = LOGGER;
 
@@ -232,6 +239,17 @@ public class RetryingSupplier<V, E extends Exception> {
             this.retriableExceptions = (retriableExceptions == null)
                     ? new ArrayList<>()
                     : new ArrayList<>(retriableExceptions);
+            return this;
+        }
+
+        /**
+         * Sets a regular expression matched against the messages of the thrown exception and its causes;
+         * a match classifies the exception as retriable even when its type does not. This mirrors the
+         * semantics of the internal {@code custom.retriable.exception} connector option. A {@code null}
+         * pattern (the default) disables the message-based classification.
+         */
+        public Builder<V, E> customRetriableMessagePattern(String customRetriableMessagePattern) {
+            this.customRetriableMessagePattern = customRetriableMessagePattern;
             return this;
         }
 

--- a/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.function.ThrowingRunnable;
+import io.debezium.function.ThrowingSupplier;
+
+/**
+ * Allows to re-try an action producing a value if exception is thrown during the execution.
+ * The action is re-tried {@code retries} number of times.
+ * The delay between attempts is defined by {@link DelayStrategy}.
+ * Optionally, an auto-heal action can be provided, which is executed before each retry: when it succeeds the action
+ * is retried immediately, when it fails (or when no auto-heal is configured) the delay strategy is applied.
+ * Optionally, a list of retriable exception types can be provided: if the list is empty, the action is retried for
+ * all exceptions, otherwise it is retried only for exceptions which are, or contain in their cause chain, an
+ * instance of one of the supplied types. A non-retriable exception is propagated immediately.
+ * This class hosts the retry loop shared with {@link RetryingRunnable}.
+ */
+public class RetryingSupplier<V, E extends Exception> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingSupplier.class);
+
+    private final int retries;
+    private final ThrowingSupplier<V, E> doGet;
+    private final ThrowingRunnable<E> doAutoHeal;
+    private final DelayStrategy delayStrategy;
+    private final List<Class<? extends Exception>> retriableExceptions;
+    private final String name;
+
+    private RetryingSupplier(Builder<V, E> b) {
+        this.retries = b.retries;
+        this.doGet = b.doGet;
+        this.doAutoHeal = b.doAutoHeal;
+        this.delayStrategy = b.delayStrategy;
+        this.retriableExceptions = b.retriableExceptions;
+        this.name = b.name;
+    }
+
+    public static <V, E extends Exception> Builder<V, E> builder() {
+        return new Builder<>();
+    }
+
+    public V getWrapped(Function<Throwable, E> exceptionWrapper) throws E {
+        try {
+            return get();
+        }
+        catch (InterruptedException ex) {
+            throw exceptionWrapper.apply(ex);
+        }
+    }
+
+    public V get() throws E, InterruptedException {
+        // 0 retries means retries are disabled,
+        // -1 means infinite retries; int range is not infinite, but in this case probably a sufficient approximation.
+        // We start from `retries` as the last call attempt is done out of the retry loop and this last call either
+        // succeeds or throws an exception which is propagated further. I.e. the actual number of calls is `retries+1`,
+        // meaning one ordinary call and #`retries` is it fails.
+        int attempts = retries;
+        while (attempts != 0) {
+            try {
+                final V result = doGet.get();
+                if (attempts != retries) {
+                    LOGGER.info("{} succeeded after {} retry attempt(s)", name, retries - attempts);
+                }
+                return result;
+            }
+            catch (InterruptedException ex) {
+                throw ex;
+            }
+            catch (Exception ex) {
+                if (!isRetriable(ex)) {
+                    throwAsEOrRuntime(ex);
+                }
+                attempts--;
+                String retriesExplained = retries == -1 ? "infinity" : String.valueOf(retries);
+                LOGGER.info("{} failed with exception, will try and auto heal (if configured); attempt #{} out of {}",
+                        name,
+                        retries - attempts,
+                        retriesExplained,
+                        ex);
+
+                if (doAutoHeal == null) {
+                    executeDelayStrategy();
+                }
+                else {
+                    try {
+                        doAutoHeal.run();
+                    }
+                    catch (InterruptedException exAutoHeal) {
+                        throw exAutoHeal;
+                    }
+                    catch (Exception exAutoHeal) {
+                        LOGGER.info("Auto heal of {} failed with exception, will retry later; attempt #{} out of {}",
+                                name,
+                                retries - attempts,
+                                retriesExplained,
+                                exAutoHeal);
+                        executeDelayStrategy();
+                    }
+                }
+            }
+        }
+        final V result = doGet.get();
+        if (retries > 0) {
+            LOGGER.info("{} succeeded after {} retry attempt(s)", name, retries);
+        }
+        return result;
+    }
+
+    private void executeDelayStrategy() throws InterruptedException {
+        delayStrategy.sleepWhen(true);
+        // DelayStrategy catches interrupted exception during the sleep and just set back interrupted status.
+        // We need to re-throw the InterruptedException to avoid unwanted cycles in the retry loop, e.g. when
+        // executor service running this action shuts down. Without re-throwing the exception it would
+        // result into cycling in the retry loop without any sleep in DelayStrategy until the running thread is
+        // killed by the executor service.
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException(name + " was interrupted while sleeping in DelayStrategy");
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given exception should be retried. When no retriable exception types were
+     * configured (empty list), every exception is retriable. Otherwise the exception is retriable only if it, or
+     * any exception in its cause chain, is an instance of one of the configured types (or a descendant thereof).
+     */
+    private boolean isRetriable(Exception ex) {
+        if (retriableExceptions.isEmpty()) {
+            return true;
+        }
+        Throwable current = ex;
+        Throwable slow = ex; // Floyd's cycle guard
+        boolean advanceSlow = false;
+        while (current != null) {
+            for (Class<? extends Exception> retriable : retriableExceptions) {
+                if (retriable.isInstance(current)) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+            if (advanceSlow) {
+                slow = slow.getCause();
+                if (current == slow) {
+                    break; // cycle detected
+                }
+            }
+            advanceSlow = !advanceSlow;
+        }
+        return false;
+    }
+
+    /**
+     * Re-throws the given exception. Inside {@link #get()} a caught {@link Exception} must be either {@code E} or a
+     * {@link RuntimeException}, so this cast is safe; it lets us propagate a non-retriable exception while keeping
+     * the checked {@code throws E} contract.
+     */
+    @SuppressWarnings("unchecked")
+    private void throwAsEOrRuntime(Exception ex) throws E {
+        if (ex instanceof RuntimeException) {
+            throw (RuntimeException) ex;
+        }
+        throw (E) ex;
+    }
+
+    public static final class Builder<V, E extends Exception> {
+        private int retries = 0;
+        private ThrowingSupplier<V, E> doGet;
+        private ThrowingRunnable<E> doAutoHeal;
+        private DelayStrategy delayStrategy = DelayStrategy.none();
+        private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>();
+        private String name = "Operation";
+
+        private Builder() {
+        }
+
+        public Builder<V, E> retries(int retries) {
+            this.retries = retries;
+            return this;
+        }
+
+        public Builder<V, E> doGet(ThrowingSupplier<V, E> doGet) {
+            this.doGet = doGet;
+            return this;
+        }
+
+        public Builder<V, E> doAutoHeal(ThrowingRunnable<E> doAutoHeal) {
+            this.doAutoHeal = doAutoHeal;
+            return this;
+        }
+
+        public Builder<V, E> delayStrategy(DelayStrategy delayStrategy) {
+            this.delayStrategy = delayStrategy;
+            return this;
+        }
+
+        /**
+         * Sets the name used in log messages to identify the retried operation.
+         */
+        public Builder<V, E> name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the list of retriable exception types. If empty (the default), all exceptions are retried;
+         * otherwise only exceptions assignable to one of the supplied types are retried. A {@code null} argument
+         * is treated as an empty list (retry all).
+         */
+        public Builder<V, E> retriableExceptions(List<Class<? extends Exception>> retriableExceptions) {
+            this.retriableExceptions = (retriableExceptions == null)
+                    ? new ArrayList<>()
+                    : new ArrayList<>(retriableExceptions);
+            return this;
+        }
+
+        @SafeVarargs
+        public final Builder<V, E> retriableExceptions(Class<? extends Exception>... retriableExceptions) {
+            this.retriableExceptions = new ArrayList<>();
+            if (retriableExceptions != null) {
+                for (Class<? extends Exception> type : retriableExceptions) {
+                    if (type != null) {
+                        this.retriableExceptions.add(type);
+                    }
+                }
+            }
+            return this;
+        }
+
+        public RetryingSupplier<V, E> build() {
+            if (doGet == null) {
+                throw new IllegalStateException("doGet must be provided");
+            }
+            return new RetryingSupplier<>(this);
+        }
+    }
+}

--- a/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
@@ -73,7 +73,7 @@ public class RetryingSupplier<V, E extends Exception> {
             try {
                 final V result = doGet.get();
                 if (attempts != retries) {
-                    logger.info("{} succeeded after {} retry attempt(s)", name, retries - attempts);
+                    logger.debug("{} succeeded after {} retry attempt(s)", name, retries - attempts);
                 }
                 return result;
             }
@@ -115,7 +115,7 @@ public class RetryingSupplier<V, E extends Exception> {
         }
         final V result = doGet.get();
         if (retries > 0) {
-            logger.info("{} succeeded after {} retry attempt(s)", name, retries);
+            logger.debug("{} succeeded after {} retry attempt(s)", name, retries);
         }
         return result;
     }

--- a/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
+++ b/debezium-util/src/main/java/io/debezium/util/RetryingSupplier.java
@@ -24,6 +24,7 @@ import io.debezium.function.ThrowingSupplier;
  * Optionally, a list of retriable exception types can be provided: if the list is empty, the action is retried for
  * all exceptions, otherwise it is retried only for exceptions which are, or contain in their cause chain, an
  * instance of one of the supplied types. A non-retriable exception is propagated immediately.
+ * Log messages are emitted through the configurable logger, so delegating adapters keep their own log category.
  * This class hosts the retry loop shared with {@link RetryingRunnable}.
  */
 public class RetryingSupplier<V, E extends Exception> {
@@ -36,6 +37,7 @@ public class RetryingSupplier<V, E extends Exception> {
     private final DelayStrategy delayStrategy;
     private final List<Class<? extends Exception>> retriableExceptions;
     private final String name;
+    private final Logger logger;
 
     private RetryingSupplier(Builder<V, E> b) {
         this.retries = b.retries;
@@ -44,6 +46,7 @@ public class RetryingSupplier<V, E extends Exception> {
         this.delayStrategy = b.delayStrategy;
         this.retriableExceptions = b.retriableExceptions;
         this.name = b.name;
+        this.logger = b.logger;
     }
 
     public static <V, E extends Exception> Builder<V, E> builder() {
@@ -70,7 +73,7 @@ public class RetryingSupplier<V, E extends Exception> {
             try {
                 final V result = doGet.get();
                 if (attempts != retries) {
-                    LOGGER.info("{} succeeded after {} retry attempt(s)", name, retries - attempts);
+                    logger.info("{} succeeded after {} retry attempt(s)", name, retries - attempts);
                 }
                 return result;
             }
@@ -83,7 +86,7 @@ public class RetryingSupplier<V, E extends Exception> {
                 }
                 attempts--;
                 String retriesExplained = retries == -1 ? "infinity" : String.valueOf(retries);
-                LOGGER.info("{} failed with exception, will try and auto heal (if configured); attempt #{} out of {}",
+                logger.info("{} failed with exception, will try and auto heal (if configured); attempt #{} out of {}",
                         name,
                         retries - attempts,
                         retriesExplained,
@@ -100,7 +103,7 @@ public class RetryingSupplier<V, E extends Exception> {
                         throw exAutoHeal;
                     }
                     catch (Exception exAutoHeal) {
-                        LOGGER.info("Auto heal of {} failed with exception, will retry later; attempt #{} out of {}",
+                        logger.info("Auto heal of {} failed with exception, will retry later; attempt #{} out of {}",
                                 name,
                                 retries - attempts,
                                 retriesExplained,
@@ -112,7 +115,7 @@ public class RetryingSupplier<V, E extends Exception> {
         }
         final V result = doGet.get();
         if (retries > 0) {
-            LOGGER.info("{} succeeded after {} retry attempt(s)", name, retries);
+            logger.info("{} succeeded after {} retry attempt(s)", name, retries);
         }
         return result;
     }
@@ -179,6 +182,7 @@ public class RetryingSupplier<V, E extends Exception> {
         private DelayStrategy delayStrategy = DelayStrategy.none();
         private List<Class<? extends Exception>> retriableExceptions = new ArrayList<>();
         private String name = "Operation";
+        private Logger logger = LOGGER;
 
         private Builder() {
         }
@@ -208,6 +212,14 @@ public class RetryingSupplier<V, E extends Exception> {
          */
         public Builder<V, E> name(String name) {
             this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the logger used for retry messages, so that delegating adapters keep their own log category.
+         */
+        public Builder<V, E> logger(Logger logger) {
+            this.logger = logger;
             return this;
         }
 

--- a/debezium-util/src/test/java/io/debezium/util/DelayStrategyTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/DelayStrategyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the jittered exponential {@link DelayStrategy}.
+ */
+public class DelayStrategyTest {
+
+    private static final Duration INITIAL = Duration.ofMillis(20);
+    private static final Duration MAX = Duration.ofMillis(80);
+
+    @Test
+    void shouldRejectNonPositiveInitialDelay() {
+        assertThatThrownBy(() -> DelayStrategy.exponentialWithJitter(Duration.ZERO, MAX, 2.0, 0.25))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectMaxDelayLowerThanInitialDelay() {
+        assertThatThrownBy(() -> DelayStrategy.exponentialWithJitter(MAX, INITIAL, 2.0, 0.25))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectBackOffMultiplierNotGreaterThanOne() {
+        assertThatThrownBy(() -> DelayStrategy.exponentialWithJitter(INITIAL, MAX, 1.0, 0.25))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectJitterFactorOutsideValidRange() {
+        assertThatThrownBy(() -> DelayStrategy.exponentialWithJitter(INITIAL, MAX, 2.0, -0.1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DelayStrategy.exponentialWithJitter(INITIAL, MAX, 2.0, 1.0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldNotSleepWhenCriteriaIsNotMet() {
+        final DelayStrategy strategy = DelayStrategy.exponentialWithJitter(INITIAL, MAX, 2.0, 0.25);
+        assertThat(strategy.sleepWhen(false)).isFalse();
+    }
+
+    @Test
+    void shouldSleepAtLeastTheJitteredLowerBoundAndStayAtMaximum() {
+        // Jitter randomizes each sleep within +/- 25% of the current delay, so only the
+        // lower bound is asserted; upper bounds would be flaky on loaded CI workers.
+        final DelayStrategy strategy = DelayStrategy.exponentialWithJitter(INITIAL, MAX, 2.0, 0.25);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(15); // 20 - 25%
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(30); // 40 - 25%
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(60); // 80 - 25%
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(60); // stays at the maximum
+    }
+
+    @Test
+    void shouldFollowThePlainExponentialProgressionWhenJitterIsZero() {
+        final DelayStrategy strategy = DelayStrategy.exponentialWithJitter(INITIAL, MAX, 2.0, 0.0);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(20);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(40);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(80);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(80);
+    }
+
+    @Test
+    void shouldResetProgressionWhenCriteriaIsNotMet() {
+        // A wide gap between the steps (20ms vs 200ms) keeps the upper-bound assertion
+        // meaningful without being flaky on loaded CI workers.
+        final DelayStrategy strategy = DelayStrategy.exponentialWithJitter(Duration.ofMillis(20), Duration.ofMillis(2000), 10.0, 0.0);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(20);
+        assertThat(elapsedMs(strategy)).isGreaterThanOrEqualTo(200);
+        assertThat(strategy.sleepWhen(false)).isFalse();
+        final long restarted = elapsedMs(strategy);
+        assertThat(restarted).isGreaterThanOrEqualTo(20);
+        assertThat(restarted).isLessThan(200);
+    }
+
+    private long elapsedMs(DelayStrategy strategy) {
+        final long start = System.nanoTime();
+        assertThat(strategy.sleepWhen(true)).isTrue();
+        return (System.nanoTime() - start) / 1_000_000;
+    }
+}

--- a/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Tests RetryingSupplier.
+ * Refactored and inspired by: io.debezium.util.RetryingRunnableTest
+ */
+public class RetryingSupplierTest {
+
+    private final List<Class<? extends Exception>> retriableExceptions = List.of(SQLRecoverableException.class);
+    private final AtomicInteger runs = new AtomicInteger();
+    private final AtomicInteger heals = new AtomicInteger();
+    private final AtomicInteger sleeps = new AtomicInteger();
+
+    private final DelayStrategy countingDelay = criteria -> {
+        if (criteria) {
+            sleeps.incrementAndGet();
+        }
+        return criteria;
+    };
+
+    @BeforeEach
+    void init() {
+        runs.set(0);
+        heals.set(0);
+        sleeps.set(0);
+    }
+
+    @Test
+    void shouldReturnValueWithoutRetryWhenNeverFailing() throws InterruptedException, SQLException {
+        assertThat(getNeverFailing(10).get()).isEqualTo(1);
+        assertThat(runs.get()).isEqualTo(1);
+        assertThat(heals.get()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldIgnoreInfiniteRetryWhenSupplierDoesNotFail() throws InterruptedException, SQLException {
+        assertThat(getNeverFailing(-1).get()).isEqualTo(1);
+        assertThat(runs.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReturnValueAfterRetries() throws InterruptedException, SQLException {
+        assertThat(getTwoTimesFailing(10, null).get()).isEqualTo(3);
+
+        // Supplier should fail 2 times and 3rd time it should succeed.
+        assertThat(runs.get()).isEqualTo(3);
+        assertThat(heals.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldRetryAsManyTimesAsRequestedWhenAlwaysFails() {
+        assertThatThrownBy(() -> getAlwaysFailing(5, null).get()).isInstanceOf(SQLException.class);
+
+        // Should be called 6 times - 1 call + 5 retries.
+        assertThat(runs.get()).isEqualTo(6);
+        assertThat(heals.get()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldNotRetryWhenRetriesAreDisabled() {
+        assertThatThrownBy(() -> getAlwaysFailing(0, null).get()).isInstanceOf(SQLException.class);
+
+        assertThat(runs.get()).isEqualTo(1);
+        assertThat(heals.get()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldNotRetryForNonMatchingSuppliedRetriableExceptions() {
+        assertThatThrownBy(() -> getAlwaysFailing(5, retriableExceptions).get()).isInstanceOf(SQLException.class);
+
+        assertThat(runs.get()).isEqualTo(1);
+        assertThat(heals.get()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldRetryForMatchingSuppliedRetriableCause() throws InterruptedException, SQLException {
+        assertThat(getTwoTimesFailingWithRetriableCause(10).get()).isEqualTo(3);
+
+        assertThat(runs.get()).isEqualTo(3);
+        assertThat(heals.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldApplyDelayForEveryFailureWithoutAutoHeal() throws InterruptedException, SQLException {
+        assertThat(RetryingSupplier.<Integer, SQLException> builder()
+                .retries(10)
+                .doGet(this::failTwiceThenReturn)
+                .delayStrategy(countingDelay)
+                .build()
+                .get()).isEqualTo(3);
+
+        assertThat(runs.get()).isEqualTo(3);
+        assertThat(sleeps.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSkipDelayWhenAutoHealSucceeds() throws InterruptedException, SQLException {
+        assertThat(RetryingSupplier.<Integer, SQLException> builder()
+                .retries(10)
+                .doGet(this::failTwiceThenReturn)
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(countingDelay)
+                .build()
+                .get()).isEqualTo(3);
+
+        assertThat(heals.get()).isEqualTo(2);
+        assertThat(sleeps.get()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldApplyDelayWhenAutoHealFails() throws InterruptedException, SQLException {
+        assertThat(RetryingSupplier.<Integer, SQLException> builder()
+                .retries(10)
+                .doGet(this::failTwiceThenReturn)
+                .doAutoHeal(() -> {
+                    heals.incrementAndGet();
+                    throw new SQLException("Heal failed");
+                })
+                .delayStrategy(countingDelay)
+                .build()
+                .get()).isEqualTo(3);
+
+        assertThat(heals.get()).isEqualTo(2);
+        assertThat(sleeps.get()).isEqualTo(2);
+    }
+
+    private int failTwiceThenReturn() throws SQLException {
+        int call = runs.incrementAndGet();
+        if (call <= 2) {
+            throw new SQLException(String.format("Good try, but I fail this time (call #%s)", call));
+        }
+        return call;
+    }
+
+    private RetryingSupplier<Integer, SQLException> getNeverFailing(int retries) {
+        return RetryingSupplier.<Integer, SQLException> builder()
+                .retries(retries)
+                .doGet(runs::incrementAndGet)
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .build();
+    }
+
+    private RetryingSupplier<Integer, SQLException> getAlwaysFailing(int retries,
+                                                                     List<Class<? extends Exception>> retriableExceptions) {
+        return RetryingSupplier.<Integer, SQLException> builder()
+                .retries(retries)
+                .doGet(() -> {
+                    runs.incrementAndGet();
+                    throw new SQLException("Good try, but I always fail");
+                })
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .build();
+    }
+
+    private RetryingSupplier<Integer, SQLException> getTwoTimesFailing(int retries,
+                                                                       List<Class<? extends Exception>> retriableExceptions) {
+        return RetryingSupplier.<Integer, SQLException> builder()
+                .retries(retries)
+                .doGet(this::failTwiceThenReturn)
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .build();
+    }
+
+    private RetryingSupplier<Integer, SQLException> getTwoTimesFailingWithRetriableCause(int retries) {
+        return RetryingSupplier.<Integer, SQLException> builder()
+                .retries(retries)
+                .doGet(() -> {
+                    int call = runs.incrementAndGet();
+                    if (call <= 2) {
+                        throw new DebeziumException(new SQLRecoverableException(
+                                String.format("Good try, but I fail this time (call #%s)", call)));
+                    }
+                    return call;
+                })
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .build();
+    }
+}

--- a/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
@@ -100,6 +100,50 @@ public class RetryingSupplierTest {
     }
 
     @Test
+    void shouldNotWalkCauseChainWhenDisabled() {
+        assertThatThrownBy(() -> RetryingSupplier.<Integer, SQLException> builder()
+                .retries(10)
+                .doGet(() -> {
+                    int call = runs.incrementAndGet();
+                    if (call <= 2) {
+                        throw new DebeziumException(new SQLRecoverableException("Nested but the walk is off"));
+                    }
+                    return call;
+                })
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .walkCauseChain(false)
+                .build()
+                .get()).isInstanceOf(DebeziumException.class);
+
+        assertThat(runs.get()).isEqualTo(1);
+        assertThat(heals.get()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldStillRetryTopLevelExceptionWhenWalkDisabled() throws InterruptedException, SQLException {
+        assertThat(RetryingSupplier.<Integer, SQLException> builder()
+                .retries(10)
+                .doGet(() -> {
+                    int call = runs.incrementAndGet();
+                    if (call <= 2) {
+                        throw new SQLRecoverableException("Top-level retriable");
+                    }
+                    return call;
+                })
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .walkCauseChain(false)
+                .build()
+                .get()).isEqualTo(3);
+
+        assertThat(runs.get()).isEqualTo(3);
+        assertThat(heals.get()).isEqualTo(2);
+    }
+
+    @Test
     void shouldRetryForCustomRetriableMessageOnCause() throws InterruptedException, SQLException {
         assertThat(getTwoTimesFailingWithCustomRetriableMessage(10, ".*try again later.*").get()).isEqualTo(3);
 

--- a/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/RetryingSupplierTest.java
@@ -100,6 +100,23 @@ public class RetryingSupplierTest {
     }
 
     @Test
+    void shouldRetryForCustomRetriableMessageOnCause() throws InterruptedException, SQLException {
+        assertThat(getTwoTimesFailingWithCustomRetriableMessage(10, ".*try again later.*").get()).isEqualTo(3);
+
+        assertThat(runs.get()).isEqualTo(3);
+        assertThat(heals.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotRetryForNonMatchingCustomRetriableMessage() {
+        assertThatThrownBy(() -> getTwoTimesFailingWithCustomRetriableMessage(10, ".*unrelated pattern.*").get())
+                .isInstanceOf(SQLException.class);
+
+        assertThat(runs.get()).isEqualTo(1);
+        assertThat(heals.get()).isEqualTo(0);
+    }
+
+    @Test
     void shouldApplyDelayForEveryFailureWithoutAutoHeal() throws InterruptedException, SQLException {
         assertThat(RetryingSupplier.<Integer, SQLException> builder()
                 .retries(10)
@@ -182,6 +199,23 @@ public class RetryingSupplierTest {
                 .doAutoHeal(heals::incrementAndGet)
                 .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
                 .retriableExceptions(retriableExceptions)
+                .build();
+    }
+
+    private RetryingSupplier<Integer, SQLException> getTwoTimesFailingWithCustomRetriableMessage(int retries, String pattern) {
+        return RetryingSupplier.<Integer, SQLException> builder()
+                .retries(retries)
+                .doGet(() -> {
+                    int call = runs.incrementAndGet();
+                    if (call <= 2) {
+                        throw new SQLException(new IllegalStateException("Overloaded, try again later please"));
+                    }
+                    return call;
+                })
+                .doAutoHeal(heals::incrementAndGet)
+                .delayStrategy(DelayStrategy.linear(Duration.ofMillis(100)))
+                .retriableExceptions(retriableExceptions)
+                .customRetriableMessagePattern(pattern)
                 .build();
     }
 


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2345

This consolidates the duplicated retry loops around a single implementation, as requested in the review of #7362 (which will drop its `RetryExecutor` class and build on `RetryingSupplier` at its next iteration).

Commit 1 (`debezium-util`, no behavior change):

- New `RetryingSupplier<V, E extends Exception>`: value-returning twin of `RetryingRunnable` with the same builder contract, generic in the checked exception type so callers keep their `throws` contracts. It hosts the single retry loop with the semantics established by dbz#2329: the `DelayStrategy` is applied after every failed attempt when no auto-heal is configured, a successful auto-heal retries immediately, and a failed auto-heal applies the delay. Log messages carry an operation name and report success after retries.
- `RetryingRunnable` becomes a thin adapter over `RetryingSupplier<Void>`. Public API and behavior are unchanged; `RetryingRunnableTest` passes as is.
- New `DelayStrategy.exponentialWithJitter(initialDelay, maxDelay, backOffMultiplier, jitterFactor)`: each sleep is randomized within +/- jitterFactor of the current delay so that concurrent retry loops hitting the same resource do not wake up in lockstep. Existing factories are untouched.
- New `RetryingSupplierTest` mirroring `RetryingRunnableTest`, plus dedicated cases asserting when the delay strategy is invoked across the no-heal / heal-succeeds / heal-fails paths.

Commit 2 (`debezium-embedded`, one deliberate behavior change):

- `RetryingCallable` becomes a thin adapter over `RetryingSupplier`, removing the second copy of the loop.
- Behavior change, intentional: `RetriableException` is now also matched through the cause chain (same principle as `io.debezium.util.ErrorHandler`), so a retriable exception wrapped by a connector triggers a retry instead of failing the task. Bounded by the same `errors.max.retries` configuration. If you prefer to keep the engine untouched here, this commit can be dropped and proposed separately; commit 1 is self-contained.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
