### PR TITLE
debezium/dbz#2446 Add both operands in MathOps.add for BigInteger overloads

### DIFF
--- a/debezium-util/src/main/java/io/debezium/util/MathOps.java
+++ b/debezium-util/src/main/java/io/debezium/util/MathOps.java
@@ -692,7 +692,7 @@ public final class MathOps {
     }
 
     public static Number add(BigInteger first, BigInteger second) {
-        return second.add(second);
+        return first.add(second);
     }
 
     public static Number add(BigInteger first, AtomicInteger second) {
@@ -779,7 +779,7 @@ public final class MathOps {
     }
 
     public static Number add(BigDecimal first, BigInteger second) {
-        return second.add(second);
+        return first.add(new BigDecimal(second));
     }
 
     public static Number add(BigDecimal first, AtomicInteger second) {

--- a/debezium-util/src/test/java/io/debezium/util/MathOpsTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/MathOpsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit test for {@link MathOps}, exercising the mixed-type {@code add} overloads through the
+ * {@code add(Number, Number)} entry point that {@code Document.increment} relies on.
+ *
+ * @author Debezium Authors
+ */
+public class MathOpsTest {
+
+    // Regression: the BigInteger + BigInteger overload used to drop the first operand and double the
+    // second (second.add(second)), so an increment returned 2 * increment instead of current + increment.
+    @Test
+    @FixFor("debezium/dbz#2446")
+    public void addsTwoBigIntegers() {
+        Number current = BigInteger.valueOf(100);
+        Number increment = BigInteger.valueOf(5);
+        assertThat(MathOps.add(current, increment)).isEqualTo(BigInteger.valueOf(105));
+    }
+
+    // Regression: the BigDecimal + BigInteger overload had the same second.add(second) defect.
+    @Test
+    @FixFor("debezium/dbz#2446")
+    public void addsBigDecimalAndBigInteger() {
+        Number current = new BigDecimal("100");
+        Number increment = BigInteger.valueOf(5);
+        assertThat(MathOps.add(current, increment)).isEqualTo(new BigDecimal("105"));
+    }
+
+    // The mirror overload (BigInteger + BigDecimal) was already correct; guard it against regressing.
+    @Test
+    @FixFor("debezium/dbz#2446")
+    public void addsBigIntegerAndBigDecimal() {
+        Number current = BigInteger.valueOf(100);
+        Number increment = new BigDecimal("5");
+        assertThat(MathOps.add(current, increment)).isEqualTo(new BigDecimal("105"));
+    }
+
+    // A negative operand must decrement, matching Document.increment's documented contract.
+    @Test
+    @FixFor("debezium/dbz#2446")
+    public void addingNegativeBigIntegerDecrements() {
+        Number current = BigInteger.valueOf(100);
+        Number increment = BigInteger.valueOf(-30);
+        assertThat(MathOps.add(current, increment)).isEqualTo(BigInteger.valueOf(70));
+    }
+}


### PR DESCRIPTION
Fixes [debezium/dbz#2446](https://github.com/debezium/dbz/issues/2446).

### What

`io.debezium.util.MathOps.add(...)` had two `BigInteger`-involving overloads that returned `second.add(second)` — discarding the first operand and doubling the second — where every other overload folds in both operands:

```java
public static Number add(BigInteger first, BigInteger second) {
    return second.add(second);   // -> first.add(second)
}
public static Number add(BigDecimal first, BigInteger second) {
    return second.add(second);   // -> first.add(new BigDecimal(second))
}
```

### Impact

`MathOps.add` backs `Document.increment(...)` / `Array.increment(...)` (`BasicDocument#increment`, `BasicArray#increment`). Incrementing a `BigInteger`-valued field returned `2 × increment` instead of `current + increment`, contradicting the `increment` javadoc ("increment the numeric value in the given field by the designated amount"):

```java
Document doc = Document.create();
doc.setNumber("counter", BigInteger.valueOf(100));
doc.increment("counter", Value.create(BigInteger.valueOf(5)));
// counter == 10, expected 105
```

A negative operand compounded it (`100 + (-30)` yielded `-60` instead of `70`).

### Fix

Use both operands, mirroring the sibling overloads (`add(BigDecimal, BigDecimal)` → `second.add(first)`, `add(BigInteger, BigDecimal)` → `second.add(new BigDecimal(first))`).

### Tests

`MathOps` had no test class. Added `MathOpsTest` covering both fixed overloads (through the `add(Number, Number)` entry point that `Document.increment` uses), the already-correct mirror overload as a guard, and a negative-operand (decrement) case. Verified the new tests fail against the previous code and pass with the fix; the full `debezium-util` suite (174 tests) is green.
