### PR TITLE
debezium/dbz#2403 Document secondary unique constraint limitations

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -312,9 +312,11 @@ endif::community[]
 |`INSERT ... ON CONFLICT ... DO UPDATE SET ...`
 |Configured primary key only
 
+ifdef::community[]
 |SingleStore
 |`INSERT ... ON DUPLICATE KEY UPDATE ...`
 |Any unique index
+endif::community[]
 
 |SQL Server
 |`MERGE ...`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -281,49 +281,75 @@ If the primary key value already exists, the operation updates values in the row
 If the specified primary key value doesn't exist, an `insert` adds a new row.
 
 Each database dialect handles idempotent writes differently, because there is no SQL standard for _upsert_ operations.
-The following table shows the `upsert` DML syntax for the database dialects that {prodname} supports:
+The following table shows the `upsert` DML syntax for the database dialects that {prodname} supports, and the constraint that each dialect evaluates to decide between the insert and the update action:
 
 |===
-|Dialect |Upsert Syntax
+|Dialect |Upsert Syntax |Constraint that triggers the update action
 
 |CockroachDB
 |`INSERT ... ON CONFLICT ... DO UPDATE SET ...`
+|Configured primary key only
 
 |Db2
 |`MERGE ...`
+|Configured primary key only
+
+|MariaDB
+|`INSERT ... ON DUPLICATE KEY UPDATE ...`
+|Any unique index
 
 |MySQL
 |`INSERT ... ON DUPLICATE KEY UPDATE ...`
+|Any unique index
 
 |Oracle
 |`MERGE ...`
+|Configured primary key only
 
 |PostgreSQL
 |`INSERT ... ON CONFLICT ... DO UPDATE SET ...`
+|Configured primary key only
 
 |SingleStore
 |`INSERT ... ON DUPLICATE KEY UPDATE ...`
+|Any unique index
 
 |SQL Server
 |`MERGE ...`
+|Configured primary key only
 
 |StarRocks
 |`INSERT ...` (PRIMARY KEY tables execute inserts as upserts)
+|Table primary key
 
 |===
 
 [WARNING]
 ====
 Secondary unique constraints can create ordering dependencies between records that have different primary keys.
-Kafka guarantees record order only within a partition.
-If dependent records are routed to different partitions, the sink connector might apply them out of source order, causing a unique constraint violation.
+Kafka guarantees record order only within a partition, and the connector batches and reduces events based only on the configured primary key.
+For these reasons, avoid defining secondary unique constraints or secondary unique indexes on destination tables.
+If a uniqueness rule must be enforced, enforce it in the source database, and omit the constraint from the destination table.
 
-MySQL and SingleStore use `INSERT ... ON DUPLICATE KEY UPDATE`, which reacts to a conflict with any unique index, not only the configured primary key.
-A secondary unique-key conflict can therefore update an existing row whose primary key differs from the incoming record, potentially causing data inconsistency without reporting an error.
+If dependent records are routed to different partitions, the sink connector might apply them out of source order.
+How the resulting conflict surfaces depends on the dialect, as shown in the preceding table:
 
