### PR TITLE
debezium/dbz#2431 Fix read.only incremental snapshot failing on hot standby due to pg_current_xact_id()

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -70,7 +70,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class);
 
-    private static final String FORCE_NEW_TRANSACTION = "SELECT * FROM pg_current_xact_id();";
+    private static final String FORCE_NEW_TRANSACTION = "SELECT (CASE pg_is_in_recovery() WHEN 't' THEN NULL::xid8 ELSE pg_current_xact_id() END) AS txid;";
     private static final String CURRENT_SNAPSHOT = "SELECT * FROM pg_current_snapshot();";
 
     private final PostgresConnection jdbcConnection;
@@ -234,7 +234,13 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
         try {
             jdbcConnection.query(FORCE_NEW_TRANSACTION, rs -> {
                 if (rs.next()) {
-                    LOGGER.trace("Created new transaction ID {}", rs.getString(1));
+                    String txId = rs.getString(1);
+                    if (txId != null) {
+                        LOGGER.trace("Created new transaction ID {}", txId);
+                    }
+                    else {
+                        LOGGER.trace("Skipping transaction ID assignment on hot standby");
+                    }
                 }
             });
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
@@ -71,7 +71,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
     }
 
     @Test
-    @FixFor("DBZ-2431")
+    @FixFor("debezium/dbz#2431")
     void forceTransactionQueryIsRecoveryAware() throws Exception {
         Field field = PostgresReadOnlyIncrementalSnapshotChangeEventSource.class
                 .getDeclaredField("FORCE_NEW_TRANSACTION");
@@ -83,7 +83,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
     }
 
     @Test
-    @FixFor("DBZ-2431")
+    @FixFor("debezium/dbz#2431")
     void forceNewTransactionIdIsNoOpOnHotStandby() throws Exception {
         // Simulate a hot standby: pg_is_in_recovery() = true, so the CASE returns NULL
         stubQueryResult(null);
@@ -95,7 +95,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
     }
 
     @Test
