### PR TITLE
debezium/dbz#2279 Add the StringifyFields transformation to debezium-connect-plugins

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Kafka Connect SMT that serializes selected record-value fields to JSON strings.
+ * <p>
+ * Some sinks accept a JSON <em>string</em> but reject a native struct, array or map for a
+ * schema-flexible column, for example a Databricks Delta {@code VARIANT} column or a JSON/JSONB
+ * column. After a document is flattened, such as by the MongoDB {@code ExtractNewDocumentState}
+ * transformation, nested fields arrive as native structs and arrays, which those columns cannot
+ * accept directly.
+ * <p>
+ * This transformation converts the configured fields into their JSON-string representation, so that
+ * scalar fields remain strongly typed while a schema-flexible field is written as JSON text. Fields
+ * that are already strings, or that are absent, are left untouched.
+ * <p>
+ * Configuration: {@code fields} &mdash; a comma-separated list of top-level value field names to
+ * serialize.
+ * <p>
+ * If a targeted field cannot be serialized to JSON, the transformation logs the offending record's
+ * context (field name, schema type and name, value class, and value) at {@code ERROR} level and
+ * throws a {@link ConnectException}. The stream then halts and the offset is not committed past the
+ * record, so that no data is dropped silently. To skip such records instead, set
+ * {@code errors.tolerance=all}.
+ *
+ * @param <R> the type of {@link ConnectRecord} that the transformation applies to
+ */
+public class StringifyFields<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringifyFields.class);
+
+    public static final String FIELDS_CONFIG = "fields";
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(
+            FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH,
+            "Comma-separated list of value field names to serialize to a JSON string.");
+
+    private Set<String> fields;
+    private final JsonConverter jsonConverter = new JsonConverter();
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // Depending on the runtime, transformation config values arrive either already parsed
+        // through ConfigDef as a List, or as the raw comma-separated String, so accept both.
+        Object raw = configs.get(FIELDS_CONFIG);
+        this.fields = new LinkedHashSet<>();
+        if (raw instanceof List) {
+            for (Object f : (List<?>) raw) {
+                this.fields.add(f.toString().trim());
+            }
+        }
+        else if (raw != null) {
+            for (String f : raw.toString().split(",")) {
+                if (!f.trim().isEmpty()) {
+                    this.fields.add(f.trim());
+                }
+            }
+        }
+        // schemas.enable=false emits plain JSON without the Connect schema envelope.
+        Map<String, Object> converterConfig = new HashMap<>();
+        converterConfig.put("schemas.enable", false);
+        converterConfig.put("converter.type", "value");
+        jsonConverter.configure(converterConfig);
+    }
+
+    @Override
+    public R apply(R record) {
+        if (!(record.value() instanceof Struct)) {
+            return record;
+        }
+        Struct value = (Struct) record.value();
+        Schema schema = value.schema();
+
+        // Build a new schema in which the targeted fields become STRING.
+        SchemaBuilder builder = SchemaBuilder.struct().name(schema.name()).version(schema.version());
+        for (Field field : schema.fields()) {
+            if (fields.contains(field.name())) {
+                builder.field(field.name(), field.schema().isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
+            }
+            else {
+                builder.field(field.name(), field.schema());
+            }
+        }
+        Schema newSchema = builder.build();
+
+        Struct newValue = new Struct(newSchema);
+        for (Field field : schema.fields()) {
+            Object fieldValue = value.get(field);
+            if (fields.contains(field.name()) && fieldValue != null && !(fieldValue instanceof String)) {
+                newValue.put(field.name(), toJsonString(field.name(), field.schema(), fieldValue));
+            }
+            else {
+                newValue.put(field.name(), fieldValue);
+            }
+        }
+
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                newSchema, newValue, record.timestamp(), record.headers());
+    }
+
+    /**
+     * Serializes a single field value to its JSON representation.
+     */
+    private String toJsonString(String fieldName, Schema fieldSchema, Object fieldValue) {
+        try {
+            byte[] json = ((Converter) jsonConverter).fromConnectData("_stringify", fieldSchema, fieldValue);
+            return new String(json, java.nio.charset.StandardCharsets.UTF_8);
+        }
+        catch (Exception e) {
+            // A field that cannot be serialized must halt the stream rather than be dropped or
+            // corrupted silently, so log enough context to identify the offending record and then
+            // re-throw, which leaves the offset uncommitted.
+            String schemaType = fieldSchema == null ? "null" : String.valueOf(fieldSchema.type());
+            String schemaName = fieldSchema == null ? "null" : String.valueOf(fieldSchema.name());
+            String valueClass = fieldValue == null ? "null" : fieldValue.getClass().getName();
+            LOGGER.error("Failed to serialize field '{}' (schema type={}, schema name={}, value class={}) to a JSON "
+                    + "string. The record is not modified and the stream halts, so that no data is dropped or "
+                    + "committed past this point. Value: {}",
+                    fieldName, schemaType, schemaName, valueClass, fieldValue, e);
+            throw new ConnectException("Could not serialize field '" + fieldName
+                    + "' (schema type=" + schemaType + ", value class=" + valueClass + ") to a JSON string", e);
+        }
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+        jsonConverter.close();
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
@@ -7,7 +7,6 @@ package io.debezium.transforms;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,14 +18,15 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.Module;
+import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.metadata.ConfigDescriptor;
+import io.debezium.util.Strings;
 
 /**
  * A Kafka Connect SMT that serializes selected record-value fields to JSON strings.
@@ -74,20 +74,14 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
 
     @Override
     public void configure(Map<String, ?> configs) {
-        // Depending on the runtime, transformation config values arrive either already parsed
-        // through ConfigDef as a List, or as the raw comma-separated String, so accept both.
-        Object raw = configs.get(FIELDS_CONFIG);
+        final Configuration config = Configuration.from(configs);
+        final SmtManager<R> smtManager = new SmtManager<>(config);
+        smtManager.validate(config, Field.setOf(FIELDS_FIELD));
+
         this.fields = new LinkedHashSet<>();
-        if (raw instanceof List) {
-            for (Object f : (List<?>) raw) {
-                this.fields.add(f.toString().trim());
-            }
-        }
-        else if (raw != null) {
-            for (String f : raw.toString().split(",")) {
-                if (!f.trim().isEmpty()) {
-                    this.fields.add(f.trim());
-                }
+        for (String field : config.getList(FIELDS_FIELD)) {
+            if (!Strings.isNullOrBlank(field)) {
+                this.fields.add(field.trim());
             }
         }
         // schemas.enable=false emits plain JSON without the Connect schema envelope.
@@ -137,7 +131,7 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
      */
     private String toJsonString(String fieldName, Schema fieldSchema, Object fieldValue) {
         try {
-            byte[] json = ((Converter) jsonConverter).fromConnectData("_stringify", fieldSchema, fieldValue);
+            byte[] json = jsonConverter.fromConnectData("_stringify", fieldSchema, fieldValue);
             return new String(json, java.nio.charset.StandardCharsets.UTF_8);
         }
         catch (Exception e) {

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
@@ -6,9 +6,8 @@
 package io.debezium.transforms;
 
 import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.components.Versioned;
@@ -41,8 +40,19 @@ import io.debezium.util.Strings;
  * scalar fields remain strongly typed while a schema-flexible field is written as JSON text. Fields
  * that are already strings, or that are absent, are left untouched.
  * <p>
- * Configuration: {@code fields} &mdash; a comma-separated list of top-level value field names to
- * serialize.
+ * Configuration: {@code fields} &mdash; a comma-separated list of value field names to serialize. A
+ * name may address a nested field with dot notation, for example {@code after.payload}, which lets
+ * the transformation reach into a change-event envelope without a prior flattening step. Each path
+ * segment except the last must resolve to a {@code STRUCT}; the final segment is the field whose
+ * value is retyped to a JSON string. A bare name such as {@code payload} targets a top-level field,
+ * so existing configurations keep working unchanged.
+ * <p>
+ * When a nested target lives inside a structure that is shared under more than one field of the same
+ * named schema &mdash; most notably a change-event envelope's {@code before} and {@code after}, which
+ * share one record schema &mdash; the same path must be configured under every such field (for
+ * example {@code after.payload} <em>and</em> {@code before.payload}). Otherwise the retyped and the
+ * original copies of that schema would carry the same name but different field types, which the
+ * Connect schema model does not allow.
  * <p>
  * If a targeted field cannot be serialized to JSON, the transformation logs the offending record's
  * context (field name, schema type and name, value class, and value) at {@code ERROR} level and
@@ -63,13 +73,19 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
             .withType(ConfigDef.Type.LIST)
             .withImportance(ConfigDef.Importance.HIGH)
             .required()
-            .withDescription("Comma-separated list of value field names to serialize to a JSON string.");
+            .withDescription("Comma-separated list of value field names to serialize to a JSON string. "
+                    + "Use dot notation, such as 'after.payload', to target a nested field.");
 
-    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(
-            FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH,
-            FIELDS_FIELD.description());
+    /**
+     * A node in the trie of configured field paths. {@link #target} marks a node whose field is
+     * itself serialized; {@link #children} holds the next path segment for deeper targets.
+     */
+    private static final class PathNode {
+        private boolean target;
+        private final Map<String, PathNode> children = new LinkedHashMap<>();
+    }
 
-    private Set<String> fields;
+    private PathNode root;
     private final JsonConverter jsonConverter = new JsonConverter();
 
     @Override
@@ -78,11 +94,20 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
         final SmtManager<R> smtManager = new SmtManager<>(config);
         smtManager.validate(config, Field.setOf(FIELDS_FIELD));
 
-        this.fields = new LinkedHashSet<>();
-        for (String field : config.getList(FIELDS_FIELD)) {
-            if (!Strings.isNullOrBlank(field)) {
-                this.fields.add(field.trim());
+        this.root = new PathNode();
+        for (String path : config.getList(FIELDS_FIELD)) {
+            if (Strings.isNullOrBlank(path)) {
+                continue;
             }
+            PathNode node = root;
+            for (String segment : path.split("\\.", -1)) {
+                if (Strings.isNullOrBlank(segment)) {
+                    throw new ConnectException("Invalid field path '" + path + "' in '" + FIELDS_CONFIG
+                            + "': path segments must not be empty");
+                }
+                node = node.children.computeIfAbsent(segment.trim(), k -> new PathNode());
+            }
+            node.target = true;
         }
         // schemas.enable=false emits plain JSON without the Connect schema envelope.
         Map<String, Object> converterConfig = new HashMap<>();
@@ -97,33 +122,75 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
             return record;
         }
         Struct value = (Struct) record.value();
-        Schema schema = value.schema();
-
-        // Build a new schema in which the targeted fields become STRING.
-        SchemaBuilder builder = SchemaBuilder.struct().name(schema.name()).version(schema.version());
-        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
-            if (fields.contains(field.name())) {
-                builder.field(field.name(), field.schema().isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
-            }
-            else {
-                builder.field(field.name(), field.schema());
-            }
-        }
-        Schema newSchema = builder.build();
-
-        Struct newValue = new Struct(newSchema);
-        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
-            Object fieldValue = value.get(field);
-            if (fields.contains(field.name()) && fieldValue != null && !(fieldValue instanceof String)) {
-                newValue.put(field.name(), toJsonString(field.name(), field.schema(), fieldValue));
-            }
-            else {
-                newValue.put(field.name(), fieldValue);
-            }
-        }
+        Schema newSchema = retypeSchema(value.schema(), root, "");
+        Struct newValue = transformStruct(value, newSchema, root, "");
 
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
                 newSchema, newValue, record.timestamp(), record.headers());
+    }
+
+    /**
+     * Builds a copy of {@code schema} in which every targeted field is retyped to STRING, descending
+     * into nested structs for paths that reach deeper than the current level.
+     */
+    private Schema retypeSchema(Schema schema, PathNode node, String pathPrefix) {
+        SchemaBuilder builder = org.apache.kafka.connect.transforms.util.SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        if (schema.isOptional()) {
+            builder.optional();
+        }
+        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
+            PathNode child = node.children.get(field.name());
+            if (child == null) {
+                builder.field(field.name(), field.schema());
+            }
+            else if (child.target) {
+                // A field that is itself a target is serialized whole; any deeper paths under it are
+                // subsumed by the JSON string and ignored.
+                builder.field(field.name(), field.schema().isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
+            }
+            else {
+                String path = pathPrefix.isEmpty() ? field.name() : pathPrefix + "." + field.name();
+                if (field.schema().type() != Schema.Type.STRUCT) {
+                    throw new ConnectException("Field path '" + path + "' in '" + FIELDS_CONFIG
+                            + "' navigates into a non-struct field of type " + field.schema().type()
+                            + "; only struct fields can contain nested targets");
+                }
+                builder.field(field.name(), retypeSchema(field.schema(), child, path));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Builds the transformed value for {@code value} against {@code newSchema}, serializing targeted
+     * fields and recursing into nested structs for deeper paths.
+     */
+    private Struct transformStruct(Struct value, Schema newSchema, PathNode node, String pathPrefix) {
+        Struct newValue = new Struct(newSchema);
+        for (org.apache.kafka.connect.data.Field field : value.schema().fields()) {
+            Object fieldValue = value.get(field);
+            PathNode child = node.children.get(field.name());
+            String path = pathPrefix.isEmpty() ? field.name() : pathPrefix + "." + field.name();
+            if (child == null) {
+                newValue.put(field.name(), fieldValue);
+            }
+            else if (child.target) {
+                if (fieldValue != null && !(fieldValue instanceof String)) {
+                    newValue.put(field.name(), toJsonString(path, field.schema(), fieldValue));
+                }
+                else {
+                    newValue.put(field.name(), fieldValue);
+                }
+            }
+            else if (fieldValue == null) {
+                newValue.put(field.name(), null);
+            }
+            else {
+                Schema childSchema = newSchema.field(field.name()).schema();
+                newValue.put(field.name(), transformStruct((Struct) fieldValue, childSchema, child, path));
+            }
+        }
+        return newValue;
     }
 
     /**
@@ -152,7 +219,9 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
 
     @Override
     public ConfigDef config() {
-        return CONFIG_DEF;
+        final ConfigDef config = new ConfigDef();
+        Field.group(config, null, FIELDS_FIELD);
+        return config;
     }
 
     @Override

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
@@ -12,8 +12,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -23,6 +23,10 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.debezium.Module;
+import io.debezium.config.Field;
+import io.debezium.metadata.ConfigDescriptor;
 
 /**
  * A Kafka Connect SMT that serializes selected record-value fields to JSON strings.
@@ -48,15 +52,22 @@ import org.slf4j.LoggerFactory;
  *
  * @param <R> the type of {@link ConnectRecord} that the transformation applies to
  */
-public class StringifyFields<R extends ConnectRecord<R>> implements Transformation<R> {
+public class StringifyFields<R extends ConnectRecord<R>> implements Transformation<R>, Versioned, ConfigDescriptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StringifyFields.class);
 
     public static final String FIELDS_CONFIG = "fields";
 
+    private static final Field FIELDS_FIELD = Field.create(FIELDS_CONFIG)
+            .withDisplayName("Fields to serialize")
+            .withType(ConfigDef.Type.LIST)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .required()
+            .withDescription("Comma-separated list of value field names to serialize to a JSON string.");
+
     private static final ConfigDef CONFIG_DEF = new ConfigDef().define(
             FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH,
-            "Comma-separated list of value field names to serialize to a JSON string.");
+            FIELDS_FIELD.description());
 
     private Set<String> fields;
     private final JsonConverter jsonConverter = new JsonConverter();
@@ -96,7 +107,7 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
 
         // Build a new schema in which the targeted fields become STRING.
         SchemaBuilder builder = SchemaBuilder.struct().name(schema.name()).version(schema.version());
-        for (Field field : schema.fields()) {
+        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
             if (fields.contains(field.name())) {
                 builder.field(field.name(), field.schema().isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
             }
@@ -107,7 +118,7 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
         Schema newSchema = builder.build();
 
         Struct newValue = new Struct(newSchema);
-        for (Field field : schema.fields()) {
+        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
             Object fieldValue = value.get(field);
             if (fields.contains(field.name()) && fieldValue != null && !(fieldValue instanceof String)) {
                 newValue.put(field.name(), toJsonString(field.name(), field.schema(), fieldValue));
@@ -148,6 +159,16 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
     @Override
     public ConfigDef config() {
         return CONFIG_DEF;
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+
+    @Override
+    public Field.Set getConfigFields() {
+        return Field.setOf(FIELDS_FIELD);
     }
 
     @Override

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/StringifyFields.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -24,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.Module;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.data.SchemaUtil;
 import io.debezium.metadata.ConfigDescriptor;
 import io.debezium.util.Strings;
 
@@ -87,6 +91,7 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
 
     private PathNode root;
     private final JsonConverter jsonConverter = new JsonConverter();
+    private Cache<Schema, Schema> schemaUpdateCache;
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -114,6 +119,11 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
         converterConfig.put("schemas.enable", false);
         converterConfig.put("converter.type", "value");
         jsonConverter.configure(converterConfig);
+
+        // The retyped schema depends only on the input schema and the configured paths, both fixed
+        // after configuration, so it is cached per input schema to avoid rebuilding it per record and
+        // to keep a stable schema identity for downstream converters and the schema registry.
+        schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
     }
 
     @Override
@@ -122,7 +132,11 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
             return record;
         }
         Struct value = (Struct) record.value();
-        Schema newSchema = retypeSchema(value.schema(), root, "");
+        Schema newSchema = schemaUpdateCache.get(value.schema());
+        if (newSchema == null) {
+            newSchema = retypeSchema(value.schema(), root, "");
+            schemaUpdateCache.put(value.schema(), newSchema);
+        }
         Struct newValue = transformStruct(value, newSchema, root, "");
 
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
@@ -134,10 +148,7 @@ public class StringifyFields<R extends ConnectRecord<R>> implements Transformati
      * into nested structs for paths that reach deeper than the current level.
      */
     private Schema retypeSchema(Schema schema, PathNode node, String pathPrefix) {
-        SchemaBuilder builder = org.apache.kafka.connect.transforms.util.SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
-        if (schema.isOptional()) {
-            builder.optional();
-        }
+        SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema);
         for (org.apache.kafka.connect.data.Field field : schema.fields()) {
             PathNode child = node.children.get(field.name());
             if (child == null) {

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/metadata/TransformsMetadataProvider.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/metadata/TransformsMetadataProvider.java
@@ -19,6 +19,7 @@ import io.debezium.transforms.GeometryFormatTransformer;
 import io.debezium.transforms.HeaderToValue;
 import io.debezium.transforms.Neo4jCudConverter;
 import io.debezium.transforms.SchemaChangeEventFilter;
+import io.debezium.transforms.StringifyFields;
 import io.debezium.transforms.SwapGeometryCoordinates;
 import io.debezium.transforms.TimezoneConverter;
 import io.debezium.transforms.ToLogicalTopicRouter;
@@ -51,6 +52,7 @@ public class TransformsMetadataProvider implements ComponentMetadataProvider {
                 componentMetadataFactory.createComponentMetadata(new OpenLineage<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new PartitionRouting<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new SchemaChangeEventFilter<>(), io.debezium.Module.version()),
+                componentMetadataFactory.createComponentMetadata(new StringifyFields<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new SwapGeometryCoordinates<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new TimezoneConverter<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new VectorToJsonConverter<>(), io.debezium.Module.version()),

--- a/debezium-connect-plugins/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/debezium-connect-plugins/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -6,6 +6,7 @@ io.debezium.transforms.ExtractNewRecordState
 io.debezium.transforms.ExtractSchemaToNewRecord
 io.debezium.transforms.HeaderToValue
 io.debezium.transforms.SchemaChangeEventFilter
+io.debezium.transforms.StringifyFields
 io.debezium.transforms.TimezoneConverter
 io.debezium.transforms.outbox.EventRouter
 io.debezium.transforms.partitions.PartitionRouting

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link StringifyFields} transformation, which serializes selected struct or
+ * array fields to a JSON string so that they can feed a schema-flexible column while sibling scalar
+ * fields remain strongly typed.
+ */
+class StringifyFieldsTest {
+
+    private final StringifyFields<SourceRecord> smt = new StringifyFields<>();
+
+    @AfterEach
+    void close() {
+        smt.close();
+    }
+
+    private SourceRecord recordWith(Schema valueSchema, Struct value) {
+        return new SourceRecord(null, null, "topic", 0, null, null, valueSchema, value);
+    }
+
+    /** Value schema: id INT32, props STRUCT{a INT32, b STRING}, name STRING. */
+    private Schema valueSchemaWithProps() {
+        Schema props = SchemaBuilder.struct().name("props")
+                .field("a", Schema.INT32_SCHEMA)
+                .field("b", Schema.STRING_SCHEMA)
+                .build();
+        return SchemaBuilder.struct().name("Value")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("props", props)
+                .field("name", Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    @Test
+    void serializesStructFieldToJsonStringAndRetypesToString() {
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "props"));
+        Schema schema = valueSchemaWithProps();
+        Struct props = new Struct(schema.field("props").schema()).put("a", 1).put("b", "x");
+        Struct value = new Struct(schema).put("id", 7).put("props", props).put("name", "n");
+
+        SourceRecord out = smt.apply(recordWith(schema, value));
+        Struct outValue = (Struct) out.value();
+
+        // The target field is now a STRING holding the JSON, while its siblings keep their types.
+        assertThat(out.valueSchema().field("props").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(out.valueSchema().field("id").schema().type()).isEqualTo(Schema.Type.INT32);
+        assertThat((String) outValue.get("props")).isEqualTo("{\"a\":1,\"b\":\"x\"}");
+        assertThat(outValue.get("id")).isEqualTo(7);
+        assertThat(outValue.get("name")).isEqualTo("n");
+    }
+
+    @Test
+    void acceptsCommaSeparatedStringConfig() {
+        // Some runtimes pass transformation config values as raw strings rather than parsing them
+        // through ConfigDef.
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "props"));
+        Schema schema = valueSchemaWithProps();
+        Struct props = new Struct(schema.field("props").schema()).put("a", 2).put("b", "y");
+        Struct value = new Struct(schema).put("id", 1).put("props", props).put("name", "z");
+
+        Struct out = (Struct) smt.apply(recordWith(schema, value)).value();
+        assertThat((String) out.get("props")).isEqualTo("{\"a\":2,\"b\":\"y\"}");
+    }
+
+    @Test
+    void acceptsListConfig() {
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, List.of("props")));
+        Schema schema = valueSchemaWithProps();
+        Struct props = new Struct(schema.field("props").schema()).put("a", 3).put("b", "w");
+        Struct value = new Struct(schema).put("id", 1).put("props", props).put("name", "q");
+
+        Struct out = (Struct) smt.apply(recordWith(schema, value)).value();
+        assertThat((String) out.get("props")).isEqualTo("{\"a\":3,\"b\":\"w\"}");
+    }
+
+    @Test
+    void leavesUntargetedFieldsUntouched() {
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "props"));
+        Schema schema = valueSchemaWithProps();
+        Struct props = new Struct(schema.field("props").schema()).put("a", 1).put("b", "x");
+        Struct value = new Struct(schema).put("id", 42).put("props", props).put("name", "keep");
+
+        SourceRecord out = smt.apply(recordWith(schema, value));
+        // Untargeted fields keep their original schema types.
+        assertThat(out.valueSchema().field("name").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(((Struct) out.value()).get("name")).isEqualTo("keep");
+    }
+
+    @Test
+    void passesThroughWhenTargetFieldIsNull() {
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "props"));
+        Schema optionalProps = SchemaBuilder.struct().name("props")
+                .field("a", Schema.INT32_SCHEMA).optional().build();
+        Schema schema = SchemaBuilder.struct().name("Value")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("props", optionalProps)
+                .build();
+        Struct value = new Struct(schema).put("id", 1); // props is left null
+
+        SourceRecord out = smt.apply(recordWith(schema, value));
+        // The schema is still retyped to an optional STRING, and the value stays null.
+        assertThat(out.valueSchema().field("props").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(((Struct) out.value()).get("props")).isNull();
+    }
+
+    @Test
+    void passesThroughNonStructValue() {
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "props"));
+        SourceRecord tombstone = recordWith(null, null);
+        SourceRecord out = smt.apply(tombstone);
+        assertThat(out.value()).isNull();
+    }
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
@@ -6,10 +6,12 @@
 package io.debezium.transforms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -64,6 +66,14 @@ class StringifyFieldsTest {
         assertThat((String) outValue.get("props")).isEqualTo("{\"a\":1,\"b\":\"x\"}");
         assertThat(outValue.get("id")).isEqualTo(7);
         assertThat(outValue.get("name")).isEqualTo("n");
+    }
+
+    @Test
+    void rejectsAMissingFieldsConfigurationAtConfigureTime() {
+        // SmtManager validates the required option during the configuration pass, so a deployment that
+        // forgets it fails while the connector is being set up rather than on the first record.
+        assertThatThrownBy(() -> smt.configure(Map.of()))
+                .isInstanceOf(ConfigException.class);
     }
 
     @Test

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/StringifyFieldsTest.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -136,5 +137,83 @@ class StringifyFieldsTest {
         SourceRecord tombstone = recordWith(null, null);
         SourceRecord out = smt.apply(tombstone);
         assertThat(out.value()).isNull();
+    }
+
+    /** Envelope-like value schema: id INT32, after STRUCT{payload STRUCT{a INT32, b STRING}, tag STRING}. */
+    private Schema envelopeSchema(boolean optionalAfter) {
+        Schema payload = SchemaBuilder.struct().name("payload")
+                .field("a", Schema.INT32_SCHEMA)
+                .field("b", Schema.STRING_SCHEMA)
+                .build();
+        SchemaBuilder after = SchemaBuilder.struct().name("after")
+                .field("payload", payload)
+                .field("tag", Schema.STRING_SCHEMA);
+        if (optionalAfter) {
+            after.optional();
+        }
+        return SchemaBuilder.struct().name("Envelope")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("after", after.build())
+                .build();
+    }
+
+    @Test
+    void serializesNestedFieldViaDotNotation() {
+        // A dot path reaches into a struct and retypes only the leaf, without a prior flattening step.
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "after.payload"));
+        Schema schema = envelopeSchema(false);
+        Struct payload = new Struct(schema.field("after").schema().field("payload").schema()).put("a", 5).put("b", "x");
+        Struct after = new Struct(schema.field("after").schema()).put("payload", payload).put("tag", "t");
+        Struct value = new Struct(schema).put("id", 9).put("after", after);
+
+        SourceRecord out = smt.apply(recordWith(schema, value));
+        Schema outAfterSchema = out.valueSchema().field("after").schema();
+        Struct outAfter = (Struct) ((Struct) out.value()).get("after");
+
+        // Only the leaf is retyped to STRING; the containing struct and its siblings keep their types.
+        assertThat(outAfterSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(outAfterSchema.field("payload").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(outAfterSchema.field("tag").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat((String) outAfter.get("payload")).isEqualTo("{\"a\":5,\"b\":\"x\"}");
+        assertThat(outAfter.get("tag")).isEqualTo("t");
+        assertThat(((Struct) out.value()).get("id")).isEqualTo(9);
+    }
+
+    @Test
+    void passesThroughWhenIntermediateStructIsNull() {
+        // If a struct along the path is absent, there is nothing to serialize and the value stays null.
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "after.payload"));
+        Schema schema = envelopeSchema(true);
+        Struct value = new Struct(schema).put("id", 1); // after is left null
+
+        SourceRecord out = smt.apply(recordWith(schema, value));
+        Schema outAfterSchema = out.valueSchema().field("after").schema();
+
+        // The nested schema is still rewritten (payload is now STRING) but the null value is preserved.
+        assertThat(outAfterSchema.field("payload").schema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(((Struct) out.value()).get("after")).isNull();
+    }
+
+    @Test
+    void throwsWhenPathNavigatesIntoNonStruct() {
+        // A path that descends past a scalar field is a configuration mistake surfaced on the record.
+        smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "id.nope"));
+        Schema schema = envelopeSchema(false);
+        Struct after = new Struct(schema.field("after").schema())
+                .put("payload", new Struct(schema.field("after").schema().field("payload").schema()).put("a", 1).put("b", "x"))
+                .put("tag", "t");
+        Struct value = new Struct(schema).put("id", 3).put("after", after);
+
+        assertThatThrownBy(() -> smt.apply(recordWith(schema, value)))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("id");
+    }
+
+    @Test
+    void rejectsEmptyPathSegmentAtConfigureTime() {
+        assertThatThrownBy(() -> smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "after.")))
+                .isInstanceOf(ConnectException.class);
+        assertThatThrownBy(() -> smt.configure(Map.of(StringifyFields.FIELDS_CONFIG, "after..payload")))
+                .isInstanceOf(ConnectException.class);
     }
 }

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -55,6 +55,7 @@
 ** xref:transformations/neo4j-cud-converter.adoc[Neo4j CUD Converter]
 ** xref:transformations/enforce-record-size.adoc[Enforce Record Size]
 ** xref:transformations/swap-geometry-coordinates.adoc[Swap Geometry Coordinates]
