### PR TITLE
[docs] Revert DBZ-10001 Remove callouts from 3.6 MongoDB doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -109,10 +109,10 @@ You specify the replica member that the connector reads from by configuring the 
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
 To reduce the load on the primary, it's possible to configure the connector to read from a secondary node, by setting `readPreference=secondaryPreferred`.
-Under normal operating conditions, configuring the connector to read from a secondary node does not significantly increase data-capture latency.
+Under normal operating conditions, configuring the connector to read from a secondary node does not significantly increase data-capture latency. 
 However, events captured from a secondary can arrive later than they would from the primary due to resource contention or network latency.
-Additional latency can also occur because change streams emit events only after changes are majority committed.
-A change is majority committed when a majority of voting replica set members confirm that they have written the change to their journals.
+Additional latency can also occur because change streams emit events only after changes are majority committed. 
+A change is majority committed when a majority of voting replica set members confirm that they have written the change to their journals. 
 As a result, a secondary node can emit an event only after it receives confirmation that the change has been majority committed.
 
 // Type: assembly
@@ -589,41 +589,43 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 [source,json,index=0]
 ----
 {
- "schema": {
+ "schema": { // <1>
    ...
   },
- "payload": {
+ "payload": { // <2>
    ...
  },
- "schema": {
+ "schema": { // <3>
    ...
  },
- "payload": {
+ "payload": { // <4>
    ...
  },
 }
 ----
 
-The following list describes the fields in the preceding change event example:
+.Overview of change event basic content
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-`schema` (first)::
-The first `schema` field is part of the event key.
-It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion.
-In other words, the first `schema` field describes the structure of the key for the document that was changed.
+|1
+|`schema`
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the key for the document that was changed.
 
-`payload` (first)::
-The first `payload` field is part of the event key.
-It has the structure described by the previous `schema` field and it contains the key for the document that was changed.
+|2
+|`payload`
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the document that was changed.
 
-`schema` (second)::
-The second `schema` field is part of the event value.
-It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion.
-In other words, the second `schema` describes the structure of the document that was changed.
-Typically, this schema contains nested schemas.
+|3
+|`schema`
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the document that was changed. Typically, this schema contains nested schemas.
 
-`payload` (second)::
-The second `payload` field is part of the event value.
-It has the structure described by the previous `schema` field and it contains the actual data for the document that was changed.
+|4
+|`payload`
+|The second `payload` field is part of the event value. It has the structure described by the previous `schema` field and it contains the actual data for the document that was changed.
+
+|===
 
 By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See xref:mongodb-topic-names[topic names].
 
@@ -671,11 +673,11 @@ Every change event that captures a change to the `customers` collection has the 
 [source,json,indent=0]
 ----
   {
-    "schema": {
+    "schema": { // <1>
       "type": "struct",
-      "name": "fulfillment.inventory.customers.Key",
-      "optional": false,
-      "fields": [
+      "name": "fulfillment.inventory.customers.Key", // <2>
+      "optional": false, // <3>
+      "fields": [ // <4>
         {
           "field": "id",
           "type": "string",
@@ -683,38 +685,43 @@ Every change event that captures a change to the `customers` collection has the 
         }
       ]
     },
-    "payload": {
+    "payload": { // <5>
       "id": "1004"
     }
   }
 ----
 
-The following list describes the fields in the preceding change event key example:
+.Description of change event key
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-`schema`::
-The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
+|1
+|`schema`
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
-`fulfillment.inventory.customers.Key`::
-Name of the schema that defines the structure of the key's payload.
-This schema describes the structure of the key for the document that was changed.
-Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`.
+|2
+|`fulfillment.inventory.customers.Key`
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. 
 In the preceding example, the `name` field includes the following values:
 
-`fulfillment`::: The name of the connector that generated the event.
-`inventory`::: The database that contains the collection that the operation changed.
-`customers`::: The collection that contains the document that the operation updated.
+`fulfillment`:: The name of the connector that generated the event.
+`inventory`:: The database that contains the collection that the operation changed.
+`customers`:: The collection that contains the document that the operation updated.
 
-`schema.optional`::
-Indicates whether the event key must contain a value in its `payload` field.
-In this example, a value in the key's payload is required.
-A value in the key's payload field is optional when a document does not have a key.
+|3
+|`optional`
+|Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a document does not have a key.
 
-`schema.fields`::
-Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required.
+|4
+|`fields`
+|Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required.
 
-`schema.payload`::
-Contains the key for the document for which this change event was generated.
-In this example, the key contains a single `id` field of type `string` whose value is `1004`.
+|5
+|`payload`
+|Contains the key for the document for which this change event was generated. In this example, the key contains a single `id` field of type `string` whose value is `1004`.
+
+|===
 
 This example uses a document with an integer identifier, but any valid MongoDB document identifier works the same way, including a document identifier. For a document identifier, an event key's `payload.id` value is a string that represents the updated document's original `_id` field as a MongoDB extended JSON serialization that uses strict mode. The following table provides examples of how different types of `_id` fields are represented.
 
@@ -770,13 +777,13 @@ The following example shows the value portion of a change event that the connect
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
 {
-    "schema": {
+    "schema": { // <1>
       "type": "struct",
       "fields": [
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json",
+          "name": "io.debezium.data.Json", // <2>
           "version": 1,
           "field": "after"
         },
@@ -853,7 +860,7 @@ The following example shows the value portion of a change event that the connect
             }
           ],
           "optional": false,
-          "name": "io.debezium.connector.mongo.Source",
+          "name": "io.debezium.connector.mongo.Source", // <3>
           "field": "source"
         },
         {
@@ -878,11 +885,11 @@ The following example shows the value portion of a change event that the connect
         }
       ],
       "optional": false,
-      "name": "dbserver1.inventory.customers.Envelope"
+      "name": "dbserver1.inventory.customers.Envelope" // <4>
       },
-    "payload": {
-      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}",
-      "source": {
+    "payload": { // <5>
+      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}", // <6>
+      "source": { // <7>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -896,59 +903,57 @@ The following example shows the value portion of a change event that the connect
         "ord": 31,
         "h": 1546547425148721999
       },
-      "op": "c",
-      "ts_ms": 1558965515240,
-      "ts_us": 1558965515240142,
-      "ts_ns": 1558965515240142879,
+      "op": "c", // <8>
+      "ts_ms": 1558965515240, // <9>
+      "ts_us": 1558965515240142, // <10>
+      "ts_ns": 1558965515240142879, // <11>
     }
   }
 ----
 
-The following list describes select fields in the preceding _create_ event value example:
+.Descriptions of _create_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-`schema`::
-The value's schema, which describes the structure of the value's payload.
-A change event's value schema is the same in every change event that the connector generates for a particular collection.
+|1
+|`schema`
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular collection.
 
-`name` (io.debezium.data.Json)::
-In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
-+
-`io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields.
-This schema is specific to the `customers` collection.
-A _create_ event is the only kind of event that contains an `after` field.
-An _update_ event contains a `filter` field and a `patch` field.
-A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field.
+|2
+|`name`
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload.
 
-`name` (io.debezium.connector.mongo.Source)::
-`io.debezium.connector.mongo.Source` is the schema for the payload's `source` field.
-This schema is specific to the MongoDB connector.
-The connector uses it for all events that it generates.
+`io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field.
 
-`name` (dbserver1.inventory.customers.Envelope)::
-`dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection.
-This schema is specific to the collection.
+|3
+|`name`
+a|`io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates.
 
-`payload`::
-The value's actual data.
-This is the information that the change event is providing.
-+
-It may appear that the JSON representations of the events are much larger than the documents they describe.
-This is because the JSON representation must include the schema and the payload portions of the message.
+|4
+|`name`
+a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection.
+
+|5
+|`payload`
+a|The value's actual data. This is the information that the change event is providing.
+
+It may appear that the JSON representations of the events are much larger than the documents they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-`payload.after`::
-An optional field that specifies the state of the document after the event occurred.
+|6
+|`after`
+|An optional field that specifies the state of the document after the event occurred.
 In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields.
 The `after` value is always a string.
 By convention, it contains a JSON representation of the document.
 MongoDB oplog entries contain the full state of a document only for _create_ events and also for `update` events, when the `capture.mode` option is set to `change_streams_update_full`;
 in other words, a _create_ event is the only kind of event that contains an _after_ field regardless of `capture.mode` option.
 
-`payload.source`::
-Mandatory field that describes the source metadata for the event.
-This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction.
-The source metadata includes:
-+
+|7
+|`source`
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
+
 * {prodname} version.
 * Name of the connector that generated the event.
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
@@ -958,22 +963,33 @@ The source metadata includes:
 * Unique identifier of the MongoDB operation (the `h` field in the oplog event).
 * Unique identifiers of the MongoDB session `lsid` and transaction number `txnNumber` in case the change was executed inside a transaction (change streams capture mode only).
 
-`payload.source.op`::
-Mandatory string that describes the type of operation that caused the connector to generate the event.
-In this example, `c` indicates that the operation created a document.
-Valid values are:
-+
+|8
+|`op`
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are:
+
 * `c` = create
 * `u` = update
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-`ts_ms`, `ts_us`, `ts_ns`::
-Optional field that displays the time at which the connector processed the event in millisecond, microsecond, and nanosecond formats.
+|9
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task. 
+
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|10
+|`ts_us`
+a|Optional field that displays the time at which the connector processed the event, in microseconds.
 The time is based on the system clock in the JVM running the Kafka Connect task.
-+
-In the `source` object, `ts_ms` indicates the time that the change was made in the database.
-By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|9
+|`ts_ns`
+a|Optional field that displays the time at which the connector processed the event, in nanoseconds.
+The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
 
 [id="mongodb-update-events"]
 === _update_ events
@@ -1002,18 +1018,18 @@ Here is an example of a change event value in an event that the connector genera
 {
     "schema": { ... },
     "payload": {
-      "op": "u",
-      "ts_ms": 1465491461815,
-      "ts_us": 1465491461815698,
-      "ts_ns": 1465491461815698142,
-      "before":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"unknown\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
-      "after":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne Marie\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
+      "op": "u", // <1>
+      "ts_ms": 1465491461815, // <2>
+      "ts_us": 1465491461815698, // <2>
+      "ts_ns": 1465491461815698142, // <2>
+      "before":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"unknown\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}", // <3>
+      "after":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne Marie\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}", // <4>
       "updateDescription": {
         "removedFields": null,
-        "updatedFields": "{\"first_name\": \"Anne Marie\"}",
+        "updatedFields": "{\"first_name\": \"Anne Marie\"}", // <5>
         "truncatedArrays": null
       },
-      "source": {
+      "source": { // <6>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -1035,39 +1051,42 @@ Here is an example of a change event value in an event that the connector genera
   }
 ----
 
-The following list describes select fields in the preceding _update_ event value example:
+.Descriptions of _update_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-`payload.op`::
-Mandatory string that describes the type of operation that caused the connector to generate the event.
-In this example, `u` indicates that the operation updated a document.
+|1
+|`op`
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document.
 
-`ts_ms`, `ts_us`, `ts_ns`::
-Optional field that displays the time at which the connector processed the event in millisecond, microsecond, and nanosecond formats.
-The time is based on the system clock in the JVM running the Kafka Connect task.
-+
-In the `source` object, `ts_ms` indicates the time that the change was made in the database.
-By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+|2
+|`ts_ms`, `ts_us`, `ts_ns`
+a|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task. 
 
-`payload.before`::
-Contains the JSON string representation of the actual MongoDB document before change.
-+
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|3
+|`before`
+|Contains the JSON string representation of the actual MongoDB document before change.
+
 An _update_ event value does not contain a `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
-`payload.after`::
-Contains the JSON string representation of the actual MongoDB document.
-+
-An _update_ event value does not contain an `after` field if the capture mode is not set to `change_streams_update_full`.
+|4
+|`after`
+a|Contains the JSON string representation of the actual MongoDB document.
 
-`payload.updateDescription.updatedFields`::
-Contains the JSON string representation of the updated field values of the document.
-The connector serializes this field using the mode specified by the xref:mongodb-property-json-serialization-mode[`json.serialization.mode`] connector property.
-In this example, the update changed the `first_name` field to a new value.
+An _update_ event value does not contain an `after` field if the capture mode is not set to `change_streams_update_full`
 
-`payload.source`::
-Mandatory field that describes the source metadata for the event.
-This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog.
-The source metadata includes:
-+
+|5
+|`updatedFields`
+|Contains the JSON string representation of the updated field values of the document. In this example, the update changed the `first_name` field to a new value.
+
+|6
+|`source`
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes:
+
 * {prodname} version.
 * Name of the connector that generated the event.
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
@@ -1075,6 +1094,8 @@ The source metadata includes:
 * If the event was part of a snapshot.
 * Timestamp for when the change was made in the database and ordinal of the event within the timestamp.
 * Unique identifiers of the MongoDB session `lsid` and transaction number `txnNumber` in case the change was executed inside a transaction.
+
+|===
 
 [WARNING]
 ====
@@ -1101,12 +1122,12 @@ Here is an example of a _delete_ event for a document in the `customers` collect
 {
     "schema": { ... },
     "payload": {
-      "op": "d",
-      "ts_ms": 1465495462115,
-      "ts_us": 1465495462115748,
-      "ts_ns": 1465495462115748263,
-      "before":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne Marie\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
-      "source": {
+      "op": "d", // <1>
+      "ts_ms": 1465495462115, // <2>
+      "ts_us": 1465495462115748, // <2>
+      "ts_ns": 1465495462115748263, // <2>
+      "before":"{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne Marie\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",// <3>
+      "source": { // <4>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -1124,29 +1145,32 @@ Here is an example of a _delete_ event for a document in the `customers` collect
   }
 ----
 
-The following list describes select fields in the preceding _delete_ event value example:
+.Descriptions of _delete_ event value fields
+[cols="1,2,7",options="header",subs="+attributes"]
+|===
+|Item |Field name |Description
 
-`payload.op`::
-Mandatory string that describes the type of operation.
-The `op` field value is `d`, signifying that this document was deleted.
+|1
+|`op`
+a|Mandatory string that describes the type of operation. The `op` field value is `d`, signifying that this document was deleted.
 
-`ts_ms`, `ts_us`, `ts_ns`::
-Optional field that displays the time at which the connector processed the event in millisecond, microsecond, and nanosecond formats.
-The time is based on the system clock in the JVM running the Kafka Connect task.
-+
-In the `source` object, `ts_ms` indicates the time that the change was made in the database.
-By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+|2
+|`ts_ms`, `ts_us`. `ts_ns`
+a|Optional field that displays the time at which the connector processed the event.
+The time is based on the system clock in the JVM running the Kafka Connect task. 
 
-`payload.before`::
-Contains the JSON string representation of the actual MongoDB document before change.
-+
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|3
+|`before`
+|Contains the JSON string representation of the actual MongoDB document before change.
+
 An _update_ event value does not contain a `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
-`payload.source`::
-Mandatory field that describes the source metadata for the event.
-This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog.
-The source metadata includes:
-+
+|4
+|`source`
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes:
+
 * {prodname} version.
 * Name of the connector that generated the event.
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
@@ -1155,6 +1179,8 @@ The source metadata includes:
 * Timestamp for when the change was made in the database and ordinal of the event within the timestamp.
 * Unique identifier of the MongoDB operation (the `h` field in the oplog event).
 * Unique identifiers of the MongoDB session `lsid` and transaction number `txnNumber` in case the change was executed inside a transaction (change streams capture mode only).
+
+|===
 
 MongoDB connector events are designed to work with link:{link-kafka-docs}/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
@@ -1329,10 +1355,10 @@ For example, from a terminal window, enter the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-cat <<EOF >debezium-container-for-{context}.yaml
+cat <<EOF >debezium-container-for-{context}.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-RUN mkdir -p /opt/kafka/plugins/debezium
+RUN mkdir -p /opt/kafka/plugins/debezium // <2>
 RUN cd /opt/kafka/plugins/debezium/ \
 && curl -O {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip \
 && unzip debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip \
@@ -1343,14 +1369,18 @@ EOF
 ----
 =====================================================================
 +
-The following list describes the purpose of select lines in the preceding command:
+[cols="1,7",options="header"]
+|===
+|Item |Description
 
-`cat <<EOF >debezium-container-for-{context}.yaml`::
-You can specify any file name that you want.
+|1
+|You can specify any file name that you want.
 
-`RUN mkdir -p /opt/kafka/plugins/debezium`::
-Specifies the path to your Kafka Connect plug-ins directory.
+|2
+|Specifies the path to your Kafka Connect plug-ins directory.
 If your Kafka Connect plug-ins directory is in a different location, replace this path with the actual path of your directory.
+
+|===
 +
 The command creates a Dockerfile with the name `debezium-container-for-mongodb.yaml` in the current directory.
 
@@ -1394,23 +1424,27 @@ kind: KafkaConnect
 metadata:
   name: my-connect-cluster
   annotations:
-    strimzi.io/use-connector-resources: "true"
+    strimzi.io/use-connector-resources: "true" // <1>
 spec:
   #...
-  image: debezium-container-for-mongodb
+  image: debezium-container-for-mongodb  // <2>
 
   ...
 ----
 =====================================================================
 +
-The following list describes select fields in the preceding `KafkaConnect` custom resource example:
+[cols="1,7",options="header"]
+|===
+|Item |Description
 
-`metadata.annotations`::
-`metadata.annotations` indicates to the Cluster Operator that `KafkaConnector` resources are used to configure connectors in this Kafka Connect cluster.
+|1
+|`metadata.annotations` indicates to the Cluster Operator that `KafkaConnector` resources are used to configure connectors in this Kafka Connect cluster.
 
-`spec.image`::
-`spec.image` specifies the name of the image that you created to run your Debezium connector.
+|2
+|`spec.image` specifies the name of the image that you created to run your Debezium connector.
 This property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
+
+|===
 
 .. Apply the `KafkaConnect` CR to the OpenShift Kafka Connect environment by entering the following command:
 +
@@ -1436,37 +1470,41 @@ and captures changes that occur in the `inventory` collection.
 [source,yaml,options="nowrap",subs="+attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnector
-metadata:
-  name: inventory-connector-{context}
-  labels:
-    strimzi.io/cluster: my-connect-cluster
-spec:
-  class: io.debezium.connector.mongodb.MongoDbConnector
-  config:
-    mongodb.connection.string: mongodb://192.168.99.100:27017/?replicaSet=rs0
-    topic.prefix: inventory-connector-{context}
-    collection.include.list: inventory[.]*
+  kind: KafkaConnector
+  metadata:
+    name: inventory-connector-{context} // <1>
+    labels: strimzi.io/cluster: my-connect-cluster
+  spec:
+    class: io.debezium.connector.mongodb.MongoDbConnector // <2>
+    config:
+     mongodb.connection.string: mongodb://192.168.99.100:27017/?replicaSet=rs0 // <3>
+     topic.prefix: inventory-connector-{context} // <4>
+     collection.include.list: inventory[.]* // <5>
 ----
 =====================================================================
 +
-The following list describes select fields in the preceding `KafkaConnector` configuration example:
+.Descriptions of settings in the MongoDB `inventory-connector.yaml` example
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
 
-`metadata.name`::
-The name that is used to register the connector with Kafka Connect.
+|1
+|The name that is used to register the connector with Kafka Connect.
 
-`spec.class`::
-The name of the MongoDB connector class.
+|2
+|The name of the MongoDB connector class.
 
-`config.mongodb.connection.string`::
-The host addresses to use to connect to the MongoDB replica set.
+|3
+|The host addresses to use to connect to the MongoDB replica set.
 
-`config.topic.prefix`::
-The _logical name_ of the MongoDB replica set.
+|4
+|The _logical name_ of the MongoDB replica set.
 The logical name forms a namespace for generated events, and is used in the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
 
-`config.collection.include.list`::
-An optional list of regular expressions that match the collection namespaces (for example, __<dbName>.<collectionName>__) of all collections to be monitored.
+|5
+|An optional list of regular expressions that match the collection namespaces (for example, __<dbName>.<collectionName>__) of all collections to be monitored.
+
+|===
 
 . Create your connector instance with Kafka Connect.
 For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:
@@ -1492,33 +1530,20 @@ Optionally, you can filter out collections that are not needed.
 [source,json]
 ----
 {
-  "name": "inventory-connector",
+  "name": "inventory-connector", // <1>
   "config": {
-    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector",
-    "mongodb.connection.string": "mongodb://192.168.99.100:27017/?replicaSet=rs0",
-    "topic.prefix": "fullfillment",
-    "collection.include.list": "inventory[.]*"
+    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", // <2>
+    "mongodb.connection.string": "mongodb://192.168.99.100:27017/?replicaSet=rs0", // <3>
+    "topic.prefix": "fullfillment", // <4>
+    "collection.include.list": "inventory[.]*" // <5>
   }
 }
 ----
-
-The following list describes select fields in the preceding connector configuration example:
-
-`name`::
-The name of our connector when we register it with a Kafka Connect service.
-
-`config.connector.class`::
-The name of the MongoDB connector class.
-
-`config.mongodb.connection.string`::
-The connection string to use to connect to the MongoDB replica set.
-
-`config.topic.prefix`::
-The _logical name_ of the MongoDB replica set, which forms a namespace for generated events and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-
-`config.collection.include.list`::
-A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored.
-This is optional.
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of the MongoDB connector class.
+<3> The connection string to use to connect to the MongoDB replica set.
+<4> The _logical name_ of the MongoDB replica set, which forms a namespace for generated events and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+<5> A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored. This is optional.
 
 endif::community[]
 
@@ -1827,7 +1852,7 @@ Fully-qualified names for fields are of the form _databaseName_._collectionName_
 |Specifies whether a _delete_ event is followed by a tombstone event.
 Set one of the following options:
 
-`true`:: A delete operation is represented by a _delete_ event and a subsequent tombstone event.
+`true`:: A delete operation is represented by a _delete_ event and a subsequent tombstone event. 
 
 `false`:: After a delete operation, the connector emits only a _delete_ event.
 
@@ -1835,7 +1860,7 @@ After a source record is deleted, emitting a tombstone event (the default behavi
 
 |[[mongodb-property-schema-name-adjustment-mode]]<<mongodb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
 |none
-|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings: 
 
 * `none` does not apply any adjustment.
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore.
@@ -1843,12 +1868,12 @@ After a source record is deleted, emitting a tombstone event (the default behavi
 
 |[[mongodb-property-field-name-adjustment-mode]]<<mongodb-property-field-name-adjustment-mode,`+field.name.adjustment.mode+`>>
 |none
-|Specifies how the connector adjusts field names for compatibility with the message converter used by the connector.
-Set one of the following options:
+|Specifies how the connector adjusts field names for compatibility with the message converter used by the connector. 
+Set one of the following options: 
 
 `none`:: The connector does not adjust field names.
 `avro`:: The connector replaces characters that cannot are not valid in Avro type names with underscores.
-`avro_unicode`:: The connector replaces underscores and characters that are not valid in Avro type names with the equivalent unicode, such as _uxxxx.
+`avro_unicode`:: The connector replaces underscores and characters that are not valid in Avro type names with the equivalent unicode, such as _uxxxx. 
 +
 Note: The underscore character ('`_`') represents an escape sequence similar to a backslash in Java.
 
@@ -1948,7 +1973,7 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 ifdef::community[]
 |[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `+source.struct.version+`>>
 |v2
-|Schema version for the `source` block in CDC events.
+|Schema version for the `source` block in CDC events. 
 {prodname} 0.10 introduced a few breaking changes to the structure of the `source` block in order to unify the exposed structure across all the connectors.
 Set this option to `v1` if you want the connector to produce events that use the source block structure from earlier versions.
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
@@ -2270,7 +2295,7 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 |`No default`
 |Defines tags that customize MBean object names by adding metadata that provides contextual information.
 Specify a comma-separated list of key-value pairs.
-Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example,
+Each key represents a tag for the MBean object name, and the corresponding value represents a value for the key, for example, 
 `k1=v1,k2=v2`
 
 The connector appends the specified tags to the base MBean object name.


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Reverts commit inadvertently pushed directly to 3.6

## Description
Cleaning up a small spill. When trying to backport the change for DBZ-10001 from `main` to 3.6, I inadvertently added the cherry-pick directly to my 3.6 local branch and pushed it directly to the remote. 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
