### PR TITLE
debezium/dbz#2366: fix extended string table alias parsing

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/ExtendedStringParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/ExtendedStringParser.java
@@ -46,9 +46,7 @@ public class ExtendedStringParser extends AbstractSingleColumnSqlRedoPreamblePar
         startIndex = parseQuotedValue(update, startIndex, value -> this.tableName = value);
         startIndex = parseQuotedValue(update, startIndex, value -> this.schemaName = value);
 
-        if (startsWithAtIndexThrow(SET, startIndex, update)) {
-            startIndex += SET.length();
-        }
+        startIndex = indexOfThrow(SET, update, startIndex) + SET.length();
 
         startIndex = parseQuotedValue(update, startIndex, value -> this.columnName = value);
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ExtendedStringParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ExtendedStringParserTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.logminer.parser.ExtendedStringParser;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+/**
+ * @author Sergei Nikolaev
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.ANY_LOGMINER)
+public class ExtendedStringParserTest {
+
+    private static final ExtendedStringParser parser = new ExtendedStringParser();
+
+    @Test
+    @FixFor("debezium/dbz#2366")
+    public void shouldParseExtendedStringBeginRedoSqlWithTableAlias() {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST_TABLE"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("DATA").create())
+                .create();
+
+        final String redoSql = "DECLARE\n" +
+                " TempLob CLOB;\n" +
+                " buf_c   VARCHAR2(32767);\n" +
+                " Stmt    CLOB;\n" +
+                "BEGIN\n" +
+                " DBMS_LOB.CreateTemporary(TempLob, FALSE);\n" +
+                " Stmt := 'update \"DEBEZIUM\".\"TEST_TABLE\" a set a.\"DATA\" = :DATA where a.\"ID\" = ''1'';';";
+
+        final LogMinerDmlEntry entry = parser.parse(redoSql, table);
+
+        assertThat(parser.getColumnName()).isEqualTo("DATA");
+        assertThat(entry.getNewValues()[0]).isEqualTo("1");
+        assertThat(entry.getOldValues()[0]).isEqualTo("1");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2366")
+    public void shouldParseExtendedStringBeginRedoSqlWithoutTableAlias() {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST_TABLE"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("DATA").create())
+                .create();
+
+        final String redoSql = "DECLARE\n" +
+                " TempLob CLOB;\n" +
+                " buf_c   VARCHAR2(32767);\n" +
+                " Stmt    CLOB;\n" +
+                "BEGIN\n" +
+                " DBMS_LOB.CreateTemporary(TempLob, FALSE);\n" +
+                " Stmt := 'update \"DEBEZIUM\".\"TEST_TABLE\" set \"DATA\" = :DATA where \"ID\" = ''1'';';";
+
+        final LogMinerDmlEntry entry = parser.parse(redoSql, table);
+
+        assertThat(parser.getColumnName()).isEqualTo("DATA");
+        assertThat(entry.getNewValues()[0]).isEqualTo("1");
+        assertThat(entry.getOldValues()[0]).isEqualTo("1");
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2366

## Description
Skips table alias before `set` during parsing an update statement instead of throwing an exception.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