+** xref:transformations/stringify-fields.adoc[Stringify Fields]
 * Post Processors
 ** xref:post-processors/index.adoc[Overview]
 ** xref:post-processors/reselect-columns.adoc[Reselect Columns]

--- a/documentation/modules/ROOT/pages/transformations/index.adoc
+++ b/documentation/modules/ROOT/pages/transformations/index.adoc
@@ -51,6 +51,9 @@ The following SMTs are provided by {prodname}:
 |xref:transformations/enforce-record-size.adoc[Enforce Record Size]
 |Enforces a maximum record size by proportionally truncating large string and bytes columns when a change event exceeds the configured limit.
 
+|xref:transformations/stringify-fields.adoc[Stringify Fields]
+|Serializes the fields that you specify to JSON strings, so that nested data can be written to a column that accepts only JSON text, such as a Delta `VARIANT` column.
+
 |xref:transformations/vitess-use-local-vgtid.adoc[Vitess Use Local VGTID]
 |A transformation that reduces the size of VGTIDs that the Vitess connector emits.
 To reduce the amount of data in the event message, the SMT writes only the VGTID for the shard in which a change occurs.

--- a/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
+++ b/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
@@ -77,6 +77,7 @@ The log entry contains information about the following fields:
 
 The stream halts, and the offset is not committed past the record, so that no data is dropped silently.
 
