### PR TITLE
debezium/dbz#360 Add DDL parser regression tests for reported parsing issues

### DIFF
--- a/debezium-ddl-parser/src/test/resources/mariadb/examples/function_call_default_without_parentheses.sql
+++ b/debezium-ddl-parser/src/test/resources/mariadb/examples/function_call_default_without_parentheses.sql
@@ -1,0 +1,3 @@
+-- debezium/dbz#68: MariaDB allows a bare function call as a column DEFAULT (MySQL requires parentheses)
+ALTER TABLE product_indicator ADD uid VARCHAR(32) DEFAULT UUID_SHORT() NOT NULL COMMENT 'Unique product indicator identifier.' AFTER id;
+CREATE TABLE t1 (id INT, uid VARCHAR(36) DEFAULT UUID());

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/aggregate_function_names_as_identifiers.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/aggregate_function_names_as_identifiers.sql
@@ -1,0 +1,3 @@
+-- debezium/dbz#360: aggregate function names used as column names
+ALTER TABLE favourites CHANGE order_id sum int(11) DEFAULT NULL;
+CREATE TABLE t1 (sum INT, count INT, avg INT, min INT, max INT);

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/alter_database_versioned_comment.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/alter_database_versioned_comment.sql
@@ -1,0 +1,3 @@
+-- debezium/dbz#690: version-gated executable comment in ALTER DATABASE
+ALTER DATABASE exchange_otc /*!40100 DEFAULT CHARACTER SET utf8mb4 */;
+ALTER DATABASE exchange_otc /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci */;

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/not_secondary_column_attribute.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/not_secondary_column_attribute.sql
@@ -1,0 +1,4 @@
+-- debezium/dbz#71: NOT SECONDARY column attribute (MySQL HeatWave)
+CREATE TABLE t1 (id INT NOT SECONDARY);
+CREATE TABLE t2 (`method` set('ALL','CREDIT_CARD','PIX') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT SECONDARY, PRIMARY KEY (`method`));
+ALTER TABLE t1 ADD COLUMN payload JSON NOT SECONDARY;

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/unicode_column_attribute.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/unicode_column_attribute.sql
@@ -1,0 +1,3 @@
+-- debezium/dbz#1272: UNICODE character set shorthand on a column
+ALTER TABLE descriptors MODIFY Description VARCHAR(512) UNICODE;
+CREATE TABLE t1 (a CHAR(10) UNICODE, b VARCHAR(20) UNICODE);


### PR DESCRIPTION
Fixes debezium/dbz#360
Fixes debezium/dbz#1272
Fixes debezium/dbz#690
Fixes debezium/dbz#71

## Description

Several open parsing issues no longer reproduce on the Oracle grammar that became the default in 3.6 — the migration fixed them. This adds regression coverage to the antlr4test corpus so the fixed behavior is locked in, and the issues can be closed with CI evidence rather than a manual check.

Each reported statement was replayed against a real MySQL 8.0.46 server (via `PREPARE`, or by executing it where `PREPARE` is not supported) to confirm the syntax is valid, then against both grammars:

| Issue | Statement under test | MySQL 8.0.46 | Oracle grammar | Legacy PT grammar |
|---|---|---|---|---|
| debezium/dbz#360 | `ALTER TABLE favourites CHANGE order_id sum int(11) DEFAULT NULL` | accepted | parses | parses |
| debezium/dbz#1272 | `ALTER TABLE descriptors MODIFY Description VARCHAR(512) UNICODE` | accepted | parses | **fails** |
| debezium/dbz#690 | `ALTER DATABASE exchange_otc /*!40100 DEFAULT CHARACTER SET utf8mb4 */` | accepted | parses | **fails** |
| debezium/dbz#71 | `... set('ALL','CREDIT_CARD','PIX') ... NOT SECONDARY` (HeatWave column attribute) | accepted | parses | **fails** |

debezium/dbz#360 already parsed on both grammars, so it appears to have been fixed earlier; the test is included to keep it covered.

### Also included: a MariaDB case (not closing an issue)

debezium/dbz#68 reports `ALTER TABLE ... ADD uid VARCHAR(32) DEFAULT UUID_SHORT() NOT NULL ...` failing. That statement is **not valid MySQL** — a bare function call as a column default is rejected by MySQL 8.0.46 with error 1064 (MySQL requires `DEFAULT (expr)`), while MariaDB 11.8 accepts it and reports `DEFAULT uuid_short()` in `SHOW CREATE TABLE`. The connector in that report is `MySqlConnector` pointed at MariaDB. The MariaDB grammar already parses the statement, so a MariaDB corpus test is added to keep that covered; the issue itself likely belongs with the MariaDB connector rather than the MySQL one, so it is left open for maintainers to reclassify.

## Testing

* `./mvnw install -pl debezium-ddl-parser -DskipITs` — the antlr4test corpus picks up the five new example files and passes
* Verified each new file is actually exercised by the plugin (introducing a deliberate syntax error makes the build fail)
* Legacy corpus (`mysql/examples/legacy`) is untouched, since the PT grammar rejects most of these statements by design
