### PR TITLE
debezium/dbz#2041 Register the delayed PostgreSQL types in dependency order

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -11,9 +11,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.Immutable;
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.util.Collect;
 
@@ -72,7 +75,8 @@ public class TypeRegistry {
     private static final String SQL_ENUM_VALUES = "SELECT t.enumtypid as id, array_agg(t.enumlabel ORDER BY t.enumsortorder) as values "
             + "FROM pg_catalog.pg_enum t GROUP BY id";
 
-    private static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+    @VisibleForTesting
+    static final String SQL_TYPES = "SELECT t.oid AS oid, t.typname AS name, n.nspname AS schema_name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
             + "FROM pg_catalog.pg_type t "
             + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "LEFT JOIN (" + SQL_ENUM_VALUES + ") e ON (t.oid = e.id) "
@@ -532,10 +536,54 @@ public class TypeRegistry {
             }
         }
 
-        // Resolve delayed builders
+        resolveDelayedBuilders(delayResolvedBuilders);
+    }
+
+    /**
+     * Registers the delayed builders dependency-first. A delayed type whose base or element type is delayed
+     * as well must be built after that dependency has been registered, otherwise
+     * {@link PostgresType.Builder#build()} resolves the dependency with an individual {@code SQL_OID_LOOKUP}
+     * query. The order in which the types are read from the database is not guaranteed to be a dependency
+     * order, so it is established here.
+     * <p>
+     * The dependencies are walked with an explicit stack to keep long chains of types off the JVM stack, and
+     * a builder is taken out of {@code unresolved} when it is first visited, so that a cycle cannot loop.
+     */
+    private void resolveDelayedBuilders(List<TypeBuilderWithSchema> delayResolvedBuilders) {
+        final Map<Integer, TypeBuilderWithSchema> unresolved = new HashMap<>();
         for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
-            addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
+            unresolved.put(builderWithSchema.oid(), builderWithSchema);
         }