-If a destination table contains secondary unique constraints, route all dependent events through the same Kafka partition, preserve source event order, and set xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer=false`].
-For a table with dependencies between arbitrary rows, using a single partition for its Kafka topic provides this ordering.
+* Dialects that use `INSERT ... ON DUPLICATE KEY UPDATE` react to a conflict with any unique index, not only the configured primary key.
+A secondary unique-key conflict can therefore update an existing row whose primary key differs from the incoming record, causing silent data inconsistency.
+* Dialects that use `INSERT ... ON CONFLICT` or `MERGE` detect conflicts only on the configured primary key.
+A conflict with a secondary unique constraint causes the write to fail with a constraint violation error, rather than silently modifying a different row.
+
+If a destination table must retain a secondary unique constraint, all of the following conditions are required:
+
+* Route all dependent events through the same Kafka partition, and preserve the source event order.
+For a table with dependencies between arbitrary rows, use a single partition for its Kafka topic.
 Setting `tasks.max=1` alone does not restore ordering between records that are already in different partitions.
+* Keep xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer`] at its default value of `false`.
+Reduction by primary key can remove intermediate row states that are required to satisfy secondary unique constraints.
+* Set xref:jdbc-property-batch-size[`batch.size`] to `1` if a batch might contain multiple events for a primary key that does not yet exist in the destination table.
+Some dialects and driver configurations process a batch in a single pass, rather than validating each row against the effects of the preceding rows in the same batch.
+For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`, and PostgreSQL combines the batch into a single multi-row statement when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is enabled.
+In both cases, the batch fails.
 ====
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -362,7 +362,7 @@ A conflict involving a secondary unique constraint can therefore update an exist
 A conflict involving a secondary unique constraint causes the write operation to fail with a constraint violation error rather than updating a different row.
 |===
 
-For a destination table to retain a secondary unique constraint, the data pipeline must meet all of the following requirements:
+To prevent data inconsistencies when a destination table includes a secondary unique constraint, the data pipeline must meet all of the following requirements:
 
 Dependent events routed through the same partition::
 Route all dependent events through the same Kafka partition, and preserve the source event order.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -281,7 +281,7 @@ If the primary key value already exists, the operation updates values in the row
 If the specified primary key value doesn't exist, an `insert` adds a new row.
 
 Each database dialect handles idempotent writes differently, because there is no SQL standard for _upsert_ operations.
-The following table shows the `upsert` DML syntax for the database dialects that {prodname} supports, and the constraint that each dialect evaluates to decide between the insert and the update action:
+The following table shows the upsert DML syntax for each database dialect that {prodname} supports and which constraints trigger an update action when processing an `upsert` operation.
 
 |===
 |Dialect |Upsert Syntax |Constraint that triggers the update action
@@ -326,31 +326,55 @@ The following table shows the `upsert` DML syntax for the database dialects that
 
 [WARNING]
 ====
+Secondary unique constraints can create ordering dependencies.
+For more information about their use, see xref:sink-connector-secondary-unique-constraints[secondary unique constraints].
+====
+
+// Type: concept
+// ModuleID: debezium-jdbc-connector-secondary-unique-constraints
+[id="sink-connector-secondary-unique-constraints"]
+=== Secondary unique constraints in sink connectors
+
 Secondary unique constraints can create ordering dependencies between records that have different primary keys.
 Kafka guarantees record order only within a partition, and the connector batches and reduces events based only on the configured primary key.
-For these reasons, avoid defining secondary unique constraints or secondary unique indexes on destination tables.
-If a uniqueness rule must be enforced, enforce it in the source database, and omit the constraint from the destination table.
+For these reasons, you should avoid defining secondary unique constraints or secondary unique indexes on destination tables.
+If a uniqueness rule must be enforced, enforce the rule in the source database, and omit the constraint from the destination table.
+
+.Understanding the risk
 
 If dependent records are routed to different partitions, the sink connector might apply them out of source order.
-How the resulting conflict surfaces depends on the dialect, as shown in the preceding table:
+The following table shows how different database dialects respond to a resulting conflict:
 
-* Dialects that use `INSERT ... ON DUPLICATE KEY UPDATE` react to a conflict with any unique index, not only the configured primary key.
+.Dialect-specific behavior when secondary unique constraint conflicts occur
+|===
+|Dialect |Behavior
+
+|Dialects that use `INSERT ... ON DUPLICATE KEY UPDATE`
+|React to a conflict with any unique index, not only the configured primary key.
 A secondary unique-key conflict can therefore update an existing row whose primary key differs from the incoming record, causing silent data inconsistency.
-* Dialects that use `INSERT ... ON CONFLICT` or `MERGE` detect conflicts only on the configured primary key.
+
+|Dialects that use `INSERT ... ON CONFLICT` or `MERGE`
+|Detect conflicts only on the configured primary key.
 A conflict with a secondary unique constraint causes the write to fail with a constraint violation error, rather than silently modifying a different row.
+|===
 
-If a destination table must retain a secondary unique constraint, all of the following conditions are required:
+For a destination table to retain a secondary unique constraint, the data pipeline must meet all of the following requirements:
 
-* Route all dependent events through the same Kafka partition, and preserve the source event order.
+Dependent events routed through the same partition::
+Route all dependent events through the same Kafka partition, and preserve the source event order.
 For a table with dependencies between arbitrary rows, use a single partition for its Kafka topic.
-Setting `tasks.max=1` alone does not restore ordering between records that are already in different partitions.
-* Keep xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer`] at its default value of `false`.
+Setting `tasks.max=1` is not sufficient to restore ordering between records that are already in different partitions.
+
+Reduction buffering disabled::
+The default value (`false`) is retained for the xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer`] property.
 Reduction by primary key can remove intermediate row states that are required to satisfy secondary unique constraints.
-* Set xref:jdbc-property-batch-size[`batch.size`] to `1` if a batch might contain multiple events for a primary key that does not yet exist in the destination table.
+
+Batch size set to `1`::
+The xref:jdbc-property-batch-size[`batch.size`] property is set to `1` if a batch might contain multiple events for a primary key that does not yet exist in the destination table.
++
 Some dialects and driver configurations process a batch in a single pass, rather than validating each row against the effects of the preceding rows in the same batch.
 For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`, and PostgreSQL combines the batch into a single multi-row statement when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is enabled.
