### PR TITLE
debezium/dbz#2232 Name serial columns as the driver does while streaming

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
@@ -27,6 +27,7 @@ public class ColumnMetaData {
     private final int length;
     private final int scale;
     private final String typeName;
+    private final String driverTypeName;
 
     /**
      * Create a metadata structure representing a column.
@@ -38,9 +39,10 @@ public class ColumnMetaData {
      * @param hasDefaultValue {@code true} if the column has a default value specified, {@code false} otherwise
      * @param defaultValueExpression the parsed default value literal for the column
      * @param typeModifier the attribute type modifier
+     * @param driverTypeName the type name the JDBC driver reports for the column, {@code null} when unavailable
      */
     ColumnMetaData(String columnName, PostgresType postgresType, boolean key, boolean optional, boolean hasDefaultValue, String defaultValueExpression,
-                   int typeModifier) {
+                   int typeModifier, String driverTypeName) {
         this.columnName = columnName;
         this.postgresType = postgresType;
         this.key = key;
@@ -68,8 +70,12 @@ public class ColumnMetaData {
             scale = postgresType.getDefaultScale();
         }
 
+        // A serial column carries the OID of its underlying int2/int4/int8 type, so a name taken from the
+        // OID loses the serial nature that the driver reports during snapshot (debezium/dbz#2232).
+        this.driverTypeName = driverTypeName != null ? driverTypeName : postgresType.getName();
+
         // Constructs a fully qualified type name, including dimensions if applicable
-        String type = postgresType.getName();
+        String type = this.driverTypeName;
         if (postgresType.isVector()) {
             // pgvector uses a single dimension modifier, e.g. vector(3) rather than vector(3,0)
             if (length != Column.UNSET_INT_VALUE) {
@@ -116,5 +122,9 @@ public class ColumnMetaData {
 
     public String getTypeName() {
         return typeName;
+    }
+
+    public String getDriverTypeName() {
+        return driverTypeName;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -334,6 +334,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // Perform several out-of-bands database metadata queries
         Map<String, Optional<String>> columnDefaults;
         Map<String, Boolean> columnOptionality;
+        Map<String, String> columnTypeNames;
         List<String> primaryKeyColumns;
 
         final DatabaseMetaData databaseMetadata = connection.connection().getMetaData();
@@ -346,6 +347,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 .collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::defaultValueExpression));
 
         columnOptionality = readColumns.stream().collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::isOptional));
+        columnTypeNames = readColumns.stream().collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::typeName));
         primaryKeyColumns = connection.readPrimaryKeyNames(databaseMetadata, tableId);
         if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
             LOGGER.warn("Primary keys are not defined for table '{}', defaulting to unique indices", tableName);
@@ -386,7 +388,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             final boolean hasDefault = columnDefaults.containsKey(columnName);
             final String defaultValueExpression = columnDefaults.getOrDefault(columnName, Optional.empty()).orElse(null);
 
-            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, hasDefault, defaultValueExpression, attypmod));
+            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, hasDefault, defaultValueExpression, attypmod,
+                    columnTypeNames.get(columnName)));
             columnNames.add(columnName);
         }
 
@@ -690,7 +693,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                     .jdbcType(columnMetadata.getPostgresType().getRootType().getJdbcId())
                     .nativeType(columnMetadata.getPostgresType().getRootType().getOid())
                     .optional(columnMetadata.isOptional())
-                    .type(columnMetadata.getPostgresType().getName(), columnMetadata.getTypeName())
+                    .type(columnMetadata.getDriverTypeName(), columnMetadata.getTypeName())
                     .length(columnMetadata.getLength())
                     .scale(columnMetadata.getScale());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OpenLineageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OpenLineageIT.java
@@ -214,10 +214,9 @@ public class OpenLineageIT extends AbstractAsyncEngineConnectorTest {
         int expected = decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.PGOUTPUT ? 6 : 7;
         assertThat(runningEvents).hasSize(expected);
 
-        String pkValue = decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.PGOUTPUT ? "int4" : "serial";
         assertCorrectInputDataset(runningEvents.get(1).getInputs(), "postgres.s1.a", List.of("pk;serial", "aa;int4"));
         assertCorrectInputDataset(runningEvents.get(2).getInputs(), "postgres.s2.a", List.of("pk;serial", "aa;int4"));
-        assertCorrectInputDataset(runningEvents.get(5).getInputs(), "postgres.s1.a", List.of("pk;" + pkValue, "aa;int4", "bb;varchar"));
+        assertCorrectInputDataset(runningEvents.get(5).getInputs(), "postgres.s1.a", List.of("pk;serial", "aa;int4", "bb;varchar"));
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -99,6 +99,7 @@ import io.debezium.junit.SkipWhenDatabaseVersion;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.relational.RelationalChangeRecordEmitter;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -4995,6 +4996,31 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Collections.singletonList(new SchemaAndValueField("'quoted'", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "some text")),
                 consumer.remove(),
                 Envelope.FieldName.AFTER);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2232")
