### PR TITLE
debezium/dbz#1235 Use the column name as the decoders deliver it

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -37,7 +37,6 @@ import io.debezium.relational.TableSchema;
 import io.debezium.schema.DataCollectionSchema;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 /**
  * Emits change data based on a logical decoding event coming as protobuf or JSON message.
@@ -214,8 +213,8 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
         Object[] values = new Object[Math.max(schemaColumns.size(), columnsWithoutToasted)];
 
         for (ReplicationMessage.Column column : columns) {
-            // DBZ-298 Quoted column names will be sent like that in messages, but stored unquoted in the column names
-            final String columnName = Strings.unquoteIdentifierPart(column.getName());
+            // Decoders deliver the name unquoted; unquoting again mangles names that look quoted
+            final String columnName = column.getName();
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -54,7 +54,6 @@ import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
-import io.debezium.util.Strings;
 
 /**
  * Decodes messages from the PG logical replication plug-in ("pgoutput").
@@ -358,7 +357,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         Set<String> seenLowercaseColumnNames = new HashSet<>();
         for (short i = 0; i < columnCount; ++i) {
             byte flags = buffer.get();
-            String columnName = Strings.unquoteIdentifierPart(readString(buffer));
+            // pgoutput sends column names unquoted
+            String columnName = readString(buffer);
             int columnType = buffer.getInt();
             int attypmod = buffer.getInt();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -4980,6 +4980,23 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         }
     }
 
+    @Test
+    @FixFor("debezium/dbz#1235")
+    public void shouldStreamColumnWhoseNameIsItselfQuoted() throws Exception {
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS quoted_column_table;",
+                "CREATE TABLE quoted_column_table (pk SERIAL, \"'quoted'\" TEXT, PRIMARY KEY(pk));");
+        startConnector();
+        consumer = testConsumer(1);
+
+        executeAndWait("INSERT INTO quoted_column_table (\"'quoted'\") VALUES ('some text');");
+
+        assertRecordSchemaAndValues(
+                Collections.singletonList(new SchemaAndValueField("'quoted'", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "some text")),
+                consumer.remove(),
+                Envelope.FieldName.AFTER);
+    }
+
     private String getMessagePrefix(SourceRecord record) {
         Struct message = ((Struct) record.value()).getStruct(LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_KEY);
         return message.getString(LogicalDecodingMessageMonitor.DEBEZIUM_LOGICAL_DECODING_MESSAGE_PREFIX_KEY);


### PR DESCRIPTION
Fixes debezium/dbz#1235

## Description

`Strings.unquoteIdentifierPart` is not idempotent, and a PostgreSQL column name is currently run through it twice, so a name that itself starts and ends with a quote character (for example a column named `'quoted'`) is mangled.

The two decoders differ in how they put the name on the wire, which is why the second unquoting went unnoticed:

| Decoder | Wire format | Effect |
| --- | --- | --- |
| decoderbufs | quoted — [`decoderbufs.c:419`](https://github.com/debezium/postgres-decoderbufs/blob/main/src/decoderbufs.c) calls `quote_identifier(NameStr(attr->attname))` | `PgProtoReplicationMessage` correctly strips one layer, then `PostgresChangeRecordEmitter` strips another |
| pgoutput | raw — PostgreSQL sends `pq_sendstring(out, NameStr(att->attname))` in `logicalrep_write_rel` | `PgOutputMessageDecoder` unquotes a name that was never quoted |

This also answers the question left open on the issue: yes, pgoutput is affected too, at a different line than the one the reporter pointed at.

The failure is quiet rather than loud. Once the name no longer matches the relational model:

* with decoderbufs, `getPosition` finds no column, logs `Internal schema is out-of-sync with incoming decoder events` and omits the column from the change event;
* with pgoutput the relation message itself carries the mangled name, so the column is exposed as `quoted` while a snapshot of the same table reports `'quoted'` — the same topic ends up with two incompatible schemas.

Because pgoutput builds `columnDefaults`, `columnOptionality` and `primaryKeyColumns` by looking the name up against JDBC metadata, the mangled name also loses the column's default value, forces it to optional and drops its primary key flag. The duplicate-name guard hashes the mangled name as well, so `'a'` and `a` in one table could collide and raise a spurious "columns that differ only by case" error.

`PgProtoReplicationMessage` is deliberately left alone: decoderbufs really does quote the name, and removing that call would break `schemaChanged()`, which compares the message name against the table columns directly.

### Note on behaviour

For pgoutput, the field name of such a column changes from `quoted` to `'quoted'`, which is what the snapshot has always emitted for it and what the table actually contains. With `field.name.adjustment.mode` set, the name is sanitized as usual.

### How this survived

The emitter-level call dates back to DBZ-298, when the message carried the name as the protobuf plug-in had produced it, and it survived the DBZ-777 rewrite with its comment intact. `4e8cedd094` (DBZ-379) then added the same unquoting to `PgProtoReplicationMessage` without removing the first one, and `2f92553d8f` (DBZ-766) gave the new pgoutput decoder a copy of it. The existing quoted-identifier fixture, `"Quoted_"" . Text_Column"`, does not catch any of this: after one unquoting it starts with `Q`, so a second pass is a no-op.

## Tests

`RecordsStreamProducerIT#shouldStreamColumnWhoseNameIsItselfQuoted` covers a streaming insert into a column named `'quoted'`; there was no streaming coverage of quoted identifiers before. It fails on `main` under both decoders — with pgoutput the field is missing from the schema, with decoderbufs the field is present but null — and reverting either production change alone brings the failure back.

Verified locally against PostgreSQL 17 with both decoders: `RecordsStreamProducerIT` (131), `PostgresConnectorIT` (119 pgoutput / 112 decoderbufs) and `PostgresSchemaIT` (9) pass.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
