### PR TITLE
debezium/dbz#2292 Centralize Utility class for exclude/include validation logic

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/ConnectorConfigValidationHelper.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/ConnectorConfigValidationHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.config;
+
+/**
+ * Utility class providing shared validation helpers for connector configuration.
+ */
+public final class ConnectorConfigValidationHelper {
+
+    private ConnectorConfigValidationHelper() {
+    }
+
+    /**
+     * Validates that an include list and an exclude list are not both specified for the same filter type.
+     * When both are present, a validation problem is reported on the exclude field.
+     *
+     * @param config the configuration
+     * @param includeField the include list field
+     * @param excludeField the exclude list field
+     * @param problems the validation output
+     * @return 1 if both lists are specified, 0 otherwise
+     */
+    public static int validateExcludeField(Configuration config,
+                                           Field includeField,
+                                           Field excludeField,
+                                           Field.ValidationOutput problems) {
+        final String includeList = config.getString(includeField);
+        final String excludeList = config.getString(excludeField);
+
+        if (includeList != null && excludeList != null) {
+            problems.accept(excludeField, excludeList, "\"%s\" is already specified".formatted(includeField.name()));
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -24,6 +24,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.ConfigurationNames;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
@@ -704,31 +705,8 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         return snapshotOrderByRowCount;
     }
 
-    /**
-     * Validates that include and exclude lists are not both specified for the same filter type.
-     *
-     * @param config the configuration
-     * @param includeField the include list field
-     * @param excludeField the exclude list field
-     * @param problems the validation output
-     * @return 1 if both lists are specified, 0 otherwise
-     */
-    private static int validateExcludeList(Configuration config,
-                                           Field includeField,
-                                           Field excludeField,
-                                           ValidationOutput problems) {
-        String includeList = config.getString(includeField);
-        String excludeList = config.getString(excludeField);
-
-        if (includeList != null && excludeList != null) {
-            problems.accept(excludeField, excludeList, "\"%s\" is already specified".formatted(includeField.name()));
-            return 1;
-        }
-        return 0;
-    }
-
     private static int validateColumnExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        return validateExcludeList(config, COLUMN_INCLUDE_LIST, COLUMN_EXCLUDE_LIST, problems);
+        return ConnectorConfigValidationHelper.validateExcludeField(config, COLUMN_INCLUDE_LIST, COLUMN_EXCLUDE_LIST, problems);
     }
 
     @Override
@@ -746,7 +724,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     }
 
     private static int validateTableExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        return validateExcludeList(config, TABLE_INCLUDE_LIST, TABLE_EXCLUDE_LIST, problems);
