### PR TITLE
debezium/dbz#2398 Bind PostgreSQL numeric arrays without a type modifier to their element values

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -5,15 +5,18 @@
  */
 package io.debezium.connector.jdbc.dialect.postgres;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.VariableScaleDecimal;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
@@ -54,8 +57,17 @@ public class ArrayType extends AbstractType {
         if (nativeElementType != null) {
             return nativeElementType;
         }
+        if (isVariableScaleDecimalElement(schema)) {
+            // The scalar handler maps VariableScaleDecimal to double precision, which would round the
+            // exact values of a numeric[] away.
+            return "numeric";
+        }
         JdbcType elementJdbcType = dialect.getSchemaType(schema.valueSchema());
         return elementJdbcType.getTypeName(schema.valueSchema(), isKey);
+    }
+
+    private static boolean isVariableScaleDecimalElement(Schema schema) {
+        return VariableScaleDecimal.LOGICAL_NAME.equals(schema.valueSchema().name());
     }
 
     /**
@@ -77,7 +89,20 @@ public class ArrayType extends AbstractType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         final String elementTypeName = baseElementTypeName(getElementTypeName(this.getDialect(), schema, false));
-        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, elementTypeName));
+        return List.of(new ValueBindDescriptor(index, unwrapElements(schema, value), java.sql.Types.ARRAY, elementTypeName));
+    }
+
+    /**
+     * Unwraps {@link VariableScaleDecimal} elements to their {@code BigDecimal} value, which is what
+     * {@link java.sql.Connection#createArrayOf} can encode. Every other element type is passed through.
+     */
+    static Object unwrapElements(Schema schema, Object value) {
+        if (!isVariableScaleDecimalElement(schema)) {
+            return value;
+        }
+        return ((Collection<?>) value).stream()
+                .map(element -> element == null ? null : VariableScaleDecimal.toLogical((Struct) element).getDecimalValue().orElseThrow())
+                .toList();
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -18,6 +18,7 @@ import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.util.SchemaUtils;
 
 /**
  * An implementation of {@link JdbcType} for {@code ARRAY} column types.
@@ -57,17 +58,13 @@ public class ArrayType extends AbstractType {
         if (nativeElementType != null) {
             return nativeElementType;
         }
-        if (isVariableScaleDecimalElement(schema)) {
+        if (SchemaUtils.isVariableScaleDecimal(schema.valueSchema())) {
             // The scalar handler maps VariableScaleDecimal to double precision, which would round the
             // exact values of a numeric[] away.
             return "numeric";
         }
         JdbcType elementJdbcType = dialect.getSchemaType(schema.valueSchema());
         return elementJdbcType.getTypeName(schema.valueSchema(), isKey);
-    }
-
-    private static boolean isVariableScaleDecimalElement(Schema schema) {
-        return VariableScaleDecimal.LOGICAL_NAME.equals(schema.valueSchema().name());
     }
 
     /**
@@ -97,7 +94,7 @@ public class ArrayType extends AbstractType {
      * {@link java.sql.Connection#createArrayOf} can encode. Every other element type is passed through.
      */
     static Object unwrapElements(Schema schema, Object value) {
-        if (!isVariableScaleDecimalElement(schema)) {
+        if (!SchemaUtils.isVariableScaleDecimal(schema.valueSchema())) {
             return value;
         }
         return ((Collection<?>) value).stream()

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -7,9 +7,18 @@ package io.debezium.connector.jdbc.dialect.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import io.debezium.data.VariableScaleDecimal;
+import io.debezium.doc.FixFor;
 
 /**
  * Unit tests for the PostgreSQL {@link ArrayType} handler.
@@ -77,6 +86,31 @@ class ArrayTypeTest {
         assertThat(ArrayType.nativeElementTypeName("_TEXT")).isNull();
         assertThat(ArrayType.nativeElementTypeName("_INT4")).isNull();
         assertThat(ArrayType.nativeElementTypeName("_UUID")).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2398")
+    @DisplayName("Should unwrap VariableScaleDecimal elements to their decimal value")
+    void testUnwrapsVariableScaleDecimalElements() {
+        // Connection#createArrayOf cannot encode a Struct; the driver renders it through toString().
+        final Schema elementSchema = VariableScaleDecimal.optionalSchema();
+        final Schema arraySchema = SchemaBuilder.array(elementSchema).optional().build();
+        final List<Object> elements = Arrays.asList(
+                VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("1.25")),
+                null);
+
+        assertThat(ArrayType.unwrapElements(arraySchema, elements))
+                .isEqualTo(Arrays.asList(new BigDecimal("1.25"), null));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2398")
+    @DisplayName("Should pass elements of other types through untouched")
+    void testPassesOtherElementsThrough() {
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+        final List<Object> elements = List.of("a", "b");
+
+        assertThat(ArrayType.unwrapElements(arraySchema, elements)).isSameAs(elements);
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -35,6 +35,7 @@ import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.Enum;
 import io.debezium.data.Json;
 import io.debezium.data.Uuid;
+import io.debezium.data.VariableScaleDecimal;
 import io.debezium.doc.FixFor;
 import io.debezium.time.StructuredDate;
 import io.debezium.time.StructuredDuration;
@@ -699,6 +700,87 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new BigDecimal[]{
                     new BigDecimal("1.25"), new BigDecimal("2.50"), new BigDecimal("-9999999.99") });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2398")
+    public void testShouldWorkWithUnboundedNumericArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        // A numeric[] column without a type modifier has no precision/scale, so the source emits each
+        // element as a VariableScaleDecimal struct rather than a Decimal.
+        final Schema elementSchema = VariableScaleDecimal.optionalSchema();
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.array(elementSchema).optional().build(),
+                Arrays.asList(
+                        VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("1.25")),
+                        VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("2.50")),
+                        VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("-9999999.99"))),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        final String sql = "CREATE TABLE %s (id int not null, data numeric[], primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getArray(2).getArray()).isEqualTo(new BigDecimal[]{
+                    new BigDecimal("1.25"), new BigDecimal("2.50"), new BigDecimal("-9999999.99") });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2398")
+    public void testShouldCreateNumericArrayColumnForUnboundedNumericArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema elementSchema = VariableScaleDecimal.optionalSchema();
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.array(elementSchema).optional().build(),
+                List.of(VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("1.25"))),
+                config);
+
+        consume(createRecord);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().assertColumn(destinationTable, "data", "_numeric");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getArray(2).getArray()).isEqualTo(new BigDecimal[]{ new BigDecimal("1.25") });
             return null;
         });
     }

--- a/debezium-sink/src/main/java/io/debezium/util/SchemaUtils.java
+++ b/debezium-sink/src/main/java/io/debezium/util/SchemaUtils.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 import org.apache.kafka.connect.data.Schema;
 
+import io.debezium.data.VariableScaleDecimal;
+
 public class SchemaUtils {
     private static final String SCHEMA_PARAMETER_COLUMN_TYPE = "__debezium.source.column.type";
     private static final String SCHEMA_PARAMETER_COLUMN_SIZE = "__debezium.source.column.length";
@@ -30,6 +32,10 @@ public class SchemaUtils {
 
     public static Optional<String> getSourceColumnName(Schema schema) {
         return getSchemaParameter(schema, SCHEMA_PARAMETER_COLUMN_NAME);
+    }
+
+    public static boolean isVariableScaleDecimal(Schema schema) {
+        return VariableScaleDecimal.LOGICAL_NAME.equals(schema.name());
     }
 
     public static Optional<String> getSchemaParameter(Schema schema, String parameterName) {

--- a/debezium-sink/src/test/java/io/debezium/util/SchemaUtilsTest.java
+++ b/debezium-sink/src/test/java/io/debezium/util/SchemaUtilsTest.java
@@ -79,4 +79,13 @@ class SchemaUtilsTest {
 
         assertThat(SchemaUtils.getSchemaParameter(schema, "__debezium.source.column.type")).isEmpty();
     }
+
+    @FixFor("debezium/dbz#2398")
+    @Test
+    void shouldDetectVariableScaleDecimalSchema() {
+        Schema schema = SchemaBuilder.struct().name("io.debezium.data.VariableScaleDecimal").build();
+
+        assertThat(SchemaUtils.isVariableScaleDecimal(schema)).isTrue();
+        assertThat(SchemaUtils.isVariableScaleDecimal(Schema.FLOAT64_SCHEMA)).isFalse();
+    }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2398

## Description

A PostgreSQL `numeric` column without a type modifier carries no precision or scale, so the source emits the elements of a `numeric[]` column as `io.debezium.data.VariableScaleDecimal` structs. Writing such a column to a PostgreSQL sink fails on the first record:

```
INSERT INTO public.t (id,data) VALUES (('1'::int2),('{"Struct{scale=2,value=[B@2e51ede1}",...}'))
ERROR: invalid input syntax for type double precision: "Struct{scale=2,value=[B@2e51ede1}"
```

`ArrayType#getElementTypeName` resolves the element type through the element schema's handler, and `VariableScaleDecimalType#getTypeName` answers `double precision` — correct for a scalar, where a single value carries no precision information, but wrong for an array: with `schema.evolution=basic` the sink then creates a `double precision[]` column and rounds the exact values away. `ArrayType#bind` also passes the elements to `Connection#createArrayOf` untouched, which cannot encode a `Struct`, so the driver renders it through `toString()`.

The scalar path already unwraps the struct in `VariableScaleDecimalType#bind`; only the array path was missing the equivalent. `ArrayType` now resolves such an element to `numeric` and unwraps the elements to their `BigDecimal` value before binding.

`numeric(10,2)[]` is unaffected: its element schema is a `Decimal` carrying the precision and scale, and keeps resolving as before (debezium/dbz#2100).

**Scope.** The scalar `VariableScaleDecimalType#getTypeName` mapping is deliberately left untouched. Changing it is what debezium/dbz#1163 and debezium/dbz#854 are about, and other dialects depend on the current behaviour — the e2e pipeline tests assert `double precision` for scalar `VariableScaleDecimal` columns, including for Oracle `NUMBER`. Special values (`NaN`, `Infinity`) behave exactly as they do for a scalar, which cannot be represented as a `BigDecimal` either.

The UNNEST batch path is out of scope here: it fails for every array column, not only this one, which is debezium/dbz#2399.

The dialect type mapping table in the documentation lists `io.debezium.data.VariableScaleDecimal` as `Types.DOUBLE`, which is the scalar mapping and is unchanged here, so the table still holds and the documentation is not updated.

**Tests.** `ArrayTypeTest` covers the element unwrapping directly (including a null element and the pass-through for other element types). `JdbcSinkColumnTypeMappingIT` gains a round trip into a pre-created `numeric[]` column and one asserting that `schema.evolution=basic` creates the column as `numeric[]` rather than `double precision[]`. Reverting either half of the change fails them with the reported errors: dropping the unwrapping gives `invalid input syntax for type numeric: "Struct{scale=2,value=[B@...}"`, and dropping the element type name silently loses the scale (`2.50` comes back as `2.5`).

Verified with `it-postgresql` (`JdbcSinkColumnTypeMappingIT`, 120 tests across PostgreSQL, MySQL and SQL Server) and the module's 337 unit tests.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

