### PR TITLE
debezium/dbz#2399 Write records with an array column row-wise instead of an UNNEST batch

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -188,11 +188,15 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
      * records take the row-wise path as well. An enum field is handled row-wise for a related reason:
      * the array cast above is derived from the field schema, which for an enum only resolves to the
      * character varying fallback, whereas the cast has to name the destination column's enum type.
+     * An {@code ARRAY} field cannot be batched at all: this path binds one array per column holding the
+     * value of every row, so an array column would need an array of arrays, and the cast derived above
+     * would be {@code ?::text[][]}, which {@code UNNEST} flattens into scalars the column rejects.
      */
     private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
         return record.jdbcFields().values().stream()
                 .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT
                         || field.getSchema().type() == Schema.Type.BYTES
+                        || field.getSchema().type() == Schema.Type.ARRAY
                         || Enum.LOGICAL_NAME.equals(field.getSchema().name()));
     }
 

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestArrayIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestArrayIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkTest;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+
+/**
+ * UNNEST batch write tests for PostgreSQL with array columns.
+ *
+ * <p>The UNNEST path binds one array per column carrying the value of every row in the batch, which an
+ * array column cannot express. Records with an ARRAY field must therefore fall back to the row-wise
+ * path, which this test verifies end to end.</p>
+ *
+ * @author Debezium Authors
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-postgresql")
+@ExtendWith(PostgresSinkDatabaseContextProvider.class)
+public class JdbcSinkUnnestArrayIT extends AbstractJdbcSinkTest {
+
+    public JdbcSinkUnnestArrayIT(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2399")
+    public void testUnnestBatchWithArrayColumn(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord record1 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "col_array", arraySchema, List.of("a", "b"), config);
+        final JdbcKafkaSinkRecord record2 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2, "col_array", arraySchema, List.of("c"), config);
+
+        // A single call with more than one record produces one multi-record batch, which is the
+        // precondition for the UNNEST statement (a single record takes the per-row path).
+        consume(List.of(record1, record2));
+
+        getSink().assertRows(destinationTableName(record1), rs -> {
+            assertThat(rs.getArray("col_array").getArray()).isEqualTo(new String[]{ "a", "b" });
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getArray("col_array").getArray()).isEqualTo(new String[]{ "c" });
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2399

## Description

With `dialect.postgres.unnest.insert.enabled=true`, a batch holding more than one record fails for any array column:

```
ERROR: column "col_array" is of type text[] but expression is of type text
```

`getBatchInsertStatement` derives each column's cast from the field schema, and for an array field that schema type is `ArrayType`, whose `getTypeName` already ends in `[]`. The placeholder therefore becomes `?::text[][]`, and `UNNEST` over it flattens one level too many and yields `text` scalars the column rejects. The values cannot be reshaped either: this path binds one array per column holding the value of every row, so an array column would need an array of arrays.

Records carrying an array field now take the row-wise path through the existing `hasUnnestUnsupportedField` escape hatch, which already serves the geometric `STRUCT` types (debezium/dbz#2135), `bytea` fields (debezium/dbz#2357) and enum fields (debezium/dbz#1344).

A single-record batch was never affected, because `getBatchInsertStatement` already returns empty for one record and the write takes the row-wise path — which is why the existing array tests did not catch this.

**Tests.** `JdbcSinkUnnestArrayIT` writes two records with a `text[]` column in one batch with UNNEST enabled, mirroring `JdbcSinkUnnestBytesIT`. Reverting the change fails it with the error above. Verified alongside `JdbcSinkUnnestBehaviorIT`, `JdbcSinkUnnestBytesIT`, `JdbcSinkColumnTypeMappingIT` and `JdbcSinkInsertModeIT` (242 tests across PostgreSQL, MySQL and SQL Server) and the module's 335 unit tests.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
