### PR TITLE
debezium/dbz#2470 Propagate standalone DDL GTID events with binlog buffering

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/EventBuffer.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/EventBuffer.java
@@ -116,6 +116,9 @@ public class EventBuffer<T extends BinlogStreamingChangeEventSource<P, O>, P ext
                 // signals a new transaction for MariaDB, treat like QUERY events with BEGIN
                 beginTransaction(partition, offsetContext, event);
             }
+            else {
+                consumeEvent(partition, offsetContext, event);
+            }
         }
         else if (event.getHeader().getEventType() == EventType.XID) {
             completeTransaction(partition, offsetContext, true, event);

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/EventBuffer.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/EventBuffer.java
@@ -112,7 +112,7 @@ public class EventBuffer<T extends BinlogStreamingChangeEventSource<P, O>, P ext
             // then we don't create a new transaction for this. This typically happens
             // for DDL operations which are always transaction scoped.
             MariadbGtidEventData gtidEventData = (MariadbGtidEventData) event.getData();
-            if ((gtidEventData.getFlags() & 0x01) != 0x01) {
+            if ((gtidEventData.getFlags() & MariadbGtidEventData.FL_STANDALONE) == 0) {
                 // signals a new transaction for MariaDB, treat like QUERY events with BEGIN
                 beginTransaction(partition, offsetContext, event);
             }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderBufferIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderBufferIT.java
@@ -69,6 +69,7 @@ public abstract class BinlogReaderBufferIT<C extends SourceConnector> extends Ab
     @SkipWhenDatabaseIs(value = SkipWhenDatabaseIs.Type.MYSQL, reason = "MariaDB-specific GTID behavior")
     @SkipWhenDatabaseIs(value = SkipWhenDatabaseIs.Type.PERCONA, reason = "MariaDB-specific GTID behavior")
     @Test
+    @FixFor("debezium/dbz#2470")
     void shouldPropagateGtidForStandaloneDdl() throws SQLException, InterruptedException {
         config = DATABASE.defaultConfig()
                 .with(BinlogConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderBufferIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderBufferIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.junit.SkipWhenDatabaseIs;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
 import io.debezium.connector.binlog.util.TestHelper;
 import io.debezium.connector.binlog.util.UniqueDatabase;
@@ -63,6 +64,49 @@ public abstract class BinlogReaderBufferIT<C extends SourceConnector> extends Ab
         finally {
             Files.delete(SCHEMA_HISTORY_PATH);
         }
+    }
+
+    @SkipWhenDatabaseIs(value = SkipWhenDatabaseIs.Type.MYSQL, reason = "MariaDB-specific GTID behavior")
+    @SkipWhenDatabaseIs(value = SkipWhenDatabaseIs.Type.PERCONA, reason = "MariaDB-specific GTID behavior")
+    @Test
+    void shouldPropagateGtidForStandaloneDdl() throws SQLException, InterruptedException {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))
+                .with(BinlogConnectorConfig.PORT, System.getProperty("database.replica.port", "3306"))
+                .with(BinlogConnectorConfig.USER, "snapper")
+                .with(BinlogConnectorConfig.PASSWORD, "snapperpass")
+                .with(BinlogConnectorConfig.SERVER_ID, 18765)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(BinlogConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(BinlogConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
+                .with(BinlogConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(BinlogConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER, 10_000)
+                .with(FileSchemaHistory.FILE_PATH, SCHEMA_HISTORY_PATH)
+                .build();
+
+        start(getConnectorClass(), config);
+        consumeRecordsByTopic(5 + 9 + 9 + 4 + 11 + 1);
+
+        final String currentGtidSet;
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("ALTER TABLE products ADD COLUMN volume FLOAT");
+            currentGtidSet = connection.queryAndMap("SELECT @@GLOBAL.gtid_binlog_pos", rs -> {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+                throw new IllegalStateException("Could not get GTID set");
+            });
+        }
+
+        final SourceRecords records = consumeRecordsByTopic(1);
+        final SourceRecord ddlRecord = records.recordsForTopic(DATABASE.getServerName()).get(0);
+        final Struct source = ((Struct) ddlRecord.value()).getStruct("source");
+        final String ddlGtid = source.getString(BinlogSourceInfo.GTID_KEY);
+
+        assertThat(ddlGtid).isNotNull();
+        assertThat(currentGtidSet.split(",")).contains(ddlGtid);
     }
 
     @Test

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbStreamingChangeEventSource.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbStreamingChangeEventSource.java
@@ -117,8 +117,12 @@ public class MariaDbStreamingChangeEventSource extends BinlogStreamingChangeEven
             setEventTimestamp(event, event.getHeader().getTimestamp());
         }
 
-        // With compatibility mode 4, this event equates to a new transaction.
-        handleTransactionBegin(partition, offsetContext, event, null);
+        // With compatibility mode 4, non-standalone GTID events equate to a new transaction.
+        // Standalone events do not have a following commit, so starting a transaction for them
+        // would leave transaction state open and notify incremental snapshots too early.
+        if ((gtidEvent.getFlags() & MariadbGtidEventData.FL_STANDALONE) == 0) {
+            handleTransactionBegin(partition, offsetContext, event, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes debezium/dbz#2470

## Description

When MariaDB emits a standalone GTID event for a DDL statement, the GTID event has flag 1 set because no commit event follows it. With `binlog.buffer.size` enabled, `EventBuffer` correctly avoids opening a transaction for that event, but previously returned without forwarding it to the streaming event handler. As a result, the DDL schema change record could be emitted without its GTID and the GTID accumulator would not observe that position.

This change forwards standalone MariaDB GTID events directly to the event consumer while leaving regular transaction buffering unchanged.

A MariaDB integration test executes a standalone `ALTER TABLE` with buffering enabled and verifies that the schema change record contains a GTID present in `@@GLOBAL.gtid_binlog_pos`. The test fails before the fix because `source.gtid` is null.

## Testing

- `MariaDbBinlogReaderBufferIT#shouldPropagateGtidForStandaloneDdl`
- Full `MariaDbBinlogReaderBufferIT` test class: 5 tests passed
- Binlog connector build with formatting and checkstyle validation

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
