### PR TITLE
debezium/dbz#2326 Do not allow mining upper boundary to go backward

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -259,6 +259,18 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDescription("Specifies the minimum number of logs to mine per redo thread. " +
                     "Setting this to 0 disables the cap, and all available logs are mined in a single pass.");
 
+    public static final Field LOG_MINING_LOG_COUNT_GROWTH_MAX = Field.create("log.mining.log.count.growth.max")
+            .withDisplayName("Maximum automatic growth of the log count per redo thread")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(4)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Specifies the maximum number of logs per redo thread the mining window grows to automatically " +
+                    "when a long-running transaction holds the window start in place. Defaults to 4. " +
+                    "A 'log.mining.log.count.min' above this value takes precedence. " +
+                    "The mining window may exceed this count when re-covering previously mined logs; the value bounds automatic growth, not the window itself.");
+
     public static final Field LOG_MINING_BATCH_SIZE_MAX = Field.create("log.mining.batch.size.max")
             .withDisplayName("Maximum batch size for reading redo/archive logs.")
             .withType(Type.LONG)
@@ -965,7 +977,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_SQL_RELAXED_QUOTE_DETECTION, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST, LOG_MINING_RESUME_POSITION_INTERVAL_MS,
                     LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START, LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS, LOG_MINING_PATH_DICTIONARY,
                     LOG_MINING_USE_CTE_QUERY,
-                    LOG_MINING_REDO_THREAD_SCN_ADJUSTMENT, LOG_MINING_HASH_AREA_SIZE, LOG_MINING_SORT_AREA_SIZE, LOG_MINING_LOG_COUNT_MIN)
+                    LOG_MINING_REDO_THREAD_SCN_ADJUSTMENT, LOG_MINING_HASH_AREA_SIZE, LOG_MINING_SORT_AREA_SIZE, LOG_MINING_LOG_COUNT_MIN,
+                    LOG_MINING_LOG_COUNT_GROWTH_MAX)
             .group(Field.Group.CONNECTOR, INTERVAL_HANDLING_MODE, UNAVAILABLE_VALUE_PLACEHOLDER, BINARY_HANDLING_MODE, SCHEMA_NAME_ADJUSTMENT_MODE,
                     LEGACY_DECIMAL_HANDLING_STRATEGY)
             .group(Field.Group.CONNECTOR_ADVANCED, QUERY_FETCH_SIZE, OBJECT_ID_CACHE_SIZE)
@@ -1060,6 +1073,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final boolean logMiningDeferredTransactionStart;
     private final Duration logMiningDeferredTransactionRetention;
     private final Integer logMiningMinimumLogCount;
+    private final Integer logMiningLogCountGrowthMax;
 
     private final String openLogReplicatorSource;
     private final String openLogReplicatorHostname;
@@ -1163,6 +1177,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningDeferredTransactionStart = config.getBoolean(LOG_MINING_BUFFER_DEFERRED_TRANSACTION_START);
         this.logMiningDeferredTransactionRetention = Duration.ofMillis(config.getLong(LOG_MINING_BUFFER_DEFERRED_TRANSACTION_RETENTION_MS));
         this.logMiningMinimumLogCount = config.getInteger(LOG_MINING_LOG_COUNT_MIN);
+        this.logMiningLogCountGrowthMax = config.getInteger(LOG_MINING_LOG_COUNT_GROWTH_MAX);
 
         this.logMiningEhCacheConfiguration = config.subset("log.mining.buffer.ehcache", false);
 
@@ -1942,6 +1957,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public Integer getLogMiningMinimumLogCount() {
         return logMiningMinimumLogCount;
+    }
+
+    public Integer getLogMiningLogCountGrowthMax() {
+        return logMiningLogCountGrowthMax;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -265,7 +265,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
             .withDefault(4)
-            .withValidation(Field::isPositiveInteger)
+            .withValidation(Field::isPositiveInteger, OracleConnectorConfig::validateLogMiningLogCountGrowthMax)
             .withDescription("Specifies the maximum number of logs per redo thread the mining window grows to automatically " +
                     "when a long-running transaction holds the window start in place. Defaults to 4. " +
                     "A 'log.mining.log.count.min' above this value takes precedence. " +
@@ -2502,6 +2502,22 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 final Set<String> racNodes = Strings.setOf(config.getString(RAC_NODES), String::new);
                 if (!racNodes.isEmpty()) {
                     LOGGER.warn("The property '{}' is set, but is ignored due to using read-only mode.", RAC_NODES.name());
+                }
+            }
+        }
+        return 0;
+    }
+
+    public static int validateLogMiningLogCountGrowthMax(Configuration config, Field field, ValidationOutput problems) {
+        if (isLogMiner(config)) {
+            final int minimumLogCount = config.getInteger(LOG_MINING_LOG_COUNT_MIN);
+            final LogMiningStrategy strategy = LogMiningStrategy.parse(config.getString(LOG_MINING_STRATEGY));
+            if (minimumLogCount > 0 && (LogMiningStrategy.HYBRID.equals(strategy) || LogMiningStrategy.ONLINE_CATALOG.equals(strategy))) {
+                final int growthMax = config.getInteger(field);
+                if (minimumLogCount >= growthMax) {
+                    LOGGER.warn("The configured '{}' of {} meets or exceeds '{}' of {}; automatic log count growth is disabled " +
+                            "and each mining step targets the configured minimum.",
+                            LOG_MINING_LOG_COUNT_MIN.name(), minimumLogCount, LOG_MINING_LOG_COUNT_GROWTH_MAX.name(), growthMax);
                 }
             }
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -2152,7 +2152,11 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
                     // capped window sizing that would otherwise collapse to the minimum log count.
                     final CommitScn commitScn = getOffsetContext().getCommitScn();
                     final Scn minedBoundary = commitScn != null ? commitScn.getMaxCommittedScn() : Scn.NULL;
-                    return new CappedLogFileSessionSelector(minimumLogCountPerThread, maximumRedoLogFileSize, minedBoundary);
+                    return new CappedLogFileSessionSelector(
+                            minimumLogCountPerThread,
+                            connectorConfig.getLogMiningLogCountGrowthMax(),
+                            maximumRedoLogFileSize,
+                            minedBoundary);
                 }
             }
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.annotation.VisibleForTesting;
 import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.CommitScn;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnection.NonRelationalTableException;
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -2146,7 +2147,12 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             switch (connectorConfig.getLogMiningStrategy()) {
                 case HYBRID, ONLINE_CATALOG: {
                     final long maximumRedoLogFileSize = connection.getMaximumRedoLogFileSize();
-                    return new CappedLogFileSessionSelector(minimumLogCountPerThread, maximumRedoLogFileSize);
+                    // The maximum committed SCN across redo threads is a lower bound on the upper
+                    // boundary of the last mining session before a restart; seeding it restores the
+                    // capped window sizing that would otherwise collapse to the minimum log count.
+                    final CommitScn commitScn = getOffsetContext().getCommitScn();
+                    final Scn minedBoundary = commitScn != null ? commitScn.getMaxCommittedScn() : Scn.NULL;
+                    return new CappedLogFileSessionSelector(minimumLogCountPerThread, maximumRedoLogFileSize, minedBoundary);
                 }
             }
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -34,7 +34,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
     private final long redoLogSizeInBytes;
 
     private int logsPerRedoThread;
