### PR TITLE
debezium/dbz#2448 fix(oracle): resolve ORA-00933 for primary key boundaries on Oracle 11g

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -866,3 +866,4 @@ skdus531
 Junsu Lee
 Björn Bärtschi
 Raju Surarapu
+dingqianwen

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -487,6 +487,29 @@ public class OracleConnection extends JdbcConnection {
     @Override
     public String buildSelectPrimaryKeyBoundaries(TableId tableId, long size, String projection, String orderBy, String condition) {
         final TableId truncatedTableId = new TableId(null, tableId.schema(), tableId.table());
+        // Oracle 11g and earlier
+        if (getOracleVersion().getMajor() < 12) {
+            StringBuilder innerSql = new StringBuilder("SELECT ")
+                    .append(projection)
+                    .append(", ROWNUM AS RNUM FROM (SELECT ")
+                    .append(projection)
+                    .append(" FROM ")
+                    .append(quotedTableIdString(truncatedTableId));
+            if (!Strings.isNullOrBlank(condition)) {
+                innerSql.append(" WHERE ").append(condition);
+            }
+            innerSql.append(" ORDER BY ").append(orderBy).append(")");
+            // Target row index corresponds to OFFSET size FETCH NEXT 1 (1-based index)
+            long targetRow = size + 1;
+            return new StringBuilder("SELECT ")
+                    .append(projection)
+                    .append(" FROM (")
+                    .append(innerSql)
+                    .append(") WHERE RNUM = ")
+                    .append(targetRow)
+                    .toString();
+        }
+        // Oracle 12c+
         StringBuilder sql = new StringBuilder("SELECT ")
                 .append(projection)
                 .append(" FROM ")


### PR DESCRIPTION
Fixes debezium/dbz#2448 

Oracle 11g does not support ANSI SQL 'OFFSET...FETCH' syntax (introduced in 12c). 
Executing boundary queries on 11g resulted in syntax errors during chunk splitting:
`Caused by: Error : 933 ... SQL = SELECT "ID" FROM ... ORDER BY "ID" OFFSET ... ROWS FETCH NEXT 1 ROWS ONLY`

Solution:
- Checked version via `getOracleVersion().getMajor() < 12`, following the existing pattern used in `buildSelectWithRowLimits`.
- Implemented a 3-layer ROWNUM subquery for Oracle 11g boundary selection to bypass the missing OFFSET-FETCH support.
- Retained standard `OFFSET...FETCH` syntax for Oracle 12c+.

Note: The ROWNUM fallback implementation has been tested and verified to work correctly on Oracle 11g environments.