-    @FixFor("DBZ-2431")
+    @FixFor("debezium/dbz#2431")
     void forceNewTransactionIdLogsTransactionOnPrimary() throws Exception {
         // Simulate a primary: pg_is_in_recovery() = false, so a real transaction ID is returned
         stubQueryResult("12345");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
@@ -26,6 +26,8 @@ import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.logging.LogInterceptor;
+
+import ch.qos.logback.classic.Level;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -89,6 +91,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
         stubQueryResult(null);
 
         LogInterceptor logInterceptor = new LogInterceptor(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class);
+        logInterceptor.setLoggerLevel(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class, Level.TRACE);
 
         assertThatNoException().isThrownBy(this::invokeForceNewTransactionId);
         assertThat(logInterceptor.containsMessage("Skipping transaction ID assignment on hot standby")).isTrue();
@@ -101,6 +104,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
         stubQueryResult("12345");
 
         LogInterceptor logInterceptor = new LogInterceptor(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class);
+        logInterceptor.setLoggerLevel(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class, Level.TRACE);
 
         assertThatNoException().isThrownBy(this::invokeForceNewTransactionId);
         assertThat(logInterceptor.containsMessage("Created new transaction ID 12345")).isTrue();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
@@ -26,14 +26,14 @@ import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.logging.LogInterceptor;
-
-import ch.qos.logback.classic.Level;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Clock;
+
+import ch.qos.logback.classic.Level;
 
 /**
  * Unit tests for {@link PostgresReadOnlyIncrementalSnapshotChangeEventSource}.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.util.Clock;
+
+/**
+ * Unit tests for {@link PostgresReadOnlyIncrementalSnapshotChangeEventSource}.
+ */
+public class PostgresReadOnlyIncrementalSnapshotChangeEventSourceTest {
+
+    @Mock
+    private RelationalDatabaseConnectorConfig config;
+    @Mock
+    private PostgresConnection jdbcConnection;
+    @Mock
+    private PostgresSchema schema;
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private EventDispatcher dispatcher;
+    @Mock
+    private Clock clock;
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private SnapshotProgressListener progressListener;
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private DataChangeEventListener dataChangeEventListener;
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private NotificationService notificationService;
+
+    private PostgresReadOnlyIncrementalSnapshotChangeEventSource<PostgresPartition> source;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        source = new PostgresReadOnlyIncrementalSnapshotChangeEventSource<>(
+                config, jdbcConnection, dispatcher, schema, clock,
+                progressListener, dataChangeEventListener, notificationService);
+    }
+
+    @Test
+    @FixFor("DBZ-2431")
+    void forceTransactionQueryIsRecoveryAware() throws Exception {
+        Field field = PostgresReadOnlyIncrementalSnapshotChangeEventSource.class
+                .getDeclaredField("FORCE_NEW_TRANSACTION");
+        field.setAccessible(true);
+        String sql = (String) field.get(null);
+
+        assertThat(sql).contains("pg_is_in_recovery()");
+        assertThat(sql).contains("pg_current_xact_id()");
+    }
+
+    @Test
+    @FixFor("DBZ-2431")
+    void forceNewTransactionIdIsNoOpOnHotStandby() throws Exception {
+        // Simulate a hot standby: pg_is_in_recovery() = true, so the CASE returns NULL
+        stubQueryResult(null);
+
+        LogInterceptor logInterceptor = new LogInterceptor(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class);
+
+        assertThatNoException().isThrownBy(this::invokeForceNewTransactionId);
+        assertThat(logInterceptor.containsMessage("Skipping transaction ID assignment on hot standby")).isTrue();
+    }
+
+    @Test
+    @FixFor("DBZ-2431")
+    void forceNewTransactionIdLogsTransactionOnPrimary() throws Exception {
+        // Simulate a primary: pg_is_in_recovery() = false, so a real transaction ID is returned
+        stubQueryResult("12345");
+
+        LogInterceptor logInterceptor = new LogInterceptor(PostgresReadOnlyIncrementalSnapshotChangeEventSource.class);
+
+        assertThatNoException().isThrownBy(this::invokeForceNewTransactionId);
+        assertThat(logInterceptor.containsMessage("Created new transaction ID 12345")).isTrue();
+    }
+
+    private void stubQueryResult(String txId) throws Exception {
+        doAnswer(invocation -> {
+            JdbcConnection.ResultSetConsumer consumer = invocation.getArgument(1);
+            ResultSet rs = mock(ResultSet.class);
+            when(rs.next()).thenReturn(true);
+            when(rs.getString(1)).thenReturn(txId);
+            consumer.accept(rs);
+            return jdbcConnection;
+        }).when(jdbcConnection).query(anyString(), any(JdbcConnection.ResultSetConsumer.class));
+    }
+
+    private void invokeForceNewTransactionId() throws Exception {
+        Method method = PostgresReadOnlyIncrementalSnapshotChangeEventSource.class
+                .getDeclaredMethod("forceNewTransactionId");
+        method.setAccessible(true);
+        method.invoke(source);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [2431](https://github.com/debezium/dbz/issues/2431)

When `read.only=true` is configured and the connector restarts mid-snapshot, `preIncrementalSnapshotStart` calls `forceNewTransactionId()` which executes `pg_current_xact_id()`. On a PostgreSQL hot standby this fails because standbys cannot assign transaction IDs to user sessions.

## Changes

- Replace the bare `pg_current_xact_id()` call in `FORCE_NEW_TRANSACTION` with a `CASE pg_is_in_recovery()` guard that returns `NULL` on a hot standby — the same pattern already used in `PostgresConnection.currentTransactionId()`
- Handle the `NULL` result gracefully in `forceNewTransactionId()` with a trace log instead of attempting to log the transaction ID

On a primary the behaviour is completely unchanged.

## Test plan

- `forceTransactionQueryIsRecoveryAware` — asserts the SQL constant contains both `pg_is_in_recovery()` and `pg_current_xact_id()`
- `forceNewTransactionIdIsNoOpOnHotStandby` — mocks a `NULL` result (standby) and verifies no exception is thrown and the standby skip message is logged
- `forceNewTransactionIdLogsTransactionOnPrimary` — mocks a real transaction ID result and verifies the primary path is unchanged