### PR TITLE
debezium/dbz#2401 Accept qualified table names in FLUSH TABLES

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -108,6 +108,16 @@ public class MySqlAntlrDdlParserTest
     }
 
     @Test
+    @FixFor("debezium/dbz#2401")
+    public void shouldParseFlushTablesWithQualifiedTableNames() {
+        parser.parse("FLUSH TABLES `mysql`.`user`", tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+
+        parser.parse("FLUSH TABLES mysql.user, other.tbl FOR EXPORT", tables);
+        assertThat(parser.getParsingExceptionsFromWalker()).isEmpty();
+    }
+
+    @Test
     public void testMultiColumnAlterWithDefaults() {
         String ddl = "CREATE TABLE ALTER_DATE_TIME (ID int primary key);"
                 + "ALTER TABLE ALTER_DATE_TIME ADD COLUMN (CREATED timestamp not null default current_timestamp, C time not null default '08:00');";

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2694,7 +2694,7 @@ logType
 flushTables
     : (TABLES_SYMBOL | TABLE_SYMBOL) (
         WITH_SYMBOL READ_SYMBOL LOCK_SYMBOL
-        | identifierList flushTablesOptions?
+        | tableRefList flushTablesOptions?
     )?
     ;
 

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
@@ -8,6 +8,8 @@ flush local tables Foo;
 flush tables Foo, Bar;
 flush tables Foo, Bar for export;
 flush tables Foo, Bar with read lock;
+flush tables `mysql`.`user`;
+flush tables mysql.user, Bar for export;
 #end
 #begin
 -- 'FLUSH TABLE' is an alias for 'FLUSH TABLES' (https://dev.mysql.com/doc/refman/8.0/en/flush.html)


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2401

### Problem

The non-legacy MySQL DDL parser cannot parse a `FLUSH TABLES` statement whose tables are schema-qualified:

```
io.debezium.text.ParsingException: DDL statement couldn't be parsed. [...] 'FLUSH TABLES `mysql`.`user`'
extraneous input '.' expecting {<EOF>, '(', ALTER_SYMBOL, ...}
```

This breaks schema history recovery when such a statement was recorded. Switching to `ddl.parser.type: legacy` is the current workaround.

### Root cause

`flushTables` in `MySqlParser.g4` accepted `identifierList` (`ident_string_list` in `sql_yacc.yy`), which is a list of bare identifiers and cannot express a `db.tbl` qualifier. MySQL's own grammar uses `table_list`, which is built from `table_ident` and does allow the qualifier; the legacy Debezium grammar likewise uses `tables` → `tableName`.

### Fix

Use `tableRefList` in `flushTables`. `tableRef` is `qualifiedIdentifier | dotIdentifier`, so both `db.tbl` and `.tbl` forms parse. This is a grammar-only change — no parser listener references `flushTables`.

### Testing

- New `MySqlAntlrDdlParserTest#shouldParseFlushTablesWithQualifiedTableNames` covering `` FLUSH TABLES `mysql`.`user` `` and a multi-table `FOR EXPORT` variant. Verified it fails with the reported error without the grammar change.
- Extended the `mysql/examples/ddl_flush.sql` corpus fixture with the qualified forms.
- `MySqlAntlrDdlParserTest` (173) and `MySqlPtAntlrDdlParserTest` (165) pass, as does the `debezium-ddl-parser` corpus suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
