### PR TITLE
debezium/dbz#2235 Align JDBC TINYINT expectations with INT8 mapping

### DIFF
--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -286,6 +286,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     }
 
     @TestTemplate
+    @FixFor("debezium/dbz#2235")
     @SkipWhenSource(value = { SourceType.POSTGRES, SourceType.ORACLE }, reason = "No TINYINT data type support")
     public void testTinyIntDataType(Source source, Sink sink) throws Exception {
         assertDataType(source,
@@ -293,14 +294,15 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 "tinyint",
                 List.of(10, 12),
                 (record) -> {
-                    final boolean columnTypePropagated = source.getOptions().isColumnTypePropagated();
-                    assertColumn(sink, record, "id", getInt16Type());
-                    assertColumn(sink, record, "data", columnTypePropagated ? getInt8Type() : getInt16Type());
+                    final boolean mysqlSource = source.getType().is(SourceType.MYSQL);
+                    assertColumn(sink, record, "id", mysqlSource ? getInt8Type() : getInt16Type());
+                    assertColumn(sink, record, "data", mysqlSource || source.getOptions().isColumnTypePropagated() ? getInt8Type() : getInt16Type());
                 },
                 ResultSet::getInt);
     }
 
     @TestTemplate
+    @FixFor("debezium/dbz#2235")
     @SkipWhenSource(value = { SourceType.POSTGRES, SourceType.ORACLE, SourceType.SQLSERVER }, reason = "No TINYINT(n) data type support")
     public void testTinyIntWithSizeDataType(Source source, Sink sink) throws Exception {
         assertDataType(source,
@@ -308,10 +310,8 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 "tinyint(2)",
                 List.of(10, 12),
                 (record) -> {
-                    final SourceConnectorOptions options = source.getOptions();
-                    final boolean mysqlInt8 = SinkType.MYSQL.is(sink.getType()) && options.isColumnTypePropagated();
-                    assertColumn(sink, record, "id", getInt16Type());
-                    assertColumn(sink, record, "data", mysqlInt8 ? getInt8Type() : getInt16Type());
+                    assertColumn(sink, record, "id", getInt8Type());
+                    assertColumn(sink, record, "data", getInt8Type());
                 },
                 ResultSet::getInt);
     }


### PR DESCRIPTION
Related to debezium/dbz#2235
Follow-up to #7669

## Description

Updates the JDBC end-to-end test expectations after signed MySQL `TINYINT`
columns were changed to emit INT8 schemas.

MySQL `TINYINT` columns now expect the target INT8 type regardless of column
type propagation. SQL Server `TINYINT` retains its existing INT16 expectation
because it represents an unsigned 8-bit value.

## Testing

* `./mvnw process-sources -pl debezium-connector-jdbc -am`
* `./mvnw install -pl debezium-connector-jdbc -am -Dquick`
* `./mvnw -pl debezium-connector-jdbc -DskipTests -DskipITs verify`

The targeted JDBC MySQL end-to-end tests were not run locally because Docker
Desktop had no remaining storage space. They are covered by the JDBC MySQL CI
jobs.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
