### PR TITLE
debezium/dbz#2139 Prevent infinite retries on authentication exceptions

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -865,3 +865,4 @@ Timur Rakhmatullin
 skdus531
 Junsu Lee
 Björn Bärtschi
+rajusurarapu149

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -865,4 +865,4 @@ Timur Rakhmatullin
 skdus531
 Junsu Lee
 Björn Bärtschi
-rajusurarapu149
+Raju Surarapu

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -116,6 +116,9 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             typeRegistrySchemaFilter = buildTypeRegistrySchemaFilter(connectorConfig, tempConnection);
         }
         catch (DebeziumException e) {
+            if (PostgresErrorHandler.containsPermanentError(e)) {
+                throw new ConnectException("Non-retriable failure obtaining database encoding; failing task.", e);
+            }
             throw new RetriableException("Couldn't obtain encoding for database", e);
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -116,7 +116,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             typeRegistrySchemaFilter = buildTypeRegistrySchemaFilter(connectorConfig, tempConnection);
         }
         catch (DebeziumException e) {
-            if (PostgresErrorHandler.containsPermanentError(e)) {
+            if (PostgresErrorHandler.isPermanentError(e)) {
                 throw new ConnectException("Non-retriable failure obtaining database encoding; failing task.", e);
             }
             throw new RetriableException("Couldn't obtain encoding for database", e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Set;
 
+import org.postgresql.util.PSQLState;
+
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.util.Collect;
@@ -29,9 +31,32 @@ public class PostgresErrorHandler extends ErrorHandler {
         return Collect.unmodifiableSet(IOException.class, SQLException.class);
     }
 
+    /**
+     * Returns true if the exception (or any cause in its chain) is a permanent SQL error
+     * that should not be retried, such as an authentication or authorization failure.
+     *
+     * Called on every exception during streaming (via isRetriable) and directly during
+     * startup (from PostgresConnectorTask.start).
+     */
+    protected static boolean containsPermanentError(Throwable t) {
+        for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+            if (cause instanceof SQLException) {
+                final String sqlState = ((SQLException) cause).getSQLState();
+                if (sqlState != null && !PSQLState.isConnectionError(sqlState)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // Introduced for testing only
     @Override
     protected boolean isRetriable(Throwable throwable) {
+        // Check for permanent errors first so the task fails immediately instead of retrying forever.
+        if (containsPermanentError(throwable)) {
+            return false;
+        }
         return super.isRetriable(throwable);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -9,8 +9,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Set;
 
-import org.postgresql.util.PSQLState;
-
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.util.Collect;
@@ -34,15 +32,12 @@ public class PostgresErrorHandler extends ErrorHandler {
     /**
      * Returns true if the exception (or any cause in its chain) is a permanent SQL error
      * that should not be retried, such as an authentication or authorization failure.
-     *
-     * Called on every exception during streaming (via isRetriable) and directly during
-     * startup (from PostgresConnectorTask.start).
      */
-    protected static boolean containsPermanentError(Throwable t) {
+    protected static boolean isPermanentError(Throwable t) {
         for (Throwable cause = t; cause != null; cause = cause.getCause()) {
             if (cause instanceof SQLException) {
                 final String sqlState = ((SQLException) cause).getSQLState();
-                if (sqlState != null && !PSQLState.isConnectionError(sqlState)) {
+                if (sqlState != null && sqlState.startsWith("28")) {
                     return true;
                 }
             }
@@ -54,7 +49,7 @@ public class PostgresErrorHandler extends ErrorHandler {
     @Override
     protected boolean isRetriable(Throwable throwable) {
         // Check for permanent errors first so the task fails immediately instead of retrying forever.
-        if (containsPermanentError(throwable)) {
+        if (isPermanentError(throwable)) {
             return false;
         }
         return super.isRetriable(throwable);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4706,4 +4706,82 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
             TestHelper.execute("DROP TABLE IF EXISTS t_long;", "DROP TABLE IF EXISTS t_short;");
         }
     }
+
+    @Test
+    @FixFor("debezium/dbz#2139")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 10, reason = "Database version less than 10.0")
+    public void testShouldFailTaskWhenRoleCannotLogin() throws Exception {
+        // Start from a clean slate and create the database objects + a dedicated user
+        TestHelper.dropAllSchemas();
+        TestHelper.dropPublication();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+
+        TestHelper.execute(
+                "DROP USER IF EXISTS canarytest;",
+                "CREATE USER canarytest WITH REPLICATION LOGIN PASSWORD 'canarytest';",
+                "GRANT ALL PRIVILEGES ON DATABASE postgres TO canarytest;",
+                "GRANT ALL ON ALL TABLES IN SCHEMA public TO canarytest;",
+                "GRANT USAGE ON SCHEMA public TO canarytest;");
+
+        // Pre-create the publication as superuser so the non-superuser 'canarytest'
+        // does not need to run CREATE PUBLICATION ... FOR ALL TABLES (which requires superuser).
+        TestHelper.execute("CREATE PUBLICATION " + ReplicationConnection.Builder.DEFAULT_PUBLICATION_NAME
+                + " FOR ALL TABLES;");
+
+        try {
+            Configuration config = TestHelper.defaultConfig()
+                    .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                    .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
+                    .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+                    .with(PostgresConnectorConfig.DATABASE_CONFIG_PREFIX + JdbcConfiguration.USER, "canarytest")
+                    .with(PostgresConnectorConfig.DATABASE_CONFIG_PREFIX + JdbcConfiguration.PASSWORD, "canarytest")
+                    .build();
+
+            // The engine's completion callback fires when the task terminates.
+            // For a permanent auth failure the task must FAIL (error != null),
+            // not retry indefinitely.
+            final CountDownLatch latch = new CountDownLatch(1);
+            final DebeziumEngine.CompletionCallback completionCallback = (success, message, error) -> {
+                if (!success && error != null) {
+                    latch.countDown();
+                }
+            };
+
+            start(PostgresConnector.class, config, completionCallback);
+            assertConnectorIsRunning();
+            waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+            // Now permanently break the connection: revoke the role's ability to log in
+            // and terminate its active backend so it is forced to reconnect.
+            TestHelper.execute("ALTER USER canarytest NOLOGIN;");
+            TestHelper.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity " +
+                            "WHERE usename = 'canarytest' AND pid <> pg_backend_pid();");
+
+            // The task should transition to FAILED (the engine completes with an error),
+            // rather than looping forever in a retriable-restart state.
+            if (!latch.await(TestHelper.waitTimeForRecords() * 15L, TimeUnit.SECONDS)) {
+                fail("Connector task did not fail within the expected time after the role was denied login");
+            }
+
+            assertConnectorNotRunning();
+        }
+        finally {
+            stopConnector();
+
+            // re-enable login so the role can be cleaned up
+            TestHelper.execute("ALTER USER canarytest LOGIN;");
+            // revoke database-level grant (blocks DROP USER otherwise)
+            TestHelper.execute("REVOKE ALL PRIVILEGES ON DATABASE postgres FROM canarytest;");
+            // drop owned objects + remaining privileges
+            TestHelper.execute("DROP OWNED BY canarytest CASCADE;");
+            // now the role can be dropped
+            TestHelper.execute("DROP USER IF EXISTS canarytest;");
+            // clean up the pre-created publication
+            TestHelper.dropPublication();
+        }
+    }
+}
+
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -4783,5 +4783,3 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         }
     }
 }
-
-}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -19,7 +19,11 @@ import io.debezium.connector.base.DefaultQueueProvider;
 import io.debezium.pipeline.DataChangeEvent;
 
 public class PostgresErrorHandlerTest {
+
+    private static final String ROLE_AUTHORIZATION_ERROR = "FATAL: role not permitted to log in";
+    private static final String PASSWORD_AUTHENTICATION_ERROR = "FATAL: password authentication failed for user debezium";
     private static final String A_CLASSIFIED_EXCEPTION = "Database connection failed when writing to copy";
+
     private final PostgresErrorHandler errorHandler = new PostgresErrorHandler(
             new PostgresConnectorConfig(Configuration.create()
                     .with(CommonConnectorConfig.TOPIC_PREFIX, "postgres")
@@ -68,4 +72,41 @@ public class PostgresErrorHandlerTest {
         RuntimeException testException = new RuntimeException();
         assertThat(errorHandler.isRetriable(testException)).isFalse();
     }
+
+    @Test
+    void connectionFailureIsNotPermanent() {
+        PSQLException psqlException = new PSQLException(A_CLASSIFIED_EXCEPTION, PSQLState.CONNECTION_FAILURE);
+        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isFalse();
+    }
+
+    @Test
+    void authorizationFailureIsPermanent() {
+        PSQLException psqlException = new PSQLException(ROLE_AUTHORIZATION_ERROR, PSQLState.INVALID_AUTHORIZATION_SPECIFICATION);
+        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isTrue();
+    }
+
+    @Test
+    void invalidPasswordIsPermanent() {
+        PSQLException psqlException = new PSQLException(PASSWORD_AUTHENTICATION_ERROR, PSQLState.INVALID_PASSWORD);
+        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isTrue();
+    }
+
+    @Test
+    void authorizationFailureWrappedInDebeziumExceptionIsPermanent() {
+        // Mirrors getDatabaseCharset() wrapping PSQLException in DebeziumException during start()
+        PSQLException psqlException = new PSQLException(ROLE_AUTHORIZATION_ERROR, PSQLState.INVALID_AUTHORIZATION_SPECIFICATION);
+        DebeziumException wrapper = new DebeziumException("Couldn't obtain encoding for database", psqlException);
+        assertThat(PostgresErrorHandler.containsPermanentError(wrapper)).isTrue();
+    }
+
+    @Test
+    void nonSqlExceptionIsNotPermanent() {
+        assertThat(PostgresErrorHandler.containsPermanentError(new RuntimeException("boom"))).isFalse();
+    }
+
+    @Test
+    void nullIsNotPermanent() {
+        assertThat(PostgresErrorHandler.containsPermanentError(null)).isFalse();
+    }
+
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -76,19 +76,19 @@ public class PostgresErrorHandlerTest {
     @Test
     void connectionFailureIsNotPermanent() {
         PSQLException psqlException = new PSQLException(A_CLASSIFIED_EXCEPTION, PSQLState.CONNECTION_FAILURE);
-        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isFalse();
+        assertThat(PostgresErrorHandler.isPermanentError(psqlException)).isFalse();
     }
 
     @Test
     void authorizationFailureIsPermanent() {
         PSQLException psqlException = new PSQLException(ROLE_AUTHORIZATION_ERROR, PSQLState.INVALID_AUTHORIZATION_SPECIFICATION);
-        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isTrue();
+        assertThat(PostgresErrorHandler.isPermanentError(psqlException)).isTrue();
     }
 
     @Test
     void invalidPasswordIsPermanent() {
         PSQLException psqlException = new PSQLException(PASSWORD_AUTHENTICATION_ERROR, PSQLState.INVALID_PASSWORD);
-        assertThat(PostgresErrorHandler.containsPermanentError(psqlException)).isTrue();
+        assertThat(PostgresErrorHandler.isPermanentError(psqlException)).isTrue();
     }
 
     @Test
@@ -96,17 +96,17 @@ public class PostgresErrorHandlerTest {
         // Mirrors getDatabaseCharset() wrapping PSQLException in DebeziumException during start()
         PSQLException psqlException = new PSQLException(ROLE_AUTHORIZATION_ERROR, PSQLState.INVALID_AUTHORIZATION_SPECIFICATION);
         DebeziumException wrapper = new DebeziumException("Couldn't obtain encoding for database", psqlException);
-        assertThat(PostgresErrorHandler.containsPermanentError(wrapper)).isTrue();
+        assertThat(PostgresErrorHandler.isPermanentError(wrapper)).isTrue();
     }
 
     @Test
     void nonSqlExceptionIsNotPermanent() {
-        assertThat(PostgresErrorHandler.containsPermanentError(new RuntimeException("boom"))).isFalse();
+        assertThat(PostgresErrorHandler.isPermanentError(new RuntimeException("boom"))).isFalse();
     }
 
     @Test
     void nullIsNotPermanent() {
-        assertThat(PostgresErrorHandler.containsPermanentError(null)).isFalse();
+        assertThat(PostgresErrorHandler.isPermanentError(null)).isFalse();
     }
 
 }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -401,3 +401,4 @@ antonio0,Antonio Marino
 JunWang222,Jun Wang
 nickchomey,Nick Chomey
 bisbeb,Björn Bärtschi
+rajusurarapu149,Raju Surarapu


### PR DESCRIPTION
Fixes debezium/dbz#2139 

## Description
Fail task on permanent auth/authorization errors instead of retrying forever

Problem:
When the PostgreSQL connector encountered a permanent authentication or authorization failure (e.g. "role is not permitted  to log in", SQLSTATE class 28) during task startup or streaming, the error was wrapped in a RetriableException and the task retried indefinitely, never transitioning to the FAILED state. This masked a permanent, unrecoverable condition and left the connector stuck in a RESTARTING loop.

Fix:
1. Introduced PostgresErrorHandler.containsPermanentError(Throwable), a static helper that walks the exception cause chain and classifies a SQLException as permanent when its SQLSTATE is not one of the five transient connection-error codes recognized by the PostgreSQL JDBC driver (PSQLState.isConnectionError), e.g. 08001, 08003, 08004,
08006, 08007. Any other SQL error including 28000 (INVALID_AUTHORIZATION_SPECIFICATION) and 28P01 (INVALID_PASSWORD) is treated as permanent.
2. Updated isRetriable() to check containsPermanentError() first. If the error is permanent, it immediately returns false instead of letting the base class treat it as retriable. This causes the connector to fail with a ConnectException and move the task to the FAILED state instead of retrying indefinitely.
3. Updated the startup error handling in PostgresConnectorTask to call containsPermanentError() 

Testing:
Added six unit tests to verify containsPermanentError() correctly tells permanent errors (like auth and password failures) apart from transient connection errors, and kept the existing tests for isRetriable() to make sure streaming behavior still works as expected. Also added an integration test that reproduces the original issue - killing the backend connection to trigger a login failure and confirms the task now fails properly instead of retrying forever.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
