### PR TITLE
debezium/dbz#2355 Document UNNEST batch inserts as applicable to CockroachDB

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1933,9 +1933,11 @@ If a batch includes multiple events for the same primary key while `use.reductio
 
 The task then stops.
 
-For information about the performance benefits of enabling the UNNEST function for PostgreSQL, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
+For more information about how the connector's use of the UNNEST function improves write performance for PostgreSQL and CockroachDB databases, see the following resources:
 
-For information about the performance benefits of enabling the UNNEST function for CockroachDB, see link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
+* link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
+
+* link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
 
 |[[jdbc-property-dialect-sqlserver-identity-insert]]<<jdbc-property-dialect-sqlserver-identity-insert, `+dialect.sqlserver.identity.insert+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1922,6 +1922,9 @@ The default is `public`; however, if the PostGIS extension was installed in anot
 When enabled, uses `UNNEST()` for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
 This optimization is compatible with `INSERT` and `UPSERT` modes.
 
+If a batch can include more than one event for the same primary key, as is common on update-heavy topics, also set <<jdbc-property-use-reduction-buffer, `+use.reduction.buffer+`>> to `true`.
+Without it, the combined statement fails with the database error `ON CONFLICT command cannot affect row a second time` and the task stops.
+
 For information about the performance benefits of enabling the UNNEST function, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
 For the equivalent CockroachDB guidance, see link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1919,14 +1919,23 @@ The default is `public`; however, if the PostGIS extension was installed in anot
 |`false`
 |Specifies whether to enable `UNNEST`-based batch inserts for PostgreSQL and CockroachDB.
 
-When enabled, uses `UNNEST()` for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
+Set the value to `true` to enable the connector to use `UNNEST()` for batch inserts.
+After you enable batching, instead of submitting multiple SQL statements to the target database, the connector accumulates multiple change events up to the `batch.size` limit, and then submits the events to the target database in a single SQL statement.
+Reducing the number of SQL statements in this way can improve performance for certain workloads.
 This optimization is compatible with `INSERT` and `UPSERT` modes.
 
-If a batch can include more than one event for the same primary key, as is common on update-heavy topics, also set <<jdbc-property-use-reduction-buffer, `+use.reduction.buffer+`>> to `true`.
-Without it, the combined statement fails with the database error `ON CONFLICT command cannot affect row a second time` and the task stops.
+For topics that receive a high volume of updates for the same primary key, you can further improve the effectiveness of batching by setting <<jdbc-property-use-reduction-buffer, `+use.reduction.buffer+`>> to `true`.
+This setting enables the connector to combine multiple events for a primary key into a single final operation before it writes to the database.
 
-For information about the performance benefits of enabling the UNNEST function, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
-For the equivalent CockroachDB guidance, see link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
+If a batch includes multiple events for the same primary key while `use.reduction.buffer` is set to `false`, the attempt to combine statements fails, and the database returns the following error:
+
+`ON CONFLICT command cannot affect row a second time.`
+
+The task then stops.
+
+For information about the performance benefits of enabling the UNNEST function for PostgreSQL, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
+
+For information about the performance benefits of enabling the UNNEST function for CockroachDB, see link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
 
 |[[jdbc-property-dialect-sqlserver-identity-insert]]<<jdbc-property-dialect-sqlserver-identity-insert, `+dialect.sqlserver.identity.insert+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1917,12 +1917,13 @@ The default is `public`; however, if the PostGIS extension was installed in anot
 
 |[[jdbc-property-dialect-postgres-unnest-insert-enabled]]<<jdbc-property-dialect-postgres-unnest-insert-enabled, `+dialect.postgres.unnest.insert.enabled+`>>
 |`false`
-|Specifies whether to enable `UNNEST`-based batch inserts for PostgreSQL.
+|Specifies whether to enable `UNNEST`-based batch inserts for PostgreSQL and CockroachDB.
 
-When enabled, uses PostgreSQL `UNNEST()` for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
+When enabled, uses `UNNEST()` for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
 This optimization is compatible with `INSERT` and `UPSERT` modes.
 
 For information about the performance benefits of enabling the UNNEST function, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.
+For the equivalent CockroachDB guidance, see link:https://www.cockroachlabs.com/docs/stable/performance-best-practices-overview#use-multi-row-statements-instead-of-multiple-single-row-statements["Use multi-row statements instead of multiple single-row statements"^] in the CockroachDB documentation.
 
 |[[jdbc-property-dialect-sqlserver-identity-insert]]<<jdbc-property-dialect-sqlserver-identity-insert, `+dialect.sqlserver.identity.insert+`>>
 |`false`


### PR DESCRIPTION
The JDBC sink option `dialect.postgres.unnest.insert.enabled` is documented as PostgreSQL only, but the CockroachDB dialect inherits the UNNEST batch write path and the generated statements run on CockroachDB (validated against CockroachDB v25.4.13 with the 3.7.0.Alpha1 sink, details in the issue).

Updates the property description to include CockroachDB, adds a link to the CockroachDB multi-row statement guidance alongside the existing PostgreSQL reference, and documents that batches which can repeat a primary key require `use.reduction.buffer=true` (https://github.com/debezium/dbz/issues/2356).

One known limitation on CockroachDB targets, found during validation and filed separately: tables with binary columns currently fail in the UNNEST path because the dialect DDL type alias `bytes` is not accepted by `createArrayOf` (https://github.com/debezium/dbz/issues/2357).

Closes https://github.com/debezium/dbz/issues/2355