### PR TITLE
debezium/dbz#2468 Add binary.handling.mode with per-field selectors to the JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -203,18 +203,17 @@ public class DefaultRecordWriter implements RecordWriter {
             throw e;
         }
         progressListener().tableCreated();
-        warnWhenBinaryHandlingDoesNotApply(record, record.allFields().keySet());
+        warnForSchemaEvolvedBinaryColumns(record, record.allFields().keySet());
 
         return readTable(collectionId);
     }
 
     /**
-     * Schema evolution derives column types from the record schema alone, so a {@code BYTES} field
-     * always produces a binary column, to which a textual binary handling mode never applies. Warns
-     * for such fields so that the silent mismatch is visible; encoded landings require a pre-created
-     * character column or the source connector's {@code binary.handling.mode}.
+     * Warns when schema evolution creates a binary column for a field configured with a textual
+     * binary handling mode. Schema evolution derives the column type from the record schema, while
+     * sink-side encoding applies only when an existing destination column is a character type.
      */
-    private void warnWhenBinaryHandlingDoesNotApply(JdbcSinkRecord record, Collection<String> fieldNames) {
+    private void warnForSchemaEvolvedBinaryColumns(JdbcSinkRecord record, Collection<String> fieldNames) {
         if (!config.isBinaryHandlingEnabled()) {
             return;
         }
@@ -225,8 +224,8 @@ public class DefaultRecordWriter implements RecordWriter {
             }
             final JdbcSinkConnectorConfig.BinaryHandlingMode mode = config.getBinaryHandlingMode(record.topicName(), field.getName());
             if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != mode) {
-                LOGGER.warn("Schema evolution created a binary column for field '{}' of topic '{}'; binary handling mode '{}' does not apply to binary columns. "
-                        + "Pre-create a character column, or use the source connector's binary.handling.mode for encoded landings.",
+                LOGGER.warn("Schema evolution created a binary column for field '{}' in topic '{}', so binary handling mode '{}' does not apply. "
+                        + "Pre-create a character column or configure binary.handling.mode on the source connector.",
                         field.getName(), record.topicName(), mode.getValue());
             }
         }
@@ -283,7 +282,7 @@ public class DefaultRecordWriter implements RecordWriter {
             throw e;
         }
         progressListener().tableAltered();
-        warnWhenBinaryHandlingDoesNotApply(record, missingFields);
+        warnForSchemaEvolvedBinaryColumns(record, missingFields);
 
         return readTable(collectionId);
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -10,7 +10,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ import org.apache.kafka.connect.errors.DataException;
 import org.hibernate.JDBCException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
-import org.hibernate.jdbc.Work;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.batch.Batch;
@@ -148,19 +147,20 @@ public class DefaultRecordWriter implements RecordWriter {
         if (table == null) {
             return null;
         }
-        final JdbcSinkConnectorConfig.BinaryHandlingMode mode = dialect.resolveBinaryHandlingMode(table, record, field);
-        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES == mode) {
+        final BinaryHandling.Resolution resolution = dialect.resolveBinaryHandling(table, record, field);
+        if (!resolution.isEncoded()) {
             return null;
         }
+        final int targetJdbcType = resolution.targetColumn().getJdbcType();
         if (value == null) {
-            return List.of(new ValueBindDescriptor(index, null, Types.VARCHAR));
+            return List.of(new ValueBindDescriptor(index, null, targetJdbcType));
         }
         final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(value);
         if (bytes == null) {
             // Let the regular binding report an unexpected value type.
             return null;
         }
-        return List.of(new ValueBindDescriptor(index, mode.encode(bytes), Types.VARCHAR));
+        return List.of(new ValueBindDescriptor(index, resolution.mode().encode(bytes), targetJdbcType));
     }
 
     private TableDescriptor readTable(CollectionId collectionId) {
@@ -386,10 +386,10 @@ public class DefaultRecordWriter implements RecordWriter {
                         session.doWork(conn -> {
                             for (var entry : resolved.values()) {
                                 if (!entry.inserts().isEmpty()) {
-                                    performTableWrite(conn, entry.table(), entry.inserts());
+                                    performTableWrites(conn, entry.table(), entry.inserts());
                                 }
                                 if (!entry.deletes().isEmpty()) {
-                                    performTableWrite(conn, entry.table(), entry.deletes());
+                                    performTableWrites(conn, entry.table(), entry.deletes());
                                 }
                             }
                         });
@@ -421,7 +421,7 @@ public class DefaultRecordWriter implements RecordWriter {
         final Transaction transaction = getSession().beginTransaction();
 
         try {
-            getSession().doWork(processBatch(tableDescriptor, statementInfo, records));
+            getSession().doWork(connection -> performTableWrites(connection, tableDescriptor, records));
             transaction.commit();
             processMetrics(records, statementInfo);
         }
@@ -468,8 +468,12 @@ public class DefaultRecordWriter implements RecordWriter {
         performWrite(conn, table, getSqlStatementInfo(table, records), records);
     }
 
-    private Work processBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
-        return conn -> performWrite(conn, table, statementInfo, records);
+    /**
+     * Writes records for a single table. Subclasses can partition a write when their statement shape
+     * requires homogeneous records.
+     */
+    protected void performTableWrites(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
+        performTableWrite(conn, table, records);
     }
 
     protected void performWrite(Connection conn, TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -202,8 +203,33 @@ public class DefaultRecordWriter implements RecordWriter {
             throw e;
         }
         progressListener().tableCreated();
+        warnWhenBinaryHandlingDoesNotApply(record, record.allFields().keySet());
 
         return readTable(collectionId);
+    }
+
+    /**
+     * Schema evolution derives column types from the record schema alone, so a {@code BYTES} field
+     * always produces a binary column, to which a textual binary handling mode never applies. Warns
+     * for such fields so that the silent mismatch is visible; encoded landings require a pre-created
+     * character column or the source connector's {@code binary.handling.mode}.
+     */
+    private void warnWhenBinaryHandlingDoesNotApply(JdbcSinkRecord record, Collection<String> fieldNames) {
+        if (!config.isBinaryHandlingEnabled()) {
+            return;
+        }
+        for (String fieldName : fieldNames) {
+            final FieldDescriptor field = record.allFields().get(fieldName);
+            if (field == null || !BinaryHandling.isRawBytesSchema(field.getSchema(), dialect.getSchemaType(field.getSchema()))) {
+                continue;
+            }
+            final JdbcSinkConnectorConfig.BinaryHandlingMode mode = config.getBinaryHandlingMode(record.topicName(), field.getName());
+            if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != mode) {
+                LOGGER.warn("Schema evolution created a binary column for field '{}' of topic '{}'; binary handling mode '{}' does not apply to binary columns. "
+                        + "Pre-create a character column, or use the source connector's binary.handling.mode for encoded landings.",
+                        field.getName(), record.topicName(), mode.getValue());
+            }
+        }
     }
 
     private boolean hasTable(CollectionId collectionId) {
@@ -257,6 +283,7 @@ public class DefaultRecordWriter implements RecordWriter {
             throw e;
         }
         progressListener().tableAltered();
+        warnWhenBinaryHandlingDoesNotApply(record, missingFields);
 
         return readTable(collectionId);
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -10,6 +10,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.batch.Batch;
 import io.debezium.sink.batch.BatchRecord;
@@ -98,10 +100,10 @@ public class DefaultRecordWriter implements RecordWriter {
     /**
      * Bind key field values to the query for a single record.
      */
-    protected int bindKeyValuesToQuery(JdbcSinkRecord record, QueryBinder query, int index) {
+    protected int bindKeyValuesToQuery(JdbcSinkRecord record, TableDescriptor table, QueryBinder query, int index) {
         final Struct keySource = record.filteredKey();
         if (keySource != null) {
-            index = bindFieldValuesToQuery(record, query, index, keySource, record.keyFieldNames());
+            index = bindFieldValuesToQuery(record, table, query, index, keySource, record.keyFieldNames());
         }
         return index;
     }
@@ -109,14 +111,14 @@ public class DefaultRecordWriter implements RecordWriter {
     /**
      * Bind non-key field values to the query for a single record.
      */
-    protected int bindNonKeyValuesToQuery(JdbcSinkRecord record, QueryBinder query, int index) {
-        return bindFieldValuesToQuery(record, query, index, record.getPayload(), record.nonKeyFieldNames());
+    protected int bindNonKeyValuesToQuery(JdbcSinkRecord record, TableDescriptor table, QueryBinder query, int index) {
+        return bindFieldValuesToQuery(record, table, query, index, record.getPayload(), record.nonKeyFieldNames());
     }
 
     /**
      * Bind field values to the query for a single record.
      */
-    protected int bindFieldValuesToQuery(JdbcSinkRecord record, QueryBinder query, int index, Struct source, Set<String> fieldNames) {
+    protected int bindFieldValuesToQuery(JdbcSinkRecord record, TableDescriptor table, QueryBinder query, int index, Struct source, Set<String> fieldNames) {
         for (String fieldName : fieldNames) {
             final JdbcFieldDescriptor field = record.jdbcFields().get(fieldName);
 
@@ -127,12 +129,38 @@ public class DefaultRecordWriter implements RecordWriter {
             else {
                 value = source.get(fieldName);
             }
-            List<ValueBindDescriptor> boundValues = dialect.bindValue(field, index, value);
+            List<ValueBindDescriptor> boundValues = maybeBindBytesAsCharacter(record, field, table, index, value);
+            if (boundValues == null) {
+                boundValues = dialect.bindValue(field, index, value);
+            }
 
             boundValues.forEach(query::bind);
             index += boundValues.size();
         }
         return index;
+    }
+
+    /**
+     * Returns an encoded string binding when the field and destination column resolve to a textual
+     * binary handling mode. Returns {@code null} to use the regular binding.
+     */
+    protected List<ValueBindDescriptor> maybeBindBytesAsCharacter(JdbcSinkRecord record, JdbcFieldDescriptor field, TableDescriptor table, int index, Object value) {
+        if (table == null) {
+            return null;
+        }
+        final JdbcSinkConnectorConfig.BinaryHandlingMode mode = dialect.resolveBinaryHandlingMode(table, record, field);
+        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES == mode) {
+            return null;
+        }
+        if (value == null) {
+            return List.of(new ValueBindDescriptor(index, null, Types.VARCHAR));
+        }
+        final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(value);
+        if (bytes == null) {
+            // Let the regular binding report an unexpected value type.
+            return null;
+        }
+        return List.of(new ValueBindDescriptor(index, mode.encode(bytes), Types.VARCHAR));
     }
 
     private TableDescriptor readTable(CollectionId collectionId) {
@@ -393,7 +421,7 @@ public class DefaultRecordWriter implements RecordWriter {
         final Transaction transaction = getSession().beginTransaction();
 
         try {
-            getSession().doWork(processBatch(statementInfo, records));
+            getSession().doWork(processBatch(tableDescriptor, statementInfo, records));
             transaction.commit();
             processMetrics(records, statementInfo);
         }
@@ -437,14 +465,14 @@ public class DefaultRecordWriter implements RecordWriter {
      * Subclasses can override to change the write strategy (e.g., UNNEST).
      */
     protected void performTableWrite(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
-        performWrite(conn, getSqlStatementInfo(table, records), records);
+        performWrite(conn, table, getSqlStatementInfo(table, records), records);
     }
 
-    private Work processBatch(SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
-        return conn -> performWrite(conn, statementInfo, records);
+    private Work processBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
+        return conn -> performWrite(conn, table, statementInfo, records);
     }
 
-    protected void performWrite(Connection conn, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {
+    protected void performWrite(Connection conn, TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {
         try (PreparedStatement prepareStatement = conn.prepareStatement(statementInfo.statement())) {
             QueryBinder queryBinder = getQueryBinderResolver().resolve(prepareStatement);
             Stopwatch allbindStopwatch = Stopwatch.reusable();
@@ -452,7 +480,7 @@ public class DefaultRecordWriter implements RecordWriter {
             for (JdbcSinkRecord record : records) {
                 Stopwatch singlebindStopwatch = Stopwatch.reusable();
                 singlebindStopwatch.start();
-                bindValues(record, queryBinder);
+                bindValues(record, table, queryBinder);
                 singlebindStopwatch.stop();
 
                 Stopwatch addBatchStopwatch = Stopwatch.reusable();
@@ -479,22 +507,22 @@ public class DefaultRecordWriter implements RecordWriter {
         }
     }
 
-    protected void bindValues(JdbcSinkRecord record, QueryBinder queryBinder) {
+    protected void bindValues(JdbcSinkRecord record, TableDescriptor table, QueryBinder queryBinder) {
         int index;
         if (record.isDelete()) {
-            bindKeyValuesToQuery(record, queryBinder, 1);
+            bindKeyValuesToQuery(record, table, queryBinder, 1);
             return;
         }
 
         switch (getConfig().getInsertMode()) {
             case INSERT:
             case UPSERT:
-                index = bindKeyValuesToQuery(record, queryBinder, 1);
-                bindNonKeyValuesToQuery(record, queryBinder, index);
+                index = bindKeyValuesToQuery(record, table, queryBinder, 1);
+                bindNonKeyValuesToQuery(record, table, queryBinder, index);
                 break;
             case UPDATE:
-                index = bindNonKeyValuesToQuery(record, queryBinder, 1);
-                bindKeyValuesToQuery(record, queryBinder, index);
+                index = bindNonKeyValuesToQuery(record, table, queryBinder, 1);
+                bindKeyValuesToQuery(record, table, queryBinder, index);
                 break;
         }
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/DefaultRecordWriter.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.metadata.CollectionId;
@@ -56,6 +59,18 @@ import io.debezium.util.Stopwatch;
 public class DefaultRecordWriter implements RecordWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRecordWriter.class);
+
+    private enum BinaryBindingKind {
+        BYTES,
+        STRING,
+        OTHER
+    }
+
+    private record BinaryFieldBinding(String fieldName, boolean key, Class<?> jdbcType, BinaryBindingKind kind) {
+    }
+
+    private record BinaryBindingSignature(List<BinaryFieldBinding> fields) {
+    }
 
     private final SharedSessionContract session;
     private final QueryBinderResolver queryBinderResolver;
@@ -417,13 +432,13 @@ public class DefaultRecordWriter implements RecordWriter {
     public void write(TableDescriptor tableDescriptor, List<JdbcSinkRecord> records) {
         Stopwatch writeStopwatch = Stopwatch.reusable();
         writeStopwatch.start();
-        SqlStatementInfo statementInfo = getSqlStatementInfo(tableDescriptor, records);
         final Transaction transaction = getSession().beginTransaction();
 
         try {
             getSession().doWork(connection -> performTableWrites(connection, tableDescriptor, records));
             transaction.commit();
-            processMetrics(records, statementInfo);
+            // The statements are derived per write group; the metrics only need the delete flag.
+            processMetrics(records, records.get(0).isDelete());
         }
         catch (Exception e) {
             transaction.rollback();
@@ -434,7 +449,11 @@ public class DefaultRecordWriter implements RecordWriter {
     }
 
     protected void processMetrics(List<JdbcSinkRecord> records, SqlStatementInfo statementInfo) {
-        if (statementInfo.isDelete()) {
+        processMetrics(records, statementInfo.isDelete());
+    }
+
+    private void processMetrics(List<JdbcSinkRecord> records, boolean deletes) {
+        if (deletes) {
             progressListener().deleted(records.size());
         }
         else {
@@ -469,11 +488,54 @@ public class DefaultRecordWriter implements RecordWriter {
     }
 
     /**
-     * Writes records for a single table. Subclasses can partition a write when their statement shape
-     * requires homogeneous records.
+     * Splits records into contiguous groups with a consistent binary parameter shape. SQL generation
+     * derives its parameter bindings from the first record, so a JDBC batch cannot mix raw byte arrays
+     * and encoded strings for the same field. Keeping groups contiguous preserves input record order.
      */
     protected void performTableWrites(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
-        performTableWrite(conn, table, records);
+        if (!config.isBinaryHandlingEnabled() || records.size() < 2) {
+            // Bindings cannot differ per record, so skip the per-record signature resolution.
+            performTableWrite(conn, table, records);
+            return;
+        }
+        for (List<JdbcSinkRecord> group : partitionRecordsByBinaryBinding(table, records)) {
+            performTableWrite(conn, table, group);
+        }
+    }
+
+    private List<List<JdbcSinkRecord>> partitionRecordsByBinaryBinding(TableDescriptor table, List<JdbcSinkRecord> records) {
+        final List<List<JdbcSinkRecord>> groups = new ArrayList<>();
+        BinaryBindingSignature previousSignature = null;
+
+        for (JdbcSinkRecord record : records) {
+            final BinaryBindingSignature signature = resolveBinaryBindingSignature(table, record);
+            if (!signature.equals(previousSignature)) {
+                groups.add(new ArrayList<>());
+                previousSignature = signature;
+            }
+            groups.get(groups.size() - 1).add(record);
+        }
+        return groups;
+    }
+
+    private BinaryBindingSignature resolveBinaryBindingSignature(TableDescriptor table, JdbcSinkRecord record) {
+        final List<BinaryFieldBinding> fields = record.jdbcFields().values().stream()
+                .filter(field -> field.getSchema().type() == Schema.Type.BYTES)
+                .sorted(Comparator.comparing(JdbcFieldDescriptor::getName).thenComparing(JdbcFieldDescriptor::isKey))
+                .map(field -> {
+                    final JdbcType jdbcType = dialect.getSchemaType(field.getSchema());
+                    final BinaryHandling.Resolution resolution = dialect.resolveBinaryHandling(table, record, field);
+                    final BinaryBindingKind kind;
+                    if (!BinaryHandling.isRawBytesSchema(field.getSchema(), jdbcType)) {
+                        kind = BinaryBindingKind.OTHER;
+                    }
+                    else {
+                        kind = resolution.isEncoded() ? BinaryBindingKind.STRING : BinaryBindingKind.BYTES;
+                    }
+                    return new BinaryFieldBinding(field.getName(), field.isKey(), jdbcType.getClass(), kind);
+                })
+                .toList();
+        return new BinaryBindingSignature(fields);
     }
 
     protected void performWrite(Connection conn, TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) throws SQLException {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -673,6 +673,14 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     }
 
     /**
+     * Returns whether any binary handling configuration is active. When this returns {@code false},
+     * every field resolves to {@link BinaryHandlingMode#BYTES} and bindings cannot differ per record.
+     */
+    public boolean isBinaryHandlingEnabled() {
+        return BinaryHandlingMode.BYTES != binaryHandlingMode || !binaryHandlingSelectors.isEmpty();
+    }
+
+    /**
      * Resolves the mode for a field. Selectors are evaluated in the order {@code base64},
      * {@code base64-url-safe}, {@code hex}, and {@code bytes}. The first pattern that matches the
      * topic-qualified name or the plain field name takes precedence over the global mode. A field

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -189,11 +189,12 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR))
             .withWidth(ConfigDef.Width.SHORT)
             .withImportance(ConfigDef.Importance.LOW)
-            .withDescription("Specifies how BYTES fields are bound when the destination column is a character type: "
+            .withDescription("Specifies how BYTES fields that resolve to a raw binary JDBC type are bound when the destination column is a character type: "
                     + "'bytes' (default) binds the original bytes and delegates conversion to the destination database; "
                     + "'base64' binds a Base64-encoded string; "
                     + "'base64-url-safe' binds a URL-safe Base64-encoded string; "
                     + "'hex' binds a hex-encoded string. "
+                    + "Logical types backed by BYTES retain their logical JDBC mapping. "
                     + "Binary destination columns always receive the original bytes. "
                     + "This setting does not affect table creation or schema evolution.");
 
@@ -272,14 +273,14 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withDescription("Name of the schema where postgis extension is installed. Default is public");
 
     public static final Field POSTGRES_UNNEST_INSERT_FIELD = Field.create(POSTGRES_UNNEST_INSERT)
-            .withDisplayName("Enable UNNEST-based batch inserts for PostgreSQL")
+            .withDisplayName("Enable UNNEST-based batch inserts for PostgreSQL-compatible targets")
             .withType(Type.BOOLEAN)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(ConfigDef.Width.SHORT)
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDefault(false)
             .withDescription(
-                    "When enabled, uses PostgreSQL UNNEST() for batch inserts which can significantly improve performance by reducing the number of SQL statements executed. "
+                    "When enabled, uses PostgreSQL-compatible UNNEST() statements for batch inserts which can significantly improve performance by reducing the number of SQL statements executed. "
                             +
                             "This optimization is compatible with INSERT and UPSERT modes. " +
                             "Instead of executing multiple INSERT statements with JDBC batching, a single INSERT statement with UNNEST is used to insert all records at once. "

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -8,10 +8,15 @@ package io.debezium.connector.jdbc;
 import static io.debezium.sink.filter.FieldFilterFactory.FieldNameFilter;
 
 import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -36,6 +41,7 @@ import io.debezium.connector.jdbc.naming.TemporaryBackwardCompatibleCollectionNa
 import io.debezium.sink.SinkConnectorConfig;
 import io.debezium.sink.filter.FieldFilterFactory;
 import io.debezium.sink.naming.CollectionNamingStrategy;
+import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
 
 /**
@@ -59,6 +65,11 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String INSERT_MODE = "insert.mode";
     public static final String TRUNCATE_ENABLED = "truncate.enabled";
     public static final String SCHEMA_EVOLUTION = "schema.evolution";
+    public static final String BINARY_HANDLING_MODE = "binary.handling.mode";
+    public static final String BINARY_HANDLING_SELECTOR_BASE64 = "binary.handling.selector.base64";
+    public static final String BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE = "binary.handling.selector.base64-url-safe";
+    public static final String BINARY_HANDLING_SELECTOR_HEX = "binary.handling.selector.hex";
+    public static final String BINARY_HANDLING_SELECTOR_BYTES = "binary.handling.selector.bytes";
     public static final String QUOTE_IDENTIFIERS = "quote.identifiers";
     public static final String COLUMN_NAMING_STRATEGY = "column.naming.strategy";
     public static final String COLLECTION_TABLE_FORMAT = "collection.table.format";
@@ -171,6 +182,64 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
             .withImportance(ConfigDef.Importance.LOW)
             .withDescription("When enabled, table, column, and other identifiers are quoted based on the database dialect. " +
                     "When disabled, only explicit cases where the dialect requires quoting will be used, such as names starting with an underscore.");
+
+    public static final Field BINARY_HANDLING_MODE_FIELD = Field.create(BINARY_HANDLING_MODE)
+            .withDisplayName("Binary handling mode for character columns")
+            .withEnum(BinaryHandlingMode.class, BinaryHandlingMode.BYTES)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR))
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Specifies how BYTES fields are bound when the destination column is a character type: "
+                    + "'bytes' (default) binds the original bytes and delegates conversion to the destination database; "
+                    + "'base64' binds a Base64-encoded string; "
+                    + "'base64-url-safe' binds a URL-safe Base64-encoded string; "
+                    + "'hex' binds a hex-encoded string. "
+                    + "Binary destination columns always receive the original bytes. "
+                    + "This setting does not affect table creation or schema evolution.");
+
+    public static final Field BINARY_HANDLING_SELECTOR_BASE64_FIELD = Field.create(BINARY_HANDLING_SELECTOR_BASE64)
+            .withDisplayName("Fields bound as Base64 strings to character-typed target columns")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(Field::isListOfRegex)
+            .withDescription("A comma-separated list of regular expressions that select BYTES fields to bind as "
+                    + "Base64-encoded strings when the destination column is a character type, overriding '"
+                    + BINARY_HANDLING_MODE + "'. Expressions match either '<topic>:<field>' or '<field>'.");
+
+    public static final Field BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE_FIELD = Field.create(BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE)
+            .withDisplayName("Fields bound as URL-safe Base64 strings to character-typed target columns")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(Field::isListOfRegex)
+            .withDescription("A comma-separated list of regular expressions that select BYTES fields to bind as "
+                    + "URL-safe Base64-encoded strings when the destination column is a character type, overriding '"
+                    + BINARY_HANDLING_MODE + "'. Expressions match either '<topic>:<field>' or '<field>'.");
+
+    public static final Field BINARY_HANDLING_SELECTOR_HEX_FIELD = Field.create(BINARY_HANDLING_SELECTOR_HEX)
+            .withDisplayName("Fields bound as hex strings to character-typed target columns")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(Field::isListOfRegex)
+            .withDescription("A comma-separated list of regular expressions that select BYTES fields to bind as "
+                    + "hex-encoded strings when the destination column is a character type, overriding '"
+                    + BINARY_HANDLING_MODE + "'. Expressions match either '<topic>:<field>' or '<field>'.");
+
+    public static final Field BINARY_HANDLING_SELECTOR_BYTES_FIELD = Field.create(BINARY_HANDLING_SELECTOR_BYTES)
+            .withDisplayName("Fields always bound as raw bytes")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(Field::isListOfRegex)
+            .withDescription("A comma-separated list of regular expressions that select BYTES fields to bind as the "
+                    + "original bytes, overriding '" + BINARY_HANDLING_MODE
+                    + "'. Expressions match either '<topic>:<field>' or '<field>'.");
 
     public static final String DEFAULT_TIME_ZONE = "UTC";
     public static final String USE_TIME_ZONE = "use.time.zone";
@@ -303,6 +372,11 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     PRIMARY_KEY_MODE_FIELD,
                     PRIMARY_KEY_FIELDS_FIELD,
                     SCHEMA_EVOLUTION_FIELD,
+                    BINARY_HANDLING_MODE_FIELD,
+                    BINARY_HANDLING_SELECTOR_BASE64_FIELD,
+                    BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE_FIELD,
+                    BINARY_HANDLING_SELECTOR_HEX_FIELD,
+                    BINARY_HANDLING_SELECTOR_BYTES_FIELD,
                     QUOTE_IDENTIFIERS_FIELD,
                     COLLECTION_NAMING_STRATEGY_FIELD,
                     COLUMN_NAMING_STRATEGY_FIELD,
@@ -369,6 +443,67 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     }
 
     /**
+     * Defines how {@code BYTES} values are bound to character destination columns.
+     */
+    public enum BinaryHandlingMode implements EnumeratedValue {
+        /**
+         * Bind the original bytes and delegate conversion to the destination database.
+         */
+        BYTES("bytes"),
+
+        /**
+         * The bytes are bound as a Base64-encoded string.
+         */
+        BASE64("base64"),
+
+        /**
+         * The bytes are bound as a URL-safe Base64-encoded string.
+         */
+        BASE64_URL_SAFE("base64-url-safe"),
+
+        /**
+         * The bytes are bound as a hex-encoded string.
+         */
+        HEX("hex");
+
+        private final String mode;
+
+        BinaryHandlingMode(String mode) {
+            this.mode = mode;
+        }
+
+        public static BinaryHandlingMode parse(String value) {
+            for (BinaryHandlingMode option : BinaryHandlingMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return BinaryHandlingMode.BYTES;
+        }
+
+        @Override
+        public String getValue() {
+            return mode;
+        }
+
+        /**
+         * Encodes the bytes in the textual representation for this mode.
+         */
+        public String encode(byte[] bytes) {
+            switch (this) {
+                case BASE64:
+                    return Base64.getEncoder().encodeToString(bytes);
+                case BASE64_URL_SAFE:
+                    return Base64.getUrlEncoder().encodeToString(bytes);
+                case HEX:
+                    return HexConverter.convertToHexString(bytes);
+                default:
+                    throw new IllegalStateException("Mode '" + mode + "' does not define a textual encoding");
+            }
+        }
+    }
+
+    /**
      * Different modes that the destination table's schema can be evolved.
      */
     public enum SchemaEvolutionMode implements EnumeratedValue {
@@ -432,6 +567,9 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final Configuration config;
 
     private final InsertMode insertMode;
+    private final BinaryHandlingMode binaryHandlingMode;
+    private final List<BinaryHandlingSelector> binaryHandlingSelectors;
+    private final Map<String, BinaryHandlingMode> binaryHandlingModeByField = new ConcurrentHashMap<>();
     private final boolean deleteEnabled;
     private final boolean truncateEnabled;
     private final String collectionNameFormat;
@@ -459,6 +597,14 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public JdbcSinkConnectorConfig(Map<String, String> props) {
         config = Configuration.from(props);
         this.insertMode = InsertMode.parse(config.getString(INSERT_MODE));
+        this.binaryHandlingMode = BinaryHandlingMode.parse(config.getString(BINARY_HANDLING_MODE_FIELD));
+        this.binaryHandlingSelectors = Stream.of(
+                new BinaryHandlingSelector(BinaryHandlingMode.BASE64, selectorPatterns(config, BINARY_HANDLING_SELECTOR_BASE64_FIELD)),
+                new BinaryHandlingSelector(BinaryHandlingMode.BASE64_URL_SAFE, selectorPatterns(config, BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE_FIELD)),
+                new BinaryHandlingSelector(BinaryHandlingMode.HEX, selectorPatterns(config, BINARY_HANDLING_SELECTOR_HEX_FIELD)),
+                new BinaryHandlingSelector(BinaryHandlingMode.BYTES, selectorPatterns(config, BINARY_HANDLING_SELECTOR_BYTES_FIELD)))
+                .filter(selector -> !selector.patterns().isEmpty())
+                .toList();
         this.deleteEnabled = config.getBoolean(DELETE_ENABLED_FIELD);
         this.truncateEnabled = config.getBoolean(TRUNCATE_ENABLED_FIELD);
         this.collectionNameFormat = config.getString(COLLECTION_NAME_FORMAT_FIELD);
@@ -516,6 +662,55 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     public InsertMode getInsertMode() {
         return insertMode;
+    }
+
+    /**
+     * Returns the global mode without applying field selectors.
+     */
+    public BinaryHandlingMode getBinaryHandlingMode() {
+        return binaryHandlingMode;
+    }
+
+    /**
+     * Resolves the mode for a field. Selectors are evaluated in the order {@code base64},
+     * {@code base64-url-safe}, {@code hex}, and {@code bytes}. The first pattern that matches the
+     * topic-qualified name or the plain field name takes precedence over the global mode. A field
+     * that matches selectors of multiple modes is logged once as a likely misconfiguration.
+     */
+    public BinaryHandlingMode getBinaryHandlingMode(String topicName, String fieldName) {
+        if (binaryHandlingSelectors.isEmpty()) {
+            return binaryHandlingMode;
+        }
+        return binaryHandlingModeByField.computeIfAbsent(topicName + ":" + fieldName, qualifiedName -> {
+            final List<BinaryHandlingMode> matches = binaryHandlingSelectors.stream()
+                    .filter(selector -> selector.patterns().stream()
+                            .anyMatch(pattern -> pattern.matcher(qualifiedName).matches() || pattern.matcher(fieldName).matches()))
+                    .map(BinaryHandlingSelector::mode)
+                    .toList();
+            if (matches.isEmpty()) {
+                return binaryHandlingMode;
+            }
+            if (matches.size() > 1) {
+                LOGGER.warn("Field '{}' matches binary handling selectors for multiple modes {}; using '{}' by the fixed selector precedence",
+                        qualifiedName,
+                        matches.stream().map(BinaryHandlingMode::getValue).toList(),
+                        matches.get(0).getValue());
+            }
+            return matches.get(0);
+        });
+    }
+
+    private static Set<Pattern> selectorPatterns(Configuration config, Field field) {
+        try {
+            return Strings.setOfRegex(config.getString(field), Pattern.CASE_INSENSITIVE);
+        }
+        catch (PatternSyntaxException e) {
+            // Field validation reports the invalid expression together with its property name.
+            return Set.of();
+        }
+    }
+
+    private record BinaryHandlingSelector(BinaryHandlingMode mode, Set<Pattern> patterns) {
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -212,13 +212,13 @@ public class JdbcSinkConnectorTask extends SinkTask {
 
     /**
      * Creates the appropriate RecordWriter based on dialect and configuration.
-     * If PostgreSQL UNNEST optimization is enabled, returns UnnestRecordWriter;
-     * otherwise returns StandardRecordWriter.
+     * If the PostgreSQL-compatible UNNEST optimization is enabled, returns UnnestRecordWriter;
+     * otherwise returns DefaultRecordWriter.
      */
     private RecordWriter createRecordWriter(StatelessSession session, QueryBinderResolver queryBinderResolver,
                                             JdbcSinkConnectorConfig config, DatabaseDialect databaseDialect, SinkProgressListener progressListener) {
         // Use UNNEST writer when explicitly enabled (opt-in)
-        // This allows any PostgreSQL-compatible dialect to use UNNEST without code changes
+        // This allows PostgreSQL-compatible dialects, such as CockroachDB, to use UNNEST.
         if (config.isPostgresUnnestInsertEnabled()) {
             LOGGER.info("Using UnnestRecordWriter for UNNEST optimization");
             return new UnnestRecordWriter(session, queryBinderResolver, config, databaseDialect, progressListener);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.connector.jdbc;
 
+import java.io.StringReader;
 import java.sql.Array;
 import java.sql.Blob;
-import java.sql.Clob;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -32,6 +32,11 @@ public class PreparedStatementQueryBinder implements QueryBinder {
     public void bind(ValueBindDescriptor valueBindDescriptor) {
         try {
             if (valueBindDescriptor.getTargetSqlType() != null) {
+                if (valueBindDescriptor.getValue() == null) {
+                    LOGGER.trace("Binding parameter #{} as NULL with Jdbc Type {}", valueBindDescriptor.getIndex(), valueBindDescriptor.getTargetSqlType());
+                    binder.setNull(valueBindDescriptor.getIndex(), valueBindDescriptor.getTargetSqlType());
+                    return;
+                }
                 switch (valueBindDescriptor.getTargetSqlType()) {
                     case Types.ARRAY -> {
                         LOGGER.trace("Binding parameter #{} as ARRAY", valueBindDescriptor.getIndex());
@@ -39,11 +44,13 @@ public class PreparedStatementQueryBinder implements QueryBinder {
                         Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getElementTypeName(), collection.toArray());
                         binder.setArray(valueBindDescriptor.getIndex(), array);
                     }
-                    case Types.CLOB -> {
-                        LOGGER.trace("Binding parameter #{} as CLOB", valueBindDescriptor.getIndex());
-                        final Clob clob = binder.getConnection().createClob();
-                        clob.setString(1, (String) valueBindDescriptor.getValue());
-                        binder.setClob(valueBindDescriptor.getIndex(), clob);
+                    case Types.CLOB, Types.LONGVARCHAR -> {
+                        LOGGER.trace("Binding parameter #{} as a character stream", valueBindDescriptor.getIndex());
+                        binder.setCharacterStream(valueBindDescriptor.getIndex(), new StringReader((String) valueBindDescriptor.getValue()));
+                    }
+                    case Types.NCLOB, Types.LONGNVARCHAR -> {
+                        LOGGER.trace("Binding parameter #{} as a national character stream", valueBindDescriptor.getIndex());
+                        binder.setNCharacterStream(valueBindDescriptor.getIndex(), new StringReader((String) valueBindDescriptor.getValue()));
                     }
                     case Types.BLOB -> {
                         LOGGER.trace("Binding parameter #{} as BLOB", valueBindDescriptor.getIndex());

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
@@ -12,6 +12,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -19,8 +20,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.hibernate.SharedSessionContract;
-import org.hibernate.Transaction;
-import org.hibernate.jdbc.Work;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,7 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.Stopwatch;
 
 /**
- * UNNEST-optimized implementation for PostgreSQL that writes batches using SQL arrays.
+ * UNNEST-optimized implementation for PostgreSQL-compatible targets that writes batches using SQL arrays.
  * This approach can provide 5-10x performance improvement for bulk inserts/upserts.
  *
  * For batch statements (isBatchStatement=true), uses UNNEST with PreparedStatement.setArray().
@@ -49,22 +48,68 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UnnestRecordWriter.class);
 
+    private enum BinaryBindingKind {
+        BYTES,
+        STRING,
+        OTHER
+    }
+
+    private record BinaryFieldBinding(String fieldName, boolean key, Class<?> jdbcType, BinaryBindingKind kind) {
+    }
+
+    private record BinaryBindingSignature(List<BinaryFieldBinding> fields) {
+    }
+
     public UnnestRecordWriter(SharedSessionContract session, QueryBinderResolver queryBinderResolver,
                               JdbcSinkConnectorConfig config, DatabaseDialect dialect, SinkProgressListener progressListener) {
         super(session, queryBinderResolver, config, dialect, progressListener);
     }
 
+    /**
+     * Splits records into contiguous groups with a consistent binary parameter shape. UNNEST derives
+     * its SQL array element types from the first record, so a group cannot mix raw byte arrays and
+     * encoded string arrays. Keeping groups contiguous preserves the input record order.
+     */
     @Override
-    public void write(TableDescriptor tableDescriptor, List<JdbcSinkRecord> records) {
-        // If it's a batch statement (UNNEST), use column-wise binding
-        // Otherwise delegate to parent's standard row-wise binding
-        SqlStatementInfo sqlStatementInfo = getSqlStatementInfo(tableDescriptor, records);
-        if (sqlStatementInfo.isBatchStatement()) {
-            writeUnnestBatch(tableDescriptor, sqlStatementInfo, records);
+    protected void performTableWrites(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
+        for (List<JdbcSinkRecord> group : partitionRecordsByBinaryBinding(table, records)) {
+            performTableWrite(conn, table, group);
         }
-        else {
-            super.write(tableDescriptor, records);
+    }
+
+    private List<List<JdbcSinkRecord>> partitionRecordsByBinaryBinding(TableDescriptor table, List<JdbcSinkRecord> records) {
+        final List<List<JdbcSinkRecord>> groups = new ArrayList<>();
+        BinaryBindingSignature previousSignature = null;
+
+        for (JdbcSinkRecord record : records) {
+            final BinaryBindingSignature signature = resolveBinaryBindingSignature(table, record);
+            if (!signature.equals(previousSignature)) {
+                groups.add(new ArrayList<>());
+                previousSignature = signature;
+            }
+            groups.get(groups.size() - 1).add(record);
         }
+        return groups;
+    }
+
+    private BinaryBindingSignature resolveBinaryBindingSignature(TableDescriptor table, JdbcSinkRecord record) {
+        final List<BinaryFieldBinding> fields = record.jdbcFields().values().stream()
+                .filter(field -> field.getSchema().type() == Schema.Type.BYTES)
+                .sorted(Comparator.comparing(JdbcFieldDescriptor::getName).thenComparing(JdbcFieldDescriptor::isKey))
+                .map(field -> {
+                    final JdbcType jdbcType = getDialect().getSchemaType(field.getSchema());
+                    final BinaryHandling.Resolution resolution = getDialect().resolveBinaryHandling(table, record, field);
+                    final BinaryBindingKind kind;
+                    if (!BinaryHandling.isRawBytesSchema(field.getSchema(), jdbcType)) {
+                        kind = BinaryBindingKind.OTHER;
+                    }
+                    else {
+                        kind = resolution.isEncoded() ? BinaryBindingKind.STRING : BinaryBindingKind.BYTES;
+                    }
+                    return new BinaryFieldBinding(field.getName(), field.isKey(), jdbcType.getClass(), kind);
+                })
+                .toList();
+        return new BinaryBindingSignature(fields);
     }
 
     @Override
@@ -76,26 +121,6 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         else {
             super.performTableWrite(conn, table, records);
         }
-    }
-
-    /**
-     * Write records using UNNEST approach with column-wise binding.
-     */
-    private void writeUnnestBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
-        Stopwatch writeStopwatch = Stopwatch.reusable();
-        writeStopwatch.start();
-        final Transaction transaction = getSession().beginTransaction();
-        try {
-            getSession().doWork(processUnnestBatch(table, statementInfo.statement(), records));
-            transaction.commit();
-            processMetrics(records, statementInfo);
-        }
-        catch (Exception e) {
-            transaction.rollback();
-            throw e;
-        }
-        writeStopwatch.stop();
-        LOGGER.trace("[PERF] Total UNNEST write execution time {}", writeStopwatch.durations());
     }
 
     void performUnnestBatch(Connection conn, TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) throws SQLException {
@@ -122,16 +147,6 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
             LOGGER.debug("UNNEST batch insert affected {} rows", updateCount);
             LOGGER.trace("[PERF] Execute UNNEST batch execution time {}", executeStopwatch.durations());
         }
-    }
-
-    /**
-     * Process a batch using UNNEST approach where each column's values are passed as a SQL array.
-     * Uses PreparedStatement.setArray() for optimal performance and query plan caching.
-     */
-    private Work processUnnestBatch(TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) {
-        return conn -> {
-            performUnnestBatch(conn, table, sqlStatement, records);
-        };
     }
 
     /**
@@ -283,19 +298,20 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      */
     private String getSqlTypeName(TableDescriptor table, JdbcSinkRecord record, JdbcFieldDescriptor field) {
         // Encoded binary values use a text array to match the cast in the UNNEST statement.
-        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != getDialect().resolveBinaryHandlingMode(table, record, field)) {
+        if (getDialect().resolveBinaryHandling(table, record, field).isEncoded()) {
             return "text";
         }
+
+        final Schema schema = field.getSchema();
+        final JdbcType type = getDialect().getSchemaType(schema);
 
         // The driver resolves the array element type by this name, so raw binary values must use
         // the canonical "bytea" name; dialect type names such as CockroachDB's "bytes" have no
         // corresponding server array type registered with the driver.
-        if (BinaryHandling.isPlainBytesSchema(field.getSchema())) {
+        if (BinaryHandling.isRawBytesSchema(schema, type)) {
             return "bytea";
         }
 
-        Schema schema = field.getSchema();
-        JdbcType type = getDialect().getSchemaType(schema);
         String typeName = type.getTypeName(schema, field.isKey());
 
         // Remove array brackets: text[][] -> text

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
@@ -12,7 +12,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -48,68 +47,9 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UnnestRecordWriter.class);
 
-    private enum BinaryBindingKind {
-        BYTES,
-        STRING,
-        OTHER
-    }
-
-    private record BinaryFieldBinding(String fieldName, boolean key, Class<?> jdbcType, BinaryBindingKind kind) {
-    }
-
-    private record BinaryBindingSignature(List<BinaryFieldBinding> fields) {
-    }
-
     public UnnestRecordWriter(SharedSessionContract session, QueryBinderResolver queryBinderResolver,
                               JdbcSinkConnectorConfig config, DatabaseDialect dialect, SinkProgressListener progressListener) {
         super(session, queryBinderResolver, config, dialect, progressListener);
-    }
-
-    /**
-     * Splits records into contiguous groups with a consistent binary parameter shape. UNNEST derives
-     * its SQL array element types from the first record, so a group cannot mix raw byte arrays and
-     * encoded string arrays. Keeping groups contiguous preserves the input record order.
-     */
-    @Override
-    protected void performTableWrites(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
-        for (List<JdbcSinkRecord> group : partitionRecordsByBinaryBinding(table, records)) {
-            performTableWrite(conn, table, group);
-        }
-    }
-
-    private List<List<JdbcSinkRecord>> partitionRecordsByBinaryBinding(TableDescriptor table, List<JdbcSinkRecord> records) {
-        final List<List<JdbcSinkRecord>> groups = new ArrayList<>();
-        BinaryBindingSignature previousSignature = null;
-
-        for (JdbcSinkRecord record : records) {
-            final BinaryBindingSignature signature = resolveBinaryBindingSignature(table, record);
-            if (!signature.equals(previousSignature)) {
-                groups.add(new ArrayList<>());
-                previousSignature = signature;
-            }
-            groups.get(groups.size() - 1).add(record);
-        }
-        return groups;
-    }
-
-    private BinaryBindingSignature resolveBinaryBindingSignature(TableDescriptor table, JdbcSinkRecord record) {
-        final List<BinaryFieldBinding> fields = record.jdbcFields().values().stream()
-                .filter(field -> field.getSchema().type() == Schema.Type.BYTES)
-                .sorted(Comparator.comparing(JdbcFieldDescriptor::getName).thenComparing(JdbcFieldDescriptor::isKey))
-                .map(field -> {
-                    final JdbcType jdbcType = getDialect().getSchemaType(field.getSchema());
-                    final BinaryHandling.Resolution resolution = getDialect().resolveBinaryHandling(table, record, field);
-                    final BinaryBindingKind kind;
-                    if (!BinaryHandling.isRawBytesSchema(field.getSchema(), jdbcType)) {
-                        kind = BinaryBindingKind.OTHER;
-                    }
-                    else {
-                        kind = resolution.isEncoded() ? BinaryBindingKind.STRING : BinaryBindingKind.BYTES;
-                    }
-                    return new BinaryFieldBinding(field.getName(), field.isKey(), jdbcType.getClass(), kind);
-                })
-                .toList();
-        return new BinaryBindingSignature(fields);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/UnnestRecordWriter.java
@@ -28,6 +28,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.Stopwatch;
@@ -59,7 +60,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         // Otherwise delegate to parent's standard row-wise binding
         SqlStatementInfo sqlStatementInfo = getSqlStatementInfo(tableDescriptor, records);
         if (sqlStatementInfo.isBatchStatement()) {
-            writeUnnestBatch(sqlStatementInfo, records);
+            writeUnnestBatch(tableDescriptor, sqlStatementInfo, records);
         }
         else {
             super.write(tableDescriptor, records);
@@ -70,7 +71,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
     protected void performTableWrite(Connection conn, TableDescriptor table, List<JdbcSinkRecord> records) throws SQLException {
         SqlStatementInfo statementInfo = getSqlStatementInfo(table, records);
         if (statementInfo.isBatchStatement()) {
-            performUnnestBatch(conn, statementInfo.statement(), records);
+            performUnnestBatch(conn, table, statementInfo.statement(), records);
         }
         else {
             super.performTableWrite(conn, table, records);
@@ -80,12 +81,12 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
     /**
      * Write records using UNNEST approach with column-wise binding.
      */
-    private void writeUnnestBatch(SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
+    private void writeUnnestBatch(TableDescriptor table, SqlStatementInfo statementInfo, List<JdbcSinkRecord> records) {
         Stopwatch writeStopwatch = Stopwatch.reusable();
         writeStopwatch.start();
         final Transaction transaction = getSession().beginTransaction();
         try {
-            getSession().doWork(processUnnestBatch(statementInfo.statement(), records));
+            getSession().doWork(processUnnestBatch(table, statementInfo.statement(), records));
             transaction.commit();
             processMetrics(records, statementInfo);
         }
@@ -97,14 +98,14 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         LOGGER.trace("[PERF] Total UNNEST write execution time {}", writeStopwatch.durations());
     }
 
-    void performUnnestBatch(Connection conn, String sqlStatement, List<JdbcSinkRecord> records) throws SQLException {
+    void performUnnestBatch(Connection conn, TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) throws SQLException {
         try (PreparedStatement prepareStatement = conn.prepareStatement(sqlStatement)) {
 
             Stopwatch allbindStopwatch = Stopwatch.reusable();
             allbindStopwatch.start();
 
             // Bind column arrays for UNNEST using setArray()
-            bindArraysForUnnest(records, conn, prepareStatement);
+            bindArraysForUnnest(table, records, conn, prepareStatement);
 
             allbindStopwatch.stop();
             LOGGER.trace("[PERF] All records bind execution time for UNNEST {}", allbindStopwatch.durations());
@@ -127,9 +128,9 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Process a batch using UNNEST approach where each column's values are passed as a SQL array.
      * Uses PreparedStatement.setArray() for optimal performance and query plan caching.
      */
-    private Work processUnnestBatch(String sqlStatement, List<JdbcSinkRecord> records) {
+    private Work processUnnestBatch(TableDescriptor table, String sqlStatement, List<JdbcSinkRecord> records) {
         return conn -> {
-            performUnnestBatch(conn, sqlStatement, records);
+            performUnnestBatch(conn, table, sqlStatement, records);
         };
     }
 
@@ -141,7 +142,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * For UPDATE: bind non-key fields first, then key fields
      * For DELETE: bind only key fields
      */
-    private void bindArraysForUnnest(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps) throws SQLException {
+    private void bindArraysForUnnest(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps) throws SQLException {
         if (records.isEmpty()) {
             return;
         }
@@ -150,20 +151,20 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
         int parameterIndex = 1;
 
         if (firstRecord.isDelete()) {
-            bindKeyFieldArrays(records, conn, ps, parameterIndex);
+            bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
         }
         else {
             switch (getConfig().getInsertMode()) {
                 case INSERT:
                 case UPSERT:
                     // For INSERT/UPSERT: key fields first, then non-key fields
-                    parameterIndex = bindKeyFieldArrays(records, conn, ps, parameterIndex);
-                    bindNonKeyFieldArrays(records, conn, ps, parameterIndex);
+                    parameterIndex = bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
+                    bindNonKeyFieldArrays(table, records, conn, ps, parameterIndex);
                     break;
                 case UPDATE:
                     // For UPDATE: non-key fields first, then key fields
-                    parameterIndex = bindNonKeyFieldArrays(records, conn, ps, parameterIndex);
-                    bindKeyFieldArrays(records, conn, ps, parameterIndex);
+                    parameterIndex = bindNonKeyFieldArrays(table, records, conn, ps, parameterIndex);
+                    bindKeyFieldArrays(table, records, conn, ps, parameterIndex);
                     break;
             }
         }
@@ -173,7 +174,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Bind key field arrays using setArray().
      * Each column's values across all records are collected into an array and bound as a single parameter.
      */
-    private int bindKeyFieldArrays(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
+    private int bindKeyFieldArrays(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
         JdbcSinkRecord firstRecord = records.get(0);
         Set<String> keyFieldNames = firstRecord.keyFieldNames();
 
@@ -196,12 +197,12 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
                     }
                 }
 
-                columnValues.add(transformValue(field, value));
+                columnValues.add(transformValue(table, record, field, value));
             }
 
             // Convert to array and bind using setArray()
-            String sqlTypeName = getSqlTypeName(firstRecord.jdbcFields().get(fieldName));
-            Array sqlArray = conn.createArrayOf(sqlTypeName, columnValues.toArray());
+            String sqlTypeName = getSqlTypeName(table, firstRecord, firstRecord.jdbcFields().get(fieldName));
+            Array sqlArray = conn.createArrayOf(sqlTypeName, toElementArray(sqlTypeName, columnValues));
             ps.setArray(parameterIndex++, sqlArray);
         }
 
@@ -212,7 +213,7 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * Bind non-key field arrays using setArray().
      * Each column's values across all records are collected into an array and bound as a single parameter.
      */
-    private int bindNonKeyFieldArrays(List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
+    private int bindNonKeyFieldArrays(TableDescriptor table, List<JdbcSinkRecord> records, Connection conn, PreparedStatement ps, int startIndex) throws SQLException {
         JdbcSinkRecord firstRecord = records.get(0);
         Set<String> nonKeyFieldNames = firstRecord.nonKeyFieldNames();
 
@@ -233,20 +234,35 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
                     value = payload.get(fieldName);
                 }
 
-                columnValues.add(transformValue(field, value));
+                columnValues.add(transformValue(table, record, field, value));
             }
 
             // Convert to array and bind using setArray()
-            String sqlTypeName = getSqlTypeName(firstRecord.jdbcFields().get(fieldName));
-            Array sqlArray = conn.createArrayOf(sqlTypeName, columnValues.toArray());
+            String sqlTypeName = getSqlTypeName(table, firstRecord, firstRecord.jdbcFields().get(fieldName));
+            Array sqlArray = conn.createArrayOf(sqlTypeName, toElementArray(sqlTypeName, columnValues));
             ps.setArray(parameterIndex++, sqlArray);
         }
 
         return parameterIndex;
     }
 
-    private Object transformValue(JdbcFieldDescriptor field, Object value) {
-        List<ValueBindDescriptor> boundValues = getDialect().bindValue(field, 1, value);
+    /**
+     * Converts the collected values to the array type required by {@link Connection#createArrayOf}.
+     */
+    private static Object[] toElementArray(String sqlTypeName, List<Object> columnValues) {
+        // The PostgreSQL driver uses the Java component type to select its array encoder. A typed
+        // byte[][] selects the bytea encoder; a byte[] element in Object[] is treated as ambiguous.
+        if ("bytea".equals(sqlTypeName)) {
+            return columnValues.toArray(new byte[0][]);
+        }
+        return columnValues.toArray();
+    }
+
+    private Object transformValue(TableDescriptor table, JdbcSinkRecord record, JdbcFieldDescriptor field, Object value) {
+        List<ValueBindDescriptor> boundValues = maybeBindBytesAsCharacter(record, field, table, 1, value);
+        if (boundValues == null) {
+            boundValues = getDialect().bindValue(field, 1, value);
+        }
         if (boundValues.size() != 1) {
             throw new ConnectException(
                     String.format("UNNEST does not support types that expand to multiple bind parameters (field: '%s', type: '%s'). "
@@ -265,7 +281,19 @@ public class UnnestRecordWriter extends DefaultRecordWriter {
      * - Length modifiers: varchar(255) -> varchar
      * - Precision/scale: numeric(10,2) -> numeric
      */
-    private String getSqlTypeName(JdbcFieldDescriptor field) {
+    private String getSqlTypeName(TableDescriptor table, JdbcSinkRecord record, JdbcFieldDescriptor field) {
+        // Encoded binary values use a text array to match the cast in the UNNEST statement.
+        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != getDialect().resolveBinaryHandlingMode(table, record, field)) {
+            return "text";
+        }
+
+        // The driver resolves the array element type by this name, so raw binary values must use
+        // the canonical "bytea" name; dialect type names such as CockroachDB's "bytes" have no
+        // corresponding server array type registered with the driver.
+        if (BinaryHandling.isPlainBytesSchema(field.getSchema())) {
+            return "bytea";
+        }
+
         Schema schema = field.getSchema();
         JdbcType type = getDialect().getSchemaType(schema);
         String typeName = type.getTypeName(schema, field.isKey());

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -16,12 +16,14 @@ import org.apache.kafka.connect.data.Schema;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.engine.jdbc.Size;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkRecord;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.field.FieldDescriptor;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
 /**
@@ -209,6 +211,20 @@ public interface DatabaseDialect {
      * @return the query binding SQL fragment
      */
     String getQueryBindingWithValueCast(ColumnDescriptor column, Schema schema, JdbcType type);
+
+    /**
+     * Resolves how a field is bound for the destination table. A textual mode binds the value as an
+     * encoded string, and {@link JdbcSinkConnectorConfig.BinaryHandlingMode#BYTES} uses the regular
+     * binding.
+     *
+     * @param table the table descriptor, never {@code null}
+     * @param record the sink record the field belongs to, never {@code null}
+     * @param field the field descriptor, never {@code null}
+     * @return the resolved binary handling mode
+     */
+    default JdbcSinkConnectorConfig.BinaryHandlingMode resolveBinaryHandlingMode(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
+        return JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES;
+    }
 
     /**
      * Gets the maximum length of a VARCHAR field in a primary key column.

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -16,11 +16,11 @@ import org.apache.kafka.connect.data.Schema;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.engine.jdbc.Size;
 
-import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkRecord;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.field.FieldDescriptor;
@@ -213,17 +213,15 @@ public interface DatabaseDialect {
     String getQueryBindingWithValueCast(ColumnDescriptor column, Schema schema, JdbcType type);
 
     /**
-     * Resolves how a field is bound for the destination table. A textual mode binds the value as an
-     * encoded string, and {@link JdbcSinkConnectorConfig.BinaryHandlingMode#BYTES} uses the regular
-     * binding.
+     * Resolves how a field is bound for the destination table.
      *
      * @param table the table descriptor, never {@code null}
      * @param record the sink record the field belongs to, never {@code null}
      * @param field the field descriptor, never {@code null}
-     * @return the resolved binary handling mode
+     * @return the resolved binary handling mode and destination column
      */
-    default JdbcSinkConnectorConfig.BinaryHandlingMode resolveBinaryHandlingMode(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
-        return JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES;
+    default BinaryHandling.Resolution resolveBinaryHandling(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
+        return BinaryHandling.Resolution.bytes(null);
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -83,6 +83,7 @@ import io.debezium.connector.jdbc.type.debezium.TimeType;
 import io.debezium.connector.jdbc.type.debezium.TimestampType;
 import io.debezium.connector.jdbc.type.debezium.VariableScaleDecimalType;
 import io.debezium.connector.jdbc.type.debezium.ZonedTimeType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.data.vector.DoubleVector;
 import io.debezium.data.vector.FloatVector;
 import io.debezium.data.vector.SparseDoubleVector;
@@ -742,10 +743,22 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         }
     }
 
+    @Override
+    public JdbcSinkConnectorConfig.BinaryHandlingMode resolveBinaryHandlingMode(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
+        final String columnName = resolveColumnName(field);
+        final ColumnDescriptor column = table.hasColumn(columnName) ? table.getColumnByName(columnName) : null;
+        return BinaryHandling.resolve(connectorConfig, record.topicName(), field, column);
+    }
+
     protected String columnQueryBindingFromField(String fieldName, TableDescriptor table, JdbcSinkRecord record) {
         final FieldDescriptor field = record.allFields().get(fieldName);
         final String columnName = resolveColumnName(field);
         final ColumnDescriptor column = table.getColumnByName(columnName);
+
+        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, record, field)) {
+            // An encoded string must not use a binary-specific query binding.
+            return "?";
+        }
 
         final Object value;
         if (record.nonKeyFieldNames().contains(fieldName)) {
@@ -836,6 +849,10 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         final JdbcFieldDescriptor field = record.jdbcFields().get(fieldName);
         final String columnName = resolveColumnName(field);
         final ColumnDescriptor column = table.getColumnByName(columnName);
+        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, record, field)) {
+            // An encoded string must not use a binary-specific query binding.
+            return toIdentifier(columnName) + "=?";
+        }
         return toIdentifier(columnName) + "=" + field.getQueryBinding(column, record.getPayload(), getSchemaType(field.getSchema()));
     }
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -744,10 +744,10 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
     }
 
     @Override
-    public JdbcSinkConnectorConfig.BinaryHandlingMode resolveBinaryHandlingMode(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
+    public BinaryHandling.Resolution resolveBinaryHandling(TableDescriptor table, JdbcSinkRecord record, FieldDescriptor field) {
         final String columnName = resolveColumnName(field);
         final ColumnDescriptor column = table.hasColumn(columnName) ? table.getColumnByName(columnName) : null;
-        return BinaryHandling.resolve(connectorConfig, record.topicName(), field, column);
+        return BinaryHandling.resolve(connectorConfig, record.topicName(), field, getSchemaType(field.getSchema()), column);
     }
 
     protected String columnQueryBindingFromField(String fieldName, TableDescriptor table, JdbcSinkRecord record) {
@@ -755,7 +755,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         final String columnName = resolveColumnName(field);
         final ColumnDescriptor column = table.getColumnByName(columnName);
 
-        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, record, field)) {
+        if (resolveBinaryHandling(table, record, field).isEncoded()) {
             // An encoded string must not use a binary-specific query binding.
             return "?";
         }
@@ -849,7 +849,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         final JdbcFieldDescriptor field = record.jdbcFields().get(fieldName);
         final String columnName = resolveColumnName(field);
         final ColumnDescriptor column = table.getColumnByName(columnName);
-        if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, record, field)) {
+        if (resolveBinaryHandling(table, record, field).isEncoded()) {
             // An encoded string must not use a binary-specific query binding.
             return toIdentifier(columnName) + "=?";
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -177,14 +177,14 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
             final io.debezium.sink.field.FieldDescriptor field = firstRecord.allFields().get(fieldName);
 
             // Encoded binary values use text arrays instead of the bytea type implied by the schema.
-            if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, firstRecord, field)) {
+            if (resolveBinaryHandling(table, firstRecord, field).isEncoded()) {
                 return "?::text[]";
             }
 
             // Raw binary values are always bound as bytea arrays; the canonical name keeps the cast
             // aligned with the array element type the driver binds, also on dialects whose BYTES
             // type name differs (e.g. CockroachDB's "bytes").
-            if (BinaryHandling.isPlainBytesSchema(field.getSchema())) {
+            if (BinaryHandling.isRawBytesSchema(field.getSchema(), getSchemaType(field.getSchema()))) {
                 return "?::bytea[]";
             }
 
@@ -217,10 +217,11 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
      * value of every row, so an array column would need an array of arrays, and the cast derived above
      * would be {@code ?::text[][]}, which {@code UNNEST} flattens into scalars the column rejects.
      */
-    private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
+    private boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
         return record.jdbcFields().values().stream()
                 .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT
-                        || (field.getSchema().type() == Schema.Type.BYTES && !BinaryHandling.isPlainBytesSchema(field.getSchema()))
+                        || (field.getSchema().type() == Schema.Type.BYTES
+                                && !BinaryHandling.isRawBytesSchema(field.getSchema(), getSchemaType(field.getSchema())))
                         || field.getSchema().type() == Schema.Type.ARRAY
                         || Enum.LOGICAL_NAME.equals(field.getSchema().name()));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -29,6 +29,7 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.data.Enum;
 import io.debezium.metadata.CollectionId;
 import io.debezium.sink.column.ColumnDescriptor;
@@ -174,6 +175,19 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         // This ensures the same SQL string regardless of batch size -> single query plan
         builder.appendList(",", allFields, (fieldName) -> {
             final io.debezium.sink.field.FieldDescriptor field = firstRecord.allFields().get(fieldName);
+
+            // Encoded binary values use text arrays instead of the bytea type implied by the schema.
+            if (JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES != resolveBinaryHandlingMode(table, firstRecord, field)) {
+                return "?::text[]";
+            }
+
+            // Raw binary values are always bound as bytea arrays; the canonical name keeps the cast
+            // aligned with the array element type the driver binds, also on dialects whose BYTES
+            // type name differs (e.g. CockroachDB's "bytes").
+            if (BinaryHandling.isPlainBytesSchema(field.getSchema())) {
+                return "?::bytea[]";
+            }
+
             final Schema fieldSchema = field.getSchema();
             final String columnType = getSchemaType(fieldSchema).getTypeName(fieldSchema, field.isKey());
 
@@ -194,9 +208,9 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
      * values to {@link Connection#createArrayOf}, which only accepts scalar elements; a {@code STRUCT}
      * field (the geometric types point/box/lseg/path/polygon and circle/line) needs the per-value
      * {@code JdbcType#bind()} the row-wise path applies, so such records are handled row-wise instead.
-     * {@code BYTES} fields are also excluded: the PostgreSQL driver cannot encode {@code bytea} array
-     * elements ({@code createArrayOf} rejects {@code byte[]} nested inside {@code Object[]}), so such
-     * records take the row-wise path as well. An enum field is handled row-wise for a related reason:
+     * Plain {@code BYTES} fields can use this path. Raw values use a typed {@code byte[][]} array,
+     * while encoded values use a text array. Logical types backed by {@code BYTES}, such as
+     * {@code Decimal}, continue to use row-wise binding. An enum field is handled row-wise because
      * the array cast above is derived from the field schema, which for an enum only resolves to the
      * character varying fallback, whereas the cast has to name the destination column's enum type.
      * An {@code ARRAY} field cannot be batched at all: this path binds one array per column holding the
@@ -206,7 +220,7 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
     private static boolean hasUnnestUnsupportedField(JdbcSinkRecord record) {
         return record.jdbcFields().values().stream()
                 .anyMatch(field -> field.getSchema().type() == Schema.Type.STRUCT
-                        || field.getSchema().type() == Schema.Type.BYTES
+                        || (field.getSchema().type() == Schema.Type.BYTES && !BinaryHandling.isPlainBytesSchema(field.getSchema()))
                         || field.getSchema().type() == Schema.Type.ARRAY
                         || Enum.LOGICAL_NAME.equals(field.getSchema().name()));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractBytesType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractBytesType.java
@@ -17,7 +17,7 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractBytesType extends AbstractType {
+public abstract class AbstractBytesType extends AbstractType implements RawBytesJdbcType {
 
     @Override
     public String[] getRegistrationKeys() {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/RawBytesJdbcType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/RawBytesJdbcType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type;
+
+/**
+ * Identifies a {@link JdbcType} that binds Kafka Connect {@code BYTES} values as raw bytes.
+ * Logical types that use a {@code BYTES} schema do not implement this interface.
+ *
+ * @author Minjae Lee
+ */
+public interface RawBytesJdbcType extends JdbcType {
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectBytesType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectBytesType.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.jdbc.Size;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.RawBytesJdbcType;
 import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
@@ -21,7 +22,7 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
  *
  * @author Chris Cranford
  */
-public class ConnectBytesType extends AbstractConnectSchemaType {
+public class ConnectBytesType extends AbstractConnectSchemaType implements RawBytesJdbcType {
 
     public static final ConnectBytesType INSTANCE = new ConnectBytesType();
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/BinaryHandling.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/BinaryHandling.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.util;
+
+import java.sql.Types;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.BinaryHandlingMode;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.field.FieldDescriptor;
+
+/**
+ * Resolves how the JDBC sink binds {@code BYTES} fields to destination columns.
+ *
+ * @author Minjae Lee
+ */
+public final class BinaryHandling {
+
+    private BinaryHandling() {
+    }
+
+    /**
+     * Resolves the mode for a field and destination column. A textual mode applies only to an
+     * unnamed {@code BYTES} schema that targets a character column. {@link BinaryHandlingMode#BYTES}
+     * indicates that the regular binding applies.
+     */
+    public static BinaryHandlingMode resolve(JdbcSinkConnectorConfig config, String topicName, FieldDescriptor field, ColumnDescriptor column) {
+        if (column == null || !isPlainBytesSchema(field.getSchema()) || !isCharacterType(column.getJdbcType())) {
+            return BinaryHandlingMode.BYTES;
+        }
+        return config.getBinaryHandlingMode(topicName, field.getName());
+    }
+
+    /**
+     * Returns whether the schema is an unnamed {@code BYTES} schema. Named logical schemas such as
+     * {@code Decimal} and {@code Bits} use separate type mappings and are not subject to this setting.
+     */
+    public static boolean isPlainBytesSchema(Schema schema) {
+        return schema.type() == Schema.Type.BYTES && schema.name() == null;
+    }
+
+    /**
+     * Returns whether the JDBC type is a character type.
+     */
+    public static boolean isCharacterType(int jdbcType) {
+        switch (jdbcType) {
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.CLOB:
+            case Types.NCLOB:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/BinaryHandling.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/BinaryHandling.java
@@ -11,6 +11,8 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.BinaryHandlingMode;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.RawBytesJdbcType;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.field.FieldDescriptor;
 
@@ -25,23 +27,22 @@ public final class BinaryHandling {
     }
 
     /**
-     * Resolves the mode for a field and destination column. A textual mode applies only to an
-     * unnamed {@code BYTES} schema that targets a character column. {@link BinaryHandlingMode#BYTES}
-     * indicates that the regular binding applies.
+     * Resolves how a field is bound to its destination column. A textual mode applies only when the
+     * field resolves to a raw {@code BYTES} JDBC type and targets a character column.
      */
-    public static BinaryHandlingMode resolve(JdbcSinkConnectorConfig config, String topicName, FieldDescriptor field, ColumnDescriptor column) {
-        if (column == null || !isPlainBytesSchema(field.getSchema()) || !isCharacterType(column.getJdbcType())) {
-            return BinaryHandlingMode.BYTES;
+    public static Resolution resolve(JdbcSinkConnectorConfig config, String topicName, FieldDescriptor field, JdbcType jdbcType, ColumnDescriptor column) {
+        if (column == null || !isRawBytesSchema(field.getSchema(), jdbcType) || !isCharacterType(column.getJdbcType())) {
+            return Resolution.bytes(column);
         }
-        return config.getBinaryHandlingMode(topicName, field.getName());
+        return new Resolution(config.getBinaryHandlingMode(topicName, field.getName()), column);
     }
 
     /**
-     * Returns whether the schema is an unnamed {@code BYTES} schema. Named logical schemas such as
-     * {@code Decimal} and {@code Bits} use separate type mappings and are not subject to this setting.
+     * Returns whether the schema resolves to a JDBC type that binds values as raw bytes. Logical
+     * types such as {@code Decimal} and {@code Bits} use separate type mappings and are excluded.
      */
-    public static boolean isPlainBytesSchema(Schema schema) {
-        return schema.type() == Schema.Type.BYTES && schema.name() == null;
+    public static boolean isRawBytesSchema(Schema schema, JdbcType jdbcType) {
+        return schema.type() == Schema.Type.BYTES && jdbcType instanceof RawBytesJdbcType;
     }
 
     /**
@@ -60,6 +61,22 @@ public final class BinaryHandling {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    /**
+     * The resolved binary handling mode and its destination column. The column may be {@code null}
+     * when the destination could not be resolved; {@link #isEncoded()} then always returns
+     * {@code false}, so callers only read {@link #targetColumn()} for encoded resolutions.
+     */
+    public record Resolution(BinaryHandlingMode mode, ColumnDescriptor targetColumn) {
+
+        public static Resolution bytes(ColumnDescriptor targetColumn) {
+            return new Resolution(BinaryHandlingMode.BYTES, targetColumn);
+        }
+
+        public boolean isEncoded() {
+            return mode != BinaryHandlingMode.BYTES;
         }
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/DefaultRecordWriterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/DefaultRecordWriterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.hibernate.SharedSessionContract;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
+import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.connect.ConnectBytesType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.field.FieldDescriptor;
+import io.debezium.sink.spi.SinkProgressListener;
+
+@Tag("UnitTests")
+class DefaultRecordWriterTest extends AbstractBaseJdbcSinkTest {
+
+    private static final String ENCODED_TOPIC = "encoded";
+    private static final String RAW_TOPIC = "raw";
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    void performTableWritesShouldPartitionAlternatingBindingModesIntoContiguousGroups() throws SQLException {
+        final DatabaseDialect dialect = binaryHandlingDialect();
+        final DefaultRecordWriter writer = writerSpy(dialect, binaryHandlingEnabledConfig());
+
+        final JdbcSinkRecord encoded1 = bytesRecord(ENCODED_TOPIC);
+        final JdbcSinkRecord raw = bytesRecord(RAW_TOPIC);
+        final JdbcSinkRecord encoded2 = bytesRecord(ENCODED_TOPIC);
+
+        writer.performTableWrites(mock(Connection.class), table(), List.of(encoded1, raw, encoded2));
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<List<JdbcSinkRecord>> groups = ArgumentCaptor.forClass(List.class);
+        verify(writer, times(3)).performTableWrite(any(Connection.class), any(TableDescriptor.class), groups.capture());
+        assertThat(groups.getAllValues().get(0)).containsExactly(encoded1);
+        assertThat(groups.getAllValues().get(1)).containsExactly(raw);
+        assertThat(groups.getAllValues().get(2)).containsExactly(encoded2);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    void performTableWritesShouldKeepUniformBatchInSingleGroup() throws SQLException {
+        final DatabaseDialect dialect = binaryHandlingDialect();
+        final DefaultRecordWriter writer = writerSpy(dialect, binaryHandlingEnabledConfig());
+
+        final List<JdbcSinkRecord> records = List.of(bytesRecord(ENCODED_TOPIC), bytesRecord(ENCODED_TOPIC), bytesRecord(ENCODED_TOPIC));
+        writer.performTableWrites(mock(Connection.class), table(), records);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<List<JdbcSinkRecord>> groups = ArgumentCaptor.forClass(List.class);
+        verify(writer, times(1)).performTableWrite(any(Connection.class), any(TableDescriptor.class), groups.capture());
+        assertThat(groups.getValue()).containsExactlyElementsOf(records);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    void performTableWritesShouldSkipSignatureResolutionWhenBinaryHandlingDisabled() throws SQLException {
+        final DatabaseDialect dialect = binaryHandlingDialect();
+        final DefaultRecordWriter writer = writerSpy(dialect, getConfig(Map.of(JdbcSinkConnectorConfig.INSERT_MODE, "insert")));
+
+        final List<JdbcSinkRecord> records = List.of(bytesRecord(ENCODED_TOPIC), bytesRecord(RAW_TOPIC));
+        writer.performTableWrites(mock(Connection.class), table(), records);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<List<JdbcSinkRecord>> groups = ArgumentCaptor.forClass(List.class);
+        verify(writer, times(1)).performTableWrite(any(Connection.class), any(TableDescriptor.class), groups.capture());
+        assertThat(groups.getValue()).containsExactlyElementsOf(records);
+        verify(dialect, never()).resolveBinaryHandling(any(), any(), any());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    void performTableWritesShouldSkipSignatureResolutionForSingleRecord() throws SQLException {
+        final DatabaseDialect dialect = binaryHandlingDialect();
+        final DefaultRecordWriter writer = writerSpy(dialect, binaryHandlingEnabledConfig());
+
+        writer.performTableWrites(mock(Connection.class), table(), List.of(bytesRecord(ENCODED_TOPIC)));
+
+        verify(writer, times(1)).performTableWrite(any(Connection.class), any(TableDescriptor.class), anyList());
+        verify(dialect, never()).resolveBinaryHandling(any(), any(), any());
+    }
+
+    private DefaultRecordWriter writerSpy(DatabaseDialect dialect, JdbcSinkConnectorConfig config) throws SQLException {
+        final DefaultRecordWriter writer = spy(new DefaultRecordWriter(
+                mock(SharedSessionContract.class), new QueryBinderResolver(), config, dialect, SinkProgressListener.NO_OP()));
+        doNothing().when(writer).performTableWrite(any(Connection.class), any(TableDescriptor.class), anyList());
+        return writer;
+    }
+
+    /**
+     * A dialect whose resolution encodes fields from the encoded topic and keeps raw bytes otherwise,
+     * mirroring a topic-qualified selector configuration.
+     */
+    private DatabaseDialect binaryHandlingDialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getSchemaType(Schema.OPTIONAL_BYTES_SCHEMA)).thenReturn(ConnectBytesType.INSTANCE);
+        when(dialect.resolveBinaryHandling(any(), any(JdbcSinkRecord.class), any())).thenAnswer(invocation -> {
+            final JdbcSinkRecord record = invocation.getArgument(1);
+            if (ENCODED_TOPIC.equals(record.topicName())) {
+                return new BinaryHandling.Resolution(JdbcSinkConnectorConfig.BinaryHandlingMode.HEX, characterColumn());
+            }
+            return BinaryHandling.Resolution.bytes(null);
+        });
+        return dialect;
+    }
+
+    private JdbcSinkConnectorConfig binaryHandlingEnabledConfig() {
+        return getConfig(Map.of(
+                JdbcSinkConnectorConfig.INSERT_MODE, "insert",
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "hex"));
+    }
+
+    private static JdbcSinkRecord bytesRecord(String topicName) {
+        final JdbcSinkRecord record = mock(JdbcSinkRecord.class);
+        when(record.topicName()).thenReturn(topicName);
+        when(record.jdbcFields()).thenReturn(Map.of("data",
+                new JdbcFieldDescriptor(new FieldDescriptor(Schema.OPTIONAL_BYTES_SCHEMA, "data", false), false)));
+        return record;
+    }
+
+    private static TableDescriptor table() {
+        return TableDescriptor.builder().tableName("t").build();
+    }
+
+    private static ColumnDescriptor characterColumn() {
+        return ColumnDescriptor.builder()
+                .columnName("data")
+                .jdbcType(Types.VARCHAR)
+                .typeName("text")
+                .build();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigBinaryHandlingModeTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.BinaryHandlingMode;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the {@code binary.handling.mode} configuration and its per-field selectors.
+ *
+ * @author Minjae Lee
+ */
+class JdbcSinkConnectorConfigBinaryHandlingModeTest {
+
+    private static final byte[] NON_UTF8_BYTES = { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0 };
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("binary.handling.mode defaults to bytes")
+    void shouldDefaultToBytes() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of());
+        assertThat(config.getBinaryHandlingMode()).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(config.getBinaryHandlingMode("topic", "data")).isEqualTo(BinaryHandlingMode.BYTES);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("binary.handling.mode parses all supported values")
+    void shouldParseAllModes() {
+        assertThat(mode("bytes")).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(mode("base64")).isEqualTo(BinaryHandlingMode.BASE64);
+        assertThat(mode("base64-url-safe")).isEqualTo(BinaryHandlingMode.BASE64_URL_SAFE);
+        assertThat(mode("hex")).isEqualTo(BinaryHandlingMode.HEX);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("selectors override the global mode by field name")
+    void shouldResolveSelectorByFieldName() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64",
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "data_hex",
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BYTES, "data_raw.*"));
+
+        assertThat(config.getBinaryHandlingMode("topic", "data_hex")).isEqualTo(BinaryHandlingMode.HEX);
+        assertThat(config.getBinaryHandlingMode("topic", "data_raw_1")).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(config.getBinaryHandlingMode("topic", "other")).isEqualTo(BinaryHandlingMode.BASE64);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("selectors match topic-qualified <topic>:<field> names")
+    void shouldResolveSelectorByTopicQualifiedName() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BASE64_URL_SAFE, "server1\\.inventory\\.orders:payload"));
+
+        assertThat(config.getBinaryHandlingMode("server1.inventory.orders", "payload")).isEqualTo(BinaryHandlingMode.BASE64_URL_SAFE);
+        assertThat(config.getBinaryHandlingMode("server1.inventory.other", "payload")).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(config.getBinaryHandlingMode("server1.inventory.orders", "other")).isEqualTo(BinaryHandlingMode.BYTES);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("selector evaluation order is base64, base64-url-safe, hex, bytes")
+    void shouldResolveOverlappingSelectorsInFixedOrder() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "data.*",
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BASE64, "data_b64"));
+
+        assertThat(config.getBinaryHandlingMode("topic", "data_b64")).isEqualTo(BinaryHandlingMode.BASE64);
+        assertThat(config.getBinaryHandlingMode("topic", "data_other")).isEqualTo(BinaryHandlingMode.HEX);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("selector matching is case-insensitive")
+    void shouldMatchSelectorsCaseInsensitively() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "DATA"));
+
+        assertThat(config.getBinaryHandlingMode("topic", "data")).isEqualTo(BinaryHandlingMode.HEX);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("textual modes encode bytes deterministically")
+    void shouldEncodeBytes() {
+        assertThat(BinaryHandlingMode.BASE64.encode(NON_UTF8_BYTES)).isEqualTo("/9j/4A==");
+        assertThat(BinaryHandlingMode.BASE64_URL_SAFE.encode(NON_UTF8_BYTES)).isEqualTo("_9j_4A==");
+        assertThat(BinaryHandlingMode.HEX.encode(NON_UTF8_BYTES)).isEqualTo("ffd8ffe0");
+        assertThatThrownBy(() -> BinaryHandlingMode.BYTES.encode(NON_UTF8_BYTES))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("invalid selector regex fails validation")
+    void shouldFailValidationOnInvalidSelectorRegex() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(JdbcSinkConnectorConfig.CONNECTION_URL, "jdbc:mysql://localhost:3306/db");
+        props.put(JdbcSinkConnectorConfig.CONNECTION_USER, "user");
+        props.put(JdbcSinkConnectorConfig.CONNECTION_PASSWORD, "pass");
+        props.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "data([");
+
+        assertThatThrownBy(() -> new JdbcSinkConnectorConfig(props).validate())
+                .isInstanceOf(ConnectException.class);
+    }
+
+    private static BinaryHandlingMode mode(String value) {
+        return new JdbcSinkConnectorConfig(Map.of(JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, value)).getBinaryHandlingMode();
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfigBinaryHandlingModeTest.java
@@ -119,6 +119,19 @@ class JdbcSinkConnectorConfigBinaryHandlingModeTest {
                 .isInstanceOf(ConnectException.class);
     }
 
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("binary handling is reported enabled only when a mode or selector is configured")
+    void shouldReportBinaryHandlingEnabledOnlyWhenConfigured() {
+        assertThat(new JdbcSinkConnectorConfig(Map.of()).isBinaryHandlingEnabled()).isFalse();
+        assertThat(new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "bytes")).isBinaryHandlingEnabled()).isFalse();
+        assertThat(new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "hex")).isBinaryHandlingEnabled()).isTrue();
+        assertThat(new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BASE64, "data")).isBinaryHandlingEnabled()).isTrue();
+    }
+
     private static BinaryHandlingMode mode(String value) {
         return new JdbcSinkConnectorConfig(Map.of(JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, value)).getBinaryHandlingMode();
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
@@ -141,6 +141,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
 
         when(dialect.getSchemaType(timestampSchema)).thenReturn(tsType);
         when(dialect.getSchemaType(dateSchema)).thenReturn(dateType);
+        when(dialect.resolveBinaryHandlingMode(any(), any(), any()))
+                .thenReturn(JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES);
 
         LocalDateTime transformedTs = LocalDateTime.of(2024, 1, 15, 10, 30, 0);
         when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))
@@ -171,7 +173,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(record.getPayload()).thenReturn(payload);
         when(record.jdbcFields()).thenReturn(Map.of("ts_col", tsField, "date_col", dateField));
 
-        writer.performUnnestBatch(conn, "INSERT INTO t SELECT * FROM UNNEST(?::timestamp[],?::date[])", List.of(record));
+        writer.performUnnestBatch(conn, TableDescriptor.builder().tableName("t").build(),
+                "INSERT INTO t SELECT * FROM UNNEST(?::timestamp[],?::date[])", List.of(record));
 
         // Verify dialect.bindValue was called for value transformation
         verify(dialect).bindValue(tsField, 1, 1705312200000L);
@@ -207,6 +210,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         JdbcType geoType = mock(JdbcType.class);
         when(geoType.getTypeName(any(), any(Boolean.class))).thenReturn("geometry");
         when(dialect.getSchemaType(geometrySchema)).thenReturn(geoType);
+        when(dialect.resolveBinaryHandlingMode(any(), any(), any()))
+                .thenReturn(JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES);
 
         // Geometry returns TWO ValueBindDescriptors (wkb bytes + srid)
         when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))
@@ -227,7 +232,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         when(record.getPayload()).thenReturn(payload);
         when(record.jdbcFields()).thenReturn(Map.of("geom", geoField));
 
-        assertThatThrownBy(() -> writer.performUnnestBatch(conn, "INSERT INTO t SELECT * FROM UNNEST(?::geometry[])", List.of(record)))
+        assertThatThrownBy(() -> writer.performUnnestBatch(conn, TableDescriptor.builder().tableName("t").build(),
+                "INSERT INTO t SELECT * FROM UNNEST(?::geometry[])", List.of(record)))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("UNNEST does not support types that expand to multiple bind parameters")
                 .hasMessageContaining("geom");

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/UnnestRecordWriterTest.java
@@ -36,6 +36,7 @@ import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.field.JdbcFieldDescriptor;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.BinaryHandling;
 import io.debezium.sink.spi.SinkProgressListener;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 
@@ -141,8 +142,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
 
         when(dialect.getSchemaType(timestampSchema)).thenReturn(tsType);
         when(dialect.getSchemaType(dateSchema)).thenReturn(dateType);
-        when(dialect.resolveBinaryHandlingMode(any(), any(), any()))
-                .thenReturn(JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES);
+        when(dialect.resolveBinaryHandling(any(), any(), any()))
+                .thenReturn(BinaryHandling.Resolution.bytes(null));
 
         LocalDateTime transformedTs = LocalDateTime.of(2024, 1, 15, 10, 30, 0);
         when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))
@@ -210,8 +211,8 @@ class UnnestRecordWriterTest extends AbstractBaseJdbcSinkTest {
         JdbcType geoType = mock(JdbcType.class);
         when(geoType.getTypeName(any(), any(Boolean.class))).thenReturn("geometry");
         when(dialect.getSchemaType(geometrySchema)).thenReturn(geoType);
-        when(dialect.resolveBinaryHandlingMode(any(), any(), any()))
-                .thenReturn(JdbcSinkConnectorConfig.BinaryHandlingMode.BYTES);
+        when(dialect.resolveBinaryHandling(any(), any(), any()))
+                .thenReturn(BinaryHandling.Resolution.bytes(null));
 
         // Geometry returns TWO ValueBindDescriptors (wkb bytes + srid)
         when(dialect.bindValue(any(JdbcFieldDescriptor.class), anyInt(), any()))

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
@@ -75,6 +75,14 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     }
 
     /**
+     * Whether the dialect runs the schema evolution interaction test; dialects without schema
+     * evolution test coverage upstream opt out.
+     */
+    protected boolean supportsSchemaEvolution() {
+        return true;
+    }
+
+    /**
      * DDL for a table with a single {@code data} column of the given type; override for dialects
      * with a non-standard {@code CREATE TABLE} syntax.
      */
@@ -131,6 +139,49 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     public void testNamedRawBytesFieldIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
         final Schema namedBytesSchema = SchemaBuilder.bytes().name("com.example.Binary").optional().build();
         assertBytesLandsInCharacterColumn(factory, "hex", namedBytesSchema, NON_UTF8_BYTES, "ffd8ffe0");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testSchemaEvolutionCreatesBinaryColumnsThatKeepRawBytes(SinkRecordFactory factory) throws Exception {
+        Assumptions.assumeTrue(supportsSchemaEvolution(), "Dialect does not run schema evolution tests");
+
+        final Map<String, String> properties = binaryHandlingSinkConfig("base64");
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+
+        // Schema evolution derives column types from the record schema alone, so both the created
+        // and the altered-in BYTES columns are binary and the textual mode does not apply to them.
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", Schema.OPTIONAL_BYTES_SCHEMA, NON_UTF8_BYTES, config);
+        consume(createRecord);
+
+        final JdbcKafkaSinkRecord alterRecord = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2,
+                List.of("data", "data2"),
+                List.of(Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA),
+                List.of(NON_UTF8_BYTES, NON_UTF8_BYTES),
+                config);
+        consume(alterRecord);
+
+        getSink().assertRows(destinationTableName(createRecord), rs -> {
+            final Map<Integer, byte[][]> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), new byte[][]{ rs.getBytes(2), rs.getBytes(3) });
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2);
+            assertThat(rows.get(1)[0]).isEqualTo(NON_UTF8_BYTES);
+            assertThat(rows.get(1)[1]).isNull();
+            assertThat(rows.get(2)[0]).isEqualTo(NON_UTF8_BYTES);
+            assertThat(rows.get(2)[1]).isEqualTo(NON_UTF8_BYTES);
+            return null;
+        });
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
@@ -8,10 +8,14 @@ package io.debezium.connector.jdbc.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
@@ -44,6 +48,29 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
      * The binary column type used for raw byte landings, e.g. {@code bytea} or {@code varbinary(16)}.
      */
     protected abstract String binaryColumnType();
+
+    /**
+     * The large character column type used to verify stream bindings. Dialects that return
+     * {@code null} do not run this test.
+     */
+    protected String largeCharacterColumnType() {
+        return null;
+    }
+
+    /**
+     * The national character column type, e.g. {@code nvarchar(max)} or {@code nvarchar2(64)}.
+     * Dialects that return {@code null} do not run this test.
+     */
+    protected String nationalCharacterColumnType() {
+        return null;
+    }
+
+    /**
+     * The fixed-length character column type used to verify landings that the destination pads.
+     */
+    protected String fixedLengthCharacterColumnType() {
+        return "char(16)";
+    }
 
     /**
      * DDL for a table with a single {@code data} column of the given type; override for dialects
@@ -94,6 +121,73 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     @FixFor("debezium/dbz#2468")
     public void testBytesFieldWithHexModeIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
         assertBytesLandsInCharacterColumn(factory, "hex", NON_UTF8_BYTES, "ffd8ffe0");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testNamedRawBytesFieldIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
+        final Schema namedBytesSchema = SchemaBuilder.bytes().name("com.example.Binary").optional().build();
+        assertBytesLandsInCharacterColumn(factory, "hex", namedBytesSchema, NON_UTF8_BYTES, "ffd8ffe0");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldIsBoundAsStringToNationalCharacterColumn(SinkRecordFactory factory) throws Exception {
+        final String nationalColumnType = nationalCharacterColumnType();
+        Assumptions.assumeTrue(nationalColumnType != null, "Dialect does not define a national character column type for this test");
+        assertBytesLandsInColumn(factory, "hex", nationalColumnType, Schema.OPTIONAL_BYTES_SCHEMA, NON_UTF8_BYTES, "ffd8ffe0", false);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldIsBoundAsStringToFixedLengthCharacterColumn(SinkRecordFactory factory) throws Exception {
+        // Whether the padding of a fixed-length column is returned varies per database, so the
+        // landed value is compared without its trailing padding; encoded values never end in spaces.
+        assertBytesLandsInColumn(factory, "hex", fixedLengthCharacterColumnType(), Schema.OPTIONAL_BYTES_SCHEMA, NON_UTF8_BYTES, "ffd8ffe0", true);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testLargeAndNullBytesValuesAreBoundToLargeCharacterColumn(SinkRecordFactory factory) throws Exception {
+        final String largeColumnType = largeCharacterColumnType();
+        Assumptions.assumeTrue(largeColumnType != null, "Dialect does not define a large character column type for this test");
+
+        final byte[] largeBytes = new byte[64 * 1024];
+        for (int index = 0; index < largeBytes.length; index++) {
+            largeBytes[index] = (byte) (index % 251);
+        }
+        final String expected = Base64.getEncoder().encodeToString(largeBytes);
+
+        final Map<String, String> properties = binaryHandlingSinkConfig("base64");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final List<JdbcKafkaSinkRecord> records = List.of(
+                factory.createRecordWithSchemaValue(topicName, (byte) 1, "data", Schema.OPTIONAL_BYTES_SCHEMA, largeBytes, config),
+                factory.createRecordWithSchemaValue(topicName, (byte) 2, "data", Schema.OPTIONAL_BYTES_SCHEMA, null, config));
+
+        final String destinationTable = destinationTableName(records.get(0));
+        getSink().execute(singleDataColumnTableDdl(destinationTable, largeColumnType));
+
+        consume(records);
+
+        getSink().assertRows(destinationTable, rs -> {
+            final Map<Integer, String> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), rs.getString(2));
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2);
+            assertThat(rows.get(1)).isEqualTo(expected);
+            assertThat(rows.get(2)).isNull();
+            return null;
+        });
     }
 
     @ParameterizedTest
@@ -165,6 +259,16 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     }
 
     private void assertBytesLandsInCharacterColumn(SinkRecordFactory factory, String mode, Object value, String expected) throws Exception {
+        assertBytesLandsInCharacterColumn(factory, mode, Schema.OPTIONAL_BYTES_SCHEMA, value, expected);
+    }
+
+    private void assertBytesLandsInCharacterColumn(SinkRecordFactory factory, String mode, Schema fieldSchema, Object value, String expected) throws Exception {
+        assertBytesLandsInColumn(factory, mode, characterColumnType(), fieldSchema, value, expected, false);
+    }
+
+    private void assertBytesLandsInColumn(SinkRecordFactory factory, String mode, String columnType, Schema fieldSchema, Object value, String expected,
+                                          boolean ignoreTrailingPadding)
+            throws Exception {
         final Map<String, String> properties = binaryHandlingSinkConfig(mode);
         startSinkConnector(properties);
         assertSinkConnectorIsRunning();
@@ -177,18 +281,19 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
                 topicName,
                 (byte) 1,
                 "data",
-                Schema.OPTIONAL_BYTES_SCHEMA,
+                fieldSchema,
                 value,
                 config);
 
         final String destinationTable = destinationTableName(createRecord);
-        getSink().execute(singleDataColumnTableDdl(destinationTable, characterColumnType()));
+        getSink().execute(singleDataColumnTableDdl(destinationTable, columnType));
 
         consume(createRecord);
 
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
-            assertThat(rs.getString(2)).isEqualTo(expected);
+            final String landed = rs.getString(2);
+            assertThat(ignoreTrailingPadding ? landed.stripTrailing() : landed).isEqualTo(expected);
             return null;
         });
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
@@ -8,10 +8,12 @@ package io.debezium.connector.jdbc.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -225,6 +227,20 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     @ParameterizedTest
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
     @FixFor("debezium/dbz#2468")
+    public void testTopicQualifiedModesUseSeparateRowWiseBatchesWithEncodedRecordsFirst(SinkRecordFactory factory) throws Exception {
+        assertTopicQualifiedModesUseSeparateRowWiseBatches(factory, true);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testTopicQualifiedModesUseSeparateRowWiseBatchesWithRawRecordsFirst(SinkRecordFactory factory) throws Exception {
+        assertTopicQualifiedModesUseSeparateRowWiseBatches(factory, false);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
     public void testSelectorsOverrideGlobalModePerField(SinkRecordFactory factory) throws Exception {
         final Map<String, String> properties = binaryHandlingSinkConfig("base64");
         properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "data_hex");
@@ -296,5 +312,58 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
             assertThat(ignoreTrailingPadding ? landed.stripTrailing() : landed).isEqualTo(expected);
             return null;
         });
+    }
+
+    private void assertTopicQualifiedModesUseSeparateRowWiseBatches(SinkRecordFactory factory, boolean encodedRecordsFirst) throws Exception {
+        final String tableName = randomTableName();
+        final String encodedTopic = "encoded_" + tableName;
+        final String rawTopic = "raw_" + tableName;
+
+        final Map<String, String> properties = binaryHandlingSinkConfig("bytes");
+        properties.put(JdbcSinkConnectorConfig.COLLECTION_NAME_FORMAT, tableName);
+        properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, Pattern.quote(encodedTopic) + ":data");
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "false");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final List<JdbcKafkaSinkRecord> encodedRecords = List.of(
+                createRecord(factory, encodedTopic, (byte) 1, new byte[]{ 0x01, 0x11 }, config),
+                createRecord(factory, encodedTopic, (byte) 2, new byte[]{ 0x02, 0x22 }, config));
+        final List<JdbcKafkaSinkRecord> rawRecords = List.of(
+                createRecord(factory, rawTopic, (byte) 3, new byte[]{ 0x41, 0x31 }, config),
+                createRecord(factory, rawTopic, (byte) 4, new byte[]{ 0x42, 0x32 }, config));
+        final List<JdbcKafkaSinkRecord> batch = new ArrayList<>();
+        if (encodedRecordsFirst) {
+            batch.addAll(encodedRecords);
+            batch.addAll(rawRecords);
+        }
+        else {
+            batch.addAll(rawRecords);
+            batch.addAll(encodedRecords);
+        }
+
+        final String destinationTable = getSink().formatTableName(tableName);
+        getSink().execute(singleDataColumnTableDdl(destinationTable, characterColumnType()));
+
+        consume(batch);
+
+        getSink().assertRows(destinationTable, rs -> {
+            final Map<Integer, String> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), rs.getString(2));
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2, 3, 4);
+            assertThat(rows.get(1)).isEqualTo("0111");
+            assertThat(rows.get(2)).isEqualTo("0222");
+            // Raw bytes targeting a character column retain the dialect's existing conversion behavior.
+            assertThat(rows.get(3)).isNotNull();
+            assertThat(rows.get(4)).isNotNull();
+            return null;
+        });
+    }
+
+    private JdbcKafkaSinkRecord createRecord(SinkRecordFactory factory, String topicName, byte key, byte[] value, JdbcSinkConnectorConfig config) {
+        return factory.createRecordWithSchemaValue(topicName, key, "data", Schema.OPTIONAL_BYTES_SCHEMA, value, config);
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
@@ -21,12 +21,14 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import io.debezium.connector.jdbc.DefaultRecordWriter;
 import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
 
 /**
  * Common tests for {@code binary.handling.mode} and its per-field selectors.
@@ -72,14 +74,6 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
      */
     protected String fixedLengthCharacterColumnType() {
         return "char(16)";
-    }
-
-    /**
-     * Whether the dialect runs the schema evolution interaction test; dialects without schema
-     * evolution test coverage upstream opt out.
-     */
-    protected boolean supportsSchemaEvolution() {
-        return true;
     }
 
     /**
@@ -145,8 +139,6 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
     @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
     @FixFor("debezium/dbz#2468")
     public void testSchemaEvolutionCreatesBinaryColumnsThatKeepRawBytes(SinkRecordFactory factory) throws Exception {
-        Assumptions.assumeTrue(supportsSchemaEvolution(), "Dialect does not run schema evolution tests");
-
         final Map<String, String> properties = binaryHandlingSinkConfig("base64");
         properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
         startSinkConnector(properties);
@@ -155,9 +147,10 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
         final String tableName = randomTableName();
         final String topicName = topicName("server1", "schema", tableName);
         final JdbcSinkConnectorConfig config = getConfig(properties);
+        final LogInterceptor interceptor = new LogInterceptor(DefaultRecordWriter.class);
 
-        // Schema evolution derives column types from the record schema alone, so both the created
-        // and the altered-in BYTES columns are binary and the textual mode does not apply to them.
+        // Schema evolution derives types from the record schema, so it creates binary columns for
+        // both fields. The sink therefore keeps their values as raw bytes and logs the mismatch.
         final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
                 topicName, (byte) 1, "data", Schema.OPTIONAL_BYTES_SCHEMA, NON_UTF8_BYTES, config);
         consume(createRecord);
@@ -182,6 +175,11 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdb
             assertThat(rows.get(2)[1]).isEqualTo(NON_UTF8_BYTES);
             return null;
         });
+
+        final String warningPrefix = "Schema evolution created a binary column for field";
+        assertThat(interceptor.countOccurrences(warningPrefix)).isEqualTo(2);
+        assertThat(interceptor.containsWarnMessage("field 'data' in topic '" + topicName + "'")).isTrue();
+        assertThat(interceptor.containsWarnMessage("field 'data2' in topic '" + topicName + "'")).isTrue();
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+
+/**
+ * Common tests for {@code binary.handling.mode} and its per-field selectors.
+ *
+ * @author Minjae Lee
+ */
+public abstract class AbstractJdbcSinkBinaryHandlingModeTest extends AbstractJdbcSinkTest {
+
+    protected static final byte[] NON_UTF8_BYTES = { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0 };
+
+    public AbstractJdbcSinkBinaryHandlingModeTest(Sink sink) {
+        super(sink);
+    }
+
+    /**
+     * The character column type used for encoded string landings, e.g. {@code text} or {@code varchar(64)}.
+     */
+    protected abstract String characterColumnType();
+
+    /**
+     * The binary column type used for raw byte landings, e.g. {@code bytea} or {@code varbinary(16)}.
+     */
+    protected abstract String binaryColumnType();
+
+    /**
+     * DDL for a table with a single {@code data} column of the given type; override for dialects
+     * with a non-standard {@code CREATE TABLE} syntax.
+     */
+    protected String singleDataColumnTableDdl(String tableName, String dataColumnType) {
+        return String.format("CREATE TABLE %s (id int not null, data %s, primary key(id))", tableName, dataColumnType);
+    }
+
+    /**
+     * DDL for the selector test table with the {@code data_hex}, {@code data_b64}, and {@code data_raw}
+     * columns; override for dialects with a non-standard {@code CREATE TABLE} syntax.
+     */
+    protected String selectorColumnsTableDdl(String tableName) {
+        return String.format("CREATE TABLE %s (id int not null, data_hex %s, data_b64 %s, data_raw %s, primary key(id))",
+                tableName, characterColumnType(), characterColumnType(), binaryColumnType());
+    }
+
+    /**
+     * The common sink configuration used by the binary handling tests.
+     */
+    protected Map<String, String> binaryHandlingSinkConfig(String binaryHandlingMode) {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, binaryHandlingMode);
+        return properties;
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldWithBase64ModeIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
+        // ByteBuffer here and byte[] in the other modes so that both value forms are covered
+        assertBytesLandsInCharacterColumn(factory, "base64", ByteBuffer.wrap(NON_UTF8_BYTES), "/9j/4A==");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldWithBase64UrlSafeModeIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
+        assertBytesLandsInCharacterColumn(factory, "base64-url-safe", NON_UTF8_BYTES, "_9j_4A==");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldWithHexModeIsBoundAsStringToCharacterColumn(SinkRecordFactory factory) throws Exception {
+        assertBytesLandsInCharacterColumn(factory, "hex", NON_UTF8_BYTES, "ffd8ffe0");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testBytesFieldWithTextualModeKeepsRawBytesForBinaryColumn(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = binaryHandlingSinkConfig("base64");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_BYTES_SCHEMA,
+                ByteBuffer.wrap(NON_UTF8_BYTES),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(singleDataColumnTableDdl(destinationTable, binaryColumnType()));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getBytes(2)).isEqualTo(NON_UTF8_BYTES);
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testSelectorsOverrideGlobalModePerField(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = binaryHandlingSinkConfig("base64");
+        properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, "data_hex");
+        properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BYTES, "data_raw");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("data_hex", "data_b64", "data_raw"),
+                List.of(Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA),
+                List.of(NON_UTF8_BYTES, NON_UTF8_BYTES, NON_UTF8_BYTES),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(selectorColumnsTableDdl(destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("ffd8ffe0");
+            assertThat(rs.getString(3)).isEqualTo("/9j/4A==");
+            assertThat(rs.getBytes(4)).isEqualTo(NON_UTF8_BYTES);
+            return null;
+        });
+    }
+
+    private void assertBytesLandsInCharacterColumn(SinkRecordFactory factory, String mode, Object value, String expected) throws Exception {
+        final Map<String, String> properties = binaryHandlingSinkConfig(mode);
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_BYTES_SCHEMA,
+                value,
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        getSink().execute(singleDataColumnTableDdl(destinationTable, characterColumnType()));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo(expected);
+            return null;
+        });
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeUnnestTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeUnnestTest.java
@@ -7,9 +7,11 @@ package io.debezium.connector.jdbc.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -119,6 +121,72 @@ public abstract class AbstractJdbcSinkBinaryHandlingModeUnnestTest extends Abstr
         });
 
         assertThat(interceptor.containsMessage(UNNEST_EXECUTED_MESSAGE)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testTopicQualifiedModesUseSeparateUnnestBatchesWithEncodedRecordsFirst(SinkRecordFactory factory) throws Exception {
+        assertTopicQualifiedModesUseSeparateUnnestBatches(factory, true);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testTopicQualifiedModesUseSeparateUnnestBatchesWithRawRecordsFirst(SinkRecordFactory factory) throws Exception {
+        assertTopicQualifiedModesUseSeparateUnnestBatches(factory, false);
+    }
+
+    private void assertTopicQualifiedModesUseSeparateUnnestBatches(SinkRecordFactory factory, boolean encodedRecordsFirst) throws Exception {
+        final String tableName = randomTableName();
+        final String encodedTopic = "encoded_" + tableName;
+        final String rawTopic = "raw_" + tableName;
+
+        final Map<String, String> properties = unnestSinkConfig("bytes");
+        properties.put(JdbcSinkConnectorConfig.COLLECTION_NAME_FORMAT, tableName);
+        properties.put(JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_HEX, Pattern.quote(encodedTopic) + ":data");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final List<JdbcKafkaSinkRecord> encodedRecords = List.of(
+                createRecord(factory, encodedTopic, (byte) 1, new byte[]{ 0x01, 0x11 }, config),
+                createRecord(factory, encodedTopic, (byte) 2, new byte[]{ 0x02, 0x22 }, config));
+        final List<JdbcKafkaSinkRecord> rawRecords = List.of(
+                createRecord(factory, rawTopic, (byte) 3, new byte[]{ 0x41, 0x31 }, config),
+                createRecord(factory, rawTopic, (byte) 4, new byte[]{ 0x42, 0x32 }, config));
+        final List<JdbcKafkaSinkRecord> batch = new ArrayList<>();
+        if (encodedRecordsFirst) {
+            batch.addAll(encodedRecords);
+            batch.addAll(rawRecords);
+        }
+        else {
+            batch.addAll(rawRecords);
+            batch.addAll(encodedRecords);
+        }
+
+        final String destinationTable = getSink().formatTableName(tableName);
+        getSink().execute(singleDataColumnTableDdl(destinationTable, characterColumnType()));
+
+        final LogInterceptor interceptor = new LogInterceptor(UnnestRecordWriter.class);
+        interceptor.setLoggerLevel(UnnestRecordWriter.class, Level.DEBUG);
+
+        consume(batch);
+
+        getSink().assertRows(destinationTable, rs -> {
+            final Map<Integer, String> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), rs.getString(2));
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2, 3, 4);
+            assertThat(rows.get(1)).isEqualTo("0111");
+            assertThat(rows.get(2)).isEqualTo("0222");
+            assertThat(rows.get(3)).isNotNull();
+            assertThat(rows.get(4)).isNotNull();
+            return null;
+        });
+
+        assertThat(interceptor.countOccurrences(UNNEST_EXECUTED_MESSAGE)).isEqualTo(2);
     }
 
     private Map<String, String> unnestSinkConfig(String binaryHandlingMode) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeUnnestTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/AbstractJdbcSinkBinaryHandlingModeUnnestTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.debezium.connector.jdbc.JdbcKafkaSinkRecord;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.UnnestRecordWriter;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
+import io.debezium.connector.jdbc.util.SinkRecordFactory;
+import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
+
+import ch.qos.logback.classic.Level;
+
+/**
+ * Binary handling tests for the {@code UNNEST}-based batch write path, shared by the dialects that
+ * derive from the PostgreSQL dialect.
+ *
+ * @author Minjae Lee
+ */
+public abstract class AbstractJdbcSinkBinaryHandlingModeUnnestTest extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    private static final String UNNEST_EXECUTED_MESSAGE = "UNNEST batch insert affected";
+
+    public AbstractJdbcSinkBinaryHandlingModeUnnestTest(Sink sink) {
+        super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testEncodedBinaryFieldsUseUnnestBatchPath(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = unnestSinkConfig("hex");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final List<JdbcKafkaSinkRecord> batch = List.of(
+                createRecord(factory, topicName, (byte) 1, new byte[]{ (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x01 }, config),
+                createRecord(factory, topicName, (byte) 2, new byte[]{ (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x02 }, config),
+                createRecord(factory, topicName, (byte) 3, new byte[]{ (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x03 }, config));
+
+        final String destinationTable = destinationTableName(batch.get(0));
+        getSink().execute(singleDataColumnTableDdl(destinationTable, characterColumnType()));
+
+        final LogInterceptor interceptor = new LogInterceptor(UnnestRecordWriter.class);
+        interceptor.setLoggerLevel(UnnestRecordWriter.class, Level.DEBUG);
+
+        consume(batch);
+
+        getSink().assertRows(destinationTable, rs -> {
+            final Map<Integer, String> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), rs.getString(2));
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2, 3);
+            assertThat(rows.get(1)).isEqualTo("ffd8ff01");
+            assertThat(rows.get(2)).isEqualTo("ffd8ff02");
+            assertThat(rows.get(3)).isEqualTo("ffd8ff03");
+            return null;
+        });
+
+        // The encoded string binding is array-compatible, so the batch stays on the UNNEST path
+        assertThat(interceptor.containsMessage(UNNEST_EXECUTED_MESSAGE)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2468")
+    public void testRawBinaryFieldsUseUnnestBatchPathAsTypedByteaArrays(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = unnestSinkConfig("base64");
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final List<JdbcKafkaSinkRecord> batch = List.of(
+                createRecord(factory, topicName, (byte) 1, new byte[]{ 0x01, 0x02 }, config),
+                createRecord(factory, topicName, (byte) 2, new byte[]{ 0x03, 0x04 }, config));
+
+        // The destination column is binary, so the field keeps the raw bytes binding; the batch
+        // stays on the UNNEST path with the values passed as a typed byte[][] array.
+        final String destinationTable = destinationTableName(batch.get(0));
+        getSink().execute(singleDataColumnTableDdl(destinationTable, binaryColumnType()));
+
+        final LogInterceptor interceptor = new LogInterceptor(UnnestRecordWriter.class);
+        interceptor.setLoggerLevel(UnnestRecordWriter.class, Level.DEBUG);
+
+        consume(batch);
+
+        getSink().assertRows(destinationTable, rs -> {
+            final Map<Integer, byte[]> rows = new HashMap<>();
+            do {
+                rows.put(rs.getInt(1), rs.getBytes(2));
+            } while (rs.next());
+            assertThat(rows).containsOnlyKeys(1, 2);
+            assertThat(rows.get(1)).isEqualTo(new byte[]{ 0x01, 0x02 });
+            assertThat(rows.get(2)).isEqualTo(new byte[]{ 0x03, 0x04 });
+            return null;
+        });
+
+        assertThat(interceptor.containsMessage(UNNEST_EXECUTED_MESSAGE)).isTrue();
+    }
+
+    private Map<String, String> unnestSinkConfig(String binaryHandlingMode) {
+        final Map<String, String> properties = binaryHandlingSinkConfig(binaryHandlingMode);
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "true");
+        return properties;
+    }
+
+    private JdbcKafkaSinkRecord createRecord(SinkRecordFactory factory, String topicName, byte key, byte[] value, JdbcSinkConnectorConfig config) {
+        return factory.createRecordWithSchemaValue(topicName, key, "data", Schema.OPTIONAL_BYTES_SCHEMA, value, config);
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkBinaryHandlingModeIT.java
@@ -37,4 +37,9 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "bytea";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "text";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.cockroachdb;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeUnnestTest;
+import io.debezium.connector.jdbc.junit.jupiter.CockroachDbSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for CockroachDB, including the UNNEST batch write path, which the
+ * CockroachDB dialect inherits from the PostgreSQL dialect.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-cockroachdb")
+@ExtendWith(CockroachDbSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeUnnestTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "text";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "bytea";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.db2;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.Db2SinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for Db2.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-db2")
+@ExtendWith(Db2SinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "varchar(64)";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "varbinary(16)";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/db2/JdbcSinkBinaryHandlingModeIT.java
@@ -36,4 +36,9 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "varbinary(16)";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "clob(1m)";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.mysql;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.MySqlSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for MySQL.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-mysql")
+@ExtendWith(MySqlSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "longtext";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "varbinary(16)";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkBinaryHandlingModeIT.java
@@ -34,6 +34,11 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
 
     @Override
     protected String binaryColumnType() {
-        return "varbinary(16)";
+        return "longblob";
+    }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "longtext";
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkBinaryHandlingModeIT.java
@@ -36,4 +36,14 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "blob";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "nclob";
+    }
+
+    @Override
+    protected String nationalCharacterColumnType() {
+        return "nvarchar2(64)";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.oracle;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.OracleSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for Oracle.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-oracle")
+@ExtendWith(OracleSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "varchar2(64)";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "blob";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.postgres;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeUnnestTest;
+import io.debezium.connector.jdbc.junit.jupiter.PostgresSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for PostgreSQL, including the UNNEST batch write path.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-postgresql")
+@ExtendWith(PostgresSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeUnnestTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "text";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "bytea";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkBinaryHandlingModeIT.java
@@ -36,4 +36,9 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "bytea";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "text";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestBytesIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkUnnestBytesIT.java
@@ -27,10 +27,10 @@ import io.debezium.doc.FixFor;
 /**
  * UNNEST batch write tests for PostgreSQL with binary columns.
  *
- * <p>The UNNEST path binds each column with {@code Connection#createArrayOf}, which the PostgreSQL
- * driver cannot serve for {@code bytea} elements (it rejects {@code byte[]} nested inside
- * {@code Object[]}). Records with a BYTES field must therefore fall back to the row-wise path,
- * which this test verifies end to end.</p>
+ * <p>The UNNEST path binds each column with {@code Connection#createArrayOf}. The PostgreSQL driver
+ * rejects {@code byte[]} elements nested inside a generic {@code Object[]}, so the writer passes
+ * {@code bytea} columns as a typed {@code byte[][]} array, which engages the driver's dedicated
+ * {@code bytea} element encoder. This test verifies the binary landing end to end.</p>
  *
  * @author Virag Tripathi
  */

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
@@ -36,4 +36,9 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "varbinary(16)";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        return "longtext";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
@@ -41,4 +41,10 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String largeCharacterColumnType() {
         return "longtext";
     }
+
+    @Override
+    protected boolean supportsSchemaEvolution() {
+        // Upstream has no schema evolution IT coverage for this dialect
+        return false;
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
@@ -41,10 +41,4 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String largeCharacterColumnType() {
         return "longtext";
     }
-
-    @Override
-    protected boolean supportsSchemaEvolution() {
-        // Upstream has no schema evolution IT coverage for this dialect
-        return false;
-    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.singlestore;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.SingleStoreSinkDatabaseContextProvider;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+
+/**
+ * Binary handling mode tests for SingleStore.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-singlestore")
+@ExtendWith(SingleStoreSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "text";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "varbinary(16)";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkBinaryHandlingModeIT.java
@@ -36,4 +36,15 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
     protected String binaryColumnType() {
         return "varbinary(16)";
     }
+
+    @Override
+    protected String largeCharacterColumnType() {
+        // ntext reports the LONGNVARCHAR JDBC type, exercising the national character stream binding
+        return "ntext";
+    }
+
+    @Override
+    protected String nationalCharacterColumnType() {
+        return "nvarchar(max)";
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.sqlserver;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.SqlServerSinkDatabaseContextProvider;
+
+/**
+ * Binary handling mode tests for MS SQL Server.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-sqlserver")
+@ExtendWith(SqlServerSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "varchar(max)";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "varbinary(16)";
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
@@ -32,6 +32,9 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
         return "string";
     }
 
+    // No largeCharacterColumnType override: STRING caps at 65,533 characters, which cannot
+    // hold the Base64 encoding of the 64 KiB payload used by the large-value test.
+
     @Override
     protected String binaryColumnType() {
         return "varbinary(16)";

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
@@ -52,4 +52,10 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
                 "CREATE TABLE %s (id tinyint NOT NULL, data_hex %s NULL, data_b64 %s NULL, data_raw %s NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
                 tableName, characterColumnType(), characterColumnType(), binaryColumnType());
     }
+
+    @Override
+    protected boolean supportsSchemaEvolution() {
+        // Upstream has no schema evolution IT coverage for this dialect
+        return false;
+    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
@@ -52,10 +52,4 @@ public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandling
                 "CREATE TABLE %s (id tinyint NOT NULL, data_hex %s NULL, data_b64 %s NULL, data_raw %s NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
                 tableName, characterColumnType(), characterColumnType(), binaryColumnType());
     }
-
-    @Override
-    protected boolean supportsSchemaEvolution() {
-        // Upstream has no schema evolution IT coverage for this dialect
-        return false;
-    }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkBinaryHandlingModeIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.integration.starrocks;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.debezium.connector.jdbc.integration.AbstractJdbcSinkBinaryHandlingModeTest;
+import io.debezium.connector.jdbc.junit.jupiter.Sink;
+import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
+
+/**
+ * Binary handling mode tests for StarRocks.
+ *
+ * @author Minjae Lee
+ */
+@Tag("all")
+@Tag("it")
+@Tag("it-starrocks")
+@ExtendWith(StarRocksSinkDatabaseContextProvider.class)
+public class JdbcSinkBinaryHandlingModeIT extends AbstractJdbcSinkBinaryHandlingModeTest {
+
+    public JdbcSinkBinaryHandlingModeIT(Sink sink) {
+        super(sink);
+    }
+
+    @Override
+    protected String characterColumnType() {
+        return "string";
+    }
+
+    @Override
+    protected String binaryColumnType() {
+        return "varbinary(16)";
+    }
+
+    @Override
+    protected String singleDataColumnTableDdl(String tableName, String dataColumnType) {
+        return String.format("CREATE TABLE %s (id tinyint NOT NULL, data %s NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
+                tableName, dataColumnType);
+    }
+
+    @Override
+    protected String selectorColumnsTableDdl(String tableName) {
+        return String.format(
+                "CREATE TABLE %s (id tinyint NOT NULL, data_hex %s NULL, data_b64 %s NULL, data_raw %s NULL) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
+                tableName, characterColumnType(), characterColumnType(), binaryColumnType());
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/BinaryHandlingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/BinaryHandlingTest.java
@@ -12,11 +12,14 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.BinaryHandlingMode;
+import io.debezium.connector.jdbc.type.connect.ConnectBytesType;
+import io.debezium.connector.jdbc.type.connect.ConnectDecimalType;
 import io.debezium.doc.FixFor;
 import io.debezium.sink.column.ColumnDescriptor;
 import io.debezium.sink.field.FieldDescriptor;
@@ -37,8 +40,10 @@ class BinaryHandlingTest {
         final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
                 JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
 
-        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BASE64);
-        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.CLOB))).isEqualTo(BinaryHandlingMode.BASE64);
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), ConnectBytesType.INSTANCE, column(Types.VARCHAR)).mode())
+                .isEqualTo(BinaryHandlingMode.BASE64);
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), ConnectBytesType.INSTANCE, column(Types.CLOB)).mode())
+                .isEqualTo(BinaryHandlingMode.BASE64);
     }
 
     @Test
@@ -49,9 +54,12 @@ class BinaryHandlingTest {
                 JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
         final JdbcSinkConnectorConfig defaultConfig = new JdbcSinkConnectorConfig(Map.of());
 
-        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), column(Types.VARBINARY))).isEqualTo(BinaryHandlingMode.BYTES);
-        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), null)).isEqualTo(BinaryHandlingMode.BYTES);
-        assertThat(BinaryHandling.resolve(defaultConfig, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), ConnectBytesType.INSTANCE, column(Types.VARBINARY)).mode())
+                .isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), ConnectBytesType.INSTANCE, null).mode())
+                .isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(defaultConfig, TOPIC, bytesField(), ConnectBytesType.INSTANCE, column(Types.VARCHAR)).mode())
+                .isEqualTo(BinaryHandlingMode.BYTES);
     }
 
     @Test
@@ -62,7 +70,21 @@ class BinaryHandlingTest {
                 JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
         final FieldDescriptor decimalField = new FieldDescriptor(Decimal.schema(2), "data", false);
 
-        assertThat(BinaryHandling.resolve(config, TOPIC, decimalField, column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(config, TOPIC, decimalField, ConnectDecimalType.INSTANCE, column(Types.VARCHAR)).mode())
+                .isEqualTo(BinaryHandlingMode.BYTES);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("resolves a textual mode for named schemas that use the raw BYTES type")
+    void shouldResolveTextualModeForNamedRawBytesSchema() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "hex"));
+        final Schema namedBytesSchema = SchemaBuilder.bytes().name("com.example.Binary").optional().build();
+        final FieldDescriptor namedBytesField = new FieldDescriptor(namedBytesSchema, "data", false);
+
+        assertThat(BinaryHandling.resolve(config, TOPIC, namedBytesField, ConnectBytesType.INSTANCE, column(Types.VARCHAR)).mode())
+                .isEqualTo(BinaryHandlingMode.HEX);
     }
 
     @Test
@@ -73,9 +95,10 @@ class BinaryHandlingTest {
                 JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64",
                 JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BYTES, "data"));
 
-        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), ConnectBytesType.INSTANCE, column(Types.VARCHAR)).mode())
+                .isEqualTo(BinaryHandlingMode.BYTES);
         assertThat(BinaryHandling.resolve(config, TOPIC, new FieldDescriptor(Schema.OPTIONAL_BYTES_SCHEMA, "other", false),
-                column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BASE64);
+                ConnectBytesType.INSTANCE, column(Types.VARCHAR)).mode()).isEqualTo(BinaryHandlingMode.BASE64);
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/BinaryHandlingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/BinaryHandlingTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig.BinaryHandlingMode;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.field.FieldDescriptor;
+
+/**
+ * Unit tests for the {@link BinaryHandling} resolution logic.
+ *
+ * @author Minjae Lee
+ */
+class BinaryHandlingTest {
+
+    private static final String TOPIC = "server1.inventory.orders";
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("resolves a textual mode for plain BYTES fields targeting character columns")
+    void shouldResolveTextualModeForPlainBytesFieldWithCharacterTarget() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
+
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BASE64);
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.CLOB))).isEqualTo(BinaryHandlingMode.BASE64);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("resolves bytes for binary targets, missing columns, and the default configuration")
+    void shouldResolveBytesOutsideCharacterTargetsWithTextualMode() {
+        final JdbcSinkConnectorConfig textualConfig = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
+        final JdbcSinkConnectorConfig defaultConfig = new JdbcSinkConnectorConfig(Map.of());
+
+        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), column(Types.VARBINARY))).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(textualConfig, TOPIC, bytesField(), null)).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(defaultConfig, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("resolves bytes for logical types that use the BYTES schema type")
+    void shouldResolveBytesForLogicalBytesSchemas() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64"));
+        final FieldDescriptor decimalField = new FieldDescriptor(Decimal.schema(2), "data", false);
+
+        assertThat(BinaryHandling.resolve(config, TOPIC, decimalField, column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("selectors decide the mode per field")
+    void shouldFollowSelectorResolution() {
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.BINARY_HANDLING_MODE, "base64",
+                JdbcSinkConnectorConfig.BINARY_HANDLING_SELECTOR_BYTES, "data"));
+
+        assertThat(BinaryHandling.resolve(config, TOPIC, bytesField(), column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BYTES);
+        assertThat(BinaryHandling.resolve(config, TOPIC, new FieldDescriptor(Schema.OPTIONAL_BYTES_SCHEMA, "other", false),
+                column(Types.VARCHAR))).isEqualTo(BinaryHandlingMode.BASE64);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2468")
+    @DisplayName("character type detection covers all character JDBC types")
+    void shouldDetectCharacterTypes() {
+        assertThat(BinaryHandling.isCharacterType(Types.CHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.VARCHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.LONGVARCHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.NCHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.NVARCHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.LONGNVARCHAR)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.CLOB)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.NCLOB)).isTrue();
+        assertThat(BinaryHandling.isCharacterType(Types.BINARY)).isFalse();
+        assertThat(BinaryHandling.isCharacterType(Types.VARBINARY)).isFalse();
+        assertThat(BinaryHandling.isCharacterType(Types.BLOB)).isFalse();
+        assertThat(BinaryHandling.isCharacterType(Types.INTEGER)).isFalse();
+    }
+
+    private static FieldDescriptor bytesField() {
+        return new FieldDescriptor(Schema.OPTIONAL_BYTES_SCHEMA, "data", false);
+    }
+
+    private static ColumnDescriptor column(int jdbcType) {
+        return ColumnDescriptor.builder()
+                .columnName("data")
+                .jdbcType(jdbcType)
+                .typeName("any")
+                .build();
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -2102,6 +2102,9 @@ For binary destination columns, the connector always binds the original bytes.
 Named `BYTES` schemas that retain the raw binary JDBC mapping are also eligible for encoding.
 Logical types that use `BYTES` as their underlying schema type, such as `Decimal`, retain their logical JDBC mapping and are not affected.
 The setting does not change the column types that the connector creates or adds through schema evolution.
+Schema evolution derives column types from the record schema alone, so for a `BYTES` field it always creates a binary column, to which a textual mode does not apply; the connector logs a warning when this occurs.
+To combine encoded landings with automatic schema evolution, either pre-create the destination columns as character types, or set `binary.handling.mode` on the source connector instead, which emits the fields with a string schema so that schema evolution creates character columns.
+Use this sink-side setting when different sinks that consume the same topics require different representations.
 
 Ensure that the destination character column can hold the encoded value.
 Base64 encoding requires approximately four characters for every three input bytes, while hexadecimal encoding requires two characters for every input byte.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -313,7 +313,7 @@ Set the value of the xref:jdbc-property-batch-size[`batch.size`] property to `1`
 +
 Some dialects and driver configurations process a batch in a single pass, rather than validating each row against the effects of the preceding rows in the same batch.
 For example, `MERGE`-based dialects can attempt two `INSERT` operations for the same primary key instead of an `INSERT` followed by an `UPDATE`.
-Similarly, when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is set to `true`, PostgreSQL combines a batch into a single multi-row statement.
+Similarly, when xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] is set to `true`, PostgreSQL and CockroachDB combine a batch into a single multi-row statement.
 In each of these cases, the batch fails.
 
 // Type: reference
@@ -2087,7 +2087,7 @@ The connector adds missing columns to the table by comparing the incoming event'
 
 |[[jdbc-property-binary-handling-mode]]<<jdbc-property-binary-handling-mode, `+binary.handling.mode+`>>
 |`bytes`
-|Specifies how the connector binds fields that use the Kafka Connect `BYTES` schema when the corresponding destination column is a character type, for example, `CHAR`, `VARCHAR`, `TEXT`, or `CLOB`.
+|Specifies how the connector binds fields that use the Kafka Connect `BYTES` schema and resolve to a raw binary JDBC type when the corresponding destination column is a character type, for example, `CHAR`, `VARCHAR`, `TEXT`, or `CLOB`.
 The following options are available:
 
 `bytes`:: Specifies that the connector binds binary values as raw bytes.
@@ -2099,7 +2099,12 @@ Depending on the database, the write might fail instead.
 
 This setting applies only to existing character columns.
 For binary destination columns, the connector always binds the original bytes.
+Named `BYTES` schemas that retain the raw binary JDBC mapping are also eligible for encoding.
+Logical types that use `BYTES` as their underlying schema type, such as `Decimal`, retain their logical JDBC mapping and are not affected.
 The setting does not change the column types that the connector creates or adds through schema evolution.
+
+Ensure that the destination character column can hold the encoded value.
+Base64 encoding requires approximately four characters for every three input bytes, while hexadecimal encoding requires two characters for every input byte.
 
 |[[jdbc-property-binary-handling-selector-base64]]<<jdbc-property-binary-handling-selector-base64, `+binary.handling.selector.base64+`>>
 |No default
@@ -2146,9 +2151,9 @@ The default is `public`; however, if the PostGIS extension was installed in anot
 
 |[[jdbc-property-dialect-postgres-unnest-insert-enabled]]<<jdbc-property-dialect-postgres-unnest-insert-enabled, `+dialect.postgres.unnest.insert.enabled+`>>
 |`false`
-|Specifies whether to enable `UNNEST`-based batch inserts for PostgreSQL.
+|Specifies whether to enable `UNNEST`-based batch inserts for PostgreSQL and CockroachDB targets.
 
-When enabled, uses PostgreSQL `UNNEST()` for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
+When enabled, the connector uses PostgreSQL-compatible `UNNEST()` statements for batch inserts, which can significantly improve performance by reducing the number of SQL statements executed.
 This optimization is compatible with `INSERT` and `UPSERT` modes.
 
 For information about the performance benefits of enabling the UNNEST function, see link:https://www.tigerdata.com/blog/boosting-postgres-insert-performance["Boosting Postgres Insert Performance"^] in the Tiger Data blog.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -2102,9 +2102,10 @@ For binary destination columns, the connector always binds the original bytes.
 Named `BYTES` schemas that retain the raw binary JDBC mapping are also eligible for encoding.
 Logical types that use `BYTES` as their underlying schema type, such as `Decimal`, retain their logical JDBC mapping and are not affected.
 The setting does not change the column types that the connector creates or adds through schema evolution.
-Schema evolution derives column types from the record schema alone, so for a `BYTES` field it always creates a binary column, to which a textual mode does not apply; the connector logs a warning when this occurs.
-To combine encoded landings with automatic schema evolution, either pre-create the destination columns as character types, or set `binary.handling.mode` on the source connector instead, which emits the fields with a string schema so that schema evolution creates character columns.
-Use this sink-side setting when different sinks that consume the same topics require different representations.
+For a `BYTES` field, schema evolution derives the destination type from the record schema and creates a binary column.
+Because textual modes apply only to existing character columns, the connector logs a warning when this occurs.
+For encoded landings, either pre-create the destination columns as character types or, when supported, configure `binary.handling.mode` on the source connector so that it emits fields with a string schema.
+The sink-side setting remains useful when sinks that consume the same topics require different representations.
 
 Ensure that the destination character column can hold the encoded value.
 Base64 encoding requires approximately four characters for every three input bytes, while hexadecimal encoding requires two characters for every input byte.

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -506,6 +506,8 @@ Because CockroachDB supports the PostgreSQL communication protocol, it works wit
 As a sink target, CockroachDB supports idempotent writes through the same xref:jdbc-property-insert-mode[`insert.mode=upsert`] setting that the connector uses for other databases.
 For CockroachDB, the connector generates `INSERT ... ON CONFLICT ... DO UPDATE SET ...` statements.
 
+Because the CockroachDB dialect derives from the PostgreSQL dialect, the `UNNEST`-based batch write optimization that the xref:jdbc-property-dialect-postgres-unnest-insert-enabled[`dialect.postgres.unnest.insert.enabled`] property enables also applies to CockroachDB targets.
+
 CockroachDB uses the `SERIALIZABLE` transaction isolation level.
 As a result, if CockroachDB detects a conflict between concurrent transactions, it might temporarily abort one of the transactions and return SQLSTATE `40001`.
 The connector treats these conflicts as retriable and retries the flush according to the xref:jdbc-property-flush-max-retries[`flush.max.retries`] and xref:jdbc-property-flush-retry-delay-ms[`flush.retry.delay.ms`] settings.
@@ -2082,6 +2084,47 @@ During startup or topic partition assignment, the connector validates that resol
 The connector does not validate the table structure against incoming events.
 `basic`:: Specifies that basic evolution occurs.
 The connector adds missing columns to the table by comparing the incoming event's record schema to the database table structure.
+
+|[[jdbc-property-binary-handling-mode]]<<jdbc-property-binary-handling-mode, `+binary.handling.mode+`>>
+|`bytes`
+|Specifies how the connector binds fields that use the Kafka Connect `BYTES` schema when the corresponding destination column is a character type, for example, `CHAR`, `VARCHAR`, `TEXT`, or `CLOB`.
+The following options are available:
+
+`bytes`:: Specifies that the connector binds binary values as raw bytes.
+When raw bytes are written to a character column, the destination database determines whether to convert the value and which textual representation to use.
+Depending on the database, the write might fail instead.
+`base64`:: Specifies that the connector binds binary values as Base64-encoded strings.
+`base64-url-safe`:: Specifies that the connector binds binary values as URL-safe Base64-encoded strings.
+`hex`:: Specifies that the connector binds binary values as hexadecimal-encoded (base16) strings.
+
+This setting applies only to existing character columns.
+For binary destination columns, the connector always binds the original bytes.
+The setting does not change the column types that the connector creates or adds through schema evolution.
+
+|[[jdbc-property-binary-handling-selector-base64]]<<jdbc-property-binary-handling-selector-base64, `+binary.handling.selector.base64+`>>
+|No default
+|Specifies a comma-separated list of regular expressions that select fields to bind as Base64-encoded strings, overriding the xref:jdbc-property-binary-handling-mode[`binary.handling.mode`] setting.
+The connector matches each expression against the topic-qualified field name, in the form `_<topicName>_:_<fieldName>_`, and against the plain field name.
+Matching is case-insensitive and must cover the entire name.
+For example, `server1\.inventory\.orders:payload` matches the `payload` field only in the `server1.inventory.orders` topic.
+
+If a field matches multiple selector properties, the connector evaluates the properties in the following order: `base64`, `base64-url-safe`, `hex`, and `bytes`.
+The first matching property determines the mode, and the connector logs a warning for the field, because overlapping selectors usually indicate a configuration mistake.
+
+|[[jdbc-property-binary-handling-selector-base64-url-safe]]<<jdbc-property-binary-handling-selector-base64-url-safe, `+binary.handling.selector.base64-url-safe+`>>
+|No default
+|Specifies a comma-separated list of regular expressions that select fields to bind as URL-safe Base64-encoded strings, overriding the xref:jdbc-property-binary-handling-mode[`binary.handling.mode`] setting.
+For information about matching and selector precedence, see the description of the xref:jdbc-property-binary-handling-selector-base64[`binary.handling.selector.base64`] property.
+
+|[[jdbc-property-binary-handling-selector-hex]]<<jdbc-property-binary-handling-selector-hex, `+binary.handling.selector.hex+`>>
+|No default
+|Specifies a comma-separated list of regular expressions that select fields to bind as hexadecimal-encoded (base16) strings, overriding the xref:jdbc-property-binary-handling-mode[`binary.handling.mode`] setting.
+For information about matching and selector precedence, see the description of the xref:jdbc-property-binary-handling-selector-base64[`binary.handling.selector.base64`] property.
+
+|[[jdbc-property-binary-handling-selector-bytes]]<<jdbc-property-binary-handling-selector-bytes, `+binary.handling.selector.bytes+`>>
+|No default
+|Specifies a comma-separated list of regular expressions that select fields to bind as raw bytes, overriding the xref:jdbc-property-binary-handling-mode[`binary.handling.mode`] setting.
+For information about matching and selector precedence, see the description of the xref:jdbc-property-binary-handling-selector-base64[`binary.handling.selector.base64`] property.
 
 |[[jdbc-property-collection-name-format]]<<jdbc-property-collection-name-format, `+collection.name.format+`>>
 |`+${topic}+`


### PR DESCRIPTION
Fixes debezium/dbz#2468

## Summary

Adds sink-side `binary.handling.mode` support for Kafka Connect `BYTES` fields written to character columns.

- Supports `bytes` (default), `base64`, `base64-url-safe`, and `hex`
- Supports field- and topic-qualified selectors
- Keeps binary target columns as raw bytes
- Safely handles mixed raw and encoded records in row-wise and UNNEST batches
- Preserves existing behavior when the default `bytes` mode is used

Schema evolution remains based on the Connect record schema. Therefore, with `schema.evolution=basic`, a `BYTES` field still creates or adds a binary column even when a textual mode is selected. The connector now logs a warning when this occurs.

## Testing

- Added unit tests for configuration, selectors, and encoding
- Added integration tests for character and binary target columns
- Added coverage for mixed raw and encoded records in row-wise and UNNEST paths
- Added schema evolution coverage for created and added binary columns

## Follow-up question

For a future follow-up, I’d be interested in thoughts on allowing schema evolution to create character columns for fields resolved to a textual binary handling mode. Unlike the current schema evolution model, this would make a value-handling option influence generated DDL. It would also require defining dialect-specific character types and sizing, as well as handling conflicts when multiple topics routed to the same table resolve the same field differently. Feedback on whether this coupling would be desirable, and on the preferred semantics, would be appreciated.
