### PR TITLE
debezium/dbz#2349 Implement Neo4j CUD SMT relational-to-graph

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/Neo4jCudConverter.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/Neo4jCudConverter.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.Module;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.data.Envelope;
+import io.debezium.metadata.ConfigDescriptor;
+import io.debezium.transforms.neo4j.CudEvent;
+import io.debezium.transforms.neo4j.CudEventFactory;
+import io.debezium.transforms.neo4j.CudEventSerializer;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
+
+/**
+ * A Kafka Connect SMT that converts Debezium change events into Neo4j CUD format,
+ * enabling CDC pipelines from relational databases to Neo4j via the Neo4j Kafka sink connector.
+ *
+ * @param <R> the subtype of {@link ConnectRecord} on which the transformation will operate
+ * @see <a href="https://neo4j.com/docs/kafka/current/sink/cud-file-format/">Neo4j CUD format</a>
+ */
+public class Neo4jCudConverter<R extends ConnectRecord<R>> implements Transformation<R>, Versioned, ConfigDescriptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jCudConverter.class);
+
+    private SmtManager<R> smtManager;
+    private Neo4jCudConverterConfig converterConfig;
+    private CudEventFactory eventFactory;
+    private CudEventSerializer serializer;
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final var config = Configuration.from(props);
+        this.smtManager = new SmtManager<>(config);
+        this.smtManager.validate(config, Neo4jCudConverterConfig.ALL_FIELDS);
+        this.converterConfig = Neo4jCudConverterConfig.from(config, props);
+        this.eventFactory = new CudEventFactory(converterConfig);
+        this.serializer = new CudEventSerializer();
+    }
+
+    @Override
+    public R apply(R record) {
+        if (record.value() == null) {
+            return handleTombstone(record);
+        }
+        if (isNotValidMessage(record)) {
+            return record;
+        }
+
+        return handleMessage(record);
+    }
+
+    @Override
+    public ConfigDef config() {
+        final var config = new ConfigDef();
+        // Per-table mapping keys (table.<name>.*) are dynamic and parsed from the raw properties, so
+        // only the global output settings are statically declared here.
+        Field.group(config, null,
+                Neo4jCudConverterConfig.OUTPUT_MODE,
+                Neo4jCudConverterConfig.TOMBSTONES_ENABLED);
+        return config;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+
+    @Override
+    public Field.Set getConfigFields() {
+        return Neo4jCudConverterConfig.ALL_FIELDS;
+    }
+
+    private R handleMessage(R record) {
+        final var message = (Struct) record.value();
+
+        final var table = getTableFromSource(message);
+        final var mapping = converterConfig.mappingFor(table);
+        if (mapping == null) {
+            LOGGER.debug("No Neo4j mapping configured for table '{}'; passing record through unchanged", table);
+            return record;
+        }
+
+        final var op = resolveOperation(message);
+        if (op == null) {
+            return record;
+        }
+
+        final var data = resolveData(message, op);
+        final var cudOp = op == Envelope.Operation.DELETE ? CudEvent.Operation.DELETE : CudEvent.Operation.MERGE;
+        final var events = eventFactory.buildEvents(data, cudOp, mapping);
+
+        final var serializedContent = converterConfig.outputMode() == OutputMode.ARRAY
+                ? serializer.serializeArray(events)
+                : serializer.serializeSingle(events.get(0));
+
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                Schema.STRING_SCHEMA,
+                serializedContent,
+                record.timestamp(),
+                record.headers());
+    }
+
+    private boolean isNotValidMessage(R record) {
+        return !smtManager.isValidEnvelope(record);
+    }
+
+    private R handleTombstone(R record) {
+        if (converterConfig.tombstonesEnabled()) {
+            LOGGER.trace("Passing through tombstone record");
+            return record;
+        }
+        return null;
+    }
+
+    private Envelope.Operation resolveOperation(Struct envelope) {
+        final var op = Envelope.Operation.forCode(envelope.getString(Envelope.FieldName.OPERATION));
+
+        if (op == Envelope.Operation.TRUNCATE || op == Envelope.Operation.MESSAGE) {
+            LOGGER.debug("Skipping non-DML operation: {}", envelope.getString(Envelope.FieldName.OPERATION));
+            return null;
+        }
+        return op;
+    }
+
+    private Struct resolveData(Struct envelope, Envelope.Operation op) {
+        if (op == Envelope.Operation.DELETE) {
+            return envelope.getStruct(Envelope.FieldName.BEFORE);
+        }
+        return envelope.getStruct(Envelope.FieldName.AFTER);
+    }
+
+    private String getTableFromSource(Struct envelope) {
+        try {
+            final var source = envelope.getStruct(Envelope.FieldName.SOURCE);
+            return source == null ? null : source.getString("table");
+        }
+        catch (DataException e) {
+            return null;
+        }
+    }
+
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/metadata/TransformsMetadataProvider.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/metadata/TransformsMetadataProvider.java
@@ -17,6 +17,7 @@ import io.debezium.transforms.ExtractNewRecordState;
 import io.debezium.transforms.ExtractSchemaToNewRecord;
 import io.debezium.transforms.GeometryFormatTransformer;
 import io.debezium.transforms.HeaderToValue;
+import io.debezium.transforms.Neo4jCudConverter;
 import io.debezium.transforms.SchemaChangeEventFilter;
 import io.debezium.transforms.SwapGeometryCoordinates;
 import io.debezium.transforms.TimezoneConverter;
