### PR TITLE
Dbz 9958 conditionalize refs to dbs w upstream only support in jdbc connector doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -22,7 +22,22 @@ toc::[]
 endif::community[]
 
 The {prodname} JDBC connector is a Kafka Connect sink connector implementation that can consume events from multiple source topics, and then write those events to a relational database by using a JDBC driver.
-This connector supports a wide variety of database dialects, including CockroachDB, Db2, MySQL, Oracle, PostgreSQL, SingleStore, SQL Server, and StarRocks.
+You can use this connector with a range of databases.
+It provides support for the following database dialects:
+
+ifdef::community[]
+* CockroachDB
+* Db2
+* MySQL
+* Oracle
+* PostgreSQL
+ifdef::community[]
+* SingleStore
+endif::community[]
+* SQL Server
+ifdef::community[]
+* StarRocks
+endif::community[]
 
 // Type: assembly
 // ModuleID: debezium-jdbc-connector-how-the-debezium-connector-works
@@ -44,94 +59,12 @@ The {prodname} JDBC connector provides the following features:
 * xref:jdbc-delete-mode[Delete mode]
 * xref:jdbc-idempotent-writes[Idempotent writes]
 * xref:jdbc-schema-evolution[Schema evolution]
-* xref:jdbc-singlestore-targets[SingleStore sink targets]
-* xref:jdbc-starrocks-targets[StarRocks sink targets]
-ifdef::community[]
-* xref:jdbc-cockroachdb-targets[CockroachDB sink targets]
-endif::community[]
 * xref:jdbc-quoting-case-sensitivity[JDBC quoting and case-sensitivity]
 * xref:jdbc-connection-idle-timeouts[Connection idle timeouts]
