### PR TITLE
debezium/dbz#2418 Resolve the unchanged toast placeholder of an array from its element schema

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.processors.reselect;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -15,10 +16,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
@@ -101,8 +104,6 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
     private ByteBuffer unavailableValuePlaceholderBytes;
     private Map<String, String> unavailableValuePlaceholderMap;
     private String unavailableValuePlaceholderJson;
-    private List<Integer> unavailablePlaceholderIntArray;
-    private List<Long> unavailablePlaceholderLongArray;
     private RelationalDatabaseSchema schema;
     private RelationalDatabaseConnectorConfig connectorConfig;
     private CustomConverterRegistry customConverterRegistry;
@@ -389,12 +390,6 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
         this.unavailableValuePlaceholderBytes = ByteBuffer.wrap(connectorConfig.getUnavailableValuePlaceholder());
         this.unavailableValuePlaceholderMap = Map.of(this.unavailableValuePlaceholder, this.unavailableValuePlaceholder);
         this.unavailableValuePlaceholderJson = "{\"" + this.unavailableValuePlaceholder + "\":\"" + this.unavailableValuePlaceholder + "\"}";
-        unavailablePlaceholderIntArray = new ArrayList<>(unavailableValuePlaceholderBytes.limit());
-        unavailablePlaceholderLongArray = new ArrayList<>(unavailableValuePlaceholderBytes.limit());
-        for (byte b : unavailableValuePlaceholderBytes.array()) {
-            unavailablePlaceholderIntArray.add((int) b);
-            unavailablePlaceholderLongArray.add((long) b);
-        }
 
         this.valueConverterProvider = beanRegistry.lookupByName(StandardBeanNames.VALUE_CONVERTER, ValueConverterProvider.class);
         this.jdbcConnection = beanRegistry.lookupByName(StandardBeanNames.JDBC_CONNECTION, JdbcConnection.class);
