### PR TITLE
debezium/dbz#1541 Do not treat a missing server id as a different server during history recovery

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
@@ -110,8 +110,9 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
             return false;
         }
 
-        // Both positions are missing GTIDs, compare servers
-        if (getServerId(recorded) != getServerId(desired)) {
+        // Both positions are missing GTIDs, compare servers. A missing server id is not a different server:
+        // snapshot offsets never carry one, as there is no way to tell which primary of a topology wrote the change.
+        if (hasServerId(recorded) && hasServerId(desired) && getServerId(recorded) != getServerId(desired)) {
             // These are from different servers.
             // Their binlog coordinates are not related, so the only thing that is possible is to compare
             // timestamps, and assume that the server timestamps can be compared.
@@ -175,6 +176,16 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
     }
 
     /**
+     * Get whether the position carries a server unique identifier.
+     *
+     * @param document the document to inspect, should not be null
+     * @return true if the document has a server identifier, false otherwise
+     */
+    protected boolean hasServerId(Document document) {
+        return document.has(BinlogSourceInfo.SERVER_ID_KEY);
+    }
+
+    /**
      * Get the server unique identifier.
      *
      * @param document the document to inspect, should not be null
@@ -198,10 +209,10 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
      * Get the timestamp.
      *
      * @param document the document to inspect, should not be null
-     * @return the timestamp value
+     * @return the timestamp value, in seconds
      */
     protected long getTimestamp(Document document) {
-        return document.getLong(BinlogSourceInfo.TIMESTAMP_KEY, 0);
+        return document.getLong(BinlogOffsetContext.TIMESTAMP_KEY, 0);
     }
 
     /**

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
@@ -596,6 +596,34 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
     }
 
     @Test
+    @FixFor("debezium/dbz#1541")
+    void shouldCompareTimestampsOfPositionsFromDifferentServers() {
+        // The comparator has to read the timestamp key the offset is written with, or every position compares as 0.
+        assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 223344, 1_000))
+                .isAtOrBefore(positionWithServerId("mysql-bin.000007", 154, 223345, 2_000));
+        assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 223344, 2_000))
+                .isAfter(positionWithServerId("mysql-bin.000007", 154, 223345, 1_000));
+
+        // The same server keeps comparing by coordinates, even when the timestamps disagree.
+        assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 223344, 2_000))
+                .isAtOrBefore(positionWithServerId("mysql-bin.000007", 154, 223344, 1_000));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1541")
+    void shouldNotTreatPositionWithoutServerIdAsDifferentServer() {
+        // Streaming records a server id, but the restart position rebuilt by the offset loaders carries none.
+        // That pair must not take the different-servers branch: it is compared by coordinates, which here
+        // contradict the timestamps.
+        final Document withoutServerId = positionWithoutGtids("mysql-bin.000003", 154, 0, 0)
+                .set(BinlogOffsetContext.TIMESTAMP_KEY, 2_000);
+        final Document withServerId = positionWithServerId("mysql-bin.000003", 900, 223344, 1_000);
+
+        assertThatDocument(withoutServerId).isAtOrBefore(withServerId);
+        assertThatDocument(withServerId).isAfter(withoutServerId);
+    }
+
+    @Test
     void shouldNotComparePositionsWithInvalidFilenameFormat() {
         assertThrows(IllegalArgumentException.class, () -> {
             Document history = positionWithoutGtids("mysql-bin.000001", 1, 0, 0);
@@ -741,6 +769,12 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
             pos = pos.set(BinlogSourceInfo.SNAPSHOT_KEY, true);
         }
         return pos;
+    }
+
+    protected Document positionWithServerId(String filename, int position, int serverId, long timestamp) {
+        return positionWithoutGtids(filename, position, 0, 0)
+                .set(BinlogSourceInfo.SERVER_ID_KEY, serverId)
+                .set(BinlogOffsetContext.TIMESTAMP_KEY, timestamp);
     }
 
     protected PositionAssert assertThatDocument(Document position) {


### PR DESCRIPTION
Fixes debezium/dbz#1541

## Description

Schema history recovery compares every recorded position against the restart position. That restart position is not the stored offset as written, it is regenerated from the loaded offset context (`SchemaHistory#recover(Offsets, …)` calls `getOffset()` on it), and neither `MySqlOffsetContext.Loader` nor `MariaDbOffsetContext.Loader` restores the server id or the source time. So the restart position carries neither key, while every position recorded during streaming carries a server id.

`getServerId` defaults a missing key to `0`, so those pairs took the "different servers" branch. There the comparator read `ts_ms`, although an offset only ever stores `ts_sec` (`BinlogOffsetContext#offsetUsingPosition`), so the comparison was permanently `0 <= 0`. Every streaming-recorded position was accepted regardless of the restart point, and recovery replayed DDL from after it, leaving the in-memory schema ahead of where streaming resumes.

The fix stops reading a missing server id as a different server. The absence is deliberate — there is no way to tell which primary of a topology wrote the change — so those pairs are now compared by their binlog coordinates, which is what actually filters them.

The timestamp key is corrected as well. On its own it changes nothing today, because the restart position carries no timestamp either. That is also why the earlier #7026, which swapped only the key, turned every non-GTID MySQL IT red: recorded positions have `ts_sec > 0` and the restart position reads `0`, so all streaming-recorded DDL was dropped instead. The key is still worth correcting, and it keeps the branch honest for positions that do reach it — restoring a server id on load without also restoring `ts_sec` would otherwise reproduce that failure exactly.

One consequence worth naming: when two genuinely different servers are compared and the recorded side has no server id, the comparison now falls through to coordinates from unrelated coordinate spaces. Differing base names are already handled (they warn and apply the DDL). Identical base names compare as if they were one server. This is inherent to keeping the server id absent during snapshots, and the alternative is what failed CI.

The stored offset format is unchanged, and `ts_ms` was never written to an offset, so there is nothing to migrate.

The file-based schema history rework asked for in the first comment on the issue is not part of this PR — that code is being touched by #7063.

Credit to @zwang28, who reported the issue and identified the key mismatch in #7026.

## Tests

Two tests in `BinlogSourceInfoTest`, inherited by both the MySQL and MariaDB `SourceInfoTest`. The existing `positionWith` helper sets neither `server_id` nor `ts_sec`, so no test reached this branch before.

|  | `shouldCompareTimestampsOfPositionsFromDifferentServers` | `shouldNotTreatPositionWithoutServerIdAsDifferentServer` |
| --- | --- | --- |
| `main` | fails | fails |
| key swap only | passes | fails |
| this change | passes | passes |

The second test is the one that pins the fix; the first pins the contract of the branch itself, including that equal server ids keep comparing by coordinates.

Verified against the non-GTID `mysql-ci` profile: 433 tests, 0 failures, 0 errors. Reverting only the server id guard reproduces what closed #7026 (`MySqlConnectorIT.shouldConsumeAllEventsFromDatabaseUsingSnapshot`, no records for the topic). The GTID profiles and MariaDB are unaffected by construction — every GTID branch returns before this code, and MariaDB sets a GTID set even during snapshots — which is also why they stayed green on #7026.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
