### PR TITLE
debezium/dbz#76 Prevent PG silent data loss on restart with in-progress trxs

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -78,7 +78,7 @@ public class WalPositionLocator {
      *         the position has not been found yet
      */
     public Optional<Lsn> resumeFromLsn(Lsn currentLsn, ReplicationMessage message) {
-        LOGGER.trace("Processing LSN '{}', operation '{}'", currentLsn, message.getOperation());
+        LOGGER.trace("Processing LSN '{}', operation '{}' during WAL position search", currentLsn, message.getOperation());
 
         lsnSeen.add(currentLsn);
 
@@ -130,6 +130,19 @@ public class WalPositionLocator {
             return Optional.of(startStreamingLsn);
         }
         if (currentLsn.equals(lastEventStoredLsn)) {
+            // debezium/dbz#76: In PG 17+, a COMMIT's txn->end_lsn (byte after the COMMIT WAL record)
+            // can equal the next transaction's first DML change->lsn. When the stored offset
+            // records a COMMIT at this LSN but the stream delivers a non-COMMIT event at the
+            // same position, it is a false match — the stored transaction was fully processed
+            // and this event belongs to the next unprocessed transaction.
+            if (lastProcessedMessageType == Operation.COMMIT && message.getOperation() != Operation.COMMIT
+                    && lastCommitStoredLsn != null && lastCommitStoredLsn.equals(lastEventStoredLsn)) {
+                LOGGER.info("Detected false LSN match at '{}': stored event was COMMIT but received {}. Resuming from '{}'",
+                        currentLsn, message.getOperation(), firstLsnReceived);
+                startStreamingLsn = firstLsnReceived;
+                return Optional.of(startStreamingLsn);
+            }
+
             storeLsnAfterLastEventStoredLsn = true;
             // Start counting events at this LSN
             currentLsnEventCount = 1;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4622,4 +4622,82 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
             TestHelper.execute("SELECT pg_drop_replication_slot('" + SLOT + "');");
         }
     }
+
+    @Test
+    @FixFor("debezium/dbz#76")
+    void shouldNotLoseDataOnRestartWithInterleavedTransactions() throws Exception {
+        // Reproduces the silent data loss scenario reported on Zulip (debezium/dbz#76).
+        //
+        // Root cause: with provide.transaction.metadata=true and interleaved transactions,
+        // after restart WalPositionLocator can falsely match the stored COMMIT LSN to a
+        // DML event from the next transaction at the same WAL position (PG 17+ assigns
+        // txn->end_lsn = byte after COMMIT, which can equal the next DML's change->lsn).
+        //
+        // The fix: WalPositionLocator detects this false LSN match (stored event was COMMIT
+        // but received event is not COMMIT at the same position) and resumes from the first
+        // LSN received, ensuring no events are silently filtered.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS t_long;",
+                "DROP TABLE IF EXISTS t_short;",
+                "CREATE TABLE t_long (id INT PRIMARY KEY);",
+                "CREATE TABLE t_short (id INT PRIMARY KEY);");
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.t_long,public.t_short")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, Boolean.TRUE)
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+
+        // Session A: start a long-running transaction AFTER connector is streaming,
+        // so A's DML WAL positions are after the slot's starting LSN but BEFORE B's.
+        PostgresConnection connA = TestHelper.create();
+        connA.setAutoCommit(false);
+        connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(1,5)");
+
+        // Session B: auto-commit insert — Debezium processes this transaction fully,
+        // including the COMMIT record (transaction metadata), which carries lsn_commit.
+        // B's COMMIT LSN is ABOVE A's DML WAL positions because A inserted first.
+        TestHelper.execute("INSERT INTO t_short VALUES (90)");
+
+        // Consume B's transaction: BEGIN + DML + COMMIT = 3 records
+        final SourceRecords batchB = consumeRecordsByTopic(3);
+        assertThat(batchB.recordsForTopic(topicName("public.t_short"))).hasSize(1);
+
+        // Session A: insert more rows while Debezium is running (still no commit).
+        // These DMLs go into the WAL AFTER B's COMMIT position.
+        connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(6,10)");
+
+        // Stop connector — slot is preserved
+        stopConnector();
+
+        // Session A: commit the long-running transaction (while Debezium is stopped)
+        connA.connection().commit();
+        connA.close();
+
+        // Restart the connector
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+
+        // All 10 rows from A's transaction must arrive after restart.
+        // With provide.transaction.metadata=true: BEGIN + 10 DMLs + COMMIT = 12 records
+        final SourceRecords afterRestart = consumeRecordsByTopic(12);
+        final List<SourceRecord> longRecords = afterRestart.recordsForTopic(topicName("public.t_long"));
+        assertThat(longRecords).as("All 10 rows from session A's transaction must be captured")
+                .hasSize(10);
+
+        final Set<Integer> capturedIds = new HashSet<>();
+        for (SourceRecord record : longRecords) {
+            final Struct after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+            capturedIds.add(after.getInt32("id"));
+        }
+        assertThat(capturedIds).as("All IDs from 1-10 must be present — no silent data loss")
+                .containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4643,61 +4643,67 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
                 "CREATE TABLE t_long (id INT PRIMARY KEY);",
                 "CREATE TABLE t_short (id INT PRIMARY KEY);");
 