-If you prefer to have the transformation skip records that it cannot serialize, add the following entry to the configuration: `errors.tolerance=all`.
-This option applies to deployments on Kafka Connect, where the runtime applies the setting to the transformation chain.
-{prodname} Server does not provide an equivalent setting, so on that runtime a record that cannot be serialized always halts the stream.
+On Kafka Connect, if you prefer to have the transformation skip records that it cannot serialize, add the following entry to the configuration: `errors.tolerance=all`.
+The runtime then applies the setting to the transformation chain.
+
+Because {prodname} Server does not implement the Kafka Connect property `errors.tolerance=all`, if the Stringify Fields SMT cannot serialize an event message, event processing stops.

--- a/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
+++ b/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
@@ -8,19 +8,27 @@
 
 toc::[]
 
-Some sinks accept a schema-flexible column only as JSON text, and reject a native struct, array, or map.
-A Databricks Delta `VARIANT` column and a `JSON`/`JSONB` column are typical examples.
-To write nested data to such a column, {prodname} provides the Stringify Fields single message transformation (SMT), which serializes the fields that you specify into their JSON-string representation.
+Use the Stringify Fields single message transformation (SMT) to convert selected fields from struct, array, or map values to JSON strings.
 
-Fields that already contain a string, and fields that are absent from a record, are left unmodified.
-Fields that you do not list are also left unmodified, so that scalar fields retain their original, strongly typed schema.
+Some sink systems store schema-flexible columns as JSON text and do not accept native struct, array, or map values.
+Examples include Databricks Delta `VARIANT` columns and PostgreSQL `JSON` or `JSONB` columns.
+
+The transformation serializes specified fields to their JSON string representation.
+
+The transformation does not modify fields that already contain string values.
+It also does not modify fields that are absent from a record.
+Fields that are not included in the configuration remain unchanged.
+As a result, scalar fields retain their original strongly typed schema.
 
 == Use cases
 
