### PR TITLE
debezium/dbz#1344 Cast bound values to the destination enum type on PostgreSQL

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/EnumType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/EnumType.java
@@ -33,9 +33,7 @@ class EnumType extends AbstractType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-        // PostgreSQL does not implicitly cast a bound character varying value to an enum column, so the
-        // cast must be explicit.
-        return "cast(? as " + quoteTypeName(column.getTypeName()) + ")";
+        return "cast(? as %s)".formatted(quoteTypeName(column.getTypeName()));
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/EnumType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/EnumType.java
@@ -13,6 +13,7 @@ import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.connect.ConnectStringType;
 import io.debezium.data.Enum;
+import io.debezium.sink.column.ColumnDescriptor;
 
 /**
  * An implementation of {@link JdbcType} for {@link Enum} column types.
@@ -28,6 +29,25 @@ class EnumType extends AbstractType {
     @Override
     public String[] getRegistrationKeys() {
         return new String[]{ Enum.LOGICAL_NAME };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        // PostgreSQL does not implicitly cast a bound character varying value to an enum column, so the
+        // cast must be explicit.
+        return "cast(? as " + quoteTypeName(column.getTypeName()) + ")";
+    }
+
+    /**
+     * Quotes the column's type name for use in a cast. The driver reports the name qualified and quoted
+     * only for a type that is not on the search path; otherwise it reports {@code pg_type.typname}
+     * verbatim, which PostgreSQL would fold to lower case unless it is quoted here.
+     */
+    private static String quoteTypeName(String typeName) {
+        if (typeName.startsWith("\"")) {
+            return typeName;
+        }
+        return "\"" + typeName.replace("\"", "\"\"") + "\"";
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -29,6 +29,7 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Enum;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 
@@ -184,12 +185,15 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
      * {@code JdbcType#bind()} the row-wise path applies, so such records are handled row-wise instead.
      * {@code BYTES} fields are also excluded: the PostgreSQL driver cannot encode {@code bytea} array
      * elements ({@code createArrayOf} rejects {@code byte[]} nested inside {@code Object[]}), so such
-     * records take the row-wise path as well.
+     * records take the row-wise path as well. An enum field is handled row-wise for a related reason:
+     * the array cast above is derived from the field schema, which for an enum only resolves to the
+     * character varying fallback, whereas the cast has to name the destination column's enum type.
      */
     private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
         return record.jdbcFields().values().stream()
                 .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT
-                        || field.getSchema().type() == Schema.Type.BYTES);
+                        || field.getSchema().type() == Schema.Type.BYTES
+                        || Enum.LOGICAL_NAME.equals(field.getSchema().name()));
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -31,7 +31,9 @@ import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvi
 import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvider.PostgresInsertMode;
 import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.data.Enum;
 import io.debezium.data.Json;
 import io.debezium.data.Uuid;
 import io.debezium.doc.FixFor;
@@ -826,6 +828,88 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             // than String, so compare on their textual form which is stable across both representations.
             final Object[] actual = (Object[]) rs.getArray(2).getArray();
             assertThat(Arrays.stream(actual).map(String::valueOf).toArray(String[]::new)).isEqualTo(expected);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#1344")
+    public void testShouldCoerceEnumTypeToEnumColumnType(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        // Mixed case, so that the cast fails unless the type name is quoted rather than folded to lower case.
+        final String enumType = "Role_" + tableName;
+
+        final Schema enumSchema = Enum.builder("system,assistant,user").optional().build();
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", enumSchema, "user", config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(String.format("CREATE TYPE \"%s\" AS ENUM ('system','assistant','user')", enumType));
+        getSink().execute(String.format("CREATE TABLE %s (id int not null, data \"%s\", primary key(id))",
+                destinationTable, enumType));
+
+        consume(createRecord);
+
+        final JdbcKafkaSinkRecord updateRecord = factory.updateRecordWithSchemaValue(
+                topicName, (byte) 1, "data", enumSchema, "assistant", config);
+
+        consume(updateRecord);
+
+        getSink().assertColumn(destinationTable, "data", enumType);
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString(2)).isEqualTo("assistant");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#1344")
+    public void testShouldWriteEnumColumnWhenUnnestBatchIsEnabled(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final String enumType = "role_" + tableName;
+
+        final Schema enumSchema = Enum.builder("system,assistant,user").optional().build();
+
+        JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord record1 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", enumSchema, "user", config);
+        final JdbcKafkaSinkRecord record2 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2, "data", enumSchema, "assistant", config);
+
+        final String destinationTable = destinationTableName(record1);
+        getSink().execute(String.format("CREATE TYPE %s AS ENUM ('system','assistant','user')", enumType));
+        getSink().execute(String.format("CREATE TABLE %s (id int not null, data %s, primary key(id))",
+                destinationTable, enumType));
+
+        // More than one record so the UNNEST batch path is taken rather than the row-wise fallback.
+        consume(List.of(record1, record2));
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString(2)).isEqualTo("user");
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString(2)).isEqualTo("assistant");
             return null;
         });
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -31,7 +31,6 @@ import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvi
 import io.debezium.connector.jdbc.junit.jupiter.PostgresInsertModeArgumentsProvider.PostgresInsertMode;
 import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