-
-// Type: concept
-// Title: Using SingleStore as a sink target
-// ModuleID: debezium-jdbc-connector-using-singlestore-as-a-sink-target
-[[jdbc-singlestore-targets]]
-=== SingleStore sink targets
-
-To write to SingleStore, configure xref:jdbc-property-connection-url[`connection.url`] with a SingleStore JDBC URL, for example, `jdbc:singlestore://<_host_>:3306/<_database_>`.
-The SingleStore JDBC driver is included in the {prodname} JDBC connector archive, so Kafka Connect deployments that use the connector archive do not require an additional SingleStore driver JAR.
-
-SingleStore targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
-For SingleStore, the connector generates `INSERT ... ON DUPLICATE KEY UPDATE ...` statements.
-
-If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
-Automatic table creation does not expose SingleStore-specific shard key, sort key, or other table option settings.
-If the target table requires explicit shard keys, sort keys, or other SingleStore table options, create the destination table in SingleStore before the connector writes to it.
-
-For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values to the SingleStore `JSON` column type.
-The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values to the SingleStore `GEOGRAPHY` column type, and `io.debezium.data.geometry.Point` logical values to the SingleStore `GEOGRAPHYPOINT` column type.
-SingleStore supports a subset of WKT geospatial values.
-The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.
-
-// Type: concept
-// Title: Using StarRocks as a sink target
-// ModuleID: debezium-jdbc-connector-using-starrocks-as-a-sink-target
-[[jdbc-starrocks-targets]]
-=== StarRocks sink targets
-
-To write to StarRocks, configure xref:jdbc-property-connection-url[`connection.url`] with a StarRocks JDBC URL, for example, `jdbc:starrocks://<_host_>:9030/<_database_>`.
-The StarRocks JDBC driver is included in the {prodname} JDBC connector archive, so Kafka Connect deployments that use the connector archive do not require an additional StarRocks driver JAR.
-The connector automatically detects a StarRocks target from the driver, so no dialect configuration is required.
-To write to a database in a catalog other than `default_catalog`, specify a fully qualified `<_catalog_>.<_database_>` path in the connection URL, or set the xref:jdbc-property-dialect-starrocks-catalog-name[`dialect.starrocks.catalog.name`] property.
-
-StarRocks targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
-StarRocks executes `INSERT` statements against PRIMARY KEY tables as upserts, so the connector generates plain `INSERT` statements; `INSERT ... ON DUPLICATE KEY UPDATE ...` is not supported by StarRocks.
-Upsert and delete operations require the destination table to be a StarRocks PRIMARY KEY table.
-Tables that the connector creates automatically from events with key fields are always PRIMARY KEY tables.
-
-If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
-Tables that the connector creates use `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses based on the record key fields.
-StarRocks limits the encoded size of all primary key column values of a PRIMARY KEY table to 128 bytes and does not permit `FLOAT`, `DOUBLE`, or `DECIMAL` key columns.
-Automatic table creation does not expose StarRocks-specific distribution, partitioning, or other table option settings.
-If the target table requires explicit table options, create the destination table in StarRocks before the connector writes to it.
-StarRocks applies `ALTER TABLE` schema changes asynchronously; writes that arrive while a schema change is still running can fail transiently and are retried by the connector.
-
-StarRocks has no `TIME` data type.
-The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.MicroTime`, and `io.debezium.time.NanoTime` logical values, and Kafka Connect `Time` values, to `VARCHAR` columns as `HH:mm:ss.ffffff` formatted strings.
-MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
-`io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
-StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
-Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
-StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so the connector multiplies propagated character lengths by four, up to the maximum length of 1048576; `CHAR` columns whose scaled length exceeds the 255 byte `CHAR` maximum are promoted to `VARCHAR`.
-`BYTES` values are written to `VARBINARY` columns, which are limited to the same 1048576 byte maximum.
-`DECIMAL` columns support a maximum precision of 38; the connector caps larger propagated precisions at 38, and values that exceed the capped precision fail on write.
-When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
-{prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
-The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
-
-ifdef::community[]
-[[jdbc-cockroachdb-targets]]
-=== CockroachDB sink targets
-
-To enable the JDBC connector to write to CockroachDB, you must specify a PostgreSQL JDBC URL in the connector's xref:jdbc-property-connection-url[`connection.url`] property, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
-Because CockroachDB supports the PostgreSQL communication protocol, it works with the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
-
-As a sink target, CockroachDB supports idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
-For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
-
-CockroachDB uses the `SERIALIZABLE` transaction isolation level.
-As a result, if CockroachDB detects a conflict between concurrent transactions, it might temporarily abort one of the transactions and return SQLSTATE `40001`.
-The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
-Setting `flush.max.retries` to `0` disables the retries so that a conflicting flush fails immediately.
-
-For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following exceptions:
-
-* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
-* `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.
-* Propagated `money` column types are written as `decimal(19,2)` types.
-* `io.debezium.data.geometry.Geometry`, `io.debezium.data.geometry.Geography`, and `io.debezium.data.geometry.Point` logical values are written to the built-in CockroachDB `geometry` and `geography` types; no PostGIS extension schema is required.
-* `io.debezium.data.FloatVector` logical values are written to the CockroachDB `vector` column type, because CockroachDB has no `halfvec` type.
-* `io.debezium.data.SparseDoubleVector` is not supported.
+ifdef::community
+* xref:jdbc-singlestore-targets[SingleStore sink targets]
+* xref:jdbc-starrocks-targets[StarRocks sink targets]
+* xref:jdbc-cockroachdb-targets[CockroachDB sink targets]
 endif::community[]
 
 // Type: concept
@@ -431,11 +364,13 @@ The schema also defines the default values for each column.
 If the connector attempts to create a table with a nullability setting or a default value that don't want, you must either create the table manually, ahead of time, or adjust the schema of the associated field before the sink connector processes the event.
 To adjust nullability settings or default values, you can introduce a custom single message transformation that applies changes in the pipeline, or modifies the column state defined in the source database.
 
+ifdef::community[]
 For SingleStore targets, automatic table creation does not configure SingleStore-specific shard keys, sort keys, or other table options.
 For more information, see xref:jdbc-singlestore-targets[].
 
 For StarRocks targets, automatic table creation creates PRIMARY KEY tables from the record key fields, and does not configure StarRocks-specific distribution, partitioning, or other table options.
 For more information, see xref:jdbc-starrocks-targets[].
+endif::community[]
 
 A field's data type is resolved based on a predefined set of mappings.
 For more information, see xref:jdbc-field-types[JDBC field types].