+        return ConnectorConfigValidationHelper.validateExcludeField(config, TABLE_INCLUDE_LIST, TABLE_EXCLUDE_LIST, problems);
     }
 
     /**
@@ -781,11 +759,11 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     }
 
     private static int validateSchemaExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        return validateExcludeList(config, SCHEMA_INCLUDE_LIST, SCHEMA_EXCLUDE_LIST, problems);
+        return ConnectorConfigValidationHelper.validateExcludeField(config, SCHEMA_INCLUDE_LIST, SCHEMA_EXCLUDE_LIST, problems);
     }
 
     private static int validateDatabaseExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        return validateExcludeList(config, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, problems);
+        return ConnectorConfigValidationHelper.validateExcludeField(config, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, problems);
     }
 
     private static int validateMessageKeyColumnsField(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -30,6 +30,7 @@ import com.mongodb.ConnectionString;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
@@ -48,9 +49,6 @@ import io.debezium.util.Strings;
 public class MongoDbConnectorConfig extends CommonConnectorConfig implements SharedMongoDbConnectorConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbConnectorConfig.class);
-
-    protected static final String COLLECTION_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG = "\"collection.include.list\" is already specified";
-    protected static final String DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG = "\"database.include.list\" is already specified";
 
     protected static final Pattern PATTERN_SPILT = Pattern.compile(",");
 
@@ -1278,23 +1276,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
     }
 
     private static int validateCollectionExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        String includeList = config.getString(COLLECTION_INCLUDE_LIST);
-        String excludeList = config.getString(COLLECTION_EXCLUDE_LIST);
-        if (includeList != null && excludeList != null) {
-            problems.accept(COLLECTION_EXCLUDE_LIST, excludeList, COLLECTION_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG);
-            return 1;
-        }
-        return 0;
+        return ConnectorConfigValidationHelper.validateExcludeField(config, COLLECTION_INCLUDE_LIST, COLLECTION_EXCLUDE_LIST, problems);
     }
 
     private static int validateDatabaseExcludeList(Configuration config, Field field, ValidationOutput problems) {
-        String includeList = config.getString(DATABASE_INCLUDE_LIST);
-        String excludeList = config.getString(DATABASE_EXCLUDE_LIST);
-        if (includeList != null && excludeList != null) {
-            problems.accept(DATABASE_EXCLUDE_LIST, excludeList, DATABASE_INCLUDE_LIST_ALREADY_SPECIFIED_ERROR_MSG);
-            return 1;
-        }
-        return 0;
+        return ConnectorConfigValidationHelper.validateExcludeField(config, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, problems);
     }
 
     private static int validateCaptureTarget(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -28,6 +28,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.ConfigurationNames;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.DependentFieldMatcher;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
@@ -2523,14 +2524,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static int validateUsernameExcludeList(Configuration config, Field field, ValidationOutput problems) {
         if (isLogMiner(config)) {
-            final String includeList = config.getString(LOG_MINING_USERNAME_INCLUDE_LIST);
-            final String excludeList = config.getString(LOG_MINING_USERNAME_EXCLUDE_LIST);
-
-            if (includeList != null && excludeList != null) {
-                problems.accept(LOG_MINING_USERNAME_EXCLUDE_LIST, excludeList,
-                        String.format("\"%s\" is already specified", LOG_MINING_USERNAME_INCLUDE_LIST.name()));
-                return 1;
-            }
+            return ConnectorConfigValidationHelper.validateExcludeField(
+                    config, LOG_MINING_USERNAME_INCLUDE_LIST, LOG_MINING_USERNAME_EXCLUDE_LIST, problems);
         }
         return 0;
     }
@@ -2628,13 +2623,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static int validateClientIdExcludeList(Configuration config, Field field, ValidationOutput problems) {
         if (isLogMiner(config)) {
-            final String includeList = config.getString(LOG_MINING_CLIENTID_INCLUDE_LIST);
-            final String excludeList = config.getString(LOG_MINING_CLIENTID_EXCLUDE_LIST);
-            if (includeList != null && excludeList != null) {
-                problems.accept(LOG_MINING_CLIENTID_EXCLUDE_LIST, excludeList,
-                        String.format("\"%s\": is already specified", LOG_MINING_CLIENTID_INCLUDE_LIST.name()));
-                return 1;
-            }
+            return ConnectorConfigValidationHelper.validateExcludeField(
+                    config, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST, problems);
         }
         return 0;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -28,6 +28,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.ConfigurationNames;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.DependentFieldMatcher;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
@@ -2556,14 +2557,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static int validateUsernameExcludeList(Configuration config, Field field, ValidationOutput problems) {
         if (isLogMiner(config)) {
-            final String includeList = config.getString(LOG_MINING_USERNAME_INCLUDE_LIST);
-            final String excludeList = config.getString(LOG_MINING_USERNAME_EXCLUDE_LIST);
-
-            if (includeList != null && excludeList != null) {
-                problems.accept(LOG_MINING_USERNAME_EXCLUDE_LIST, excludeList,
-                        String.format("\"%s\" is already specified", LOG_MINING_USERNAME_INCLUDE_LIST.name()));
-                return 1;
-            }
+            return ConnectorConfigValidationHelper.validateExcludeField(
+                    config, LOG_MINING_USERNAME_INCLUDE_LIST, LOG_MINING_USERNAME_EXCLUDE_LIST, problems);
         }
         return 0;
     }
@@ -2661,13 +2656,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static int validateClientIdExcludeList(Configuration config, Field field, ValidationOutput problems) {
         if (isLogMiner(config)) {
-            final String includeList = config.getString(LOG_MINING_CLIENTID_INCLUDE_LIST);
-            final String excludeList = config.getString(LOG_MINING_CLIENTID_EXCLUDE_LIST);
-            if (includeList != null && excludeList != null) {
-                problems.accept(LOG_MINING_CLIENTID_EXCLUDE_LIST, excludeList,
-                        String.format("\"%s\": is already specified", LOG_MINING_CLIENTID_INCLUDE_LIST.name()));
-                return 1;
-            }
+            return ConnectorConfigValidationHelper.validateExcludeField(
+                    config, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST, problems);
         }
         return 0;
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ClientIdFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ClientIdFilterIT.java
@@ -280,7 +280,7 @@ public class ClientIdFilterIT extends AbstractAsyncEngineConnectorTest {
             Awaitility.await()
                     .atMost(Duration.ofSeconds(TestHelper.defaultMessageConsumerPollTimeout()))
                     .until(() -> logInterceptor.containsErrorMessage("Connector configuration is not valid. The " +
-                            "'log.mining.clientid.exclude.list' value is invalid: \"log.mining.clientid.include.list\": is already specified"));
+                            "'log.mining.clientid.exclude.list' value is invalid: \"log.mining.clientid.include.list\" is already specified"));
         }
         finally {
             TestHelper.dropTable(connection, "dbz8904");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
@@ -1611,15 +1612,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     private static int validateLogicalDecodingMessageExcludeList(Configuration config, Field field, Field.ValidationOutput problems) {
-        String includeList = config.getString(LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST);
-        String excludeList = config.getString(LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST);
-
-        if (includeList != null && excludeList != null) {
-            problems.accept(LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, excludeList,
-                    "\"logical_decoding_message.prefix.include.list\" is already specified");
-            return 1;
-        }
-        return 0;
+        return ConnectorConfigValidationHelper.validateExcludeField(
+                config, LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST, LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, problems);
     }
 
     private LsnFlushMode resolveLsnFlushMode(Configuration config) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -25,6 +25,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.ConfigurationNames;
+import io.debezium.config.ConnectorConfigValidationHelper;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
@@ -627,14 +628,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     }
 
     private static int validateCaptureInstanceExcludeList(Configuration config, Field field, Field.ValidationOutput problems) {
-        String includeList = config.getString(CAPTURE_INSTANCE_INCLUDE_LIST);
-        String excludeList = config.getString(CAPTURE_INSTANCE_EXCLUDE_LIST);
-
-        if (includeList != null && excludeList != null) {
-            problems.accept(CAPTURE_INSTANCE_EXCLUDE_LIST, excludeList, "\"%s\" is already specified".formatted(CAPTURE_INSTANCE_INCLUDE_LIST.name()));
-            return 1;
-        }
-        return 0;
+        return ConnectorConfigValidationHelper.validateExcludeField(config, CAPTURE_INSTANCE_INCLUDE_LIST, CAPTURE_INSTANCE_EXCLUDE_LIST, problems);
     }
 
     public List<String> getDatabaseNames() {


### PR DESCRIPTION


<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2292<the Debezium Issue Number>

## Description
<!-- Briefly describe your changes here. -->
Across multiple connectors, the same include/exclude mutual-exclusion validation logic was duplicated in several places: if both an include list and an exclude list are configured for the same filter type, a validation error is reported on the exclude field.

This PR centralizes that logic into a new ConnectorConfigValidationHelper utility class in io.debezium.config (debezium-connector-common), exposing a single validateExcludeField(config, includeField, excludeField, problems) method.
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