-import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.Enum;
 import io.debezium.data.Json;
@@ -875,14 +874,14 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
     @FixFor("debezium/dbz#1344")
-    public void testShouldWriteEnumColumnWhenUnnestBatchIsEnabled(SinkRecordFactory factory) throws Exception {
+    public void testShouldWriteEnumColumnWhenRecordsAreBatched(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
         properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
         properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
-        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
         startSinkConnector(properties);
         assertSinkConnectorIsRunning();
 
@@ -903,7 +902,7 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().execute(String.format("CREATE TABLE %s (id int not null, data %s, primary key(id))",
                 destinationTable, enumType));
 
-        // More than one record so the UNNEST batch path is taken rather than the row-wise fallback.
+        // More than one record, so that the UNNEST batch path is reached when it is enabled.
         consume(List.of(record1, record2));
 
         getSink().assertRows(destinationTable, rs -> {


### PR DESCRIPTION
Fixes debezium/dbz#1344

## Description

Sinking an `io.debezium.data.Enum` field into a PostgreSQL enum column fails:

```
ERROR: column "role" is of type role but expression is of type character varying
```

PostgreSQL does not implicitly cast a bound `character varying` value to an enum column. A literal works because it is initially of unknown type, but the sink binds values as parameters, so the cast has to be explicit.

`GeneralDatabaseDialect#getSchemaType` resolves such a field to the PostgreSQL `EnumType`, but that type has no `getQueryBinding` override, so `AbstractType` falls back to `PostgresDatabaseDialect#getQueryBindingWithValueCast`, which only casts `uuid`, `json` and `jsonb`. The neighbouring `UuidType` and `InetType` already override `getQueryBinding`; enum was simply missing.

`EnumType#getQueryBinding` now casts to the destination column's type name. No catalog query or cache is needed: the name is already on `ColumnDescriptor#typeName`, taken from `DatabaseMetaData#getColumns`.

This follows the direction given in the review of #6990, which took the dialect-based approach:

> I don't think placing this logic in the Dialect is the correct location for this. [...] in general, any casting should be handled by the type subsystem in `io.debezium.connector.jdbc.type`. [...] could this be solved by using a transform to make sure the field is encoded as a special logical type, i.e. `io.debezium.data.Enum`, and then letting the `EnumType` handle the casting? And is the enum cache even necessary in this case?

`getQueryBindingWithValueCast` is therefore left untouched. Credit to @bpaquet for the original report and analysis.

**Quoting.** The driver reports the type name qualified and quoted (`"schema"."type"`) only when the type is not on the search path; otherwise it reports `pg_type.typname` verbatim. A verbatim name would be folded to lower case by the parser, so `cast(? as Role)` fails with `type "role" does not exist`. The name is quoted here unless the driver already quoted it. Quoting is a no-op for built-in names (`cast(? as "text")` is valid), which matters when the destination column is not an enum at all.

**UNNEST batch path.** `getBatchInsertStatement` derives its array cast from the field schema (`?::<type>[]`), which for an enum only resolves to the `character varying` fallback, so that path fails with `expression is of type text` regardless of the binding above. Since it never looks at the destination column, records carrying an enum field are routed to the row-wise path via the existing `hasUnnestUnsupportedField` escape hatch, which already serves the geometric `STRUCT` types. `getBatchUpsertStatement` delegates to `getBatchInsertStatement` and is covered by the same check.

**Scope.** This covers fields whose schema is named `io.debezium.data.Enum`, i.e. what a source emits with `column.propagate.source.type` enabled. debezium/dbz#1490 reports the same symptom for a plain unnamed `STRING` field, which never reaches an enum-aware type; that one is not addressed here and remains open. An enum array column is also out of scope: an array field resolves to `ArrayType`, which takes only the element type's `getTypeName` for `createArrayOf` and never reaches the binding above.

**Tests.** `JdbcSinkColumnTypeMappingIT` gains a round trip into a hand-created enum column across both insert modes, and one over the UNNEST batch path. The first uses a mixed-case enum type name so the quoting is actually exercised. Reverting each part of the change fails them with the reported errors respectively: `is of type role_x but expression is of type character varying`, `... but expression is of type text`, and `type "role_x" does not exist`.

Verified against `it-postgresql` (340 tests) and `e2e-postgresql`, including `JdbcSinkPipelineToPostgresIT#testEnumDataType`, which covers the case where schema evolution created the destination column as `text`.

The `io.debezium.data.Enum` row of the dialect type mapping table in the documentation describes the column type used when the connector creates the table. `getTypeName` is unchanged, so that row still holds and the documentation is not updated.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