@@ -499,6 +434,83 @@ The {prodname} JDBC sink connector uses the Hibernate Agroal connection pool.
 You can customize the Agroal connection pool by setting properties in the `hibernate.agroal.*` configuration namespace.
 In the preceding example, the setting of the hibernate.agroal.idleValidation property configures the connection pool to perform idle timeout tests every 300 seconds.
 After you apply the configuration, the connection pool begins to assess unused connections every five minutes.
+
+ifdef::community[]
+[[jdbc-singlestore-targets]]
+=== SingleStore sink targets
+
+To write to SingleStore, configure xref:jdbc-property-connection-url[`connection.url`] with a SingleStore JDBC URL, for example, `jdbc:singlestore://<_host_>:3306/<_database_>`.
+The SingleStore JDBC driver is included in the {prodname} JDBC connector archive, so Kafka Connect deployments that use the connector archive do not require an additional SingleStore driver JAR.
+
+SingleStore targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+For SingleStore, the connector generates `INSERT ... ON DUPLICATE KEY UPDATE ...` statements.
+
+If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
+Automatic table creation does not expose SingleStore-specific shard key, sort key, or other table option settings.
+If the target table requires explicit shard keys, sort keys, or other SingleStore table options, create the destination table in SingleStore before the connector writes to it.
+
+For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values to the SingleStore `JSON` column type.
+The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values to the SingleStore `GEOGRAPHY` column type, and `io.debezium.data.geometry.Point` logical values to the SingleStore `GEOGRAPHYPOINT` column type.
+SingleStore supports a subset of WKT geospatial values.
+The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.
+
+[[jdbc-starrocks-targets]]
+=== StarRocks sink targets
+
+To write to StarRocks, configure xref:jdbc-property-connection-url[`connection.url`] with a StarRocks JDBC URL, for example, `jdbc:starrocks://<_host_>:9030/<_database_>`.
+The StarRocks JDBC driver is included in the {prodname} JDBC connector archive, so Kafka Connect deployments that use the connector archive do not require an additional StarRocks driver JAR.
+The connector automatically detects a StarRocks target from the driver, so no dialect configuration is required.
+To write to a database in a catalog other than `default_catalog`, specify a fully qualified `<_catalog_>.<_database_>` path in the connection URL, or set the xref:jdbc-property-dialect-starrocks-catalog-name[`dialect.starrocks.catalog.name`] property.
+
+StarRocks targets support idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+StarRocks executes `INSERT` statements against PRIMARY KEY tables as upserts, so the connector generates plain `INSERT` statements; `INSERT ... ON DUPLICATE KEY UPDATE ...` is not supported by StarRocks.
+Upsert and delete operations require the destination table to be a StarRocks PRIMARY KEY table.
+Tables that the connector creates automatically from events with key fields are always PRIMARY KEY tables.
+
+If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
+Tables that the connector creates use `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses based on the record key fields.
+StarRocks limits the encoded size of all primary key column values of a PRIMARY KEY table to 128 bytes and does not permit `FLOAT`, `DOUBLE`, or `DECIMAL` key columns.
+Automatic table creation does not expose StarRocks-specific distribution, partitioning, or other table option settings.
+If the target table requires explicit table options, create the destination table in StarRocks before the connector writes to it.
+StarRocks applies `ALTER TABLE` schema changes asynchronously; writes that arrive while a schema change is still running can fail transiently and are retried by the connector.
+
+StarRocks has no `TIME` data type.
+The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.MicroTime`, and `io.debezium.time.NanoTime` logical values, and Kafka Connect `Time` values, to `VARCHAR` columns as `HH:mm:ss.ffffff` formatted strings.
+MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
+`io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
+StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
+Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
+StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so the connector multiplies propagated character lengths by four, up to the maximum length of 1048576; `CHAR` columns whose scaled length exceeds the 255 byte `CHAR` maximum are promoted to `VARCHAR`.
+`BYTES` values are written to `VARBINARY` columns, which are limited to the same 1048576 byte maximum.
+`DECIMAL` columns support a maximum precision of 38; the connector caps larger propagated precisions at 38, and values that exceed the capped precision fail on write.
+When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
+{prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
+The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
+
+[[jdbc-cockroachdb-targets]]
+=== CockroachDB sink targets
+
+To enable the JDBC connector to write to CockroachDB, you must specify a PostgreSQL JDBC URL in the connector's xref:jdbc-property-connection-url[`connection.url`] property, for example, `jdbc:postgresql://<_host_>:26257/<_database_>`.
+Because CockroachDB supports the PostgreSQL communication protocol, it works with the PostgreSQL JDBC driver that is included in the {prodname} JDBC connector archive.
+
+As a sink target, CockroachDB supports idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
+For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
+
+CockroachDB uses the `SERIALIZABLE` transaction isolation level.
+As a result, if CockroachDB detects a conflict between concurrent transactions, it might temporarily abort one of the transactions and return SQLSTATE `40001`.
+The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
+Setting `flush.max.retries` to `0` disables the retries so that a conflicting flush fails immediately.
+
+For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following exceptions:
+
+* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
+* `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.
+* Propagated `money` column types are written as `decimal(19,2)` types.
+* `io.debezium.data.geometry.Geometry`, `io.debezium.data.geometry.Geography`, and `io.debezium.data.geometry.Point` logical values are written to the built-in CockroachDB `geometry` and `geography` types; no PostGIS extension schema is required.
+* `io.debezium.data.FloatVector` logical values are written to the CockroachDB `vector` column type, because CockroachDB has no `halfvec` type.
+* `io.debezium.data.SparseDoubleVector` is not supported.
+endif::community[]
+
 
 [[jdbc-error-handling-and-dead-letter-queues]]
 === Error handling and dead letter queues
@@ -905,7 +917,7 @@ If the connector consumes change events from topics that are populated by a {pro
 To enable the use of these stricter data type conversions, set the `column.propagate.source.type` or `datatype.propagate.source.type` properties in the source connector configuration.
 When these properties are set in the source connector, the events that it generates include additional column metadata that the JDBC connector then uses to construct columns with a stricter concrete data type.
 In the preceding table, where a second entry, marked with an asterisk, appears in a table cell, it represents the stricter data type.
-
+ifdef::community[]
 For SingleStore targets, {prodname} uses MySQL/MariaDB-compatible mappings for most dialect-specific logical types.
 SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
 Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
@@ -921,6 +933,7 @@ For example, the connector uses the following mappings:
 The SingleStore dialect writes supported `POINT`, `LINESTRING`, and `POLYGON` WKB values as WKT strings.
 
 For StarRocks targets, see xref:jdbc-starrocks-targets[] for the dialect-specific type mappings, including the string-based representation that the dialect uses for time types.
+endif::community[]
 
 // Type: reference
 // Title: Mappings between {prodname} vector data types and RDBMS column types
@@ -948,10 +961,13 @@ Sink databases must meet the following requirements to support direct mapping of
 * MariaDB version 11.7 or later
 * MySQL version 9.0 or later
 * PostgreSQL requires the pgvector extension
+ifdef::community[]
 * SingleStore requires the native `VECTOR` data type
+endif::community[]
 
-Earlier versions of MariaDB or MySQL, PostgreSQL without pgvector, and SingleStore deployments without the native `VECTOR` data type do not support special vector types.
+The connector cannot correctly map logical vector types directly to other sink targets.
 
+ifdef::community[]
 For SingleStore, `FloatVector` maps to `vector(n, F32)` and `DoubleVector` maps to `vector(n, F64)`.
 If the source column length is unavailable, the connector uses default dimensions of `2048` for `FloatVector` and `16383` for `DoubleVector`.
 
@@ -984,6 +1000,37 @@ If the source column length is unavailable, the connector uses default dimension
 |Unsupported
 
 |===
+
+endif::community[]
+
+ifdef::product[
+.Mappings between {prodname} Vector Types and Column Data Types
+|===
+|Logical Type |Db2 |MySQL |PostgreSQL |Oracle |SQL Server
+
+|io.debezium.data.DoubleVector
+|Unsupported
+|'vector'
+|`vector`
+|Unsupported
+|Unsupported
+
+|io.debezium.data.FloatVector
+|Unsupported
+|'vector'
+|`halfvec`
+|Unsupported
+|Unsupported
+
+|io.debezium.data.SparseVector
+|Unsupported
+|Unsupported
+|`sparsevec`
+|Unsupported
+|Unsupported
+
+|===
+endif::product[]
 
 [NOTE]
 ====
@@ -1181,8 +1228,11 @@ To deploy the {prodname} JDBC sink connector, install the connector archive in y
 Drivers for Oracle and Db2 are not included with the JDBC sink connector.
 You must download the drivers and install them manually.
 ====
+ifdef::community[]
 +
 The SingleStore JDBC driver is included with the JDBC connector archive.
+endif::community[]
+
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. Make sure that the path where you install the JDBC sink connector is part of the {link-kafka-docs}/#connectconfigs[Kafka Connect `plugin.path`].
 . Restart the Kafka Connect process to pick up the new JAR files.
 endif::community[]
@@ -1711,6 +1761,7 @@ Specifies the timezone used when writing temporal field types.
 `topics`::
 List of topics to consume, separated by commas.
 
+ifdef::community[]
 For a SingleStore sink, set `connection.url` to a SingleStore JDBC URL.
 For example:
 
@@ -1723,6 +1774,7 @@ For example:
     "connection.password": "<_password_>"
 }
 ----
+endif::community[]
 
 For a complete list of configuration properties that you can set for the {prodname} JDBC connector, see xref:jdbc-connector-properties[JDBC connector properties].
 
@@ -2040,12 +2092,14 @@ For information about the performance benefits of enabling the UNNEST function, 
 |Specifies whether the connector automatically sets an `IDENTITY_INSERT` before an `INSERT` or `UPSERT` operation into the identity column of SQL Server tables, and then unsets it immediately after the operation.
 When the default setting (`false`) is in effect, an `INSERT` or `UPSERT` operation into the `IDENTITY` column of a table results in a SQL exception.
 
+ifdef::community[]
 |[[jdbc-property-dialect-starrocks-catalog-name]]<<jdbc-property-dialect-starrocks-catalog-name, `+dialect.starrocks.catalog.name+`>>
 |No default
 |Specifies the name of the StarRocks catalog that the connector writes into.
 When this property is set, the connector executes `SET CATALOG <_name_>` on every new connection before any session work.
 The value must be a valid StarRocks catalog name, that is, it may contain only letters, digits, and underscores, and must not start with a digit; other values are rejected during configuration validation.
 The StarRocks JDBC driver also supports specifying the catalog directly in the connection URL, for example, `jdbc:starrocks://<_host_>:9030/<_catalog_>.<_database_>`.