-In both cases, the batch fails.
-====
+In each of these cases, the batch fails.
 
 // Type: reference
 // Title: Schema evolution modes for the {prodname} JDBC connector

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -338,7 +338,7 @@ For more information about their use, see xref:sink-connector-secondary-unique-c
 Secondary unique constraints can create ordering dependencies between records that have different primary keys.
 Kafka guarantees record order only within a partition, and the connector batches and reduces events based only on the configured primary key.
 For these reasons, you should avoid defining secondary unique constraints or secondary unique indexes on destination tables.
-If a uniqueness rule must be enforced, enforce the rule in the source database, and omit the constraint from the destination table.
+If a uniqueness rule is required, enforce the rule in the source database, and omit the constraint from the destination table.
 
 .Understanding the risk
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -346,8 +346,6 @@ Kafka guarantees record order only within a partition, and the connector batches
 For these reasons, you should avoid defining secondary unique constraints or secondary unique indexes on destination tables.
 If a uniqueness rule is required, enforce the rule in the source database, and omit the constraint from the destination table.
 
-.Understanding the risk
-
 If dependent records are routed to different partitions, the sink connector might apply them out of source order.
 The following table shows how different database dialects respond to a resulting conflict:
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -286,9 +286,11 @@ The following table shows, for each database dialect that {prodname} supports, t
 |===
 |Dialect |Upsert Syntax |Constraint that triggers the update action
 
+ifdef::community[]
 |CockroachDB
 |`INSERT ... ON CONFLICT ... DO UPDATE SET ...`
 |Configured primary key only
+endif::community[]
 
 |Db2
 |`MERGE ...`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -312,6 +312,20 @@ The following table shows the `upsert` DML syntax for the database dialects that
 
 |===
 
+[WARNING]
+====
+Secondary unique constraints can create ordering dependencies between records that have different primary keys.
+Kafka guarantees record order only within a partition.
+If dependent records are routed to different partitions, the sink connector might apply them out of source order, causing a unique constraint violation.
+
+MySQL and SingleStore use `INSERT ... ON DUPLICATE KEY UPDATE`, which reacts to a conflict with any unique index, not only the configured primary key.
+A secondary unique-key conflict can therefore update an existing row whose primary key differs from the incoming record, potentially causing data inconsistency without reporting an error.
+
+If a destination table contains secondary unique constraints, route all dependent events through the same Kafka partition, preserve source event order, and set xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer=false`].
+For a table with dependencies between arbitrary rows, using a single partition for its Kafka topic provides this ordering.
+Setting `tasks.max=1` alone does not restore ordering between records that are already in different partitions.
+====
+
 // Type: reference
 // Title: Schema evolution modes for the {prodname} JDBC connector
 // ModuleID: debezium-jdbc-connector-schema-evolution-modes
@@ -1996,6 +2010,8 @@ Choose one of the following settings:
 `true`:: The connector uses the reduction buffer to reduce change events before it writes them to the sink database.
 That is, if multiple events refer to the same primary key, the connector consolidates the SQL queries and writes only a single logical SQL change, based on the row state that is reported in the most recent offset record.
 Choose this option to reduce the SQL load on the target database.
+Do not enable the reduction buffer if destination constraints create dependencies between records with different primary keys.
+Reduction by primary key can remove intermediate row states that are required to satisfy secondary unique constraints.
 
 To optimize query processing in a PostgreSQL sink database when the reduction buffer is enabled, you must also enable the database to execute the batched queries by adding the `reWriteBatchedInserts` parameter to the JDBC connection URL.
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -374,7 +374,7 @@ Retain the default value (`false`) of the xref:jdbc-property-use-reduction-buffe
 Reduction by primary key can remove intermediate row states that are required to satisfy secondary unique constraints.
 
 Batch size set to `1`::
-The xref:jdbc-property-batch-size[`batch.size`] property is set to `1` if a batch might contain multiple events for a primary key that does not yet exist in the destination table.
+Set the value of the xref:jdbc-property-batch-size[`batch.size`] property to `1` if any batches might contain multiple events for a primary key that is not defined in the destination table.
 +
 Some dialects and driver configurations process a batch in a single pass, rather than validating each row against the effects of the preceding rows in the same batch.
 For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`, and PostgreSQL combines the batch into a single multi-row statement when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is enabled.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -377,7 +377,8 @@ Batch size set to `1`::
 Set the value of the xref:jdbc-property-batch-size[`batch.size`] property to `1` if any batches might contain multiple events for a primary key that is not defined in the destination table.
 +
 Some dialects and driver configurations process a batch in a single pass, rather than validating each row against the effects of the preceding rows in the same batch.
