### PR TITLE
debezium/dbz#2464 Guard against a missing SQL state in the heartbeat error handlers

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -869,3 +869,4 @@ Junsu Lee
 Björn Bärtschi
 Raju Surarapu
 dingqianwen
+Surya Dhaneshwar

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSourceTask.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSourceTask.java
@@ -82,6 +82,11 @@ public abstract class BinlogSourceTask<P extends Partition, O extends OffsetCont
         @Override
         public void onError(SQLException exception) throws RuntimeException {
             final String sqlErrorId = exception.getSQLState();
+            if (sqlErrorId == null) {
+                // The driver reported no SQL state, which typically indicates a connection-level
+                // failure, returning to the caller to log the exception.
+                return;
+            }
             switch (sqlErrorId) {
                 case "42000":
                     // error_er_dbaccess_denied_error, see https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_dbaccess_denied_error

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTaskTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTaskTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.binlog.BinlogSourceTask.BinlogHeartbeatErrorHandler;
+
+/**
+ * Unit tests for {@link BinlogSourceTask.BinlogHeartbeatErrorHandler}.
+ */
+public class BinlogSourceTaskTest {
+
+    private final BinlogHeartbeatErrorHandler errorHandler = new BinlogHeartbeatErrorHandler();
+
+    @Test
+    void shouldNotFailWhenSqlStateIsNotReported() {
+        // A driver is not required to populate the SQL state; a connection-level failure
+        // commonly leaves it unset. The handler must not dereference it unconditionally.
+        final SQLException exception = new SQLException("Communications link failure");
+
+        assertThatCode(() -> errorHandler.onError(exception)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldThrowWhenDatabaseAccessIsDenied() {
+        final SQLException exception = new SQLException("Access denied", "42000");
+
+        assertThatThrownBy(() -> errorHandler.onError(exception))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("42000")
+                .hasCause(exception);
+    }
+
+    @Test
+    void shouldThrowWhenDatabaseIsNotSelected() {
+        final SQLException exception = new SQLException("No database selected", "3D000");
+
+        assertThatThrownBy(() -> errorHandler.onError(exception))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("3D000")
+                .hasCause(exception);
+    }
+
+    @Test
+    void shouldTolerateUnrecognizedSqlState() {
+        // Anything that is not a permanent configuration fault is left for the caller to log,
+        // so that a transient failure does not terminate the task.
+        final SQLException exception = new SQLException("Communications link failure", "08S01");
+
+        assertThatCode(() -> errorHandler.onError(exception)).doesNotThrowAnyException();
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTaskTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceTaskTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.binlog.BinlogSourceTask.BinlogHeartbeatErrorHandler;
+import io.debezium.doc.FixFor;
 
 /**
  * Unit tests for {@link BinlogSourceTask.BinlogHeartbeatErrorHandler}.
@@ -23,6 +24,7 @@ public class BinlogSourceTaskTest {
     private final BinlogHeartbeatErrorHandler errorHandler = new BinlogHeartbeatErrorHandler();
 
     @Test
+    @FixFor("dbz#2464")
     void shouldNotFailWhenSqlStateIsNotReported() {
         // A driver is not required to populate the SQL state; a connection-level failure
         // commonly leaves it unset. The handler must not dereference it unconditionally.
@@ -32,6 +34,7 @@ public class BinlogSourceTaskTest {
     }
 
     @Test
+    @FixFor("dbz#2464")
     void shouldThrowWhenDatabaseAccessIsDenied() {
         final SQLException exception = new SQLException("Access denied", "42000");
 
@@ -42,6 +45,7 @@ public class BinlogSourceTaskTest {
     }
 
     @Test
+    @FixFor("dbz#2464")
     void shouldThrowWhenDatabaseIsNotSelected() {
         final SQLException exception = new SQLException("No database selected", "3D000");
 
@@ -52,6 +56,7 @@ public class BinlogSourceTaskTest {
     }
 
     @Test
+    @FixFor("dbz#2464")
     void shouldTolerateUnrecognizedSqlState() {
         // Anything that is not a permanent configuration fault is left for the caller to log,
         // so that a transient failure does not terminate the task.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -245,6 +245,13 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                             () -> new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL),
                             exception -> {
                                 String sqlErrorId = exception.getSQLState();
+                                if (sqlErrorId == null) {
+                                    // The driver reported no SQL state, which typically indicates a
+                                    // connection-level failure rather than an error response from the
+                                    // server. There is nothing to classify; leave it to the caller to
+                                    // log the exception.
+                                    return;
+                                }
                                 switch (sqlErrorId) {
                                     case "57P01":
                                         // Postgres error admin_shutdown, see https://www.postgresql.org/docs/12/errcodes-appendix.html

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -404,3 +404,5 @@ bisbeb,Björn Bärtschi
 rajusurarapu149,Raju Surarapu
 henm,Matthias Hengel
 mathewjustin,Justin Mathew
+surya-dl,Surya Dhaneshwar
+suryadanny,Surya Dhaneshwar


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2464

`BinlogHeartbeatErrorHandler.onError` (MySQL/MariaDB) and the equivalent lambda in `PostgresConnectorTask` switch on `SQLException#getSQLState()` without a null check. A `switch` on a String dereferences it via `hashCode()`, so when a driver reports no SQL state — typical of a connection-level failure rather than an error response from the server — the handler itself throws `NullPointerException`.

That NPE escapes `DatabaseHeartbeatImpl.forcedBeat()` before the `LOGGER.error` that would have recorded the underlying `SQLException`, so the original heartbeat failure is never logged and the task fails with a stack trace pointing only at the error handler.

Observed in production on MySQL:
```
Caused by: io.debezium.DebeziumException: Error processing binlog event
Caused by: java.lang.NullPointerException: Cannot invoke "String.hashCode()" because "<local3>" is null
    at io.debezium.connector.binlog.BinlogSourceTask$BinlogHeartbeatErrorHandler.onError(BinlogSourceTask.java:85)
    at io.debezium.heartbeat.DatabaseHeartbeatImpl.forcedBeat(DatabaseHeartbeatImpl.java:58)
    at io.debezium.heartbeat.HeartbeatImpl.heartbeat(HeartbeatImpl.java:71)
    at io.debezium.pipeline.EventDispatcher.dispatchHeartbeatEvent(EventDispatcher.java:438)
```

This returns early when no SQL state is reported, leaving the caller to log the exception — the same outcome an unrecognised SQL state already gets, so a transient failure is logged rather than terminating the task.

Covered by a new `BinlogSourceTaskTest`; removing the guard makes `shouldNotFailWhenSqlStateIsNotReported` fail with the NPE above.