### PR TITLE
debezium/dbz#2357 Fall back to row-wise writes for UNNEST batches with binary fields

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -182,10 +182,14 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
      * values to {@link Connection#createArrayOf}, which only accepts scalar elements; a {@code STRUCT}
      * field (the geometric types point/box/lseg/path/polygon and circle/line) needs the per-value
      * {@code JdbcType#bind()} the row-wise path applies, so such records are handled row-wise instead.
+     * {@code BYTES} fields are also excluded: the PostgreSQL driver cannot encode {@code bytea} array
+     * elements ({@code createArrayOf} rejects {@code byte[]} nested inside {@code Object[]}), so such
+     * records take the row-wise path as well.
      */
     private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
         return record.jdbcFields().values().stream()
-                .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT);
+                .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT
+                        || field.getSchema().type() == Schema.Type.BYTES);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkUnnestBytesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkUnnestBytesIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.cockroachdb;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.connector.jdbc.junit.jupiter.CockroachDbSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+
+/**
+ * UNNEST batch write tests for CockroachDB with binary columns.
+ *
+ * <p>The UNNEST path binds each column with {@code Connection#createArrayOf}, which the PostgreSQL
+ * driver cannot serve for {@code bytea} elements; on CockroachDB the failure surfaced even earlier
+ * because Hibernate's CockroachDB dialect names the binary DDL type {@code bytes}, an alias absent
+ * from {@code pg_type}. Records with a BYTES field must therefore fall back to the row-wise path,
+ * which this test verifies end to end against CockroachDB.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-cockroachdb")
+@ExtendWith(CockroachDbSinkDatabaseContextProvider.class)
+public class JdbcSinkUnnestBytesIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkUnnestBytesIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2357")
+    public void testUnnestBatchWithBytesColumn(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.USE_REDUCTION_BUFFER, "true");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord record1 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "col_bytes", Schema.OPTIONAL_BYTES_SCHEMA, new byte[]{ 0x01, 0x02 }, config);
+        final JdbcKafkaSinkRecord record2 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2, "col_bytes", Schema.OPTIONAL_BYTES_SCHEMA, new byte[]{ 0x03, 0x04 }, config);
+
+        // A single call with more than one record produces one multi-record batch, which is the
+        // precondition for the UNNEST statement (a single record takes the per-row path).
+        consume(List.of(record1, record2));
+
+        TestHelper.assertTable(assertDbConnection(), destinationTableName(record1))
+                .hasNumberOfRows(2)
+                .column("col_bytes").hasValues(new byte[]{ 0x01, 0x02 }, new byte[]{ 0x03, 0x04 });
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestBytesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestBytesIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.postgres;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+
+/**
+ * UNNEST batch write tests for PostgreSQL with binary columns.
+ *
+ * <p>The UNNEST path binds each column with {@code Connection#createArrayOf}, which the PostgreSQL
+ * driver cannot serve for {@code bytea} elements (it rejects {@code byte[]} nested inside
+ * {@code Object[]}). Records with a BYTES field must therefore fall back to the row-wise path,
+ * which this test verifies end to end.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-postgresql")
+@ExtendWith(PostgresSinkDatabaseContextProvider.class)
+public class JdbcSinkUnnestBytesIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkUnnestBytesIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2357")
+    public void testUnnestBatchWithBytesColumn(SinkRecordFactory factory) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.USE_REDUCTION_BUFFER, "true");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord record1 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "col_bytes", Schema.OPTIONAL_BYTES_SCHEMA, new byte[]{ 0x01, 0x02 }, config);
+        final JdbcKafkaSinkRecord record2 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2, "col_bytes", Schema.OPTIONAL_BYTES_SCHEMA, new byte[]{ 0x03, 0x04 }, config);
+
+        // A single call with more than one record produces one multi-record batch, which is the
+        // precondition for the UNNEST statement (a single record takes the per-row path).
+        consume(List.of(record1, record2));
+
+        TestHelper.assertTable(assertDbConnection(), destinationTableName(record1))
+                .hasNumberOfRows(2)
+                .column("col_bytes").hasValues(new byte[]{ 0x01, 0x02 }, new byte[]{ 0x03, 0x04 });
+    }
+}


### PR DESCRIPTION
With dialect.postgres.unnest.insert.enabled=true, a multi-record batch containing a Connect BYTES field fails and kills the task. On CockroachDB targets the dialect DDL alias 'bytes' is rejected as an array element type name; renaming it only moves the failure into the driver, because the PostgreSQL JDBC driver cannot encode bytea array elements in createArrayOf (UnsupportedOperationException: byte[] nested inside Object[]). Binary fields therefore cannot go through the UNNEST bind path on any target. Single-record flushes already take the per-row path, which makes the failure intermittent under light traffic.

Extends the existing non-bindable field check, which already routes STRUCT fields to the row-wise path, to also cover BYTES fields.

Verification: new integration tests against PostgreSQL and CockroachDB replay a multi-record batch with a BYTES column; both fail without the change (each with its respective error) and pass with it. The full unit suite and the it-postgresql and it-cockroachdb integration suites pass.

Closes https://github.com/debezium/dbz/issues/2357