### PR TITLE
debezium/dbz#2387 Use java.sql.Array during value conversion for snapshots with postgres

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -474,6 +474,7 @@ Matt Vance
 Matteo Capitanio
 Mathieu Rozieres
 Matthias Crauwels
+Matthias Hengel
 Matthias Wessendorf
 Mauricio Scheffer
 Max Kaplan

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -1557,7 +1558,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                         .map(elementConverter::convert)
                         .collect(Collectors.toList()));
             }
-            else if (data instanceof PgArray array) {
+            else if (data instanceof Array array) {
                 try {
                     final List<Object> converted;
                     if (elementType.getOid() == PgOid.TIMETZ) {
@@ -1579,7 +1580,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         });
     }
 
-    private List<Object> convertTimeWithTimeZoneArray(PgArray data, PostgresType elementType, ValueConverter elementConverter) throws SQLException {
+    private List<Object> convertTimeWithTimeZoneArray(Array data, PostgresType elementType, ValueConverter elementConverter) throws SQLException {
         final List<Object> converted = new ArrayList<>();
         try (ResultSet values = data.getResultSet()) {
             while (values.next()) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresValueConverterTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresValueConverterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+
+class PostgresValueConverterTest {
+
+    private static final int NUMERIC_ARRAY_OID = 2003;
+
+    private static final Column NUMERIC_ARRAY_COLUMN = Column.editor()
+            .name("numeric_array")
+            .type("_numeric")
+            .jdbcType(Types.ARRAY)
+            .nativeType(NUMERIC_ARRAY_OID)
+            .length(9)
+            .scale(3)
+            .optional(false)
+            .create();
+
+    private static final Field NUMERIC_ARRAY_FIELD = new Field("numeric_array", 0,
+            SchemaBuilder.array(Decimal.builder(3).optional().build()).build());
+
+    private static final List<BigDecimal> VALUES = List.of(new BigDecimal("1.100"), new BigDecimal("2.200"));
+
+    private final PostgresValueConverter converter = PostgresValueConverter.of(
+            new PostgresConnectorConfig(Configuration.create()
+                    .with(CommonConnectorConfig.TOPIC_PREFIX, "test")
+                    .build()),
+            StandardCharsets.UTF_8,
+            null);
+
+    private final ValueConverter elementConverter = value -> value;
+
+    @Test
+    public void shouldConvertArrayFromJdbcArrayThatIsNotAPgArray() {
+        Object converted = converter.convertArray(NUMERIC_ARRAY_COLUMN, NUMERIC_ARRAY_FIELD, PostgresType.UNKNOWN,
+                elementConverter, jdbcArrayOf(VALUES.toArray()));
+
+        assertThat(converted).isEqualTo(VALUES);
+    }
+
+    @Test
+    public void shouldConvertArrayFromList() {
+        Object converted = converter.convertArray(NUMERIC_ARRAY_COLUMN, NUMERIC_ARRAY_FIELD, PostgresType.UNKNOWN,
+                elementConverter, VALUES);
+
+        assertThat(converted).isEqualTo(VALUES);
+    }
+
+    @Test
+    public void shouldRejectValueThatIsNeitherAnArrayNorAList() {
+        assertThatThrownBy(() -> converter.convertArray(NUMERIC_ARRAY_COLUMN, NUMERIC_ARRAY_FIELD,
+                PostgresType.UNKNOWN, elementConverter, "{1.100,2.200}"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unexpected value for JDBC type " + Types.ARRAY);
+    }
+
+    private static Array jdbcArrayOf(Object[] values) {
+        return (Array) Proxy.newProxyInstance(
+                PostgresValueConverterTest.class.getClassLoader(),
+                new Class<?>[]{ Array.class },
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getArray":
+                            return values;
+                        case "getBaseType":
+                            return Types.NUMERIC;
+                        case "toString":
+                            return "java.sql.Array" + List.of(values);
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        default:
+                            throw new UnsupportedOperationException(method.getName());
+                    }
+                });
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -402,3 +402,4 @@ JunWang222,Jun Wang
 nickchomey,Nick Chomey
 bisbeb,Björn Bärtschi
 rajusurarapu149,Raju Surarapu
+henm,Matthias Hengel


### PR DESCRIPTION
Fixes debezium/dbz#2387

## Description

When using the AWS Advanced JDBC driver, a driver-specific implementation of java.sql.Array is returned by the driver instead of the expected PgArray. This leads to failure during taking snapshots of tables containing arrays.

This PR changes the value conversion from relying on the driver-specific PgArray to using the common interface java.sql.Array.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
