### PR TITLE
docs: clarify schema history topic retention requirements

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -684,7 +684,7 @@ For information about capturing data from a new table that has undergone structu
 .Procedure
 
 1. Stop the connector.
-2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`documentation/modules/ROOT/partials/modules/all-connectors property`].
 3. Apply the following changes to the connector configuration:
 .. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to `recovery`.
 .. Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
@@ -3037,9 +3037,10 @@ This connector captures changes only from the `inventory` table.
 Specifies the the connector uses `my-cluster-kafka-bootstrap:9092` as the Kafka broker for connecting to the database schema history topic when it writes or reads DDL statements.
 When a connector restarts, it recovers the database schemas that existed in the binlog at the point in time when the connector stopped.
 
-`schema.history.internal.kafka.topic::
-Specifies the name of the database schema history topic.
-This topic is for internal use only and should not be used by consumers.
+
+
+
+
 
 . Create your connector instance with Kafka Connect.
 For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:
@@ -3117,6 +3118,7 @@ Specifies the Kafka brokers that the connector uses to write and recover DDL sta
 `schema.history.internal.kafka.topic`::
 Specifies the name of the database schema history topic.
 This topic is for internal use only and should not be used by consumers.
+This topic must be configured with infinite retention (`cleanup.policy=delete`, `retention.ms=-1`); insufficient retention can cause the connector to throw a `SchemaHistoryException`.
 
 `include.schema.changes`::
 Specifies whether the connector should generate events for DDL changes and emit them to the `fulfillment` schema change topic for use by consumers.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -684,7 +684,7 @@ For information about capturing data from a new table that has undergone structu
 .Procedure
 
 1. Stop the connector.
-2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`documentation/modules/ROOT/partials/modules/all-connectors property`].
+2. Remove the internal database schema history topic that is specified by the xref:{context}-property-database-history-kafka-topic[`schema.history.internal.kafka.topic property`].
 3. Apply the following changes to the connector configuration:
 .. Set the xref:{context}-property-snapshot-mode[`snapshot.mode`] to `recovery`.
 .. Set the value of xref:{context}-property-database-history-store-only-captured-tables-ddl[`schema.history.internal.store.only.captured.tables.ddl`] to `false`.
@@ -3118,7 +3118,9 @@ Specifies the Kafka brokers that the connector uses to write and recover DDL sta
 `schema.history.internal.kafka.topic`::
 Specifies the name of the database schema history topic.
 This topic is for internal use only and should not be used by consumers.
-This topic must be configured with infinite retention (`cleanup.policy=delete`, `retention.ms=-1`); insufficient retention can cause the connector to throw a `SchemaHistoryException`.
+ifdef::community[]
+To learn more about the topic configuration requirements, see xref:install.html#configuring-debezium
+endif::community[]
 
 `include.schema.changes`::
 Specifies whether the connector should generate events for DDL changes and emit them to the `fulfillment` schema change topic for use by consumers.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-mariadb-mysql.adoc
@@ -3037,10 +3037,12 @@ This connector captures changes only from the `inventory` table.
 Specifies the the connector uses `my-cluster-kafka-bootstrap:9092` as the Kafka broker for connecting to the database schema history topic when it writes or reads DDL statements.
 When a connector restarts, it recovers the database schemas that existed in the binlog at the point in time when the connector stopped.
 
-
-
-
-
+`schema.history.internal.kafka.topic::
+Specifies the name of the database schema history topic.
+This topic is for internal use only and should not be used by consumers.
+ifdef::community[]
+To learn more about the topic configuration requirements, see xref:install.html#configuring-debezium
+endif::community[]
 
 . Create your connector instance with Kafka Connect.
 For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:


### PR DESCRIPTION
Fixes debezium/dbz#2447 

## Description
While reviewing the schema history topic configuration for the MySQL connector, I noticed the property description doesn't mention the retention requirements needed to avoid a SchemaHistoryException. This PR adds a brief clarification that the topic must be configured with infinite retention, and notes the resulting exception if this isn't configured correctly.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`