### PR TITLE
debezium/dbz#1953 Sunset and remove continuous mining

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -820,17 +820,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDescription("Specifies the inner body the Ehcache <cache/> tag for the rollbacks cache, but " +
                     "should not include the <key-type/> nor the <value-type/> attributes as these are managed by Debezium.");
 
-    @Deprecated
-    public static final Field LOG_MINING_CONTINUOUS_MINE = Field.create("log.mining.continuous.mine")
-            .withDisplayName("Should log mining session configured with CONTINUOUS_MINE setting?")
-            .withType(Type.BOOLEAN)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withDefault(false)
-            .withValidation(Field::isBoolean)
-            .withDescription("(Deprecated) if true, CONTINUOUS_MINE option will be added to the log mining session. " +
-                    "This will manage log files switches seamlessly.");
-
     public static final Field OBJECT_ID_CACHE_SIZE = Field.createInternal("object.id.cache.size")
             .withDisplayName("Controls the maximum size of the object ID cache")
             .withType(Type.INT)
@@ -969,7 +958,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_SCN_GAP_DETECTION_TIME_INTERVAL_MAX_MS, LOG_MINING_LOG_QUERY_MAX_RETRIES, LOG_MINING_LOG_BACKOFF_INITIAL_DELAY_MS,
                     LOG_MINING_LOG_BACKOFF_MAX_DELAY_MS, LOG_MINING_SESSION_MAX_MS, LOG_MINING_WINDOW_MAX_MS, LOG_MINING_TRANSACTION_SNAPSHOT_BOUNDARY_MODE,
                     LOG_MINING_READ_ONLY, LOG_MINING_FLUSH_TABLE_NAME, LOG_MINING_QUERY_FILTER_MODE, LOG_MINING_RESTART_CONNECTION, LOG_MINING_MAX_SCN_DEVIATION_MS,
-                    LOG_MINING_SCHEMA_CHANGES_USERNAME_EXCLUDE_LIST, LOG_MINING_INCLUDE_REDO_SQL, OLR_SOURCE, OLR_HOST, OLR_PORT, LOG_MINING_CONTINUOUS_MINE,
+                    LOG_MINING_SCHEMA_CHANGES_USERNAME_EXCLUDE_LIST, LOG_MINING_INCLUDE_REDO_SQL, OLR_SOURCE, OLR_HOST, OLR_PORT,
                     LOG_MINING_BUFFER_EHCACHE_GLOBAL_CONFIG, LOG_MINING_BUFFER_EHCACHE_TRANSACTIONS_CONFIG, LOG_MINING_BUFFER_EHCACHE_PROCESSED_TRANSACTIONS_CONFIG,
                     LOG_MINING_BUFFER_EHCACHE_SCHEMA_CHANGES_CONFIG, LOG_MINING_BUFFER_EHCACHE_EVENTS_CONFIG, LOG_MINING_BUFFER_EHCACHE_ROLLBACKS_CONFIG,
                     LOG_MINING_SQL_RELAXED_QUOTE_DETECTION, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST, LOG_MINING_RESUME_POSITION_INTERVAL_MS,
@@ -1051,7 +1040,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final String logMiningInifispanGlobalConfiguration;
     private final Set<String> logMiningSchemaChangesUsernameExcludes;
     private final Boolean logMiningIncludeRedoSql;
-    private final boolean logMiningContinuousMining;
     private final Configuration logMiningEhCacheConfiguration;
     private final boolean logMiningUseSqlRelaxedQuoteDetection;
     private final Set<String> logMiningClientIdIncludes;
@@ -1145,7 +1133,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningInifispanGlobalConfiguration = config.getString(LOG_MINING_BUFFER_INFINISPAN_CACHE_GLOBAL);
         this.logMiningSchemaChangesUsernameExcludes = Strings.setOf(config.getString(LOG_MINING_SCHEMA_CHANGES_USERNAME_EXCLUDE_LIST), String::new);
         this.logMiningIncludeRedoSql = config.getBoolean(LOG_MINING_INCLUDE_REDO_SQL);
-        this.logMiningContinuousMining = config.getBoolean(LOG_MINING_CONTINUOUS_MINE);
         this.logMiningUseSqlRelaxedQuoteDetection = config.getBoolean(LOG_MINING_SQL_RELAXED_QUOTE_DETECTION);
         this.logMiningClientIdIncludes = Strings.setOfTrimmed(config.getString(LOG_MINING_CLIENTID_INCLUDE_LIST), String::new);
         this.logMiningClientIdExcludes = Strings.setOfTrimmed(config.getString(LOG_MINING_CLIENTID_EXCLUDE_LIST), String::new);
