### PR TITLE
debezium/dbz#2381 Allow nonreserved keywords as unquoted identifiers in the MySQL DDL parser

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/DdlNormalizer.java
@@ -18,7 +18,8 @@ import java.util.regex.Pattern;
  * text represents identifiers and must not be converted. In that case, callers
  * should pass {@code ansiQuotesMode=true} to skip the conversion.
  *
- * Also adds backticks around reserved keywords when used as identifiers.
+ * Also adds backticks around keywords that the grammar cannot parse as unquoted
+ * identifiers (see {@code KEYWORDS_REQUIRING_BACKTICKS}) when they are used as identifiers.
  *
  * @author Debezium Authors
  */
@@ -38,33 +39,128 @@ public class DdlNormalizer {
      * - Group 4: Backtick identifiers   {@code `identifier`}
      *
      */
-    private static final Pattern QUOTED_LITERAL_PATTERN = Pattern.compile(
-            "(--[^\\n]*|#[^\\n]*|/\\*(?!!).*?\\*/)|(\'(?:\'\'|[^\'\\\\]|\\\\.)*\')|\"((?:[^\"\\\\]|\\\\.|\"\")*)\"|(`(?:``|[^`])*`)",
+    private static final Pattern QUOTED_LITERAL_PATTERN = Pattern.compile("""
+            (--[^\\n]*|#[^\\n]*|/\\*(?!!).*?\\*/)\
+            |('(?:''|[^'\\\\]|\\\\.)*')\
+            |"((?:[^"\\\\]|\\\\.|"")*)"\
+            |(`(?:``|[^`])*`)""",
             Pattern.DOTALL);
 
     /**
-     * Reserved keywords that need backticks when used as identifiers.
+     * Window function keywords (plus JSON_TABLE): reserved words since MySQL 8.0, but valid
+     * unquoted identifiers on MySQL 5.7 and older, so DDL using them as identifiers can still
+     * reach the parser (older sources, schema history). Missing from
+     * {@code identifierKeywordsUnambiguous} in the migrated grammar.
      */
-    private static final Pattern RESERVED_KEYWORD_PATTERN = Pattern.compile(
-            "\\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|JSON_TABLE|LAG|LAST_VALUE|LEAD|NTH_VALUE|NTILE|PERCENT_RANK|RANK|ROW_NUMBER)\\b",
+    private static final String WINDOW_FUNCTION_KEYWORDS = "CUME_DIST|DENSE_RANK|FIRST_VALUE|JSON_TABLE|LAG|LAST_VALUE|LEAD|NTH_VALUE|NTILE|PERCENT_RANK|RANK|ROW_NUMBER";
+
+    /**
+     * Version-gated keywords introduced by MySQL 8.0.32+ (URL) and 8.2.0+/9.x lexer gates:
+     * mostly nonreserved keywords (URL, AUTO, MANUAL, PARALLEL, VECTOR) or not keywords at all
+     * (ONLINE, OFFLINE) on real servers, so MySQL accepts them as unquoted identifiers — only
+     * QUALIFY and TABLESAMPLE are reserved, from 8.2 on. Their tokens are missing from
+     * {@code identifierKeywordsUnambiguous}, so the grammar rejects them in identifier
+     * positions (debezium/dbz#2381). The upstream Oracle grammar in antlr/grammars-v4 has the
+     * same omission; this group can be removed once the upstream fix (antlr/grammars-v4#4963)
+     * is synced into the Debezium grammar.
+     */
+    private static final String VERSION_GATED_KEYWORDS = "AUTO|MANUAL|OFFLINE|ONLINE|PARALLEL|QUALIFY|TABLESAMPLE|URL|VECTOR";
+
+    /**
+     * All keywords the grammar cannot parse as unquoted identifiers; they are backtick-quoted
+     * when they appear in identifier positions.
+     */
+    private static final String KEYWORDS_REQUIRING_BACKTICKS = WINDOW_FUNCTION_KEYWORDS + "|" + VERSION_GATED_KEYWORDS;
+
+    private static final Pattern KEYWORDS_REQUIRING_BACKTICKS_PATTERN = Pattern.compile(
+            "\\b(" + KEYWORDS_REQUIRING_BACKTICKS + ")\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Table name positions: after CREATE/ALTER/DROP/RENAME/TRUNCATE TABLE (including
+     * TEMPORARY and IF [NOT] EXISTS variants), FROM, JOIN, INTO, REFERENCES,
+     * ON ({@code CREATE INDEX ... ON t}, {@code CREATE TRIGGER ... ON t}),
+     * LIKE ({@code CREATE TABLE t2 LIKE t}),
+     * and after TO ({@code RENAME TABLE ... TO t}, {@code RENAME COLUMN ... TO c}).
+     */
+    private static final String TABLE_NAME_ANCHORS = """
+            CREATE\\s+(?:TEMPORARY\\s+)?TABLE(?:\\s+IF\\s+NOT\\s+EXISTS)?\
+            |ALTER\\s+TABLE|DROP\\s+(?:TEMPORARY\\s+)?TABLE(?:\\s+IF\\s+EXISTS)?\
+            |RENAME\\s+TABLE|TRUNCATE(?:\\s+TABLE)?\
+            |REFERENCES|FROM|JOIN|INTO|TO|ON|LIKE""";
+
+    /**
+     * Column clause positions: ADD/CHANGE/MODIFY/ALTER/DROP [COLUMN] (the COLUMN word is
+     * optional in all of them, e.g. {@code ALTER TABLE t DROP url}), RENAME COLUMN,
+     * and AFTER ({@code ADD COLUMN c INT AFTER c2}).
+     */
+    private static final String COLUMN_CLAUSE_ANCHORS = "ADD(?:\\s+COLUMN)?|CHANGE(?:\\s+COLUMN)?|MODIFY(?:\\s+COLUMN)?|ALTER(?:\\s+COLUMN)?|DROP(?:\\s+COLUMN)?|RENAME\\s+COLUMN|AFTER";
+
+    /**
+     * Column definitions: keyword directly followed by a data type.
+     */
+    private static final Pattern COLUMN_DEFINITION_CONTEXT_PATTERN = Pattern.compile(
+            "\\b(" + KEYWORDS_REQUIRING_BACKTICKS + ")\\s+(" + """
+                    (?:VAR)?CHAR|CHARACTER|NCHAR|NVARCHAR|NATIONAL|(?:TINY|SMALL|MEDIUM|BIG)?INT|INTEGER|INT[12348]|MIDDLEINT\
+                    |DECIMAL|DEC|FIXED|NUMERIC|FLOAT|FLOAT[48]|DOUBLE|REAL|SERIAL\
+                    |JSON|(?:TINY|MEDIUM|LONG)?TEXT|(?:TINY|MEDIUM|LONG)?BLOB|LONG|DATE|DATETIME|TIMESTAMP|TIME|YEAR\
+                    |ENUM|SET|BINARY|VARBINARY|BIT|BOOL|BOOLEAN|VECTOR\
+                    |GEOMETRY|GEOMETRYCOLLECTION|POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON""" + ")\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Index and constraint name positions: [ADD] [UNIQUE|FULLTEXT|SPATIAL] INDEX/KEY,
+     * CREATE [UNIQUE|FULLTEXT|SPATIAL] INDEX, DROP INDEX, [ADD] CONSTRAINT,
+     * DROP/ALTER CHECK.
+     */
+    private static final String INDEX_OR_CONSTRAINT_ANCHORS = """
+            (?:ADD\\s+)?(?:UNIQUE\\s+|FULLTEXT\\s+|SPATIAL\\s+)?(?:INDEX|KEY)\
+            |CREATE\\s+(?:UNIQUE\\s+|FULLTEXT\\s+|SPATIAL\\s+)?INDEX|DROP\\s+INDEX\
+            |(?:ADD\\s+)?CONSTRAINT|(?:DROP|ALTER)\\s+CHECK""";
+
+    /**
+     * Non-table schema object name positions: DATABASE/SCHEMA/VIEW/TRIGGER/PROCEDURE/
+     * FUNCTION/EVENT (including IF [NOT] EXISTS variants), USE, and PARTITION names.
+     * The anchor word always directly precedes the name, so leading verbs
+     * ({@code CREATE OR REPLACE VIEW}, {@code REORGANIZE PARTITION}) need no handling.
+     */
+    private static final String OBJECT_NAME_ANCHORS = "(?:DATABASE|SCHEMA|VIEW|TRIGGER|PROCEDURE|FUNCTION|EVENT)(?:\\s+IF(?:\\s+NOT)?\\s+EXISTS)?|USE|PARTITION";
+
+    /**
+     * All identifier-position anchors above, combined into a single alternation: they share
+     * the same {@code anchor <keyword>} shape and the same replacement, so one scan covers
+     * table names, column clauses, index/constraint names and schema object names.
+     */
+    private static final Pattern IDENTIFIER_CONTEXT_PATTERN = Pattern.compile(
+            "\\b(" + TABLE_NAME_ANCHORS + "|" + COLUMN_CLAUSE_ANCHORS + "|" + INDEX_OR_CONSTRAINT_ANCHORS + "|" + OBJECT_NAME_ANCHORS + ")\\s+("
+                    + KEYWORDS_REQUIRING_BACKTICKS + ")\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Labels in stored routines: {@code <keyword>:}.
+     */
+    private static final Pattern LABEL_CONTEXT_PATTERN = Pattern.compile(
+            "\\b(" + KEYWORDS_REQUIRING_BACKTICKS + ")\\s*:",
             Pattern.CASE_INSENSITIVE);
 
     /**
      * Normalizes MySQL DDL by converting double-quoted strings to single-quoted strings
-     * while preserving backtick-quoted identifiers, and adding backticks around reserved
-     * keywords when used as identifiers. Assumes the server is NOT in ANSI_QUOTES mode.
+     * while preserving backtick-quoted identifiers, and adding backticks around
+     * grammar-restricted keywords used as identifiers. Assumes the server is NOT in
+     * ANSI_QUOTES mode.
      *
      * @param ddlContent The DDL statement to normalize
      * @return Normalized DDL with double-quoted strings converted to single quotes
-     *         and reserved keywords backtick-quoted, or the original input if null or empty
+     *         and grammar-restricted keywords backtick-quoted, or the original input
+     *         if null or empty
      */
     public static String normalize(String ddlContent) {
         return normalize(ddlContent, false);
     }
 
     /**
-     * Normalizes MySQL DDL by adding backticks around reserved keywords when used as
-     * identifiers. When {@code ansiQuotesMode} is false, also converts double-quoted
+     * Normalizes MySQL DDL by adding backticks around grammar-restricted keywords used
+     * as identifiers. When {@code ansiQuotesMode} is false, also converts double-quoted
      * strings to single-quoted strings (for servers using the default sql_mode where
      * double quotes delimit string literals). When {@code ansiQuotesMode} is true,
      * double-quoted text is left as-is because it represents identifiers.
@@ -125,28 +221,22 @@ public class DdlNormalizer {
     }
 
     /**
-     * Adds backticks around reserved keywords when used as identifiers (not as keywords).
-     * Targets specific contexts: table names, column names, aliases, labels.
+     * Adds backticks around the {@code KEYWORDS_REQUIRING_BACKTICKS} entries when used as
+     * identifiers (not as keywords).
+     * Targets specific contexts: table names, column clauses, column definitions,
+     * index/constraint names, schema object names (database, view, trigger, routine,
+     * event, partition) and labels.
      * Only ever invoked on the plain SQL segments between comments, string literals and
      * quoted identifiers, so their content is never rewritten.
      */
     private static String addBackticksToReservedKeywords(String ddl) {
-        String result = ddl;
+        if (!KEYWORDS_REQUIRING_BACKTICKS_PATTERN.matcher(ddl).find()) {
+            return ddl;
+        }
 
-        // Pattern for table names after CREATE TABLE, ALTER TABLE, DROP TABLE, FROM, JOIN, etc.
-        result = result.replaceAll(
-                "(?i)\\b(CREATE\\s+TABLE|ALTER\\s+TABLE|DROP\\s+TABLE|FROM|JOIN|LEFT\\s+JOIN|RIGHT\\s+JOIN|INNER\\s+JOIN|OUTER\\s+JOIN|INTO)\\s+(CUME_DIST|DENSE_RANK|FIRST_VALUE|JSON_TABLE|LAG|LAST_VALUE|LEAD|NTH_VALUE|NTILE|PERCENT_RANK|RANK|ROW_NUMBER)\\b",
-                "$1 `$2`");
-
-        // Pattern for column names in column definitions
-        result = result.replaceAll(
-                "(?i)\\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|JSON_TABLE|LAG|LAST_VALUE|LEAD|NTH_VALUE|NTILE|PERCENT_RANK|RANK|ROW_NUMBER)\\s+((?:VAR)?CHAR|INT|BIGINT|DECIMAL|NUMERIC|FLOAT|DOUBLE|JSON|TEXT|BLOB|DATE|DATETIME|TIMESTAMP|TIME|YEAR|ENUM|SET|BINARY|VARBINARY|BIT|BOOL|BOOLEAN)\\b",
-                "`$1` $2");
-
-        // Pattern for labels in stored procedures: <keyword>:
-        result = result.replaceAll(
-                "(?i)\\b(CUME_DIST|DENSE_RANK|FIRST_VALUE|JSON_TABLE|LAG|LAST_VALUE|LEAD|NTH_VALUE|NTILE|PERCENT_RANK|RANK|ROW_NUMBER)\\s*:",
-                "`$1`:");
+        String result = IDENTIFIER_CONTEXT_PATTERN.matcher(ddl).replaceAll("$1 `$2`");
+        result = COLUMN_DEFINITION_CONTEXT_PATTERN.matcher(result).replaceAll("`$1` $2");
+        result = LABEL_CONTEXT_PATTERN.matcher(result).replaceAll("`$1`:");
 
         return result;
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -345,4 +345,78 @@ public class MySqlAntlrDdlParserTest
         parser.parse("ALTER TABLE inventory.\"customers\" ADD COLUMN \"middle_name\" varchar(255) NULL", tables);
         assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
     }
+
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void shouldParseNonReservedKeywordsAsUnquotedIdentifiers() {
+        String ddl = "CREATE TABLE url (url VARCHAR(700));" +
+                "ALTER TABLE url ADD account_id BIGINT;" +
+                "ALTER TABLE url CHANGE url url VARCHAR(700) NOT NULL;" +
+                "CREATE TABLE auto (auto INT);" +
+                "CREATE TABLE manual (manual INT);" +
+                "CREATE TABLE offline (offline INT);" +
+                "CREATE TABLE online (online INT, id INT);" +
+                "CREATE TABLE parallel (parallel INT, id INT);" +
+                "CREATE TABLE vector (vector INT);" +
+                "CREATE TABLE qualify (qualify INT);" +
+                "CREATE TABLE tablesample (tablesample INT);" +
+                "ALTER TABLE vector ADD COLUMN online TINYINT;" +
+                "ALTER TABLE auto RENAME COLUMN auto TO manual;" +
+                "ALTER TABLE parallel ADD INDEX parallel (id);" +
+                "ALTER TABLE online ADD CONSTRAINT online CHECK (id > 0);" +
+                // COLUMN is optional in the DROP branch of alterListItem.
+                "ALTER TABLE vector DROP online;";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+        assertThat(tables.size()).isEqualTo(9);
+
+        Table url = tables.forTable(null, null, "url");
+        assertThat(url.columnWithName("url")).isNotNull();
+        assertThat(url.columnWithName("account_id")).isNotNull();
+
+        Table vector = tables.forTable(null, null, "vector");
+        assertThat(vector.columnWithName("vector")).isNotNull();
+        assertThat(vector.columnWithName("online")).isNull();
+
+        Table auto = tables.forTable(null, null, "auto");
+        assertThat(auto.columnWithName("manual")).isNotNull();
+        assertThat(auto.columnWithName("auto")).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void shouldParseNonReservedKeywordIdentifiersInExtendedDdlClauses() {
+        String ddl = "CREATE TABLE IF NOT EXISTS url (id INT PRIMARY KEY);" +
+                "CREATE INDEX idx_url ON url (id);" +
+                "CREATE TABLE offline (id INT PRIMARY KEY, FOREIGN KEY (id) REFERENCES url (id));" +
+                "CREATE TABLE t2 LIKE url;" +
+                "ALTER TABLE offline ADD COLUMN online INT;" +
+                "ALTER TABLE offline ALTER COLUMN online SET DEFAULT 1;" +
+                "ALTER TABLE offline ADD COLUMN c2 INT AFTER online;" +
+                "TRUNCATE TABLE t2;" +
+                "DROP TABLE IF EXISTS t2;" +
+                "CREATE TABLE pt (id INT) PARTITION BY RANGE (id) " +
+                "(PARTITION auto VALUES LESS THAN (10), PARTITION pmax VALUES LESS THAN MAXVALUE);" +
+                "ALTER TABLE pt DROP PARTITION auto;" +
+                "CREATE TABLE typed (url GEOMETRY, manual CHARACTER(5), online SERIAL);" +
+                "CREATE TRIGGER parallel BEFORE INSERT ON url FOR EACH ROW SET @x = 1;" +
+                "DROP TRIGGER parallel;" +
+                "CREATE DATABASE auto;" +
+                "USE auto;" +
+                "CREATE TABLE t3 (id INT);";
+        parser.parse(ddl, tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        Table offline = tables.forTable(null, null, "offline");
+        assertThat(offline.columnWithName("online")).isNotNull();
+        assertThat(offline.columnWithName("c2")).isNotNull();
+
+        Table typed = tables.forTable(null, null, "typed");
+        assertThat(typed.columnWithName("url")).isNotNull();
+        assertThat(typed.columnWithName("manual")).isNotNull();
+        assertThat(typed.columnWithName("online")).isNotNull();
+
+        assertThat(tables.forTable(null, null, "t2")).isNull();
+        assertThat(tables.forTable("auto", null, "t3")).isNotNull();
+    }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/antlr/DdlNormalizerTest.java
@@ -394,4 +394,261 @@ public class DdlNormalizerTest {
         String expected = "CREATE TABLE `RANK` (\"id\" INT, \"name\" VARCHAR(50))";
         assertThat(DdlNormalizer.normalize(input, true)).isEqualTo(expected);
     }
+
+    @DisplayName("Given version-gated keyword as table and column name When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testGatedKeywordAsTableAndColumnName() {
+        for (String keyword : new String[]{ "url", "auto", "manual", "offline", "online", "parallel", "vector", "qualify", "tablesample" }) {
+            String input = "CREATE TABLE " + keyword + " (" + keyword + " INT)";
+            String expected = "CREATE TABLE `" + keyword + "` (`" + keyword + "` INT)";
+            assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("Given keyword table name in ALTER TABLE When normalize Then add backticks to table name only")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testUrlAsAlterTableTarget() {
+        String input = "ALTER TABLE URL ADD account_id BIGINT";
+        String expected = "ALTER TABLE `URL` ADD account_id BIGINT";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword column in CHANGE clause When normalize Then add backticks to old and new name")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordInChangeColumn() {
+        String input = "ALTER TABLE URL CHANGE url url VARCHAR(700)";
+        String expected = "ALTER TABLE `URL` CHANGE `url` `url` VARCHAR(700)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword column in ADD COLUMN with TINYINT When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordInAddColumn() {
+        String input = "ALTER TABLE vector ADD COLUMN online TINYINT";
+        String expected = "ALTER TABLE `vector` ADD COLUMN `online` TINYINT";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword columns in RENAME COLUMN When normalize Then add backticks to both sides")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordInRenameColumn() {
+        String input = "ALTER TABLE auto RENAME COLUMN auto TO manual";
+        String expected = "ALTER TABLE `auto` RENAME COLUMN `auto` TO `manual`";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword column in DROP with and without COLUMN word When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordInDropColumn() {
+        // COLUMN is optional in the DROP branch of alterListItem; both spellings are valid MySQL.
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 DROP COLUMN url"))
+                .isEqualTo("ALTER TABLE t1 DROP COLUMN `url`");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 DROP url"))
+                .isEqualTo("ALTER TABLE t1 DROP `url`");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 DROP vector, DROP auto"))
+                .isEqualTo("ALTER TABLE t1 DROP `vector`, DROP `auto`");
+        // The bare DROP anchor must not swallow the more specific DROP variants.
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 DROP INDEX online"))
+                .isEqualTo("ALTER TABLE t1 DROP INDEX `online`");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 DROP FOREIGN KEY fk_name"))
+                .isEqualTo("ALTER TABLE t1 DROP FOREIGN KEY fk_name");
+    }
+
+    @DisplayName("Given keyword table name in RENAME TABLE When normalize Then add backticks to source and target")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordInRenameTable() {
+        String input = "RENAME TABLE url TO archive, t1 TO parallel";
+        String expected = "RENAME TABLE `url` TO archive, t1 TO `parallel`";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword index names When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordAsIndexName() {
+        String input = "ALTER TABLE t1 ADD INDEX parallel (id), ADD UNIQUE KEY qualify (id)";
+        String expected = "ALTER TABLE t1 ADD INDEX `parallel` (id), ADD UNIQUE KEY `qualify` (id)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword constraint name When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordAsConstraintName() {
+        String input = "ALTER TABLE t1 ADD CONSTRAINT online CHECK (id > 0)";
+        String expected = "ALTER TABLE t1 ADD CONSTRAINT `online` CHECK (id > 0)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword column with VECTOR type When normalize Then only the column name gets backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordColumnWithVectorType() {
+        String input = "CREATE TABLE t1 (vector VECTOR(3))";
+        String expected = "CREATE TABLE t1 (`vector` VECTOR(3))";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given VECTOR used as a data type When normalize Then do not add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testVectorAsDataTypeNotBackticked() {
+        String input = "CREATE TABLE t1 (embedding VECTOR(3))";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given AUTO_INCREMENT attribute When normalize Then AUTO is not backticked")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testAutoIncrementNotBackticked() {
+        String input = "CREATE TABLE t1 (id INT AUTO_INCREMENT, PRIMARY KEY (id))";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given url inside string literals When normalize Then literal content is preserved")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testUrlInsideStringLiteralsPreserved() {
+        String input = "CREATE TABLE t1 (c VARCHAR(500) DEFAULT 'http://url:8080/path' COMMENT 'copied from url')";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given QUALIFY used as a query clause When normalize Then do not add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testQualifyClauseNotBackticked() {
+        String input = "SELECT id, ROW_NUMBER() OVER (ORDER BY id) rn FROM t1 QUALIFY rn = 1";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(input);
+    }
+
+    @DisplayName("Given IF [NOT] EXISTS and TEMPORARY variants When normalize Then table name still gets backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testIfExistsAndTemporaryVariants() {
+        assertThat(DdlNormalizer.normalize("CREATE TABLE IF NOT EXISTS url (id INT)"))
+                .isEqualTo("CREATE TABLE IF NOT EXISTS `url` (id INT)");
+        assertThat(DdlNormalizer.normalize("DROP TABLE IF EXISTS url"))
+                .isEqualTo("DROP TABLE IF EXISTS `url`");
+        assertThat(DdlNormalizer.normalize("CREATE TEMPORARY TABLE auto (id INT)"))
+                .isEqualTo("CREATE TEMPORARY TABLE `auto` (id INT)");
+    }
+
+    @DisplayName("Given TRUNCATE with keyword table name When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testTruncateKeywordTable() {
+        assertThat(DdlNormalizer.normalize("TRUNCATE TABLE url")).isEqualTo("TRUNCATE TABLE `url`");
+        assertThat(DdlNormalizer.normalize("TRUNCATE url")).isEqualTo("TRUNCATE `url`");
+    }
+
+    @DisplayName("Given CREATE INDEX ON keyword table When normalize Then backtick index name and table name")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testCreateIndexOnKeywordTable() {
+        String input = "CREATE UNIQUE INDEX parallel ON url (id)";
+        String expected = "CREATE UNIQUE INDEX `parallel` ON `url` (id)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given foreign key referencing keyword table When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testReferencesKeywordTable() {
+        String input = "ALTER TABLE t1 ADD FOREIGN KEY (x) REFERENCES url (id) ON DELETE CASCADE";
+        String expected = "ALTER TABLE t1 ADD FOREIGN KEY (x) REFERENCES `url` (id) ON DELETE CASCADE";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given CREATE TABLE LIKE keyword table When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testCreateTableLikeKeywordTable() {
+        String input = "CREATE TABLE t2 LIKE url";
+        String expected = "CREATE TABLE t2 LIKE `url`";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given ALTER [COLUMN] and AFTER with keyword column When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testAlterColumnAndAfterKeywordColumn() {
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 ALTER COLUMN online SET DEFAULT 1"))
+                .isEqualTo("ALTER TABLE t1 ALTER COLUMN `online` SET DEFAULT 1");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 ALTER online DROP DEFAULT"))
+                .isEqualTo("ALTER TABLE t1 ALTER `online` DROP DEFAULT");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE t1 ADD COLUMN c INT AFTER url"))
+                .isEqualTo("ALTER TABLE t1 ADD COLUMN c INT AFTER `url`");
+    }
+
+    @DisplayName("Given keyword partition names When normalize Then add backticks but not to PARTITION BY")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordPartitionNames() {
+        String input = "CREATE TABLE pt (id INT) PARTITION BY RANGE (id) (PARTITION auto VALUES LESS THAN (10))";
+        String expected = "CREATE TABLE pt (id INT) PARTITION BY RANGE (id) (PARTITION `auto` VALUES LESS THAN (10))";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+        assertThat(DdlNormalizer.normalize("ALTER TABLE pt DROP PARTITION auto"))
+                .isEqualTo("ALTER TABLE pt DROP PARTITION `auto`");
+    }
+
+    @DisplayName("Given keyword database names When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordDatabaseNames() {
+        assertThat(DdlNormalizer.normalize("CREATE DATABASE IF NOT EXISTS url"))
+                .isEqualTo("CREATE DATABASE IF NOT EXISTS `url`");
+        assertThat(DdlNormalizer.normalize("USE url")).isEqualTo("USE `url`");
+        assertThat(DdlNormalizer.normalize("DROP DATABASE url")).isEqualTo("DROP DATABASE `url`");
+    }
+
+    @DisplayName("Given keyword names for other schema objects When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordObjectNames() {
+        assertThat(DdlNormalizer.normalize("CREATE OR REPLACE VIEW auto AS SELECT 1"))
+                .isEqualTo("CREATE OR REPLACE VIEW `auto` AS SELECT 1");
+        assertThat(DdlNormalizer.normalize("DROP TRIGGER IF EXISTS online"))
+                .isEqualTo("DROP TRIGGER IF EXISTS `online`");
+        assertThat(DdlNormalizer.normalize("CREATE PROCEDURE parallel() SELECT 1"))
+                .isEqualTo("CREATE PROCEDURE `parallel`() SELECT 1");
+        assertThat(DdlNormalizer.normalize("DROP FUNCTION manual")).isEqualTo("DROP FUNCTION `manual`");
+        assertThat(DdlNormalizer.normalize("DROP EVENT offline")).isEqualTo("DROP EVENT `offline`");
+    }
+
+    @DisplayName("Given DROP/ALTER CHECK with keyword constraint name When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testDropAlterCheckKeywordName() {
+        assertThat(DdlNormalizer.normalize("ALTER TABLE ck ALTER CHECK online NOT ENFORCED"))
+                .isEqualTo("ALTER TABLE ck ALTER CHECK `online` NOT ENFORCED");
+        assertThat(DdlNormalizer.normalize("ALTER TABLE ck DROP CHECK online"))
+                .isEqualTo("ALTER TABLE ck DROP CHECK `online`");
+    }
+
+    @DisplayName("Given keyword columns with extended data types When normalize Then add backticks")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testKeywordColumnsWithExtendedTypes() {
+        String input = "CREATE TABLE ty (url GEOMETRY, auto CHARACTER(5), online SERIAL, manual DEC(5,2), offline POINT, parallel LONG)";
+        String expected = "CREATE TABLE ty (`url` GEOMETRY, `auto` CHARACTER(5), `online` SERIAL, `manual` DEC(5,2), `offline` POINT, `parallel` LONG)";
+        assertThat(DdlNormalizer.normalize(input)).isEqualTo(expected);
+    }
+
+    @DisplayName("Given keyword-like anchors in legitimate keyword usage When normalize Then only identifiers are rewritten")
+    @Test
+    @FixFor("debezium/dbz#2381")
+    public void testLegitimateKeywordUsageUnchanged() {
+        // AFTER INSERT is trigger timing, not a column position; ON auto is a table position
+        assertThat(DdlNormalizer.normalize("CREATE TRIGGER trg AFTER INSERT ON auto FOR EACH ROW SET @a = 1"))
+                .isEqualTo("CREATE TRIGGER trg AFTER INSERT ON `auto` FOR EACH ROW SET @a = 1");
+        String hint = "SELECT id FROM t1 USE INDEX (idx1) WHERE id = DATABASE()";
+        assertThat(DdlNormalizer.normalize(hint)).isEqualTo(hint);
+    }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2381

## Description

Nine nonreserved MySQL keywords cannot be used as unquoted identifiers, because their lexer tokens are missing from `identifierKeywordsUnambiguous`. Each token appears in the parser grammar only in the clause that introduced it, so a table, index or constraint with one of these names fails to parse:

```sql
CREATE TABLE url (id INT);           -- mismatched input 'url' expecting {'.', ACCOUNT_SYMBOL, ...}
CREATE TABLE vector (id INT);        -- no viable alternative at input 'vector'
CREATE TABLE auto (auto INT);        -- no viable alternative at input 'auto'
ALTER TABLE t1 ADD INDEX qualify (id);
```

Per review feedback, the fix is implemented in `DdlNormalizer` instead of `MySqlParser.g4`, keeping the grammar files aligned with upstream antlr/grammars-v4: the nine keywords (`URL`, `AUTO`, `MANUAL`, `OFFLINE`, `ONLINE`, `PARALLEL`, `QUALIFY`, `TABLESAMPLE`, `VECTOR`) are added to the reserved-keyword backticking that already handles the window function keywords (`RANK`, `LAG`, ...). The keyword list is defined once, split by provenance into `WINDOW_FUNCTION_KEYWORDS` (reserved words since MySQL 8.0, valid identifiers on pre-8.0 sources) and `VERSION_GATED_KEYWORDS` (the nine keywords above — removable as a group once the upstream fix is synced), combined into `KEYWORDS_REQUIRING_BACKTICKS` and shared by all context patterns. The identifier contexts were extended to cover the failing DDL shapes:

- table names after `CREATE/ALTER/DROP/RENAME/TRUNCATE TABLE` (including `TEMPORARY` and `IF [NOT] EXISTS` variants), `FROM`, `JOIN`, `INTO`, `TO`, `ON` (`CREATE INDEX/TRIGGER ... ON t`), `LIKE`, `REFERENCES`
- `ADD/CHANGE/MODIFY/ALTER [COLUMN]`, `DROP COLUMN`, `RENAME COLUMN` targets and `AFTER <col>` placement
- column definitions (`<keyword> <type>`), with the recognized type list extended (`TINYINT` family, `CHARACTER`/`NCHAR`/`NVARCHAR`, `SERIAL`, `DEC`/`FIXED`, `LONG`, spatial types, `VECTOR`, ...)
- index and constraint names (`[ADD] [UNIQUE|FULLTEXT|SPATIAL] INDEX/KEY`, `CREATE/DROP INDEX`, `[ADD] CONSTRAINT`, `DROP/ALTER CHECK`)
- other schema object names: `DATABASE`/`SCHEMA`/`VIEW`/`TRIGGER`/`PROCEDURE`/`FUNCTION`/`EVENT` (with `IF [NOT] EXISTS`), `USE`, and `PARTITION` names
- stored-routine labels

Every rewritten shape was validated against a real MySQL 8.4 server (statements executed with keyword identifiers) before being added to the patterns.

Once the upstream fix (antlr/grammars-v4#4963) lands and the grammar is synced, these entries can be removed together with the window-function ones.

Scope note: like the existing window-keyword handling, the normalizer only rewrites identifier positions in DDL clauses. It does not rewrite keywords inside expressions or index column lists (e.g. `CHECK (online > 0)`), which also keeps it from ever touching legitimate keyword usage — the `QUALIFY` query clause, the `VECTOR(n)` data type, `AUTO_INCREMENT`, or string literals such as `DEFAULT 'http://url:8080'`.

debezium/dbz#2381 was filed for `URL`; the other eight share the identical root cause and are handled here rather than split across separate PRs.

### How these were found and verified

The keyword tokens defined in `MySqlLexer.g4` were substituted into identifier positions (table name, column name, index name, constraint name, partition name, `ALTER TABLE` target, `RENAME ... TO` target), and every candidate statement was replayed against real MySQL servers before being compared against the parser.

Their status was then confirmed against the server's own keyword catalogue rather than inferred:

```sql
SELECT WORD, RESERVED FROM INFORMATION_SCHEMA.KEYWORDS WHERE WORD IN (...);
```

| keyword | lexer gate | MySQL 8.0.46 | MySQL 8.4.11 | MySQL 9.7.2 |
|---|---|---|---|---|
| `url` | `>= 80032` | keyword, nonreserved | keyword, nonreserved | keyword, nonreserved |
| `s3`, `bulk` *(already allowed)* | `>= 80032` / `>= 80200` | nonreserved | nonreserved | nonreserved |
| `auto`, `manual`, `parallel` | `>= 80200` | not a keyword | keyword, nonreserved | keyword, nonreserved |
| `vector` | none | not a keyword | not a keyword | keyword, nonreserved |
| `online`, `offline` | none | not a keyword | not a keyword | not a keyword |
| `qualify`, `tablesample` | `>= 80200` | not a keyword | **reserved** | **reserved** |

Nonreserved keywords are usable as unquoted identifiers by definition, so seven of the nine are valid identifiers on every MySQL release line the connector supports (8.0.x, 8.4.x, 9.0, 9.1).

Two entries stand out:

* `ONLINE` and `OFFLINE` are not MySQL keywords in any supported version — they appear to be left over from the MySQL 5.6 `ALTER TABLE ... ONLINE/OFFLINE` syntax. The grammar defines tokens for them with no version gate, so it rejects two perfectly ordinary words as identifiers on every server.
* `VECTOR` only became a keyword in MySQL 9.0, with the `VECTOR` data type, and it is nonreserved there too. Because its token also has no version gate, `CREATE TABLE vector (...)` fails even against 8.0 and 8.4 servers where the word has no special meaning at all.

### Why `QUALIFY` and `TABLESAMPLE` are included too

They are the only two of the nine that MySQL actually reserves, from 8.2 onwards, so on a modern server they are not valid identifiers — but on MySQL 8.0.x they are not keywords at all, and that release line is supported by the connector and currently breaks on them.

Being permissive here is safe: the DDL parser consumes statements from the binlog, which the source server has already executed. A statement that MySQL 8.4 rejects can never reach the parser from an 8.4 source, so accepting it cannot produce an incorrect table schema. The opposite error is not free — rejecting valid DDL stops the connector.

Version-gating the two entries would be the precise alternative, but it would have no effect today: `MySqlLexerBase`/`MySqlParserBase` set `serverVersion` to `80200` in their constructors and `MySqlAntlrDdlParser` never overrides it with the actual server version, so every source is parsed as if it were MySQL 8.2 regardless of what it really is. That hardcoding is worth addressing on its own; this PR does not attempt it.

Backticking `QUALIFY` only in identifier positions does not disturb the `QUALIFY` query clause — `SELECT id, ROW_NUMBER() OVER (ORDER BY id) rn FROM t1 QUALIFY rn = 1` passes through the normalizer unchanged, and a test case covering it is included.

## Testing

* `DdlNormalizerTest` — each of the nine keywords in every rewritten context, plus negative cases: `VECTOR(3)` as a data type, `AUTO_INCREMENT`, keyword text inside string literals and comments (`DEFAULT 'http://url:8080'`), and the `QUALIFY` query clause are left untouched
* `MySqlAntlrDdlParserTest#shouldParseNonReservedKeywordsAsUnquotedIdentifiers` — parses the statements above end-to-end through `MySqlAntlrDdlParser` (which applies the normalizer) and asserts no parsing errors and correct table/column registration, including `RENAME COLUMN`
* `debezium-ddl-parser` is untouched relative to `main`; the antlr4test corpus passes unchanged
* The keyword/server matrix above was verified against real MySQL 8.0.46, 8.4.11 and 9.7.2 via `INFORMATION_SCHEMA.KEYWORDS` and `PREPARE`