+
+        final Deque<TypeBuilderWithSchema> unbuilt = new ArrayDeque<>();
+        for (TypeBuilderWithSchema builderWithSchema : delayResolvedBuilders) {
+            final TypeBuilderWithSchema root = unresolved.remove(builderWithSchema.oid());
+            if (root == null) {
+                // Already registered as a dependency of a previously processed type
+                continue;
+            }
+            unbuilt.push(root);
+            while (!unbuilt.isEmpty()) {
+                final TypeBuilderWithSchema current = unbuilt.peek();
+                final TypeBuilderWithSchema dependency = takeUnresolvedDependency(current, unresolved);
+                if (dependency != null) {
+                    unbuilt.push(dependency);
+                }
+                else {
+                    unbuilt.pop();
+                    addType(current.builder().build(), current.schemaName());
+                }
+            }
+        }
+    }
+
+    /**
+     * @return one type the given type depends on and that is not registered yet, or {@code null} if there is none
+     */
+    private static TypeBuilderWithSchema takeUnresolvedDependency(TypeBuilderWithSchema builderWithSchema,
+                                                                  Map<Integer, TypeBuilderWithSchema> unresolved) {
+        final TypeBuilderWithSchema parent = unresolved.remove(builderWithSchema.parentTypeOid());
+        return parent != null ? parent : unresolved.remove(builderWithSchema.elementTypeOid());
     }
 
     private void collectBuilders(ResultSet rs, List<TypeBuilderWithSchema> builders) throws SQLException {
@@ -543,7 +591,7 @@ public class TypeRegistry {
             TypeBuilderWithSchema builderWithSchema = createTypeBuilderFromResultSet(rs);
             // If the type has neither a base type nor an element type,
             // we can build and add it immediately.
-            if (!builderWithSchema.builder().hasParentType() && !builderWithSchema.builder().hasElementType()) {
+            if (builderWithSchema.parentTypeOid() == 0 && builderWithSchema.elementTypeOid() == 0) {
                 addType(builderWithSchema.builder().build(), builderWithSchema.schemaName());
                 continue;
             }
@@ -554,7 +602,7 @@ public class TypeRegistry {
         }
     }
 
-    private record TypeBuilderWithSchema(PostgresType.Builder builder, String schemaName) {
+    private record TypeBuilderWithSchema(PostgresType.Builder builder, String schemaName, int oid, int parentTypeOid, int elementTypeOid) {
     }
 
     private TypeBuilderWithSchema createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
@@ -575,14 +623,16 @@ public class TypeRegistry {
                 modifiers,
                 getTypeInfo(connection));
 
+        int elementTypeOid = 0;
         if (CATEGORY_ENUM.equals(category)) {
             String[] enumValues = (String[]) rs.getArray("enum_values").getArray();
             builder = builder.enumValues(Arrays.asList(enumValues));
         }
         else if (CATEGORY_ARRAY.equals(category)) {
-            builder = builder.elementType((int) rs.getLong("element"));
+            elementTypeOid = (int) rs.getLong("element");
+            builder = builder.elementType(elementTypeOid);
         }
-        return new TypeBuilderWithSchema(builder.parentType(parentTypeOid), schemaName);
+        return new TypeBuilderWithSchema(builder.parentType(parentTypeOid), schemaName, oid, parentTypeOid, elementTypeOid);
     }
 
     private PostgresType resolveUnknownType(String name) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/ConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/ConnectionIT.java
@@ -20,11 +20,14 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.util.Testing;
+
+import ch.qos.logback.classic.Level;
 
 public class ConnectionIT implements Testing {
 
@@ -137,6 +140,65 @@ public class ConnectionIT implements Testing {
                 conn.execute("DROP SCHEMA IF EXISTS dbz2350 CASCADE");
             }
         }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2041")
+    void shouldPrimeDependentTypesWithoutIndividualLookups() throws SQLException {
+        try (PostgresConnection conn = TestHelper.create()) {
+            conn.execute(
+                    "DROP SCHEMA IF EXISTS dbz2041 CASCADE",
+                    "CREATE SCHEMA dbz2041",
+                    "CREATE DOMAIN dbz2041.base_domain AS varchar(50)",
+                    "CREATE DOMAIN dbz2041.dependent_domain AS dbz2041.base_domain",
+                    // Rewrites the pg_type row of the base domain, so that the types are read back with the
+                    // dependent one first, as it happens on databases where the catalog has been updated.
+                    "ALTER DOMAIN dbz2041.base_domain SET NOT NULL");
+
+            final long baseTypeOid = conn.queryAndMap(
+                    "SELECT 'dbz2041.base_domain'::regtype::oid",
+                    rs -> {
+                        rs.next();
+                        return rs.getLong(1);
+                    });
+            assertThat(readTypeScanOrder(conn))
+                    .as("the types are no longer read with the dependent one first, so debezium/dbz#2041 is not reproduced")
+                    .containsSubsequence("dependent_domain", "base_domain");
+
+            final LogInterceptor logInterceptor = new LogInterceptor(TypeRegistry.class);
+            logInterceptor.setLoggerLevel(TypeRegistry.class, Level.TRACE);
+
+            TestHelper.getTypeRegistry();
+
+            assertThat(logInterceptor.containsMessage("Priming type registry with database types"))
+                    .as("the interceptor is attached and TRACE is enabled")
+                    .isTrue();
+            // Priming has to register the base domain first, rather than look it up on its own
+            assertThat(logInterceptor.containsMessage("Type OID '" + baseTypeOid + "' not cached")).isFalse();
+        }
+        finally {
+            try (PostgresConnection conn = TestHelper.create()) {
+                conn.execute("DROP SCHEMA IF EXISTS dbz2041 CASCADE");
+            }
+        }
+    }
+
+    /**
+     * @return the types of the {@code dbz2041} schema, in the order in which the registry reads the types.
+     *         The schema is filtered here rather than in the query, as an additional predicate lets
+     *         PostgreSQL use an index on pg_type and return the types in a different order.
+     */
+    private List<String> readTypeScanOrder(PostgresConnection conn) throws SQLException {
+        return conn.queryAndMap(TypeRegistry.SQL_TYPES,
+                rs -> {
+                    final List<String> typeNames = new ArrayList<>();
+                    while (rs.next()) {
+                        if ("dbz2041".equals(rs.getString("schema_name"))) {
+                            typeNames.add(rs.getString("name"));
+                        }
+                    }
+                    return typeNames;
+                });
     }
 
     private void assertUnqualifiedTypeNames(String searchPath) throws SQLException {


### PR DESCRIPTION
Fixes debezium/dbz#2041

## Description

`TypeRegistry#prime()` collects the types that have a base type (`typbasetype`) or an element type (`typelem`) and registers them after the types that have neither, in the order in which they were read from the database. That order is whatever order the catalog is scanned in, not a dependency order, so whenever a delayed type's dependency is registered later, `PostgresType.Builder#build()` resolves it through `TypeRegistry#get(oid)`, which misses the cache and issues an individual `SQL_OID_LOOKUP` query.

On a database with many custom types that turns startup into thousands of sequential round trips, which is what the issue reports as a 30+ minute startup.

The delayed types are now registered dependency-first. The dependencies are walked with an explicit stack, so that long chains of types stay off the JVM stack, and a builder is removed from the pending map when it is first visited, so that a cyclic catalog cannot loop. A dependency that is not part of the result set at all — for instance when priming is filtered to a set of schemas — is still resolved with a single lookup, as before.

Reproducer and effect, on PostgreSQL 15 with 3000 domains plus 3000 domains derived from them (12611 rows in `pg_type`). A plain `ALTER DOMAIN ... SET NOT NULL` on the base domains is enough to have the catalog return the dependent types first:

| | `SQL_OID_LOOKUP` queries per start | priming |
|---|---|---|
| before | 6000 | 392-564 ms |
| after | 0 | 23-134 ms |

The queries were counted on the server with `log_statement = all`. The timings are from a connection to localhost; with a 20 ms round trip those 6000 queries alone are two minutes of startup for this database, and the issue reports databases an order of magnitude larger.

Two side effects worth naming:

- Before this change a dependency that was resolved out of order was built twice — once by `resolveUnknownType`, once when the outer loop reached its own builder — leaving two instances for one OID. Now it is built once.
- The unqualified type name aliases registered in `addType` keep the first type of a given name, so with same-named types in different schemas the alias can now point to a different one. That tie was already decided by the physical scan order, i.e. it was never stable; this test relies on exactly that instability to reproduce the issue.

This picks up the analysis and the review discussion from debezium/debezium#7462 (closed for inactivity), including @Naros' suggestion to resolve the remaining types in a dependency order rather than to batch the lookups.

Tests: `ConnectionIT#shouldPrimeDependentTypesWithoutIndividualLookups` creates a domain and a domain derived from it, inverts the order in which the catalog returns them, and asserts that priming does not look up the base domain by OID. It fails on `main` and passes with the change. `ConnectionIT`, `DomainTypesIT`, `PostgresEnumIT`, `PostgresSchemaIT`, `RecordsSnapshotProducerIT` and `RecordsStreamProducerIT` pass (193 tests).

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