@@ -1652,15 +1639,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
         /**
          * This strategy uses LogMiner with data dictionary in online catalog.
-         * This option will not capture DDL , but acts fast on REDO LOG switch events
-         * This option does not use CONTINUOUS_MINE option
+         * This option will not capture DDL, but acts fast on REDO LOG switch events
          */
         ONLINE_CATALOG("online_catalog"),
 
         /**
          * This strategy uses LogMiner with data dictionary in REDO LOG files.
          * This option will capture DDL, but will develop some lag on REDO LOG switch event and will eventually catch up
-         * This option does not use CONTINUOUS_MINE option
          *
          * @deprecated to be removed in Debezium 3.7, use {@link #HYBRID} or {@link #ONLINE_CATALOG} instead
          */
@@ -2245,24 +2230,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public boolean isLogMiningIncludeRedoSql() {
         return logMiningIncludeRedoSql;
-    }
-
-    /**
-     * Returns whether the LogMiner adapter should use continuous mining or not.
-     *
-     * @return true continuous mining should be used
-     */
-    @Deprecated
-    public boolean isLogMiningContinuousMining(OracleDatabaseVersion version) {
-        if (logMiningContinuousMining) {
-            if (version.getMajor() > 12) {
-                // Guards against users who may set this mistakenly, logs a WARN and explicitly sets the state
-                // within the streaming source explicitly to false
-                LOGGER.warn("Continuous mining is no longer available in Oracle {} and won't be used.", version);
-                return false;
-            }
-        }
-        return logMiningContinuousMining;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
@@ -242,7 +242,7 @@ public abstract class AbstractLogMinerStreamingAdapter
         final Scn oldestScn = getOldestScnAvailableInLogs(connectorConfig, connection);
         final List<LogFile> logFiles = getOrderedLogsFromScn(connectorConfig, oldestScn, connection);
         if (!logFiles.isEmpty()) {
-            try (var context = new LogMinerSessionContext(connection, false, LogMiningStrategy.ONLINE_CATALOG, connectorConfig.getLogMiningPathToDictionary())) {
+            try (var context = new LogMinerSessionContext(connection, LogMiningStrategy.ONLINE_CATALOG, connectorConfig.getLogMiningPathToDictionary())) {
                 context.addLogFiles(getMostRecentLogFilesForSearch(logFiles));
                 context.startSession(Scn.NULL, Scn.NULL, false);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -115,7 +115,6 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     private final OracleDatabaseSchema schema;
     private final LogMinerStreamingChangeEventSourceMetrics metrics;
     private final JdbcConfiguration jdbcConfiguration;
-    private final boolean useContinuousMining;
     private final LogFileCollector logCollector;
     private final LogMinerSessionContext sessionContext;
     private final LogMinerDmlParser dmlParser;
@@ -157,9 +156,8 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         this.schema = schema;
         this.metrics = metrics;
         this.jdbcConfiguration = JdbcConfiguration.adapt(jdbcConfig);
-        this.useContinuousMining = connectorConfig.isLogMiningContinuousMining(streamingConnection.getOracleVersion());
         this.logCollector = new LogFileCollector(connectorConfig, streamingConnection);
-        this.sessionContext = new LogMinerSessionContext(streamingConnection, useContinuousMining, connectorConfig.getLogMiningStrategy(),
+        this.sessionContext = new LogMinerSessionContext(streamingConnection, connectorConfig.getLogMiningStrategy(),
                 connectorConfig.getLogMiningPathToDictionary());
         this.dmlParser = new LogMinerDmlParser(connectorConfig);
         this.reconstructColumnDmlParser = new LogMinerColumnResolverDmlParser(connectorConfig);
@@ -211,7 +209,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             }
 
             // Fail-fast check: makes sure the offset SCN is still available in the logs
-            if (!useContinuousMining && offsetScn.compareTo(firstScn.subtract(Scn.ONE)) < 0) {
+            if (offsetScn.compareTo(firstScn.subtract(Scn.ONE)) < 0) {
                 // offsetScn is the exclusive lower bound, so must be >= (firstScn - 1)
                 throw new DebeziumException("Online REDO LOG files or archive log files do not contain the offset scn " +
                         offsetScn + ". Please perform a new snapshot.");
@@ -1135,19 +1133,16 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
 
         detectRedoThreadTransitions(logFilesResult.redoThreadState());
 
-        Scn upperBoundaryScn = upperBoundsScn;
-        if (!useContinuousMining) {
-            SessionLogSelection sessionLogSelection = logFileSessionSelector.selectLogsForSession(logFilesResult, upperBoundsScn);
+        SessionLogSelection sessionLogSelection = logFileSessionSelector.selectLogsForSession(logFilesResult, upperBoundsScn);
 
-            sessionLogFilesChanged = !sessionLogSelection.logFiles().equals(sessionLogFiles);
-            sessionLogFiles = sessionLogSelection.logFiles();
+        sessionLogFilesChanged = !sessionLogSelection.logFiles().equals(sessionLogFiles);
+        sessionLogFiles = sessionLogSelection.logFiles();
 
-            if (sessionLogFilesChanged) {
-                LOGGER.trace("LogMiner session log files list changed, forcing a new mining session.");
-            }
-
-            upperBoundaryScn = sessionLogSelection.effectiveUpperBounds();
+        if (sessionLogFilesChanged) {
+            LOGGER.trace("LogMiner session log files list changed, forcing a new mining session.");
         }
+
+        Scn upperBoundaryScn = sessionLogSelection.effectiveUpperBounds();
 
         metrics.setRedoLogStatuses(streamingConnection.queryAndMap(
                 SqlUtils.redoLogStatusQuery(),
@@ -1167,23 +1162,19 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      * @throws SQLException if a database exception occurs
      */
     protected void applyLogsToSession() throws SQLException {
-        if (!useContinuousMining) {
-            sessionContext.removeAllLogFilesFromSession();
-        }
+        sessionContext.removeAllLogFilesFromSession();
 
-        if (!useContinuousMining) {
-            sessionContext.addLogFiles(sessionLogFiles);
+        sessionContext.addLogFiles(sessionLogFiles);
 
-            // These need to be updated when we prepare the session so that log switch check works
-            currentRedoLogSequences = currentLogFiles.stream()
-                    .filter(LogFile::isCurrent)
-                    .map(LogFile::getSequence)
-                    .toList();
+        // These need to be updated when we prepare the session so that log switch check works
+        currentRedoLogSequences = currentLogFiles.stream()
+                .filter(LogFile::isCurrent)
+                .map(LogFile::getSequence)
+                .toList();
 
-            metrics.setMinedLogFileNames(sessionLogFiles.stream()
-                    .map(LogFile::getFileName)
-                    .collect(Collectors.toSet()));
-        }
+        metrics.setMinedLogFileNames(sessionLogFiles.stream()
+                .map(LogFile::getFileName)
+                .collect(Collectors.toSet()));
 
         metrics.setCurrentLogFileNames(currentLogFiles.stream()
                 .filter(LogFile::isCurrent)

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerSessionContext.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerSessionContext.java
@@ -30,7 +30,6 @@ public class LogMinerSessionContext implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(LogMinerSessionContext.class);
 
     private final OracleConnection connection;
-    private final boolean useContinuousMining;
     private final LogMiningStrategy strategy;
     private final String dictionaryFilePath;
 
@@ -39,9 +38,8 @@ public class LogMinerSessionContext implements AutoCloseable {
     private Scn currentSessionStartScn = Scn.NULL;
     private Scn currentSessionEndScn = Scn.NULL;
 
-    public LogMinerSessionContext(OracleConnection connection, boolean useContinuousMining, LogMiningStrategy strategy, String dictionaryFilePath) {
+    public LogMinerSessionContext(OracleConnection connection, LogMiningStrategy strategy, String dictionaryFilePath) {
         this.connection = connection;
-        this.useContinuousMining = useContinuousMining;
         this.strategy = strategy;
         this.dictionaryFilePath = dictionaryFilePath;
     }
@@ -205,10 +203,6 @@ public class LogMinerSessionContext implements AutoCloseable {
                 break;
             default:
                 miningOptions.add("DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG");
-        }
-
-        if (useContinuousMining) {
-            miningOptions.add("DBMS_LOGMNR.CONTINUOUS_MINE");
         }
 
         if (committedDataOnly) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/ResumePositionProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/ResumePositionProvider.java
@@ -86,7 +86,7 @@ public class ResumePositionProvider implements AutoCloseable {
                     connection.resetSessionToCdb();
                 }
 
-                sessionContext = new LogMinerSessionContext(connection, false, LogMiningStrategy.ONLINE_CATALOG, connectorConfig.getLogMiningPathToDictionary());
+                sessionContext = new LogMinerSessionContext(connection, LogMiningStrategy.ONLINE_CATALOG, connectorConfig.getLogMiningPathToDictionary());
             }
 
             sessionContext.removeAllLogFilesFromSession();


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1953

## Description
Oracle deprecated the continuous mining feature in Oracle 12c and removed it entirely in Oracle 19c. Given that Oracle 19c is the eldest LTS version officially supported, it's time to sunset this feature.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
