### PR TITLE
docs: add BOOTSTRAP_SERVERS env variable to tutorial Kafka Connect commands

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-restarting-kafka-connect-service.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-restarting-kafka-connect-service.adoc
@@ -67,7 +67,7 @@ This command starts Kafka Connect using the same options you used when you initi
 
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
+$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e BOOTSTRAP_SERVERS=kafka:9092 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
 ----
 
 The Kafka Connect service starts, connects to Kafka, reads the previous service's configuration, and starts the registered connectors that will resume where they last left off.

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
@@ -19,7 +19,7 @@ The following command runs a new container using the {debezium-docker-label} ver
 
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
+$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e BOOTSTRAP_SERVERS=kafka:9092 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
 ----
 
 `-it`:: The container is interactive,
@@ -28,6 +28,7 @@ which means the terminal's standard input and output are attached to the contain
 `--name connect`:: The name of the container.
 `-p 8083:8083`:: Maps port `8083` in the container to the same port on the Docker host.
 This enables applications outside of the container to use Kafka Connect's REST API to set up and manage new container instances.
+`-e BOOTSTRAP_SERVERS=kafka:9092`:: Specifies the Kafka broker that Kafka Connect uses to bootstrap itself.
 `-e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses`:: Sets environment variables required by the {prodname} image.
 `--link kafka:kafka --link mysql:mysql`:: Links the container to the containers that are running Kafka and the MySQL server.
 --
@@ -38,7 +39,7 @@ ifdef::community[]
 If you use Podman, run the following command:
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ podman run -it --rm --name connect --pod dbz -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses quay.io/debezium/connect:{debezium-docker-label}
+$ podman run -it --rm --name connect --pod dbz -e GROUP_ID=1 -e BOOTSTRAP_SERVERS=kafka:9092 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses quay.io/debezium/connect:{debezium-docker-label}
 ----
 ====
 +


### PR DESCRIPTION
## Summary

The tutorial for starting Kafka Connect is missing the `BOOTSTRAP_SERVERS` environment variable. Without it, the Debezium Connect image defaults to `0.0.0.0:9092`, which causes Kafka Connect to attempt connecting to itself instead of the Kafka broker, resulting in an endless rebootstrap loop:

```
[AdminClient clientId=adminclient-1] Connection to node -1 (/127.0.0.1:9092) could not be established.
[AdminClient clientId=adminclient-1] Rebootstrapping with Cluster(id = null, nodes = [0.0.0.0:9092 ...])
```

Fixes debezium/dbz#2186

## Changes

Added `-e BOOTSTRAP_SERVERS=kafka:9092` to all Kafka Connect `docker run` / `podman run` commands in the tutorial, and added a description of the variable in the options list:

- `proc-starting-kafka-connect.adoc` — `docker run` command and `podman run` variant
- `proc-restarting-kafka-connect-service.adoc` — restart command

## How to reproduce

Start Kafka Connect **without** `BOOTSTRAP_SERVERS`:
```bash
docker run -it --rm --name connect -p 8083:8083 \
  -e GROUP_ID=1 \
  -e CONFIG_STORAGE_TOPIC=my_connect_configs \
  -e OFFSET_STORAGE_TOPIC=my_connect_offsets \
  -e STATUS_STORAGE_TOPIC=my_connect_statuses \
  --link kafka:kafka quay.io/debezium/connect:3.6.1.Final
```
→ endless rebootstrap loop in the logs.

Start **with** `-e BOOTSTRAP_SERVERS=kafka:9092` → connects successfully.