-        final Configuration config = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
-                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.t_long,public.t_short")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
-                .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, Boolean.TRUE)
-                .build();
+        try {
+            final Configuration config = TestHelper.defaultConfig()
+                    .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                    .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.t_long,public.t_short")
+                    .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                    .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, Boolean.TRUE)
+                    .build();
 
-        start(PostgresConnector.class, config);
-        assertConnectorIsRunning();
-        waitForStreamingRunning();
+            start(PostgresConnector.class, config);
+            assertConnectorIsRunning();
+            waitForStreamingRunning();
 
-        // Session A: start a long-running transaction AFTER connector is streaming,
-        // so A's DML WAL positions are after the slot's starting LSN but BEFORE B's.
-        PostgresConnection connA = TestHelper.create();
-        connA.setAutoCommit(false);
-        connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(1,5)");
+            // Session A: start a long-running transaction AFTER connector is streaming,
+            // so A's DML WAL positions are after the slot's starting LSN but BEFORE B's.
+            PostgresConnection connA = TestHelper.create();
+            connA.setAutoCommit(false);
+            connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(1,5)");
 
-        // Session B: auto-commit insert — Debezium processes this transaction fully,
-        // including the COMMIT record (transaction metadata), which carries lsn_commit.
-        // B's COMMIT LSN is ABOVE A's DML WAL positions because A inserted first.
-        TestHelper.execute("INSERT INTO t_short VALUES (90)");
+            // Session B: auto-commit insert — Debezium processes this transaction fully,
+            // including the COMMIT record (transaction metadata), which carries lsn_commit.
+            // B's COMMIT LSN is ABOVE A's DML WAL positions because A inserted first.
+            TestHelper.execute("INSERT INTO t_short VALUES (90)");
 
-        // Consume B's transaction: BEGIN + DML + COMMIT = 3 records
-        final SourceRecords batchB = consumeRecordsByTopic(3);
-        assertThat(batchB.recordsForTopic(topicName("public.t_short"))).hasSize(1);
+            // Consume B's transaction: BEGIN + DML + COMMIT = 3 records
+            final SourceRecords batchB = consumeRecordsByTopic(3);
+            assertThat(batchB.recordsForTopic(topicName("public.t_short"))).hasSize(1);
 
-        // Session A: insert more rows while Debezium is running (still no commit).
-        // These DMLs go into the WAL AFTER B's COMMIT position.
-        connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(6,10)");
+            // Session A: insert more rows while Debezium is running (still no commit).
+            // These DMLs go into the WAL AFTER B's COMMIT position.
+            connA.executeWithoutCommitting("INSERT INTO t_long SELECT generate_series(6,10)");
 
-        // Stop connector — slot is preserved
-        stopConnector();
+            // Stop connector — slot is preserved
+            stopConnector();
 
-        // Session A: commit the long-running transaction (while Debezium is stopped)
-        connA.connection().commit();
-        connA.close();
+            // Session A: commit the long-running transaction (while Debezium is stopped)
+            connA.connection().commit();
+            connA.close();
 
-        // Restart the connector
-        start(PostgresConnector.class, config);
-        assertConnectorIsRunning();
-        waitForStreamingRunning();
+            // Restart the connector
+            start(PostgresConnector.class, config);
+            assertConnectorIsRunning();
+            waitForStreamingRunning();
 
-        // All 10 rows from A's transaction must arrive after restart.
-        // With provide.transaction.metadata=true: BEGIN + 10 DMLs + COMMIT = 12 records
-        final SourceRecords afterRestart = consumeRecordsByTopic(12);
-        final List<SourceRecord> longRecords = afterRestart.recordsForTopic(topicName("public.t_long"));
-        assertThat(longRecords).as("All 10 rows from session A's transaction must be captured")
-                .hasSize(10);
+            // All 10 rows from A's transaction must arrive after restart.
+            // With provide.transaction.metadata=true: BEGIN + 10 DMLs + COMMIT = 12 records
+            final SourceRecords afterRestart = consumeRecordsByTopic(12);
+            final List<SourceRecord> longRecords = afterRestart.recordsForTopic(topicName("public.t_long"));
+            assertThat(longRecords).as("All 10 rows from session A's transaction must be captured")
+                    .hasSize(10);
 
-        final Set<Integer> capturedIds = new HashSet<>();
-        for (SourceRecord record : longRecords) {
-            final Struct after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
-            capturedIds.add(after.getInt32("id"));
+            final Set<Integer> capturedIds = new HashSet<>();
+            for (SourceRecord record : longRecords) {
+                final Struct after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+                capturedIds.add(after.getInt32("id"));
+            }
+            assertThat(capturedIds).as("All IDs from 1-10 must be present — no silent data loss")
+                    .containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         }
-        assertThat(capturedIds).as("All IDs from 1-10 must be present — no silent data loss")
-                .containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        finally {
+            stopConnector();
+            TestHelper.execute("DROP TABLE IF EXISTS t_long;", "DROP TABLE IF EXISTS t_short;");
+        }
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#76
Fixes debezium/dbz#51

## Description
Prevents silent data loss on restart with in-progress transactions by capping the commitable LSN.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
