### PR TITLE
debezium/dbz#2481 Replace Oracle-specific "redo log" terminology in BaseSourceTask with database-neutral wording

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-connector-common/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -97,9 +97,9 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
             if (offset == null) {
                 if (snapshotter.shouldSnapshotOnSchemaError()) {
-                    // We are in schema only recovery mode, use the existing redo log position
-                    // would like to also verify redo log position exists, but it defaults to 0 which is technically valid
-                    throw new DebeziumException("Could not find existing redo log information while attempting schema only recovery snapshot");
+                    // We are in schema only recovery mode, use the existing transaction log position
+                    // would like to also verify transaction log position exists, but it defaults to 0 which is technically valid
+                    throw new DebeziumException("Could not find existing transaction log information while attempting schema only recovery snapshot");
                 }
                 LOGGER.info("Connector started with no previous offset for partition '{}'", partition);
                 if (schema.isHistorized()) {

--- a/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
@@ -113,7 +113,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
 
         assertThatThrownBy(() -> baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
                 .isInstanceOf(DebeziumException.class)
-                .hasMessage("Could not find existing redo log information while attempting schema only recovery snapshot");
+                .hasMessage("Could not find existing transaction log information while attempting schema only recovery snapshot");
 
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2481