-For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`, and PostgreSQL combines the batch into a single multi-row statement when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is enabled.
+For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`.
+Similarly, when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is set to `true`, PostgreSQL combines a batch into a single multi-row statement.
 In each of these cases, the batch fails.
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -281,7 +281,7 @@ If the primary key value already exists, the operation updates values in the row
 If the specified primary key value doesn't exist, an `insert` adds a new row.
 
 Each database dialect handles idempotent writes differently, because there is no SQL standard for _upsert_ operations.
-The following table shows the upsert DML syntax for each database dialect that {prodname} supports and which constraints trigger an update action when processing an `upsert` operation.
+The following table shows, for each database dialect that {prodname} supports, the upsert DML syntax and the constraints that trigger an update action during an upsert operation.
 
 |===
 |Dialect |Upsert Syntax |Constraint that triggers the update action

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -354,8 +354,8 @@ The following table shows how different database dialects handle conflicts invol
 |Dialect |Behavior
 
 |Dialects that use `INSERT ... ON DUPLICATE KEY UPDATE`
-|React to a conflict with any unique index, not only the configured primary key.
-A secondary unique-key conflict can therefore update an existing row whose primary key differs from the incoming record, causing silent data inconsistency.
+|Consider conflicts on any unique index, not only the configured primary key.
+A conflict involving a secondary unique constraint can therefore update an existing row whose primary key differs from the incoming record, causing silent data inconsistency.
 
 |Dialects that use `INSERT ... ON CONFLICT` or `MERGE`
 |Detect conflicts only on the configured primary key.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -322,9 +322,11 @@ endif::community[]
 |`MERGE ...`
 |Configured primary key only
 
+ifdef::community[]
 |StarRocks
 |`INSERT ...` (PRIMARY KEY tables execute inserts as upserts)
 |Table primary key
+endif::community[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -346,7 +346,7 @@ Kafka guarantees record order only within a partition, and the connector batches
 For these reasons, you should avoid defining secondary unique constraints or secondary unique indexes on destination tables.
 If a uniqueness rule is required, enforce the rule in the source database, and omit the constraint from the destination table.
 
-If dependent records are routed to different partitions, the sink connector might apply them out of source order.
+If dependent records are routed to different partitions, the sink connector might apply records out of source order, which can lead to inconsistent results.
 The following table shows how different database dialects respond to a resulting conflict:
 
 .Dialect-specific behavior when secondary unique constraint conflicts occur

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -370,7 +370,7 @@ For a table with dependencies between arbitrary rows, use a single partition for
 Setting `tasks.max=1` is not sufficient to restore ordering between records that are already in different partitions.
 
 Reduction buffering disabled::
-The default value (`false`) is retained for the xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer`] property.
+Retain the default value (`false`) of the xref:jdbc-property-use-reduction-buffer[`use.reduction.buffer`] property.
 Reduction by primary key can remove intermediate row states that are required to satisfy secondary unique constraints.
 
 Batch size set to `1`::

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -347,7 +347,7 @@ For these reasons, you should avoid defining secondary unique constraints or sec
 If a uniqueness rule is required, enforce the rule in the source database, and omit the constraint from the destination table.
 
 If dependent records are routed to different partitions, the sink connector might apply records out of source order, which can lead to inconsistent results.
-The following table shows how different database dialects respond to a resulting conflict:
+The following table shows how different database dialects handle conflicts involving secondary unique constraints:
 
 .Dialect-specific behavior when secondary unique constraint conflicts occur
 |===

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -358,8 +358,8 @@ The following table shows how different database dialects handle conflicts invol
 A conflict involving a secondary unique constraint can therefore update an existing row whose primary key differs from the incoming record, causing silent data inconsistency.
 
 |Dialects that use `INSERT ... ON CONFLICT` or `MERGE`
-|Detect conflicts only on the configured primary key.
-A conflict with a secondary unique constraint causes the write to fail with a constraint violation error, rather than silently modifying a different row.
+|Consider conflicts only on the configured primary key.
+A conflict involving a secondary unique constraint causes the write operation to fail with a constraint violation error rather than updating a different row.
 |===
 
 For a destination table to retain a secondary unique constraint, the data pipeline must meet all of the following requirements:


### PR DESCRIPTION
Fixes debezium/dbz#2403

## Description

Documents the JDBC sink limitations when destination tables contain secondary unique constraints.

The update explains that:

- dependent records from different Kafka partitions can be applied out of source order;
- MySQL and SingleStore upserts can match a secondary unique index and silently update a row with a different primary key; and
- primary-key reduction can discard intermediate states required to satisfy a secondary unique constraint.

It also documents the safe processing conditions: route dependent events through the same partition, preserve source order, and disable the reduction buffer.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