@@ -52,7 +53,8 @@ public class TransformsMetadataProvider implements ComponentMetadataProvider {
                 componentMetadataFactory.createComponentMetadata(new SchemaChangeEventFilter<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new SwapGeometryCoordinates<>(), io.debezium.Module.version()),
                 componentMetadataFactory.createComponentMetadata(new TimezoneConverter<>(), io.debezium.Module.version()),
-                componentMetadataFactory.createComponentMetadata(new VectorToJsonConverter<>(), io.debezium.Module.version()));
+                componentMetadataFactory.createComponentMetadata(new VectorToJsonConverter<>(), io.debezium.Module.version()),
+                componentMetadataFactory.createComponentMetadata(new Neo4jCudConverter<>(), io.debezium.Module.version()));
     }
 
 }

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEvent.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+public interface CudEvent {
+
+    String type();
+
+    Operation op();
+
+    enum Operation {
+        MERGE("merge"),
+        MATCH("match"),
+        DELETE("delete");
+
+        private final String value;
+
+        Operation(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+
+import io.debezium.time.Conversions;
+import io.debezium.time.Date;
+import io.debezium.time.IsoTime;
+import io.debezium.time.IsoTimestamp;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.NanoTime;
+import io.debezium.time.NanoTimestamp;
+import io.debezium.time.Time;
+import io.debezium.time.Timestamp;
+import io.debezium.transforms.neo4j.CudEvent.Operation;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
+
+public class CudEventFactory {
+
+    private final Neo4jCudConverterConfig config;
+
+    public CudEventFactory(Neo4jCudConverterConfig config) {
+        this.config = config;
+    }
+
+    public List<CudEvent> buildEvents(Struct data, Operation cudOp, TableMappingConfig mapping) {
+        if (mapping.nodeMode() == NodeMode.NODE) {
+            return buildNodeModeEvents(data, cudOp, mapping);
+        }
+        return buildRelationshipModeEvents(data, cudOp, mapping);
+    }
+
+    private List<CudEvent> buildNodeModeEvents(Struct data, Operation cudOp, TableMappingConfig mapping) {
+        final List<CudEvent> events = new ArrayList<>();
+        events.add(buildNodeEvent(data, cudOp, mapping));
+
+        if (cudOp != Operation.DELETE) {
+            for (final var relMapping : mapping.relationships()) {
+                columnValue(data, relMapping.fkColumn()).ifPresent(fkValue -> events.add(
+                        buildRelationshipForNodeMode(data, cudOp, mapping, relMapping, fkValue)));
+            }
+        }
+        return events;
+    }
+
+    private CudNodeEvent buildNodeEvent(Struct data, Operation cudOp, TableMappingConfig mapping) {
+        final var ids = extractIdProperties(data, mapping);
+
+        if (cudOp == Operation.DELETE) {
+            return new CudNodeEvent(cudOp, mapping.nodeLabels(), ids, null, mapping.deleteDetach());
+        }
+
+        final var excludedColumns = columnsExcludedFromProperties(mapping);
+        final var properties = extractProperties(data, excludedColumns, mapping);
+        return new CudNodeEvent(cudOp, mapping.nodeLabels(), ids, properties, null);
+    }
+
+    private CudRelationshipEvent buildRelationshipForNodeMode(Struct data, Operation cudOp, TableMappingConfig mapping,
+                                                              RelationshipMapping relMapping, Object fkValue) {
+        final var sourceIds = extractIdProperties(data, mapping);
+        final var targetIds = Map.<String, Object> of(relMapping.targetId(), fkValue);
+
+        final var from = new CudRelationshipEvent.Endpoint(mapping.nodeLabels(), sourceIds, Operation.MERGE);
+        final var to = new CudRelationshipEvent.Endpoint(
+                List.of(relMapping.targetLabel()), targetIds, relMapping.targetNodeOp());
+
+        final var relProps = extractRelationshipProperties(data, relMapping);
+
+        if (relMapping.direction() == RelationshipMapping.Direction.INCOMING) {
+            return new CudRelationshipEvent(cudOp, relMapping.type(), to, from, relProps);
+        }
+        return new CudRelationshipEvent(cudOp, relMapping.type(), from, to, relProps);
+    }
+
+    private List<CudEvent> buildRelationshipModeEvents(Struct data, Operation cudOp, TableMappingConfig mapping) {
+        final var mappings = mapping.relationships();
+        final var fromMapping = endpointFor(mappings, RelationshipMapping.Direction.OUTGOING);
+        final var toMapping = endpointFor(mappings, RelationshipMapping.Direction.INCOMING);
+        final var fromFkValue = requiredFkValue(data, fromMapping, mapping);
+        final var toFkValue = requiredFkValue(data, toMapping, mapping);
+        final List<CudEvent> events = new ArrayList<>();
+        final var isArray = config.outputMode() == OutputMode.ARRAY;
+
+        if (isArray && cudOp != Operation.DELETE) {
+            events.add(mergeNodeForEndpoint(fromMapping, fromFkValue));
+            events.add(mergeNodeForEndpoint(toMapping, toFkValue));
+        }
+
+        final var endpointOp = isArray ? Operation.MATCH : Operation.MERGE;
+        events.add(buildJoinRelationship(data, cudOp, fromMapping, toMapping, fromFkValue, toFkValue, endpointOp, mapping));
+        return events;
+    }
+
+    private static RelationshipMapping endpointFor(List<RelationshipMapping> mappings, RelationshipMapping.Direction direction) {
+        return mappings.stream()
+                .filter(mapping -> mapping.direction() == direction)
+                .findFirst()
+                // Guaranteed present: config validation requires exactly one outgoing and one incoming endpoint.
+                .orElseThrow(() -> new IllegalStateException("No relationship mapping with direction " + direction));
+    }
+
+    private Object requiredFkValue(Struct data, RelationshipMapping relMapping, TableMappingConfig mapping) {
+        return columnValue(data, relMapping.fkColumn())
+                .orElseThrow(() -> new DataException(String.format(
+                        "Table '%s' is mapped as a relationship, but its foreign key column '%s' is missing "
+                                + "from the record or has a null value; cannot build the relationship endpoint",
+                        mapping.tableName(), relMapping.fkColumn())));
+    }
+
+    private CudNodeEvent mergeNodeForEndpoint(RelationshipMapping mapping, Object fkValue) {
+        final var ids = Map.<String, Object> of(mapping.targetId(), fkValue);
+        return new CudNodeEvent(Operation.MERGE, List.of(mapping.targetLabel()), ids, Collections.emptyMap(), null);
+    }
+
+    private CudRelationshipEvent buildJoinRelationship(Struct data, Operation cudOp,
+                                                       RelationshipMapping fromMapping, RelationshipMapping toMapping,
+                                                       Object fromFkValue, Object toFkValue, Operation endpointOp,
+                                                       TableMappingConfig mapping) {
+        final var fromIds = Map.<String, Object> of(fromMapping.targetId(), fromFkValue);
+        final var toIds = Map.<String, Object> of(toMapping.targetId(), toFkValue);
+
+        final var from = new CudRelationshipEvent.Endpoint(List.of(fromMapping.targetLabel()), fromIds, endpointOp);
+        final var to = new CudRelationshipEvent.Endpoint(List.of(toMapping.targetLabel()), toIds, endpointOp);
+
+        final var fkColumns = mapping.fkColumns();
+        final var relProps = extractNonFkProperties(data, fkColumns, fromMapping);
+
+        // Endpoint roles are fixed by direction (outgoing = source, incoming = target), so the relationship
+        // always runs from -> to; the type and properties come from the outgoing (source) mapping.
+        return new CudRelationshipEvent(cudOp, fromMapping.type(), from, to, relProps);
+    }
+
+    private Map<String, Object> extractIdProperties(Struct data, TableMappingConfig mapping) {
+        final Map<String, Object> ids = new LinkedHashMap<>();
+        for (final var idProp : mapping.nodeIdProperties()) {
+            columnValue(data, idProp).ifPresent(value -> ids.put(idProp, value));
+        }
+        return ids;
+    }
+
+    /**
+     * Reads a column value from the record, normalizing Debezium and Kafka Connect temporal logical
+     * types to ISO-8601 strings.
+     * The schema is required to recognize these types, which is why this normalization happens
+     * here rather than in the serializer.
+     */
+    private static Optional<Object> columnValue(Struct data, Field field) {
+        return Optional.ofNullable(normalizeTemporal(data.get(field), field.schema()));
+    }
+
+    private static Optional<Object> columnValue(Struct data, String fieldName) {
+        final var field = data.schema().field(fieldName);
+        return field == null ? Optional.empty() : columnValue(data, field);
+    }
+
+    /**
+     * Converts a Debezium or Kafka Connect temporal logical-type value into an ISO-8601 string, or
+     * returns the value unchanged for any other type.
+     * Coverage spans the temporal types a source connector can emit for a column, independent of the
+     * connector's {@code time.precision.mode}:
+     *
+     * @param value the raw column value (an epoch number for the Debezium types, a {@link java.util.Date}
+     *            for the Connect logical types)
+     * @param schema the value's schema, used to detect the logical type; may be {@code null}
+     * @return the ISO-8601 string, or {@code value} unchanged when it is not a handled temporal type
+     */
+    protected static Object normalizeTemporal(Object value, Schema schema) {
+        if (value == null || schema == null || schema.name() == null) {
+            return value;
+        }
+        return switch (schema.name()) {
+            case Date.SCHEMA_NAME -> LocalDate.ofEpochDay(((Number) value).longValue()).toString();
+            case Time.SCHEMA_NAME -> IsoTime.toIsoString(Duration.ofMillis(((Number) value).longValue()), false);
+            case MicroTime.SCHEMA_NAME -> IsoTime.toIsoString(Duration.of(((Number) value).longValue(), ChronoUnit.MICROS), false);
+            case NanoTime.SCHEMA_NAME -> IsoTime.toIsoString(Duration.ofNanos(((Number) value).longValue()), false);
+            case Timestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(((Number) value).longValue(), null);
+            case MicroTimestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(Conversions.toInstantFromMicros(((Number) value).longValue()), null);
+            case NanoTimestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(Conversions.toInstantFromNanos(((Number) value).longValue()), null);
+            case org.apache.kafka.connect.data.Date.LOGICAL_NAME -> ((java.util.Date) value).toInstant().atOffset(ZoneOffset.UTC).toLocalDate().toString();
+            case org.apache.kafka.connect.data.Time.LOGICAL_NAME ->
+                IsoTime.toIsoString(((java.util.Date) value).toInstant().atOffset(ZoneOffset.UTC).toLocalTime(), false);
+            case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME -> IsoTimestamp.toIsoString(((java.util.Date) value).toInstant(), null);
+            default -> value;
+        };
+    }
+
+    private Map<String, Object> extractProperties(Struct data, Set<String> excluded, TableMappingConfig mapping) {
+        final var include = mapping.propertiesInclude();
+        final var useIncludeFilter = !include.isEmpty();
+        final Map<String, Object> properties = new LinkedHashMap<>();
+
+        for (final Field field : data.schema().fields()) {
+            final var name = field.name();
+            if (excluded.contains(name)) {
+                continue;
+            }
+            if (useIncludeFilter && !include.contains(name)) {
+                continue;
+            }
+            columnValue(data, field).ifPresent(value -> properties.put(name, value));
+        }
+        return properties;
+    }
+
+    private Map<String, Object> extractRelationshipProperties(Struct data, RelationshipMapping mapping) {
+        if (mapping.properties().isEmpty()) {
+            return Collections.emptyMap();
+        }
+        final Map<String, Object> props = new LinkedHashMap<>();
+        for (final var propName : mapping.properties()) {
+            columnValue(data, propName).ifPresent(value -> props.put(propName, value));
+        }
+        return props;
+    }
+
+    private Map<String, Object> extractNonFkProperties(Struct data, Set<String> fkColumns,
+                                                       RelationshipMapping mapping) {
+        final var relPropertyNames = mapping.properties();
+        final Map<String, Object> props = new LinkedHashMap<>();
+
+        for (final Field field : data.schema().fields()) {
+            final var name = field.name();
+            if (fkColumns.contains(name)) {
+                continue;
+            }
+            if (!relPropertyNames.isEmpty() && !relPropertyNames.contains(name)) {
+                continue;
+            }
+            columnValue(data, field).ifPresent(value -> props.put(name, value));
+        }
+        return props;
+    }
+
+    private Set<String> columnsExcludedFromProperties(TableMappingConfig mapping) {
+        final var idProps = Set.copyOf(mapping.nodeIdProperties());
+        final var fkCols = mapping.fkColumns();
+        final var explicitExclude = mapping.propertiesExclude();
+
+        final Set<String> excluded = new HashSet<>(idProps);
+        excluded.addAll(fkCols);
+        excluded.addAll(explicitExclude);
+        return excluded;
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventSerializer.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.data.VariableScaleDecimal;
+
+public class CudEventSerializer {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String serializeSingle(CudEvent event) {
+        return toJson(serializeEvent(event));
+    }
+
+    public String serializeArray(List<CudEvent> events) {
+        return toJson(events.stream()
+                .map(this::serializeEvent)
+                .collect(Collectors.toList()));
+    }
+
+    private Map<String, Object> serializeEvent(CudEvent event) {
+        return event instanceof CudNodeEvent node ? toNodeMap(node) : toRelationshipMap((CudRelationshipEvent) event);
+    }
+
+    private Map<String, Object> toNodeMap(CudNodeEvent node) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("type", node.type());
+        map.put("op", node.op().value());
+        map.put("labels", node.labels());
+        map.put("ids", toPropertyValues(node.ids()));
+
+        if (node.properties() != null) {
+            map.put("properties", toPropertyValues(node.properties()));
+        }
+        if (node.detach() != null) {
+            map.put("detach", node.detach());
+        }
+        return map;
+    }
+
+    private Map<String, Object> toRelationshipMap(CudRelationshipEvent rel) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("type", rel.type());
+        map.put("op", rel.op().value());
+        map.put("rel_type", rel.relType());
+        map.put("from", toEndpointMap(rel.from()));
+        map.put("to", toEndpointMap(rel.to()));
+        map.put("properties", toPropertyValues(rel.properties()));
+        return map;
+    }
+
+    private Map<String, Object> toEndpointMap(CudRelationshipEvent.Endpoint endpoint) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("labels", endpoint.labels());
+        map.put("ids", toPropertyValues(endpoint.ids()));
+        map.put("op", endpoint.op().value());
+        return map;
+    }
+
+    private Map<String, Object> toPropertyValues(Map<String, Object> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return properties;
+        }
+        final Map<String, Object> converted = new LinkedHashMap<>();
+        for (final var entry : properties.entrySet()) {
+            final var value = toValue(entry.getValue());
+            if (value != null) {
+                converted.put(entry.getKey(), value);
+            }
+        }
+        return converted;
+    }
+
+    Object toValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Byte b) {
+            return b.longValue();
+        }
+        if (value instanceof Short s) {
+            return s.longValue();
+        }
+        if (value instanceof Integer i) {
+            return i.longValue();
+        }
+        if (value instanceof Float f) {
+            return f.doubleValue();
+        }
+        if (value instanceof BigDecimal bigDecimal) {
+            // Neo4j has no arbitrary-precision numeric type.
+            // With decimal.handling.mode=precise a decimal reaches the SMT as a BigDecimal; serialize it to its exact string representation
+            // rather than risking precision loss by converting to a Double.
+            return bigDecimal.toPlainString();
+        }
+        if (value instanceof Struct struct) {
+            if (VariableScaleDecimal.LOGICAL_NAME.equals(struct.schema().name())) {
+                return VariableScaleDecimal.toLogical(struct).toString();
+            }
+            return structToJson(struct);
+        }
+        if (value instanceof Map<?, ?> m) {
+            return toJson(m);
+        }
+        return value;
+    }
+
+    private String structToJson(Struct struct) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        for (final Field field : struct.schema().fields()) {
+            final var fieldValue = struct.get(field);
+            if (fieldValue != null) {
+                map.put(field.name(), toValue(fieldValue));
+            }
+        }
+        return toJson(map);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        }
+        catch (JsonProcessingException e) {
+            throw new ConnectException("Failed to serialize CUD event to JSON", e);
+        }
+    }
+
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudNodeEvent.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudNodeEvent.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.List;
+import java.util.Map;
+
+public record CudNodeEvent(Operation op, List<String> labels, Map<String, Object> ids, Map<String, Object> properties, Boolean detach) implements CudEvent {
+
+    @Override
+    public String type() {
+        return "node";
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudRelationshipEvent.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudRelationshipEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.List;
+import java.util.Map;
+
+public record CudRelationshipEvent(Operation op, String relType, Endpoint from, Endpoint to, Map<String, Object> properties) implements CudEvent {
+
+    @Override
+    public String type() {
+        return "relationship";
+    }
+
+    public record Endpoint(List<String> labels, Map<String, Object> ids, Operation op) {
+
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConfigParser.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConfigParser.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import io.debezium.config.Configuration;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
+import io.debezium.util.Strings;
+
+class Neo4jCudConfigParser {
+
+    private static final String TABLE_PREFIX = "table.";
+    private static final String RELATIONSHIP_PREFIX = "relationship.";
+
+    // Recognized structural sub-keys within a table.<name>. namespace. Anything else is a typo or an
+    // unsupported option and is rejected at configure() time rather than silently ignored.
+    private static final Set<String> KNOWN_NODE_KEYS = Set.of(
+            "node.mode", "node.labels", "node.id.properties",
+            "node.properties.include", "node.properties.exclude", "node.delete.detach");
+    private static final Set<String> KNOWN_RELATIONSHIP_KEYS = Set.of(
+            "type", "direction", "target.label", "target.id", "target.node.op", "properties");
+
+    static Neo4jCudConverterConfig parse(Configuration config, Map<String, ?> rawProps) {
+        final var outputMode = OutputMode.parse(config.getString(Neo4jCudConverterConfig.OUTPUT_MODE));
+        final var tombstonesEnabled = config.getBoolean(Neo4jCudConverterConfig.TOMBSTONES_ENABLED);
+
+        final var byTable = groupByTable(rawProps);
+        final Map<String, TableMappingConfig> tableMappings = new LinkedHashMap<>();
+        for (final var entry : byTable.entrySet()) {
+            tableMappings.put(entry.getKey(), buildTableMapping(entry.getKey(), entry.getValue()));
+        }
+
+        return new Neo4jCudConverterConfig(
+                outputMode, tombstonesEnabled, Collections.unmodifiableMap(tableMappings));
+    }
+
+    /**
+     * Groups the dynamic {@code table.<tableName>.<subKey>} properties by table name, stripping the
+     * {@code table.<tableName>.} prefix from each key. Mirrors {@link #groupByFkColumn} one level up.
+     */
+    private static Map<String, Map<String, String>> groupByTable(Map<String, ?> rawProps) {
+        final Map<String, Map<String, String>> grouped = new LinkedHashMap<>();
+        for (final var entry : rawProps.entrySet()) {
+            final var key = entry.getKey();
+            if (!key.startsWith(TABLE_PREFIX)) {
+                continue;
+            }
+            final var withoutPrefix = key.substring(TABLE_PREFIX.length());
+            final var dotIndex = withoutPrefix.indexOf('.');
+            if (dotIndex < 0) {
+                continue;
+            }
+            final var tableName = withoutPrefix.substring(0, dotIndex);
+            final var subKey = withoutPrefix.substring(dotIndex + 1);
+            grouped.computeIfAbsent(tableName, k -> new LinkedHashMap<>())
+                    .put(subKey, String.valueOf(entry.getValue()));
+        }
+        return grouped;
+    }
+
+    private static TableMappingConfig buildTableMapping(String tableName, Map<String, String> subKeys) {
+        validateKnownKeys(tableName, subKeys);
+
+        final var nodeMode = NodeMode.parse(subKeys.get("node.mode"));
+        final var nodeLabels = Strings.listOfTrimmed(subKeys.get("node.labels"), Function.identity());
+        final var nodeIdProperties = Strings.listOfTrimmed(subKeys.get("node.id.properties"), Function.identity());
+        final var propertiesInclude = toSet(Strings.listOfTrimmed(subKeys.get("node.properties.include"), Function.identity()));
+        final var propertiesExclude = toSet(Strings.listOfTrimmed(subKeys.get("node.properties.exclude"), Function.identity()));
+        final var deleteDetach = subKeys.containsKey("node.delete.detach")
+                ? Boolean.parseBoolean(subKeys.get("node.delete.detach"))
+                : true;
+        final var relationships = parseRelationships(nodeMode, subKeys);
+
+        return new TableMappingConfig(
+                tableName, nodeMode, nodeLabels, nodeIdProperties,
+                propertiesInclude, propertiesExclude, deleteDetach, relationships);
+    }
+
+    /**
+     * Rejects any sub-key under a {@code table.<name>.} namespace that is not a recognized structural
+     * option, so typos (for example {@code node.lable}) fail fast instead of being silently dropped.
+     * Relationship keys are validated on their sub-key ({@code type}, {@code target.label}, ...), with
+     * any non-blank foreign-key column name accepted between {@code relationship.} and that sub-key.
+     */
+    private static void validateKnownKeys(String tableName, Map<String, String> subKeys) {
+        for (final var subKey : subKeys.keySet()) {
+            if (KNOWN_NODE_KEYS.contains(subKey)) {
+                continue;
+            }
+            if (subKey.startsWith(RELATIONSHIP_PREFIX)) {
+                final var withoutPrefix = subKey.substring(RELATIONSHIP_PREFIX.length());
+                final var dotIndex = withoutPrefix.indexOf('.');
+                if (dotIndex > 0 && KNOWN_RELATIONSHIP_KEYS.contains(withoutPrefix.substring(dotIndex + 1))) {
+                    continue;
+                }
+            }
+            throw new ConfigException(TABLE_PREFIX + tableName + "." + subKey, null,
+                    "Unknown configuration property for table '" + tableName + "'");
+        }
+    }
+
+    private static Set<String> toSet(List<String> list) {
+        if (list.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Set.copyOf(list);
+    }
+
+    private static List<RelationshipMapping> parseRelationships(NodeMode nodeMode, Map<String, String> subKeys) {
+        final var grouped = groupByFkColumn(subKeys);
+        final List<RelationshipMapping> mappings = new ArrayList<>();
+        for (final var entry : grouped.entrySet()) {
+            mappings.add(buildMapping(nodeMode, entry.getKey(), entry.getValue()));
+        }
+        return Collections.unmodifiableList(mappings);
+    }
+
+    private static Map<String, Map<String, String>> groupByFkColumn(Map<String, String> subKeys) {
+        final Map<String, Map<String, String>> grouped = new LinkedHashMap<>();
+        for (final var entry : subKeys.entrySet()) {
+            final var key = entry.getKey();
+            if (!key.startsWith(RELATIONSHIP_PREFIX)) {
+                continue;
+            }
+            final var withoutPrefix = key.substring(RELATIONSHIP_PREFIX.length());
+            final var dotIndex = withoutPrefix.indexOf('.');
+            if (dotIndex < 0) {
+                continue;
+            }
+            final var fkColumn = withoutPrefix.substring(0, dotIndex);
+            final var subKey = withoutPrefix.substring(dotIndex + 1);
+            grouped.computeIfAbsent(fkColumn, k -> new LinkedHashMap<>())
+                    .put(subKey, entry.getValue());
+        }
+        return grouped;
+    }
+
+    private static RelationshipMapping buildMapping(NodeMode nodeMode, String fkColumn, Map<String, String> subKeys) {
+        final var type = requireNonBlank(subKeys.get("type"), RELATIONSHIP_PREFIX + fkColumn + ".type");
+        final var targetLabel = requireNonBlank(subKeys.get("target.label"), RELATIONSHIP_PREFIX + fkColumn + ".target.label");
+
+        final var direction = parseDirection(nodeMode, subKeys.get("direction"), RELATIONSHIP_PREFIX + fkColumn + ".direction");
+
+        final var targetNodeOp = parseTargetNodeOp(
+                subKeys.getOrDefault("target.node.op", "match"),
+                RELATIONSHIP_PREFIX + fkColumn + ".target.node.op");
+
+        return new RelationshipMapping(
+                fkColumn,
+                type,
+                direction,
+                targetLabel,
+                subKeys.getOrDefault("target.id", fkColumn),
+                targetNodeOp,
+                Strings.listOfTrimmed(subKeys.get("properties"), Function.identity()));
+    }
+
+    private static RelationshipMapping.Direction parseDirection(NodeMode nodeMode, String value, String key) {
+        if (Strings.isNullOrBlank(value)) {
+            // In relationship mode direction fixes the join endpoints (outgoing = source, incoming = target),
+            // so it is required on both mappings and has no default.
+            if (nodeMode == NodeMode.RELATIONSHIP) {
+                throw new ConfigException(key, null, "Required when node.mode=relationship; must be 'outgoing' or 'incoming'");
+            }
+            return RelationshipMapping.Direction.OUTGOING;
+        }
+        return switch (value.toLowerCase()) {
+            case "outgoing" -> RelationshipMapping.Direction.OUTGOING;
+            case "incoming" -> RelationshipMapping.Direction.INCOMING;
+            default -> throw new ConfigException(key, value, "Must be 'outgoing' or 'incoming'");
+        };
+    }
+
+    private static CudEvent.Operation parseTargetNodeOp(String value, String key) {
+        try {
+            return CudEvent.Operation.valueOf(value.toUpperCase());
+        }
+        catch (IllegalArgumentException e) {
+            throw new ConfigException(key, value, "Must be 'match' or 'merge'");
+        }
+    }
+
+    private static String requireNonBlank(String value, String key) {
+        if (Strings.isNullOrBlank(value)) {
+            throw new ConfigException(key, null, "Required");
+        }
+        return value;
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConverterConfig.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConverterConfig.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.config.Field;
+
+/**
+ * Top-level configuration for the Neo4j CUD converter.
+ * Holds the global output settings shared by the whole SMT instance plus one
+ * {@link TableMappingConfig} per configured source table. Mappings are keyed by the bare table name
+ * and looked up per record via {@link #mappingFor(String)}.
+ */
+public class Neo4jCudConverterConfig {
+
+    public static final Field OUTPUT_MODE = Field.create("output.mode")
+            .withDisplayName("Output mode")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(OutputMode.ARRAY.getValue())
+            .withEnum(OutputMode.class)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("'array' packs all CUD events into a JSON array; 'single' produces one CUD event per record.");
+
+    public static final Field TOMBSTONES_ENABLED = Field.create("tombstones.enabled")
+            .withDisplayName("Tombstones enabled")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withDefault(true)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Whether to pass through tombstone records.");
+
+    // Only the global keys are statically declared. Per-table mapping keys (table.<name>.*) are
+    // dynamic and parsed directly from the raw properties, like relationship.<fk>.* subkeys.
+    public static final Field.Set ALL_FIELDS = Field.setOf(OUTPUT_MODE, TOMBSTONES_ENABLED);
+
+    private final OutputMode outputMode;
+    private final boolean tombstonesEnabled;
+    private final Map<String, TableMappingConfig> tableMappings;
+
+    Neo4jCudConverterConfig(OutputMode outputMode, boolean tombstonesEnabled,
+                            Map<String, TableMappingConfig> tableMappings) {
+        this.outputMode = outputMode;
+        this.tombstonesEnabled = tombstonesEnabled;
+        this.tableMappings = tableMappings;
+
+        validate();
+    }
+
+    public static Neo4jCudConverterConfig from(Configuration config, Map<String, ?> rawProps) {
+        return Neo4jCudConfigParser.parse(config, rawProps);
+    }
+
+    private void validate() {
+        if (tableMappings.isEmpty()) {
+            throw new ConfigException("table.<table_name>.*", null,
+                    "At least one per-table mapping is required, for example table.<table_name>.node.id.properties");
+        }
+    }
+
+    public OutputMode outputMode() {
+        return outputMode;
+    }
+
+    public boolean tombstonesEnabled() {
+        return tombstonesEnabled;
+    }
+
+    public Map<String, TableMappingConfig> tableMappings() {
+        return tableMappings;
+    }
+
+    /**
+     * Returns the mapping configured for the given source table, or {@code null} when no mapping is
+     * configured (the record is passed through unchanged) or when {@code table} is {@code null}.
+     */
+    public TableMappingConfig mappingFor(String table) {
+        return table == null ? null : tableMappings.get(table);
+    }
+
+    public enum NodeMode implements EnumeratedValue {
+        NODE("node"),
+        RELATIONSHIP("relationship");
+
+        private final String value;
+
+        NodeMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static NodeMode parse(String value) {
+            return EnumeratedValue.parse(NodeMode.class, value, NODE.value);
+        }
+    }
+
+    public enum OutputMode implements EnumeratedValue {
+        ARRAY("array"),
+        SINGLE("single");
+
+        private final String value;
+
+        OutputMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static OutputMode parse(String value) {
+            return EnumeratedValue.parse(OutputMode.class, value, ARRAY.value);
+        }
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/RelationshipMapping.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/RelationshipMapping.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.List;
+
+public record RelationshipMapping(String fkColumn, String type, Direction direction, String targetLabel, String targetId, CudEvent.Operation targetNodeOp,
+        List<String> properties) {
+
+    public enum Direction {
+        OUTGOING,
+        INCOMING
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/TableMappingConfig.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/TableMappingConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
+
+/**
+ * Immutable mapping for a single source table.
+ * A {@link Neo4jCudConverterConfig} holds one of these per configured table and dispatches to the
+ * matching mapping based on the {@code source.table} of each change event.
+ */
+public class TableMappingConfig {
+
+    private final String tableName;
+    private final NodeMode nodeMode;
+    private final List<String> nodeLabels;
+    private final List<String> nodeIdProperties;
+    private final Set<String> propertiesInclude;
+    private final Set<String> propertiesExclude;
+    private final boolean deleteDetach;
+    private final List<RelationshipMapping> relationships;
+    private final Set<String> fkColumns;
+
+    TableMappingConfig(String tableName, NodeMode nodeMode, List<String> nodeLabels, List<String> nodeIdProperties,
+                       Set<String> propertiesInclude, Set<String> propertiesExclude, boolean deleteDetach,
+                       List<RelationshipMapping> relationships) {
+        this.tableName = tableName;
+        this.nodeMode = nodeMode;
+        this.nodeLabels = nodeLabels;
+        this.nodeIdProperties = nodeIdProperties;
+        this.propertiesInclude = propertiesInclude;
+        this.propertiesExclude = propertiesExclude;
+        this.deleteDetach = deleteDetach;
+        this.relationships = relationships;
+        this.fkColumns = relationships.stream()
+                .map(RelationshipMapping::fkColumn)
+                .collect(Collectors.toSet());
+
+        validate();
+    }
+
+    private void validate() {
+        final var prefix = "table." + tableName + ".";
+        if (nodeMode == NodeMode.NODE && nodeIdProperties.isEmpty()) {
+            throw new ConfigException(prefix + "node.id.properties", null, "Required when node.mode=node");
+        }
+        if (nodeMode == NodeMode.NODE && nodeLabels.isEmpty()) {
+            throw new ConfigException(prefix + "node.labels", null, "Required when node.mode=node");
+        }
+        if (nodeMode == NodeMode.RELATIONSHIP) {
+            if (relationships.size() != 2) {
+                throw new ConfigException(prefix + "relationship.*", relationships.size(),
+                        "node.mode=relationship requires exactly two relationship mappings (a source and a target endpoint)");
+            }
+            final var outgoing = relationships.stream()
+                    .filter(r -> r.direction() == RelationshipMapping.Direction.OUTGOING).count();
+            final var incoming = relationships.stream()
+                    .filter(r -> r.direction() == RelationshipMapping.Direction.INCOMING).count();
+            if (outgoing != 1 || incoming != 1) {
+                throw new ConfigException(prefix + "relationship.<fk_column>.direction", null,
+                        "node.mode=relationship requires exactly one outgoing (source) and one incoming (target) relationship endpoint");
+            }
+        }
+        if (!propertiesInclude.isEmpty() && !propertiesExclude.isEmpty()) {
+            throw new ConfigException(prefix + "node.properties.include and " + prefix
+                    + "node.properties.exclude are mutually exclusive");
+        }
+    }
+
+    public String tableName() {
+        return tableName;
+    }
+
+    public NodeMode nodeMode() {
+        return nodeMode;
+    }
+
+    public List<String> nodeLabels() {
+        return nodeLabels;
+    }
+
+    public List<String> nodeIdProperties() {
+        return nodeIdProperties;
+    }
+
+    public Set<String> propertiesInclude() {
+        return propertiesInclude;
+    }
+
+    public Set<String> propertiesExclude() {
+        return propertiesExclude;
+    }
+
+    public boolean deleteDetach() {
+        return deleteDetach;
+    }
+
+    public List<RelationshipMapping> relationships() {
+        return relationships;
+    }
+
+    public Set<String> fkColumns() {
+        return fkColumns;
+    }
+}

--- a/debezium-connect-plugins/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/debezium-connect-plugins/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -14,3 +14,4 @@ io.debezium.transforms.VectorToJsonConverter
 io.debezium.transforms.openlineage.OpenLineage
 io.debezium.transforms.SwapGeometryCoordinates
 io.debezium.transforms.GeometryFormatTransformer
+io.debezium.transforms.Neo4jCudConverter

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
@@ -1,0 +1,1037 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.data.Envelope;
+import io.debezium.time.Date;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.Timestamp;
+
+class Neo4jCudConverterTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Schema SOURCE_SCHEMA = SchemaBuilder.struct()
+            .field("lsn", Schema.INT32_SCHEMA)
+            .field("ts_ms", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("ts_us", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("ts_ns", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("table", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    private static final Schema CUSTOMER_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("first_name", Schema.STRING_SCHEMA)
+            .field("last_name", Schema.STRING_SCHEMA)
+            .field("email", Schema.STRING_SCHEMA)
+            .build();
+
+    private static final Schema ORDER_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("customer_id", Schema.INT32_SCHEMA)
+            .field("total", Schema.FLOAT64_SCHEMA)
+            .field("status", Schema.STRING_SCHEMA)
+            .build();
+
+    private static final Schema ORDER_ITEM_SCHEMA = SchemaBuilder.struct()
+            .field("order_id", Schema.INT32_SCHEMA)
+            .field("product_id", Schema.INT32_SCHEMA)
+            .field("quantity", Schema.INT32_SCHEMA)
+            .build();
+
+    @Nested
+    @DisplayName("Configuration validation")
+    class ConfigValidation {
+
+        @Test
+        @DisplayName("Rejects a config with no per-table mappings")
+        void rejectsEmptyConfig() {
+            final var transform = new Neo4jCudConverter<SourceRecord>();
+            final var props = Map.<String, String> of(
+                    "output.mode", "array");
+
+            assertThatThrownBy(() -> transform.configure(props))
+                    .isInstanceOf(ConfigException.class);
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Rejects node mode without id properties")
+        void rejectsNodeModeWithoutIdProperties() {
+            final var transform = new Neo4jCudConverter<SourceRecord>();
+            final var props = Map.<String, String> of(
+                    "table.customers.node.labels", "Customer");
+
+            assertThatThrownBy(() -> transform.configure(props))
+                    .isInstanceOf(ConfigException.class);
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Rejects relationship mode without relationship config")
+        void rejectsRelationshipModeWithoutRelConfig() {
+            final var transform = new Neo4jCudConverter<SourceRecord>();
+            final var props = Map.<String, String> of(
+                    "table.order_items.node.mode", "relationship");
+
+            assertThatThrownBy(() -> transform.configure(props))
+                    .isInstanceOf(ConfigException.class);
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Rejects both include and exclude properties")
+        void rejectsMutuallyExclusiveFilters() {
+            final var transform = new Neo4jCudConverter<SourceRecord>();
+            final var props = Map.<String, String> of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.include", "name",
+                    "table.customers.node.properties.exclude", "email");
+
+            assertThatThrownBy(() -> transform.configure(props))
+                    .isInstanceOf(ConfigException.class);
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing column or typo handling")
+    class MissingColumnHandling {
+
+        @Test
+        @DisplayName("A configured column absent from the record schema due to a typo is skipped")
+        void typoedIdColumnDoesNotThrow() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "custmer_id"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(asMap(events.get(0), "ids")).isEmpty();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A null foreign key in relationship mode fails with a clear error, not a Map NPE")
+        void nullFkInRelationshipModeThrows() {
+            final var transform = configureOrderItemTransform("array");
+
+            final var nullableSchema = SchemaBuilder.struct()
+                    .field("order_id", Schema.OPTIONAL_INT32_SCHEMA)
+                    .field("product_id", Schema.INT32_SCHEMA)
+                    .field("quantity", Schema.INT32_SCHEMA)
+                    .build();
+            final var after = new Struct(nullableSchema);
+            after.put("order_id", null);
+            after.put("product_id", 200);
+            after.put("quantity", 3);
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(nullableSchema)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+                    envelope.schema(), envelope.create(after, createSource("order_items"), Instant.now()));
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("order_id");
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Node mode with array output")
+    class NodeModeArrayOutput {
+
+        @Test
+        @DisplayName("Transforms CREATE into a single-element array with node merge")
+        void createEvent() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+
+            final var node = events.get(0);
+            assertThat(node.get("type")).isEqualTo("node");
+            assertThat(node.get("op")).isEqualTo("merge");
+            assertThat(node.get("labels")).isEqualTo(List.of("Customer"));
+            assertThat(asMap(node, "ids")).containsEntry("id", 1004);
+            assertThat(asMap(node, "properties")).containsEntry("first_name", "John");
+            assertThat(asMap(node, "properties")).doesNotContainKey("id");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Transforms READ (snapshot) into a merge event")
+        void readEvent() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var record = createCustomerRecord("r", customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events.get(0).get("op")).isEqualTo("merge");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Transforms UPDATE into a merge event with updated properties")
+        void updateEvent() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var after = customerAfter();
+            after.put("email", "new@mail.org");
+            final var record = createCustomerRecord("u", after, customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events.get(0).get("op")).isEqualTo("merge");
+            assertThat(asMap(events.get(0), "properties")).containsEntry("email", "new@mail.org");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Transforms DELETE into a delete event reading from before")
+        void deleteEvent() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var record = createDeleteRecord(customerEnvelope(), customerAfter(), "customers");
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("op")).isEqualTo("delete");
+            assertThat(events.get(0).get("detach")).isEqualTo(true);
+            assertThat(events.get(0)).doesNotContainKey("properties");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("DELETE with detach=false omits detach flag")
+        void deleteWithoutDetach() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.delete.detach", "false"));
+            final var record = createDeleteRecord(customerEnvelope(), customerAfter(), "customers");
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events.get(0).get("detach")).isEqualTo(false);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Excludes columns listed in node.properties.exclude")
+        void excludeProperties() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.exclude", "email"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var props = asMap(parseArray(result).get(0), "properties");
+            assertThat(props).doesNotContainKey("email");
+            assertThat(props).containsKey("first_name");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Includes only columns listed in node.properties.include")
+        void includeProperties() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.include", "email"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var props = asMap(parseArray(result).get(0), "properties");
+            assertThat(props).containsOnlyKeys("email");
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Node mode with FK relationships")
+    class NodeModeWithRelationships {
+
+        @Test
+        @DisplayName("CREATE produces node + relationship in array mode")
+        void createWithFk() throws Exception {
+            final var transform = configureOrderTransform();
+            final var record = createOrderRecord();
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(2);
+
+            final var nodeEvent = events.get(0);
+            assertThat(nodeEvent.get("type")).isEqualTo("node");
+            assertThat(asMap(nodeEvent, "properties")).doesNotContainKey("customer_id");
+
+            final var relEvent = events.get(1);
+            assertThat(relEvent.get("type")).isEqualTo("relationship");
+            assertThat(relEvent.get("rel_type")).isEqualTo("PLACED_BY");
+            assertThat(asMap(asMap(relEvent, "from"), "ids")).containsEntry("id", 5001);
+            assertThat(asMap(asMap(relEvent, "to"), "ids")).containsEntry("id", 1004);
+            assertThat(asMap(relEvent, "to").get("op")).isEqualTo("match");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("DELETE in node mode produces only a node delete, no relationship events")
+        void deleteSkipsRelationships() throws Exception {
+            final var transform = configureOrderTransform();
+            final var record = createDeleteRecord(orderEnvelope(), orderAfter(), "orders");
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(events.get(0).get("op")).isEqualTo("delete");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Null FK value skips the relationship event")
+        void nullFkSkipped() throws Exception {
+            final var nullableOrderSchema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("customer_id", Schema.OPTIONAL_INT32_SCHEMA)
+                    .field("total", Schema.FLOAT64_SCHEMA)
+                    .field("status", Schema.STRING_SCHEMA)
+                    .build();
+            final var nullableAfter = new Struct(nullableOrderSchema);
+            nullableAfter.put("id", 5001);
+            nullableAfter.put("customer_id", null);
+            nullableAfter.put("total", 99.95);
+            nullableAfter.put("status", "pending");
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(nullableOrderSchema)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var source = createSource("orders");
+            final var payload = envelope.create(nullableAfter, source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.orders",
+                    envelope.schema(), payload);
+
+            final var transform = configureOrderTransform();
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Single output mode")
+    class SingleOutputMode {
+
+        @Test
+        @DisplayName("Produces a single JSON object, not an array")
+        void singleNodeOutput() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "output.mode", "single"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var result = transform.apply(record);
+
+            final var json = (String) result.value();
+            final var parsed = OBJECT_MAPPER.readValue(json, Map.class);
+            assertThat(parsed.get("type")).isEqualTo("node");
+            assertThat(result.valueSchema()).isEqualTo(Schema.STRING_SCHEMA);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("FK columns excluded from properties even in single mode")
+        void fkExcludedInSingleMode() throws Exception {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("output.mode", "single");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.id", "id");
+
+            final var transform = configureTransform(props);
+            final var record = createOrderRecord();
+
+            final var result = transform.apply(record);
+
+            final var parsed = OBJECT_MAPPER.readValue((String) result.value(), Map.class);
+            assertThat(asMap(parsed, "properties")).doesNotContainKey("customer_id");
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Relationship mode (join tables)")
+    class RelationshipMode {
+
+        @Test
+        @DisplayName("Array mode: produces node merges for both endpoints + relationship")
+        void joinTableArrayMode() throws Exception {
+            final var transform = configureOrderItemTransform("array");
+            final var record = createOrderItemRecord();
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(3);
+
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(events.get(0).get("labels")).isEqualTo(List.of("Order"));
+
+            assertThat(events.get(1).get("type")).isEqualTo("node");
+            assertThat(events.get(1).get("labels")).isEqualTo(List.of("Product"));
+
+            final var rel = events.get(2);
+            assertThat(rel.get("type")).isEqualTo("relationship");
+            assertThat(rel.get("rel_type")).isEqualTo("CONTAINS");
+            assertThat(asMap(rel, "from").get("labels")).isEqualTo(List.of("Order"));
+            assertThat(asMap(rel, "from").get("op")).isEqualTo("match");
+            assertThat(asMap(rel, "to").get("labels")).isEqualTo(List.of("Product"));
+            assertThat(asMap(rel, "to").get("op")).isEqualTo("match");
+            assertThat(asMap(rel, "properties")).containsEntry("quantity", 3);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Single mode: produces relationship with merge endpoints, no separate node events")
+        void joinTableSingleMode() throws Exception {
+            final var transform = configureOrderItemTransform("single");
+            final var record = createOrderItemRecord();
+
+            final var result = transform.apply(record);
+
+            final var parsed = OBJECT_MAPPER.readValue((String) result.value(), Map.class);
+            assertThat(parsed.get("type")).isEqualTo("relationship");
+            assertThat(asMap(parsed, "from").get("labels")).isEqualTo(List.of("Order"));
+            assertThat(asMap(parsed, "from").get("op")).isEqualTo("merge");
+            assertThat(asMap(parsed, "to").get("labels")).isEqualTo(List.of("Product"));
+            assertThat(asMap(parsed, "to").get("op")).isEqualTo("merge");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Endpoint roles follow direction, not config order: swapping direction reverses the relationship")
+        void directionDeterminesEndpoints() throws Exception {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("output.mode", "single");
+            // product_id is the source (outgoing), order_id is the target (incoming) -> reversed orientation.
+            props.put("table.order_items.relationship.product_id.direction", "outgoing");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+            props.put("table.order_items.relationship.product_id.target.id", "id");
+            props.put("table.order_items.relationship.order_id.direction", "incoming");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.order_id.target.id", "id");
+            final var transform = configureTransform(props);
+            final var record = createOrderItemRecord();
+
+            final var result = transform.apply(record);
+
+            final var parsed = OBJECT_MAPPER.readValue((String) result.value(), Map.class);
+            assertThat(parsed.get("type")).isEqualTo("relationship");
+            assertThat(asMap(parsed, "from").get("labels")).isEqualTo(List.of("Product"));
+            assertThat(asMap(parsed, "to").get("labels")).isEqualTo(List.of("Order"));
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("DELETE on join table produces relationship delete")
+        void joinTableDelete() throws Exception {
+            final var transform = configureOrderItemTransform("array");
+            final var before = orderItemAfter();
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(ORDER_ITEM_SCHEMA)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var source = createSource("order_items");
+            final var payload = envelope.delete(before, source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+                    envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("relationship");
+            assertThat(events.get(0).get("op")).isEqualTo("delete");
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Per-table dispatch")
+    class PerTableDispatch {
+
+        @Test
+        @DisplayName("A single SMT routes a customer record to the customers mapping")
+        void dispatchesCustomerRecord() throws Exception {
+            final var transform = configureMultiTableTransform();
+            final var record = createCustomerRecord("c", customerAfter());
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(events.get(0).get("labels")).isEqualTo(List.of("Customer"));
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A single SMT routes an order record to the orders mapping")
+        void dispatchesOrderRecord() throws Exception {
+            final var transform = configureMultiTableTransform();
+            final var record = createOrderRecord();
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(2);
+            assertThat(events.get(0).get("labels")).isEqualTo(List.of("Order"));
+            assertThat(events.get(1).get("rel_type")).isEqualTo("PLACED_BY");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A single SMT routes a join-table record to the relationship mapping")
+        void dispatchesOrderItemRecord() throws Exception {
+            final var transform = configureMultiTableTransform();
+            final var record = createOrderItemRecord();
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(3);
+            assertThat(events.get(2).get("type")).isEqualTo("relationship");
+            assertThat(events.get(2).get("rel_type")).isEqualTo("CONTAINS");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A record for an unconfigured table passes through unchanged")
+        void unmappedTablePassthrough() {
+            final var transform = configureMultiTableTransform();
+            final var envelope = customerEnvelope();
+            final var source = createSource("products");
+            final var payload = envelope.create(customerAfter(), source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.products",
+                    envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isSameAs(record);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A record with no source.table passes through unchanged")
+        void missingTablePassthrough() {
+            final var transform = configureMultiTableTransform();
+            final var envelope = customerEnvelope();
+            final var source = createSource(null);
+            final var payload = envelope.create(customerAfter(), source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.customers",
+                    envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isSameAs(record);
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Passthrough and tombstone handling")
+    class PassthroughAndTombstones {
+
+        @Test
+        @DisplayName("Tombstone with tombstones.enabled=true passes through")
+        void tombstonePassthrough() {
+            final var transform = configureCustomerTransform();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test", null, null);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isSameAs(record);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Tombstone with tombstones.enabled=false is dropped")
+        void tombstoneDropped() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "tombstones.enabled", "false"));
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test", null, null);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Non-envelope record passes through unchanged")
+        void nonEnvelopePassthrough() {
+            final var transform = configureCustomerTransform();
+            final var schema = SchemaBuilder.struct().name("some.random.Schema")
+                    .field("id", Schema.INT32_SCHEMA).build();
+            final var value = new Struct(schema);
+            value.put("id", 1);
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test", schema, value);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isSameAs(record);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Truncate operation passes through unchanged")
+        void truncatePassthrough() {
+            final var transform = configureCustomerTransform();
+            final var envelope = customerEnvelope();
+            final var source = createSource("customers");
+            source.put("lsn", 1234);
+            final var payload = envelope.truncate(source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test",
+                    envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            assertThat(result).isSameAs(record);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Output record preserves original key and topic")
+        void preservesKeyAndTopic() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var keySchema = SchemaBuilder.struct().field("id", Schema.INT32_SCHEMA).build();
+            final var key = new Struct(keySchema);
+            key.put("id", 1004);
+
+            final var envelope = customerEnvelope();
+            final var after = customerAfter();
+            final var source = createSource("customers");
+            final var payload = envelope.create(after, source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(),
+                    "dbserver1.public.customers", keySchema, key, envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            assertThat(result.topic()).isEqualTo("dbserver1.public.customers");
+            assertThat(result.keySchema()).isEqualTo(keySchema);
+            assertThat(((Struct) result.key()).getInt32("id")).isEqualTo(1004);
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("E2E: Full test pipeline")
+    class EcommercePipeline {
+
+        @Test
+        @DisplayName("Full pipeline through one SMT: customer, order with FK, order_item join table")
+        void fullEcommercePipeline() throws Exception {
+            final var transform = configureMultiTableTransform();
+
+            final var customerResult = transform.apply(createCustomerRecord("c", customerAfter()));
+
+            final var customerEvents = parseArray(customerResult);
+            assertThat(customerEvents).hasSize(1);
+            assertThat(asMap(customerEvents.get(0), "ids")).containsEntry("id", 1004);
+            assertThat(asMap(customerEvents.get(0), "properties"))
+                    .containsEntry("first_name", "John")
+                    .containsEntry("last_name", "Foo")
+                    .containsEntry("email", "john@foo.org");
+
+            final var orderResult = transform.apply(createOrderRecord());
+
+            final var orderEvents = parseArray(orderResult);
+            assertThat(orderEvents).hasSize(2);
+
+            final var orderNode = orderEvents.get(0);
+            assertThat(orderNode.get("labels")).isEqualTo(List.of("Order"));
+            assertThat(asMap(orderNode, "ids")).containsEntry("id", 5001);
+            assertThat(asMap(orderNode, "properties"))
+                    .containsEntry("total", 99.95)
+                    .containsEntry("status", "pending")
+                    .doesNotContainKey("customer_id");
+
+            final var placedByRel = orderEvents.get(1);
+            assertThat(placedByRel.get("rel_type")).isEqualTo("PLACED_BY");
+            assertThat(asMap(asMap(placedByRel, "to"), "ids")).containsEntry("id", 1004);
+
+            final var orderItemResult = transform.apply(createOrderItemRecord());
+
+            final var orderItemEvents = parseArray(orderItemResult);
+            assertThat(orderItemEvents).hasSize(3);
+
+            assertThat(orderItemEvents.get(0).get("type")).isEqualTo("node");
+            assertThat(orderItemEvents.get(0).get("labels")).isEqualTo(List.of("Order"));
+            assertThat(asMap(orderItemEvents.get(0), "properties")).isEmpty();
+
+            assertThat(orderItemEvents.get(1).get("type")).isEqualTo("node");
+            assertThat(orderItemEvents.get(1).get("labels")).isEqualTo(List.of("Product"));
+
+            final var containsRel = orderItemEvents.get(2);
+            assertThat(containsRel.get("rel_type")).isEqualTo("CONTAINS");
+            assertThat(asMap(containsRel, "properties")).containsEntry("quantity", 3);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Full delete lifecycle: delete customer cascades with detach")
+        void deleteLifecycle() throws Exception {
+            final var transform = configureCustomerTransform();
+            final var createRecord = createCustomerRecord("c", customerAfter());
+            transform.apply(createRecord);
+
+            final var deleteRecord = createDeleteRecord(customerEnvelope(), customerAfter(), "customers");
+
+            final var result = transform.apply(deleteRecord);
+
+            final var events = parseArray(result);
+            final var deleteNode = events.get(0);
+            assertThat(deleteNode.get("op")).isEqualTo("delete");
+            assertThat(deleteNode.get("labels")).isEqualTo(List.of("Customer"));
+            assertThat(asMap(deleteNode, "ids")).containsEntry("id", 1004);
+            assertThat(deleteNode.get("detach")).isEqualTo(true);
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Relationship direction")
+    class RelationshipDirection {
+
+        @Test
+        @DisplayName("Incoming direction swaps from/to endpoints")
+        void incomingDirection() throws Exception {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "HAS_ORDER");
+            props.put("table.orders.relationship.customer_id.direction", "incoming");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.id", "id");
+
+            final var transform = configureTransform(props);
+            final var record = createOrderRecord();
+
+            final var result = transform.apply(record);
+
+            final var events = parseArray(result);
+            final var rel = events.get(1);
+            assertThat(asMap(rel, "from").get("labels")).isEqualTo(List.of("Customer"));
+            assertThat(asMap(rel, "to").get("labels")).isEqualTo(List.of("Order"));
+
+            transform.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Temporal type mapping")
+    class TemporalTypeMapping {
+
+        private final Schema eventSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("hire_date", Date.schema())
+                .field("created_at", Timestamp.schema())
+                .field("updated_at", MicroTimestamp.schema())
+                .build();
+
+        @Test
+        @DisplayName("Emits temporal columns as ISO-8601 strings")
+        void mapsTemporalColumnsToIsoStrings() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.employees.node.labels", "Employee",
+                    "table.employees.node.id.properties", "id"));
+
+            final var after = new Struct(eventSchema);
+            after.put("id", 7);
+            after.put("hire_date", 19723); // 2024-01-01
+            after.put("created_at", 1704112245123L); // 2024-01-01T12:30:45.123Z
+            after.put("updated_at", 1704112245123456L); // 2024-01-01T12:30:45.123456Z
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(eventSchema)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var payload = envelope.create(after, createSource("employees"), Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.employees",
+                    envelope.schema(), payload);
+
+            final var events = parseArray(transform.apply(record));
+            final var properties = asMap(events.get(0), "properties");
+
+            assertThat(properties).containsEntry("hire_date", "2024-01-01");
+            assertThat(properties).containsEntry("created_at", "2024-01-01T12:30:45.123Z");
+            assertThat(properties).containsEntry("updated_at", "2024-01-01T12:30:45.123456Z");
+
+            transform.close();
+        }
+    }
+
+    private Neo4jCudConverter<SourceRecord> configureTransform(Map<String, String> props) {
+        final var transform = new Neo4jCudConverter<SourceRecord>();
+        transform.configure(props);
+        return transform;
+    }
+
+    private Neo4jCudConverter<SourceRecord> configureCustomerTransform() {
+        return configureTransform(Map.of(
+                "table.customers.node.labels", "Customer",
+                "table.customers.node.id.properties", "id"));
+    }
+
+    private Neo4jCudConverter<SourceRecord> configureOrderTransform() {
+        final var props = new HashMap<String, String>();
+        props.put("table.orders.node.labels", "Order");
+        props.put("table.orders.node.id.properties", "id");
+        props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+        props.put("table.orders.relationship.customer_id.target.label", "Customer");
+        props.put("table.orders.relationship.customer_id.target.id", "id");
+        return configureTransform(props);
+    }
+
+    private Neo4jCudConverter<SourceRecord> configureOrderItemTransform(String outputMode) {
+        final var props = new HashMap<String, String>();
+        props.put("table.order_items.node.mode", "relationship");
+        props.put("output.mode", outputMode);
+        props.put("table.order_items.relationship.order_id.direction", "outgoing");
+        props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+        props.put("table.order_items.relationship.order_id.target.label", "Order");
+        props.put("table.order_items.relationship.order_id.target.id", "id");
+        props.put("table.order_items.relationship.product_id.direction", "incoming");
+        props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+        props.put("table.order_items.relationship.product_id.target.label", "Product");
+        props.put("table.order_items.relationship.product_id.target.id", "id");
+        props.put("table.order_items.relationship.order_id.properties", "quantity");
+        return configureTransform(props);
+    }
+
+    /**
+     * Configures a single SMT instance with mappings for all three tables, exercising per-table
+     * dispatch: customers (node), orders (node + FK relationship) and order_items (relationship).
+     */
+    private Neo4jCudConverter<SourceRecord> configureMultiTableTransform() {
+        final var props = new HashMap<String, String>();
+        props.put("table.customers.node.labels", "Customer");
+        props.put("table.customers.node.id.properties", "id");
+
+        props.put("table.orders.node.labels", "Order");
+        props.put("table.orders.node.id.properties", "id");
+        props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+        props.put("table.orders.relationship.customer_id.target.label", "Customer");
+        props.put("table.orders.relationship.customer_id.target.id", "id");
+
+        props.put("table.order_items.node.mode", "relationship");
+        props.put("table.order_items.relationship.order_id.direction", "outgoing");
+        props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+        props.put("table.order_items.relationship.order_id.target.label", "Order");
+        props.put("table.order_items.relationship.order_id.target.id", "id");
+        props.put("table.order_items.relationship.order_id.properties", "quantity");
+        props.put("table.order_items.relationship.product_id.direction", "incoming");
+        props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+        props.put("table.order_items.relationship.product_id.target.label", "Product");
+        props.put("table.order_items.relationship.product_id.target.id", "id");
+        return configureTransform(props);
+    }
+
+    private Envelope customerEnvelope() {
+        return Envelope.defineSchema()
+                .withName("test.Envelope")
+                .withRecord(CUSTOMER_SCHEMA)
+                .withSource(SOURCE_SCHEMA)
+                .build();
+    }
+
+    private Envelope orderEnvelope() {
+        return Envelope.defineSchema()
+                .withName("test.Envelope")
+                .withRecord(ORDER_SCHEMA)
+                .withSource(SOURCE_SCHEMA)
+                .build();
+    }
+
+    private Struct customerAfter() {
+        final var after = new Struct(CUSTOMER_SCHEMA);
+        after.put("id", 1004);
+        after.put("first_name", "John");
+        after.put("last_name", "Foo");
+        after.put("email", "john@foo.org");
+        return after;
+    }
+
+    private Struct orderAfter() {
+        final var after = new Struct(ORDER_SCHEMA);
+        after.put("id", 5001);
+        after.put("customer_id", 1004);
+        after.put("total", 99.95);
+        after.put("status", "pending");
+        return after;
+    }
+
+    private Struct orderItemAfter() {
+        final var after = new Struct(ORDER_ITEM_SCHEMA);
+        after.put("order_id", 5001);
+        after.put("product_id", 200);
+        after.put("quantity", 3);
+        return after;
+    }
+
+    private Struct createSource(String table) {
+        final var source = new Struct(SOURCE_SCHEMA);
+        source.put("lsn", 1234);
+        source.put("ts_ms", 1711900800000L);
+        source.put("ts_us", 1711900800000000L);
+        source.put("ts_ns", 1711900800000000000L);
+        source.put("table", table);
+        return source;
+    }
+
+    private SourceRecord createCustomerRecord(String op, Struct after) {
+        return createCustomerRecord(op, after, null);
+    }
+
+    private SourceRecord createCustomerRecord(String op, Struct after, Struct before) {
+        final var envelope = customerEnvelope();
+        final var source = createSource("customers");
+        final Struct payload;
+        if ("u".equals(op)) {
+            payload = envelope.update(before, after, source, Instant.now());
+        }
+        else {
+            payload = envelope.create(after, source, Instant.now());
+        }
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "test.customers",
+                envelope.schema(), payload);
+    }
+
+    private SourceRecord createOrderRecord() {
+        final var envelope = orderEnvelope();
+        final var source = createSource("orders");
+        final var after = orderAfter();
+        final var payload = envelope.create(after, source, Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "test.orders",
+                envelope.schema(), payload);
+    }
+
+    private SourceRecord createOrderItemRecord() {
+        final var envelope = Envelope.defineSchema()
+                .withName("test.Envelope")
+                .withRecord(ORDER_ITEM_SCHEMA)
+                .withSource(SOURCE_SCHEMA)
+                .build();
+        final var source = createSource("order_items");
+        final var after = orderItemAfter();
+        final var payload = envelope.create(after, source, Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+                envelope.schema(), payload);
+    }
+
+    private SourceRecord createDeleteRecord(Envelope envelope, Struct before, String table) {
+        final var source = createSource(table);
+        final var payload = envelope.delete(before, source, Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "test",
+                envelope.schema(), payload);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> parseArray(SourceRecord record) throws JsonProcessingException {
+        final var json = (String) record.value();
+        return OBJECT_MAPPER.readValue(json, List.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Map<String, Object> parent, String key) {
+        return (Map<String, Object>) parent.get(key);
+    }
+
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/AbstractNeo4jCudConverterIT.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/AbstractNeo4jCudConverterIT.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.config.Configuration;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.transforms.Neo4jCudConverter;
+
+public abstract class AbstractNeo4jCudConverterIT<T extends SourceConnector> extends AbstractAsyncEngineConnectorTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    protected abstract Class<T> getConnectorClass();
+
+    protected abstract JdbcConnection databaseConnection();
+
+    protected abstract Configuration.Builder getConfigurationBuilder();
+
+    protected abstract void createTables() throws Exception;
+
+    protected abstract void waitForStreamingStarted() throws InterruptedException;
+
+    protected abstract String topicName(String table);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        createTables();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        stopConnector();
+        assertNoRecordsToConsume();
+    }
+
+    @Test
+    @DisplayName("INSERT on entity table produces a node merge CUD event from real CDC")
+    void shouldTransformInsertToNodeMerge() throws Exception {
+        startStreaming("customers");
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+
+        final var records = consumeRecordsByTopic(1);
+        final var record = records.recordsForTopic(topicName("customers")).get(0);
+
+        try (var smt = configuredTransform(allTablesConfig())) {
+            final var result = smt.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+
+            final var node = events.get(0);
+            assertThat(node.get("type")).isEqualTo("node");
+            assertThat(node.get("op")).isEqualTo("merge");
+            assertThat(node.get("labels")).isEqualTo(List.of("Customer"));
+            assertThat(asMap(node, "ids")).containsEntry("id", 1004);
+            assertThat(asMap(node, "properties"))
+                    .containsEntry("first_name", "John")
+                    .containsEntry("last_name", "Foo")
+                    .containsEntry("email", "john@foo.org")
+                    .doesNotContainKey("id");
+        }
+    }
+
+    @Test
+    @DisplayName("UPDATE produces a node merge CUD event with updated properties from real CDC")
+    void shouldTransformUpdateToNodeMerge() throws Exception {
+        startStreaming("customers");
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+        consumeRecordsByTopic(1);
+
+        databaseConnection().execute(
+                "UPDATE customers SET email = 'new@mail.org' WHERE id = 1004");
+
+        final var records = consumeRecordsByTopic(1);
+        final var record = records.recordsForTopic(topicName("customers")).get(0);
+
+        try (var smt = configuredTransform(allTablesConfig())) {
+            final var result = smt.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events.get(0).get("op")).isEqualTo("merge");
+            assertThat(asMap(events.get(0), "properties"))
+                    .containsEntry("email", "new@mail.org");
+        }
+    }
+
+    @Test
+    @DisplayName("DELETE produces a node delete CUD event with detach from real CDC")
+    void shouldTransformDeleteToNodeDelete() throws Exception {
+        startStreaming("customers");
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+        consumeRecordsByTopic(1);
+
+        databaseConnection().execute("DELETE FROM customers WHERE id = 1004");
+
+        final var records = consumeRecordsByTopic(2);
+        final var deleteRecord = records.recordsForTopic(topicName("customers")).get(0);
+
+        try (var smt = configuredTransform(allTablesConfig())) {
+            final var result = smt.apply(deleteRecord);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("op")).isEqualTo("delete");
+            assertThat(events.get(0).get("detach")).isEqualTo(true);
+            assertThat(asMap(events.get(0), "ids")).containsEntry("id", 1004);
+        }
+    }
+
+    @Test
+    @DisplayName("INSERT on entity with FK produces node + relationship CUD events from real CDC")
+    void shouldTransformInsertWithFkToNodeAndRelationship() throws Exception {
+        startStreaming("customers,orders");
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+        consumeRecordsByTopic(1);
+
+        insertOrder(5001, 1004, 99.95, "pending");
+
+        final var records = consumeRecordsByTopic(1);
+        final var record = records.recordsForTopic(topicName("orders")).get(0);
+
+        try (var smt = configuredTransform(allTablesConfig())) {
+            final var result = smt.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(2);
+
+            final var node = events.get(0);
+            assertThat(node.get("type")).isEqualTo("node");
+            assertThat(node.get("labels")).isEqualTo(List.of("Order"));
+            assertThat(asMap(node, "properties"))
+                    .containsEntry("status", "pending")
+                    .doesNotContainKey("customer_id");
+
+            final var rel = events.get(1);
+            assertThat(rel.get("type")).isEqualTo("relationship");
+            assertThat(rel.get("rel_type")).isEqualTo("PLACED_BY");
+            assertThat(asMap(asMap(rel, "to"), "ids")).containsEntry("id", 1004);
+        }
+    }
+
+    @Test
+    @DisplayName("INSERT on join table produces node merges + relationship from real CDC")
+    void shouldTransformJoinTableInsertToRelationship() throws Exception {
+        startStreaming("customers,orders,products,order_items");
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+        insertProduct(200, "Widget", 19.99);
+        insertOrder(5001, 1004, 99.95, "pending");
+        consumeRecordsByTopic(3);
+
+        insertOrderItem(5001, 200, 3);
+
+        final var records = consumeRecordsByTopic(1);
+        final var record = records.recordsForTopic(topicName("order_items")).get(0);
+
+        try (var smt = configuredTransform(allTablesConfig())) {
+            final var result = smt.apply(record);
+
+            final var events = parseArray(result);
+            assertThat(events).hasSize(3);
+
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(events.get(0).get("labels")).isEqualTo(List.of("Order"));
+
+            assertThat(events.get(1).get("type")).isEqualTo("node");
+            assertThat(events.get(1).get("labels")).isEqualTo(List.of("Product"));
+
+            final var rel = events.get(2);
+            assertThat(rel.get("type")).isEqualTo("relationship");
+            assertThat(rel.get("rel_type")).isEqualTo("CONTAINS");
+            assertThat(asMap(rel, "properties")).containsEntry("quantity", 3);
+        }
+    }
+
+    @Test
+    @DisplayName("Full e-commerce pipeline: customer, order, order_item through real CDC")
+    void shouldHandleFullEcommercePipeline() throws Exception {
+        startStreaming("customers,orders,products,order_items");
+
+        insertCustomer(1004, "John", "Foo", "john@foo.org");
+        insertProduct(200, "Widget", 19.99);
+        insertOrder(5001, 1004, 99.95, "pending");
+        insertOrderItem(5001, 200, 3);
+
+        final var records = consumeRecordsByTopic(4);
+
+        try (var customerSmt = configuredTransform(allTablesConfig())) {
+            final var customerRecord = records.recordsForTopic(topicName("customers")).get(0);
+            final var customerEvents = parseArray(customerSmt.apply(customerRecord));
+            assertThat(customerEvents).hasSize(1);
+            assertThat(customerEvents.get(0).get("type")).isEqualTo("node");
+            assertThat(asMap(customerEvents.get(0), "ids")).containsEntry("id", 1004);
+        }
+
+        try (var orderSmt = configuredTransform(allTablesConfig())) {
+            final var orderRecord = records.recordsForTopic(topicName("orders")).get(0);
+            final var orderEvents = parseArray(orderSmt.apply(orderRecord));
+            assertThat(orderEvents).hasSize(2);
+            assertThat(orderEvents.get(1).get("rel_type")).isEqualTo("PLACED_BY");
+        }
+
+        try (var orderItemSmt = configuredTransform(allTablesConfig())) {
+            final var orderItemRecord = records.recordsForTopic(topicName("order_items")).get(0);
+            final var orderItemEvents = parseArray(orderItemSmt.apply(orderItemRecord));
+            assertThat(orderItemEvents).hasSize(3);
+            assertThat(orderItemEvents.get(2).get("rel_type")).isEqualTo("CONTAINS");
+            assertThat(asMap(orderItemEvents.get(2), "properties")).containsEntry("quantity", 3);
+        }
+    }
+
+    // --- DML helpers (standard SQL, override if dialect requires) ---
+
+    protected void insertCustomer(int id, String firstName, String lastName, String email) throws SQLException {
+        databaseConnection().execute(String.format(
+                "INSERT INTO customers (id, first_name, last_name, email) VALUES (%d, '%s', '%s', '%s')",
+                id, firstName, lastName, email));
+    }
+
+    protected void insertOrder(int id, int customerId, double total, String status) throws SQLException {
+        databaseConnection().execute(String.format(
+                "INSERT INTO orders (id, customer_id, total, status) VALUES (%d, %d, %s, '%s')",
+                id, customerId, total, status));
+    }
+
+    protected void insertProduct(int id, String name, double price) throws SQLException {
+        databaseConnection().execute(String.format(
+                "INSERT INTO products (id, name, price) VALUES (%d, '%s', %s)",
+                id, name, price));
+    }
+
+    protected void insertOrderItem(int orderId, int productId, int quantity) throws SQLException {
+        databaseConnection().execute(String.format(
+                "INSERT INTO order_items (order_id, product_id, quantity) VALUES (%d, %d, %d)",
+                orderId, productId, quantity));
+    }
+
+    // --- SMT configuration helpers ---
+
+    /**
+     * A single SMT configuration covering every table in the pipeline. One transform instance
+     * dispatches per-table mappings by matching {@code source.table} against the {@code table.<name>.*}
+     * namespaces, so all IT cases share this config rather than one transform per table.
+     */
+    private Map<String, String> allTablesConfig() {
+        final var config = new HashMap<String, String>();
+
+        config.put("table.customers.node.labels", "Customer");
+        config.put("table.customers.node.id.properties", "id");
+
+        config.put("table.orders.node.labels", "Order");
+        config.put("table.orders.node.id.properties", "id");
+        config.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+        config.put("table.orders.relationship.customer_id.target.label", "Customer");
+        config.put("table.orders.relationship.customer_id.target.id", "id");
+
+        config.put("table.order_items.node.mode", "relationship");
+        config.put("table.order_items.relationship.order_id.direction", "outgoing");
+        config.put("table.order_items.relationship.order_id.type", "CONTAINS");
+        config.put("table.order_items.relationship.order_id.target.label", "Order");
+        config.put("table.order_items.relationship.order_id.target.id", "id");
+        config.put("table.order_items.relationship.product_id.direction", "incoming");
+        config.put("table.order_items.relationship.product_id.type", "CONTAINS");
+        config.put("table.order_items.relationship.product_id.target.label", "Product");
+        config.put("table.order_items.relationship.product_id.target.id", "id");
+        config.put("table.order_items.relationship.order_id.properties", "quantity");
+        return config;
+    }
+
+    // --- Infrastructure helpers ---
+
+    protected void startStreaming(String tables) throws Exception {
+        final var tableList = buildTableIncludeList(tables);
+        final var config = getConfigurationBuilder()
+                .with("table.include.list", tableList)
+                .build();
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+        waitForStreamingStarted();
+        assertNoRecordsToConsume();
+    }
+
+    protected String buildTableIncludeList(String commaSeparatedTables) {
+        final var sb = new StringBuilder();
+        for (final var table : commaSeparatedTables.split(",")) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(schemaPrefix()).append(".").append(table.trim());
+        }
+        return sb.toString();
+    }
+
+    protected String schemaPrefix() {
+        return "public";
+    }
+
+    private Neo4jCudConverter<SourceRecord> configuredTransform(Map<String, String> config) {
+        final var smt = new Neo4jCudConverter<SourceRecord>();
+        smt.configure(config);
+        return smt;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> parseArray(SourceRecord record) throws JsonProcessingException {
+        final var json = (String) record.value();
+        return OBJECT_MAPPER.readValue(json, List.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Map<String, Object> parent, String key) {
+        return (Map<String, Object>) parent.get(key);
+    }
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventFactoryTemporalTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventFactoryTemporalTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.time.Date;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.NanoTime;
+import io.debezium.time.NanoTimestamp;
+import io.debezium.time.Time;
+import io.debezium.time.Timestamp;
+import io.debezium.time.ZonedTime;
+import io.debezium.time.ZonedTimestamp;
+
+class CudEventFactoryTemporalTest {
+
+    @Test
+    @DisplayName("Converts io.debezium.time.Date (days since epoch) to an ISO date string")
+    void convertsDate() {
+        // 2024-01-01 is 19723 days after 1970-01-01
+        assertThat(CudEventFactory.normalizeTemporal(19723, Date.schema())).isEqualTo("2024-01-01");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.Timestamp (epoch millis) to a UTC ISO datetime with millisecond precision")
+    void convertsTimestamp() {
+        assertThat(CudEventFactory.normalizeTemporal(1704112245123L, Timestamp.schema()))
+                .isEqualTo("2024-01-01T12:30:45.123Z");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.MicroTimestamp (epoch micros) to a UTC ISO datetime with microsecond precision")
+    void convertsMicroTimestamp() {
+        assertThat(CudEventFactory.normalizeTemporal(1704112245123456L, MicroTimestamp.schema()))
+                .isEqualTo("2024-01-01T12:30:45.123456Z");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.NanoTimestamp (epoch nanos) to a UTC ISO datetime with nanosecond precision")
+    void convertsNanoTimestamp() {
+        assertThat(CudEventFactory.normalizeTemporal(1704112245123456789L, NanoTimestamp.schema()))
+                .isEqualTo("2024-01-01T12:30:45.123456789Z");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.Time (millis since midnight) to a UTC ISO time with millisecond precision")
+    void convertsTime() {
+        assertThat(CudEventFactory.normalizeTemporal(45045123, Time.schema())).isEqualTo("12:30:45.123Z");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.MicroTime (micros since midnight) to a UTC ISO time with microsecond precision")
+    void convertsMicroTime() {
+        assertThat(CudEventFactory.normalizeTemporal(45045123456L, MicroTime.schema())).isEqualTo("12:30:45.123456Z");
+    }
+
+    @Test
+    @DisplayName("Converts io.debezium.time.NanoTime (nanos since midnight) to a UTC ISO time with nanosecond precision")
+    void convertsNanoTime() {
+        assertThat(CudEventFactory.normalizeTemporal(45045123456789L, NanoTime.schema())).isEqualTo("12:30:45.123456789Z");
+    }
+
+    @Test
+    @DisplayName("Converts a connect-mode Date (java.util.Date) to an ISO date string")
+    void convertsConnectDate() {
+        final var value = java.util.Date.from(Instant.parse("2024-01-01T00:00:00Z"));
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Date.SCHEMA))
+                .isEqualTo("2024-01-01");
+    }
+
+    @Test
+    @DisplayName("Converts a connect-mode Time (java.util.Date) to a UTC ISO time string")
+    void convertsConnectTime() {
+        final var value = java.util.Date.from(Instant.parse("1970-01-01T12:30:45.123Z"));
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Time.SCHEMA))
+                .isEqualTo("12:30:45.123Z");
+    }
+
+    @Test
+    @DisplayName("Converts a connect-mode Timestamp (java.util.Date) to a UTC ISO datetime string")
+    void convertsConnectTimestamp() {
+        final var value = java.util.Date.from(Instant.parse("2024-01-01T12:30:45.123Z"));
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Timestamp.SCHEMA))
+                .isEqualTo("2024-01-01T12:30:45.123Z");
+    }
+
+    @Test
+    @DisplayName("Leaves ZonedTime untouched since it already arrives as an ISO string")
+    void passesZonedTimeThrough() {
+        assertThat(CudEventFactory.normalizeTemporal("12:30:45Z", ZonedTime.schema())).isEqualTo("12:30:45Z");
+    }
+
+    @Test
+    @DisplayName("Normalizes timestamps to UTC with a trailing Z, matching Debezium's isostring convention")
+    void timestampIsUtcWithZ() {
+        assertThat((String) CudEventFactory.normalizeTemporal(0L, Timestamp.schema())).isEqualTo("1970-01-01T00:00:00Z");
+    }
+
+    @Test
+    @DisplayName("Date is rendered without an offset so it is valid Neo4j date() input")
+    void dateHasNoOffset() {
+        assertThat((String) CudEventFactory.normalizeTemporal(19723, Date.schema())).doesNotContain("Z", "+");
+    }
+
+    @Test
+    @DisplayName("Leaves ZonedTimestamp untouched since it already arrives as an ISO string")
+    void passesZonedTimestampThrough() {
+        assertThat(CudEventFactory.normalizeTemporal("2024-01-01T12:30:45Z", ZonedTimestamp.schema()))
+                .isEqualTo("2024-01-01T12:30:45Z");
+    }
+
+    @Test
+    @DisplayName("Passes a plain INT64 (no logical name) through unchanged")
+    void passesPlainLongThrough() {
+        assertThat(CudEventFactory.normalizeTemporal(1704112245123L, Schema.INT64_SCHEMA)).isEqualTo(1704112245123L);
+    }
+
+    @Test
+    @DisplayName("Returns null unchanged")
+    void passesNullThrough() {
+        assertThat(CudEventFactory.normalizeTemporal(null, Date.schema())).isNull();
+    }
+
+    @Test
+    @DisplayName("Returns the value unchanged when the schema is null")
+    void passesThroughWhenSchemaNull() {
+        assertThat(CudEventFactory.normalizeTemporal(42, null)).isEqualTo(42);
+    }
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventSerializerTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventSerializerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.data.VariableScaleDecimal;
+import io.debezium.transforms.neo4j.CudEvent.Operation;
+
+class CudEventSerializerTest {
+
+    private CudEventSerializer serializer;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        serializer = new CudEventSerializer();
+    }
+
+    @Nested
+    @DisplayName("Node event serialization")
+    class NodeEvents {
+
+        @Test
+        @DisplayName("Serializes a merge node event with labels, ids and properties")
+        void serializeMergeNode() throws Exception {
+            final var event = new CudNodeEvent(Operation.MERGE,
+                    List.of("Customer"),
+                    Map.of("id", 1004L),
+                    Map.of("first_name", "John", "email", "john@foo.org"),
+                    null);
+
+            final var json = serializer.serializeSingle(event);
+
+            final var parsed = parseJson(json);
+            assertThat(parsed.get("type")).isEqualTo("node");
+            assertThat(parsed.get("op")).isEqualTo("merge");
+            assertThat(parsed.get("labels")).isEqualTo(List.of("Customer"));
+            assertThat(asMap(parsed, "ids")).containsEntry("id", 1004);
+            assertThat(asMap(parsed, "properties")).containsEntry("first_name", "John");
+            assertThat(parsed).doesNotContainKey("detach");
+        }
+
+        @Test
+        @DisplayName("Serializes a delete node event with detach flag and no properties")
+        void serializeDeleteNode() throws Exception {
+            final var event = new CudNodeEvent(Operation.DELETE,
+                    List.of("Customer"),
+                    Map.of("id", 1004L),
+                    null,
+                    true);
+
+            final var json = serializer.serializeSingle(event);
+
+            final var parsed = parseJson(json);
+            assertThat(parsed.get("op")).isEqualTo("delete");
+            assertThat(parsed.get("detach")).isEqualTo(true);
+            assertThat(parsed).doesNotContainKey("properties");
+        }
+
+        @Test
+        @DisplayName("Serializes multiple labels")
+        void serializeMultipleLabels() throws Exception {
+            final var event = new CudNodeEvent(Operation.MERGE,
+                    List.of("Person", "Employee"),
+                    Map.of("id", 1L),
+                    Collections.emptyMap(),
+                    null);
+
+            final var json = serializer.serializeSingle(event);
+
+            final var parsed = parseJson(json);
+            assertThat(parsed.get("labels")).isEqualTo(List.of("Person", "Employee"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Relationship event serialization")
+    class RelationshipEvents {
+
+        @Test
+        @DisplayName("Serializes a merge relationship with from/to endpoints")
+        void serializeMergeRelationship() throws Exception {
+            final var from = new CudRelationshipEvent.Endpoint(
+                    List.of("Order"), Map.of("id", 5001L), Operation.MERGE);
+            final var to = new CudRelationshipEvent.Endpoint(
+                    List.of("Customer"), Map.of("id", 1004L), Operation.MATCH);
+            final var event = new CudRelationshipEvent(Operation.MERGE, "PLACED_BY", from, to, Collections.emptyMap());
+
+            final var json = serializer.serializeSingle(event);
+
+            final var parsed = parseJson(json);
+            assertThat(parsed.get("type")).isEqualTo("relationship");
+            assertThat(parsed.get("rel_type")).isEqualTo("PLACED_BY");
+            assertThat(asMap(parsed, "from")).containsEntry("op", "merge");
+            assertThat(asMap(parsed, "to")).containsEntry("op", "match");
+        }
+    }
+
+    @Nested
+    @DisplayName("Array serialization")
+    class ArrayEvents {
+
+        @Test
+        @DisplayName("Serializes a list of events as a JSON array")
+        void serializeArray() throws Exception {
+            final var nodeEvent = new CudNodeEvent(Operation.MERGE,
+                    List.of("Order"), Map.of("id", 5001L),
+                    Map.of("total", 99.95), null);
+            final var from = new CudRelationshipEvent.Endpoint(
+                    List.of("Order"), Map.of("id", 5001L), Operation.MERGE);
+            final var to = new CudRelationshipEvent.Endpoint(
+                    List.of("Customer"), Map.of("id", 1004L), Operation.MATCH);
+            final var relEvent = new CudRelationshipEvent(Operation.MERGE, "PLACED_BY",
+                    from, to, Collections.emptyMap());
+
+            final var json = serializer.serializeArray(List.of(nodeEvent, relEvent));
+
+            final var parsed = objectMapper.readValue(json, List.class);
+            assertThat(parsed).hasSize(2);
+            assertThat(((Map<?, ?>) parsed.get(0)).get("type")).isEqualTo("node");
+            assertThat(((Map<?, ?>) parsed.get(1)).get("type")).isEqualTo("relationship");
+        }
+    }
+
+    @Nested
+    @DisplayName("Type conversion")
+    class TypeConversion {
+
+        @Test
+        @DisplayName("Converts Byte to Long")
+        void convertByte() {
+            assertThat(serializer.toValue((byte) 42)).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("Converts Short to Long")
+        void convertShort() {
+            assertThat(serializer.toValue((short) 256)).isEqualTo(256L);
+        }
+
+        @Test
+        @DisplayName("Converts Integer to Long")
+        void convertInteger() {
+            assertThat(serializer.toValue(100)).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("Converts Float to Double")
+        void convertFloat() {
+            assertThat(serializer.toValue(3.14f)).isEqualTo(3.140000104904175);
+        }
+
+        @Test
+        @DisplayName("Serializes BigDecimal from precise mode to its exact String representation")
+        void serializesBigDecimalAsString() {
+            assertThat(serializer.toValue(new BigDecimal("99.95"))).isEqualTo("99.95");
+        }
+
+        @Test
+        @DisplayName("Preserves trailing-zero scale when serializing BigDecimal to String")
+        void serializesBigDecimalPreservingScale() {
+            assertThat(serializer.toValue(new BigDecimal("1.500"))).isEqualTo("1.500");
+        }
+
+        @Test
+        @DisplayName("Passes Long through unchanged")
+        void passLong() {
+            assertThat(serializer.toValue(42L)).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("Passes String through unchanged")
+        void passString() {
+            assertThat(serializer.toValue("hello")).isEqualTo("hello");
+        }
+
+        @Test
+        @DisplayName("Passes Boolean through unchanged")
+        void passBoolean() {
+            assertThat(serializer.toValue(true)).isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("Returns null for null input")
+        void passNull() {
+            assertThat(serializer.toValue(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("Serializes VariableScaleDecimal from precise mode to its exact String representation")
+        void serializesVariableScaleDecimalAsString() {
+            final var struct = VariableScaleDecimal.fromLogical(VariableScaleDecimal.schema(), new BigDecimal("123.456"));
+
+            assertThat(serializer.toValue(struct)).isEqualTo("123.456");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseJson(String json) throws JsonProcessingException {
+        return objectMapper.readValue(json, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Map<String, Object> parent, String key) {
+        return (Map<String, Object>) parent.get(key);
+    }
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/Neo4jCudConfigParserTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/Neo4jCudConfigParserTest.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
+
+class Neo4jCudConfigParserTest {
+
+    private static Neo4jCudConverterConfig parse(Map<String, String> props) {
+        return Neo4jCudConfigParser.parse(Configuration.from(props), props);
+    }
+
+    private static TableMappingConfig mapping(Map<String, String> props, String table) {
+        return parse(props).mappingFor(table);
+    }
+
+    @Nested
+    @DisplayName("Node and output field parsing")
+    class FieldParsing {
+
+        @Test
+        @DisplayName("Parses minimal valid config with node labels and id properties")
+        void parsesMinimalConfig() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id");
+
+            final var config = parse(props);
+            final var customers = config.mappingFor("customers");
+
+            assertThat(customers.nodeMode()).isEqualTo(NodeMode.NODE);
+            assertThat(customers.nodeLabels()).isEqualTo(List.of("Customer"));
+            assertThat(customers.nodeIdProperties()).isEqualTo(List.of("id"));
+            assertThat(customers.deleteDetach()).isTrue();
+            assertThat(config.outputMode()).isEqualTo(OutputMode.ARRAY);
+            assertThat(config.tombstonesEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Parses multiple comma-separated node labels")
+        void parsesMultipleLabels() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Person, Employee",
+                    "table.customers.node.id.properties", "id");
+
+            assertThat(mapping(props, "customers").nodeLabels()).isEqualTo(List.of("Person", "Employee"));
+        }
+
+        @Test
+        @DisplayName("Parses composite id properties")
+        void parsesCompositeIds() {
+            final var props = Map.of(
+                    "table.order_items.node.labels", "OrderItem",
+                    "table.order_items.node.id.properties", "order_id, product_id");
+
+            assertThat(mapping(props, "order_items").nodeIdProperties()).isEqualTo(List.of("order_id", "product_id"));
+        }
+
+        @Test
+        @DisplayName("Parses output.mode=single as a global setting")
+        void parsesSingleOutputMode() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "output.mode", "single");
+
+            assertThat(parse(props).outputMode()).isEqualTo(OutputMode.SINGLE);
+        }
+
+        @Test
+        @DisplayName("Parses node.mode=relationship")
+        void parsesRelationshipNodeMode() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThat(mapping(props, "order_items").nodeMode()).isEqualTo(NodeMode.RELATIONSHIP);
+        }
+
+        @Test
+        @DisplayName("Parses node.delete.detach=false")
+        void parsesDetachFalse() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.delete.detach", "false");
+
+            assertThat(mapping(props, "customers").deleteDetach()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Parses tombstones.enabled=false as a global setting")
+        void parsesTombstonesFalse() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "tombstones.enabled", "false");
+
+            assertThat(parse(props).tombstonesEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Parses include properties filter")
+        void parsesIncludeFilter() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.include", "first_name, email");
+
+            final var customers = mapping(props, "customers");
+            assertThat(customers.propertiesInclude()).containsExactlyInAnyOrder("first_name", "email");
+            assertThat(customers.propertiesExclude()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Parses exclude properties filter")
+        void parsesExcludeFilter() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.exclude", "internal_flag");
+
+            final var customers = mapping(props, "customers");
+            assertThat(customers.propertiesExclude()).containsExactly("internal_flag");
+            assertThat(customers.propertiesInclude()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Returns empty list for missing optional comma-separated fields")
+        void emptyForMissingOptionalFields() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id");
+
+            final var customers = mapping(props, "customers");
+            assertThat(customers.propertiesInclude()).isEmpty();
+            assertThat(customers.propertiesExclude()).isEmpty();
+            assertThat(customers.relationships()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Multi-table parsing")
+    class MultiTableParsing {
+
+        @Test
+        @DisplayName("Parses several tables into distinct mappings under one config")
+        void parsesMultipleTables() {
+            final var props = new HashMap<String, String>();
+            props.put("table.customers.node.labels", "Customer");
+            props.put("table.customers.node.id.properties", "id");
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+
+            final var config = parse(props);
+
+            assertThat(config.tableMappings()).containsOnlyKeys("customers", "orders");
+            assertThat(config.mappingFor("customers").nodeLabels()).isEqualTo(List.of("Customer"));
+            assertThat(config.mappingFor("orders").nodeLabels()).isEqualTo(List.of("Order"));
+            assertThat(config.mappingFor("orders").relationships()).hasSize(1);
+            assertThat(config.mappingFor("customers").relationships()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Returns null for a table with no configured mapping")
+        void unmappedTableReturnsNull() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id");
+
+            assertThat(parse(props).mappingFor("products")).isNull();
+        }
+
+        @Test
+        @DisplayName("Relationships of one table are scoped to that table only")
+        void relationshipsAreScopedPerTable() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.customers.node.labels", "Customer");
+            props.put("table.customers.node.id.properties", "id");
+
+            final var config = parse(props);
+
+            assertThat(config.mappingFor("orders").fkColumns()).containsExactly("customer_id");
+            assertThat(config.mappingFor("customers").fkColumns()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Relationship parsing")
+    class RelationshipParsing {
+
+        @Test
+        @DisplayName("Parses a single relationship mapping with all fields")
+        void parsesSingleRelationship() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.direction", "outgoing");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.id", "cust_id");
+            props.put("table.orders.relationship.customer_id.target.node.op", "merge");
+            props.put("table.orders.relationship.customer_id.properties", "weight");
+
+            final var rel = mapping(props, "orders").relationships().get(0);
+
+            assertThat(rel.fkColumn()).isEqualTo("customer_id");
+            assertThat(rel.type()).isEqualTo("PLACED_BY");
+            assertThat(rel.direction()).isEqualTo(RelationshipMapping.Direction.OUTGOING);
+            assertThat(rel.targetLabel()).isEqualTo("Customer");
+            assertThat(rel.targetId()).isEqualTo("cust_id");
+            assertThat(rel.targetNodeOp()).isEqualTo(CudEvent.Operation.MERGE);
+            assertThat(rel.properties()).isEqualTo(List.of("weight"));
+        }
+
+        @Test
+        @DisplayName("Applies defaults for optional relationship fields")
+        void appliesRelationshipDefaults() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+
+            final var rel = mapping(props, "orders").relationships().get(0);
+
+            assertThat(rel.direction()).isEqualTo(RelationshipMapping.Direction.OUTGOING);
+            assertThat(rel.targetId()).isEqualTo("customer_id");
+            assertThat(rel.targetNodeOp()).isEqualTo(CudEvent.Operation.MATCH);
+            assertThat(rel.properties()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Parses incoming direction")
+        void parsesIncomingDirection() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "HAS_ORDER");
+            props.put("table.orders.relationship.customer_id.direction", "incoming");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+
+            final var rel = mapping(props, "orders").relationships().get(0);
+
+            assertThat(rel.direction()).isEqualTo(RelationshipMapping.Direction.INCOMING);
+        }
+
+        @Test
+        @DisplayName("Selects endpoints by direction, independent of config key order")
+        void parsesMultipleRelationships() {
+            // product_id is declared first, but direction (not order) fixes the endpoints.
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+
+            final var relationships = mapping(props, "order_items").relationships();
+
+            assertThat(relationships).hasSize(2);
+            final var source = relationships.stream()
+                    .filter(r -> r.direction() == RelationshipMapping.Direction.OUTGOING).findFirst().orElseThrow();
+            final var target = relationships.stream()
+                    .filter(r -> r.direction() == RelationshipMapping.Direction.INCOMING).findFirst().orElseThrow();
+            assertThat(source.fkColumn()).isEqualTo("order_id");
+            assertThat(target.fkColumn()).isEqualTo("product_id");
+        }
+
+        @Test
+        @DisplayName("Parses relationship properties as comma-separated list")
+        void parsesRelationshipProperties() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.order_id.properties", "quantity, price");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            final var rel = mapping(props, "order_items").relationships().stream()
+                    .filter(r -> r.direction() == RelationshipMapping.Direction.OUTGOING).findFirst().orElseThrow();
+
+            assertThat(rel.properties()).isEqualTo(List.of("quantity", "price"));
+        }
+
+        @Test
+        @DisplayName("Exposes FK column names as a set")
+        void exposesFkColumns() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThat(mapping(props, "order_items").fkColumns()).containsExactlyInAnyOrder("order_id", "product_id");
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation errors")
+    class ValidationErrors {
+
+        @Test
+        @DisplayName("Rejects a config with no per-table mappings")
+        void rejectsEmptyConfig() {
+            final var props = Map.of("output.mode", "single");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("table.<table_name>");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=node without node.id.properties, naming the table")
+        void rejectsNodeModeWithoutIdProperties() {
+            final var props = Map.of("table.customers.node.labels", "Customer");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("table.customers.node.id.properties");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship without any relationship config")
+        void rejectsRelationshipModeWithoutRelConfig() {
+            final var props = Map.of("table.order_items.node.mode", "relationship");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("relationship");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship with a single mapping (needs two endpoints)")
+        void rejectsRelationshipModeWithSingleMapping() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("exactly two");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship with more than two mappings")
+        void rejectsRelationshipModeWithThreeMappings() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+            props.put("table.order_items.relationship.customer_id.direction", "outgoing");
+            props.put("table.order_items.relationship.customer_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.customer_id.target.label", "Customer");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("exactly two");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship when an endpoint omits direction")
+        void rejectsRelationshipModeWithoutDirection() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("direction");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship when both endpoints are outgoing")
+        void rejectsRelationshipModeWithTwoOutgoing() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "outgoing");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("one outgoing");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=relationship when both endpoints are incoming")
+        void rejectsRelationshipModeWithTwoIncoming() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "incoming");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("one incoming");
+        }
+
+        @Test
+        @DisplayName("Rejects an invalid direction value")
+        void rejectsInvalidDirection() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("table.order_items.relationship.order_id.direction", "sideways");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("outgoing");
+        }
+
+        @Test
+        @DisplayName("Rejects both include and exclude properties set")
+        void rejectsMutuallyExclusiveFilters() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.properties.include", "name",
+                    "table.customers.node.properties.exclude", "email");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class);
+        }
+
+        @Test
+        @DisplayName("Rejects relationship mapping without type")
+        void rejectsRelationshipWithoutType() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("relationship.customer_id.type");
+        }
+
+        @Test
+        @DisplayName("Rejects relationship mapping without target.label")
+        void rejectsRelationshipWithoutTargetLabel() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("relationship.customer_id.target.label");
+        }
+
+        @Test
+        @DisplayName("Rejects invalid target.node.op value at configure time")
+        void rejectsInvalidTargetNodeOp() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.node.op", "create");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("target.node.op")
+                    .hasMessageContaining("match");
+        }
+
+        @Test
+        @DisplayName("Rejects node.mode=node without node.labels, naming the table")
+        void rejectsNodeModeWithoutLabels() {
+            final var props = Map.of("table.customers.node.id.properties", "id");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("table.customers.node.labels");
+        }
+
+        @Test
+        @DisplayName("Rejects a misspelled node sub-key instead of silently ignoring it")
+        void rejectsUnknownNodeKey() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "table.customers.node.lable", "Customer");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("table.customers.node.lable")
+                    .hasMessageContaining("Unknown");
+        }
+
+        @Test
+        @DisplayName("Rejects a misspelled relationship sub-key")
+        void rejectsUnknownRelationshipKey() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.labol", "Customer");
+
+            assertThatThrownBy(() -> parse(props))
+                    .isInstanceOf(ConfigException.class)
+                    .hasMessageContaining("table.orders.relationship.customer_id.target.labol")
+                    .hasMessageContaining("Unknown");
+        }
+    }
+
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/Neo4jCudConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/Neo4jCudConverterIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.transforms.neo4j.AbstractNeo4jCudConverterIT;
+
+public class Neo4jCudConverterIT extends AbstractNeo4jCudConverterIT<PostgresConnector> {
+
+    @BeforeEach
+    void prepareDatabase() {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Override
+    protected Class<PostgresConnector> getConnectorClass() {
+        return PostgresConnector.class;
+    }
+
+    @Override
+    protected JdbcConnection databaseConnection() {
+        return TestHelper.create();
+    }
+
+    @Override
+    protected Configuration.Builder getConfigurationBuilder() {
+        return TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, true);
+    }
+
+    @Override
+    protected void createTables() throws Exception {
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS order_items CASCADE;"
+                        + "DROP TABLE IF EXISTS orders CASCADE;"
+                        + "DROP TABLE IF EXISTS products CASCADE;"
+                        + "DROP TABLE IF EXISTS customers CASCADE;"
+                        + "CREATE TABLE customers ("
+                        + "  id INTEGER PRIMARY KEY,"
+                        + "  first_name VARCHAR(100),"
+                        + "  last_name VARCHAR(100),"
+                        + "  email VARCHAR(255)"
+                        + ");"
+                        + "CREATE TABLE products ("
+                        + "  id INTEGER PRIMARY KEY,"
+                        + "  name VARCHAR(200),"
+                        + "  price DECIMAL(10,2)"
+                        + ");"
+                        + "CREATE TABLE orders ("
+                        + "  id INTEGER PRIMARY KEY,"
+                        + "  customer_id INTEGER REFERENCES customers(id),"
+                        + "  total DECIMAL(10,2),"
+                        + "  status VARCHAR(50)"
+                        + ");"
+                        + "CREATE TABLE order_items ("
+                        + "  order_id INTEGER REFERENCES orders(id),"
+                        + "  product_id INTEGER REFERENCES products(id),"
+                        + "  quantity INTEGER,"
+                        + "  PRIMARY KEY (order_id, product_id)"
+                        + ")");
+    }
+
+    @Override
+    protected void waitForStreamingStarted() throws InterruptedException {
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+    }
+
+    @Override
+    protected String topicName(String table) {
+        return TestHelper.topicName("public." + table);
+    }
+}

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -52,6 +52,7 @@
 ** xref:transformations/timescaledb.adoc[TimescaleDB Integration]
 ** xref:transformations/decode-logical-decoding-message-content.adoc[Decode Logical Decoding Message Content]
 ** xref:transformations/vector-to-json.adoc[Vector Data Types to JSON Types]
+** xref:transformations/neo4j-cud-converter.adoc[Neo4j CUD Converter]
 ** xref:transformations/enforce-record-size.adoc[Enforce Record Size]
 ** xref:transformations/swap-geometry-coordinates.adoc[Swap Geometry Coordinates]
 * Post Processors

--- a/documentation/modules/ROOT/pages/transformations/neo4j-cud-converter.adoc
+++ b/documentation/modules/ROOT/pages/transformations/neo4j-cud-converter.adoc
@@ -1,0 +1,550 @@
+[id="neo4j-cud-converter"]
+= Neo4j CUD Converter
+
+:toc:
+:toc-placement: macro
+:linkattrs:
+:icons: font
+:source-highlighter: highlight.js
+
+toc::[]
+
+The `Neo4jCudConverter` SMT converts {prodname} change events into https://neo4j.com/docs/kafka/current/sink/cud-file-format/[Neo4j CUD format], enabling CDC pipelines from relational databases to Neo4j via the Neo4j Kafka sink connector.
+
+The SMT is stateless and processes one message at a time.
+It supports all {prodname} operations (`c`, `r`, `u`, `d`) and maps them to CUD operations (`merge` for create/read/update, `delete` for delete).
+
+The SMT supports two modes:
+
+`node.mode=node` (default)::
+Treats the table row as a graph node. Foreign key columns can be configured to produce relationship events.
+
+`node.mode=relationship`::
+Treats the table row as a graph relationship (for join tables). No entity node is created.
+
+[[neo4j-cud-converter-per-table-mappings]]
+== Per-table mappings
+
+A single `Neo4jCudConverter` instance can map several source tables at once.
+Each table has its own mapping, declared under a `table.<table_name>.` namespace, and the SMT dispatches every record to the matching mapping by reading the table name from the change event's `source` block.
+
+[source]
+----
+transforms=neo4j
+transforms.neo4j.type=io.debezium.transforms.Neo4jCudConverter
+
+# customers -> (:Customer)
+transforms.neo4j.table.customers.node.labels=Customer
+transforms.neo4j.table.customers.node.id.properties=id
+
+# orders -> (:Order)-[:PLACED_BY]->(:Customer)
+transforms.neo4j.table.orders.node.labels=Order
+transforms.neo4j.table.orders.node.id.properties=id
+transforms.neo4j.table.orders.relationship.customer_id.type=PLACED_BY
+transforms.neo4j.table.orders.relationship.customer_id.target.label=Customer
+transforms.neo4j.table.orders.relationship.customer_id.target.id=id
+----
+
+The structural options documented below are always configured with the full path `table.<table_name>.node.*` or `table.<table_name>.relationship.<fk_column>.*`.
+Configuring at least one table mapping is required; a configuration with no `table.<table_name>.*` mapping is rejected.
+
+Matching uses the bare table name from `source.table` (for example `orders`, not `public.orders`).
+The `<table_name>` you use in the `table.<table_name>.` namespace must match this value *exactly*: the comparison is case-sensitive and performed by simple string equality, with no normalization.
+For example, `table.customers.node.labels` applies only to change events whose `source.table` is exactly `customers` (not `Customers`, `CUSTOMERS`, or `public.customers`).
+A record whose table has no configured mapping, or a record with no `source.table` field, passes through *unchanged*.
+
+[NOTE]
+====
+Because matching is on the bare table name, identically-named tables in different schemas (for example `sales.orders` and `archive.orders`) cannot be distinguished by a single SMT instance.
+To map them differently, route each with a Kafka Connect predicate to a separate `Neo4jCudConverter` instance, or use separate connectors.
+====
+
+[NOTE]
+====
+A dot (`.`) separates the namespace segments of a configuration key, so `<table_name>` cannot itself contain a dot.
+Table names may contain any other character (for example underscores, as in `table.order_items.*`).
+A table whose name contains a dot cannot be mapped by name; route it with a Kafka Connect predicate to a dedicated `Neo4jCudConverter` instance instead.
+====
+
+The `output.mode` and `tombstones.enabled` options are *global*: they are configured once per SMT instance (without a `table.<table_name>.` prefix) and define a single output contract for the downstream Neo4j sink, regardless of how many tables are mapped.
+
+[[neo4j-cud-converter-output-modes]]
+== Output modes
+
+The `output.mode` property controls the output format:
+
+`array` (default)::
+Packs all CUD events (node + relationships) into a JSON array in a single Kafka record.
+This guarantees ordering between node and relationship events.
+The output requires a xref:neo4j-cud-converter-split-step[split step] before the Neo4j sink connector can consume it.
+
+`single`::
+Produces one CUD event per Kafka record.
+The output is directly consumable by the Neo4j sink connector.
+Due to the Kafka Connect `apply()` API constraint, only one event is emitted per input record.
+With `node.mode=node`, only the node event is emitted (no relationships).
+With `node.mode=relationship`, only the relationship event is emitted.
+
+[[neo4j-cud-converter-split-step]]
+== Splitting the array output
+
+When using `output.mode=array`, the SMT writes JSON arrays to the Debezium Kafka topics.
+The Neo4j sink connector expects one CUD event per record, not an array.
+A split step is needed between the SMT output and the Neo4j sink connector to split each array into individual CUD records.
+
+The split step must preserve the order of elements within each array so that node events are always processed before their relationship events.
+
+=== ksqlDB
+
+If you are running Confluent Platform, ksqlDB provides the `EXPLODE` function to split arrays into individual records.
+
+Create a stream over the Debezium topic:
+
+[source,sql]
+----
+CREATE STREAM orders_cud_arrays (
+  cud_events ARRAY<VARCHAR>
+) WITH (
+  KAFKA_TOPIC='dbserver1.public.orders',
+  VALUE_FORMAT='JSON'
+);
+----
+
+Split the array into individual records:
+
+[source,sql]
+----
+CREATE STREAM orders_cud_events AS
+  SELECT EXPLODE(cud_events) AS cud_event
+  FROM orders_cud_arrays
+  EMIT CHANGES;
+----
+
+The Neo4j sink connector then consumes from the `ORDERS_CUD_EVENTS` topic.
+
+=== Kafka Streams
+
+A lightweight Kafka Streams application can read JSON arrays and produce individual records.
+This is a good option for users on vanilla Apache Kafka who want a JVM-based solution.
+
+[source,java]
+----
+StreamsBuilder builder = new StreamsBuilder();
+builder.<String, String>stream("dbserver1.public.orders")
+    .flatMapValues(value -> {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> events = new ArrayList<>();
+        for (JsonNode node : mapper.readTree(value)) {
+            events.add(node.toString());
+        }
+        return events;
+    })
+    .to("orders-cud-events");
+----
+
+=== Apache Flink
+
+A Flink job can read from the Debezium topics and produce individual records.
+This is a good option for users who already have Flink infrastructure.
+
+=== Choosing a split step
+
+The choice depends on what is already available in your infrastructure:
+
+[cols="30%a,70%a",options="header"]
+|===
+|Infrastructure
+|Recommended split step
+
+|Confluent Platform
+|ksqlDB (simplest, no code needed)
+
+|Vanilla Apache Kafka
+|Kafka Streams (lightweight JVM application)
+
+|Apache Flink
+|Flink job
+|===
+
+[[neo4j-cud-converter-type-mapping]]
+== Type mapping
+
+{prodname} represents column values using Kafka Connect schema types and logical types.
+The SMT maps these to the property types that Neo4j supports.
+Because CUD events are serialized as JSON, values with no direct JSON representation (temporal, decimal, and nested structures) are emitted as strings or lists.
+
+.Type mapping from {prodname} to Neo4j
+[cols="40%a,25%a,35%a",options="header"]
+|===
+|{prodname} / Kafka Connect type
+|Neo4j property type
+|Notes
+
+|`INT8`, `INT16`, `INT32`, `INT64`
+|`Long`
+|Neo4j stores all integers as 64-bit, so narrower integers are widened.
+
+|`FLOAT32`, `FLOAT64`
+|`Double`
+|Neo4j stores all floating-point numbers as 64-bit.
+
+|`BOOLEAN`
+|`Boolean`
+|
+
+|`STRING`
+|`String`
+|
+
+|`BYTES`
+|`String` (Base64)
+|Serialized as a Base64-encoded string in the JSON payload.
+
+|`io.debezium.time.Date`
+|`String`
+|ISO-8601 date with no offset, for example `2024-01-01`. Compatible with Neo4j `date()`.
+
+|`io.debezium.time.Time`, `io.debezium.time.MicroTime`, `io.debezium.time.NanoTime`
+|`String`
+|ISO-8601 time of day at UTC with a trailing `Z`, for example `12:30:45.123Z` (milli-, micro-, and nanosecond precision respectively). Compatible with Neo4j `time()`.
+
+|`io.debezium.time.Timestamp`
+|`String`
+|ISO-8601 date-time at UTC with millisecond precision, for example `2024-01-01T12:30:45.123Z`. Compatible with Neo4j `datetime()`.
+
+|`io.debezium.time.MicroTimestamp`
+|`String`
+|ISO-8601 date-time at UTC with microsecond precision, for example `2024-01-01T12:30:45.123456Z`. Compatible with Neo4j `datetime()`.
+
+|`io.debezium.time.NanoTimestamp`
+|`String`
+|ISO-8601 date-time at UTC with nanosecond precision, for example `2024-01-01T12:30:45.123456789Z`. Compatible with Neo4j `datetime()`.
+
+|`io.debezium.time.ZonedTimestamp`
+|`String`
+|ISO-8601 date-time with its original zone offset, for example `2024-01-01T12:30:45Z`. Passed through unchanged. Compatible with Neo4j `datetime()`.
+
+|`io.debezium.time.ZonedTime`
+|`String`
+|ISO-8601 time of day with its original zone offset, for example `12:30:45Z`. Passed through unchanged. Compatible with Neo4j `time()`.
+
+|`org.apache.kafka.connect.data.Date`, `org.apache.kafka.connect.data.Time`, `org.apache.kafka.connect.data.Timestamp`
+|`String`
+|The Kafka Connect logical types emitted when the source connector uses `time.precision.mode=connect`. Normalized to the same ISO-8601 strings as their `io.debezium.time` counterparts (date without offset; time and date-time at UTC with a trailing `Z`, millisecond precision).
+
+|`io.debezium.data.Json`
+|`String`
+|Stored as a JSON string.
+
+|`org.apache.kafka.connect.data.Decimal`, `io.debezium.data.VariableScaleDecimal`
+|`Double` or `String`
+|Depends on the source connector's `decimal.handling.mode`. See xref:neo4j-cud-converter-decimal-handling[Decimal handling].
+
+|`STRUCT` (nested)
+|`String` (JSON)
+|Serialized as a JSON string, because Neo4j properties are flat.
+
+|`ARRAY`
+|`List`
+|Neo4j supports homogeneous lists.
+
+|`MAP`
+|`String` (JSON)
+|Serialized as a JSON string.
+
+|`null`
+|(property omitted)
+|Null values are not written as properties.
+|===
+
+[NOTE]
+====
+Time-of-day and date-time values (`Time`, `MicroTime`, `NanoTime`, `Timestamp`, `MicroTimestamp`, `NanoTimestamp`, and the corresponding Kafka Connect logical types) are normalized to UTC and rendered with a trailing `Z`, consistent with {prodname}'s `time.precision.mode=isostring` convention, which represents temporal values as ISO-8601 strings at the UTC time zone.
+`Date` is rendered without an offset, because Neo4j `date()` does not accept one.
+`ZonedTimestamp` and `ZonedTime` keep their original zone offset and are passed through unchanged.
+A downstream consumer can convert these strings into native Neo4j temporals in Cypher, for example with `date()`, `time()`, or `datetime()`.
+====
+
+[[neo4j-cud-converter-decimal-handling]]
+== Decimal handling
+
+Neo4j property types are limited to `Long`, `Double`, `String`, `Boolean`, and arrays of those.
+There is no arbitrary-precision numeric type, so `java.math.BigDecimal` values (represented in {prodname} by `org.apache.kafka.connect.data.Decimal` or `io.debezium.data.VariableScaleDecimal`) cannot be stored losslessly as a numeric property.
+
+How a decimal reaches the SMT is controlled by the source connector's `decimal.handling.mode`, so set it according to your needs:
+
+`decimal.handling.mode=double`::
+Decimals arrive as a `FLOAT64` schema (`java.lang.Double`) and are mapped to a Neo4j `Double`.
+Choose this when you need to perform numeric operations in Neo4j and can accept the precision limits of a 64-bit float.
+
+`decimal.handling.mode=string`::
+Decimals arrive as a `STRING` schema (`java.lang.String`) and are mapped to a Neo4j `String`.
+Choose this when you need exact precision and do not need to perform numeric operations in Neo4j.
+
+When `decimal.handling.mode` is left at its default (`precise`), the value reaches the SMT as a `BigDecimal` (`Decimal` or `VariableScaleDecimal`).
+Rather than silently converting to a `Double` (risking precision loss) or failing the record, the SMT serializes the value to its exact string representation.
+A precise decimal therefore materializes as a Neo4j `String`.
+Users who want a numeric `Double` property should explicitly set `decimal.handling.mode=double`.
+
+[[neo4j-cud-converter-configuration-options]]
+== Configuration options
+
+The node and relationship options below are per-table: each is shown with its full path, where `<table_name>` is the bare source table name it applies to (see xref:neo4j-cud-converter-per-table-mappings[Per-table mappings]).
+The output options (`output.mode`, `tombstones.enabled`) are global and carry no `table.<table_name>.` prefix.
+
+=== Node configuration
+
+.Neo4jCudConverter node configuration options
+[cols="30%a,10%a,10%a,50%a",options="header"]
+|===
+|Property
+|Default
+|Importance
+|Description
+
+|[[neo4j-node-mode]]<<neo4j-node-mode, `table.<table_name>.node.mode`>>
+|`node`
+|high
+a|Controls the entity type:
+
+* `node`: treats the table row as a graph node.
+* `relationship`: treats the table row as a graph relationship (for join tables). No entity node is created.
+
+|[[neo4j-node-labels]]<<neo4j-node-labels, `table.<table_name>.node.labels`>>
+|
+|high
+|Comma-separated list of Neo4j labels to apply to the node. Set explicitly for each table.
+
+|[[neo4j-node-id-properties]]<<neo4j-node-id-properties, `table.<table_name>.node.id.properties`>>
+|
+|high
+|Comma-separated list of column names to use as CUD key properties (`ids`). Required when `node.mode=node`.
+
+|[[neo4j-node-properties-include]]<<neo4j-node-properties-include, `table.<table_name>.node.properties.include`>>
+|
+|medium
+|Comma-separated list of columns to include as node properties. Mutually exclusive with `table.<table_name>.node.properties.exclude`.
+
+|[[neo4j-node-properties-exclude]]<<neo4j-node-properties-exclude, `table.<table_name>.node.properties.exclude`>>
+|
+|medium
+|Comma-separated list of columns to exclude from node properties. FK columns mapped to relationships are excluded automatically.
+
+|[[neo4j-node-delete-detach]]<<neo4j-node-delete-detach, `table.<table_name>.node.delete.detach`>>
+|`true`
+|medium
+|Whether to set `detach: true` on delete operations, removing the node and all its relationships.
+|===
+
+=== Relationship configuration
+
+Relationships are configured per foreign key column using the property pattern `table.<table_name>.relationship.<fk_column>.*`.
+You can configure multiple relationships by repeating the pattern with different FK column names.
+
+[NOTE]
+====
+The number of relationship mappings you configure depends on `node.mode`:
+
+* With `node.mode=node`, you can configure zero or more relationship mappings; each foreign key column produces its own relationship from the entity node.
+* With `node.mode=relationship`, you must configure *exactly two* relationship mappings, one for each foreign key column of the join table. These two mappings become the endpoints of the join relationship, and each must set `direction`: exactly one `outgoing` (the source endpoint) and one `incoming` (the target endpoint). The relationship always runs from the `outgoing` node to the `incoming` node, so the orientation is deterministic and independent of configuration order. Configuring fewer or more than two mappings, omitting `direction`, or not assigning exactly one `outgoing` and one `incoming`, is a configuration error.
+
+The `table.<table_name>.node.*` properties (`table.<table_name>.node.labels`, `table.<table_name>.node.id.properties`, `table.<table_name>.node.properties.include`, `table.<table_name>.node.properties.exclude`, and `table.<table_name>.node.delete.detach`) apply only to `node.mode=node` and have no effect when `node.mode=relationship`, because no entity node is created.
+====
+
+.Neo4jCudConverter relationship configuration options
+[cols="30%a,10%a,10%a,50%a",options="header"]
+|===
+|Property
+|Default
+|Importance
+|Description
+
+|[[neo4j-rel-type]]<<neo4j-rel-type, `table.<table_name>.relationship.<fk_column>.type`>>
+|
+|high
+|The Neo4j relationship type (e.g., `PLACED_BY`, `CONTAINS`). Required when a relationship mapping is defined.
+
+|[[neo4j-rel-direction]]<<neo4j-rel-direction, `table.<table_name>.relationship.<fk_column>.direction`>>
+|`outgoing`
+|medium
+a|Relationship direction. In `node.mode=node` it controls the orientation of the FK relationship and defaults to `outgoing`. In `node.mode=relationship` it is *required* on both endpoints and identifies each endpoint's role: exactly one mapping must be `outgoing` (the source) and one `incoming` (the target).
+
+* `outgoing`: source node to target node.
+* `incoming`: target node to source node.
+
+|[[neo4j-rel-target-label]]<<neo4j-rel-target-label, `table.<table_name>.relationship.<fk_column>.target.label`>>
+|
+|high
+|The label of the target node. Required when a relationship mapping is defined.
+
+|[[neo4j-rel-target-id]]<<neo4j-rel-target-id, `table.<table_name>.relationship.<fk_column>.target.id`>>
+|Same as `<fk_column>`
+|medium
+|The property name on the target node that the FK value maps to.
+
+|[[neo4j-rel-target-node-op]]<<neo4j-rel-target-node-op, `table.<table_name>.relationship.<fk_column>.target.node.op`>>
+|`match`
+|medium
+a|How to handle the target node in the CUD relationship event:
+
+* `match`: the target node must already exist.
+* `merge`: create the target node with key properties if it does not exist.
+
+|[[neo4j-rel-properties]]<<neo4j-rel-properties, `table.<table_name>.relationship.<fk_column>.properties`>>
+|
+|medium
+|Comma-separated list of columns to include as relationship properties.
+|===
+
+=== Output configuration
+
+.Neo4jCudConverter output configuration options
+[cols="30%a,10%a,10%a,50%a",options="header"]
+|===
+|Property
+|Default
+|Importance
+|Description
+
+|[[neo4j-output-mode]]<<neo4j-output-mode, `output.mode`>>
+|`array`
+|high
+a|Controls the output format:
+
+* `array`: packs all CUD events into a JSON array. Requires a xref:neo4j-cud-converter-split-step[split step] before the Neo4j sink connector.
+* `single`: produces one CUD event per record. Directly consumable by the Neo4j sink connector.
+
+|[[neo4j-tombstones-enabled]]<<neo4j-tombstones-enabled, `tombstones.enabled`>>
+|`true`
+|low
+|Whether to pass through tombstone records (null value) emitted after delete events for Kafka log compaction.
+|===
+
+[[example-neo4j-cud-converter]]
+== Examples
+
+The following examples map a `customers`, an `orders`, and an `order_items` table.
+A single `Neo4jCudConverter` instance handles all three, with one `table.<table_name>.` namespace per table:
+
+[source]
+----
+transforms=neo4j
+transforms.neo4j.type=io.debezium.transforms.Neo4jCudConverter
+
+# customers: entity table without relationships
+transforms.neo4j.table.customers.node.labels=Customer
+transforms.neo4j.table.customers.node.id.properties=id
+
+# orders: entity table with a foreign key relationship
+transforms.neo4j.table.orders.node.labels=Order
+transforms.neo4j.table.orders.node.id.properties=id
+transforms.neo4j.table.orders.relationship.customer_id.type=PLACED_BY
+transforms.neo4j.table.orders.relationship.customer_id.target.label=Customer
+transforms.neo4j.table.orders.relationship.customer_id.target.id=id
+
+# order_items: join table (many-to-many relationship)
+transforms.neo4j.table.order_items.node.mode=relationship
+transforms.neo4j.table.order_items.relationship.order_id.direction=outgoing
+transforms.neo4j.table.order_items.relationship.order_id.type=CONTAINS
+transforms.neo4j.table.order_items.relationship.order_id.target.label=Order
+transforms.neo4j.table.order_items.relationship.order_id.target.id=id
+transforms.neo4j.table.order_items.relationship.product_id.direction=incoming
+transforms.neo4j.table.order_items.relationship.product_id.type=CONTAINS
+transforms.neo4j.table.order_items.relationship.product_id.target.label=Product
+transforms.neo4j.table.order_items.relationship.product_id.target.id=id
+transforms.neo4j.table.order_items.relationship.order_id.properties=quantity
+----
+
+The SMT reads `source.table` from each change event and applies the matching table mapping.
+The three subsections below walk through the output each mapping produces.
+
+=== Entity table without relationships
+
+The `customers` table has no foreign key columns, so its mapping declares only the node label and id:
+
+[source]
+----
+transforms.neo4j.table.customers.node.labels=Customer
+transforms.neo4j.table.customers.node.id.properties=id
+----
+
+An INSERT event produces the following CUD output (wrapped in an array by default):
+
+[source,json]
+----
+[
+  {
+    "type": "node",
+    "op": "merge",
+    "labels": ["Customer"],
+    "ids": { "id": 1004 },
+    "properties": {
+      "first_name": "John",
+      "last_name": "Foo",
+      "email": "john@foo.org"
+    }
+  }
+]
+----
+
+=== Entity table with foreign key relationship
+
+The `orders` table has a `customer_id` foreign key, so its mapping adds a relationship using the `table.<table_name>.relationship.<fk_column>.*` properties:
+
+[source]
+----
+transforms.neo4j.table.orders.node.labels=Order
+transforms.neo4j.table.orders.node.id.properties=id
+transforms.neo4j.table.orders.relationship.customer_id.type=PLACED_BY
+transforms.neo4j.table.orders.relationship.customer_id.target.label=Customer
+transforms.neo4j.table.orders.relationship.customer_id.target.id=id
+----
+
+An INSERT event produces an array with the node event followed by the relationship event:
+
+[source,json]
+----
+[
+  {
+    "type": "node",
+    "op": "merge",
+    "labels": ["Order"],
+    "ids": { "id": 5001 },
+    "properties": { "total": 99.95, "status": "pending" }
+  },
+  {
+    "type": "relationship",
+    "op": "merge",
+    "rel_type": "PLACED_BY",
+    "from": { "labels": ["Order"], "ids": { "id": 5001 }, "op": "merge" },
+    "to": { "labels": ["Customer"], "ids": { "id": 1004 }, "op": "match" },
+    "properties": {}
+  }
+]
+----
+
+The `customer_id` column is automatically excluded from the node properties because it is configured as a relationship.
+
+=== Join table (many-to-many relationship)
+
+The `order_items` join table uses `node.mode=relationship` to suppress the entity node and emit only the relationship:
+
+[source]
+----
+transforms.neo4j.table.order_items.node.mode=relationship
+transforms.neo4j.table.order_items.relationship.order_id.direction=outgoing
+transforms.neo4j.table.order_items.relationship.order_id.type=CONTAINS
+transforms.neo4j.table.order_items.relationship.order_id.target.label=Order
+transforms.neo4j.table.order_items.relationship.order_id.target.id=id
+transforms.neo4j.table.order_items.relationship.product_id.direction=incoming
+transforms.neo4j.table.order_items.relationship.product_id.type=CONTAINS
+transforms.neo4j.table.order_items.relationship.product_id.target.label=Product
+transforms.neo4j.table.order_items.relationship.product_id.target.id=id
+transforms.neo4j.table.order_items.relationship.order_id.properties=quantity
+----
+
+The `order_id` mapping is `outgoing` (the source) and `product_id` is `incoming` (the target), so the relationship runs `(Order)-[:CONTAINS]->(Product)` regardless of configuration order.
+The relationship `type` and `properties` are taken from the `outgoing` (source) mapping.
+
+With `output.mode=array` (the default), the output includes node merges for the referenced endpoints followed by the relationship event.
+Non-FK columns on the join table (like `quantity`) become relationship properties.


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2274
Based on https://github.com/debezium/debezium-design-documents/issues/55
  ## Description

  Implement a new `Neo4jCudConverter` Single Message Transform that converts Debezium CDC envelope events into Neo4j's CUD format
Add SMT documentation with configuration details, examples and split step section

  ### Tests

  - unit tests for each compontents + a\ PostgreSQL integration test** (`Neo4jCudConverterIT`) that covers  INSERT, UPDATE, DELETE, FK relationships, join tables, and a full use case (e-commerce) pipeline (customers → orders → order\_items)

  ## PR Checklist

  - [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
  - [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
  - [x] One feature/change per PR unless tightly coupled
  - [x] Do a rebase on upstream `main`