### PR TITLE
debezium/dbz#2400 Bump PostgreSQL JDBC driver to 42.7.13 for CVE-2026-54291

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <version.hibernate>7.2.6.Final</version.hibernate>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.7.11</version.postgresql.driver>
+        <version.postgresql.driver>42.7.13</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.41.0</version.mysql.binlog>
         <version.singlestore.driver>1.2.11</version.singlestore.driver>


### PR DESCRIPTION
The build pins version.postgresql.driver=42.7.11, which is in the affected range of CVE-2026-54291 (GHSA-j92g-9f8w-j867, severity high): silent channel-binding authentication downgrade in pgjdbc, affecting >= 42.7.4 and < 42.7.12. The driver ships in released artifacts including the JDBC sink and CockroachDB connectors, and Confluent Hub's verification scan flagged it in the 3.7.0.Alpha1 archives.

Bumps the driver to 42.7.13, the current latest patch release.

Verification: with the bumped driver, the JDBC sink integration suites for PostgreSQL and CockroachDB pass locally (insert modes, transaction conflict retries, UNNEST batches).

cc @Naros: if this can make the 3.7.0.Final cut, the Final artifacts and our refreshed Confluent Hub submission ship clear of the flagged range.

Closes https://github.com/debezium/dbz/issues/2400