-After a document is flattened, for example by the xref:transformations/mongodb-event-flattening.adoc[MongoDB new document state extraction] transformation, nested fields arrive as native structs and arrays.
-A column that accepts only JSON text cannot store those values directly.
+Use the Stringify Fields SMT when a sink column stores JSON text but the source record contains nested fields as native data structures.
 
-By applying the transformation to the nested fields, you can preserve a strongly typed schema for the scalar fields of a record, and write a single schema-flexible field, such as `properties`, as JSON text.
+After a document is flattened, for example, by the {link-prefix}:{link-mongodb-event-flattening}#mongodb-new-document-state-extraction[MongoDB new document state extraction] transformation, nested fields are represented as native structs and arrays.
+Columns that store JSON text cannot store these values directly.
+
+By applying the Stringify Fields SMT to selected nested fields, you can write schema-flexible content as JSON text while preserving the strongly typed schema of scalar fields.
+For example, you can serialize a field such as `properties` to JSON text and leave all other fields unchanged.
 
 == Configuration
 
@@ -58,6 +66,17 @@ The following table lists the configuration options for the transformation.
 
 == Error handling
 
-If the transformation cannot serialize a field that you specify, it logs the context of the record, that is, the field name, the schema type and name, the value class, and the value, at `ERROR` level, and then throws an exception.
+If the transformation cannot serialize a field that you specify, it logs the context of the record at `ERROR` level, and then throws an exception.
+The log entry contains information about the following fields:
+
+* Field name
+* Schema type
+* Schema name
+* Value class
+* Value
+
 The stream halts, and the offset is not committed past the record, so that no data is dropped silently.
