### PR TITLE
debezium/dbz#2466 Add common assembly descriptor for Debezium Embedded

### DIFF
--- a/debezium-assembly-descriptors/src/main/resources/assemblies/embedded-distribution.xml
+++ b/debezium-assembly-descriptors/src/main/resources/assemblies/embedded-distribution.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>embedded-common</id>
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>${project.artifactId}</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <!-- Get the files from the top-level directory -->
+            <directory>${project.basedir}/..</directory>
+            <outputDirectory>${project.artifactId}</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>CHANGELOG*</include>
+                <include>CONTRIBUTING*</include>
+                <include>COPYRIGHT*</include>
+                <include>LICENSE*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -135,4 +135,45 @@
             </resource>
         </resources>
     </build>
+    <profiles>
+        <profile>
+            <id>assembly</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${version.assembly.plugin}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.debezium</groupId>
+                                <artifactId>debezium-assembly-descriptors</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>
+                                    <descriptorRefs>
+                                        <descriptorRef>embedded-distribution</descriptorRef>
+                                    </descriptorRefs>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2466

## Description
This PR introduces a pre-packaged common core assembly for the Debezium Embedded runtime, containing all core transitive dependencies (Jackson, SLF4J, Connect APIs, etc.) while omitting connector-specific drivers. 

Once published to Maven Central during releases, this zip/tarball allows downstream runtimes such as the Python `pydebeziumai` library to download and set up Debezium dependencies directly via standard file downloads, eliminating the requirement for a local Maven (`mvn`) installation on the user's system.

### Changes:
1. **Assembly Descriptor**: Created `embedded-distribution.xml` inside `debezium-assembly-descriptors` packaging all transitive runtime dependencies into a folder structure matching Debezium connector distributions.
2. **Module Profile**: Added the `assembly` profile to `debezium-embedded/pom.xml` to build and attach the `.zip` and `.tar.gz` packages during release runs.

### Verification:
Built and verified the assembly packaging structure locally:
```bash
./mvnw clean package -Passembly -pl debezium-assembly-descriptors,debezium-embedded -am -DskipTests
```
Verified that the output `target/debezium-embedded-3.7.0-SNAPSHOT-embedded-common.zip` contains all required core transitive dependency JARs.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
