### PR TITLE
debezium/dbz#2442 AsyncEmbeddedEngine SourceTask.stop() is never called when the ChangeConsumer is blocked at shutdown, leaving the postgresql replication slot alive

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -77,6 +77,7 @@ import io.debezium.spi.storage.OffsetStoreProvider;
 import io.debezium.storage.kafka.offset.KafkaConnectOffsetUtil;
 import io.debezium.util.DelayStrategy;
 import io.debezium.util.KafkaConnectUtil;
+import io.debezium.util.Threads;
 
 /**
  * Implementation of {@link DebeziumEngine} which allows to run multiple tasks in parallel and also
@@ -701,19 +702,32 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
      * @param tasks {@link List<EngineSourceTask>} of source tasks which should be stopped.
      */
     private void stopSourceTasks(final List<EngineSourceTask> tasks) {
-        final Set<EngineSourceTask> pendingStopTasks = ConcurrentHashMap.newKeySet();
-        pendingStopTasks.addAll(tasks);
+        final ExecutorService stopTaskService = Threads.newFixedThreadPool(AsyncEmbeddedEngine.class,
+                config.getString(EmbeddedEngineConfig.ENGINE_NAME), "task-stop", Math.max(tasks.size(), 1));
+        final Set<ConnectorTaskId> tasksNotStopped = ConcurrentHashMap.newKeySet();
+        tasks.forEach(task -> tasksNotStopped.add(task.context().connectorTaskId()));
         try {
             LOGGER.debug("Stopping source connector tasks.");
-            final ExecutorCompletionService<Void> taskCompletionService = new ExecutorCompletionService(taskService);
+            final ExecutorCompletionService<Void> taskCompletionService = new ExecutorCompletionService(stopTaskService);
+            final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
             for (EngineSourceTask task : tasks) {
                 final long commitTimeout = Configuration.from(task.context().config()).getLong(EmbeddedEngineConfig.OFFSET_COMMIT_TIMEOUT_MS);
                 taskCompletionService.submit(() -> {
-                    LOGGER.debug("Committing task's offset.");
-                    commitOffsets(task.context().offsetStorageWriter(), task.context().clock(), commitTimeout, task.connectTask());
-                    LOGGER.debug("Stopping Connect task.");
-                    if (pendingStopTasks.remove(task)) {
-                        task.connectTask().stop();
+                    LoggingContext.clear();
+                    try (LoggingContext loggingContext = LoggingContext.forTask(task.context().connectorTaskId())) {
+                        Thread.currentThread().setContextClassLoader(this.classLoader);
+                        try {
+                            LOGGER.debug("Committing task's offset.");
+                            commitOffsets(task.context().offsetStorageWriter(), task.context().clock(), commitTimeout, task.connectTask());
+                        }
+                        finally {
+                            LOGGER.debug("Stopping Connect task.");
+                            task.connectTask().stop();
+                            tasksNotStopped.remove(task.context().connectorTaskId());
+                        }
+                    }
+                    finally {
+                        Thread.currentThread().setContextClassLoader(originalTccl);
                     }
                     return null;
                 });
@@ -749,27 +763,30 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
             LOGGER.warn("Failure during stopping tasks, stopping them immediately. Failed with ", e);
         }
         finally {
-            // Make sure task service is shut down and no other tasks can be run.
+            // Make sure both executors are shut down and no other tasks can be run.
             taskService.shutdownNow();
-            stopAbandonedTasks(pendingStopTasks);
+            shutdownStopTaskServiceForcefully(stopTaskService);
+            if (!tasksNotStopped.isEmpty()) {
+                LOGGER.warn("Stopping of task(s) {} timed out or failed, the task(s) may still be running.", tasksNotStopped);
+            }
         }
     }
 
-    private void stopAbandonedTasks(final Set<EngineSourceTask> pendingStopTasks) {
-        for (EngineSourceTask task : List.copyOf(pendingStopTasks)) {
-            if (pendingStopTasks.remove(task)) {
-                LOGGER.warn("Stop of task {} was discarded together with the task service, stopping the task directly to avoid leaving it running.",
-                        task.context().connectorTaskId());
-                final long startTime = System.nanoTime();
-                try {
-                    task.connectTask().stop();
-                    LOGGER.info("Stopped abandoned task {} in {} ms.", task.context().connectorTaskId(), (System.nanoTime() - startTime) / 1_000_000);
-                    connectorCallback.ifPresent(ConnectorCallback::taskStopped);
-                }
-                catch (Throwable t) {
-                    LOGGER.error("Failed to stop abandoned task {} after {} ms.", task.context().connectorTaskId(), (System.nanoTime() - startTime) / 1_000_000, t);
-                }
+    /**
+     * Shuts down the executor which runs the stop callables. Interrupts right away the callables already got the
+     * whole {@code task.management.timeout.ms}, so whatever still runs is overdue. Then waits, bounded by the same
+     * timeout, for the interrupted callables to finish stopping their tasks while the offset store is still available.
+     */
+    private void shutdownStopTaskServiceForcefully(final ExecutorService stopTaskService) {
+        stopTaskService.shutdownNow();
+        try {
+            if (!stopTaskService.awaitTermination(config.getLong(AsyncEngineConfig.TASK_MANAGEMENT_TIMEOUT_MS), TimeUnit.MILLISECONDS)) {
+                LOGGER.warn("Stop task executor did not terminate within the task management timeout, giving up on waiting.");
             }
+        }
+        catch (InterruptedException e) {
+            LOGGER.warn("Interrupted while waiting for the stop task executor to terminate.");
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -925,35 +942,41 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
      */
     private static boolean commitOffsets(final OffsetStorageWriter offsetWriter, final io.debezium.util.Clock clock, final long commitTimeout, final SourceTask task)
             throws InterruptedException, TimeoutException {
-        final long timeout = clock.currentTimeInMillis() + commitTimeout;
-        if (!offsetWriter.beginFlush(commitTimeout, TimeUnit.MILLISECONDS)) {
-            LOGGER.trace("No offset to be committed.");
-            return false;
-        }
-
-        try {
-            final Future<Void> flush = offsetWriter.doFlush((Throwable error, Void result) -> {
-            });
-            if (flush == null) {
-                LOGGER.warn("Flushing process probably failed, please check previous log for more details.");
-                offsetWriter.cancelFlush();
+        // Serialize whole flush cycles on the shared writer: the offset commit can be called concurrently from the
+        // record processing thread and from the task stop thread, and interleaving two flush cycles could make one
+        // thread cancel the flush begun by the other one. Both the flush wait and the lock hold time are bounded by
+        // the commit timeout, so this cannot block the stop path forever.
+        synchronized (offsetWriter) {
+            final long timeout = clock.currentTimeInMillis() + commitTimeout;
+            if (!offsetWriter.beginFlush(commitTimeout, TimeUnit.MILLISECONDS)) {
+                LOGGER.trace("No offset to be committed.");
                 return false;
             }
 
-            flush.get(Math.max(timeout - clock.currentTimeInMillis(), 0), TimeUnit.MILLISECONDS);
-            task.commit();
+            try {
+                final Future<Void> flush = offsetWriter.doFlush((Throwable error, Void result) -> {
+                });
+                if (flush == null) {
+                    LOGGER.warn("Flushing process probably failed, please check previous log for more details.");
+                    offsetWriter.cancelFlush();
+                    return false;
+                }
+
+                flush.get(Math.max(timeout - clock.currentTimeInMillis(), 0), TimeUnit.MILLISECONDS);
+                task.commit();
+            }
+            catch (InterruptedException e) {
+                LOGGER.debug("Flush of the offsets interrupted, canceling the flush.");
+                offsetWriter.cancelFlush();
+                throw e;
+            }
+            catch (Exception e) {
+                LOGGER.warn("Flush of the offsets failed, canceling the flush.", e);
+                offsetWriter.cancelFlush();
+                return false;
+            }
+            return true;
         }
-        catch (InterruptedException e) {
-            LOGGER.debug("Flush of the offsets interrupted, canceling the flush.");
-            offsetWriter.cancelFlush();
-            throw e;
-        }
-        catch (Exception e) {
-            LOGGER.warn("Flush of the offsets failed, canceling the flush.", e);
-            offsetWriter.cancelFlush();
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -16,8 +16,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -699,6 +701,8 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
      * @param tasks {@link List<EngineSourceTask>} of source tasks which should be stopped.
      */
     private void stopSourceTasks(final List<EngineSourceTask> tasks) {
+        final Set<EngineSourceTask> pendingStopTasks = ConcurrentHashMap.newKeySet();
+        pendingStopTasks.addAll(tasks);
         try {
             LOGGER.debug("Stopping source connector tasks.");
             final ExecutorCompletionService<Void> taskCompletionService = new ExecutorCompletionService(taskService);
@@ -708,7 +712,9 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
                     LOGGER.debug("Committing task's offset.");
                     commitOffsets(task.context().offsetStorageWriter(), task.context().clock(), commitTimeout, task.connectTask());
                     LOGGER.debug("Stopping Connect task.");
-                    task.connectTask().stop();
+                    if (pendingStopTasks.remove(task)) {
+                        task.connectTask().stop();
+                    }
                     return null;
                 });
             }
@@ -745,6 +751,25 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         finally {
             // Make sure task service is shut down and no other tasks can be run.
             taskService.shutdownNow();
+            stopAbandonedTasks(pendingStopTasks);
+        }
+    }
+
+    private void stopAbandonedTasks(final Set<EngineSourceTask> pendingStopTasks) {
+        for (EngineSourceTask task : List.copyOf(pendingStopTasks)) {
+            if (pendingStopTasks.remove(task)) {
+                LOGGER.warn("Stop of task {} was discarded together with the task service, stopping the task directly to avoid leaving it running.",
+                        task.context().connectorTaskId());
+                final long startTime = System.nanoTime();
+                try {
+                    task.connectTask().stop();
+                    LOGGER.info("Stopped abandoned task {} in {} ms.", task.context().connectorTaskId(), (System.nanoTime() - startTime) / 1_000_000);
+                    connectorCallback.ifPresent(ConnectorCallback::taskStopped);
+                }
+                catch (Throwable t) {
+                    LOGGER.error("Failed to stop abandoned task {} after {} ms.", task.context().connectorTaskId(), (System.nanoTime() - startTime) / 1_000_000, t);
+                }
+            }
         }
     }
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
@@ -497,6 +498,56 @@ public class AsyncEmbeddedEngineTest {
         assertThat(error).isNotNull();
         assertThat(error).isInstanceOf(IllegalStateException.class);
         assertThat(error.getMessage()).isEqualTo("Engine has been already shut down.");
+    }
+
+    @Test
+    void testTaskIsStoppedEvenWhenConsumerIsBlockedDuringShutdown() throws Exception {
+        final Properties props = new Properties();
+
+        props.setProperty(ConnectorConfig.NAME_CONFIG, "debezium-engine");
+        props.setProperty(ConnectorConfig.CONNECTOR_CLASS_CONFIG, DebeziumAsyncEngineTestUtils.StopTrackingConnector.class.getName());
+        props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, OFFSET_STORE_PATH.toAbsolutePath().toString());
+        props.put(SimpleSourceConnector.BATCH_COUNT, 1);
+
+        // short timeout so the engine gives up on the starved stop callable quickly
+        props.setProperty(AsyncEngineConfig.TASK_MANAGEMENT_TIMEOUT_MS.name(), "1000");
+
+        DebeziumAsyncEngineTestUtils.StopTrackingTask.stopInvoked.set(false);
+
+        final ReentrantLock blockedSink = new ReentrantLock();
+
+        DebeziumEngine.Builder<SourceRecord> builder = new AsyncEmbeddedEngine.AsyncEngineBuilder<>();
+
+        engine = builder
+                .using(props)
+                .using(new TestEngineConnectorCallback())
+                .notifying((records, committer) -> {
+                    blockedSink.lock();
+                    blockedSink.unlock();
+                }).build();
+
+        blockedSink.lock();
+
+        try {
+            engineExecSrv.submit(() -> {
+                LoggingContext.forConnector(getClass().getSimpleName(), "", "engine");
+                engine.run();
+            });
+
+            // the engine must be blocked
+            Awaitility.await()
+                    .atMost(AbstractConnectorTest.waitTimeForEngine(), TimeUnit.SECONDS)
+                    .until(blockedSink::hasQueuedThreads);
+
+            engine.close();
+
+            assertThat(isEngineRunning.get()).isFalse();
+            assertThat(runningTasks.get()).isEqualTo(0);
+            assertThat(DebeziumAsyncEngineTestUtils.StopTrackingTask.stopInvoked.get()).isTrue();
+        }
+        finally {
+            blockedSink.unlock();
+        }
     }
 
     @Test

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/DebeziumAsyncEngineTestUtils.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/DebeziumAsyncEngineTestUtils.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.connect.connector.Task;
@@ -108,6 +109,25 @@ public class DebeziumAsyncEngineTestUtils {
                 }
                 throw new IllegalStateException("Exception during start of the task");
             }
+        }
+    }
+
+    public static class StopTrackingConnector extends SimpleSourceConnector {
+
+        @Override
+        public Class<? extends Task> taskClass() {
+            return StopTrackingTask.class;
+        }
+    }
+
+    public static class StopTrackingTask extends SimpleSourceConnector.SimpleConnectorTask {
+
+        public static final AtomicBoolean stopInvoked = new AtomicBoolean(false);
+
+        @Override
+        public void stop() {
+            stopInvoked.set(true);
+            super.stop();
         }
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2442

## Description
<!-- Briefly describe your changes here. -->
If the ChangeConsumer is still blocked when engine.close() is called, the stop callable never gets a chance to run . It goes to the same taskService pool that runs record polling, and the blocked consumer is holding that thread. After `task.management.timeout.ms` the engine gives up and shutdownNow() just throws the queued callable away, so                                SourceTask.stop() is never called. The engine still reports STOPPED though. Now this abandoned task keeps its walsender and the slot stays active. So whenever the next replacement connector tries to bring it up it will fail witj replication slot is active for PID N.                            
                                                                                                                    
The fix is to stop these leftover tasks directly on the shutdown thread after shutdownNow() in finally block.
                                                                                                                    
Added a test to AsyncEmbeddedEngineTest that blocks the consumer, closes the engine, and                        
checks the task actually got stopped before close() returned. It fails without the fix.  

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