-To skip such records instead, set `errors.tolerance=all`.
+
+If you prefer to have the transformation skip records that it cannot serialize, add the following entry to the configuration: `errors.tolerance=all`.
+This option applies to deployments on Kafka Connect, where the runtime applies the setting to the transformation chain.
+{prodname} Server does not provide an equivalent setting, so on that runtime a record that cannot be serialized always halts the stream.

--- a/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
+++ b/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
@@ -1,0 +1,63 @@
+[id="stringify-fields"]
+= Stringify Fields
+:toc:
+:toc-placement: macro
+:linkattrs:
+:icons: font
+:source-highlighter: highlight.js
+
+toc::[]
+
+Some sinks accept a schema-flexible column only as JSON text, and reject a native struct, array, or map.
+A Databricks Delta `VARIANT` column and a `JSON`/`JSONB` column are typical examples.
+To write nested data to such a column, {prodname} provides the Stringify Fields single message transformation (SMT), which serializes the fields that you specify into their JSON-string representation.
+
+Fields that already contain a string, and fields that are absent from a record, are left unmodified.
+Fields that you do not list are also left unmodified, so that scalar fields retain their original, strongly typed schema.
+
+== Use cases
+
+After a document is flattened, for example by the xref:transformations/mongodb-event-flattening.adoc[MongoDB new document state extraction] transformation, nested fields arrive as native structs and arrays.
+A column that accepts only JSON text cannot store those values directly.
+
+By applying the transformation to the nested fields, you can preserve a strongly typed schema for the scalar fields of a record, and write a single schema-flexible field, such as `properties`, as JSON text.
+
+== Configuration
+
+The following example shows how to configure the transformation to serialize the `properties` field:
+
+[source]
+----
+transforms=stringify
+transforms.stringify.type=io.debezium.transforms.StringifyFields
+transforms.stringify.fields=properties
+----
+
+To serialize more than one field, specify a comma-separated list, as in the following example:
+
+[source]
+----
+transforms.stringify.fields=properties,metadata
+----
+
+== Configuration options
+
+The following table lists the configuration options for the transformation.
+
+[cols="30%a,15%a,55%a",options="header"]
+|===
+|Property
+|Default
+|Description
+
+|[[stringify-fields-fields]]<<stringify-fields-fields, `fields`>>
+|No default value.
+|A comma-separated list of the top-level value fields to serialize to a JSON string.
+
+|===
+
+== Error handling
+
+If the transformation cannot serialize a field that you specify, it logs the context of the record, that is, the field name, the schema type and name, the value class, and the value, at `ERROR` level, and then throws an exception.
+The stream halts, and the offset is not committed past the record, so that no data is dropped silently.
+To skip such records instead, set `errors.tolerance=all`.