+endif::community[]
 
 |[[jdbc-property-batch-size]]<<jdbc-property-batch-size, `+batch.size+`>>
 |`500`

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -797,6 +797,7 @@ The following table maps {prodname} logical types to dialect-specific column typ
 |`blob`
 |`bit(n)`
 |`bit varying`
+
 `bit(n)`^1^
 |`blob`
 |`varbinary(n)`
@@ -840,7 +841,9 @@ The following table maps {prodname} logical types to dialect-specific column typ
 |`varchar(128)`
 |`time`
 |`interval`
-|`interval year to month` +
+
+|`interval year to month`  
+
 `interval day to second`
 |`varchar(128)`
 
@@ -848,6 +851,7 @@ The following table maps {prodname} logical types to dialect-specific column typ
 |`clob`
 `varchar(n)`^1^
 |`longtext`
+
 `varchar`^1^
 |`ltree`
 |`clob`
@@ -856,21 +860,27 @@ The following table maps {prodname} logical types to dialect-specific column typ
 
 |io.debezium.data.Uuid
 |`clob`
+
 `varchar(n)`^1^
 |`uuid`
 |`text`
+
 `varchar(n)`^1^
 |`clob`
+
 `varchar2(n)`^1^
 |`varchar`
 
 |io.debezium.data.Tsvector
 |`clob`
