### PR TITLE
debezium/dbz#2415 Create ConfigValue for deprecated aliases

### DIFF
--- a/debezium-config/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-config/src/main/java/io/debezium/config/Configuration.java
@@ -2027,7 +2027,12 @@ public interface Configuration {
     default Map<String, ConfigValue> validate(Field.Set fields) {
         // Create a map of configuration values for each field ...
         Map<String, ConfigValue> configValuesByFieldName = new HashMap<>();
-        fields.forEach(field -> configValuesByFieldName.put(field.name(), new ConfigValue(field.name())));
+        fields.forEach(field -> {
+            configValuesByFieldName.put(field.name(), new ConfigValue(field.name()));
+            for (String alias : field.deprecatedAliases()) {
+                configValuesByFieldName.put(alias, new ConfigValue(alias));
+            }
+        });
 
         // If any dependents don't exist ...
         fields.forEachMissingDependent(missingDependent -> {

--- a/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -14,6 +14,7 @@ import static io.debezium.relational.RelationalDatabaseConnectorConfig.HOSTNAME;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -23,6 +24,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -580,5 +582,53 @@ public class ConfigurationTest {
 
         // XStream field should not be validated when LogMiner is selected
         assertThat(validationResult.get("xstream.server.name").errorMessages()).isEmpty();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2415")
+    public void shouldReturnConfigValuesForDeprecatedAliases() {
+        Field fieldWithAlias = Field.create("canonical.name")
+                .withType(ConfigDef.Type.STRING)
+                .withWidth(ConfigDef.Width.MEDIUM)
+                .withImportance(ConfigDef.Importance.HIGH)
+                .withDescription("A field with a deprecated alias")
+                .withDeprecatedAliases("old.name");
+
+        Field requiredField = Field.create("required.field")
+                .withType(ConfigDef.Type.STRING)
+                .withWidth(ConfigDef.Width.MEDIUM)
+                .withImportance(ConfigDef.Importance.HIGH)
+                .withDescription("A required field")
+                .required();
+
+        Field.Set fields = Field.setOf(fieldWithAlias, requiredField);
+
+        ConfigDef configDef = new ConfigDef();
+        Field.group(configDef, "test-group", fieldWithAlias, requiredField);
+
+        Configuration config = Configuration.create()
+                .with("canonical.name", "some-value")
+                .build();
+
+        Map<String, ConfigValue> results = config.validate(fields);
+
+        // ConfigDef includes both the canonical name and the deprecated alias
+        assertThat(configDef.configKeys()).containsKey("canonical.name");
+        assertThat(configDef.configKeys()).containsKey("old.name");
+
+        // Verify that validate() returns a ConfigValue for every key in ConfigDef,
+        // including deprecated aliases. Kafka Connect's AbstractHerder iterates
+        // all ConfigDef keys and calls configValue.errors() on each matching
+        // ConfigValue; a missing entry causes an NPE (DBZ-2415).
+        List<String> missingKeys = new ArrayList<>();
+        for (String configKey : configDef.configKeys().keySet()) {
+            if (!results.containsKey(configKey)) {
+                missingKeys.add(configKey);
+            }
+        }
+        assertThat(missingKeys)
+                .as("Every ConfigDef key must have a corresponding ConfigValue from validate(), "
+                        + "otherwise Kafka Connect's AbstractHerder will throw an NPE")
+                .isEmpty();
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2415

## Description
In a recent change, `Field.group` adds deprecated aliases to the `ConfigDef`. When Kafka Connect iterates all `ConfigDef` keys, it expects there to be a matching `ConfigValue`; however, for these deprecated aliases there is not.

Rather than fall back to the old behavior where deprecated aliases were not registered in `Field.group`, this PR guarantees that a `ConfigValue` is constructed for deprecated aliases to satisfy Kafka Connect's requirements.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