--- a/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
+++ b/documentation/modules/ROOT/pages/transformations/stringify-fields.adoc
@@ -48,6 +48,28 @@ To serialize more than one field, specify a comma-separated list, as in the foll
 transforms.stringify.fields=properties,metadata
 ----
 
+=== Nested fields
+
+A field name can use dot notation to target a field that is nested inside a struct, so that you can reach into a change-event envelope without first applying a flattening transformation.
+For example, `after.payload` serializes the `payload` field that is nested inside the `after` struct.
+Each path segment except the last must resolve to a struct; the final segment is the field whose value is retyped to a JSON string.
+A name without a dot, such as `payload`, targets a top-level field, so existing configurations continue to work unchanged.
+
+[source]
+----
+transforms.stringify.fields=after.payload
+----
+
+[WARNING]
+====
+When a nested target is inside a structure that is shared under more than one field of the same named schema, configure the same path under every such field.
+The most common case is a change-event envelope, in which the `before` and `after` fields share a single record schema.
+To serialize a nested field there, specify the path under both `after` and `before`, as in `after.payload,before.payload`.
+If you retype the field under only one of them, the retyped and the original copies of that schema carry the same name but different field types, which the Kafka Connect schema model does not allow, and the connector fails.
+====
+
+If a non-final path segment resolves to a field that is not a struct, the transformation throws an exception when it processes a record, rather than when you configure it.
+
 == Configuration options
 
 The following table lists the configuration options for the transformation.