+
 `varchar(n)`^1^
 |`longtext`
+
 `varchar`^1^
 |`tsvector`
 |`clob`
+
 `varchar2(n)`^1^
 |`varchar`
 

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -469,6 +469,7 @@ Tables that the connector creates automatically from events with key fields are 
 
 If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, the connector can create or alter destination tables from event schemas.
 Tables that the connector creates use `PRIMARY KEY (...) DISTRIBUTED BY HASH (...)` clauses based on the record key fields.
+
 StarRocks limits the encoded size of all primary key column values of a PRIMARY KEY table to 128 bytes and does not permit `FLOAT`, `DOUBLE`, or `DECIMAL` key columns.
 Automatic table creation does not expose StarRocks-specific distribution, partitioning, or other table option settings.
 If the target table requires explicit table options, create the destination table in StarRocks before the connector writes to it.
@@ -476,14 +477,22 @@ StarRocks applies `ALTER TABLE` schema changes asynchronously; writes that arriv
 
 StarRocks has no `TIME` data type.
 The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.MicroTime`, and `io.debezium.time.NanoTime` logical values, and Kafka Connect `Time` values, to `VARCHAR` columns as `HH:mm:ss.ffffff` formatted strings.
+
 MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
+
 `io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
-StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
+S
+tarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
+
 Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
