### PR TITLE
debezium/dbz#1589 Minimize LogMiner stalls due to log inconsistency

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -1155,6 +1155,14 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
 
         Scn upperBoundaryScn = sessionLogSelection.effectiveUpperBounds();
 
+        // When the collector truncated the consistency range at a tolerated log sequence gap, the
+        // mining session must not read beyond the boundary the logs are consistent through.
+        final Scn consistentThroughScn = logFilesResult.consistentThroughScn();
+        if (!consistentThroughScn.isNull() && consistentThroughScn.compareTo(upperBoundaryScn) < 0) {
+            LOGGER.debug("Mining session upper boundary capped to consistent SCN {} due to a log sequence gap.", consistentThroughScn);
+            upperBoundaryScn = consistentThroughScn;
+        }
+
         metrics.setRedoLogStatuses(streamingConnection.queryAndMap(
                 SqlUtils.redoLogStatusQuery(),
                 rs -> {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -68,9 +68,18 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
     public SessionLogSelection selectLogsForSession(LogFilesResult logFilesResult, Scn upperBoundary) {
         Scn effectiveUpperBoundary = upperBoundary;
 
+        // When the collector truncated the consistency range at a log sequence gap, do not read beyond it
+        final Scn consistentThroughScn = logFilesResult.consistentThroughScn();
+        if (!consistentThroughScn.isNull() && consistentThroughScn.compareTo(effectiveUpperBoundary) < 0) {
+            effectiveUpperBoundary = consistentThroughScn;
+        }
+
+        // Restrict the selection to logs within the consistent mining window
+        final List<LogFile> availableLogs = getConsistentLogFiles(logFilesResult);
+
         // Groups all collected logs by redo thread, sorted in ascending order by sequence.
         // The ordering is important for this algorithm when inspecting what is the first/last logs per thread.
-        final Map<Integer, List<LogFile>> logsByThread = logFilesResult.logFiles().stream()
+        final Map<Integer, List<LogFile>> logsByThread = availableLogs.stream()
                 .sorted(Comparator.comparing(LogFile::getSequence))
                 .collect(Collectors.groupingBy(LogFile::getThread));
 
@@ -102,9 +111,15 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         for (RedoThread redoThread : logFilesResult.redoThreadState().getThreads()) {
             if (redoThread.isOpen()) {
                 final List<LogFile> threadLogs = cappedLogsByThread.get(redoThread.getThreadId());
-                if (threadLogs == null) {
-                    // Should never happen, just sanity check
-                    throw new DebeziumException("Redo thread %d is open, expected logs".formatted(redoThread.getThreadId()));
+                if (threadLogs == null || threadLogs.isEmpty()) {
+                    if (consistentThroughScn.isNull()) {
+                        // Should never happen, just sanity check
+                        throw new DebeziumException("Redo thread %d is open, expected logs".formatted(redoThread.getThreadId()));
+                    }
+                    // All the thread's logs start at or beyond the consistent boundary; the thread
+                    // contributes nothing to this session and the boundary already precedes its logs.
+                    allThreadsMineOnline = false;
+                    continue;
                 }
 
                 // Checks if the last log in the thread's capped list is an online redo log.
@@ -125,7 +140,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         }
 
         if (allThreadsMineOnline) {
-            LOGGER.debug("All threads are reading online redo, using all logs and reading up to {}.", upperBoundary);
+            LOGGER.debug("All threads are reading online redo, using all logs and reading up to {}.", effectiveUpperBoundary);
             if (logsPerRedoThread > minimumLogsPerRedoThread) {
                 logsPerRedoThread = minimumLogsPerRedoThread;
                 LOGGER.debug("All threads reading online redo, resetting log count per redo thread to {}.", logsPerRedoThread);
@@ -134,13 +149,13 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
             // there is no cap to widen, so clear the baseline to avoid growing the log count on
             // the next iteration only to reset it within the same call.
             previousBudgetLogsByThread = null;
-            recordEffectiveUpperBoundary(upperBoundary);
+            recordEffectiveUpperBoundary(effectiveUpperBoundary);
             return new SessionLogSelection(
-                    logFilesResult.logFiles().stream()
+                    availableLogs.stream()
                             .sorted(Comparator.comparingInt(LogFile::getThread)
                                     .thenComparing(LogFile::getSequence))
                             .toList(),
-                    upperBoundary);
+                    effectiveUpperBoundary);
         }
 
         LOGGER.debug("Using capped logs, reading up to {}.", effectiveUpperBoundary);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileCollector.java
@@ -55,6 +55,7 @@ public class LogFileCollector {
     private final boolean archiveLogOnlyMode;
     private final List<String> archiveLogDestinationNames;
     private final OracleConnection connection;
+    private final boolean tolerateSequenceGaps;
 
     public LogFileCollector(OracleConnectorConfig connectorConfig, OracleConnection connection) {
         this.initialDelay = connectorConfig.getLogMiningInitialDelay();
@@ -64,6 +65,7 @@ public class LogFileCollector {
         this.archiveLogOnlyMode = connectorConfig.isArchiveLogOnlyMode();
         this.archiveLogDestinationNames = connectorConfig.getArchiveDestinationNameResolver().getDestinationNames(connection);
         this.connection = connection;
+        this.tolerateSequenceGaps = isGapToleranceSupported(connectorConfig);
     }
 
     /**
@@ -86,13 +88,14 @@ public class LogFileCollector {
 
             // Fetch logs
             final List<LogFile> files = getLogsForOffsetScn(offsetScn);
-            if (!isLogFileListConsistent(offsetScn, files, currentRedoThreadState)) {
+            final ConsistencyCheckResult consistency = checkLogFileListConsistency(offsetScn, files, currentRedoThreadState);
+            if (!consistency.consistent()) {
                 LOGGER.info("No logs available yet (attempt {})...", attempt + 1);
                 retryStrategy.sleepWhen(true);
                 continue;
             }
 
-            return new LogFilesResult(files, currentRedoThreadState);
+            return new LogFilesResult(files, currentRedoThreadState, consistency.consistentThroughScn());
         }
 
         try {
@@ -256,10 +259,29 @@ public class LogFileCollector {
      * @param startScn the read position system change number, should not be {@code null}
      * @param logs the list of logs to inspect, should not be {@code null}
      * @param currentRedoThreadState the current database redo thread state, should not be {@code null}
-     * @return {@code true} if the logs are consistent; {@code false} otherwise
+     * @return {@code true} if the logs are fully consistent without truncation; {@code false} otherwise
      */
     @VisibleForTesting
     public boolean isLogFileListConsistent(Scn startScn, List<LogFile> logs, RedoThreadState currentRedoThreadState) {
+        final ConsistencyCheckResult result = checkLogFileListConsistency(startScn, logs, currentRedoThreadState);
+        return result.consistent() && result.consistentThroughScn().isNull();
+    }
+
+    /**
+     * Checks consistency of the list of log files for redo threads in the {@code currentRedoThreadState} state.
+     * <p>
+     * When sequence gaps can be tolerated by the mining strategy, an open redo thread with a sequence gap
+     * above the read position does not fail the check; instead the thread is treated as consistent up to
+     * the gap and the result carries the minimum such boundary across all threads so that mining can
+     * proceed with the logs that are currently available.
+     *
+     * @param startScn the read position system change number, should not be {@code null}
+     * @param logs the list of logs to inspect, should not be {@code null}
+     * @param currentRedoThreadState the current database redo thread state, should not be {@code null}
+     * @return the consistency check result, never {@code null}
+     */
+    @VisibleForTesting
+    public ConsistencyCheckResult checkLogFileListConsistency(Scn startScn, List<LogFile> logs, RedoThreadState currentRedoThreadState) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Performing consistency check on the following collected logs:");
             for (LogFile logFile : logs) {
@@ -282,17 +304,21 @@ public class LogFileCollector {
                 .collect(Collectors.toList());
 
         // Checks current redo thread state against the logs
+        Scn consistentThroughScn = Scn.NULL;
         for (Integer threadId : currentThreads) {
             final RedoThread redoThread = currentRedoThreadState.getRedoThread(threadId);
-            if (redoThread.isOpen()) {
-                if (!isOpenThreadConsistent(redoThread, startScn, redoThreadLogs.get(threadId))) {
-                    return false;
-                }
+            final ConsistencyCheckResult threadResult = redoThread.isOpen()
+                    ? checkOpenThreadConsistency(redoThread, startScn, redoThreadLogs.get(threadId))
+                    : checkClosedThreadConsistency(redoThread, startScn, redoThreadLogs.get(threadId));
+
+            if (!threadResult.consistent()) {
+                return ConsistencyCheckResult.INCONSISTENT;
             }
-            else {
-                if (!isClosedThreadConsistent(redoThread, startScn, redoThreadLogs.get(threadId))) {
-                    return false;
-                }
+
+            final Scn threadConsistentThroughScn = threadResult.consistentThroughScn();
+            if (!threadConsistentThroughScn.isNull()
+                    && (consistentThroughScn.isNull() || threadConsistentThroughScn.compareTo(consistentThroughScn) < 0)) {
+                consistentThroughScn = threadConsistentThroughScn;
             }
         }
 
@@ -303,7 +329,9 @@ public class LogFileCollector {
                 .filter(not(currentThreads::contains))
                 .forEach(this::logThreadCheckSkippedNotInDatabase);
 
-        return true;
+        return consistentThroughScn.isNull()
+                ? ConsistencyCheckResult.CONSISTENT
+                : ConsistencyCheckResult.consistentThrough(consistentThroughScn);
     }
 
     /**
@@ -337,26 +365,29 @@ public class LogFileCollector {
 
     /**
      * Checks whether the specified open {@code thread} has consistent redo-logs in the specified collection.
+     * <p>
+     * When the mining strategy tolerates sequence gaps, a gap above the read position does not fail the
+     * check; the thread is instead reported consistent up to the system change number just before the gap.
      *
      * @param thread the redo thread to inspect; should not be {@code null}
      * @param startScn the read position system change number, should not be {@code null}
      * @param threadLogs the redo-thread logs to check consistency against, may be {@code null} or empty
-     * @return {@code true} if the open thread's logs are consistent; {@code false} otherwise
+     * @return the open thread's consistency check result, never {@code null}
      */
-    private boolean isOpenThreadConsistent(RedoThread thread, Scn startScn, List<LogFile> threadLogs) {
+    private ConsistencyCheckResult checkOpenThreadConsistency(RedoThread thread, Scn startScn, List<LogFile> threadLogs) {
         final int threadId = thread.getThreadId();
         final Scn enabledScn = thread.getEnabledScn();
         final Scn checkpointScn = thread.getCheckpointScn();
 
         if (thread.isDisabled()) {
             logException(String.format("Redo thread %d expected to have ENABLED with value PUBLIC or PRIVATE.", threadId));
-            return false;
+            return ConsistencyCheckResult.INCONSISTENT;
         }
 
         if (threadLogs == null || threadLogs.isEmpty()) {
             logException(String.format("Redo thread %d is inconsistent; enabled SCN %s checkpoint SCN %s reading from SCN %s, no logs found.",
                     threadId, enabledScn, checkpointScn, startScn));
-            return false;
+            return ConsistencyCheckResult.INCONSISTENT;
         }
 
         // Consistency is expected since the ENABLED_SCN point.
@@ -370,14 +401,18 @@ public class LogFileCollector {
             if (enabledLogs.isEmpty()) {
                 logException(String.format("Redo Thread %d is inconsistent; expected logs after enabled SCN %s",
                         threadId, enabledLogs));
-                return false;
+                return ConsistencyCheckResult.INCONSISTENT;
             }
 
             final Optional<Long> missingSequence = getFirstLogMissingSequence(enabledLogs);
             if (missingSequence.isPresent()) {
+                final Optional<Scn> consistentThroughScn = getConsistentScnBeforeGap(threadId, startScn, enabledLogs, missingSequence.get());
+                if (consistentThroughScn.isPresent()) {
+                    return ConsistencyCheckResult.consistentThrough(consistentThroughScn.get());
+                }
                 logException(String.format("Redo Thread %d is inconsistent; failed to find log with sequence %d (enabled).",
                         threadId, missingSequence.get()));
-                return false;
+                return ConsistencyCheckResult.INCONSISTENT;
             }
 
             LOGGER.debug("Redo Thread {} is consistent after enabled SCN {} ({}).", threadId, enabledScn, thread.getStatus());
@@ -393,12 +428,12 @@ public class LogFileCollector {
 
                     if (allThreadArchiveLogs.isEmpty()) {
                         logException(String.format("Redo Thread %d is inconsistent; at least one archive log expected.", threadId));
-                        return false;
+                        return ConsistencyCheckResult.INCONSISTENT;
                     }
                     else if (allThreadArchiveLogs.stream().anyMatch(l -> l.isScnInLogFileRange(startScn))) {
                         logException(String.format("Redo thread %d is inconsistent; does not have a log that conatins scn %s. " +
                                 "A recent log switch may not have been archived by the Oracle ARC process yet.", threadId, startScn));
-                        return false;
+                        return ConsistencyCheckResult.INCONSISTENT;
                     }
                     else {
                         // Collects all archive logs for a given redo thread and returns the first archive log
@@ -414,15 +449,20 @@ public class LogFileCollector {
                         if (logWithRangeBeforeStartScn.isEmpty()) {
                             logException(String.format("Redo Thread %d is inconsistent; expected archive log with range just before scn %s.",
                                     threadId, startScn));
-                            return false;
+                            return ConsistencyCheckResult.INCONSISTENT;
                         }
 
-                        final Optional<Long> missingSequence = getFirstLogMissingSequence(Stream.concat(
-                                threadLogs.stream(), logWithRangeBeforeStartScn.stream()).toList());
+                        final List<LogFile> bridgedLogs = Stream.concat(
+                                threadLogs.stream(), logWithRangeBeforeStartScn.stream()).toList();
+                        final Optional<Long> missingSequence = getFirstLogMissingSequence(bridgedLogs);
                         if (missingSequence.isPresent()) {
+                            final Optional<Scn> consistentThroughScn = getConsistentScnBeforeGap(threadId, startScn, bridgedLogs, missingSequence.get());
+                            if (consistentThroughScn.isPresent()) {
+                                return ConsistencyCheckResult.consistentThrough(consistentThroughScn.get());
+                            }
                             logException(String.format("Redo Thread %d is inconsistent; an archive log with sequence %d is not available",
                                     threadId, missingSequence.get()));
-                            return false;
+                            return ConsistencyCheckResult.INCONSISTENT;
                         }
                     }
 
@@ -434,32 +474,79 @@ public class LogFileCollector {
                 }
                 catch (SQLException e) {
                     logException(String.format("Redo thread %d is inconsistent; " + e.getMessage(), threadId), e);
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
             }
 
             // Make sure the thread logs from the read position until now have no gaps
             final Optional<Long> missingSequence = getFirstLogMissingSequence(threadLogs);
             if (missingSequence.isPresent()) {
+                final Optional<Scn> consistentThroughScn = getConsistentScnBeforeGap(threadId, startScn, threadLogs, missingSequence.get());
+                if (consistentThroughScn.isPresent()) {
+                    return ConsistencyCheckResult.consistentThrough(consistentThroughScn.get());
+                }
                 logException(String.format("Redo Thread %d is inconsistent; failed to find log with sequence %d",
                         threadId, missingSequence.get()));
-                return false;
+                return ConsistencyCheckResult.INCONSISTENT;
             }
 
             LOGGER.debug("Redo Thread {} is consistent.", threadId);
         }
-        return true;
+        return ConsistencyCheckResult.CONSISTENT;
+    }
+
+    /**
+     * Computes the system change number through which the specified redo thread logs are consistent when
+     * truncating the thread's log chain just before the specified missing sequence.
+     * <p>
+     * An empty value is returned when the mining strategy does not tolerate sequence gaps or when the
+     * truncation would not allow the connector to advance beyond the read position, in which case the
+     * gap must be treated as an inconsistency.
+     *
+     * @param threadId the redo thread id
+     * @param startScn the read position system change number, should not be {@code null}
+     * @param threadLogs the redo-thread logs that contain the sequence gap, should not be {@code null}
+     * @param missingSequence the first missing log sequence in the collection
+     * @return the system change number the thread is consistent through, or empty if the gap cannot be tolerated
+     */
+    private Optional<Scn> getConsistentScnBeforeGap(int threadId, Scn startScn, List<LogFile> threadLogs, long missingSequence) {
+        if (!tolerateSequenceGaps) {
+            return Optional.empty();
+        }
+
+        // All logs with a sequence before the first missing sequence form a contiguous chain
+        final Scn consistentThroughScn = threadLogs.stream()
+                .filter(log -> log.getSequence().longValue() < missingSequence)
+                .map(LogFile::getNextScn)
+                .max(Scn::compareTo)
+                .orElse(Scn.NULL);
+
+        if (consistentThroughScn.isNull() || consistentThroughScn.compareTo(startScn) <= 0) {
+            // Truncating at the gap would not advance the read position; treat the gap as an inconsistency
+            return Optional.empty();
+        }
+
+        LOGGER.warn("Redo Thread {} has a log sequence gap at sequence {}; mining will proceed up to SCN {} " +
+                "until the missing log becomes available.", threadId, missingSequence, consistentThroughScn);
+
+        return Optional.of(consistentThroughScn);
     }
 
     /**
      * Checks whether the specified closed {@code thread} has consistent redo-logs in the specified collection.
+     * <p>
+     * When the mining strategy tolerates sequence gaps, a gap below the checkpoint of a thread that was
+     * shutdown (closed but not disabled) does not fail the check; the thread is instead reported consistent
+     * up to the system change number just before the gap, as the missing log may simply not have been
+     * archived yet. Gaps in a disabled thread's log chain remain strict inconsistencies, since a disabled
+     * thread's redo is fully archived at disable time and such a gap indicates a deleted archive log.
      *
      * @param thread the redo thread to inspect; should not be {@code null}
      * @param startScn the read position system change number, should not be {@code null}
      * @param threadLogs the redo-thread logs to check consistency against, may be {@code null} or empty
-     * @return {@code true} if the closed thread's logs are consistent; {@code false} otherwise
+     * @return the closed thread's consistency check result, never {@code null}
      */
-    private boolean isClosedThreadConsistent(RedoThread thread, Scn startScn, List<LogFile> threadLogs) {
+    private ConsistencyCheckResult checkClosedThreadConsistency(RedoThread thread, Scn startScn, List<LogFile> threadLogs) {
         final int threadId = thread.getThreadId();
         if (!thread.isDisabled()) {
             // The node was shutdown and not disabled.
@@ -477,7 +564,7 @@ public class LogFileCollector {
                     }
                     logException(String.format("Redo Thread %d stopped at SCN %s, but logs detected using SCN %s.",
                             threadId, checkpointScn, startScn));
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
 
                 final List<LogFile> logsToCheck;
@@ -492,7 +579,7 @@ public class LogFileCollector {
                     if (logsToCheck.isEmpty()) {
                         logException(String.format("Redo Thread %d is inconsistent; expected logs between enabled SCN %s and checkpoint SCN %s",
                                 threadId, enabledScn, checkpointScn));
-                        return false;
+                        return ConsistencyCheckResult.INCONSISTENT;
                     }
                 }
                 else {
@@ -505,15 +592,22 @@ public class LogFileCollector {
                     if (logsToCheck.isEmpty()) {
                         logException(String.format("Redo Thread %d is inconsistent; expected logs before checkpoint SCN %s",
                                 threadId, checkpointScn));
-                        return false;
+                        return ConsistencyCheckResult.INCONSISTENT;
                     }
                 }
 
                 final Optional<Long> missingSequence = getFirstLogMissingSequence(logsToCheck);
                 if (missingSequence.isPresent()) {
+                    // The thread's trailing logs may still be pending archival by the ARC process even
+                    // though the thread has since transitioned to the closed state, e.g. a node shutdown
+                    // or scale-down; the gap may heal once the archiver catches up.
+                    final Optional<Scn> consistentThroughScn = getConsistentScnBeforeGap(threadId, startScn, logsToCheck, missingSequence.get());
+                    if (consistentThroughScn.isPresent()) {
+                        return ConsistencyCheckResult.consistentThrough(consistentThroughScn.get());
+                    }
                     logException(String.format("Redo Thread %d is inconsistent; failed to find log with sequence %d (checkpoint).",
                             threadId, missingSequence.get()));
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
             }
             LOGGER.debug("Redo Thread {} is consistent before checkpoint SCN {} ({}).", threadId, checkpointScn, thread.getStatus());
@@ -524,7 +618,7 @@ public class LogFileCollector {
             final Scn disabledScn = thread.getDisabledScn();
             if (disabledScn.isNull() || disabledScn.asBigInteger().equals(BigInteger.ZERO)) {
                 LOGGER.debug("Redo Thread {} is disabled but has no disabled SCN; consistency check skipped.", threadId);
-                return true;
+                return ConsistencyCheckResult.CONSISTENT;
             }
 
             // If there are logs we need to check the consistency state up to the DISABLED_SCN
@@ -539,7 +633,7 @@ public class LogFileCollector {
                     }
                     logException(String.format("Redo Thread %d disabled at SCN %s, but logs detected using SCN %s.",
                             threadId, disabledScn, startScn));
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
 
                 // Consistency is expected up to the DISABLED_SCN point.
@@ -550,20 +644,23 @@ public class LogFileCollector {
                 if (disabledLogs.isEmpty()) {
                     logException(String.format("Redo Thread %d is inconsistent; expected logs before disabled SCN %s.",
                             threadId, disabledLogs));
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
 
+                // A disabled thread's redo is fully archived when the thread is disabled, so a sequence
+                // gap here indicates a deleted archive log that will never become available; no gap
+                // truncation is applied so the failure surfaces quickly.
                 final Optional<Long> missingSequence = getFirstLogMissingSequence(disabledLogs);
                 if (missingSequence.isPresent()) {
                     logException(String.format("Redo Thread %d is inconsistent; failed to find log with sequence %d.",
                             threadId, missingSequence.get()));
-                    return false;
+                    return ConsistencyCheckResult.INCONSISTENT;
                 }
             }
             LOGGER.debug("Redo Thread {} is consistent after disabled SCN {} ({}).", threadId, disabledScn, thread.getStatus());
         }
 
-        return true;
+        return ConsistencyCheckResult.CONSISTENT;
     }
 
     /**
@@ -696,6 +793,21 @@ public class LogFileCollector {
     }
 
     /**
+     * Sequence gaps can only be tolerated when the dictionary is not read from the logs themselves. For
+     * the {@code redo_log_catalog} strategy, the mined logs must form an unbroken chain that includes
+     * the dictionary, so the strict consistency check must be retained.
+     *
+     * @param connectorConfig the connector configuration, should not be {@code null}
+     * @return {@code true} if consistency can be truncated at a log sequence gap; {@code false} otherwise
+     */
+    private static boolean isGapToleranceSupported(OracleConnectorConfig connectorConfig) {
+        return switch (connectorConfig.getLogMiningStrategy()) {
+            case HYBRID, ONLINE_CATALOG -> true;
+            default -> false;
+        };
+    }
+
+    /**
      * Represents an inclusive range between two values.
      */
     @Immutable
@@ -718,11 +830,40 @@ public class LogFileCollector {
     }
 
     /**
+     * The result of a log file list consistency check.
+     * <p>
+     * A result may be fully consistent, inconsistent, or consistent up to a specific system change number
+     * when a tolerated log sequence gap truncated the consistency range. In the truncated case, mining
+     * must not read beyond {@link #consistentThroughScn()}.
+     *
+     * @param consistent whether the log file list can be safely mined
+     * @param consistentThroughScn the boundary the logs are consistent through when truncated at a
+     *         sequence gap; {@link Scn#NULL} when no truncation applies
+     */
+    @Immutable
+    public record ConsistencyCheckResult(boolean consistent, Scn consistentThroughScn) {
+
+        public static final ConsistencyCheckResult CONSISTENT = new ConsistencyCheckResult(true, Scn.NULL);
+        public static final ConsistencyCheckResult INCONSISTENT = new ConsistencyCheckResult(false, Scn.NULL);
+
+        public static ConsistencyCheckResult consistentThrough(Scn consistentThroughScn) {
+            return new ConsistencyCheckResult(true, consistentThroughScn);
+        }
+    }
+
+    /**
      * A result object when collecting Oracle logs.
      *
      * @param logFiles the logs that were fetched, never {@code null}
      * @param redoThreadState the redo thread state used when fetching logs, never {@code null}
+     * @param consistentThroughScn the boundary the logs are consistent through when a tolerated log
+     *         sequence gap truncated the consistency range; {@link Scn#NULL} when the logs are fully
+     *         consistent and no truncation applies
      */
-    public record LogFilesResult(List<LogFile> logFiles, RedoThreadState redoThreadState) {
+    public record LogFilesResult(List<LogFile> logFiles, RedoThreadState redoThreadState, Scn consistentThroughScn) {
+
+        public LogFilesResult(List<LogFile> logFiles, RedoThreadState redoThreadState) {
+            this(logFiles, redoThreadState, Scn.NULL);
+        }
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFileSessionSelector.java
@@ -32,4 +32,24 @@ public interface LogFileSessionSelector {
      * @return the selected logs and boundary based on the selector implementation
      */
     SessionLogSelection selectLogsForSession(LogFileCollector.LogFilesResult logFilesResult, Scn upperBoundary);
+
+    /**
+     * Gets the collected logs restricted to the consistent mining window.
+     * <p>
+     * When the collector truncated the consistency range at a log sequence gap, logs that start at or
+     * beyond the consistent boundary must not be added to the mining session; otherwise the full
+     * collected log list is returned unchanged.
+     *
+     * @param logFilesResult the collected log files result object, should not be {@code null}
+     * @return the logs eligible for the mining session, never {@code null}
+     */
+    default List<LogFile> getConsistentLogFiles(LogFileCollector.LogFilesResult logFilesResult) {
+        final Scn consistentThroughScn = logFilesResult.consistentThroughScn();
+        if (consistentThroughScn.isNull()) {
+            return logFilesResult.logFiles();
+        }
+        return logFilesResult.logFiles().stream()
+                .filter(log -> log.getFirstScn().compareTo(consistentThroughScn) < 0)
+                .toList();
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelector.java
@@ -22,7 +22,15 @@ public class UnboundedLogFileSessionSelector implements LogFileSessionSelector {
 
     @Override
     public SessionLogSelection selectLogsForSession(LogFileCollector.LogFilesResult logFilesResult, Scn upperBoundary) {
-        LOGGER.debug("Using all logs and reading up to {}.", upperBoundary);
-        return new SessionLogSelection(logFilesResult.logFiles(), upperBoundary);
+        Scn effectiveUpperBoundary = upperBoundary;
+
+        // When the collector truncated the consistency range at a log sequence gap, do not read beyond it
+        final Scn consistentThroughScn = logFilesResult.consistentThroughScn();
+        if (!consistentThroughScn.isNull() && consistentThroughScn.compareTo(effectiveUpperBoundary) < 0) {
+            effectiveUpperBoundary = consistentThroughScn;
+        }
+
+        LOGGER.debug("Using all consistent logs and reading up to {}.", effectiveUpperBoundary);
+        return new SessionLogSelection(getConsistentLogFiles(logFilesResult), effectiveUpperBoundary);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -1083,6 +1083,86 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(interceptor.containsMessage("resetting log count per redo thread to 1")).isTrue();
     }
 
+    @Test
+    @FixFor("dbz#1589")
+    void testConsistentThroughScnCapsBoundsAndFiltersLogs() {
+        // The collector truncated consistency at SCN 300 (SEQ3 missing); the redo log (SEQ4)
+        // starts beyond the boundary and must be excluded, and bounds capped to 300.
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 400, 4, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen(), Scn.valueOf(300)), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testOpenThreadWithAllLogsBeyondConsistentBoundaryDoesNotThrow() {
+        // Thread 1 truncated at SCN 150 (SEQ2 missing); thread 2's logs all start at or beyond
+        // the boundary and are filtered out entirely. The open-thread sanity check must not
+        // throw in that case; thread 2 simply contributes nothing to this session.
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 150, 1, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 200, 3, 1),
+                createArchiveLog("t2_arc1.log", 160, 250, 1, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 250, 2, 2));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen(), Scn.valueOf(150)), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("t1_arc1.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(150));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testConsistentThroughScnTakesPrecedenceOverMinedBoundaryFloor() {
+        // The floor from previously mined boundaries must never force mining past a log sequence
+        // gap; the collector's consistent-through boundary always wins. Once the gap heals, the
+        // floor resumes from the highest previously mined boundary, not the gap-capped one.
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
+
+        // Call 1: no gap; online mode mines through 500
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 200, 2, 1));
+        SessionLogSelection first = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(initialLogs, singleThreadOpen()), Scn.valueOf(500));
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+
+        // Call 2: SEQ3 went missing and consistency is truncated at 300, below the mined
+        // boundary; the gap cap wins and the window cannot extend across the gap
+        List<LogFile> gappedLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(gappedLogs, singleThreadOpen(), Scn.valueOf(300)), UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+
+        // Call 3: the gap healed; the window extends past the highest mined boundary (500)
+        List<LogFile> healedLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 450, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 450, 600, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 600, 5, 1));
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(healedLogs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
+    }
+
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {
         return LogFile.forArchive(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), thread, bytes, false, false);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogFileCollectorTest.java
@@ -2417,6 +2417,190 @@ public class LogFileCollectorTest {
         }
     }
 
+    @Test
+    @FixFor("dbz#1589")
+    void testOpenThreadGapAboveReadPositionTruncatesConsistency() throws Exception {
+        // The test scenario is (gap above the read position, arc process fell behind)
+        // ARC1 - 110 to NOW - SEQ5
+        // ARC1 - 090 to 100 - SEQ3
+        // ARC1 - 080 to 090 - SEQ2
+        // SEQ4 for ARC1 is missing (pending archival); read position 85 is in SEQ2
+        // Expectation: consistent through SCN 100 (just before the gap); strict view remains false.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 110, 5, 1));
+        files.add(createArchiveLog("archive2.log", 90, 100, 3, 1));
+        files.add(createArchiveLog("archive1.log", 80, 90, 2, 1));
+
+        final RedoThreadState state = getSingleThreadOpenState(Scn.valueOf(50), Scn.valueOf(111));
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(85), files, state);
+        assertThat(result.consistent()).isTrue();
+        assertThat(result.consistentThroughScn()).isEqualTo(Scn.valueOf(100));
+
+        assertThat(collector.isLogFileListConsistent(Scn.valueOf(85), files, state)).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testOpenThreadGapTruncationNotAppliedWithRedoLogCatalogStrategy() throws Exception {
+        // Same scenario as testOpenThreadGapAboveReadPositionTruncatesConsistency, but the
+        // redo_log_catalog strategy requires the dictionary from the logs, so no truncation applies.
+        // Expectation: inconsistent, wait needed.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 110, 5, 1));
+        files.add(createArchiveLog("archive2.log", 90, 100, 3, 1));
+        files.add(createArchiveLog("archive1.log", 80, 90, 2, 1));
+
+        final RedoThreadState state = getSingleThreadOpenState(Scn.valueOf(50), Scn.valueOf(111));
+        final Configuration config = getDefaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "redo_log_catalog")
+                .build();
+        final LogFileCollector collector = getLogFileCollector(config, getOracleConnectionMock(state));
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(85), files, state);
+        assertThat(result.consistent()).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testOpenThreadGapImmediatelyAboveReadPositionRemainsInconsistent() throws Exception {
+        // The test scenario is (gap right above the read position log, no forward progress possible)
+        // ARC1 - 100 to NOW - SEQ4
+        // ARC1 - 080 to 090 - SEQ2
+        // SEQ3 for ARC1 is missing; read position 101 is in SEQ4, above the gap
+        // Truncating before the gap (SCN 90) would not advance beyond the read position.
+        // Expectation: inconsistent, wait needed.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 100, 4, 1));
+        files.add(createArchiveLog("archive1.log", 80, 90, 2, 1));
+
+        final RedoThreadState state = getSingleThreadOpenState(Scn.valueOf(50), Scn.valueOf(101));
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(101), files, state);
+        assertThat(result.consistent()).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testOpenThreadEnabledAfterReadPositionGapTruncatesConsistency() throws Exception {
+        // The test scenario is (thread enabled after the read position, gap in the enabled logs)
+        // ARC1 - 110 to NOW - SEQ4
+        // ARC1 - 090 to 100 - SEQ2
+        // ARC1 - 080 to 090 - SEQ1
+        // SEQ3 for ARC1 is missing; thread enabled at 80, after the read position 70
+        // Expectation: consistent through SCN 100 (just before the gap).
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 110, 4, 1));
+        files.add(createArchiveLog("archive2.log", 90, 100, 2, 1));
+        files.add(createArchiveLog("archive1.log", 80, 90, 1, 1));
+
+        final RedoThreadState state = getSingleThreadOpenState(Scn.valueOf(80), Scn.valueOf(111));
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(70), files, state);
+        assertThat(result.consistent()).isTrue();
+        assertThat(result.consistentThroughScn()).isEqualTo(Scn.valueOf(100));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testClosedThreadCheckpointGapTruncatesConsistency() throws Exception {
+        // The test scenario is (node shutdown, trailing log still pending archival)
+        // ARC1 - 080 to NOW - SEQ5 (open thread 1, contains read position 85)
+        // ARC2 - 100 to 105 - SEQ4 (closed thread 2, checkpoint 105)
+        // ARC2 - 080 to 090 - SEQ2
+        // SEQ3 for ARC2 is missing; thread 2 is closed but enabled (shutdown, not disabled)
+        // Expectation: consistent through SCN 90 (just before thread 2's gap).
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 80, 5, 1));
+        files.add(createArchiveLog("archive4.log", 100, 105, 4, 2));
+        files.add(createArchiveLog("archive2.log", 80, 90, 2, 2));
+
+        RedoThreadState.Builder builder = RedoThreadState.builder();
+        builder = makeOpenRedoThreadState(builder.thread(), 1, Scn.valueOf(50), Scn.valueOf(111)).build();
+        builder = makeClosedRedoThreadState(builder.thread(), 2, Scn.valueOf(50), Scn.valueOf(104)).build();
+        final RedoThreadState state = builder.build();
+
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(85), files, state);
+        assertThat(result.consistent()).isTrue();
+        assertThat(result.consistentThroughScn()).isEqualTo(Scn.valueOf(90));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testDisabledThreadGapRemainsInconsistent() throws Exception {
+        // The test scenario is (thread disabled, archive log deleted)
+        // ARC1 - 080 to NOW - SEQ5 (open thread 1, contains read position 85)
+        // ARC2 - 100 to 105 - SEQ4 (disabled thread 2, disabled at 105)
+        // ARC2 - 080 to 090 - SEQ2
+        // SEQ3 for ARC2 is missing; a disabled thread's redo is fully archived at disable
+        // time, so the gap indicates a deleted archive log that will never become available.
+        // Expectation: inconsistent, no truncation.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 80, 5, 1));
+        files.add(createArchiveLog("archive4.log", 100, 105, 4, 2));
+        files.add(createArchiveLog("archive2.log", 80, 90, 2, 2));
+
+        RedoThreadState.Builder builder = RedoThreadState.builder();
+        builder = makeOpenRedoThreadState(builder.thread(), 1, Scn.valueOf(50), Scn.valueOf(111)).build();
+        builder = makeDisabledRedoThreadState(builder.thread(), 2, Scn.valueOf(50), Scn.valueOf(105)).build();
+        final RedoThreadState state = builder.build();
+
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(85), files, state);
+        assertThat(result.consistent()).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testRacMultipleThreadGapsTruncateToMinimumBoundary() throws Exception {
+        // The test scenario is (gaps on both threads, boundaries differ)
+        // ARC1 - 110 to NOW - SEQ5, ARC1 - 090 to 100 - SEQ3, ARC1 - 080 to 090 - SEQ2 (SEQ4 missing)
+        // ARC2 - 105 to NOW - SEQ4, ARC2 - 060 to 095 - SEQ2 (SEQ3 missing)
+        // Thread 1 is consistent through 100, thread 2 through 95.
+        // Expectation: consistent through SCN 95, the minimum boundary across all threads.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createRedoLog("redo1.log", 110, 5, 1));
+        files.add(createArchiveLog("t1_archive2.log", 90, 100, 3, 1));
+        files.add(createArchiveLog("t1_archive1.log", 80, 90, 2, 1));
+        files.add(createRedoLog("redo2.log", 105, 4, 2));
+        files.add(createArchiveLog("t2_archive1.log", 60, 95, 2, 2));
+
+        final RedoThreadState state = getTwoThreadOpenState(Scn.valueOf(50), Scn.valueOf(111), Scn.valueOf(50), Scn.valueOf(106));
+        final LogFileCollector collector = getGapTolerantLogFileCollector(state);
+
+        final LogFileCollector.ConsistencyCheckResult result = collector.checkLogFileListConsistency(Scn.valueOf(85), files, state);
+        assertThat(result.consistent()).isTrue();
+        assertThat(result.consistentThroughScn()).isEqualTo(Scn.valueOf(95));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testGetLogsReturnsConsistentThroughScnWhenGapTolerated() throws Exception {
+        // End-to-end getLogs: a gap above the read position must not block the collection;
+        // the result carries the full log list and the boundary the logs are consistent through.
+        final List<LogFile> files = new ArrayList<>();
+        files.add(createArchiveLog("archive1.log", 80, 90, 2, 1));
+        files.add(createArchiveLog("archive2.log", 90, 100, 3, 1));
+        files.add(createRedoLog("redo1.log", 110, 5, 1));
+
+        final RedoThreadState state = getSingleThreadOpenState(Scn.valueOf(50), Scn.valueOf(111));
+        final Configuration config = getDefaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                .build();
+        final OracleConnection connection = getOracleConnectionMock(state, files);
+        final LogFileCollector collector = getLogFileCollector(config, connection);
+
+        final LogFileCollector.LogFilesResult result = collector.getLogs(Scn.valueOf(85));
+        assertThat(result.logFiles()).hasSize(3);
+        assertThat(result.consistentThroughScn()).isEqualTo(Scn.valueOf(100));
+    }
+
     private static LogFile createRedoLog(String name, long startScn, int sequence, int threadId) {
         return createRedoLog(name, startScn, Long.MAX_VALUE, sequence, threadId);
     }
@@ -2535,6 +2719,13 @@ public class LogFileCollectorTest {
         return new LogFileCollector(new OracleConnectorConfig(configuration), connection);
     }
 
+    private LogFileCollector getGapTolerantLogFileCollector(RedoThreadState state) throws SQLException {
+        final Configuration config = getDefaultConfig()
+                .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                .build();
+        return getLogFileCollector(config, getOracleConnectionMock(state));
+    }
+
     private LogFileCollector setCollectorLogFiles(LogFileCollector collector, List<LogFile> logFiles) throws SQLException {
         return setCollectorLogFiles(collector, logFiles, Collections.emptyMap());
     }
@@ -2623,6 +2814,29 @@ public class LogFileCollectorTest {
                 .lastRedoBlock(1234L)
                 .lastRedoSequenceNumber(2L)
                 .lastRedoTime(Instant.now().minus(3, ChronoUnit.SECONDS))
+                .conId(0L);
+    }
+
+    private RedoThread.Builder makeDisabledRedoThreadState(RedoThread.Builder builder,
+                                                           int threadId, Scn enabledScn, Scn disabledScn) {
+        return builder.threadId(threadId)
+                .status("CLOSED")
+                .enabled("DISABLED")
+                .instanceName("ORCLCDB")
+                .logGroups(2L)
+                .openTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .checkpointTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .checkpointScn(disabledScn)
+                .currentGroupNumber(1L)
+                .currentSequenceNumber(1L)
+                .enabledScn(enabledScn)
+                .enabledTime(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .disabledScn(disabledScn)
+                .disabledTime(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .lastRedoScn(disabledScn)
+                .lastRedoBlock(1234L)
+                .lastRedoSequenceNumber(2L)
+                .lastRedoTime(Instant.now().minus(5, ChronoUnit.MINUTES))
                 .conId(0L);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/UnboundedLogFileSessionSelectorTest.java
@@ -69,6 +69,39 @@ public class UnboundedLogFileSessionSelectorTest {
         assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
     }
 
+    @Test
+    @FixFor("dbz#1589")
+    void testConsistentThroughScnCapsBoundsAndFiltersLogs() {
+        // The collector truncated consistency at SCN 300 (SEQ3 missing); the redo log (SEQ4)
+        // starts beyond the boundary and must be excluded, and bounds capped to 300.
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1),
+                createArchiveLog("arc2.log", 200, 300, 2, 1),
+                createRedoLog("redo1.log", 400, 4, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, emptyState(), Scn.valueOf(300)), Scn.valueOf(500));
+
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+    }
+
+    @Test
+    @FixFor("dbz#1589")
+    void testConsistentThroughScnDoesNotRaiseLowerUpperBounds() {
+        // The consistent boundary (450) is above the pre-computed upper bounds (400);
+        // the smaller pre-computed bounds must be preserved.
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 450, 1, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, emptyState(), Scn.valueOf(450)), Scn.valueOf(400));
+
+        assertThat(result.logFiles()).isEqualTo(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread) {
         return LogFile.forArchive(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), thread,
                 1024L * 1024L * 1024L, false, false);


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1589

## Description
The Oracle LogMiner implementation will periodically report that the logs are inconsistent for a redo thread when we issue a query and an online redo log is scheduled for archival, but it hasn't been archived yet. 

This PR aims to reduce the impact of inconsistency checks by attempting to cap the curated list of logs at the log sequence gap for `online_catalog` and `hybrid` mining strategies, allowing the connector to safely mine the changes without waiting and causing further backlog during high-traffic windows. Once the connector is mining real-time online redo logs, the inconsistency check will create hard stalls waiting for archival to complete.

For other mining strategies, this PR has no impact, and the existing inconsistency check behavior remains unchanged. This is because data dictionary entries are appended to the write position of the redo logs when a dictionary build operation is executed. LogMiner needs that information on the next mining pass; therefore, all logs up to where the dictionary was most recently written are necessary.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
