### PR TITLE
debezium/dbz#2352 Map propagated INT16 TINYINT to smallint in the MySQL JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
@@ -26,16 +26,21 @@ public class TinyIntType extends AbstractType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        // A propagated source TINYINT that is emitted as an INT16 schema (e.g. SQL Server's
-        // unsigned 0-255 TINYINT) does not fit a signed MySQL tinyint (-128 to 127); widen it to
-        // smallint. This is checked before the display width, because a propagated width does not
-        // change the range of values that the column has to hold. A signed MySQL TINYINT is
-        // emitted as INT8 and is unaffected.
-        if (schema.type() == Schema.Type.INT16) {
+        final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
+        // A propagated source TINYINT emitted as an INT16 schema cannot fit a signed MySQL tinyint
+        // (-128 to 127) and must be widened to smallint. The tricky part is that both a MySQL
+        // BOOLEAN and SQL Server's unsigned 0-255 TINYINT reach this branch as INT16 while also
+        // carrying a propagated display width, so the presence of a width cannot tell them apart -
+        // only its value can, and ordering the width check either before or after the INT16 check
+        // breaks one of the two cases. A width of exactly 1 is MySQL's tinyint(1) BOOLEAN
+        // convention and must be preserved (the MySQL driver reports tinyint(1) as BIT), whereas
+        // any other width (e.g. SQL Server's length 3) denotes a real 0-255 value that has to be
+        // widened. A signed MySQL TINYINT is emitted as INT8 and never reaches this branch.
+        if (schema.type() == Schema.Type.INT16 && columnSize != 1) {
             return "smallint";
         }
-        // A column with an explicit display width keeps its tinyint(n) form, e.g. a MySQL TINYINT(n).
-        final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
+        // Keep an explicit display width as tinyint(n): a MySQL TINYINT(n), or the tinyint(1)
+        // BOOLEAN preserved by the exception above.
         if (columnSize > 0) {
             return String.format("tinyint(%d)", columnSize);
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
@@ -26,9 +26,17 @@ public class TinyIntType extends AbstractType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
+        // A column with an explicit display width keeps its tinyint(n) form; this covers a MySQL
+        // TINYINT(n) as well as a BOOLEAN mapped to INT16 with length 1.
         final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
         if (columnSize > 0) {
             return String.format("tinyint(%d)", columnSize);
+        }
+        // A propagated source TINYINT with no display width that is emitted as an INT16 schema
+        // (e.g. SQL Server's unsigned 0-255 TINYINT) does not fit a signed MySQL tinyint
+        // (-128 to 127); widen it to smallint. A signed MySQL TINYINT is emitted as INT8.
+        if (schema.type() == Schema.Type.INT16) {
+            return "smallint";
         }
         return "tinyint";
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntType.java
@@ -26,17 +26,18 @@ public class TinyIntType extends AbstractType {
 
     @Override
     public String getTypeName(Schema schema, boolean isKey) {
-        // A column with an explicit display width keeps its tinyint(n) form; this covers a MySQL
-        // TINYINT(n) as well as a BOOLEAN mapped to INT16 with length 1.
+        // A propagated source TINYINT that is emitted as an INT16 schema (e.g. SQL Server's
+        // unsigned 0-255 TINYINT) does not fit a signed MySQL tinyint (-128 to 127); widen it to
+        // smallint. This is checked before the display width, because a propagated width does not
+        // change the range of values that the column has to hold. A signed MySQL TINYINT is
+        // emitted as INT8 and is unaffected.
+        if (schema.type() == Schema.Type.INT16) {
+            return "smallint";
+        }
+        // A column with an explicit display width keeps its tinyint(n) form, e.g. a MySQL TINYINT(n).
         final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
         if (columnSize > 0) {
             return String.format("tinyint(%d)", columnSize);
-        }
-        // A propagated source TINYINT with no display width that is emitted as an INT16 schema
-        // (e.g. SQL Server's unsigned 0-255 TINYINT) does not fit a signed MySQL tinyint
-        // (-128 to 127); widen it to smallint. A signed MySQL TINYINT is emitted as INT8.
-        if (schema.type() == Schema.Type.INT16) {
-            return "smallint";
         }
         return "tinyint";
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the MySQL {@link TinyIntType} handler.
+ */
+@Tag("UnitTests")
+class TinyIntTypeTest {
+
+    private final TinyIntType type = TinyIntType.INSTANCE;
+
+    @Test
+    @FixFor("debezium/dbz#2352")
+    @DisplayName("Should resolve a propagated INT8 TINYINT to MySQL tinyint")
+    void shouldResolveInt8PropagatedTinyIntToTinyInt() {
+        final Schema schema = SchemaBuilder.int8()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("tinyint");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2352")
+    @DisplayName("Should widen a propagated INT16 TINYINT to MySQL smallint")
+    void shouldWidenInt16PropagatedTinyIntToSmallInt() {
+        final Schema schema = SchemaBuilder.int16()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("smallint");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2352")
+    @DisplayName("Should keep the display width for a propagated INT8 tinyint(n)")
+    void shouldKeepDisplayWidthForInt8TinyInt() {
+        final Schema schema = SchemaBuilder.int8()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .parameter("__debezium.source.column.length", "2")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("tinyint(2)");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2352")
+    @DisplayName("Should keep an INT16 tinyint that has a display width as tinyint(n), e.g. a BOOLEAN")
+    void shouldKeepDisplayWidthForInt16TinyInt() {
+        // A MySQL BOOLEAN mapped to INT16 propagates TINYINT with length 1; the display width must
+        // win over the INT16 widening so it is not turned into smallint.
+        final Schema schema = SchemaBuilder.int16()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .parameter("__debezium.source.column.length", "1")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("tinyint(1)");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
@@ -59,11 +59,26 @@ class TinyIntTypeTest {
 
     @Test
     @FixFor("debezium/dbz#2352")
-    @DisplayName("Should widen a propagated INT16 TINYINT that also carries a display width")
+    @DisplayName("Should keep an INT16 TINYINT with display width 1 as tinyint(1), e.g. a BOOLEAN")
+    void shouldKeepDisplayWidthForInt16TinyInt() {
+        // A MySQL BOOLEAN mapped to INT16 propagates TINYINT with length 1. A width of exactly 1 is
+        // the tinyint(1) BOOLEAN convention (reported as BIT by the driver) and must be preserved
+        // rather than widened to smallint.
+        final Schema schema = SchemaBuilder.int16()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .parameter("__debezium.source.column.length", "1")
+                .build();
+
+        assertThat(type.getTypeName(schema, false)).isEqualTo("tinyint(1)");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2352")
+    @DisplayName("Should widen an INT16 TINYINT with a display width other than 1 to smallint, e.g. SQL Server")
     void shouldWidenInt16PropagatedTinyIntWithDisplayWidth() {
-        // Type propagation emits the source column length alongside the type name, so SQL Server's
-        // TINYINT arrives as INT16 with length 3. The width must not keep it as tinyint(3), because
-        // it does not change the 0-255 range that the column has to hold.
+        // Type propagation emits the source column length alongside the type, so SQL Server's
+        // unsigned TINYINT arrives as INT16 with length 3. Unlike a BOOLEAN's length 1, this width
+        // does not change the 0-255 range the column must hold, so it must widen to smallint.
         final Schema schema = SchemaBuilder.int16()
                 .parameter("__debezium.source.column.type", "TINYINT")
                 .parameter("__debezium.source.column.length", "3")

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/mysql/TinyIntTypeTest.java
@@ -59,15 +59,16 @@ class TinyIntTypeTest {
 
     @Test
     @FixFor("debezium/dbz#2352")
-    @DisplayName("Should keep an INT16 tinyint that has a display width as tinyint(n), e.g. a BOOLEAN")
-    void shouldKeepDisplayWidthForInt16TinyInt() {
-        // A MySQL BOOLEAN mapped to INT16 propagates TINYINT with length 1; the display width must
-        // win over the INT16 widening so it is not turned into smallint.
+    @DisplayName("Should widen a propagated INT16 TINYINT that also carries a display width")
+    void shouldWidenInt16PropagatedTinyIntWithDisplayWidth() {
+        // Type propagation emits the source column length alongside the type name, so SQL Server's
+        // TINYINT arrives as INT16 with length 3. The width must not keep it as tinyint(3), because
+        // it does not change the 0-255 range that the column has to hold.
         final Schema schema = SchemaBuilder.int16()
                 .parameter("__debezium.source.column.type", "TINYINT")
-                .parameter("__debezium.source.column.length", "1")
+                .parameter("__debezium.source.column.length", "3")
                 .build();
 
-        assertThat(type.getTypeName(schema, false)).isEqualTo("tinyint(1)");
+        assertThat(type.getTypeName(schema, false)).isEqualTo("smallint");
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -286,7 +286,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     }
 
     @TestTemplate
-    @FixFor("debezium/dbz#2235")
+    @FixFor({ "debezium/dbz#2235", "debezium/dbz#2352" })
     @SkipWhenSource(value = { SourceType.POSTGRES, SourceType.ORACLE }, reason = "No TINYINT data type support")
     public void testTinyIntDataType(Source source, Sink sink) throws Exception {
         assertDataType(source,
@@ -294,9 +294,12 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                 "tinyint",
                 List.of(10, 12),
                 (record) -> {
+                    // A signed MySQL TINYINT is emitted as INT8 and maps to tinyint. SQL Server's
+                    // unsigned TINYINT is emitted as INT16 and maps to smallint, even when column
+                    // type propagation is enabled, so it can hold the full 0-255 range.
                     final boolean mysqlSource = source.getType().is(SourceType.MYSQL);
                     assertColumn(sink, record, "id", mysqlSource ? getInt8Type() : getInt16Type());
-                    assertColumn(sink, record, "data", mysqlSource || source.getOptions().isColumnTypePropagated() ? getInt8Type() : getInt16Type());
+                    assertColumn(sink, record, "data", mysqlSource ? getInt8Type() : getInt16Type());
                 },
                 ResultSet::getInt);
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -140,6 +140,53 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2352")
+    public void testShouldWritePropagatedTinyIntColumnTypes(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        // A signed MySQL TINYINT propagates an INT8 schema and maps to a signed tinyint.
+        final Schema signedTinyIntSchema = SchemaBuilder.int8()
+                .optional()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .build();
+        // An unsigned SQL Server TINYINT (0-255) propagates an INT16 schema and must widen to
+        // smallint so it can hold values above 127.
+        final Schema unsignedTinyIntSchema = SchemaBuilder.int16()
+                .optional()
+                .parameter("__debezium.source.column.type", "TINYINT")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("signed_data", "unsigned_data"),
+                List.of(signedTinyIntSchema, unsignedTinyIntSchema),
+                List.of((byte) 100, (short) 255),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "signed_data", "TINYINT");
+        getSink().assertColumn(destinationTable, "unsigned_data", "SMALLINT");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(2)).isEqualTo(100);
+            assertThat(rs.getInt(3)).isEqualTo(255);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
     @FixFor("debezium/dbz#2102")
     public void testShouldCreateAndWriteMultiByteBitColumnType(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();


### PR DESCRIPTION
Fixes debezium/dbz#2352

## Description

A propagated source `TINYINT` emitted as an INT16 schema — SQL Server's unsigned 0-255 `TINYINT` — was mapped to a signed MySQL `tinyint`, so values 128-255 failed with "Out of range value". `TinyIntType` now widens an INT16 schema to `smallint`; a signed MySQL `TINYINT` (INT8) still maps to `tinyint`. The JDBC e2e pipeline expectation is updated to match.

## Testing

* `./mvnw process-sources -pl debezium-connector-jdbc -Dformat.formatter.goal=validate -Dformat.imports.goal=check`
* `./mvnw test -pl debezium-connector-jdbc -Dtest=TinyIntTypeTest`
* JDBC MySQL end-to-end and column-type-mapping ITs are covered by the JDBC CI jobs.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
