### PR TITLE
Dbz#2409 Fix nightly-build-size-check cache

### DIFF
--- a/.github/actions/build-debezium-ai/action.yml
+++ b/.github/actions/build-debezium-ai/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build Debezium AI module
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-jdbc/action.yml
+++ b/.github/actions/build-debezium-jdbc/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -30,6 +34,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
        key: ${{ inputs.maven-cache-key }}
+       save: ${{ inputs.maven-cache-save }}
 
     - name: Build JDBC
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-mariadb/action.yml
+++ b/.github/actions/build-debezium-mariadb/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -30,6 +34,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build MariaDB connector (MariaDB ${{ inputs.version-mariadb-server }} - ${{ inputs.profile }})
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-mongodb/action.yml
+++ b/.github/actions/build-debezium-mongodb/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -30,6 +34,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build MongoDB connector (MongoDB ${{ inputs.version-mongo-server }})
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-mysql/action.yml
+++ b/.github/actions/build-debezium-mysql/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -30,6 +34,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build MySQL connector (MySQL ${{ inputs.version-mysql-server }} - ${{ inputs.profile }})
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-openlineage/action.yml
+++ b/.github/actions/build-debezium-openlineage/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build Debezium OpenLineage module
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-oracle/action.yml
+++ b/.github/actions/build-debezium-oracle/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -26,6 +30,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     # We intentionally do not run the integration tests here because the runner does not have adequate space
     # for the docker container and pull requests are not permitted to fetch the container image.

--- a/.github/actions/build-debezium-postgres/action.yml
+++ b/.github/actions/build-debezium-postgres/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -26,6 +30,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build PostgreSQL connector (PostgreSQL - ${{ inputs.profile }})
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-schema-generator/action.yml
+++ b/.github/actions/build-debezium-schema-generator/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build Schema Generator
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-sqlserver/action.yml
+++ b/.github/actions/build-debezium-sqlserver/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build SQL Server connector
       shell: ${{ inputs.shell }}

--- a/.github/actions/build-debezium-storage/action.yml
+++ b/.github/actions/build-debezium-storage/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     # Required by storage module
     - name: Build Debezium (Core)

--- a/.github/actions/build-debezium-testing/action.yml
+++ b/.github/actions/build-debezium-testing/action.yml
@@ -5,6 +5,10 @@ inputs:
   maven-cache-key:
     description: "The maven build cache key"
     required: true
+  maven-cache-save:
+    description: "Whether to save the Maven cache after the job completes"
+    required: false
+    default: 'true'
   only-build:
     description: "Only build without tests, checkstyle, and format"
     required: false
@@ -22,6 +26,7 @@ runs:
     - uses: ./.github/actions/maven-cache
       with:
         key: ${{ inputs.maven-cache-key }}
+        save: ${{ inputs.maven-cache-save }}
 
     - name: Build Testing Module
       shell: ${{ inputs.shell }}

--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -5,11 +5,24 @@ inputs:
   key:
     description: "The maven cache key to use"
     required: true
+  save:
+    description: "Whether to save the cache after the job completes"
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
   steps:
+    - name: Restore Maven Repository (read-only)
+      if: ${{ inputs.save != 'true' }}
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.m2/repository
+        key: ${{ inputs.key }}
+        restore-keys: ${{ inputs.key }}
+
     - name: Cache Maven Repository
+      if: ${{ inputs.save == 'true' }}
       id: cache-check
       uses: actions/cache@v5
       with:

--- a/.github/workflows/nightly-build-size-check.yml
+++ b/.github/workflows/nightly-build-size-check.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-cassandra
         with:
           path-core: core
@@ -66,6 +67,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-db2
         with:
           path-core: core
@@ -99,6 +101,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-ibmi
         with:
           path-core: core
@@ -132,6 +135,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-ingres
         with:
           path-core: core
@@ -165,6 +169,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-informix
         with:
           path-core: core
@@ -198,6 +203,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-vitess
         with:
           path-core: core
@@ -231,6 +237,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-spanner
         with:
           path-core: core
@@ -264,6 +271,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-cockroachdb
         with:
           path-core: core
@@ -297,6 +305,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - uses: ./core/.github/actions/build-debezium-server
         with:
           path-core: core
@@ -325,6 +334,7 @@ jobs:
       - uses: ./core/.github/actions/maven-cache
         with:
           key: maven-debezium-test-build-${{ hashFiles('core/**/pom.xml') }}
+          save: 'false'
       - name: Build Debezium (Core)
         shell: bash
         run: >
@@ -357,6 +367,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -377,6 +388,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -397,6 +409,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -417,6 +430,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -437,6 +451,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -457,6 +472,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -477,6 +493,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -497,6 +514,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -517,6 +535,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -537,6 +556,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -557,6 +577,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -577,6 +598,7 @@ jobs:
         with:
           only-build: 'true'
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+          maven-cache-save: 'false'
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2409

## Description
Our future goal is to have a single cache write on CI push and all others jobs just read it. 
In this PR the cache action is prepared to act in read/write mode based on input parameter. 
The default is the current behavior read-write. 
The read behavior is only forced for the nightly-build-size-check cache

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