-    private Map<Integer, List<LogFile>> previousCappedLogsByThread;
+    private Map<Integer, List<LogFile>> previousBudgetLogsByThread;
     private Scn previousEffectiveUpperBoundary;
 
     public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes) {
@@ -53,25 +53,17 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                 .sorted(Comparator.comparing(LogFile::getSequence))
                 .collect(Collectors.groupingBy(LogFile::getThread));
 
-        Map<Integer, List<LogFile>> cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
+        Map<Integer, List<LogFile>> budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
 
-        if (previousCappedLogsByThread != null) {
-            if (cappedLogsByThread.equals(previousCappedLogsByThread)) {
-                // Same log set as last iteration: the lower watermark did not advance, so a long-running
-                // transaction may extend beyond the current cap. Grow by one log to find the end.
-                logsPerRedoThread++;
-                LOGGER.debug("Capped log set unchanged, growing log count per redo thread to {}.", logsPerRedoThread);
-                cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
-            }
-            else if (logsPerRedoThread > minimumLogsPerRedoThread) {
-                // Log set changed: the watermark advanced, so reset the count back to the configured minimum.
-                logsPerRedoThread = minimumLogsPerRedoThread;
-                LOGGER.debug("Capped log set changed, resetting log count per redo thread to {}.", logsPerRedoThread);
-                cappedLogsByThread = getThreadLogsCappedBySize(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
-            }
+        if (previousBudgetLogsByThread != null && budgetLogsByThread.equals(previousBudgetLogsByThread)) {
+            logsPerRedoThread++;
+            LOGGER.debug("Capped log set unchanged, growing log count per redo thread to {}.", logsPerRedoThread);
+            budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
         }
 
-        previousCappedLogsByThread = cappedLogsByThread;
+        previousBudgetLogsByThread = budgetLogsByThread;
+
+        Map<Integer, List<LogFile>> cappedLogsByThread = extendPastPreviousBoundary(logsByThread, budgetLogsByThread);
 
         boolean allThreadsMineOnline = true;
         for (RedoThread redoThread : logFilesResult.redoThreadState().getThreads()) {
@@ -101,8 +93,10 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
 
         if (allThreadsMineOnline) {
             LOGGER.debug("All threads are reading online redo, using all logs and reading up to {}.", upperBoundary);
-            // When all threads mine online redo logs, no upper boundary cap is necessary
-            // Resort the log files in thread+sequence order for application.
+            if (logsPerRedoThread > minimumLogsPerRedoThread) {
+                logsPerRedoThread = minimumLogsPerRedoThread;
+                LOGGER.debug("All threads reading online redo, resetting log count per redo thread to {}.", logsPerRedoThread);
+            }
             recordEffectiveUpperBoundary(upperBoundary);
             return new SessionLogSelection(
                     logFilesResult.logFiles().stream()
@@ -124,49 +118,52 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                 effectiveUpperBoundary);
     }
 
-    private Map<Integer, List<LogFile>> getThreadLogsCappedBySize(Map<Integer, List<LogFile>> logsByThread, long thresholdBytes) {
+    private Map<Integer, List<LogFile>> getThreadLogsCappedByBudget(Map<Integer, List<LogFile>> logsByThread, long thresholdBytes) {
         final Map<Integer, List<LogFile>> logsByThreadCapped = new HashMap<>();
         for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
-            final List<LogFile> threadLogs = entry.getValue();
             final List<LogFile> cappedLogs = new ArrayList<>();
 
             long accumulatedSize = 0;
-            int nextIndex = 0;
-            while (nextIndex < threadLogs.size()) {
-                final LogFile logFile = threadLogs.get(nextIndex);
+            for (LogFile logFile : entry.getValue()) {
                 accumulatedSize += logFile.getBytes();
                 cappedLogs.add(logFile);
-                nextIndex++;
 
                 if (accumulatedSize >= thresholdBytes) {
                     break;
                 }
             }
 
-            // The effective upper boundary must never regress below a boundary a previous session
-            // already mined; such a session re-reads redo without producing any new events. Extend
-            // the capped window until its top passes the previously mined boundary.
-            if (previousEffectiveUpperBoundary != null) {
-                while (nextIndex < threadLogs.size() && isWindowTopAtOrBelow(cappedLogs, previousEffectiveUpperBoundary)) {
-                    cappedLogs.add(threadLogs.get(nextIndex));
-                    nextIndex++;
-                }
-            }
-
-            // When the capped window has consumed all the thread's archive logs and reached the
-            // online redo logs, include the thread's remaining online logs so the session reads
-            // through the online upper boundary rather than being capped at a non-current online
-            // log; the marginal cost is bounded by the thread's redo log group count.
-            if (!cappedLogs.get(cappedLogs.size() - 1).isArchive()) {
-                while (nextIndex < threadLogs.size()) {
-                    cappedLogs.add(threadLogs.get(nextIndex));
-                    nextIndex++;
-                }
-            }
-
             logsByThreadCapped.put(entry.getKey(), cappedLogs);
         }
         return logsByThreadCapped;
+    }
+
+    private Map<Integer, List<LogFile>> extendPastPreviousBoundary(
+                                                                   Map<Integer, List<LogFile>> logsByThread, Map<Integer, List<LogFile>> budgetCapped) {
+        final Map<Integer, List<LogFile>> result = new HashMap<>();
+        for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
+            final List<LogFile> threadLogs = entry.getValue();
+            final List<LogFile> budgetLogs = budgetCapped.get(entry.getKey());
+            final List<LogFile> extended = new ArrayList<>(budgetLogs);
+            int nextIndex = budgetLogs.size();
+
+            if (previousEffectiveUpperBoundary != null) {
+                while (nextIndex < threadLogs.size() && isWindowTopAtOrBelow(extended, previousEffectiveUpperBoundary)) {
+                    extended.add(threadLogs.get(nextIndex));
+                    nextIndex++;
+                }
+            }
+
+            if (!extended.get(extended.size() - 1).isArchive()) {
+                while (nextIndex < threadLogs.size()) {
+                    extended.add(threadLogs.get(nextIndex));
+                    nextIndex++;
+                }
+            }
+
+            result.put(entry.getKey(), extended);
+        }
+        return result;
     }
 
     private static boolean isWindowTopAtOrBelow(List<LogFile> windowLogs, Scn boundary) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -35,6 +35,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
 
     private int logsPerRedoThread;
     private Map<Integer, List<LogFile>> previousCappedLogsByThread;
+    private Scn previousEffectiveUpperBoundary;
 
     public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes) {
         this.minimumLogsPerRedoThread = minimumLogsPerRedoThread;
@@ -102,6 +103,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
             LOGGER.debug("All threads are reading online redo, using all logs and reading up to {}.", upperBoundary);
             // When all threads mine online redo logs, no upper boundary cap is necessary
             // Resort the log files in thread+sequence order for application.
+            recordEffectiveUpperBoundary(upperBoundary);
             return new SessionLogSelection(
                     logFilesResult.logFiles().stream()
                             .sorted(Comparator.comparingInt(LogFile::getThread)
@@ -113,6 +115,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         LOGGER.debug("Using capped logs, reading up to {}.", effectiveUpperBoundary);
         // Use the calculated effective upper boundary
         // Resort the capped log files in thread+sequence order for application
+        recordEffectiveUpperBoundary(effectiveUpperBoundary);
         return new SessionLogSelection(
                 cappedLogsByThread.entrySet().stream()
                         .sorted(Map.Entry.comparingByKey())
@@ -124,20 +127,58 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
     private Map<Integer, List<LogFile>> getThreadLogsCappedBySize(Map<Integer, List<LogFile>> logsByThread, long thresholdBytes) {
         final Map<Integer, List<LogFile>> logsByThreadCapped = new HashMap<>();
         for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
+            final List<LogFile> threadLogs = entry.getValue();
             final List<LogFile> cappedLogs = new ArrayList<>();
 
             long accumulatedSize = 0;
-            for (LogFile logFile : entry.getValue()) {
+            int nextIndex = 0;
+            while (nextIndex < threadLogs.size()) {
+                final LogFile logFile = threadLogs.get(nextIndex);
                 accumulatedSize += logFile.getBytes();
                 cappedLogs.add(logFile);
+                nextIndex++;
 
                 if (accumulatedSize >= thresholdBytes) {
                     break;
                 }
             }
 
+            // The effective upper boundary must never regress below a boundary a previous session
+            // already mined; such a session re-reads redo without producing any new events. Extend
+            // the capped window until its top passes the previously mined boundary.
+            if (previousEffectiveUpperBoundary != null) {
+                while (nextIndex < threadLogs.size() && isWindowTopAtOrBelow(cappedLogs, previousEffectiveUpperBoundary)) {
+                    cappedLogs.add(threadLogs.get(nextIndex));
+                    nextIndex++;
+                }
+            }
+
+            // When the capped window has consumed all the thread's archive logs and reached the
+            // online redo logs, include the thread's remaining online logs so the session reads
+            // through the online upper boundary rather than being capped at a non-current online
+            // log; the marginal cost is bounded by the thread's redo log group count.
+            if (!cappedLogs.get(cappedLogs.size() - 1).isArchive()) {
+                while (nextIndex < threadLogs.size()) {
+                    cappedLogs.add(threadLogs.get(nextIndex));
+                    nextIndex++;
+                }
+            }
+
             logsByThreadCapped.put(entry.getKey(), cappedLogs);
         }
         return logsByThreadCapped;
+    }
+
+    private static boolean isWindowTopAtOrBelow(List<LogFile> windowLogs, Scn boundary) {
+        final LogFile lastWindowLog = windowLogs.get(windowLogs.size() - 1);
+        return !lastWindowLog.isCurrent() && lastWindowLog.getNextScn().compareTo(boundary) <= 0;
+    }
+
+    private void recordEffectiveUpperBoundary(Scn effectiveUpperBoundary) {
+        // Track the highest boundary handed to a mining session; used as the floor that
+        // subsequent capped windows must be extended past.
+        if (previousEffectiveUpperBoundary == null || effectiveUpperBoundary.compareTo(previousEffectiveUpperBoundary) > 0) {
+            previousEffectiveUpperBoundary = effectiveUpperBoundary;
+        }
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -28,6 +28,10 @@ import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
  */
 public class CappedLogFileSessionSelector implements LogFileSessionSelector {
 
+    // Hard ceiling for stall-driven budget growth; keeps a single mining session's window within
+    // the database query timeout no matter how far ahead the previously mined boundary lies.
+    private static final int MAX_LOGS_PER_REDO_THREAD = 16;
+
     private final Logger LOGGER = LoggerFactory.getLogger(CappedLogFileSessionSelector.class);
 
     private final int minimumLogsPerRedoThread;
@@ -79,7 +83,13 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         Map<Integer, List<LogFile>> budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
 
         if (previousBudgetLogsByThread != null && budgetLogsByThread.equals(previousBudgetLogsByThread)) {
-            logsPerRedoThread++;
+            // Derive the window width from the stall distance so the budget covers the already mined
+            // ground in one step instead of one log per session. The +1 floor preserves the previous
+            // linear-growth guarantee; the cap keeps a session's window within the query timeout,
+            // yielding to a configured minimum above it.
+            final int derivedLogsPerRedoThread = deriveLogsPerRedoThread(logsByThread);
+            logsPerRedoThread = Math.min(Math.max(derivedLogsPerRedoThread, logsPerRedoThread + 1),
+                    Math.max(MAX_LOGS_PER_REDO_THREAD, minimumLogsPerRedoThread));
             LOGGER.debug("Capped log set unchanged, growing log count per redo thread to {}.", logsPerRedoThread);
             budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
         }
@@ -146,9 +156,9 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
     }
 
     private int deriveLogsPerRedoThread(Map<Integer, List<LogFile>> logsByThread) {
-        // The seeded boundary marks ground already mined before the restart; the per-thread byte
-        // span up to it re-expresses the window width the budget had grown to, so the first
-        // session resumes at that width rather than re-climbing from the minimum.
+        // The previously mined boundary marks ground already covered; the per-thread byte span up
+        // to it re-expresses the window width required to cover that ground, so a seeded restart
+        // or a stalled budget resumes at that width rather than re-climbing from the minimum.
         long maxThreadBytes = 0;
         for (List<LogFile> threadLogs : logsByThread.values()) {
             long threadBytes = 0;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -36,11 +36,29 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
     private int logsPerRedoThread;
     private Map<Integer, List<LogFile>> previousBudgetLogsByThread;
     private Scn previousEffectiveUpperBoundary;
+    private boolean deriveLogCountFromSeed;
 
-    public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes) {
+    /**
+     * Creates a capped log file session selector.
+     *
+     * The previously mined boundary seeds the capped window state from the restored offsets so the
+     * window guarantees survive a connector restart. The seed is a lower bound on the upper boundary
+     * of the last mining session before the restart; the log count per redo thread is re-derived from
+     * the seeded span on the first selection, when the collected logs provide the byte sizes needed
+     * to translate the span into a per-thread log count.
+     *
+     * @param minimumLogsPerRedoThread minimum number of logs to mine per redo thread
+     * @param redoLogSizeInBytes maximum size of an online redo log in bytes
+     * @param previouslyMinedBoundary lower bound on the previously mined upper boundary; ignored when null or none
+     */
+    public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes, Scn previouslyMinedBoundary) {
         this.minimumLogsPerRedoThread = minimumLogsPerRedoThread;
         this.redoLogSizeInBytes = redoLogSizeInBytes;
         this.logsPerRedoThread = minimumLogsPerRedoThread;
+        if (previouslyMinedBoundary != null && !previouslyMinedBoundary.isNull()) {
+            this.previousEffectiveUpperBoundary = previouslyMinedBoundary;
+            this.deriveLogCountFromSeed = true;
+        }
     }
 
     @Override
@@ -52,6 +70,11 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         final Map<Integer, List<LogFile>> logsByThread = logFilesResult.logFiles().stream()
                 .sorted(Comparator.comparing(LogFile::getSequence))
                 .collect(Collectors.groupingBy(LogFile::getThread));
+
+        if (deriveLogCountFromSeed) {
+            deriveLogCountFromSeed = false;
+            logsPerRedoThread = deriveLogsPerRedoThread(logsByThread);
+        }
 
         Map<Integer, List<LogFile>> budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
 
@@ -122,6 +145,28 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                 effectiveUpperBoundary);
     }
 
+    private int deriveLogsPerRedoThread(Map<Integer, List<LogFile>> logsByThread) {
+        // The seeded boundary marks ground already mined before the restart; the per-thread byte
+        // span up to it re-expresses the window width the budget had grown to, so the first
+        // session resumes at that width rather than re-climbing from the minimum.
+        long maxThreadBytes = 0;
+        for (List<LogFile> threadLogs : logsByThread.values()) {
+            long threadBytes = 0;
+            for (LogFile logFile : threadLogs) {
+                if (logFile.getFirstScn().compareTo(previousEffectiveUpperBoundary) >= 0) {
+                    break;
+                }
+                threadBytes += logFile.getBytes();
+            }
+            maxThreadBytes = Math.max(maxThreadBytes, threadBytes);
+        }
+
+        final int derived = Math.toIntExact(Math.max(minimumLogsPerRedoThread, (maxThreadBytes + redoLogSizeInBytes - 1) / redoLogSizeInBytes));
+        LOGGER.debug("Derived log count per redo thread {} from previously mined boundary {}.", derived, previousEffectiveUpperBoundary);
+
+        return derived;
+    }
+
     private Map<Integer, List<LogFile>> getThreadLogsCappedByBudget(Map<Integer, List<LogFile>> logsByThread, long thresholdBytes) {
         final Map<Integer, List<LogFile>> logsByThreadCapped = new HashMap<>();
         for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
@@ -142,8 +187,8 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         return logsByThreadCapped;
     }
 
-    private Map<Integer, List<LogFile>> extendPastPreviousBoundary(
-                                                                   Map<Integer, List<LogFile>> logsByThread, Map<Integer, List<LogFile>> budgetCapped) {
+    private Map<Integer, List<LogFile>> extendPastPreviousBoundary(Map<Integer, List<LogFile>> logsByThread,
+                                                                   Map<Integer, List<LogFile>> budgetCapped) {
         final Map<Integer, List<LogFile>> result = new HashMap<>();
         for (Map.Entry<Integer, List<LogFile>> entry : logsByThread.entrySet()) {
             final List<LogFile> threadLogs = entry.getValue();
@@ -155,6 +200,10 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                 while (nextIndex < threadLogs.size() && isWindowTopAtOrBelow(extended, previousEffectiveUpperBoundary)) {
                     extended.add(threadLogs.get(nextIndex));
                     nextIndex++;
+                }
+                if (nextIndex > budgetLogs.size()) {
+                    LOGGER.debug("Extended thread {} window by {} logs past previously mined boundary {}.",
+                            entry.getKey(), nextIndex - budgetLogs.size(), previousEffectiveUpperBoundary);
                 }
             }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -28,13 +28,10 @@ import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
  */
 public class CappedLogFileSessionSelector implements LogFileSessionSelector {
 
-    // Hard ceiling for stall-driven budget growth; keeps a single mining session's window within
-    // the database query timeout no matter how far ahead the previously mined boundary lies.
-    private static final int MAX_LOGS_PER_REDO_THREAD = 16;
-
     private final Logger LOGGER = LoggerFactory.getLogger(CappedLogFileSessionSelector.class);
 
     private final int minimumLogsPerRedoThread;
+    private final int maximumLogsPerRedoThread;
     private final long redoLogSizeInBytes;
 
     private int logsPerRedoThread;
@@ -52,11 +49,13 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
      * to translate the span into a per-thread log count.
      *
      * @param minimumLogsPerRedoThread minimum number of logs to mine per redo thread
+     * @param maximumLogsPerRedoThread growth ceiling for the log count per redo thread; a minimum above it takes precedence
      * @param redoLogSizeInBytes maximum size of an online redo log in bytes
      * @param previouslyMinedBoundary lower bound on the previously mined upper boundary; ignored when null or none
      */
-    public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, long redoLogSizeInBytes, Scn previouslyMinedBoundary) {
+    public CappedLogFileSessionSelector(int minimumLogsPerRedoThread, int maximumLogsPerRedoThread, long redoLogSizeInBytes, Scn previouslyMinedBoundary) {
         this.minimumLogsPerRedoThread = minimumLogsPerRedoThread;
+        this.maximumLogsPerRedoThread = maximumLogsPerRedoThread;
         this.redoLogSizeInBytes = redoLogSizeInBytes;
         this.logsPerRedoThread = minimumLogsPerRedoThread;
         if (previouslyMinedBoundary != null && !previouslyMinedBoundary.isNull()) {
@@ -170,7 +169,7 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
      * @return the log count, never greater than the growth ceiling
      */
     private int clampToGrowthCeiling(int logCount) {
-        return Math.min(logCount, Math.max(MAX_LOGS_PER_REDO_THREAD, minimumLogsPerRedoThread));
+        return Math.min(logCount, Math.max(maximumLogsPerRedoThread, minimumLogsPerRedoThread));
     }
 
     private int deriveLogsPerRedoThread(Map<Integer, List<LogFile>> logsByThread) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -77,7 +77,10 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
 
         if (deriveLogCountFromSeed) {
             deriveLogCountFromSeed = false;
-            logsPerRedoThread = deriveLogsPerRedoThread(logsByThread);
+            // The seeded boundary alone preserves the pre-restart window via the extension, so
+            // clamping the derived count costs no coverage; it bounds the slice width carried into
+            // catch-up when the pin clears before any stall can apply the growth ceiling.
+            logsPerRedoThread = clampToGrowthCeiling(deriveLogsPerRedoThread(logsByThread));
         }
 
         Map<Integer, List<LogFile>> budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
@@ -85,11 +88,9 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
         if (previousBudgetLogsByThread != null && budgetLogsByThread.equals(previousBudgetLogsByThread)) {
             // Derive the window width from the stall distance so the budget covers the already mined
             // ground in one step instead of one log per session. The +1 floor preserves the previous
-            // linear-growth guarantee; the cap keeps a session's window within the query timeout,
-            // yielding to a configured minimum above it.
+            // linear-growth guarantee.
             final int derivedLogsPerRedoThread = deriveLogsPerRedoThread(logsByThread);
-            logsPerRedoThread = Math.min(Math.max(derivedLogsPerRedoThread, logsPerRedoThread + 1),
-                    Math.max(MAX_LOGS_PER_REDO_THREAD, minimumLogsPerRedoThread));
+            logsPerRedoThread = clampToGrowthCeiling(Math.max(derivedLogsPerRedoThread, logsPerRedoThread + 1));
             LOGGER.debug("Capped log set unchanged, growing log count per redo thread to {}.", logsPerRedoThread);
             budgetLogsByThread = getThreadLogsCappedByBudget(logsByThread, (long) logsPerRedoThread * redoLogSizeInBytes);
         }
@@ -153,6 +154,23 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                         .flatMap(entry -> entry.getValue().stream())
                         .toList(),
                 effectiveUpperBoundary);
+    }
+
+    /**
+     * Clamps a candidate log count per redo thread to the growth ceiling.
+     *
+     * The ceiling bounds how wide the budget may grow, whether from stall growth or from the count
+     * derived off a seeded boundary on restart, keeping the budget's contribution to a single
+     * mining session predictable. A configured minimum above the ceiling wins, so the count never
+     * drops below the user's configuration. The mined window itself may still exceed the ceiling
+     * when extending past the previously mined boundary, as that ground must be re-covered
+     * regardless of the budget.
+     *
+     * @param logCount the candidate log count per redo thread
+     * @return the log count, never greater than the growth ceiling
+     */
+    private int clampToGrowthCeiling(int logCount) {
+        return Math.min(logCount, Math.max(MAX_LOGS_PER_REDO_THREAD, minimumLogsPerRedoThread));
     }
 
     private int deriveLogsPerRedoThread(Map<Integer, List<LogFile>> logsByThread) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelector.java
@@ -97,6 +97,10 @@ public class CappedLogFileSessionSelector implements LogFileSessionSelector {
                 logsPerRedoThread = minimumLogsPerRedoThread;
                 LOGGER.debug("All threads reading online redo, resetting log count per redo thread to {}.", logsPerRedoThread);
             }
+            // Growth only widens a window capped below the online redo logs; after an online pass
+            // there is no cap to widen, so clear the baseline to avoid growing the log count on
+            // the next iteration only to reset it within the same call.
+            previousBudgetLogsByThread = null;
             recordEffectiveUpperBoundary(upperBoundary);
             return new SessionLogSelection(
                     logFilesResult.logFiles().stream()

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -258,7 +258,9 @@ public class CappedLogFileSessionSelectorTest {
         selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
 
         // Third call: new log set (arc4 added, arc1 gone => capped set differs from previous)
-        // logsPerRedoThread resets to minimumLogsPerRedoThread=2 => arc2+arc3
+        // logsPerRedoThread resets to minimumLogsPerRedoThread=2 => arc2+arc3 (top 400)
+        // dbz#2326: the previous call already mined to 400, so the window is extended past the
+        // previously mined boundary => arc2+arc3+arc4, reading up to 500
         List<LogFile> advancedLogs = List.of(
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
@@ -268,8 +270,8 @@ public class CappedLogFileSessionSelectorTest {
         SessionLogSelection third = selector.selectLogsForSession(
                 new LogFilesResult(advancedLogs, singleThreadOpen()), UPPER_BOUNDS);
         assertThat(third.logFiles()).extracting(LogFile::getFileName)
-                .containsExactly("arc2.log", "arc3.log");
-        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+                .containsExactly("arc2.log", "arc3.log", "arc4.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
     }
 
     @Test
@@ -343,7 +345,8 @@ public class CappedLogFileSessionSelectorTest {
         // Call 2: same => grow to 3 => arc1+arc2+arc3
         selector.selectLogsForSession(initialResult, UPPER_BOUNDS);
 
-        // Call 3: new logs => cap differs, logsPerRedoThread > minimum => reset to 2
+        // Call 3: new logs; capped at arc2+arc3 (top 400), extended past the previously mined
+        // boundary (400) => arc2+arc3+arc4, reading up to 500
         List<LogFile> advancedLogs = List.of(
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
@@ -352,11 +355,13 @@ public class CappedLogFileSessionSelectorTest {
         LogFilesResult advancedResult = new LogFilesResult(advancedLogs, singleThreadOpen());
         selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
 
-        // Call 4: same advanced logs => cap unchanged from call 3 => re-grow to 3 from reset minimum
+        // Call 4 (dbz#2326): advancing past the previously mined boundary (500) requires the
+        // online redo log; the thread now mines online, so all logs are used with the original
+        // upper boundary rather than re-reading only the already-mined archive range
         SessionLogSelection fourth = selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
         assertThat(fourth.logFiles()).extracting(LogFile::getFileName)
-                .containsExactly("arc2.log", "arc3.log", "arc4.log");
-        assertThat(fourth.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+                .containsExactly("arc2.log", "arc3.log", "arc4.log", "redo1.log");
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
     }
 
     @Test
@@ -381,12 +386,136 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
     }
 
+    @Test
+    @FixFor("dbz#2326")
+    void testCappedBoundaryNeverRegressesWithPinnedWatermark() {
+        // A long-running transaction pins the lower watermark, so every collection returns the
+        // same log list. Each selection must still advance the upper boundary past the previous
+        // one; a boundary that repeats produces a session that re-reads redo and emits nothing.
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // Call 1: capped at arc1, reading up to 200
+        SessionLogSelection first = pinnedSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(first.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log");
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
+
+        // Call 2: byte cap alone would repeat arc1/200; the window extends past the mined boundary
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log", "arc2.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+
+        // Call 3: advances again
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+
+        // Call 4: advancing past 400 requires the online redo log; thread now mines online
+        SessionLogSelection fourth = pinnedSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(fourth.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testOnlineModeRatchetsBoundaryForSubsequentCappedSelections() {
+        // An online-mode pass mines to the online upper boundary; a later capped selection from
+        // the still-pinned watermark must not regress below it (the dbz#2326 point-3 trace where
+        // "Using capped logs, reading up to <scn>" repeated a boundary below an earlier online pass).
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+
+        // Call 1: online mode, mined up to 500
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 200, 2, 1));
+        SessionLogSelection first = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(initialLogs, singleThreadOpen()), Scn.valueOf(500));
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+
+        // Call 2: log switches occurred; the byte cap alone would select arc1 (top 200), far below
+        // the mined boundary. The window extends until its top passes 500.
+        List<LogFile> advancedLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 550, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 550, 700, 5, 1, ONE_GB),
+                createRedoLog("redo1.log", 700, 6, 1));
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(advancedLogs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(550));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testWindowEndingOnNonCurrentOnlineLogExtendsThroughCurrent() {
+        // The byte cap lands on a non-current online redo log. Capping the boundary there would
+        // throttle online throughput for no benefit; once the window has reached the online logs,
+        // it extends through the CURRENT log and the session reads to the online upper boundary.
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createNonCurrentRedoLog("redo_active.log", 200, 300, 2, 1),
+                createRedoLog("redo_current.log", 300, 3, 1));
+
+        SessionLogSelection result = selector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testTwoThreadFloorExtensionOnlyExtendsThreadsBelowMinedBoundary() {
+        // RAC: after mining to 220, thread 2's byte-capped top (220) is at the mined boundary and
+        // must extend; thread 1's top (250) is already beyond it and keeps its byte-capped window.
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 250, 1, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 250, 2, 1),
+                createArchiveLog("t2_arc1.log", 100, 220, 1, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 220, 2, 2));
+
+        // Call 1: capped at each thread's first archive; boundary = min(250, 220) = 220
+        SessionLogSelection first = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(initialLogs, twoThreadsOpen()), UPPER_BOUNDS);
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(220));
+
+        // Call 2: thread 2 switched a new archive; only its window extends past the mined boundary
+        List<LogFile> advancedLogs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 250, 1, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 250, 2, 1),
+                createArchiveLog("t2_arc1.log", 100, 220, 1, 2, ONE_GB),
+                createArchiveLog("t2_arc2.log", 220, 330, 2, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 330, 3, 2));
+
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(advancedLogs, twoThreadsOpen()), UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactlyInAnyOrder("t1_arc1.log", "t2_arc1.log", "t2_arc2.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(250));
+    }
+
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {
         return LogFile.forArchive(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), thread, bytes, false, false);
     }
 
     private static LogFile createRedoLog(String name, long startScn, int seq, int thread) {
         return LogFile.forRedo(name, Scn.valueOf(startScn), Scn.valueOf(Long.MAX_VALUE), BigInteger.valueOf(seq), true, thread, ONE_GB);
+    }
+
+    private static LogFile createNonCurrentRedoLog(String name, long startScn, long endScn, int seq, int thread) {
+        return LogFile.forRedo(name, Scn.valueOf(startScn), Scn.valueOf(endScn), BigInteger.valueOf(seq), false, thread, ONE_GB);
     }
 
     private static RedoThreadState singleThreadOpen() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -38,7 +38,7 @@ public class CappedLogFileSessionSelectorTest {
     private static final Scn UPPER_BOUNDS = Scn.valueOf(1000);
 
     // threshold: 2 logs * 1 GB = 2 GB per thread
-    private final CappedLogFileSessionSelector selector = new CappedLogFileSessionSelector(2, ONE_GB);
+    private final CappedLogFileSessionSelector selector = new CappedLogFileSessionSelector(2, ONE_GB, Scn.NULL);
 
     @Test
     @FixFor("dbz#1713")
@@ -411,7 +411,7 @@ public class CappedLogFileSessionSelectorTest {
         // A long-running transaction pins the lower watermark, so every collection returns the
         // same log list. Each selection must still advance the upper boundary past the previous
         // one; a boundary that repeats produces a session that re-reads redo and emits nothing.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
 
         List<LogFile> logs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
@@ -448,7 +448,7 @@ public class CappedLogFileSessionSelectorTest {
         // An online-mode pass mines to the online upper boundary; a later capped selection from
         // the still-pinned watermark must not regress below it (the dbz#2326 point-3 trace where
         // "Using capped logs, reading up to <scn>" repeated a boundary below an earlier online pass).
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
 
         // Call 1: online mode, mined up to 500
         List<LogFile> initialLogs = List.of(
@@ -498,7 +498,7 @@ public class CappedLogFileSessionSelectorTest {
         // RAC: after mining to 220, the watermark advances (thread 1's starting log changes) so
         // the budget set differs and growth does not fire. Thread 2's byte-capped top (220) is
         // at the mined boundary and must extend; thread 1's top (350) is already beyond it.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
 
         List<LogFile> initialLogs = List.of(
                 createArchiveLog("t1_arc1.log", 100, 250, 1, 1, ONE_GB),
@@ -535,7 +535,7 @@ public class CappedLogFileSessionSelectorTest {
         // A commits but transaction B pins at arc2; the watermark shifts from arc1 to arc2.
         // The budget carries forward (no reset) and continues growing from the carried value
         // to find B's commit, avoiding wasted re-climb iterations from minimum.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
 
         // Calls 1-3: pinned at arc1, budget grows 1 -> 2 -> 3
         List<LogFile> pinnedLogs = List.of(
@@ -591,7 +591,7 @@ public class CappedLogFileSessionSelectorTest {
         // Forced log switches (ARCHIVE_LAG_TARGET) produce new small archive logs at the tail
         // while the watermark is pinned. The budget set is unchanged (tail logs are beyond the
         // byte threshold) so growth fires correctly on each iteration.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
 
         // Call 1: budget=1, set={arc1}; boundary=200
         List<LogFile> initialLogs = List.of(
@@ -690,6 +690,128 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(second.logFiles()).extracting(LogFile::getFileName)
                 .containsExactly("arc1.log", "arc2.log", "arc3.log");
         assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeededBoundaryDerivesWindowWidthAndGrowthContinuesFromIt() {
+        // Restart mid-pin: the boundary seeded from the restored offsets re-derives the window
+        // width on the first selection, so the session resumes at the pre-restart width and
+        // extends past the already-mined ground instead of re-climbing from the minimum.
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(400));
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createRedoLog("redo1.log", 600, 6, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // Call 1: 3 GB of logs lie below the seeded boundary => derived count 3; the budget window
+        // tops at the boundary itself, so the extension pushes one log past it
+        SessionLogSelection first = seededSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(first.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log");
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+
+        // Call 2: growth continues from the derived count (3 -> 4), not from the minimum
+        SessionLogSelection second = seededSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log", "arc5.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeedAtResumePositionOrNullSeedBehavesAsUnseeded() {
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("redo1.log", 300, 3, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // Seed at the resume position: no logs lie below it, derived count stays at minimum
+        // and the extension has nothing to push past
+        CappedLogFileSessionSelector atResumeSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(100));
+        SessionLogSelection atResume = atResumeSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(atResume.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log");
+        assertThat(atResume.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
+
+        // A none/null seed (no commits recorded in the offsets yet) is ignored entirely
+        CappedLogFileSessionSelector nullSeedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        SessionLogSelection nullSeed = nullSeedSelector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(nullSeed.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log");
+        assertThat(nullSeed.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeededBoundaryWithinOnlineRedoRunsOnlinePass() {
+        // The connector was mining online redo before the restart; the seeded boundary lies within
+        // the current log, so the first selection reaches the online redo and runs an online pass
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(800));
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createRedoLog("redo1.log", 200, 2, 1));
+
+        SessionLogSelection result = seededSelector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(result.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+        assertThat(result.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeedDerivationUsesWidestSpanAcrossThreads() {
+        // RAC: the derived count reflects the widest per-thread byte span below the seeded
+        // boundary, so no thread's window collapses below its pre-restart width
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(500));
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("t1_arc1.log", 100, 300, 1, 1, ONE_GB),
+                createArchiveLog("t1_arc2.log", 300, 500, 2, 1, ONE_GB),
+                createArchiveLog("t1_arc3.log", 500, 700, 3, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 700, 4, 1),
+                createArchiveLog("t2_arc1.log", 100, 450, 1, 2, ONE_GB),
+                createArchiveLog("t2_arc2.log", 450, 650, 2, 2, ONE_GB),
+                createRedoLog("t2_redo.log", 650, 3, 2));
+
+        // Both threads have 2 GB below the boundary => derived count 2. Thread 1's budget window
+        // tops exactly at the boundary and extends one log past it; thread 2 is already beyond.
+        SessionLogSelection result = seededSelector.selectLogsForSession(
+                new LogFilesResult(logs, twoThreadsOpen()), UPPER_BOUNDS);
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactlyInAnyOrder("t1_arc1.log", "t1_arc2.log", "t1_arc3.log", "t2_arc1.log", "t2_arc2.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(650));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeededWidthSpansForcedSwitchRuntsInOneSession() {
+        // The Finding 2 payoff: with forced-switch runts below the seeded boundary, the derived
+        // byte width covers all of them plus a full log beyond in the first session, where an
+        // unseeded restart would crawl one log per session from the minimum
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(500));
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("runt2.log", 200, 300, 2, 1, 50 * 1024 * 1024L),
+                createArchiveLog("runt3.log", 300, 400, 3, 1, 50 * 1024 * 1024L),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createArchiveLog("arc6.log", 600, 700, 6, 1, ONE_GB),
+                createRedoLog("redo1.log", 700, 7, 1));
+
+        // ~2.1 GB below the boundary => derived count 3; the 3 GB budget window already tops at
+        // 600, a full log past the previously mined ground, with no extension needed
+        SessionLogSelection result = seededSelector.selectLogsForSession(
+                new LogFilesResult(logs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(result.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "runt2.log", "runt3.log", "arc4.log", "arc5.log");
+        assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
     }
 
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -22,6 +22,9 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.LogFileCollector.LogFilesResult;
 import io.debezium.connector.oracle.logminer.LogFileSessionSelector.SessionLogSelection;
 import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
+
+import ch.qos.logback.classic.Level;
 
 /**
  * Unit tests for {@link CappedLogFileSessionSelector}.
@@ -629,6 +632,64 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(third.logFiles()).extracting(LogFile::getFileName)
                 .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log", "redo1.log");
         assertThat(third.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSteadyOnlineModeDoesNotOscillateGrowthAndReset() {
+        // In steady all-online mode the budget set is identical between iterations, which grew the
+        // log count only for the all-online branch to reset it within the same call - a grow/reset
+        // DEBUG pair and a redundant budget recomputation on every iteration. After an online pass
+        // the growth baseline is cleared, so neither message should be emitted.
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createRedoLog("redo1.log", 200, 2, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        for (int i = 0; i < 3; i++) {
+            SessionLogSelection selection = selector.selectLogsForSession(result, UPPER_BOUNDS);
+            assertThat(selection.logFiles()).containsExactlyInAnyOrderElementsOf(logs);
+            assertThat(selection.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+        }
+
+        assertThat(interceptor.containsMessage("growing log count")).isFalse();
+        assertThat(interceptor.containsMessage("resetting log count")).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testGrowthReengagesAfterLeavingOnlineMode() {
+        // An all-online pass clears the growth baseline; the first capped iteration afterward
+        // establishes a new baseline, and growth engages from the second identical capped set.
+        List<LogFile> onlineLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createRedoLog("redo1.log", 200, 2, 1));
+        selector.selectLogsForSession(new LogFilesResult(onlineLogs, singleThreadOpen()), Scn.valueOf(250));
+
+        // A burst of switches leaves a capped backlog pinned at arc1
+        List<LogFile> cappedLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createRedoLog("redo1.log", 500, 5, 1));
+        LogFilesResult cappedResult = new LogFilesResult(cappedLogs, singleThreadOpen());
+
+        // First capped call: budget=2 => arc1+arc2, no growth (baseline was cleared by the
+        // online pass); the window is already past the previously mined boundary of 250
+        SessionLogSelection first = selector.selectLogsForSession(cappedResult, UPPER_BOUNDS);
+        assertThat(first.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+
+        // Second capped call with the same set: growth fires => arc1+arc2+arc3
+        SessionLogSelection second = selector.selectLogsForSession(cappedResult, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
     }
 
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -39,7 +39,7 @@ public class CappedLogFileSessionSelectorTest {
     private static final Scn UPPER_BOUNDS = Scn.valueOf(1000);
 
     // threshold: 2 logs * 1 GB = 2 GB per thread
-    private final CappedLogFileSessionSelector selector = new CappedLogFileSessionSelector(2, ONE_GB, Scn.NULL);
+    private final CappedLogFileSessionSelector selector = new CappedLogFileSessionSelector(2, 16, ONE_GB, Scn.NULL);
 
     @Test
     @FixFor("dbz#1713")
@@ -412,7 +412,7 @@ public class CappedLogFileSessionSelectorTest {
         // A long-running transaction pins the lower watermark, so every collection returns the
         // same log list. Each selection must still advance the upper boundary past the previous
         // one; a boundary that repeats produces a session that re-reads redo and emits nothing.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         List<LogFile> logs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
@@ -449,7 +449,7 @@ public class CappedLogFileSessionSelectorTest {
         // An online-mode pass mines to the online upper boundary; a later capped selection from
         // the still-pinned watermark must not regress below it (the dbz#2326 point-3 trace where
         // "Using capped logs, reading up to <scn>" repeated a boundary below an earlier online pass).
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         // Call 1: online mode, mined up to 500
         List<LogFile> initialLogs = List.of(
@@ -499,7 +499,7 @@ public class CappedLogFileSessionSelectorTest {
         // RAC: after mining to 220, the watermark advances (thread 1's starting log changes) so
         // the budget set differs and growth does not fire. Thread 2's byte-capped top (220) is
         // at the mined boundary and must extend; thread 1's top (350) is already beyond it.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         List<LogFile> initialLogs = List.of(
                 createArchiveLog("t1_arc1.log", 100, 250, 1, 1, ONE_GB),
@@ -536,7 +536,7 @@ public class CappedLogFileSessionSelectorTest {
         // A commits but transaction B pins at arc2; the watermark shifts from arc1 to arc2.
         // The budget carries forward (no reset) and continues growing from the carried value
         // to find B's commit, avoiding wasted re-climb iterations from minimum.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         // Calls 1-3: pinned at arc1, budget grows 1 -> 2 -> 3
         List<LogFile> pinnedLogs = List.of(
@@ -592,7 +592,7 @@ public class CappedLogFileSessionSelectorTest {
         // Forced log switches (ARCHIVE_LAG_TARGET) produce new small archive logs at the tail
         // while the watermark is pinned. The budget set is unchanged (tail logs are beyond the
         // byte threshold) so growth fires correctly on each iteration.
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         // Call 1: budget=1, set={arc1}; boundary=200
         List<LogFile> initialLogs = List.of(
@@ -699,7 +699,7 @@ public class CappedLogFileSessionSelectorTest {
         // Restart mid-pin: the boundary seeded from the restored offsets re-derives the window
         // width on the first selection, so the session resumes at the pre-restart width and
         // extends past the already-mined ground instead of re-climbing from the minimum.
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(400));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(400));
 
         List<LogFile> logs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
@@ -735,13 +735,13 @@ public class CappedLogFileSessionSelectorTest {
 
         // Seed at the resume position: no logs lie below it, derived count stays at minimum
         // and the extension has nothing to push past
-        CappedLogFileSessionSelector atResumeSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(100));
+        CappedLogFileSessionSelector atResumeSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(100));
         SessionLogSelection atResume = atResumeSelector.selectLogsForSession(result, UPPER_BOUNDS);
         assertThat(atResume.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log");
         assertThat(atResume.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
 
         // A none/null seed (no commits recorded in the offsets yet) is ignored entirely
-        CappedLogFileSessionSelector nullSeedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector nullSeedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
         SessionLogSelection nullSeed = nullSeedSelector.selectLogsForSession(result, UPPER_BOUNDS);
         assertThat(nullSeed.logFiles()).extracting(LogFile::getFileName).containsExactly("arc1.log");
         assertThat(nullSeed.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
@@ -752,7 +752,7 @@ public class CappedLogFileSessionSelectorTest {
     void testSeededBoundaryWithinOnlineRedoRunsOnlinePass() {
         // The connector was mining online redo before the restart; the seeded boundary lies within
         // the current log, so the first selection reaches the online redo and runs an online pass
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(800));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(800));
 
         List<LogFile> logs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
@@ -769,7 +769,7 @@ public class CappedLogFileSessionSelectorTest {
     void testSeedDerivationUsesWidestSpanAcrossThreads() {
         // RAC: the derived count reflects the widest per-thread byte span below the seeded
         // boundary, so no thread's window collapses below its pre-restart width
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(500));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(500));
 
         List<LogFile> logs = List.of(
                 createArchiveLog("t1_arc1.log", 100, 300, 1, 1, ONE_GB),
@@ -795,7 +795,7 @@ public class CappedLogFileSessionSelectorTest {
         // The Finding 2 payoff: with forced-switch runts below the seeded boundary, the derived
         // byte width covers all of them plus a full log beyond in the first session, where an
         // unseeded restart would crawl one log per session from the minimum
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(500));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(500));
 
         List<LogFile> logs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
@@ -824,7 +824,7 @@ public class CappedLogFileSessionSelectorTest {
         // catch-up slice honors the ceiling instead of the unclamped derivation
         final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
         interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(2000));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.valueOf(2000));
         final Scn upperBounds = Scn.valueOf(5000);
 
         List<LogFile> pinnedLogs = new ArrayList<>();
@@ -833,8 +833,8 @@ public class CappedLogFileSessionSelectorTest {
         }
         pinnedLogs.add(createRedoLog("redo1.log", 2100, 21, 1));
 
-        // Call 1: 19 GB lie below the seeded boundary => derived 19, clamped to 16; the budget
-        // window tops at arc16 and the extension carries it past the boundary to arc1..arc20
+        // Call 1: 19 GB lie below the seeded boundary => the derived count of 19 clamps to the
+        // growth ceiling; the budget window tops at arc16 and the extension carries it past the boundary to arc1..arc20
         SessionLogSelection first = seededSelector.selectLogsForSession(
                 new LogFilesResult(pinnedLogs, singleThreadOpen()), upperBounds);
         assertThat(first.logFiles()).hasSize(20);
@@ -842,7 +842,8 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(interceptor.containsMessage("Derived log count per redo thread 19")).isTrue();
 
         // Call 2: the pinned transaction committed within the first window and the watermark
-        // advanced past it; no stall fires, and the catch-up slice is 16 logs, not 19
+        // advanced past it; no stall fires, and the catch-up slice honors the ceiling, not the
+        // seeded derivation of 19
         List<LogFile> catchUpLogs = new ArrayList<>();
         for (int i = 21; i <= 40; i++) {
             catchUpLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
@@ -863,7 +864,7 @@ public class CappedLogFileSessionSelectorTest {
     void testSeededCountClampYieldsToConfiguredMinimumAboveCeiling() {
         // A configured minimum above the growth ceiling wins on the seed path just as it does on
         // the stall path: the derived count of 19 clamps to the minimum of 18, never below it
-        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(18, ONE_GB, Scn.valueOf(2000));
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(18, 16, ONE_GB, Scn.valueOf(2000));
         final Scn upperBounds = Scn.valueOf(5000);
 
         List<LogFile> pinnedLogs = new ArrayList<>();
@@ -878,7 +879,7 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(first.logFiles()).hasSize(20);
         assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(2100));
 
-        // Call 2: the catch-up slice is the configured minimum of 18 logs, not the ceiling of 16
+        // Call 2: the catch-up slice is the configured minimum of 18 logs, not the ceiling
         List<LogFile> catchUpLogs = new ArrayList<>();
         for (int i = 21; i <= 40; i++) {
             catchUpLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
@@ -892,6 +893,44 @@ public class CappedLogFileSessionSelectorTest {
                 .startsWith("arc21.log")
                 .endsWith("arc38.log");
         assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(3900));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testConfiguredGrowthCeilingBoundsCarriedSliceWidth() {
+        // The growth ceiling is configuration, not a constant: with a ceiling of 4, a seeded
+        // width of 6 clamps to 4, the extension still carries the first window past the
+        // boundary, and the catch-up slice after the pin clears honors the configured value
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, 4, ONE_GB, Scn.valueOf(700));
+        final Scn upperBounds = Scn.valueOf(5000);
+
+        List<LogFile> pinnedLogs = new ArrayList<>();
+        for (int i = 1; i <= 8; i++) {
+            pinnedLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        pinnedLogs.add(createRedoLog("redo1.log", 900, 9, 1));
+
+        // Call 1: 6 GB lie below the seeded boundary => derived 6, clamped to 4; the budget
+        // window tops at arc4 and the extension carries it past the boundary to arc1..arc7
+        SessionLogSelection first = seededSelector.selectLogsForSession(
+                new LogFilesResult(pinnedLogs, singleThreadOpen()), upperBounds);
+        assertThat(first.logFiles()).hasSize(7);
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(800));
+
+        // Call 2: the pin cleared within the first window; the catch-up slice is 4 logs
+        List<LogFile> catchUpLogs = new ArrayList<>();
+        for (int i = 8; i <= 15; i++) {
+            catchUpLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        catchUpLogs.add(createRedoLog("redo1.log", 1600, 16, 1));
+
+        SessionLogSelection second = seededSelector.selectLogsForSession(
+                new LogFilesResult(catchUpLogs, singleThreadOpen()), upperBounds);
+        assertThat(second.logFiles()).hasSize(4);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .startsWith("arc8.log")
+                .endsWith("arc11.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(1200));
     }
 
     @Test
@@ -928,7 +967,7 @@ public class CappedLogFileSessionSelectorTest {
         // per session toward it
         final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
         interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         // Call 1: online pass mining up to 500; boundary 500 recorded, growth baseline cleared
         List<LogFile> onlineLogs = List.of(
@@ -969,7 +1008,7 @@ public class CappedLogFileSessionSelectorTest {
         // the query timeout; while clamped, the boundary still advances via the extension
         final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
         interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
         final Scn upperBounds = Scn.valueOf(5000);
 
         // Call 1: online pass mining up to 1850
@@ -991,7 +1030,8 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(second.logFiles()).hasSize(18);
         assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(1900));
 
-        // Call 3: stall; 18 GB lie below the mined boundary but the derived count clamps at 16;
+        // Call 3: stall; 18 GB lie below the mined boundary but the derived count clamps at the
+        // growth ceiling;
         // the budget covers arc1..arc16 and the extension adds arc17..arc19
         SessionLogSelection third = pinnedSelector.selectLogsForSession(backlogResult, upperBounds);
         assertThat(third.logFiles()).hasSize(19);
@@ -1014,7 +1054,7 @@ public class CappedLogFileSessionSelectorTest {
         // online redo, the count resets to the minimum and the growth baseline clears
         final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
         interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
-        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, 16, ONE_GB, Scn.NULL);
 
         // Call 1: online pass mining up to 500
         List<LogFile> onlineLogs = List.of(

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -817,6 +817,85 @@ public class CappedLogFileSessionSelectorTest {
 
     @Test
     @FixFor("dbz#2326")
+    void testSeededCountClampedAtCeilingWhileWindowStillReachesBoundary() {
+        // Restart mid-pin with 19 logs of mined ground: the derived count clamps at the growth
+        // ceiling while the extension still carries the first window past the seeded boundary, so
+        // the clamp costs no coverage; when the pin then clears with no stall having fired, the
+        // catch-up slice honors the ceiling instead of the unclamped derivation
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.valueOf(2000));
+        final Scn upperBounds = Scn.valueOf(5000);
+
+        List<LogFile> pinnedLogs = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            pinnedLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        pinnedLogs.add(createRedoLog("redo1.log", 2100, 21, 1));
+
+        // Call 1: 19 GB lie below the seeded boundary => derived 19, clamped to 16; the budget
+        // window tops at arc16 and the extension carries it past the boundary to arc1..arc20
+        SessionLogSelection first = seededSelector.selectLogsForSession(
+                new LogFilesResult(pinnedLogs, singleThreadOpen()), upperBounds);
+        assertThat(first.logFiles()).hasSize(20);
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(2100));
+        assertThat(interceptor.containsMessage("Derived log count per redo thread 19")).isTrue();
+
+        // Call 2: the pinned transaction committed within the first window and the watermark
+        // advanced past it; no stall fires, and the catch-up slice is 16 logs, not 19
+        List<LogFile> catchUpLogs = new ArrayList<>();
+        for (int i = 21; i <= 40; i++) {
+            catchUpLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        catchUpLogs.add(createRedoLog("redo1.log", 4100, 41, 1));
+
+        SessionLogSelection second = seededSelector.selectLogsForSession(
+                new LogFilesResult(catchUpLogs, singleThreadOpen()), upperBounds);
+        assertThat(second.logFiles()).hasSize(16);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .startsWith("arc21.log")
+                .endsWith("arc36.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(3700));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testSeededCountClampYieldsToConfiguredMinimumAboveCeiling() {
+        // A configured minimum above the growth ceiling wins on the seed path just as it does on
+        // the stall path: the derived count of 19 clamps to the minimum of 18, never below it
+        CappedLogFileSessionSelector seededSelector = new CappedLogFileSessionSelector(18, ONE_GB, Scn.valueOf(2000));
+        final Scn upperBounds = Scn.valueOf(5000);
+
+        List<LogFile> pinnedLogs = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            pinnedLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        pinnedLogs.add(createRedoLog("redo1.log", 2100, 21, 1));
+
+        // Call 1: the budget window tops at arc18 and the extension carries it to arc1..arc20
+        SessionLogSelection first = seededSelector.selectLogsForSession(
+                new LogFilesResult(pinnedLogs, singleThreadOpen()), upperBounds);
+        assertThat(first.logFiles()).hasSize(20);
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(2100));
+
+        // Call 2: the catch-up slice is the configured minimum of 18 logs, not the ceiling of 16
+        List<LogFile> catchUpLogs = new ArrayList<>();
+        for (int i = 21; i <= 40; i++) {
+            catchUpLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        catchUpLogs.add(createRedoLog("redo1.log", 4100, 41, 1));
+
+        SessionLogSelection second = seededSelector.selectLogsForSession(
+                new LogFilesResult(catchUpLogs, singleThreadOpen()), upperBounds);
+        assertThat(second.logFiles()).hasSize(18);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .startsWith("arc21.log")
+                .endsWith("arc38.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(3900));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
     void testStallGrowsLinearlyWhenBoundaryBarelyAhead() {
         // Steady pin where the mined boundary sits just past the budget window: the derived
         // width offers nothing beyond the +1 floor, so growth stays exactly linear

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -812,6 +813,155 @@ public class CappedLogFileSessionSelectorTest {
         assertThat(result.logFiles()).extracting(LogFile::getFileName)
                 .containsExactly("arc1.log", "runt2.log", "runt3.log", "arc4.log", "arc5.log");
         assertThat(result.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testStallGrowsLinearlyWhenBoundaryBarelyAhead() {
+        // Steady pin where the mined boundary sits just past the budget window: the derived
+        // width offers nothing beyond the +1 floor, so growth stays exactly linear
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+
+        List<LogFile> logs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createRedoLog("redo1.log", 400, 4, 1));
+        LogFilesResult result = new LogFilesResult(logs, singleThreadOpen());
+
+        // Call 1: capped at arc1+arc2, mined up to 300
+        selector.selectLogsForSession(result, UPPER_BOUNDS);
+
+        // Call 2: stall; 2 GB lie below the mined boundary => derived 2, the floor grows to 3
+        SessionLogSelection second = selector.selectLogsForSession(result, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 3")).isTrue();
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testStallJumpsToDerivedCountInSingleStep() {
+        // A pin re-engages after an online pass recorded a far-ahead boundary: the first stall
+        // derives the full width to the mined ground in one step instead of climbing one log
+        // per session toward it
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+
+        // Call 1: online pass mining up to 500; boundary 500 recorded, growth baseline cleared
+        List<LogFile> onlineLogs = List.of(
+                createArchiveLog("arc0.log", 100, 150, 1, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 150, 2, 1));
+        pinnedSelector.selectLogsForSession(new LogFilesResult(onlineLogs, singleThreadOpen()), Scn.valueOf(500));
+
+        // Call 2: a burst left a pinned backlog; budget=1 => {arc1}, the extension pushes past 500
+        List<LogFile> backlogLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createArchiveLog("arc6.log", 600, 700, 6, 1, ONE_GB),
+                createRedoLog("redo1.log", 700, 7, 1));
+        LogFilesResult backlogResult = new LogFilesResult(backlogLogs, singleThreadOpen());
+
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(backlogResult, UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log", "arc5.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
+
+        // Call 3: stall; 5 GB lie below the mined boundary of 600 => budget jumps 1 -> 5 in one
+        // step (linear growth would have logged 2)
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(backlogResult, UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log", "arc5.log", "arc6.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(700));
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 5")).isTrue();
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 2")).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testStallGrowthClampedAtMaximumWhileBoundaryStillAdvances() {
+        // The derived width is clamped at the growth ceiling so a session's window stays within
+        // the query timeout; while clamped, the boundary still advances via the extension
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+        final Scn upperBounds = Scn.valueOf(5000);
+
+        // Call 1: online pass mining up to 1850
+        List<LogFile> onlineLogs = List.of(
+                createArchiveLog("arc0.log", 100, 150, 1, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 150, 2, 1));
+        pinnedSelector.selectLogsForSession(new LogFilesResult(onlineLogs, singleThreadOpen()), Scn.valueOf(1850));
+
+        // Call 2: a 25-archive pinned backlog; budget=1 => {arc1}, the extension pushes past
+        // 1850 => arc1..arc18, mined up to 1900
+        List<LogFile> backlogLogs = new ArrayList<>();
+        for (int i = 1; i <= 25; i++) {
+            backlogLogs.add(createArchiveLog("arc" + i + ".log", 100 * i, 100 * (i + 1), i, 1, ONE_GB));
+        }
+        backlogLogs.add(createRedoLog("redo1.log", 2600, 26, 1));
+        LogFilesResult backlogResult = new LogFilesResult(backlogLogs, singleThreadOpen());
+
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(backlogResult, upperBounds);
+        assertThat(second.logFiles()).hasSize(18);
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(1900));
+
+        // Call 3: stall; 18 GB lie below the mined boundary but the derived count clamps at 16;
+        // the budget covers arc1..arc16 and the extension adds arc17..arc19
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(backlogResult, upperBounds);
+        assertThat(third.logFiles()).hasSize(19);
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(2000));
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 16")).isTrue();
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 17")).isFalse();
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 18")).isFalse();
+
+        // Call 4: still stalled; the budget holds at the ceiling yet the boundary advances
+        SessionLogSelection fourth = pinnedSelector.selectLogsForSession(backlogResult, upperBounds);
+        assertThat(fourth.logFiles()).hasSize(20);
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(Scn.valueOf(2100));
+        assertThat(interceptor.containsMessage("growing log count per redo thread to 17")).isFalse();
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testAllOnlineResetStillAppliesAfterDerivedGrowth() {
+        // The all-online reset must survive derived growth: once a grown budget reaches the
+        // online redo, the count resets to the minimum and the growth baseline clears
+        final LogInterceptor interceptor = new LogInterceptor(CappedLogFileSessionSelector.class);
+        interceptor.setLoggerLevel(CappedLogFileSessionSelector.class, Level.DEBUG);
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB, Scn.NULL);
+
+        // Call 1: online pass mining up to 500
+        List<LogFile> onlineLogs = List.of(
+                createArchiveLog("arc0.log", 100, 150, 1, 1, ONE_GB / 2),
+                createRedoLog("redo1.log", 150, 2, 1));
+        pinnedSelector.selectLogsForSession(new LogFilesResult(onlineLogs, singleThreadOpen()), Scn.valueOf(500));
+
+        // Calls 2-3: pinned backlog; budget climbs to the derived width of 5 as in the jump test
+        List<LogFile> backlogLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createArchiveLog("arc6.log", 600, 700, 6, 1, ONE_GB),
+                createRedoLog("redo1.log", 700, 7, 1));
+        LogFilesResult backlogResult = new LogFilesResult(backlogLogs, singleThreadOpen());
+        pinnedSelector.selectLogsForSession(backlogResult, UPPER_BOUNDS);
+        pinnedSelector.selectLogsForSession(backlogResult, UPPER_BOUNDS);
+
+        // Call 4: stall again; the derived width of 6 reaches the online redo => all threads
+        // mine online, the count resets to the minimum
+        SessionLogSelection fourth = pinnedSelector.selectLogsForSession(backlogResult, UPPER_BOUNDS);
+        assertThat(fourth.logFiles()).containsExactlyInAnyOrderElementsOf(backlogLogs);
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+        assertThat(interceptor.containsMessage("resetting log count per redo thread to 1")).isTrue();
     }
 
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/CappedLogFileSessionSelectorTest.java
@@ -243,24 +243,23 @@ public class CappedLogFileSessionSelectorTest {
     }
 
     @Test
-    @FixFor("dbz#1713")
-    void testChangedCapResultResetsToMinimum() {
-        // First call with 3 archives; watermark then advances bringing new logs; count must reset
+    @FixFor({ "dbz#1713", "dbz#2326" })
+    void testWatermarkAdvanceBudgetCarriedForward() {
+        // First call with 3 archives; watermark then advances bringing new logs.
+        // The budget does not reset on watermark shift; it only resets when all threads read online.
         List<LogFile> initialLogs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
                 createRedoLog("redo1.log", 400, 4, 1));
 
-        // First call: capped at arc1+arc2
+        // Call 1: capped at arc1+arc2
         selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
-        // Second call (same): grows to 3 => arc1+arc2+arc3
+        // Call 2 (same): grows to 3 => arc1+arc2+arc3
         selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
 
-        // Third call: new log set (arc4 added, arc1 gone => capped set differs from previous)
-        // logsPerRedoThread resets to minimumLogsPerRedoThread=2 => arc2+arc3 (top 400)
-        // dbz#2326: the previous call already mined to 400, so the window is extended past the
-        // previously mined boundary => arc2+arc3+arc4, reading up to 500
+        // Call 3: watermark advanced (arc1 gone, arc4 added); budget stays at 3,
+        // so budget set is arc2+arc3+arc4, then the extension is a no-op (already past 400)
         List<LogFile> advancedLogs = List.of(
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
@@ -301,20 +300,21 @@ public class CappedLogFileSessionSelectorTest {
     }
 
     @Test
-    @FixFor("dbz#1713")
-    void testChangedCapResultAtMinimumNoRecompute() {
+    @FixFor({ "dbz#1713", "dbz#2326" })
+    void testWatermarkAdvanceAtMinimumBudgetExtendsPastPreviousBoundary() {
         // Log set changes on second call but logsPerRedoThread was never incremented (still at minimum).
-        // The else-if branch (logsPerRedoThread > minimum) is not entered, so no recompute happens.
+        // Budget set differs from previous so no growth occurs; extension ensures no regression.
         List<LogFile> initialLogs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
                 createRedoLog("redo1.log", 400, 4, 1));
 
-        // Call 1: capped at arc1+arc2 (threshold 2GB)
+        // Call 1: capped at arc1+arc2 (threshold 2GB), mined up to 300
         selector.selectLogsForSession(new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
 
-        // Call 2: new log set (arc1 gone, arc4 added); cap differs from previous but counter was never grown
+        // Call 2: watermark advanced (arc1 gone, arc4 added); budget set is arc2+arc3 (top 400),
+        // which already passes the previously mined boundary of 300, so no extension needed
         List<LogFile> advancedLogs = List.of(
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
@@ -323,16 +323,16 @@ public class CappedLogFileSessionSelectorTest {
 
         SessionLogSelection second = selector.selectLogsForSession(
                 new LogFilesResult(advancedLogs, singleThreadOpen()), UPPER_BOUNDS);
-        // logsPerRedoThread stays at minimum (2); initial compute at 2GB threshold is used as-is
         assertThat(second.logFiles()).extracting(LogFile::getFileName)
                 .containsExactly("arc2.log", "arc3.log");
         assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
     }
 
     @Test
-    @FixFor("dbz#1713")
-    void testReGrowthAfterReset() {
-        // Grow -> reset -> then re-grow from minimum on subsequent identical iterations
+    @FixFor({ "dbz#1713", "dbz#2326" })
+    void testBudgetCarriedThroughWatermarkAdvanceThenResetsAtOnlineRedo() {
+        // Grow while pinned, watermark advances (budget carries forward), eventually reach
+        // online redo which triggers the reset back to minimum.
         List<LogFile> initialLogs = List.of(
                 createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
@@ -345,23 +345,39 @@ public class CappedLogFileSessionSelectorTest {
         // Call 2: same => grow to 3 => arc1+arc2+arc3
         selector.selectLogsForSession(initialResult, UPPER_BOUNDS);
 
-        // Call 3: new logs; capped at arc2+arc3 (top 400), extended past the previously mined
-        // boundary (400) => arc2+arc3+arc4, reading up to 500
+        // Call 3: watermark advanced (arc1 gone, arc4 added); budget stays at 3,
+        // so budget set is arc2+arc3+arc4, reading up to 500
         List<LogFile> advancedLogs = List.of(
                 createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
                 createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
                 createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
                 createRedoLog("redo1.log", 500, 5, 1));
         LogFilesResult advancedResult = new LogFilesResult(advancedLogs, singleThreadOpen());
-        selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
+        SessionLogSelection third = selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log", "arc4.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
 
-        // Call 4 (dbz#2326): advancing past the previously mined boundary (500) requires the
-        // online redo log; the thread now mines online, so all logs are used with the original
-        // upper boundary rather than re-reading only the already-mined archive range
+        // Call 4: same budget set => grow to 4; budget now covers past the online redo boundary,
+        // extension reaches online redo => all threads mine online, budget resets to minimum
         SessionLogSelection fourth = selector.selectLogsForSession(advancedResult, UPPER_BOUNDS);
         assertThat(fourth.logFiles()).extracting(LogFile::getFileName)
                 .containsExactly("arc2.log", "arc3.log", "arc4.log", "redo1.log");
         assertThat(fourth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+
+        // Call 5: new logs after full catch-up; budget was reset to 2, so budget set is arc3+arc4
+        List<LogFile> caughtUpLogs = List.of(
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createRedoLog("redo1.log", 600, 6, 1));
+        SessionLogSelection fifth = selector.selectLogsForSession(
+                new LogFilesResult(caughtUpLogs, singleThreadOpen()), UPPER_BOUNDS);
+        // Budget is 2, budget set is arc3+arc4 (top 500); extension pushes past the previously
+        // mined boundary (UPPER_BOUNDS=1000) => includes arc5+redo, all threads online
+        assertThat(fifth.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc3.log", "arc4.log", "arc5.log", "redo1.log");
+        assertThat(fifth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
     }
 
     @Test
@@ -476,8 +492,9 @@ public class CappedLogFileSessionSelectorTest {
     @Test
     @FixFor("dbz#2326")
     void testTwoThreadFloorExtensionOnlyExtendsThreadsBelowMinedBoundary() {
-        // RAC: after mining to 220, thread 2's byte-capped top (220) is at the mined boundary and
-        // must extend; thread 1's top (250) is already beyond it and keeps its byte-capped window.
+        // RAC: after mining to 220, the watermark advances (thread 1's starting log changes) so
+        // the budget set differs and growth does not fire. Thread 2's byte-capped top (220) is
+        // at the mined boundary and must extend; thread 1's top (350) is already beyond it.
         CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
 
         List<LogFile> initialLogs = List.of(
@@ -491,10 +508,12 @@ public class CappedLogFileSessionSelectorTest {
                 new LogFilesResult(initialLogs, twoThreadsOpen()), UPPER_BOUNDS);
         assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(220));
 
-        // Call 2: thread 2 switched a new archive; only its window extends past the mined boundary
+        // Call 2: thread 1 advanced (arc1 gone, arc2 appeared); thread 2 has a new archive log
+        // but its budget-capped window still starts at t2_arc1. Budget set differs from call 1
+        // (thread 1 changed), so no growth. Extension only pushes thread 2 past 220.
         List<LogFile> advancedLogs = List.of(
-                createArchiveLog("t1_arc1.log", 100, 250, 1, 1, ONE_GB),
-                createRedoLog("t1_redo.log", 250, 2, 1),
+                createArchiveLog("t1_arc2.log", 250, 350, 2, 1, ONE_GB),
+                createRedoLog("t1_redo.log", 350, 3, 1),
                 createArchiveLog("t2_arc1.log", 100, 220, 1, 2, ONE_GB),
                 createArchiveLog("t2_arc2.log", 220, 330, 2, 2, ONE_GB),
                 createRedoLog("t2_redo.log", 330, 3, 2));
@@ -502,8 +521,114 @@ public class CappedLogFileSessionSelectorTest {
         SessionLogSelection second = pinnedSelector.selectLogsForSession(
                 new LogFilesResult(advancedLogs, twoThreadsOpen()), UPPER_BOUNDS);
         assertThat(second.logFiles()).extracting(LogFile::getFileName)
-                .containsExactlyInAnyOrder("t1_arc1.log", "t2_arc1.log", "t2_arc2.log");
-        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(250));
+                .containsExactlyInAnyOrder("t1_arc2.log", "t2_arc1.log", "t2_arc2.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(330));
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testCascadingPinsBudgetCarriesAndContinuesGrowing() {
+        // Transaction A pins the watermark at arc1; budget grows to find A's commit in arc3.
+        // A commits but transaction B pins at arc2; the watermark shifts from arc1 to arc2.
+        // The budget carries forward (no reset) and continues growing from the carried value
+        // to find B's commit, avoiding wasted re-climb iterations from minimum.
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+
+        // Calls 1-3: pinned at arc1, budget grows 1 -> 2 -> 3
+        List<LogFile> pinnedLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createRedoLog("redo1.log", 600, 6, 1));
+        LogFilesResult pinnedResult = new LogFilesResult(pinnedLogs, singleThreadOpen());
+
+        // Call 1: budget=1, set={arc1}
+        pinnedSelector.selectLogsForSession(pinnedResult, UPPER_BOUNDS);
+        // Call 2: same => grow to 2, set={arc1,arc2}
+        pinnedSelector.selectLogsForSession(pinnedResult, UPPER_BOUNDS);
+        // Call 3: same => grow to 3, set={arc1,arc2,arc3}, boundary=400
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(pinnedResult, UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(Scn.valueOf(400));
+
+        // Transaction A commits; watermark shifts to arc2 (transaction B pins there).
+        // Budget carries forward at 3; budget set={arc2,arc3,arc4} differs from previous => no growth
+        List<LogFile> shiftedLogs = List.of(
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 400, 3, 1, ONE_GB),
+                createArchiveLog("arc4.log", 400, 500, 4, 1, ONE_GB),
+                createArchiveLog("arc5.log", 500, 600, 5, 1, ONE_GB),
+                createRedoLog("redo1.log", 600, 6, 1));
+        LogFilesResult shiftedResult = new LogFilesResult(shiftedLogs, singleThreadOpen());
+
+        SessionLogSelection fourth = pinnedSelector.selectLogsForSession(shiftedResult, UPPER_BOUNDS);
+        assertThat(fourth.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log", "arc4.log");
+        assertThat(fourth.effectiveUpperBounds()).isEqualTo(Scn.valueOf(500));
+
+        // Call 5: still pinned at arc2, budget set unchanged => grow to 4, set={arc2,arc3,arc4,arc5}
+        SessionLogSelection fifth = pinnedSelector.selectLogsForSession(shiftedResult, UPPER_BOUNDS);
+        assertThat(fifth.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log", "arc4.log", "arc5.log");
+        assertThat(fifth.effectiveUpperBounds()).isEqualTo(Scn.valueOf(600));
+
+        // Call 6: grow to 5, reaches online redo => all threads online, budget resets
+        SessionLogSelection sixth = pinnedSelector.selectLogsForSession(shiftedResult, UPPER_BOUNDS);
+        assertThat(sixth.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc2.log", "arc3.log", "arc4.log", "arc5.log", "redo1.log");
+        assertThat(sixth.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
+    }
+
+    @Test
+    @FixFor("dbz#2326")
+    void testForcedSwitchTailLogsDoNotSuppressGrowth() {
+        // Forced log switches (ARCHIVE_LAG_TARGET) produce new small archive logs at the tail
+        // while the watermark is pinned. The budget set is unchanged (tail logs are beyond the
+        // byte threshold) so growth fires correctly on each iteration.
+        CappedLogFileSessionSelector pinnedSelector = new CappedLogFileSessionSelector(1, ONE_GB);
+
+        // Call 1: budget=1, set={arc1}; boundary=200
+        List<LogFile> initialLogs = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createRedoLog("redo1.log", 300, 3, 1));
+        SessionLogSelection first = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(initialLogs, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(first.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log");
+        assertThat(first.effectiveUpperBounds()).isEqualTo(Scn.valueOf(200));
+
+        // Call 2: forced switch added a small runt (arc3, 27MB) at the tail; the full log list
+        // changed but the budget set is still {arc1} (1GB threshold met at arc1) => growth fires,
+        // budget=2, set={arc1,arc2}; boundary=300
+        List<LogFile> switchedLogs1 = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 350, 3, 1, 27 * 1024 * 1024L),
+                createRedoLog("redo1.log", 350, 4, 1));
+        SessionLogSelection second = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(switchedLogs1, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(second.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log");
+        assertThat(second.effectiveUpperBounds()).isEqualTo(Scn.valueOf(300));
+
+        // Call 3: another forced switch added arc4 (29MB); budget set still {arc1,arc2} (2GB
+        // threshold met at arc2) => growth fires, budget=3. At 3GB threshold the small runts
+        // don't fill the gap, so the budget reaches redo1 and all threads mine online.
+        List<LogFile> switchedLogs2 = List.of(
+                createArchiveLog("arc1.log", 100, 200, 1, 1, ONE_GB),
+                createArchiveLog("arc2.log", 200, 300, 2, 1, ONE_GB),
+                createArchiveLog("arc3.log", 300, 350, 3, 1, 27 * 1024 * 1024L),
+                createArchiveLog("arc4.log", 350, 380, 4, 1, 29 * 1024 * 1024L),
+                createRedoLog("redo1.log", 380, 5, 1));
+        SessionLogSelection third = pinnedSelector.selectLogsForSession(
+                new LogFilesResult(switchedLogs2, singleThreadOpen()), UPPER_BOUNDS);
+        assertThat(third.logFiles()).extracting(LogFile::getFileName)
+                .containsExactly("arc1.log", "arc2.log", "arc3.log", "arc4.log", "redo1.log");
+        assertThat(third.effectiveUpperBounds()).isEqualTo(UPPER_BOUNDS);
     }
 
     private static LogFile createArchiveLog(String name, long startScn, long endScn, int seq, int thread, long bytes) {

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4842,7 +4842,7 @@ This configuration property has no effect when using xref:#oracle-property-log-m
 |[[oracle-property-log-mining-log-count-growth-max]]<<oracle-property-log-mining-log-count-growth-max, `+log.mining.log.count.growth.max+`>>
 |`4`
 |The maximum number of transaction logs per redo thread that the mining window grows to automatically when a long-running transaction prevents the window start from advancing.
-Worst-case work in a single mining step is approximately this count multiplied by the online redo log size.
+The growth budget contributes at most approximately this count multiplied by the online redo log size to a single mining step.
 
 A xref:#oracle-property-log-mining-log-count-min[`log.mining.log.count.min`] value above this maximum takes precedence.
 The mining window can exceed this count when the connector re-reads previously mined logs, such as after a restart or while a transaction remains in progress; the value bounds automatic growth, not the window itself.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4837,17 +4837,21 @@ The schema and table configuration include/exclude lists can safely specify regu
 |`2`
 |The minimum number of transaction logs to read per redo thread in each mining step.
 
-This configuration property has no effect when using xref:#oracle-property-log-mining-strategy[`log.mining.strategy`] is set to `redo_log_catalog`.
+This property does not apply if `log.mining.strategy` is set to `redo_log_catalog`.
 
 |[[oracle-property-log-mining-log-count-growth-max]]<<oracle-property-log-mining-log-count-growth-max, `+log.mining.log.count.growth.max+`>>
 |`4`
-|The maximum number of transaction logs per redo thread that the mining window grows to automatically when a long-running transaction prevents the window start from advancing.
-The growth budget contributes at most approximately this count multiplied by the online redo log size to a single mining step.
+|Specifies the maximum number of redo logs per redo thread that the connector can add to the mining window when a long-running transaction prevents the window from advancing.
 
-A xref:#oracle-property-log-mining-log-count-min[`log.mining.log.count.min`] value above this maximum takes precedence.
-The mining window can exceed this count when the connector re-reads previously mined logs, such as after a restart or while a transaction remains in progress; the value bounds automatic growth, not the window itself.
+During a mining cycle, the connector can expand the window to a size that is approximately equal to the configured number of logs multiplied by the size of each online redo log.
 
-This configuration property has no effect when using xref:#oracle-property-log-mining-strategy[`log.mining.strategy`] is set to `redo_log_catalog`.
+If you set a value that is less than the value of the xref:oracle-property-log-mining-log-count-min[`log.mining.log.count.min`] property, the connector applies the larger value from that property to this property.
+That is, the connector effectively raises this maximum to satisfy that minimum.
+
+The specified limit applies to automatic mining window growth, not to the absolute count of the logs per thread that can populate the mining window.
+When the connector re-reads previously mined logs, as can occur after a restart, or while a transaction remains in progress, the count can exceed this value.
+
+This property does not apply if `log.mining.strategy` is set to `redo_log_catalog`.
 
 |[[oracle-property-log-mining-buffer-type]]<<oracle-property-log-mining-buffer-type, `+log.mining.buffer.type+`>>
 |`memory`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4839,6 +4839,16 @@ The schema and table configuration include/exclude lists can safely specify regu
 
 This configuration property has no effect when using xref:#oracle-property-log-mining-strategy[`log.mining.strategy`] is set to `redo_log_catalog`.
 
+|[[oracle-property-log-mining-log-count-growth-max]]<<oracle-property-log-mining-log-count-growth-max, `+log.mining.log.count.growth.max+`>>
+|`4`
+|The maximum number of transaction logs per redo thread that the mining window grows to automatically when a long-running transaction prevents the window start from advancing.
+Worst-case work in a single mining step is approximately this count multiplied by the online redo log size.
+
+A xref:#oracle-property-log-mining-log-count-min[`log.mining.log.count.min`] value above this maximum takes precedence.
+The mining window can exceed this count when the connector re-reads previously mined logs, such as after a restart or while a transaction remains in progress; the value bounds automatic growth, not the window itself.
+
+This configuration property has no effect when using xref:#oracle-property-log-mining-strategy[`log.mining.strategy`] is set to `redo_log_catalog`.
+
 |[[oracle-property-log-mining-buffer-type]]<<oracle-property-log-mining-buffer-type, `+log.mining.buffer.type+`>>
 |`memory`
 |The buffer type controls how the connector manages buffering transaction data.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2326

## Description
When using the new capped log mining strategy, users may notice that log switches can temporarily cause the upper boundary to go backward. In some instances this isn't an issue, but particularly in long-running transactions, this is not desired because the next read could re-read what's already been previously read, and the window will need to expand once more.

To address this, the upper boundary is now sticky and cannot go backward.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