+    public void shouldPropagateSerialTypeNamesWhileStreaming() throws Exception {
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS serial_table;",
+                "CREATE TABLE serial_table (pk SERIAL, small SMALLSERIAL, big BIGSERIAL, plain INT, PRIMARY KEY(pk));");
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(RelationalDatabaseConnectorConfig.PROPAGATE_COLUMN_SOURCE_TYPE, ".*"), false);
+
+        waitForStreamingToStart();
+
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO serial_table (plain) VALUES (1);");
+
+        // Streaming must not fall back to the int2/int4/int8 the column OID carries, or a consumer keyed
+        // on the type name sees the column change type once the snapshot ends.
+        final Schema after = assertRecordInserted("public.serial_table", PK_FIELD, 1).valueSchema().field("after").schema();
+        assertThat(after.field("pk").schema().parameters()).contains(entry(TYPE_NAME_PARAMETER_KEY, "SERIAL"));
+        assertThat(after.field("small").schema().parameters()).contains(entry(TYPE_NAME_PARAMETER_KEY, "SMALLSERIAL"));
+        assertThat(after.field("big").schema().parameters()).contains(entry(TYPE_NAME_PARAMETER_KEY, "BIGSERIAL"));
+        assertThat(after.field("plain").schema().parameters()).contains(entry(TYPE_NAME_PARAMETER_KEY, "INT4"));
     }
 
     private String getMessagePrefix(SourceRecord record) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
@@ -27,10 +27,14 @@ public class ColumnMetaDataTest {
         return new PostgresType.Builder(null, "vector", 99999, Types.OTHER, TypeRegistry.NO_TYPE_MODIFIER, null).build();
     }
 
+    private static PostgresType int4Type() {
+        return new PostgresType.Builder(null, "int4", 23, Types.INTEGER, TypeRegistry.NO_TYPE_MODIFIER, null).build();
+    }
+
     @Test
     @FixFor("debezium/dbz#2220")
     public void shouldReadPgVectorDimensionFromModifier() {
-        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, 3);
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, 3, "vector");
         assertThat(column.getLength()).isEqualTo(3);
         assertThat(column.getScale()).isEqualTo(0);
         // Single dimension modifier: vector(3), not vector(3,0).
@@ -40,8 +44,24 @@ public class ColumnMetaDataTest {
     @Test
     @FixFor("debezium/dbz#2220")
     public void shouldLeavePgVectorWithoutDimensionUnset() {
-        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, TypeRegistry.NO_TYPE_MODIFIER);
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, TypeRegistry.NO_TYPE_MODIFIER, "vector");
         assertThat(column.getLength()).isEqualTo(Column.UNSET_INT_VALUE);
         assertThat(column.getTypeName()).isEqualTo("vector");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2232")
+    public void shouldKeepSerialTypeNameReportedByDriver() {
+        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, TypeRegistry.NO_TYPE_MODIFIER, "serial");
+        assertThat(column.getDriverTypeName()).isEqualTo("serial");
+        assertThat(column.getTypeName()).startsWith("serial");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2232")
+    public void shouldFallBackToTypeNameOfOidWhenDriverReportsNone() {
+        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, TypeRegistry.NO_TYPE_MODIFIER, null);
+        assertThat(column.getDriverTypeName()).isEqualTo("int4");
+        assertThat(column.getTypeName()).startsWith("int4");
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2232

## Description
A `serial` column is reported as `serial` during snapshot but as `int4` once streaming with _pgoutput_ starts, because `PgOutputMessageDecoder` names the column after the OID the relation message carries. The name reaches consumers as `__debezium.source.column.type`, and the JDBC sink keys its `SERIAL` re-creation on it, so the column silently turns into `INTEGER` at the snapshot-to-streaming boundary. _decoderbufs_ is unaffected: it synchronizes the schema from the driver, which is why `OpenLineageIT` carried a decoder-dependent expectation.

Per @jpechane's call in the issue this takes option 1, aligning streaming with the snapshot, but not by flipping `shouldSchemaBeSynchronized()` for _pgoutput_. That flag alone does not fix it:

* the refresh it enables is gated on `schemaChanged()`, which compares OIDs, length, scale and optionality — a `serial` column carries the OID of its underlying `int4`, so nothing looks changed and no refresh happens;
* when a refresh does fire, `tableFromFromMessage()` rebuilds the column with `.type(type.getName())`, deriving the name from the OID again and overwriting what the driver reported.

`handleRelationMessage()` already queries the driver for every relation message and already harvests defaults and nullability from that result — the driver's type name is in the same rows and was simply dropped. Keeping it reaches option 1's outcome with no extra round trip and no `nextval(` heuristic of our own. `TypeRegistry` already aliases `serial`, `smallserial` and `bigserial` to their integer types, so type resolution and value conversion are untouched. A column that the driver metadata does not cover, such as one excluded by `column.exclude.list`, keeps falling back to the OID-derived name, exactly as today.

Verified on both decoders locally, including a negative control: reverting the single `.type(...)` line makes the new IT fail with `"INT4" (expected: "SERIAL")`.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
