### PR TITLE
debezium/dbz#2473 Validate username/client filters w/tracking

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -467,7 +467,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDefault(true)
-            .withValidation(Field::isRequired)
+            .withValidation(Field::isRequired, OracleConnectorConfig::validateLogMiningBufferTrackClientId)
             .withDescription("This controls whether the 'CLIENT_ID' column values are tracked. " +
                     "When set to true (the default), the 'CLIENT_ID' values are buffered and provided in events when available. " +
                     "When set to false, the 'CLIENT_ID' column is excluded from the LogMiner query and its values are not buffered, " +
@@ -479,7 +479,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDefault(true)
-            .withValidation(Field::isRequired)
+            .withValidation(Field::isRequired, OracleConnectorConfig::validateLogMiningBufferTrackUsername)
             .withDescription("This controls whether the 'USERNAME' column values are tracked. " +
                     "When set to true (the default), the 'USERNAME' values are buffered and provided in events when available. " +
                     "When set to false, the 'USERNAME' column is excluded from the LogMiner query and its values are not buffered, " +
@@ -2625,6 +2625,26 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         if (isLogMiner(config)) {
             return ConnectorConfigValidationHelper.validateExcludeField(
                     config, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST, problems);
+        }
+        return 0;
+    }
+
+    public static int validateLogMiningBufferTrackUsername(Configuration config, Field field, ValidationOutput problems) {
+        return validateTrackedAttributeFilters(config, field, problems, LOG_MINING_USERNAME_INCLUDE_LIST, LOG_MINING_USERNAME_EXCLUDE_LIST);
+    }
+
+    public static int validateLogMiningBufferTrackClientId(Configuration config, Field field, ValidationOutput problems) {
+        return validateTrackedAttributeFilters(config, field, problems, LOG_MINING_CLIENTID_INCLUDE_LIST, LOG_MINING_CLIENTID_EXCLUDE_LIST);
+    }
+
+    private static int validateTrackedAttributeFilters(Configuration config, Field field, ValidationOutput problems, Field includeList, Field excludeList) {
+        if (isLogMiner(config) && !config.getBoolean(field)) {
+            if (!Strings.isNullOrBlank(config.getString(includeList)) || !Strings.isNullOrBlank(config.getString(excludeList))) {
+                problems.accept(field, config.getBoolean(field), String.format(
+                        "The configuration property '%s' cannot be disabled when '%s' or '%s' is configured.",
+                        field.name(), includeList.name(), excludeList.name()));
+                return 1;
+            }
         }
         return 0;
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -458,4 +458,114 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
         assertThat(connectorConfig.getLogMiningDeferredTransactionRetention()).isEqualTo(Duration.ofHours(1));
     }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldFailValidationWhenUsernameTrackingDisabledWithUsernameIncludeList() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .with(OracleConnectorConfig.LOG_MINING_USERNAME_INCLUDE_LIST, "DEBEZIUM")
+                .build();
+
+        final List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldFailValidationWhenUsernameTrackingDisabledWithUsernameExcludeList() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                .build();
+
+        final List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldFailValidationWhenClientIdTrackingDisabledWithClientIdIncludeList() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                .with(OracleConnectorConfig.LOG_MINING_CLIENTID_INCLUDE_LIST, "client1")
+                .build();
+
+        final List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldFailValidationWhenClientIdTrackingDisabledWithClientIdExcludeList() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                .with(OracleConnectorConfig.LOG_MINING_CLIENTID_EXCLUDE_LIST, "client1")
+                .build();
+
+        final List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldFailValidationWhenTrackingDisabledWithFiltersForUnbufferedAdapter() {
+        final Configuration config = logMinerConfig("logminer_unbuffered")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                .build();
+
+        final List<Field> fields = List.of(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldPassValidationWhenTrackingDisabledWithoutFilters() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                .build();
+
+        final List<Field> fields = List.of(
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME,
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldPassValidationWhenTrackingEnabledWithFilters() {
+        final Configuration config = logMinerConfig("logminer")
+                .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                .with(OracleConnectorConfig.LOG_MINING_CLIENTID_EXCLUDE_LIST, "client1")
+                .build();
+
+        final List<Field> fields = List.of(
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME,
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2473")
+    public void shouldPassValidationWhenTrackingDisabledWithFiltersForNonLogMinerAdapter() {
+        final Configuration config = logMinerConfig("xstream")
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME, false)
+                .with(OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID, false)
+                .with(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "DEBEZIUM")
+                .with(OracleConnectorConfig.LOG_MINING_CLIENTID_EXCLUDE_LIST, "client1")
+                .build();
+
+        final List<Field> fields = List.of(
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_USERNAME,
+                OracleConnectorConfig.LOG_MINING_BUFFER_TRACK_CLIENT_ID);
+        assertThat(config.validateAndRecord(fields, LOGGER::error)).isTrue();
+    }
+
+    private static Configuration.Builder logMinerConfig(String adapter) {
+        return Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
+                .with(OracleConnectorConfig.CONNECTOR_ADAPTER, adapter);
+    }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2473

## Description
When username and/or client tracking is disabled, the connector should fail to start when a username and/or client include/exclude filter is specified. Such filters cannot be applied when the relevant columns aren't tracked and aren't fetched from Oracle.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
