### PR TITLE
debezium/dbz#2458 Skip signal processing when the semaphore cannot be acquired

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -990,6 +990,17 @@ public abstract class CommonConnectorConfig {
             .withValidation(Field::isPositiveInteger)
             .withDescription("Interval for looking for new signals in registered channels, given in milliseconds. Defaults to 5 seconds.");
 
+    public static final Field SIGNAL_PROCESSOR_SEMAPHORE_WAIT_MS = Field.createInternal("signal.processor.semaphore.wait.ms")
+            .withDisplayName("Signal processor semaphore wait time (ms)")
+            .withGroup(Field.createGroupEntry(Field.Group.ADVANCED))
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(10000L)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("The maximum time in milliseconds the signal processor waits to acquire its internal lock before "
+                    + "skipping a signal processing cycle. Defaults to 10 seconds.");
+
     public static final Field SIGNAL_EMIT_FAILURE_MAX_RETRIES = Field.create("signal.emit.failure.max.retries")
             .withDisplayName("Signal emit window event failure maximum retries")
             .withType(Type.INT)
@@ -1563,7 +1574,7 @@ public abstract class CommonConnectorConfig {
                     OPEN_LINEAGE_INTEGRATION_JOB_NAMESPACE, OPEN_LINEAGE_INTEGRATION_JOB_DESCRIPTION, OPEN_LINEAGE_INTEGRATION_JOB_TAGS,
                     OPEN_LINEAGE_INTEGRATION_JOB_OWNERS, OPEN_LINEAGE_INTEGRATION_DATASET_KAFKA_BOOTSTRAP_SERVER, EXTENDED_HEADERS_ENABLED, GUARDRAIL_COLLECTIONS_MAX,
                     GUARDRAIL_COLLECTIONS_LIMIT_ACTION, CUSTOM_SANITIZE_PATTERN, SIGNAL_EMIT_FAILURE_MAX_RETRIES, SIGNAL_EMIT_FAILURE_BACKOFF_INTERVAL_MS,
-                    STATISTICS_METRICS_ENABLED, OFFSET_ACTIVITY_MONITOR_INTERVAL_MS)
+                    STATISTICS_METRICS_ENABLED, OFFSET_ACTIVITY_MONITOR_INTERVAL_MS, SIGNAL_PROCESSOR_SEMAPHORE_WAIT_MS)
             .group(Field.Group.ADVANCED_HEARTBEAT, Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX, SIGNAL_POLL_INTERVAL_MS)
             .group(Field.Group.CONNECTOR, TOPIC_NAMING_STRATEGY, SinkNotificationChannel.NOTIFICATION_TOPIC, CUSTOM_METRIC_TAGS)
             .create();
