### PR TITLE
debezium/dbz#2460 Acknowledge source offsets from the previous flush snapshot

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -13,7 +13,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -200,6 +199,15 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
      * (which may be a no-op depending on the connector).
      */
     private final Map<Map<String, ?>, Map<String, ?>> lastOffsets = new HashMap<>();
+
+    /**
+     * Offsets captured at the previous flush notification. Everything in here was already covered by the
+     * offset flush that triggered the current {@link #commit()}, so acknowledging these positions with the
+     * source database can never run ahead of the durably persisted offsets. Acknowledging
+     * {@link #lastOffsets} directly would confirm positions up to a flush interval ahead of the store and,
+     * after a hard crash, the persisted offset could fall below the WAL retained by the source.
+     */
+    private final Map<Map<String, ?>, Map<String, ?>> flushedOffsets = new HashMap<>();
 
     private Duration retriableRestartWait;
 
@@ -583,15 +591,13 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         if (locked) {
             try (var rootLoggingContext = LoggingContext.initRootContext()) {
                 if (coordinator != null) {
-                    Iterator<Map<String, ?>> iterator = lastOffsets.keySet().iterator();
-                    while (iterator.hasNext()) {
-                        Map<String, ?> partition = iterator.next();
-                        Map<String, ?> lastOffset = lastOffsets.get(partition);
-
-                        LOGGER.debug("Committing offset '{}' for partition '{}'", partition, lastOffset);
-                        coordinator.commitOffset(partition, lastOffset);
-                        iterator.remove();
+                    for (Map.Entry<Map<String, ?>, Map<String, ?>> entry : flushedOffsets.entrySet()) {
+                        LOGGER.debug("Committing offset '{}' for partition '{}'", entry.getValue(), entry.getKey());
+                        coordinator.commitOffset(entry.getKey(), entry.getValue());
                     }
+                    flushedOffsets.clear();
+                    flushedOffsets.putAll(lastOffsets);
+                    lastOffsets.clear();
                 }
             }
             finally {

--- a/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.doc.FixFor;
 import io.debezium.junit.relational.TestRelationalDatabaseConfig;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.ErrorHandler;
@@ -180,6 +182,44 @@ class BaseSourceTaskTest {
             assertThat(baseSourceTask.startRootLoggingContext).isEqualTo(expectedStartRootLogging);
             assertThat(baseSourceTask.pollRootLoggingContext).isEqualTo(expectedRootLogging);
         }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2460")
+    void verifyCommitAcknowledgesOnlyFlushedGeneration() throws InterruptedException {
+        baseSourceTask.start(new HashMap<>());
+        pollAndIgnoreRetryException(baseSourceTask);
+
+        Map<String, String> partition = Map.of("server", "test");
+        Map<String, Long> offset1 = Map.of("lsn", 100L);
+        Map<String, Long> offset2 = Map.of("lsn", 200L);
+
+        // generation 1 delivered, first commit: nothing was flushed before, nothing may be acknowledged
+        baseSourceTask.commitRecord(sourceRecordWith(partition, offset1), null);
+        baseSourceTask.performCommit();
+        verify(baseSourceTask.coordinator, times(0)).commitOffset(anyMap(), anyMap());
+
+        // generation 2 delivered, second commit: acknowledges generation 1 only
+        baseSourceTask.commitRecord(sourceRecordWith(partition, offset2), null);
+        baseSourceTask.performCommit();
+        verify(baseSourceTask.coordinator, times(1)).commitOffset(partition, offset1);
+        verify(baseSourceTask.coordinator, times(0)).commitOffset(partition, offset2);
+
+        // no new records, third commit: acknowledges generation 2, the last flushed snapshot
+        baseSourceTask.performCommit();
+        verify(baseSourceTask.coordinator, times(1)).commitOffset(partition, offset2);
+
+        // nothing new flushed: no further acknowledgements
+        baseSourceTask.performCommit();
+        verify(baseSourceTask.coordinator, times(2)).commitOffset(anyMap(), anyMap());
+    }
+
+    private static SourceRecord sourceRecordWith(Map<String, ?> partition, Map<String, ?> offset) {
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("io.debezium.connector.common.Value")
+                .field("name", Schema.STRING_SCHEMA)
+                .build();
+        return new SourceRecord(partition, offset, "dummy", valueSchema, new Struct(valueSchema).put("name", "test"));
     }
 
     private static void pollAndIgnoreRetryException(BaseSourceTask<Partition, OffsetContext> baseSourceTask) throws InterruptedException {


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2460

`BaseSourceTask#performCommit()` used to acknowledge `lastOffsets`, the most recent in-memory offsets from
`poll()`, which can be up to a full offset flush interval ahead of what was durably persisted when the
`commit()` notification arrives. Since the acknowledgment authorizes the source database to discard its TX
log (`StreamingChangeEventSource#commitOffset`), a hard crash inside that window leaves the persisted
offset pointing at WAL the server has already recycled, and the connector cannot resume.

This keeps two generations of offsets: each `commit()` notification acknowledges the snapshot captured at
the previous notification, which is provably covered by the flush that triggered the current one, so the
acknowledged position can never run ahead of the offset store.

Notes:

- The source acknowledgment now lags one flush interval behind; the retention cost is bounded and the lag
  is absorbed on the next cycle. The first notification acknowledges nothing.
- On a graceful shutdown the last generation is not acknowledged; the source retains up to one extra flush
  interval of log, which the restarting connector replays from its (consistent) offsets.
- The debug log statement in `performCommit` had its arguments swapped with respect to the message text;
  fixed in passing since the line was touched anyway.
- A unit test in `BaseSourceTaskTest` covers the contract: the first notification acknowledges nothing, the
  following ones acknowledge exactly the previous generation.

Validated on a live incremental snapshot (17.5M rows) with an invariant probe comparing the slot's
`confirmed_flush_lsn` with the persisted offset on every cycle: no violation across the run, clean restart
and exact resume after a SIGKILL mid-snapshot.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
