### PR TITLE
debezium/dbz#2386 Upgrade AWS S3 SDK v2 to 2.53.1 and pin Apache HttpClient 4 for stora…

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -49,7 +49,7 @@
         <version.jedis>6.0.0</version.jedis>
 
         <!-- S3 -->
-        <version.s3>2.26.30</version.s3>
+        <version.s3>2.53.1</version.s3>
 
         <!-- Blob Storage -->
         <version.azure.blob>12.29.0</version.azure.blob>

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <!-- S3 -->
         <version.s3mock>3.10.0</version.s3mock>
+        <!-- Apache HttpClient 4, no longer provided transitively by AWS SDK apache-client (v2.53+ uses HttpClient 5) -->
+        <version.httpclient>4.5.14</version.httpclient>
 
         <!-- Azurite -->
         <version.azurite>3.33.0</version.azurite>
@@ -115,6 +117,12 @@
         <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${version.httpclient}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
debezium/dbz#2386
debezium/dbz#1738

## Description
Bump `version.s3` from `2.26.30` to `2.53.1` in the BOM.

As of AWS SDK v2.53+, the `apache-client` transport uses Apache HttpClient 5 and
no longer provides Apache HttpClient 4 transitively. Since the S3 storage tests
still depend on HttpClient 4, add an explicit test-scoped
`org.apache.httpcomponents:httpclient` dependency pinned via a new
`version.httpclient` property (`4.5.14`) in `debezium-storage-tests`.

Changes:
- `debezium-bom/pom.xml`: `version.s3` `2.26.30` → `2.53.1`
- `debezium-storage/debezium-storage-tests/pom.xml`: add `version.httpclient`
  (`4.5.14`) and an explicit test-scoped `httpclient` dependency