@@ -60,7 +82,10 @@ The following table lists the configuration options for the transformation.
 
 |[[stringify-fields-fields]]<<stringify-fields-fields, `fields`>>
 |No default value.
-|A comma-separated list of the top-level value fields to serialize to a JSON string.
+|A comma-separated list of the value fields to serialize to a JSON string.
+A field name can use dot notation, for example `after.payload`, to target a field that is nested inside a struct.
+Each path segment except the last must resolve to a struct.
+A name without a dot targets a top-level field.
 
 |===
 


### PR DESCRIPTION
Adds the `StringifyFields` transformation to `debezium-connect-plugins`.

It serializes selected record-value fields to JSON strings, so that a schema-flexible column which only accepts JSON text can receive a nested struct, array or map, while the remaining fields stay strongly typed. A Databricks Delta `VARIANT` column and a JSON/JSONB column are typical examples: they reject a native struct/array/map. This comes up whenever a document is flattened, for instance by the MongoDB `ExtractNewDocumentState` transformation, and the nested fields then arrive as native structs and arrays.

Configuration is a single `fields` option — a comma-separated list of top-level value field names to serialize. Fields that are already strings, or that are absent, are left untouched. If a targeted field cannot be serialized, the transformation logs the record's context and throws a `ConnectException`, so the stream halts and the offset is not committed past the record (`errors.tolerance=all` skips such records instead).

### Context

This transformation was written for the Databricks Zerobus sink (debezium/dbz#2279, debezium/debezium-server#294), where it is needed to write MongoDB documents to a Delta `VARIANT` column. During review of that PR, @Naros pointed out that it carries nothing sink-specific and suggested it belongs in `debezium-connect-plugins` — hence this PR.

**Merge order:** debezium/debezium-server#294 removes the transformation from the sink module, so it should land together with (or after) this PR, to avoid a window where the transformation exists in neither place.

### Tests

`StringifyFieldsTest` covers the struct/array/map cases, already-string and absent fields, and the fail-fast path — 6 tests, green.

cc @Naros