@@ -487,14 +482,44 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
 
     private boolean isUnavailableArrayValueHolder(Schema schema, Object value) {
         assert schema.type() == Type.ARRAY;
-        switch (schema.valueSchema().type()) {
+        // An array placeholder carries one element per placeholder byte, expressed in the element type,
+        // which is how the integer[] and bigint[] placeholders have always been built. Element types that
+        // hold the placeholder as a single element are already matched by the caller, element by element.
+        final Schema elementSchema = schema.valueSchema();
+        switch (elementSchema.type()) {
+            case INT16:
+                return isPlaceholderBytesPerElement(value, b -> (short) b);
             case INT32:
-                return unavailablePlaceholderIntArray.equals(value);
+                return isPlaceholderBytesPerElement(value, b -> b);
             case INT64:
-                return unavailablePlaceholderLongArray.equals(value);
+                return isPlaceholderBytesPerElement(value, b -> (long) b);
+            case FLOAT32:
+                return isPlaceholderBytesPerElement(value, b -> (float) b);
+            case FLOAT64:
+                return isPlaceholderBytesPerElement(value, b -> (double) b);
+            case BOOLEAN:
+                return isPlaceholderBytesPerElement(value, b -> b != 0);
+            case BYTES:
+                return Decimal.LOGICAL_NAME.equals(elementSchema.name())
+                        && isPlaceholderBytesPerElement(value, b -> Decimal.toLogical(elementSchema, new byte[]{ (byte) b }));
+            case STRUCT:
+                return VariableScaleDecimal.LOGICAL_NAME.equals(elementSchema.name())
+                        && isPlaceholderBytesPerElement(value, b -> VariableScaleDecimal.fromLogical(elementSchema, BigDecimal.valueOf(b)));
             default:
                 return false;
         }
+    }
+
+    private boolean isPlaceholderBytesPerElement(Object value, IntFunction<Object> elementMapper) {
+        if (!(value instanceof List<?> elements) || elements.size() != unavailableValuePlaceholderBytes.limit()) {
+            return false;
+        }
+        for (int i = 0; i < elements.size(); i++) {
+            if (!elementMapper.apply(unavailableValuePlaceholderBytes.get(i)).equals(elements.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private Object getConvertedValue(TableId tableId, Column column, org.apache.kafka.connect.data.Field field, Object value) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -1552,7 +1552,12 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     protected Object convertArray(Column column, Field fieldDefn, PostgresType elementType, ValueConverter elementConverter, Object data) {
         return convertValue(column, fieldDefn, data, Collections.emptyList(), (r) -> {
-            if (data instanceof List) {
+            if (UnchangedToastedReplicationMessageColumn.isUnchangedToastedValue(data)) {
+                // The placeholder has to be expressed in the element type, a plain string would not fit the
+                // array schema. Element types without a representation fall through to handleUnknownData.
+                unchangedToastedPlaceholder.getArrayValue(fieldDefn.schema().valueSchema()).ifPresent(r::deliver);
+            }
+            else if (data instanceof List) {
                 r.deliver(((List<?>) data).stream()
                         .map(value -> resolveArrayValue(value, elementType))
                         .map(elementConverter::convert)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
@@ -5,13 +5,20 @@
  */
 package io.debezium.connector.postgresql;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.IntFunction;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.data.Uuid;
+import io.debezium.data.VariableScaleDecimal;
 
 /**
  * Helper that returns placeholder values for unchanged toasted columns.
@@ -40,25 +47,65 @@ public class UnchangedToastedPlaceholder {
         toastPlaceholderString = new String(toastPlaceholderBinary);
         toastPlaceholderUuid = UUID.nameUUIDFromBytes(toastPlaceholderBinary).toString();
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE, toastPlaceholderString);
-        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_TEXT_ARRAY_TOAST_VALUE,
-                Arrays.asList(toastPlaceholderString));
-        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_BINARY_ARRAY_TOAST_VALUE,
-                Arrays.asList(toastPlaceholderBinary));
-        final List<Integer> toastedIntArrayPlaceholder = new ArrayList<>(toastPlaceholderBinary.length);
-        final List<Long> toastedLongArrayPlaceholder = new ArrayList<>(toastPlaceholderBinary.length);
-        for (byte b : toastPlaceholderBinary) {
-            toastedIntArrayPlaceholder.add((int) b);
-            toastedLongArrayPlaceholder.add((long) b);
-        }
-        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_INT_ARRAY_TOAST_VALUE, toastedIntArrayPlaceholder);
-        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_BIGINT_ARRAY_TOAST_VALUE, toastedLongArrayPlaceholder);
         toastPlaceholderHstore.put(toastPlaceholderString, toastPlaceholderString);
         placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_HSTORE_TOAST_VALUE, toastPlaceholderHstore);
-        placeholderValues.put(UnchangedToastedReplicationMessageColumn.UNCHANGED_UUID_TOAST_VALUE, Arrays.asList(toastPlaceholderUuid));
     }
 
     public Optional<Object> getValue(Object obj) {
         return Optional.ofNullable(placeholderValues.get(obj));
+    }
+
+    /**
+     * Returns the placeholder for an array column, expressed in the array's element type.
+     * <p>
+     * Text-like elements carry the placeholder as a single element, every other element type carries one
+     * element per placeholder byte, which is how the {@code integer[]} and {@code bigint[]} placeholders
+     * have always been built. An empty result means the element type has no placeholder representation
+     * yet, in which case the caller keeps the existing behaviour.
+     * <p>
+     * <b>NOTE:</b> a new element type has to be recognized by
+     * {@link io.debezium.processors.reselect.ReselectColumnsPostProcessor} as well, otherwise the column
+     * is no longer re-selected.
+     *
+     * @param elementSchema schema of the array's elements; never null
+     */
+    public Optional<List<Object>> getArrayValue(Schema elementSchema) {
+        switch (elementSchema.type()) {
+            case STRING:
+                return Optional.of(List.of(Uuid.LOGICAL_NAME.equals(elementSchema.name()) ? toastPlaceholderUuid : toastPlaceholderString));
+            case BYTES:
+                if (Decimal.LOGICAL_NAME.equals(elementSchema.name())) {
+                    return Optional.of(placeholderBytesAs(b -> Decimal.toLogical(elementSchema, new byte[]{ (byte) b })));
+                }
+                return Optional.of(List.of(toastPlaceholderBinary));
+            case INT16:
+                return Optional.of(placeholderBytesAs(b -> (short) b));
+            case INT32:
+                return Optional.of(placeholderBytesAs(b -> b));
+            case INT64:
+                return Optional.of(placeholderBytesAs(b -> (long) b));
+            case FLOAT32:
+                return Optional.of(placeholderBytesAs(b -> (float) b));
+            case FLOAT64:
+                return Optional.of(placeholderBytesAs(b -> (double) b));
+            case BOOLEAN:
+                return Optional.of(placeholderBytesAs(b -> b != 0));
+            case STRUCT:
+                if (VariableScaleDecimal.LOGICAL_NAME.equals(elementSchema.name())) {
+                    return Optional.of(placeholderBytesAs(b -> VariableScaleDecimal.fromLogical(elementSchema, BigDecimal.valueOf(b))));
+                }
+                return Optional.empty();
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private List<Object> placeholderBytesAs(IntFunction<Object> elementMapper) {
+        final List<Object> placeholder = new ArrayList<>(toastPlaceholderBinary.length);
+        for (byte b : toastPlaceholderBinary) {
+            placeholder.add(elementMapper.apply(b));
+        }
+        return placeholder;
     }
 
     public byte[] getToastPlaceholderBinary() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
@@ -18,27 +18,15 @@ import io.debezium.connector.postgresql.connection.AbstractReplicationMessageCol
  */
 public class UnchangedToastedReplicationMessageColumn extends AbstractReplicationMessageColumn {
 
-    private static final String TYPE_ARRAY_SUFFIX = "[]";
-    private static final String TYPE_ARRAY_PREFIX = "_";
     /**
      * Marker value indicating an unchanged TOAST column value.
      */
     public static final Object UNCHANGED_TOAST_VALUE = new Object();
-    public static final Object UNCHANGED_TEXT_ARRAY_TOAST_VALUE = new Object();
-    public static final Object UNCHANGED_BINARY_ARRAY_TOAST_VALUE = new Object();
-    public static final Object UNCHANGED_INT_ARRAY_TOAST_VALUE = new Object();
-    public static final Object UNCHANGED_BIGINT_ARRAY_TOAST_VALUE = new Object();
     public static final Object UNCHANGED_HSTORE_TOAST_VALUE = new Object();
-    public static final Object UNCHANGED_UUID_TOAST_VALUE = new Object();
 
     private static final Object[] UNCHANGED_TOAST_VALUES = {
             UnchangedToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_TEXT_ARRAY_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_BINARY_ARRAY_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_INT_ARRAY_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_BIGINT_ARRAY_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_HSTORE_TOAST_VALUE,
-            UnchangedToastedReplicationMessageColumn.UNCHANGED_UUID_TOAST_VALUE };
+            UnchangedToastedReplicationMessageColumn.UNCHANGED_HSTORE_TOAST_VALUE };
     private Object unchangedToastValue;
 
     public UnchangedToastedReplicationMessageColumn(String columnName, PostgresType type, String typeWithModifiers, boolean optional) {
@@ -70,65 +58,8 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
     }
 
     private void setUnchangedToastValue(String typeWithModifiers) {
-        typeWithModifiers = removeSizeModifierFromArrayTypes(typeWithModifiers);
-        switch (typeWithModifiers) {
-            case "text[]":
-            case "_text":
-            case "character varying[]":
-            case "_varchar":
-            case "character[]":
-            case "_bpchar":
-            case "json[]":
-            case "_json":
-            case "jsonb[]":
-            case "_jsonb":
-                unchangedToastValue = UNCHANGED_TEXT_ARRAY_TOAST_VALUE;
-                break;
-            case "bytea[]":
-            case "_bytea":
-                unchangedToastValue = UNCHANGED_BINARY_ARRAY_TOAST_VALUE;
-                break;
-            case "integer[]":
-            case "_int4":
-            case "date[]":
-            case "_date":
-                unchangedToastValue = UNCHANGED_INT_ARRAY_TOAST_VALUE;
-                break;
-            case "bigint[]":
-            case "_int8":
-                unchangedToastValue = UNCHANGED_BIGINT_ARRAY_TOAST_VALUE;
-                break;
-            case "hstore":
-                unchangedToastValue = UNCHANGED_HSTORE_TOAST_VALUE;
-                break;
-            case "uuid[]":
-            case "_uuid":
-                unchangedToastValue = UNCHANGED_UUID_TOAST_VALUE;
-                break;
-            default:
-                unchangedToastValue = UNCHANGED_TOAST_VALUE;
-        }
-    }
-
-    private boolean isArrayType(String typeWithModifiers) {
-        return typeWithModifiers.startsWith(TYPE_ARRAY_PREFIX) || typeWithModifiers.endsWith(TYPE_ARRAY_SUFFIX);
-    }
-
-    protected String removeSizeModifierFromArrayTypes(String typeWithModifiers) {
-        // Removing the size for type like _varchar(2000, 0)
-        if (isArrayType(typeWithModifiers)) {
-            final int leftParenthesis = typeWithModifiers.indexOf("(");
-            final int rightParenthesis = typeWithModifiers.lastIndexOf(")");
-            if (leftParenthesis > 0 && rightParenthesis > 0) {
-                if (rightParenthesis == typeWithModifiers.length() - 1) {
-                    typeWithModifiers = typeWithModifiers.substring(0, leftParenthesis);
-                }
-                else {
-                    typeWithModifiers = typeWithModifiers.substring(0, leftParenthesis)
-                            + typeWithModifiers.substring(rightParenthesis + 1);
-                }
-            }
-        }
-        return typeWithModifiers;
+        // Array columns carry their placeholder in the element type, which the value converter resolves from
+        // the field schema; the marker below is enough for them.
+        unchangedToastValue = "hstore".equals(typeWithModifiers) ? UNCHANGED_HSTORE_TOAST_VALUE : UNCHANGED_TOAST_VALUE;
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -6,9 +6,16 @@
 
 package io.debezium.connector.postgresql;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.data.VariableScaleDecimal;
 
 /**
  * A class that contains assertions or expected values tailored to the behaviour of a concrete decoder plugin
@@ -53,6 +60,36 @@ public class DecoderDifferences {
                 .map(String::trim)
                 .map(Long::parseLong)
                 .collect(Collectors.toList());
+    }
+
+    public static List<Double> toastedValueDoublePlaceholder() {
+        return toastedValueNumbers().map(Double::parseDouble).collect(Collectors.toList());
+    }
+
+    public static List<Float> toastedValueFloatPlaceholder() {
+        return toastedValueNumbers().map(Float::parseFloat).collect(Collectors.toList());
+    }
+
+    public static List<Short> toastedValueSmallintPlaceholder() {
+        return toastedValueNumbers().map(Short::parseShort).collect(Collectors.toList());
+    }
+
+    public static List<BigDecimal> toastedValueDecimalPlaceholder(int scale) {
+        return toastedValueNumbers().map(number -> new BigDecimal(new BigInteger(number), scale)).collect(Collectors.toList());
+    }
+
+    public static List<Boolean> toastedValueBooleanPlaceholder() {
+        return toastedValueNumbers().map(number -> Integer.parseInt(number) != 0).collect(Collectors.toList());
+    }
+
+    public static List<Struct> toastedValueVariableScaleDecimalPlaceholder(Schema elementSchema) {
+        return toastedValueNumbers()
+                .map(number -> VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal(number)))
+                .collect(Collectors.toList());
+    }
+
+    private static Stream<String> toastedValueNumbers() {
+        return Stream.of(TOASTED_VALUE_NUMBER_STRING.split(",")).map(String::trim);
     }
 
     public static boolean areDefaultValuesRefreshedEagerly() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
@@ -383,6 +383,52 @@ public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcesso
     }
 
     @Test
+    @FixFor("debezium/dbz#2418")
+    public void testToastColumnArrayReselectedForEveryElementType() throws Exception {
+        final List<String> arrayColumns = List.of("numeric_array", "decimal_array", "float_array", "real_array", "int_array", "smallint_array",
+                "bool_array");
+
+        TestHelper.execute("CREATE TABLE s1.dbz2418_toast (id int primary key, numeric_array numeric[],"
+                + " decimal_array numeric(10,2)[], float_array float8[], real_array real[], int_array integer[],"
+                + " smallint_array smallint[], bool_array boolean[], data2 int);");
+        for (String column : arrayColumns) {
+            // a compressible array stays in line, so it has to be stored externally to be toasted at all
+            TestHelper.execute("ALTER TABLE s1.dbz2418_toast ALTER COLUMN " + column + " SET STORAGE EXTERNAL;");
+        }
+
+        final LogInterceptor logInterceptor = getReselectLogInterceptor();
+
+        Configuration config = getConfigurationBuilder()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz2418_toast")
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingStarted();
+
+        TestHelper.execute(
+                "INSERT INTO s1.dbz2418_toast (id, numeric_array, decimal_array, float_array, real_array, int_array, smallint_array,"
+                        + " bool_array, data2) SELECT 1, array_agg(g::numeric), array_agg(g::numeric(10,2)), array_agg(g::float8),"
+                        + " array_agg(g::real), array_agg(g::int4), array_agg((g % 100)::int2), array_agg(g % 2 = 0), 1"
+                        + " FROM generate_series(1, 20000) g;",
+                "UPDATE s1.dbz2418_toast SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("test_server.s1.dbz2418_toast");
+
+        final Struct insert = ((Struct) tableRecords.get(0).value()).getStruct(Envelope.FieldName.AFTER);
+        final SourceRecord updateRecord = tableRecords.get(1);
+        final Struct update = ((Struct) updateRecord.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(updateRecord, "id", 1);
+        assertThat(update.get("data2")).isEqualTo(2);
+
+        // the arrays are unchanged and toasted, so they arrive as a placeholder and have to be re-selected
+        for (String column : arrayColumns) {
+            assertColumnReselectedForUnavailableValue(logInterceptor, "s1.dbz2418_toast", column);
+            assertThat(update.get(column)).as(column).isEqualTo(insert.get(column));
+        }
+    }
+
+    @Test
     @FixFor("DBZ-8277")
     public void testToastColumnReselectedWhenPrimaryKeyIsUUIDType() throws Exception {
         TestHelper.execute("CREATE TABLE s1.dbz8277_toast (id uuid primary key, data text[], data2 int);");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -2193,6 +2193,61 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2418")
+    public void shouldHandleToastedArrayColumnsOfAnyElementType() throws Exception {
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_toast_table;",
+                "CREATE TABLE test_toast_table (id SERIAL PRIMARY KEY, not_toast integer,"
+                        + " numeric_array numeric[], decimal_array numeric(10,2)[], float_array double precision[],"
+                        + " real_array real[], smallint_array smallint[], bool_array boolean[],"
+                        + " inet_array inet[], timestamp_array timestamp[]);",
+                "ALTER TABLE test_toast_table ALTER COLUMN numeric_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN decimal_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN real_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN smallint_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN float_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN bool_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN inet_array SET STORAGE EXTERNAL;",
+                "ALTER TABLE test_toast_table ALTER COLUMN timestamp_array SET STORAGE EXTERNAL;");
+        startConnector(Function.identity(), false);
+
+        // every array has to be large enough to be stored out of line, otherwise the value is not toasted
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO test_toast_table (not_toast, numeric_array, decimal_array, float_array, real_array,"
+                + " smallint_array, bool_array, inet_array, timestamp_array)"
+                + " SELECT 10, array_agg(g::numeric), array_agg(g::numeric(10,2)), array_agg(g::float8), array_agg(g::real),"
+                + " array_agg((g % 100)::int2), array_agg(g % 2 = 0),"
+                + " array_agg(('10.0.0.' || (g % 250 + 1))::inet), array_agg('2020-01-01'::timestamp + (g || ' seconds')::interval)"
+                + " FROM generate_series(1, 20000) g;");
+        consumer.remove();
+
+        // the unchanged toasted arrays now have to carry the placeholder in their own element type
+        consumer.expects(1);
+        executeAndWait("UPDATE test_toast_table SET not_toast = 2;");
+        assertRecordSchemaAndValues(Arrays.asList(
+                new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
+                new SchemaAndValueField("numeric_array", SchemaBuilder.array(VariableScaleDecimal.optionalSchema()).optional().build(),
+                        DecoderDifferences.toastedValueVariableScaleDecimalPlaceholder(VariableScaleDecimal.optionalSchema())),
+                new SchemaAndValueField("decimal_array",
+                        SchemaBuilder.array(Decimal.builder(2).parameter(TestHelper.PRECISION_PARAMETER_KEY, "10").optional().build()).optional().build(),
+                        DecoderDifferences.toastedValueDecimalPlaceholder(2)),
+                new SchemaAndValueField("float_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
+                        DecoderDifferences.toastedValueDoublePlaceholder()),
+                new SchemaAndValueField("real_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT32_SCHEMA).optional().build(),
+                        DecoderDifferences.toastedValueFloatPlaceholder()),
+                new SchemaAndValueField("smallint_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_INT16_SCHEMA).optional().build(),
+                        DecoderDifferences.toastedValueSmallintPlaceholder()),
+                new SchemaAndValueField("bool_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA).optional().build(),
+                        DecoderDifferences.toastedValueBooleanPlaceholder()),
+                new SchemaAndValueField("inet_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build(),
+                        Arrays.asList(DecoderDifferences.mandatoryToastedValuePlaceholder())),
+                new SchemaAndValueField("timestamp_array", SchemaBuilder.array(MicroTimestamp.builder().optional().build()).optional().build(),
+                        DecoderDifferences.toastedValueBigintPlaceholder())),
+                consumer.remove(),
+                Envelope.FieldName.AFTER);
+    }
+
+    @Test
     @FixFor("DBZ-7193")
     public void shouldHandleToastedArrayColumnForReplicaIdentityFullTable() throws Exception {
         TestHelper.execute(


### PR DESCRIPTION
Fixes debezium/dbz#2418

## Description

An unchanged TOASTed array column is emitted with the plain string `unavailable.value.placeholder`, which does not fit the field's `ARRAY` schema:

```
org.apache.kafka.connect.errors.DataException: Invalid Java object for schema with type ARRAY: class java.lang.String for field: "numeric_array"
```

With the default `event.converting.failure.handling.mode=warn` this only reaches the log and the column is dropped from the event, so a sink cannot tell it apart from a column that was never captured.

`UnchangedToastedReplicationMessageColumn#setUnchangedToastValue` picks the placeholder by matching the column's type name against a fixed list, and only `text[]`, `varchar[]`, `bpchar[]`, `json[]`, `jsonb[]`, `bytea[]`, `int4[]`, `date[]`, `int8[]` and `uuid[]` are on it. Everything else falls back to `UNCHANGED_TOAST_VALUE`, which `UnchangedToastedPlaceholder` maps to a `String`. `convertArray` delivers nothing for a marker value, so `handleUnknownData` returns that string for an `ARRAY` field.

That list has grown one element type at a time (DBZ-4941, DBZ-5944, DBZ-5935, DBZ-5936, DBZ-6122, DBZ-6720, DBZ-8416) and cannot be completed by enumeration — enum arrays, domain arrays and arrays of user-defined types have no type name that can be known up front.

The placeholder is now resolved from the array's element schema, which `convertArray` already has. `UnchangedToastedPlaceholder#getArrayValue` builds it for `STRING` (including `Uuid`), `BYTES` (including `Decimal`), `INT16`/`INT32`/`INT64`, `FLOAT32`/`FLOAT64` and `VariableScaleDecimal`, so the type name list is no longer needed and is removed along with the per-type marker constants.

The existing representations are kept unchanged: text-like elements carry the placeholder as a single element, numeric elements carry one element per placeholder byte, exactly as the `integer[]` and `bigint[]` placeholders have always been built.

**Scope.** Element types whose schema is a `STRUCT` keep the current behaviour, except `VariableScaleDecimal` where the numeric representation is obvious. A placeholder for geometry and the other `Struct` types is the separate design question in debezium/dbz#1601. `boolean[]` also keeps the current behaviour: every placeholder byte is non-zero, so its placeholder would be an all-`true` list that no placeholder choice can make distinguishable from a real value (see the review discussion); it stays dropped until debezium/dbz#1601 settles a representation. `hstore` is not an array and is untouched.

This is the part of debezium/dbz#680 that is still open — the `text[]` case in that issue's description was fixed by DBZ-4941, while the reporter's follow-up comment ("this issue happens for any array type") was not.

**Re-selection.** A dropped field left the value null, which `reselect.null.values` re-selected; a placeholder the post-processor does not recognize is re-selected by neither branch. `isUnavailableArrayValueHolder` knew only `INT32` and `INT64`, so it now covers the element types the connector emits.

Not covered: `uuid[]`, whose placeholder the post-processor never matched, before this change as well; and the columns that are still dropped (`boolean[]`, temporal arrays under `time.precision.mode=connect`, whose Connect logical element schemas expect `java.util.Date`), which keep arriving as null and are repaired by `reselect.null.values` as on `main`.

**Docs.** The TOAST section of `postgresql.adoc` now describes the placeholder representation per array element type, the `boolean[]` and `time.precision.mode=connect` omissions, and the `uuid[]` re-selection gap.

**Tests.** `RecordsStreamProducerIT#shouldHandleToastedArrayColumnsOfAnyElementType` covers `numeric[]`, `numeric(10,2)[]`, `float8[]`, `real[]`, `smallint[]`, `inet[]` and `timestamp[]` in one table, which exercises every branch of `getArrayValue` together with the existing `text[]`, `bytea[]`, `int4[]`, `date[]`, `int8[]` and `uuid[]` tests; `bool[]` is asserted to stay on the existing path (dropped from the event). Without the change all placeholder-carrying columns fail with the `DataException` above.

`PostgresReselectColumnsProcessorIT#testToastColumnArrayReselectedForEveryElementType` covers the re-selection of `numeric[]`, `numeric(10,2)[]`, `float8[]`, `real[]`, `integer[]` and `smallint[]` via the placeholder branch and `bool[]` via the null branch; reverting only the post-processor makes it fail.

Verified with the full `RecordsStreamProducerIT` on pgoutput (131 tests) and the 21 toasted-column tests on both pgoutput and decoderbufs, the full `PostgresReselectColumnsProcessorIT`, plus the unit tests of both modules.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
