### PR TITLE
debezium/dbz#478 Support capturing changes from multiple PDBs

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -28,7 +28,6 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 /**
  * Base class to emit change data based on a single entry event.
@@ -82,8 +81,8 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
 
                 try (OracleConnection connection = new OracleConnection(connectorConfig, true)) {
                     final String query = getReselectQuery(reselectColumns, table, connection);
-                    if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
-                        connection.setSessionToPdb(connectorConfig.getPdbName());
+                    if (connectorConfig.isUsingPluggableDatabase()) {
+                        connection.setSessionToPdb(table.id().catalog());
                     }
                     connection.prepareQuery(query,
                             ps -> prepareReselectQueryStatement(ps, table, newColumnValues),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -93,6 +93,7 @@ public class OracleConnection extends JdbcConnection {
 
     private final int queryFetchSize;
     private OracleDatabaseVersion databaseVersion;
+    private String sessionPdbName;
 
     public OracleConnection(OracleConnectorConfig connectorConfig, boolean autoCommit) {
         this(connectorConfig.getJdbcConfig(), connectorConfig.getQueryFetchSize(), autoCommit);
@@ -128,10 +129,22 @@ public class OracleConnection extends JdbcConnection {
 
     public void setSessionToPdb(String pdbName) {
         setContainerAs(pdbName);
+        this.sessionPdbName = pdbName;
     }
 
     public void resetSessionToCdb() {
         setContainerAs("cdb$root");
+        this.sessionPdbName = null;
+    }
+
+    /**
+     * Get the pluggable database the session was last pinned to via {@link #setSessionToPdb(String)},
+     * or {@code null} when the session operates against the root container.
+     *
+     * @return the pinned pluggable database name, may be {@code null}
+     */
+    public String getSessionPdbName() {
+        return sessionPdbName;
     }
 
     private void setContainerAs(String containerName) {
@@ -219,9 +232,21 @@ public class OracleConnection extends JdbcConnection {
 
     @Override
     protected String resolveCatalogName(String catalogName) {
-        final String pdbName = OracleUtils.getObjectName(config().getString("pdb.name"));
+        if (!Strings.isNullOrEmpty(sessionPdbName)) {
+            return OracleUtils.getObjectName(sessionPdbName);
+        }
+        final String pdbName = OracleUtils.getObjectName(getFirstConfiguredPdbName());
         final String databaseName = OracleUtils.getObjectName(config().getString("dbname"));
         return !OracleUtils.isObjectNameNullOrEmpty(pdbName) ? pdbName : databaseName;
+    }
+
+    private String getFirstConfiguredPdbName() {
+        final String pdbNames = config().getString("pdb.names");
+        if (!Strings.isNullOrEmpty(pdbNames)) {
+            final List<String> names = Strings.listOfTrimmed(pdbNames, String::new);
+            return names.isEmpty() ? null : names.get(0);
+        }
+        return config().getString("pdb.name");
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -88,14 +88,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withNoValidation()
             .withValidation(OracleConnectorConfig::requiredWhenNoUrl);
 
-    public static final Field PDB_NAME = Field.create(ConfigurationNames.DATABASE_CONFIG_PREFIX + "pdb.name")
-            .withDisplayName("PDB name")
-            .withType(Type.STRING)
+    public static final Field PDB_NAMES = Field.create(ConfigurationNames.DATABASE_CONFIG_PREFIX + "pdb.names")
+            .withDisplayName("PDB names")
+            .withType(Type.LIST)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION))
-            .withDescription("Name of the pluggable database when working with a multi-tenant set-up. "
-                    + "The CDB name must be given via " + DATABASE_NAME.name() + " in this case.");
+            .withDescription("Comma-separated list of the pluggable database names when working with a multi-tenant set-up. "
+                    + "The CDB name must be given via " + DATABASE_NAME.name() + " in this case. "
+                    + "The first name in the list is used as the container for connector-managed objects, "
+                    + "such as the LogMiner flush table and heartbeat action queries.")
+            .withDeprecatedAliases(ConfigurationNames.DATABASE_CONFIG_PREFIX + "pdb.name");
 
     /**
      * @deprecated to be removed in Debezium 4.0
@@ -944,7 +947,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
                     CommonConnectorConfig.QUERY_FETCH_SIZE,
                     CommonConnectorConfig.SIGNAL_DATA_COLLECTION)
-            .group(Field.Group.CONNECTION, HOSTNAME, PORT, USER, PASSWORD, DATABASE_NAME, QUERY_TIMEOUT_MS, PDB_NAME, XSTREAM_SERVER_NAME)
+            .group(Field.Group.CONNECTION, HOSTNAME, PORT, USER, PASSWORD, DATABASE_NAME, QUERY_TIMEOUT_MS, PDB_NAMES, XSTREAM_SERVER_NAME)
             .group(Field.Group.CONNECTION, RAC_NODES, URL, SECONDARY_DATABASE, SECONDARY_HOSTNAME, SECONDARY_PORT, SECONDARY_URL)
             .group(Field.Group.CONNECTION_ADVANCED, CONNECTOR_ADAPTER, LOG_MINING_STRATEGY, CAPTURE_MODE, ARCHIVE_LOG_HOURS, LOG_MINING_TRANSACTION_RETENTION_MS,
                     LOG_MINING_BATCH_SIZE_DEFAULT, LOG_MINING_BATCH_SIZE_MIN, LOG_MINING_BATCH_SIZE_MAX, LOG_MINING_BATCH_SIZE_INCREMENT,
@@ -989,7 +992,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorConfig.class);
 
     private final String databaseName;
-    private final String pdbName;
+    private final List<String> pdbNames;
     private final String xstreamOutboundServerName;
     private final IntervalHandlingMode intervalHandlingMode;
     private final SnapshotMode snapshotMode;
@@ -1078,7 +1081,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 false);
 
         this.databaseName = OracleUtils.getObjectName(config.getString(DATABASE_NAME));
-        this.pdbName = OracleUtils.getObjectName(config.getString(PDB_NAME));
+        this.pdbNames = Strings.listOfTrimmed(config.getString(PDB_NAMES), String::new).stream()
+                .filter(name -> !Strings.isNullOrBlank(name))
+                .map(OracleUtils::getObjectName)
+                .collect(Collectors.toUnmodifiableList());
         this.xstreamOutboundServerName = config.getString(XSTREAM_SERVER_NAME);
         this.intervalHandlingMode = IntervalHandlingMode.parse(config.getString(INTERVAL_HANDLING_MODE));
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE));
@@ -1181,12 +1187,28 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return databaseName;
     }
 
-    public String getPdbName() {
-        return pdbName;
+    public List<String> getPdbNames() {
+        return pdbNames;
     }
 
-    public String getCatalogName() {
-        return pdbName != null ? pdbName : databaseName;
+    public boolean isUsingPluggableDatabase() {
+        return !pdbNames.isEmpty();
+    }
+
+    public List<String> getCatalogNames() {
+        return pdbNames.isEmpty() ? List.of(databaseName) : pdbNames;
+    }
+
+    /**
+     * Get the catalog that applies when a single catalog governs all captured tables: the pluggable
+     * database when exactly one is configured, or the database name when none are. With multiple
+     * pluggable databases no single catalog applies and the first is returned only as a fallback;
+     * each table's actual catalog is carried by its {@link io.debezium.relational.TableId}.
+     *
+     * @return the default catalog name, never {@code null}
+     */
+    public String getDefaultCatalogName() {
+        return getCatalogNames().get(0);
     }
 
     public String getXStreamOutboundServerName() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -7,6 +7,7 @@ package io.debezium.connector.oracle;
 
 import java.sql.SQLException;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +52,6 @@ import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleOffsetContext> {
 
@@ -118,11 +118,11 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         Offsets<OraclePartition, OracleOffsetContext> previousOffsets = getPreviousOffsets(partitionProvider, offsetContextLoader);
 
-        // The bean registry JDBC connection should always be pinned to the PDB
-        // when the connector is configured to use a pluggable database
+        // The bean registry JDBC connection should always be pinned to the primary (first) PDB
+        // when the connector is configured to use pluggable databases
         beanRegistryJdbcConnection = connectionFactory.newConnection();
-        if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
-            beanRegistryJdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        if (connectorConfig.isUsingPluggableDatabase()) {
+            beanRegistryJdbcConnection.setSessionToPdb(connectorConfig.getPdbNames().get(0));
         }
 
         // Manual Bean Registration
@@ -236,8 +236,8 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
     private OracleConnection getHeartbeatConnection(OracleConnectorConfig connectorConfig, JdbcConfiguration jdbcConfig) {
         final OracleConnection connection = new OracleConnection(connectorConfig, jdbcConfig, true);
-        if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
-            connection.setSessionToPdb(connectorConfig.getPdbName());
+        if (connectorConfig.isUsingPluggableDatabase()) {
+            connection.setSessionToPdb(connectorConfig.getPdbNames().get(0));
         }
         return connection;
     }
@@ -337,14 +337,15 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
     private void validateGuardrailLimits(OracleConnectorConfig connectorConfig, OracleConnection connection) {
         boolean switchedToPdb = false;
         try {
-            // Set the main connection to the PDB if configured.
-            // This is done before operations that need to see PDB-specific tables like validateGuardrailLimits.
-            if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
-                connection.setSessionToPdb(connectorConfig.getPdbName());
-                switchedToPdb = true;
+            final Set<TableId> allTableIds = new HashSet<>();
+            for (String catalogName : connectorConfig.getCatalogNames()) {
+                if (connectorConfig.isUsingPluggableDatabase()) {
+                    connection.setSessionToPdb(catalogName);
+                    switchedToPdb = true;
+                }
+                allTableIds.addAll(connection.getAllTableIds(catalogName));
             }
 
-            Set<TableId> allTableIds = connection.getAllTableIds(connectorConfig.getCatalogName());
             GuardrailValidator validator = new GuardrailValidator(connectorConfig, schema);
             validator.validate(allTableIds);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePartition.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePartition.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.oracle;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -13,7 +14,6 @@ import java.util.Set;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.AbstractPartition;
 import io.debezium.util.Collect;
-import io.debezium.util.Strings;
 
 public class OraclePartition extends AbstractPartition implements Partition {
     private static final String SERVER_PARTITION_KEY = "server";
@@ -61,9 +61,10 @@ public class OraclePartition extends AbstractPartition implements Partition {
 
         @Override
         public Set<OraclePartition> getPartitions() {
-            final String databaseName = Strings.isNullOrBlank(connectorConfig.getPdbName())
+            final List<String> pdbNames = connectorConfig.getPdbNames();
+            final String databaseName = pdbNames.isEmpty()
                     ? connectorConfig.getDatabaseName()
-                    : connectorConfig.getPdbName();
+                    : String.join(",", pdbNames);
             return Collections.singleton(new OraclePartition(connectorConfig.getLogicalName(), databaseName));
         }
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.oracle;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import io.debezium.DebeziumException;
 import io.debezium.jdbc.JdbcConnection;
@@ -25,7 +26,7 @@ import io.debezium.util.Clock;
  */
 public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends SignalBasedIncrementalSnapshotChangeEventSource<OraclePartition, TableId> {
 
-    private final String pdbName;
+    private final List<String> pdbNames;
     private final OracleConnection connection;
 
     public OracleSignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
@@ -37,7 +38,7 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
                                                                  DataChangeEventListener<OraclePartition> dataChangeEventListener,
                                                                  NotificationService<OraclePartition, OracleOffsetContext> notificationService) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
-        this.pdbName = ((OracleConnectorConfig) config).getPdbName();
+        this.pdbNames = ((OracleConnectorConfig) config).getPdbNames();
         this.connection = (OracleConnection) jdbcConnection;
     }
 
@@ -51,8 +52,8 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
     protected void preReadChunk(IncrementalSnapshotContext<TableId> context) {
         super.preReadChunk(context);
 
-        if (pdbName != null) {
-            connection.setSessionToPdb(pdbName);
+        if (!pdbNames.isEmpty()) {
+            connection.setSessionToPdb(resolvePdbName(context));
         }
     }
 
@@ -60,9 +61,26 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
     protected void postReadChunk(IncrementalSnapshotContext<TableId> context) {
         super.postReadChunk(context);
 
-        if (pdbName != null) {
+        if (!pdbNames.isEmpty()) {
             connection.resetSessionToCdb();
         }
+    }
+
+    /**
+     * Resolves the pluggable database that should be current for the chunk read, preferring the
+     * catalog of the current data collection when multiple pluggable databases are configured.
+     *
+     * @param context the incremental snapshot context, should not be {@code null}
+     * @return the pluggable database name, never {@code null}
+     */
+    private String resolvePdbName(IncrementalSnapshotContext<TableId> context) {
+        if (pdbNames.size() > 1 && context.currentDataCollectionId() != null) {
+            final TableId tableId = context.currentDataCollectionId().getId();
+            if (tableId.catalog() != null && pdbNames.contains(tableId.catalog())) {
+                return tableId.catalog();
+            }
+        }
+        return pdbNames.get(0);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -12,7 +12,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
@@ -25,13 +28,18 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.jdbc.OracleConnectionFactory;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
+import io.debezium.pipeline.source.snapshot.chunked.SnapshotChunk;
+import io.debezium.pipeline.source.snapshot.chunked.SnapshotProgress;
+import io.debezium.pipeline.source.snapshot.chunked.TableChunkProgress;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -52,8 +60,10 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleSnapshotChangeEventSource.class);
 
     private final OracleConnectorConfig connectorConfig;
+    private final OracleConnectionFactory connectionFactory;
     private final OracleConnection jdbcConnection;
     private final OracleDatabaseSchema databaseSchema;
+    private final Map<String, OracleConnection> pdbLockConnections = new LinkedHashMap<>();
 
     public OracleSnapshotChangeEventSource(OracleConnectorConfig connectorConfig, OracleConnectionFactory connectionFactory,
                                            OracleDatabaseSchema schema, EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
@@ -61,67 +71,156 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
                                            NotificationService<OraclePartition, OracleOffsetContext> notificationService, SnapshotterService snapshotterService) {
         super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
         this.connectorConfig = connectorConfig;
+        this.connectionFactory = connectionFactory;
         this.jdbcConnection = connectionFactory.mainConnection();
         this.databaseSchema = schema;
     }
 
     @Override
     protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(OraclePartition partition, boolean onDemand) {
-        if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
-            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        final List<String> pdbNames = connectorConfig.getPdbNames();
+        if (pdbNames.size() == 1) {
+            // All snapshot operations occur within the single container, pin for the snapshot's duration
+            jdbcConnection.setSessionToPdb(pdbNames.get(0));
+        }
+        else if (pdbNames.size() > 1) {
+            // Operations that require a specific container pin the session on demand and restore it;
+            // anything else, such as resolving the snapshot offset, must observe the entire container
+            // hierarchy, so the main connection is anchored to the root container.
+            jdbcConnection.resetSessionToCdb();
         }
 
-        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName(), onDemand);
+        // With multiple pluggable databases there is no single catalog; the empty sentinel mirrors the
+        // binlog connector's multi-catalog convention and the catalog of record is each TableId's.
+        final String catalogName = pdbNames.size() > 1 ? "" : connectorConfig.getDefaultCatalogName();
+        return new OracleSnapshotContext(partition, catalogName, onDemand);
     }
 
     @Override
     protected void connectionPoolConnectionCreated(RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
                                                    JdbcConnection connection) {
-        if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
-            ((OracleConnection) connection).setSessionToPdb(connectorConfig.getPdbName());
+        // With multiple pluggable databases the pool connections cannot be pinned up front; they are
+        // pinned per table or per chunk as each unit of work is executed.
+        final List<String> pdbNames = connectorConfig.getPdbNames();
+        if (pdbNames.size() == 1) {
+            ((OracleConnection) connection).setSessionToPdb(pdbNames.get(0));
         }
     }
 
     @Override
     protected Set<TableId> getAllTableIds(RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx)
             throws Exception {
-        return jdbcConnection.getAllTableIds(ctx.catalogName);
-        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
-        // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"} );
+        // getAllTableIds is preferred over readTableNames as the latter is very slow, taking upwards
+        // of 30 minutes on an instance with 600 tables
+        final boolean multiplePdbNames = connectorConfig.getPdbNames().size() > 1;
+        try {
+            final Set<TableId> tableIds = new HashSet<>();
+            for (String catalogName : connectorConfig.getCatalogNames()) {
+                if (multiplePdbNames) {
+                    jdbcConnection.setSessionToPdb(catalogName);
+                }
+                tableIds.addAll(jdbcConnection.getAllTableIds(catalogName));
+            }
+            return tableIds;
+        }
+        finally {
+            if (multiplePdbNames) {
+                jdbcConnection.resetSessionToCdb();
+            }
+        }
     }
 
     @Override
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext,
                                                RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
             throws SQLException, InterruptedException {
-        if (connectorConfig.getSnapshotLockingMode().get().usesLocking()) {
-            ((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint = jdbcConnection.connection().setSavepoint("dbz_schema_snapshot");
+        if (!connectorConfig.getSnapshotLockingMode().get().usesLocking()) {
+            LOGGER.info("Schema locking was disabled in connector configuration");
+            return;
+        }
 
-            try (Statement statement = jdbcConnection.connection().createStatement()) {
-                for (TableId tableId : snapshotContext.capturedTables) {
-                    if (!sourceContext.isRunning()) {
-                        throw new InterruptedException("Interrupted while locking table " + tableId);
-                    }
-
-                    Optional<String> lockingStatement = snapshotterService.getSnapshotLock().tableLockingStatement(null, quote(tableId));
-                    if (lockingStatement.isPresent()) {
-                        LOGGER.debug("Locking table {}", tableId);
-                        statement.execute(lockingStatement.get());
-                    }
-                }
+        if (connectorConfig.getPdbNames().size() > 1) {
+            // A transaction cannot span containers, so each pluggable database's tables are locked on a
+            // dedicated connection whose transaction is held until the schema snapshot completes.
+            final Map<String, List<TableId>> tablesByCatalog = snapshotContext.capturedTables.stream()
+                    .collect(Collectors.groupingBy(TableId::catalog, LinkedHashMap::new, Collectors.toList()));
+            for (Map.Entry<String, List<TableId>> catalogTables : tablesByCatalog.entrySet()) {
+                final OracleConnection connection = connectionFactory.newConnection();
+                pdbLockConnections.put(catalogTables.getKey(), connection);
+                connection.setSessionToPdb(catalogTables.getKey());
+                lockTables(sourceContext, connection, catalogTables.getValue());
             }
         }
         else {
-            LOGGER.info("Schema locking was disabled in connector configuration");
+            ((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint = jdbcConnection.connection().setSavepoint("dbz_schema_snapshot");
+            lockTables(sourceContext, jdbcConnection, snapshotContext.capturedTables);
+        }
+    }
+
+    /**
+     * Acquires the snapshot lock for each of the specified tables using the given connection.
+     *
+     * @param sourceContext the change event source context
+     * @param connection the connection whose transaction should hold the locks
+     * @param tableIds the tables to be locked
+     * @throws SQLException if a database exception occurred
+     * @throws InterruptedException if the thread is interrupted
+     */
+    private void lockTables(ChangeEventSourceContext sourceContext, OracleConnection connection, Collection<TableId> tableIds)
+            throws SQLException, InterruptedException {
+        try (Statement statement = connection.connection().createStatement()) {
+            for (TableId tableId : tableIds) {
+                if (!sourceContext.isRunning()) {
+                    throw new InterruptedException("Interrupted while locking table " + tableId);
+                }
+
+                Optional<String> lockingStatement = snapshotterService.getSnapshotLock().tableLockingStatement(null, quote(tableId));
+                if (lockingStatement.isPresent()) {
+                    LOGGER.debug("Locking table {}", tableId);
+                    statement.execute(lockingStatement.get());
+                }
+            }
         }
     }
 
     @Override
     protected void releaseSchemaSnapshotLocks(RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
             throws SQLException {
-        if (connectorConfig.getSnapshotLockingMode().get().usesLocking()) {
+        if (!connectorConfig.getSnapshotLockingMode().get().usesLocking()) {
+            return;
+        }
+
+        if (connectorConfig.getPdbNames().size() > 1) {
+            try {
+                for (Map.Entry<String, OracleConnection> lockConnection : pdbLockConnections.entrySet()) {
+                    if (!lockConnection.getValue().isConnected()) {
+                        // The server rolls back a lost connection's transaction, silently releasing its locks;
+                        // fail so the snapshot is retried rather than risk an inconsistent schema.
+                        throw new DebeziumException("Lock connection for pluggable database '" + lockConnection.getKey()
+                                + "' was lost during the schema snapshot");
+                    }
+                    lockConnection.getValue().connection().rollback();
+                }
+            }
+            finally {
+                closePdbLockConnections();
+            }
+        }
+        else {
             jdbcConnection.connection().rollback(((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint);
         }
+    }
+
+    private void closePdbLockConnections() {
+        for (Map.Entry<String, OracleConnection> lockConnection : pdbLockConnections.entrySet()) {
+            try {
+                lockConnection.getValue().close();
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Failed to close lock connection for pluggable database '{}'", lockConnection.getKey(), e);
+            }
+        }
+        pdbLockConnections.clear();
     }
 
     @Override
@@ -153,9 +252,25 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             LOGGER.info("All eligible tables schema should be captured, capturing: {}", capturedSchemaTables);
         }
 
-        Set<String> schemas = capturedSchemaTables.stream().map(TableId::schema).collect(Collectors.toSet());
-
         final Tables.TableFilter tableFilter = getTableFilter(snapshottingTask, snapshotContext);
+        if (connectorConfig.getPdbNames().size() > 1) {
+            final Map<String, Set<String>> schemasByCatalog = capturedSchemaTables.stream()
+                    .collect(Collectors.groupingBy(TableId::catalog, Collectors.mapping(TableId::schema, Collectors.toSet())));
+            for (Map.Entry<String, Set<String>> catalogSchemas : schemasByCatalog.entrySet()) {
+                jdbcConnection.setSessionToPdb(catalogSchemas.getKey());
+                readSchemas(sourceContext, snapshotContext, catalogSchemas.getValue(), tableFilter);
+            }
+        }
+        else {
+            Set<String> schemas = capturedSchemaTables.stream().map(TableId::schema).collect(Collectors.toSet());
+            readSchemas(sourceContext, snapshotContext, schemas, tableFilter);
+        }
+    }
+
+    private void readSchemas(ChangeEventSourceContext sourceContext,
+                             RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+                             Set<String> schemas, Tables.TableFilter tableFilter)
+            throws SQLException, InterruptedException {
         for (String schema : schemas) {
             if (!sourceContext.isRunning()) {
                 throw new InterruptedException("Interrupted while reading structure of schema " + schema);
@@ -203,14 +318,28 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     protected SchemaChangeEvent getCreateTableEvent(RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
                                                     Table table)
             throws SQLException {
+        setSessionToTablePdb(jdbcConnection, table.id());
         return SchemaChangeEvent.ofCreate(
                 snapshotContext.partition,
                 snapshotContext.offset,
-                snapshotContext.catalogName,
+                table.id().catalog(),
                 table.id().schema(),
                 jdbcConnection.getTableMetadataDdl(table.id()),
                 table,
                 true);
+    }
+
+    /**
+     * Pins the connection's session to the pluggable database that contains the specified table when
+     * multiple pluggable databases are configured; no-op otherwise as the session is already pinned.
+     *
+     * @param connection the connection whose session should be pinned
+     * @param tableId the table whose pluggable database should be made current
+     */
+    private void setSessionToTablePdb(OracleConnection connection, TableId tableId) {
+        if (connectorConfig.getPdbNames().size() > 1 && !tableId.catalog().equals(connection.getSessionPdbName())) {
+            connection.setSessionToPdb(tableId.catalog());
+        }
     }
 
     @Override
@@ -244,10 +373,31 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
     @Override
     protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
+        setSessionToTablePdb(jdbcConnection, tableId);
         // Oracle TableIds carry a CDB/PDB catalog that cannot appear in a qualified name; strip it
         // before quoting (as getSnapshotSelect does), otherwise the shared implementation would emit
         // an invalid "catalog"."schema"."table".
         return jdbcConnection.getRowCount(new TableId(null, tableId.schema(), tableId.table()));
+    }
+
+    @Override
+    protected List<Column> getKeyColumnsForChunking(Table table) {
+        // This hook is invoked at the start of each table's chunk boundary preparation, and the boundary
+        // queries that follow run on the main connection; there is no dedicated per-table hook in the
+        // chunked flow, so the session is pinned to the table's container here.
+        setSessionToTablePdb(jdbcConnection, table.id());
+        return super.getKeyColumnsForChunking(table);
+    }
+
+    @Override
+    protected void doCreateDataEventsForChunk(ChangeEventSourceContext sourceContext,
+                                              RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+                                              OracleOffsetContext offset, EventDispatcher.SnapshotReceiver<OraclePartition> snapshotReceiver,
+                                              SnapshotChunk chunk, Map<TableId, TableChunkProgress> progressMap,
+                                              SnapshotProgress snapshotProgress, JdbcConnection jdbcConnection)
+            throws InterruptedException, SQLException {
+        setSessionToTablePdb((OracleConnection) jdbcConnection, chunk.getTableId());
+        super.doCreateDataEventsForChunk(sourceContext, snapshotContext, offset, snapshotReceiver, chunk, progressMap, snapshotProgress, jdbcConnection);
     }
 
     @Override
@@ -261,7 +411,8 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
     @Override
     public void close() {
-        if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
+        closePdbLockConnections();
+        if (connectorConfig.isUsingPluggableDatabase()) {
             jdbcConnection.resetSessionToCdb();
         }
     }
@@ -298,6 +449,8 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             JdbcConnection connection = connectionPool.poll();
             OracleOffsetContext offset = offsets.poll();
             try {
+                setSessionToTablePdb((OracleConnection) connection, table.id());
+
                 final int maxRetries = getTableSnapshotMaxRetries();
                 final Metronome retrySleeper = Metronome.sleeper(Duration.ofSeconds(5), clock);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerQueryBuilder.java
@@ -132,6 +132,9 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
         if (connectorConfig.isLogMiningBufferTrackClientId()) {
             columns.add("CLIENT_ID");
         }
+        if (connectorConfig.getPdbNames().size() > 1) {
+            columns.add("SRC_CON_NAME");
+        }
 
         return String.join(", ", columns) + " ";
     }
@@ -145,19 +148,28 @@ public abstract class AbstractLogMinerQueryBuilder implements LogMinerQueryBuild
     protected abstract String getPredicates(boolean isCteQuery);
 
     /**
-     * Get the multi-tenant predicate based on the configured pluggable database name.
+     * Get the multi-tenant predicate based on the configured pluggable database names.
      *
      * @return multi-tenant predicate, may be an empty string if multi-tenancy is not enabled
      */
     protected String getMultiTenantPredicate() {
-        if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
-            String pdbName = connectorConfig.getPdbName();
-            if (pdbName.startsWith("\"") && pdbName.endsWith("\"") && pdbName.length() > 2) {
-                pdbName = pdbName.substring(1, pdbName.length() - 1);
-            }
-            return "SRC_CON_NAME = '" + pdbName + "'";
+        final List<String> pdbNames = connectorConfig.getPdbNames().stream()
+                .map(AbstractLogMinerQueryBuilder::unquoteObjectName)
+                .collect(Collectors.toList());
+        if (pdbNames.isEmpty()) {
+            return EMPTY;
         }
-        return EMPTY;
+        else if (pdbNames.size() == 1) {
+            return "SRC_CON_NAME = '" + pdbNames.get(0) + "'";
+        }
+        return pdbNames.stream().collect(Collectors.joining("','", "SRC_CON_NAME IN ('", "')"));
+    }
+
+    private static String unquoteObjectName(String objectName) {
+        if (objectName.startsWith("\"") && objectName.endsWith("\"") && objectName.length() > 2) {
+            return objectName.substring(1, objectName.length() - 1);
+        }
+        return objectName;
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingAdapter.java
@@ -103,7 +103,7 @@ public abstract class AbstractLogMinerStreamingAdapter
         // such a connection, the use of commit/rollback by LogMiner will drop/invalidate the save
         // point as well. A separate connection is necessary to preserve the save point.
         try (OracleConnection conn = new OracleConnection(connectorConfig, connection.config(), false)) {
-            if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
+            if (connectorConfig.isUsingPluggableDatabase()) {
                 // The next stage cannot be run within the PDB, reset the connection to the CDB.
                 conn.resetSessionToCdb();
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -13,6 +13,7 @@ import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -305,7 +306,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
     }
 
     protected boolean isUsingPluggableDatabase() {
-        return !Strings.isNullOrBlank(connectorConfig.getPdbName());
+        return connectorConfig.isUsingPluggableDatabase();
     }
 
     /**
@@ -1710,7 +1711,7 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         // Given that the current connection is used for processing the event data, a separate connection is needed
         try (OracleConnection connection = new OracleConnection(getConfig(), false)) {
             if (isUsingPluggableDatabase()) {
-                connection.setSessionToPdb(getConfig().getPdbName());
+                connection.setSessionToPdb(tableId.catalog());
             }
 
             getBatchMetrics().tableMetadataQueryObserved();
@@ -1793,49 +1794,16 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
         final Instant start = Instant.now();
         LOGGER.trace("Checking database and table state, this may take time depending on the size of your schema.");
         try {
-            if (isUsingPluggableDatabase()) {
-                connectionFactory.mainConnection().setSessionToPdb(connectorConfig.getPdbName());
-            }
-
-            // Check if ALL supplemental logging is enabled at the database
-            if (!isDatabaseAllSupplementalLoggingEnabled()) {
-                // Check if MIN supplemental logging is enabled at the database
-                if (!isDatabaseMinSupplementalLoggingEnabled()) {
-                    throw new DebeziumException("Supplemental logging not properly configured. "
-                            + "Use: ALTER DATABASE ADD SUPPLEMENTAL LOG DATA");
-                }
-
-                // Check if ALL COLUMNS supplemental logging is enabled for each captured table
-                for (TableId tableId : schema.tableIds()) {
-                    if (!connectionFactory.mainConnection().isTableExists(tableId)) {
-                        LOGGER.warn("Database table '{}' no longer exists, supplemental log check skipped", tableId);
-                    }
-                    else if (!isTableAllColumnsSupplementalLoggingEnabled(tableId)) {
-                        LOGGER.warn("Database table '{}' not configured with supplemental logging \"(ALL) COLUMNS\"; " +
-                                "only explicitly changed columns will be captured. " +
-                                "Use: ALTER TABLE {}.{} ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS", tableId, tableId.schema(), tableId.table());
-                    }
-                    final Table table = schema.tableFor(tableId);
-                    if (table == null) {
-                        // This should never happen; however in the event something would cause it we can
-                        // at least get the table identifier thrown in the error to debug from rather
-                        // than an erroneous NPE
-                        throw new DebeziumException("Unable to find table in relational model: " + tableId);
-                    }
-                    checkTableColumnNameLengths(table);
-                }
+            final List<String> pdbNames = connectorConfig.getPdbNames();
+            if (pdbNames.isEmpty()) {
+                checkDatabaseAndTableStateForContainer(schema.tableIds());
             }
             else {
-                // ALL supplemental logging is enabled, now check table/column lengths
-                for (TableId tableId : schema.tableIds()) {
-                    final Table table = schema.tableFor(tableId);
-                    if (table == null) {
-                        // This should never happen; however in the event something would cause it we can
-                        // at least get the table identifier thrown in the error to debug from rather
-                        // than an erroneous NPE
-                        throw new DebeziumException("Unable to find table in relational model: " + tableId);
-                    }
-                    checkTableColumnNameLengths(table);
+                for (String pdbName : pdbNames) {
+                    connectionFactory.mainConnection().setSessionToPdb(pdbName);
+                    checkDatabaseAndTableStateForContainer(schema.tableIds().stream()
+                            .filter(tableId -> pdbName.equalsIgnoreCase(tableId.catalog()))
+                            .collect(Collectors.toList()));
                 }
             }
         }
@@ -1845,6 +1813,57 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
             }
         }
         LOGGER.trace("Database and table state check finished after {} ms", Duration.between(start, Instant.now()).toMillis());
+    }
+
+    /**
+     * Checks and validates the supplemental logging configuration as well as the lengths of the table
+     * and column names for the specified tables within the connection's current container.
+     *
+     * @param tableIds the tables to be checked, should not be {@code null}
+     * @throws SQLException if a database exception occurred
+     */
+    private void checkDatabaseAndTableStateForContainer(Collection<TableId> tableIds) throws SQLException {
+        // Check if ALL supplemental logging is enabled at the database
+        if (!isDatabaseAllSupplementalLoggingEnabled()) {
+            // Check if MIN supplemental logging is enabled at the database
+            if (!isDatabaseMinSupplementalLoggingEnabled()) {
+                throw new DebeziumException("Supplemental logging not properly configured. "
+                        + "Use: ALTER DATABASE ADD SUPPLEMENTAL LOG DATA");
+            }
+
+            // Check if ALL COLUMNS supplemental logging is enabled for each captured table
+            for (TableId tableId : tableIds) {
+                if (!connectionFactory.mainConnection().isTableExists(tableId)) {
+                    LOGGER.warn("Database table '{}' no longer exists, supplemental log check skipped", tableId);
+                }
+                else if (!isTableAllColumnsSupplementalLoggingEnabled(tableId)) {
+                    LOGGER.warn("Database table '{}' not configured with supplemental logging \"(ALL) COLUMNS\"; " +
+                            "only explicitly changed columns will be captured. " +
+                            "Use: ALTER TABLE {}.{} ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS", tableId, tableId.schema(), tableId.table());
+                }
+                final Table table = schema.tableFor(tableId);
+                if (table == null) {
+                    // This should never happen; however in the event something would cause it we can
+                    // at least get the table identifier thrown in the error to debug from rather
+                    // than an erroneous NPE
+                    throw new DebeziumException("Unable to find table in relational model: " + tableId);
+                }
+                checkTableColumnNameLengths(table);
+            }
+        }
+        else {
+            // ALL supplemental logging is enabled, now check table/column lengths
+            for (TableId tableId : tableIds) {
+                final Table table = schema.tableFor(tableId);
+                if (table == null) {
+                    // This should never happen; however in the event something would cause it we can
+                    // at least get the table identifier thrown in the error to debug from rather
+                    // than an erroneous NPE
+                    throw new DebeziumException("Unable to find table in relational model: " + tableId);
+                }
+                checkTableColumnNameLengths(table);
+            }
+        }
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexes.java
@@ -73,7 +73,7 @@ public final class LogMinerColumnIndexes {
 
     private final ResultSetValueResolver[] resolvers;
 
-    private final String catalogName;
+    private final String defaultCatalogName;
 
     /** Ordinal for {@code USERNAME}, or {@code null} when username tracking is disabled. */
     private final Integer usernameIndex;
@@ -85,6 +85,8 @@ public final class LogMinerColumnIndexes {
     private final Integer startTimestampIndex;
     /** Ordinal for {@code COMMIT_TIMESTAMP}, or {@code null} when commit-timestamp tracking is disabled. */
     private final Integer commitTimestampIndex;
+    /** Ordinal for {@code SRC_CON_NAME}, or {@code null} when a single catalog applies to all rows. */
+    private final Integer srcConNameIndex;
 
     /**
      * Computes all column ordinals from the given configuration flags.
@@ -93,13 +95,14 @@ public final class LogMinerColumnIndexes {
      * {@link AbstractLogMinerQueryBuilder#buildColumnList()} exactly: walk the columns in order,
      * assigning the next sequential 1-based position to each column that is included in the query.
      */
-    private LogMinerColumnIndexes(String catalogName,
+    private LogMinerColumnIndexes(String defaultCatalogName,
                                   boolean trackUsername,
                                   boolean trackRsId,
                                   boolean trackClientId,
                                   boolean trackStartTimestamp,
-                                  boolean trackCommitTimestamp) {
-        this.catalogName = catalogName;
+                                  boolean trackCommitTimestamp,
+                                  boolean multiplePdbNames) {
+        this.defaultCatalogName = defaultCatalogName;
 
         int pos = SEQUENCE;
 
@@ -108,6 +111,7 @@ public final class LogMinerColumnIndexes {
         rsIdIndex = trackRsId ? ++pos : null;
         usernameIndex = trackUsername ? ++pos : null;
         clientIdIndex = trackClientId ? ++pos : null;
+        srcConNameIndex = multiplePdbNames ? ++pos : null;
 
         this.resolvers = LogMinerEventRow.buildOptionalResolvers(this);
     }
@@ -121,12 +125,13 @@ public final class LogMinerColumnIndexes {
      */
     public static LogMinerColumnIndexes fromConfig(OracleConnectorConfig config) {
         return new LogMinerColumnIndexes(
-                config.getCatalogName(),
+                config.getDefaultCatalogName(),
                 config.isLogMiningBufferTrackUsername(),
                 config.isLogMiningBufferTrackRsId(),
                 config.isLogMiningBufferTrackClientId(),
                 config.isLogMiningBufferTrackStartTimestamp(),
-                config.isLogMiningBufferTrackCommitTimestamp());
+                config.isLogMiningBufferTrackCommitTimestamp(),
+                config.getPdbNames().size() > 1);
     }
 
     /**
@@ -147,9 +152,13 @@ public final class LogMinerColumnIndexes {
         return resolvers.length;
     }
 
-    /** Returns the catalog (database) name, used when constructing {@link io.debezium.relational.TableId}s. */
-    public String getCatalogName() {
-        return catalogName;
+    /**
+     * Returns the catalog used when constructing {@link io.debezium.relational.TableId}s and the row does
+     * not carry a {@code SRC_CON_NAME} value: the pluggable database when one is configured, or the
+     * database name when none are.
+     */
+    public String getDefaultCatalogName() {
+        return defaultCatalogName;
     }
 
     /**
@@ -190,6 +199,14 @@ public final class LogMinerColumnIndexes {
      */
     public Integer getCommitTimestampIndex() {
         return commitTimestampIndex;
+    }
+
+    /**
+     * Returns the 1-based ordinal for {@code SRC_CON_NAME}, or {@code null} if the column is absent
+     * from the query because a single catalog applies to all rows.
+     */
+    public Integer getSrcConNameIndex() {
+        return srcConNameIndex;
     }
 
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
@@ -70,6 +70,7 @@ public class LogMinerEventRow {
     private Instant startTime;
     private Instant commitTime;
     private Long transactionSequence;
+    private String srcConName;
 
     public Scn getScn() {
         return scn;
@@ -216,6 +217,10 @@ public class LogMinerEventRow {
             final int pos = indexes.getCommitTimestampIndex();
             resolvers.add((row, rs) -> row.commitTime = getTime(rs, pos));
         }
+        if (indexes.getSrcConNameIndex() != null) {
+            final int pos = indexes.getSrcConNameIndex();
+            resolvers.add((row, rs) -> row.srcConName = rs.getString(pos));
+        }
 
         return resolvers.toArray(new ResultSetValueResolver[0]);
     }
@@ -280,11 +285,12 @@ public class LogMinerEventRow {
         this.redoSql = getSqlRedo(resultSet);
 
         if (this.tableName != null) {
+            final String catalogName = srcConName != null ? srcConName : indexes.getDefaultCatalogName();
             if (schema != null) {
-                this.tableId = schema.resolveTableId(indexes.getCatalogName(), tablespaceName, tableName);
+                this.tableId = schema.resolveTableId(catalogName, tablespaceName, tableName);
             }
             else {
-                this.tableId = new TableId(indexes.getCatalogName(), tablespaceName, tableName);
+                this.tableId = new TableId(catalogName, tablespaceName, tableName);
             }
         }
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/CommitLogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/CommitLogWriterFlushStrategy.java
@@ -49,7 +49,8 @@ public class CommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
     public CommitLogWriterFlushStrategy(OracleConnectorConfig connectorConfig, OracleConnection connection) {
         this.flushTableId = TableId.parse(connectorConfig.getLogMiningFlushTableName());
         this.flushTableName = flushTableId.toDoubleQuotedString();
-        this.databasePdbName = connectorConfig.getPdbName();
+        // The flush table is maintained in the primary (first) PDB when pluggable databases are used
+        this.databasePdbName = connectorConfig.getPdbNames().isEmpty() ? null : connectorConfig.getPdbNames().get(0);
         this.connection = connection;
         createFlushTableIfNotExists();
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/ResumePositionProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/ResumePositionProvider.java
@@ -24,7 +24,6 @@ import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.util.Clock;
 import io.debezium.util.HexConverter;
-import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
 
@@ -82,7 +81,7 @@ public class ResumePositionProvider implements AutoCloseable {
                 connection = new OracleConnection(connectorConfig, jdbcConfig, false);
 
                 // LogMiner must be run in the CDB
-                if (!Strings.isNullOrEmpty(connectorConfig.getPdbName())) {
+                if (connectorConfig.isUsingPluggableDatabase()) {
                     connection.resetSessionToCdb();
                 }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -30,7 +30,6 @@ import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 import oracle.streams.ChunkColumnValue;
 import oracle.streams.DDLLCR;
@@ -309,12 +308,11 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
     private String getTableMetadataDdl(TableId tableId) throws NonRelationalTableException {
         LOGGER.info("Getting database metadata for table '{}'", tableId);
-        final String pdbName = connectorConfig.getPdbName();
         // A separate connection must be used for this out-of-bands query while processing the Xstream callback.
         // This should have negligible overhead as this should happen rarely.
         try (OracleConnection connection = new OracleConnection(connectorConfig, false)) {
-            if (!Strings.isNullOrBlank(pdbName)) {
-                connection.setSessionToPdb(pdbName);
+            if (connectorConfig.isUsingPluggableDatabase()) {
+                connection.setSessionToPdb(tableId.catalog());
             }
             return connection.getTableMetadataDdl(tableId);
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -119,6 +119,67 @@ public class OracleConnectorConfigTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#478")
+    void shouldTreatDeprecatedPdbNameAsSingleEntryPdbNames() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                defaultConfigBuilder()
+                        .with("database.pdb.name", "orclpdb1")
+                        .build());
+        assertTrue(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));
+        assertThat(connectorConfig.getPdbNames()).containsExactly("ORCLPDB1");
+        assertThat(connectorConfig.getCatalogNames()).containsExactly("ORCLPDB1");
+        assertTrue(connectorConfig.isUsingPluggableDatabase());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void shouldTreatPdbNamesAsCollectionOfPdbNames() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                defaultConfigBuilder()
+                        .with(OracleConnectorConfig.PDB_NAMES, "orclpdb1, orclpdb2")
+                        .build());
+        assertTrue(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));
+        assertThat(connectorConfig.getPdbNames()).containsExactly("ORCLPDB1", "ORCLPDB2");
+        assertThat(connectorConfig.getCatalogNames()).containsExactly("ORCLPDB1", "ORCLPDB2");
+        assertTrue(connectorConfig.isUsingPluggableDatabase());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void shouldPreferPdbNamesOverDeprecatedPdbName() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                defaultConfigBuilder()
+                        .with("database.pdb.name", "otherpdb")
+                        .with(OracleConnectorConfig.PDB_NAMES, "orclpdb1")
+                        .build());
+        assertThat(connectorConfig.getPdbNames()).containsExactly("ORCLPDB1");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void shouldHaveNoPdbNamesWhenNotConfigured() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(defaultConfigBuilder().build());
+        assertThat(connectorConfig.getPdbNames()).isEmpty();
+        assertThat(connectorConfig.getCatalogNames()).containsExactly("MYDB");
+        assertFalse(connectorConfig.isUsingPluggableDatabase());
+    }
+
+    private Configuration.Builder defaultConfigBuilder() {
+        return Configuration.create()
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
+                .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                .with(OracleConnectorConfig.USER, "debezium")
+                .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "localhost:9092")
+                .with(KafkaSchemaHistory.TOPIC, "history");
+    }
+
+    @Test
     void invalidNoHostnameNoUri() throws Exception {
 
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -3200,7 +3200,7 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
         final Configuration config;
         if (TestHelper.isUsingPdb()) {
             config = TestHelper.defaultConfig()
-                    .with(OracleConnectorConfig.PDB_NAME, TestHelper.getDatabaseName().toLowerCase())
+                    .with(OracleConnectorConfig.PDB_NAMES, TestHelper.getDatabaseName().toLowerCase())
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                     .build();
         }
@@ -3226,7 +3226,7 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
         final Configuration config;
         if (TestHelper.isUsingPdb()) {
             config = TestHelper.defaultConfig()
-                    .with(OracleConnectorConfig.PDB_NAME, "\"" + TestHelper.getDatabaseName() + "\"")
+                    .with(OracleConnectorConfig.PDB_NAMES, "\"" + TestHelper.getDatabaseName() + "\"")
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                     .build();
         }
@@ -5804,10 +5804,10 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
             Configuration tempConfig = TestHelper.defaultConfig().build();
 
             final Configuration.Builder builder = TestHelper.defaultConfig();
-            if (!Strings.isNullOrEmpty(tempConfig.getString(OracleConnectorConfig.PDB_NAME))) {
+            if (!Strings.isNullOrEmpty(tempConfig.getString(OracleConnectorConfig.PDB_NAMES))) {
                 // For this use case, both PDB and DBNAME should refer to PDB
                 // This is an unconventional configuration, but permissible.
-                builder.with(OracleConnectorConfig.DATABASE_NAME, tempConfig.getString(OracleConnectorConfig.PDB_NAME));
+                builder.with(OracleConnectorConfig.DATABASE_NAME, tempConfig.getString(OracleConnectorConfig.PDB_NAMES));
             }
             builder.with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8577")
                     .with(OracleConnectorConfig.LOG_MINING_RESTART_CONNECTION, "true");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -103,7 +103,6 @@ import io.debezium.relational.history.MemorySchemaHistory;
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
 import io.debezium.storage.file.history.FileSchemaHistory;
-import io.debezium.util.Strings;
 import io.debezium.util.Testing;
 
 import ch.qos.logback.classic.Level;
@@ -5802,12 +5801,14 @@ public class OracleConnectorIT extends AbstractAsyncEngineConnectorTest {
             TestHelper.streamTable(connection, "dbz8577");
 
             Configuration tempConfig = TestHelper.defaultConfig().build();
+            final List<String> pdbNames = new OracleConnectorConfig(tempConfig).getPdbNames();
 
             final Configuration.Builder builder = TestHelper.defaultConfig();
-            if (!Strings.isNullOrEmpty(tempConfig.getString(OracleConnectorConfig.PDB_NAMES))) {
-                // For this use case, both PDB and DBNAME should refer to PDB
+            if (!pdbNames.isEmpty()) {
+                // For this use case, both PDB and DBNAME should refer to the same, single PDB
                 // This is an unconventional configuration, but permissible.
-                builder.with(OracleConnectorConfig.DATABASE_NAME, tempConfig.getString(OracleConnectorConfig.PDB_NAMES));
+                builder.with(OracleConnectorConfig.DATABASE_NAME, pdbNames.get(0));
+                builder.with(OracleConnectorConfig.PDB_NAMES, pdbNames.get(0));
             }
             builder.with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ8577")
                     .with(OracleConnectorConfig.LOG_MINING_RESTART_CONNECTION, "true");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
@@ -126,7 +126,7 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void assertFlushTableHasExactlyOneRow(Configuration config) throws SQLException {
         try (OracleConnection conn = TestHelper.defaultConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
+            final String databasePdbName = getFlushTablePdbName(config);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 conn.setSessionToPdb(databasePdbName);
             }
@@ -136,7 +136,7 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void dropFlushTable(Configuration config) throws SQLException {
         try (OracleConnection admin = TestHelper.adminConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
+            final String databasePdbName = getFlushTablePdbName(config);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 admin.setSessionToPdb(databasePdbName);
             }
@@ -146,12 +146,17 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void insertFlushTable(Configuration config, String scnValue) throws SQLException {
         try (OracleConnection conn = TestHelper.defaultConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
+            final String databasePdbName = getFlushTablePdbName(config);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 conn.setSessionToPdb(databasePdbName);
             }
             conn.execute("INSERT INTO " + getFlushTableName() + " values (" + scnValue + ")");
         }
+    }
+
+    private static String getFlushTablePdbName(Configuration config) {
+        // The flush table is maintained in the first configured pluggable database
+        return new OracleConnectorConfig(config).getPdbNames().stream().findFirst().orElse(null);
     }
 
     private static String getFlushTableName() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
@@ -126,7 +126,7 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void assertFlushTableHasExactlyOneRow(Configuration config) throws SQLException {
         try (OracleConnection conn = TestHelper.defaultConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAME);
+            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 conn.setSessionToPdb(databasePdbName);
             }
@@ -136,7 +136,7 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void dropFlushTable(Configuration config) throws SQLException {
         try (OracleConnection admin = TestHelper.adminConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAME);
+            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 admin.setSessionToPdb(databasePdbName);
             }
@@ -146,7 +146,7 @@ public class FlushStrategyIT extends AbstractAsyncEngineConnectorTest {
 
     private void insertFlushTable(Configuration config, String scnValue) throws SQLException {
         try (OracleConnection conn = TestHelper.defaultConnection(true)) {
-            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAME);
+            final String databasePdbName = config.getString(OracleConnectorConfig.PDB_NAMES);
             if (!Strings.isNullOrEmpty(databasePdbName)) {
                 conn.setSessionToPdb(databasePdbName);
             }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerColumnIndexesTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
 
 /**
  * Unit tests for {@link LogMinerColumnIndexes}.
@@ -62,6 +63,23 @@ public class LogMinerColumnIndexesTest {
         assertThat(idx.getRsIdIndex()).isEqualTo(24);
         assertThat(idx.getUsernameIndex()).isEqualTo(25);
         assertThat(idx.getClientIdIndex()).isEqualTo(26);
+        assertThat(idx.getSrcConNameIndex()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void multiplePdbNamesShouldAddSrcConNameOrdinal() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.PDB_NAMES, "ORCLPDB1,ORCLPDB2");
+
+        assertThat(idx.getSrcConNameIndex()).isEqualTo(27);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void singlePdbNameShouldNotAddSrcConNameOrdinal() {
+        LogMinerColumnIndexes idx = fromConfig(OracleConnectorConfig.PDB_NAMES, "ORCLPDB1");
+
+        assertThat(idx.getSrcConNameIndex()).isNull();
     }
 
     @Test
@@ -143,6 +161,13 @@ public class LogMinerColumnIndexesTest {
     @Test
     void allTrackingEnabledShouldProduceFullResolverArray() {
         assertThat(fromDefaultConfig().getResolverCount()).isEqualTo(RESOLVER_COUNT_ALL_ENABLED);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    void multiplePdbNamesShouldIncreaseResolverCountByOne() {
+        assertThat(fromConfig(OracleConnectorConfig.PDB_NAMES, "ORCLPDB1,ORCLPDB2")
+                .getResolverCount()).isEqualTo(RESOLVER_COUNT_ALL_ENABLED + 1);
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -11,7 +11,7 @@ import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_BUFF
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_QUERY_FILTER_MODE;
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST;
 import static io.debezium.connector.oracle.OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST;
-import static io.debezium.connector.oracle.OracleConnectorConfig.PDB_NAME;
+import static io.debezium.connector.oracle.OracleConnectorConfig.PDB_NAMES;
 import static io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerQueryBuilder.IN_CLAUSE_MAX_ELEMENTS;
 import static io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST;
@@ -71,21 +71,27 @@ public class LogMinerQueryBuilderTest {
     @FixFor("DBZ-5648")
     public void testLogMinerQueryWithLobDisabled() {
         assertQuery(TestHelper.defaultConfig().build());
-        assertQuery(TestHelper.defaultConfig().with(PDB_NAME, "").build());
+        assertQuery(TestHelper.defaultConfig().with(PDB_NAMES, "").build());
     }
 
     @Test
     @FixFor("DBZ-7473")
     public void testLogMinerQueryWithLobDisabledAndPersistentBuffer() {
         assertQuery(TestHelper.defaultConfig().with(LOG_MINING_BUFFER_TYPE, OracleConnectorConfig.LogMiningBufferType.INFINISPAN_EMBEDDED).build());
-        assertQuery(TestHelper.defaultConfig().with(PDB_NAME, "").build());
+        assertQuery(TestHelper.defaultConfig().with(PDB_NAMES, "").build());
     }
 
     @Test
     @FixFor("DBZ-5648")
     public void testLogMinerQueryWithLobEnabled() {
         assertQuery(TestHelper.defaultConfig().with(LOB_ENABLED, true).build());
-        assertQuery(TestHelper.defaultConfig().with(PDB_NAME, "").with(LOB_ENABLED, true).build());
+        assertQuery(TestHelper.defaultConfig().with(PDB_NAMES, "").with(LOB_ENABLED, true).build());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#478")
+    public void testLogMinerQueryWithMultiplePdbNames() {
+        assertQuery(TestHelper.defaultConfig().with(OracleConnectorConfig.PDB_NAMES, "ORCLPDB1,ORCLPDB2").build());
     }
 
     @Test
@@ -258,6 +264,9 @@ public class LogMinerQueryBuilderTest {
         if (config.isLogMiningBufferTrackClientId()) {
             columns.add("CLIENT_ID");
         }
+        if (config.getPdbNames().size() > 1) {
+            columns.add("SRC_CON_NAME");
+        }
 
         return String.join(", ", columns) + " ";
     }
@@ -297,8 +306,12 @@ public class LogMinerQueryBuilderTest {
     }
 
     private String getPdbPredicate(OracleConnectorConfig config) {
-        if (!Strings.isNullOrEmpty(config.getPdbName())) {
-            return " AND SRC_CON_NAME = '" + config.getPdbName() + "'";
+        final List<String> pdbNames = config.getPdbNames();
+        if (pdbNames.size() == 1) {
+            return " AND SRC_CON_NAME = '" + pdbNames.get(0) + "'";
+        }
+        else if (pdbNames.size() > 1) {
+            return pdbNames.stream().collect(Collectors.joining("','", " AND SRC_CON_NAME IN ('", "')"));
         }
         return "";
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -264,6 +264,16 @@ public class TestHelper {
     }
 
     /**
+     * Obtain a connection using the default configuration, pinned to the specified pluggable database.
+     *
+     * @param pdbName the pluggable database to pin the connection's session to
+     */
+    public static OracleConnection defaultConnection(String pdbName) {
+        Configuration jdbcConfig = defaultConfig().build().subset(DATABASE_PREFIX, true);
+        return createConnection(JdbcConfiguration.adapt(jdbcConfig), pdbName, true);
+    }
+
+    /**
      * Returns a JdbcConfiguration for the test schema and user account.
      */
     private static JdbcConfiguration testJdbcConfig() {
@@ -358,6 +368,17 @@ public class TestHelper {
     }
 
     /**
+     * Return a test connection that is suitable for performing test database changes in tests,
+     * pinned to the specified pluggable database.
+     *
+     * @param pdbName the pluggable database to pin the connection's session to
+     */
+    public static OracleConnection testConnection(String pdbName) {
+        Configuration jdbcConfig = testConfig().build().subset(DATABASE_PREFIX, true);
+        return createConnection(JdbcConfiguration.adapt(jdbcConfig), pdbName, false);
+    }
+
+    /**
      * Return a connection that is suitable for performing test database changes that require
      * an administrator role permission.
      *
@@ -390,6 +411,17 @@ public class TestHelper {
     }
 
     /**
+     * Return a connection that is suitable for performing test database changes that require
+     * an administrator role permission, pinned to the specified pluggable database.
+     *
+     * @param pdbName the pluggable database to pin the connection's session to
+     */
+    public static OracleConnection adminConnection(String pdbName) {
+        Configuration jdbcConfig = adminConfig().build().subset(DATABASE_PREFIX, true);
+        return createConnection(JdbcConfiguration.adapt(jdbcConfig), pdbName, false);
+    }
+
+    /**
      * Create an OracleConnection.
      *
      * @param config the connector configuration
@@ -398,6 +430,19 @@ public class TestHelper {
      * @return the connection
      */
     private static OracleConnection createConnection(Configuration config, JdbcConfiguration jdbcConfig, boolean autoCommit) {
+        return createConnection(jdbcConfig, getFirstPdbName(config), autoCommit);
+    }
+
+    /**
+     * Create an OracleConnection pinned to the specified pluggable database.
+     *
+     * @param jdbcConfig the JDBC configuration
+     * @param pdbName the pluggable database to pin the connection's session to, or {@code null} to
+     *        leave the session in the container the connection was established against
+     * @param autoCommit whether the connection should enforce auto-commit
+     * @return the connection
+     */
+    private static OracleConnection createConnection(JdbcConfiguration jdbcConfig, String pdbName, boolean autoCommit) {
         // Setting this to true at least keeps existing behavior, expecting tests to set this to false
         // as needed since this connection is not used in the connector but as part of the test, to
         // perform required database SQL operations.
@@ -405,9 +450,8 @@ public class TestHelper {
         try {
             connection.setAutoCommit(autoCommit);
 
-            List<String> pdbNames = new OracleConnectorConfig(config).getPdbNames();
-            if (!pdbNames.isEmpty()) {
-                connection.setSessionToPdb(pdbNames.get(0));
+            if (!Strings.isNullOrEmpty(pdbName)) {
+                connection.setSessionToPdb(pdbName);
             }
 
             return connection;
@@ -567,9 +611,24 @@ public class TestHelper {
      * @throws RuntimeException if the role cannot be granted
      */
     public static void grantRole(String roleName, String objectName, String userName) {
-        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAMES);
+        grantRole(roleName, objectName, userName, getFirstDefaultConfigPdbName());
+    }
+
+    /**
+     * Grants the specified roles to the {@link TestHelper#SCHEMA_USER} or the user configured using the
+     * configuration option {@code database.user}, which has precedence, on the specified object within
+     * the specified pluggable database.
+     *
+     * @param roleName role to be granted
+     * @param objectName the object to grant the role against
+     * @param userName the user to whom the grant should be applied
+     * @param pdbName the pluggable database in which to perform the grant, or {@code null} to perform
+     *        it in the current container
+     * @throws RuntimeException if the role cannot be granted
+     */
+    public static void grantRole(String roleName, String objectName, String userName, String pdbName) {
         try (OracleConnection connection = adminConnection()) {
-            if (pdbName != null) {
+            if (!Strings.isNullOrEmpty(pdbName)) {
                 connection.setSessionToPdb(pdbName);
             }
             final StringBuilder sql = new StringBuilder("GRANT ").append(roleName);
@@ -594,10 +653,23 @@ public class TestHelper {
      * @throws RuntimeException if the role cannot be revoked
      */
     public static void revokeRole(String roleName) {
-        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAMES);
+        revokeRole(roleName, getFirstDefaultConfigPdbName());
+    }
+
+    /**
+     * Revokes the specified role from the {@link TestHelper#SCHEMA_USER} or the user configured using
+     * the configuration option {@code database.user}, whichever has precedence, within the specified
+     * pluggable database.
+     *
+     * @param roleName role to be revoked
+     * @param pdbName the pluggable database in which to perform the revoke, or {@code null} to perform
+     *        it in the current container
+     * @throws RuntimeException if the role cannot be revoked
+     */
+    public static void revokeRole(String roleName, String pdbName) {
         final String userName = testJdbcConfig().getString(JdbcConfiguration.USER);
         try (OracleConnection connection = adminConnection()) {
-            if (pdbName != null) {
+            if (!Strings.isNullOrEmpty(pdbName)) {
                 connection.setSessionToPdb(pdbName);
             }
             connection.execute("REVOKE " + roleName + " FROM " + userName);
@@ -605,6 +677,15 @@ public class TestHelper {
         catch (SQLException e) {
             throw new RuntimeException("Failed to revoke role '" + roleName + "' for user " + userName, e);
         }
+    }
+
+    private static String getFirstDefaultConfigPdbName() {
+        return getFirstPdbName(defaultConfig().build());
+    }
+
+    private static String getFirstPdbName(Configuration config) {
+        final List<String> pdbNames = new OracleConnectorConfig(config).getPdbNames();
+        return pdbNames.isEmpty() ? null : pdbNames.get(0);
     }
 
     public static int defaultMessageConsumerPollTimeout() {
@@ -846,7 +927,7 @@ public class TestHelper {
         if (imageTag.contains("-")) {
             imageTagSuffix = imageTag.substring(imageTag.lastIndexOf("-") + 1);
         }
-        String pdbName = connectorConfiguration.asProperties().getProperty(DATABASE_PREFIX + PDB_NAME);
+        String pdbName = getFirstConfiguredPdbName(connectorConfiguration);
         if (!imageTag.contains("-") || "xs".equals(imageTagSuffix)) {
             if (!Strings.isNullOrEmpty(pdbName)) {
                 connectorConfiguration.with(OracleConnectorConfig.DATABASE_NAME.name(), pdbName);
@@ -854,12 +935,22 @@ public class TestHelper {
         }
         else if ("noncdb".equals(imageTagSuffix)) {
             if (!Strings.isNullOrEmpty(pdbName)) {
+                connectorConfiguration.remove(OracleConnectorConfig.PDB_NAMES.name());
                 connectorConfiguration.remove(DATABASE_PREFIX + PDB_NAME);
             }
         }
         else {
             throw new RuntimeException("Invalid or unknown image tag '" + imageTagSuffix + "' for Oracle container image: " + oracleImageName);
         }
+    }
+
+    private static String getFirstConfiguredPdbName(ConnectorConfiguration connectorConfiguration) {
+        String pdbNames = connectorConfiguration.asProperties().getProperty(OracleConnectorConfig.PDB_NAMES.name());
+        if (Strings.isNullOrEmpty(pdbNames)) {
+            pdbNames = connectorConfiguration.asProperties().getProperty(DATABASE_PREFIX + PDB_NAME);
+        }
+        final List<String> names = Strings.listOfTrimmed(pdbNames, String::new);
+        return names.isEmpty() ? null : names.get(0);
     }
 
     public static long getUndoRetentionSeconds() throws SQLException {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -213,7 +213,7 @@ public class TestHelper {
         // the environment wishes to use non-CDB mode, the database.pdb.name setting should be
         // given but without a value.
         if (isUsingPdb()) {
-            builder.withDefault(OracleConnectorConfig.PDB_NAME, DATABASE);
+            builder.withDefault(DATABASE_PREFIX + PDB_NAME, DATABASE);
         }
 
         return builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
@@ -405,9 +405,9 @@ public class TestHelper {
         try {
             connection.setAutoCommit(autoCommit);
 
-            String pdbName = new OracleConnectorConfig(config).getPdbName();
-            if (!Strings.isNullOrEmpty(pdbName)) {
-                connection.setSessionToPdb(pdbName);
+            List<String> pdbNames = new OracleConnectorConfig(config).getPdbNames();
+            if (!pdbNames.isEmpty()) {
+                connection.setSessionToPdb(pdbNames.get(0));
             }
 
             return connection;
@@ -422,7 +422,7 @@ public class TestHelper {
         Configuration jdbcConfig = config.subset(DATABASE_PREFIX, true);
 
         try (OracleConnection jdbcConnection = new OracleConnection(JdbcConfiguration.adapt(jdbcConfig), true)) {
-            if (!Strings.isNullOrEmpty((new OracleConnectorConfig(defaultConfig().build())).getPdbName())) {
+            if (!(new OracleConnectorConfig(defaultConfig().build())).getPdbNames().isEmpty()) {
                 jdbcConnection.resetSessionToCdb();
             }
             jdbcConnection.execute("ALTER SYSTEM SWITCH LOGFILE");
@@ -437,7 +437,7 @@ public class TestHelper {
         Configuration jdbcConfig = config.subset(DATABASE_PREFIX, true);
 
         try (OracleConnection jdbcConnection = new OracleConnection(JdbcConfiguration.adapt(jdbcConfig), true)) {
-            if (!Strings.isNullOrEmpty((new OracleConnectorConfig(defaultConfig().build())).getPdbName())) {
+            if (!(new OracleConnectorConfig(defaultConfig().build())).getPdbNames().isEmpty()) {
                 jdbcConnection.resetSessionToCdb();
             }
             return jdbcConnection.queryAndMap("SELECT COUNT(GROUP#) FROM V$LOG", rs -> {
@@ -567,7 +567,7 @@ public class TestHelper {
      * @throws RuntimeException if the role cannot be granted
      */
     public static void grantRole(String roleName, String objectName, String userName) {
-        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAME);
+        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAMES);
         try (OracleConnection connection = adminConnection()) {
             if (pdbName != null) {
                 connection.setSessionToPdb(pdbName);
@@ -594,7 +594,7 @@ public class TestHelper {
      * @throws RuntimeException if the role cannot be revoked
      */
     public static void revokeRole(String roleName) {
-        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAME);
+        final String pdbName = defaultConfig().build().getString(OracleConnectorConfig.PDB_NAMES);
         final String userName = testJdbcConfig().getString(JdbcConfiguration.USER);
         try (OracleConnection connection = adminConnection()) {
             if (pdbName != null) {
@@ -846,7 +846,7 @@ public class TestHelper {
         if (imageTag.contains("-")) {
             imageTagSuffix = imageTag.substring(imageTag.lastIndexOf("-") + 1);
         }
-        String pdbName = connectorConfiguration.asProperties().getProperty(OracleConnectorConfig.PDB_NAME.name());
+        String pdbName = connectorConfiguration.asProperties().getProperty(DATABASE_PREFIX + PDB_NAME);
         if (!imageTag.contains("-") || "xs".equals(imageTagSuffix)) {
             if (!Strings.isNullOrEmpty(pdbName)) {
                 connectorConfiguration.with(OracleConnectorConfig.DATABASE_NAME.name(), pdbName);
@@ -854,7 +854,7 @@ public class TestHelper {
         }
         else if ("noncdb".equals(imageTagSuffix)) {
             if (!Strings.isNullOrEmpty(pdbName)) {
-                connectorConfiguration.remove(OracleConnectorConfig.PDB_NAME.name());
+                connectorConfiguration.remove(DATABASE_PREFIX + PDB_NAME);
             }
         }
         else {

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
@@ -226,7 +226,7 @@ public class EndToEndPerf {
             jdbcConfiguration.forEach((f, v) -> builder.with(ConfigurationNames.DATABASE_CONFIG_PREFIX + f, v));
 
             return builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
-                    .with(OracleConnectorConfig.PDB_NAME, "ORCLPDB1")
+                    .with(OracleConnectorConfig.PDB_NAMES, "ORCLPDB1")
                     .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                     .with(OracleConnectorConfig.CONNECTOR_ADAPTER, ConnectorAdapter.LOG_MINER)
                     .with(OracleConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -242,9 +242,9 @@ public class EndToEndPerf {
 
         private OracleConnection getTestConnection() {
             OracleConnection connection = new OracleConnection(testJdbcConfig(), false);
-            String pdbName = new OracleConnectorConfig(testConfig().build()).getPdbName();
-            if (pdbName != null) {
-                connection.setSessionToPdb(pdbName);
+            List<String> pdbNames = new OracleConnectorConfig(testConfig().build()).getPdbNames();
+            if (!pdbNames.isEmpty()) {
+                connection.setSessionToPdb(pdbNames.get(0));
             }
 
             return connection;

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -195,6 +195,13 @@ If you want the connector to capture data only from specific tables you can dire
 3. Obtain a `ROW SHARE MODE` lock on each of the captured tables to prevent structural changes from occurring during creation of the snapshot.
 +
 NOTE: {prodname} holds the locks for only a short time.
++
+[NOTE]
+====
+Because an Oracle transaction cannot span containers, when you configure the connector to capture changes from multiple pluggable databases through the xref:oracle-property-database-pdb-names[`database.pdb.names`] property, the connector opens a dedicated database connection for each pluggable database.
+Each connection holds the locks for its pluggable database's tables until the schema capture completes (Step 6), ensuring a consistent snapshot across all pluggable databases.
+The connector closes these additional connections after it releases the locks.
+====
 
 4. Read the current system change number (SCN) position from the server's redo log.
 
@@ -4030,7 +4037,8 @@ Valid values include raw TNS names and RAC connection strings.
 |No default
 |Comma-separated list of the names of the Oracle pluggable databases to capture changes from. Use this property with container database (CDB) installations only. +
 The first name in the list designates the container that the connector uses for connector-managed objects, such as the LogMiner flush table and heartbeat action queries. +
-This property replaces the deprecated `database.pdb.name` property. If you specify `database.pdb.name`, the connector treats its value as a single-entry list.
+This property replaces the deprecated `database.pdb.name` property. If you specify `database.pdb.name`, the connector treats its value as a single-entry list. +
+When multiple names are specified, the connector opens one additional connection per pluggable database during the initial snapshot to hold schema locks while it creates a consistent snapshot.
 
 |[[oracle-property-topic-prefix]]<<oracle-property-topic-prefix, `+topic.prefix+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3583,7 +3583,7 @@ spec:
     database.user: c##dbzuser
     database.password: dbz
     database.dbname: ORCLCDB
-    database.pdb.name : ORCLPDB1,
+    database.pdb.names : ORCLPDB1,
     topic.prefix: inventory-connector-{context}
     schema.history.internal.kafka.bootstrap.servers: kafka:9092
     schema.history.internal.kafka.topic: schema-changes.inventory
@@ -3612,8 +3612,8 @@ The password for the Oracle user, as specified in xref:creating-users-for-the-co
 `database.dbname`::
 The name of the database to capture changes from.
 
-`database.pdb.name`::
-The name of the Oracle pluggable database that the connector captures changes from.
+`database.pdb.names`::
+The comma-separated list of names of the Oracle pluggable databases that the connector captures changes from.
 Used in container database (CDB) installations only.
 
 `topic.prefix`::
@@ -3661,7 +3661,7 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
         "database.dbname" : "ORCLCDB",
         "topic.prefix" : "server1",
         "tasks.max" : "1",
-        "database.pdb.name" : "ORCLPDB1",
+        "database.pdb.names" : "ORCLPDB1",
         "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092",
         "schema.history.internal.kafka.topic": "schema-changes.inventory"
     }
@@ -3697,8 +3697,8 @@ Topic prefix that identifies and provides a namespace for the Oracle database se
 `tasks.max`::
 The maximum number of tasks to create for this connector.
 
-`database.pdb.name`::
-The name of the Oracle pluggable database that the connector captures changes from.
+`database.pdb.names`::
+The comma-separated list of names of the Oracle pluggable databases that the connector captures changes from.
 Used in container database (CDB) installations only.
 
 `schema.history.internal.kafka.bootstrap.servers`::
@@ -3742,7 +3742,7 @@ The following JSON example shows the same configuration as in the preceding exam
         "database.password" : "dbz",
         "database.url": "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS_LIST=(LOAD_BALANCE=OFF)(FAILOVER=ON)(ADDRESS=(PROTOCOL=TCP)(HOST=<oracle ip 1>)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=<oracle ip 2>)(PORT=1521)))(CONNECT_DATA=SERVICE_NAME=)(SERVER=DEDICATED)))",
         "database.dbname" : "ORCLCDB",
-        "database.pdb.name" : "ORCLPDB1",
+        "database.pdb.names" : "ORCLPDB1",
         "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092",
         "schema.history.internal.kafka.topic": "schema-changes.inventory"
     }
@@ -3814,7 +3814,7 @@ ifdef::community[]
         "database.user" : "c##dbzuser",
         "database.password" : "dbz",
         "database.dbname" : "ORCLCDB",
-        "database.pdb.name" : "ORCLPDB1",
+        "database.pdb.names" : "ORCLPDB1",
         "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092",
         "schema.history.internal.kafka.topic": "schema-changes.inventory"
     }
@@ -3823,8 +3823,8 @@ ifdef::community[]
 
 [IMPORTANT]
 ====
-When you configure a {prodname} Oracle connector for use with an Oracle CDB, you must specify a value for the property `database.pdb.name`, which names the PDB that you want the connector to capture changes from.
-For non-CDB installation, do *not* specify the `database.pdb.name` property.
+When you configure a {prodname} Oracle connector for use with an Oracle CDB, you must specify a value for the property `database.pdb.names`, which names one or more PDBs that you want the connector to capture changes from.
+For non-CDB installation, do *not* specify the `database.pdb.names` property.
 ====
 
 .Example: {prodname} Oracle connector configuration for non-CDB deployments
@@ -4026,9 +4026,11 @@ In a container database environment, specify the name of the root container data
 |Specifies the raw database JDBC URL. Use this property to provide flexibility in defining that database connection.
 Valid values include raw TNS names and RAC connection strings.
 
-|[[oracle-property-database-pdb-name]]<<oracle-property-database-pdb-name, `+database.pdb.name+`>>
+|[[oracle-property-database-pdb-names]]<<oracle-property-database-pdb-names, `+database.pdb.names+`>>
 |No default
-|Name of the Oracle pluggable database to connect to. Use this property with container database (CDB) installations only.
+|Comma-separated list of the names of the Oracle pluggable databases to capture changes from. Use this property with container database (CDB) installations only. +
+The first name in the list designates the container that the connector uses for connector-managed objects, such as the LogMiner flush table and heartbeat action queries. +
+This property replaces the deprecated `database.pdb.name` property. If you specify `database.pdb.name`, the connector treats its value as a single-entry list.
 
 |[[oracle-property-topic-prefix]]<<oracle-property-topic-prefix, `+topic.prefix+`>>
 |No default
@@ -4186,7 +4188,7 @@ endif::community[]
 | All tables specified in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`__<databaseName>.____<schemaName>__.__<tableName>__`) of the tables to include in a snapshot.
 
-In a multitenant container database (CDB) environment, the regular expression must include the xref:oracle-property-database-pdb-name[pluggable database (PDB) name], using the format `__<pdbName>__.__<schemaName>__.__<tableName>__`.
+In a multitenant container database (CDB) environment, the regular expression must include the xref:oracle-property-database-pdb-names[pluggable database (PDB) name], using the format `__<pdbName>__.__<schemaName>__.__<tableName>__`.
 
 To match the name of a table, {prodname} applies the regular expression that you specify as an _anchored_ regular expression.
 That is, the specified expression is matched against the entire name string of the table; it does not match substrings that might be present in a table name.
@@ -5921,7 +5923,7 @@ In the example that follows, the following properties are added to the connector
         "database.user" : "c##dbzuser",
         "database.password" : "dbz",
         "database.dbname" : "ORCLCDB",
-        "database.pdb.name" : "ORCLPDB1",
+        "database.pdb.names" : "ORCLPDB1",
         "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092",
         "schema.history.internal.kafka.topic": "schema-changes.inventory",
         "database.connection.adapter": "olr",
@@ -6311,7 +6313,7 @@ The following configuration example adds the properties `database.connection.ada
         "database.user" : "c##dbzuser",
         "database.password" : "dbz",
         "database.dbname" : "ORCLCDB",
-        "database.pdb.name" : "ORCLPDB1",
+        "database.pdb.names" : "ORCLPDB1",
         "schema.history.internal.kafka.bootstrap.servers" : "kafka:9092",
         "schema.history.internal.kafka.topic": "schema-changes.inventory",
         "database.connection.adapter": "xstream",


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#478

## Description
The Oracle connector has inherently supported capturing changes from a single-tenant database or a single PDB within a multi-tenant database.

This change introduces `database.pdb.names`, a new property to specify a comma-separated list of PDB names that Debezium will use to capture changes for. When specifying `database.pdb.name`, the legacy property, the connector operates as `database.pdb.names` with a single value, with no change in current behavior.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
