### PR TITLE
debezium/dbz#2390 Add Antonio Marino to COPYRIGHT.txt and Aliases.txt

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -62,6 +62,7 @@ Ant Kutschera
 Anton Kondratev
 Anton Martynov
 Anton Repin
+Antonio Marino
 Aravind Pedapudi
 Aravind Gm
 Archie David

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -397,3 +397,4 @@ LucjanoC,Luciano Capo
 Chaitanya-030,Chaitanya Sheth
 pugarte7,Pablo Ugarte
 MarBruhn,Marcel Bruhn
+antonio0,Antonio Marino


### PR DESCRIPTION
Adds the author of debezium-connector-cockroachdb #73, #74, and #75 (debezium/dbz#2390, debezium/dbz#2391, debezium/dbz#2392) to COPYRIGHT.txt and Aliases.txt, as requested by the contributor-check bot on those pull requests.