+
 StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so the connector multiplies propagated character lengths by four, up to the maximum length of 1048576; `CHAR` columns whose scaled length exceeds the 255 byte `CHAR` maximum are promoted to `VARCHAR`.
+
 `BYTES` values are written to `VARBINARY` columns, which are limited to the same 1048576 byte maximum.
+
 `DECIMAL` columns support a maximum precision of 38; the connector caps larger propagated precisions at 38, and values that exceed the capped precision fail on write.
 When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
+
 {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
 The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
 
@@ -842,7 +851,7 @@ The following table maps {prodname} logical types to dialect-specific column typ
 |`time`
 |`interval`
 
-|`interval year to month`  
+|`interval year to month`
 
 `interval day to second`
 |`varchar(128)`
@@ -925,11 +934,14 @@ The following table maps {prodname} logical types to dialect-specific column typ
 ^1^ When a logical type maps to more than one type, the {prodname} JDBC connector defaults to the first more generalized data type.
 If the connector consumes change events from topics that are populated by a {prodname} source connector, the JDBC connector can use stricter, more concrete data types when it sends data to some targets.
 To enable the use of these stricter data type conversions, set the `column.propagate.source.type` or `datatype.propagate.source.type` properties in the source connector configuration.
+
 When these properties are set in the source connector, the events that it generates include additional column metadata that the JDBC connector then uses to construct columns with a stricter concrete data type.
 In the preceding table, where a second entry, marked with an asterisk, appears in a table cell, it represents the stricter data type.
 ifdef::community[]
+
 For SingleStore targets, {prodname} uses MySQL/MariaDB-compatible mappings for most dialect-specific logical types.
 SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
+
 Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
 {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values are written to SingleStore `geography` columns, and `io.debezium.data.geometry.Point` logical values are written to SingleStore `geographypoint` columns.
 
@@ -1377,7 +1389,7 @@ To use an ImageStream, an ImageStream resource must be deployed to the cluster.
 For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsAPIReference}#type-Build-reference[Build schema reference] in the {NameStreamsAPIReference}.
 
 //     Future changes to the Streams content or structure could break this link in future releases.
-//     Consider removing it. 
+//     Consider removing it.
 
 `spec.plugins`::
 Lists all of the connectors that you want to include in the Kafka Connect image.
@@ -1450,7 +1462,7 @@ The following list describes select fields in the preceding `KafkaConnector` con
 The name of the Kafka connector instance that {StreamsName} creates in Kafka Connect.
 
 `metadata.labels: strimzi.io/cluster`::
-Identifies the KafkaConnect cluster resource that hosts the connector. 
+Identifies the KafkaConnect cluster resource that hosts the connector.
 {StreamsName} uses this label to associate the KafkaConnector with a specific KafkaConnect deployment.
 
 `spec.class`::

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -1013,7 +1013,7 @@ If the source column length is unavailable, the connector uses default dimension
 
 endif::community[]
 
-ifdef::product[
+ifdef::product[]
 .Mappings between {prodname} Vector Types and Column Data Types
 |===
 |Logical Type |Db2 |MySQL |PostgreSQL |Oracle |SQL Server


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9958](https://redhat.atlassian.net/browse/DBZ-9958)
## Description
Conditionalizes content in the JDBC connector docs that's related to sink targets that are supported only in the community edition (CockroachDB, SingleStore, and StarRocks).

- 42 mentions of SingleStore; 44 mentions of StarRocks; 17 of CockroachDB
- Conditionalize table, on L889 (_Mappings between {prodname} Vector Types and Column Data Types_)
- The ul on L39 that provides links to connector features does not accurately reflect the order of the topics in the file.
Reshuffled both the topic order and the list to match.  
Does not apply to `3.6`

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