@@ -1603,6 +1614,7 @@ public abstract class CommonConnectorConfig {
     private final List<TableId> signalingDataCollectionIds;
 
     private final Duration signalPollInterval;
+    private final Duration signalProcessorSemaphoreWait;
     private final Duration signalEmitFailureBackoff;
     private final int signalEmitFailureMaxRetries;
 
@@ -1655,6 +1667,7 @@ public abstract class CommonConnectorConfig {
         this.binaryHandlingMode = BinaryHandlingMode.parse(config.getString(BINARY_HANDLING_MODE));
         this.signalingDataCollections = getSignalingDataCollections(config);
         this.signalPollInterval = Duration.ofMillis(config.getLong(SIGNAL_POLL_INTERVAL_MS));
+        this.signalProcessorSemaphoreWait = Duration.ofMillis(config.getLong(SIGNAL_PROCESSOR_SEMAPHORE_WAIT_MS));
         this.signalEmitFailureMaxRetries = config.getInteger(SIGNAL_EMIT_FAILURE_MAX_RETRIES);
         this.signalEmitFailureBackoff = Duration.ofMillis(config.getLong(SIGNAL_EMIT_FAILURE_BACKOFF_INTERVAL_MS));
         this.signalEnabledChannels = getSignalEnabledChannels(config);
@@ -2298,6 +2311,10 @@ public abstract class CommonConnectorConfig {
 
     public Duration getSignalPollInterval() {
         return signalPollInterval;
+    }
+
+    public Duration getSignalProcessorSemaphoreWait() {
+        return signalProcessorSemaphoreWait;
     }
 
     public Duration getSignalEmitFailureBackoff() {

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
@@ -6,6 +6,7 @@
 package io.debezium.pipeline.signal;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +47,6 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SignalProcessor.class);
 
-    public static final int SEMAPHORE_WAIT_TIME = 10;
     public static final String DATA_COLLECTIONS_FIELD_NAME = "data-collections";
     public static final String POINT_REGEX = "\\.";
 
@@ -180,15 +180,19 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
 
     private void executeWithSemaphore(Runnable operation) {
 
+        final Duration waitTime = connectorConfig.getSignalProcessorSemaphoreWait();
         boolean acquired = false;
         try {
-            acquired = semaphore.tryAcquire(SEMAPHORE_WAIT_TIME, TimeUnit.SECONDS);
-
+            acquired = semaphore.tryAcquire(waitTime.toMillis(), TimeUnit.MILLISECONDS);
+            if (!acquired) {
+                LOGGER.warn("Could not acquire the signal processing semaphore within {}, skipping this cycle to preserve mutual exclusion", waitTime);
+                return;
+            }
             operation.run();
         }
         catch (InterruptedException e) {
-            LOGGER.error("Not able to acquire semaphore after {}s", SEMAPHORE_WAIT_TIME);
-            throw new DebeziumException("Not able to acquire semaphore during signaling processing", e);
+            Thread.currentThread().interrupt();
+            throw new DebeziumException("Interrupted while acquiring the semaphore during signal processing", e);
         }
         finally {
             if (acquired) {

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -27,6 +28,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.common.BaseSourceInfo;
+import io.debezium.doc.FixFor;
 import io.debezium.document.DocumentReader;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.CommonOffsetContext;
@@ -199,6 +201,43 @@ public class SignalProcessorTest {
                 .untilAsserted(() -> assertThat(called.intValue()).isEqualTo(5));
 
         signalProcess.stop();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2458")
+    public void shouldSkipProcessingWhenSemaphoreCannotBeAcquired() throws Exception {
+
+        final SignalChannelReader genericChannel = mock(SignalChannelReader.class);
+
+        when(genericChannel.name()).thenReturn("generic");
+        when(genericChannel.read()).thenReturn(
+                List.of(new SignalRecord("log1", "log", "{\"message\": \"signallog {}\"}", Map.of("channelOffset", -1L))),
+                List.of());
+
+        final LogInterceptor log = new LogInterceptor(Log.class);
+
+        signalProcess = new SignalProcessor<>(SourceConnector.class,
+                baseConfig(Map.of(CommonConnectorConfig.SIGNAL_PROCESSOR_SEMAPHORE_WAIT_MS.name(), 1L)),
+                Map.of(Log.NAME, new Log<>()),
+                List.of(genericChannel), documentReader, initialOffset);
+
+        // Hold the single permit so processing cannot acquire it within the configured wait and must skip
+        // the cycle rather than run the signal action without holding the lock.
+        final Semaphore semaphore = signalProcessorSemaphore(signalProcess);
+        semaphore.acquire();
+        try {
+            signalProcess.process();
+            assertThat(log.containsMessage("signallog {LSN=12345}")).isFalse();
+        }
+        finally {
+            semaphore.release();
+        }
+    }
+
+    private static Semaphore signalProcessorSemaphore(SignalProcessor<?, ?> processor) throws Exception {
+        final java.lang.reflect.Field field = SignalProcessor.class.getDeclaredField("semaphore");
+        field.setAccessible(true);
+        return (Semaphore) field.get(processor);
     }
 
     protected CommonConnectorConfig baseConfig() {


### PR DESCRIPTION
Fixes [debezium/dbz#2458](https://github.com/debezium/dbz/issues/2458).

### Problem

`SignalProcessor.executeWithSemaphore(...)` discarded the boolean result of `Semaphore.tryAcquire(timeout, unit)` and ran the guarded operation unconditionally. `tryAcquire` returns `false` on timeout (it does not throw, and the `catch` only handles `InterruptedException`), so on a timeout the signal-processing critical section executed **without holding the permit** — defeating the mutual exclusion between the two threads that enter it:

- `process()` — the `signalProcessorExecutor` thread (external channels), and
- `processSourceSignal()` — the streaming thread, reached inline from `EventDispatcher.dispatchDataChangeEvent()`.

A long-running signal action (a blocking snapshot, or an incremental `execute-snapshot` looping `readChunk()`) can exceed the 10s wait; a second action arriving meanwhile would then run concurrently and mutate shared `@NotThreadSafe` snapshot state (e.g. the incremental-snapshot context/window), risking corrupted chunk bookkeeping or `ConcurrentModificationException`.

### Fix

Per @jpechane on the issue:

- Only run the operation when the permit was actually acquired; otherwise log a warning and skip the cycle (fail-safe — the periodic `process()` retries next interval and the source signal is re-read on the next dispatch).
- Make the wait configurable via the internal `signal.processor.semaphore.wait.ms` property (default 10s, replacing the hardcoded constant) so it can be tuned from user reports and, importantly, lowered for a fast unit test.
- Restore the interrupt flag on `InterruptedException` and correct the (previously misleading) message.

### Test

`SignalProcessorTest.shouldSkipProcessingWhenSemaphoreCannotBeAcquired` holds the single permit, sets the wait to 1 ms, and asserts the signal action does not run. Verified it fails against the previous code (the action ran unguarded) and passes with the fix; the existing `SignalProcessorTest` cases stay green.
