### PR TITLE
debezium/dbz#1286 Support BC-era timestamps in Oracle

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -14,6 +14,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -686,6 +687,12 @@ public class OracleConnection extends JdbcConnection {
     public Object getColumnValue(ResultSet rs, int columnIndex, Column column, Table table) throws SQLException {
         if (column.jdbcType() == OracleTypes.JSON || "JSON".equals(column.typeName())) {
             return rs.getObject(columnIndex, OracleJsonObject.class);
+        }
+        if ("DATE".equalsIgnoreCase(column.typeName())) {
+            // The driver maps DATE columns to java.sql.Timestamp, which is bound to the hybrid
+            // Julian/Gregorian calendar; that drops the era of BC values and day-shifts dates that
+            // precede the Gregorian cut-over in 1582, so fetch such columns as LocalDateTime.
+            return rs.getObject(columnIndex, LocalDateTime.class);
         }
         return super.getColumnValue(rs, columnIndex, column, table);
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -24,7 +24,9 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,10 +92,18 @@ public class OracleValueConverters extends JdbcValueConverters {
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, false)
             .optionalEnd()
             .optionalStart()
+            .appendLiteral(' ')
+            .appendText(ChronoField.ERA, TextStyle.SHORT)
+            .optionalEnd()
+            .optionalStart()
             .appendPattern(" ")
             .optionalEnd()
             .appendOffset("+HH:MM", "")
-            .toFormatter();
+            .optionalStart()
+            .appendLiteral(' ')
+            .appendText(ChronoField.ERA, TextStyle.SHORT)
+            .optionalEnd()
+            .toFormatter(Locale.ENGLISH);
 
     private static final Pattern TO_TIMESTAMP_TZ = Pattern.compile("TO_TIMESTAMP_TZ\\('(.*)'\\)", Pattern.CASE_INSENSITIVE);
     private static final BigDecimal MICROSECONDS_PER_SECOND = new BigDecimal(1_000_000);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -20,7 +20,6 @@ import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -670,11 +669,14 @@ public class OracleValueConverters extends JdbcValueConverters {
 
     protected Object fromOracleTimeClasses(Column column, Object data) {
         try {
+            // Conversions must use the java.time accessors; java.sql.Timestamp is bound to the hybrid
+            // Julian/Gregorian calendar, which drops the era of BC values and day-shifts dates that
+            // precede the Gregorian cut-over in 1582.
             if (data instanceof TIMESTAMP) {
-                data = ((TIMESTAMP) data).timestampValue();
+                data = ((TIMESTAMP) data).toLocalDateTime();
             }
             else if (data instanceof DATE) {
-                data = ((DATE) data).timestampValue();
+                data = ((DATE) data).toLocalDateTime();
             }
             else if (data instanceof TIMESTAMPTZ) {
                 final TIMESTAMPTZ ts = (TIMESTAMPTZ) data;
@@ -682,7 +684,7 @@ public class OracleValueConverters extends JdbcValueConverters {
             }
             else if (data instanceof TIMESTAMPLTZ) {
                 final TIMESTAMPLTZ ts = (TIMESTAMPLTZ) data;
-                data = ZonedDateTime.ofInstant(ts.timestampValue(connection.connection()).toInstant(), ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC);
+                data = ts.zonedDateTimeValue(connection.connection()).withZoneSameInstant(ZoneOffset.UTC);
             }
         }
         catch (SQLException e) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/AbstractLogMinerStreamingChangeEventSource.java
@@ -1753,11 +1753,14 @@ public abstract class AbstractLogMinerStreamingChangeEventSource
      * @throws SQLException if a database exception occurred
      */
     private void setNlsSessionParameters() throws SQLException {
+        // The era suffix is required so that BC values remain distinguishable from AD values in the
+        // redo SQL; NLS_DATE_LANGUAGE pins the era markers to "AD"/"BC" regardless of database locale.
         final String NLS_SESSION_PARAMETERS = "ALTER SESSION SET "
-                + "  NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
-                + "  NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF9'"
-                + "  NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF9 TZH:TZM'"
-                + "  NLS_NUMERIC_CHARACTERS = '.,'";
+                + "  NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS AD'"
+                + "  NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF9 AD'"
+                + "  NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF9 TZH:TZM AD'"
+                + "  NLS_NUMERIC_CHARACTERS = '.,'"
+                + "  NLS_DATE_LANGUAGE = 'AMERICAN'";
         streamingConnection.executeWithoutCommitting(NLS_SESSION_PARAMETERS);
 
         // This is necessary so that TIMESTAMP WITH LOCAL TIME ZONE is returned in UTC

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/util/TimestampUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/util/TimestampUtils.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
+import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
 import java.util.Locale;
 import java.util.Objects;
@@ -31,7 +32,11 @@ public final class TimestampUtils {
             .appendPattern(".")
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, false)
             .optionalEnd()
-            .toFormatter();
+            .optionalStart()
+            .appendLiteral(' ')
+            .appendText(ChronoField.ERA, TextStyle.SHORT)
+            .optionalEnd()
+            .toFormatter(Locale.ENGLISH);
 
     private static final DateTimeFormatter TIMESTAMP_AM_PM_SHORT_FORMATTER = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
@@ -82,6 +87,9 @@ public final class TimestampUtils {
             String text = timestampMatcher.group(1);
             if (text.indexOf(" AM") > 0 || text.indexOf(" PM") > 0) {
                 return "TO_TIMESTAMP('" + text + "', 'YYYY-MM-DD HH24:MI:SS.FF A')";
+            }
+            if (text.endsWith(" AD") || text.endsWith(" BC")) {
+                return "TO_TIMESTAMP('" + text + "', 'YYYY-MM-DD HH24:MI:SS.FF AD')";
             }
             return "TO_TIMESTAMP('" + text + "', 'YYYY-MM-DD HH24:MI:SS.FF')";
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBcDateTimeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBcDateTimeIT.java
@@ -64,6 +64,38 @@ public class OracleBcDateTimeIT extends AbstractAsyncEngineConnectorTest {
     @Test
     @FixFor("debezium/dbz#1286")
     public void shouldSnapshotBcAndPreGregorianCutoverValues() throws Exception {
+        insertRows();
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BC_DATETIME_TEST")
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        assertRows();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldStreamBcAndPreGregorianCutoverValues() throws Exception {
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BC_DATETIME_TEST")
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        insertRows();
+
+        assertRows();
+    }
+
+    private void insertRows() throws Exception {
         // 2018 BC (Oracle year -2018, ISO proleptic year -2017)
         connection.executeWithoutCommitting("INSERT INTO debezium.bc_datetime_test VALUES ("
                 + "1"
@@ -89,16 +121,9 @@ public class OracleBcDateTimeIT extends AbstractAsyncEngineConnectorTest {
                 + ", TO_TIMESTAMP_TZ('1500-03-01 01:34:56.00789 -05:00', 'YYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"
                 + ")");
         connection.execute("COMMIT");
+    }
 
-        Configuration config = TestHelper.defaultConfig()
-                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BC_DATETIME_TEST")
-                .build();
-
-        start(OracleConnector.class, config);
-        assertConnectorIsRunning();
-
-        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
-
+    private void assertRows() throws Exception {
         SourceRecords records = consumeRecordsByTopic(3);
         List<SourceRecord> testRecords = records.recordsForTopic("server1.DEBEZIUM.BC_DATETIME_TEST");
         assertThat(testRecords).hasSize(3);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBcDateTimeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBcDateTimeIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope.FieldName;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+import io.debezium.util.Testing;
+
+/**
+ * Tests the behavior of temporal data types that store BC era or pre-Gregorian cut-over values.
+ *
+ * @author Chris Cranford
+ */
+public class OracleBcDateTimeIT extends AbstractAsyncEngineConnectorTest {
+
+    private OracleConnection connection;
+
+    @BeforeEach
+    void before() throws Exception {
+        connection = TestHelper.testConnection();
+
+        TestHelper.dropTable(connection, "debezium.bc_datetime_test");
+
+        setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+
+        connection.execute("CREATE TABLE bc_datetime_test ("
+                + "id numeric(9,0) primary key, "
+                + "val_date date, "
+                + "val_ts timestamp(6), "
+                + "val_tstz timestamp(6) with time zone, "
+                + "val_tsltz timestamp(6) with local time zone)");
+        TestHelper.streamTable(connection, "debezium.bc_datetime_test");
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        if (connection != null && connection.isConnected()) {
+            TestHelper.dropTable(connection, "debezium.bc_datetime_test");
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldSnapshotBcAndPreGregorianCutoverValues() throws Exception {
+        // 2018 BC (Oracle year -2018, ISO proleptic year -2017)
+        connection.executeWithoutCommitting("INSERT INTO debezium.bc_datetime_test VALUES ("
+                + "1"
+                + ", TO_DATE('-2018-03-27 12:34:56', 'SYYYY-MM-DD HH24:MI:SS')"
+                + ", TO_TIMESTAMP('-2018-03-27 12:34:56.00789', 'SYYYY-MM-DD HH24:MI:SS.FF5')"
+                + ", TO_TIMESTAMP_TZ('-2018-03-27 01:34:56.00789 -11:00', 'SYYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"
+                + ", TO_TIMESTAMP_TZ('-2018-03-27 01:34:56.00789 -11:00', 'SYYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"
+                + ")");
+        // 1 BC (Oracle year -1, ISO proleptic year 0)
+        connection.executeWithoutCommitting("INSERT INTO debezium.bc_datetime_test VALUES ("
+                + "2"
+                + ", TO_DATE('-0001-12-31 23:59:59', 'SYYYY-MM-DD HH24:MI:SS')"
+                + ", TO_TIMESTAMP('-0001-12-31 23:59:59.99999', 'SYYYY-MM-DD HH24:MI:SS.FF5')"
+                + ", NULL"
+                + ", NULL"
+                + ")");
+        // 1500 AD, before the Gregorian calendar cut-over in 1582
+        connection.executeWithoutCommitting("INSERT INTO debezium.bc_datetime_test VALUES ("
+                + "3"
+                + ", TO_DATE('1500-03-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS')"
+                + ", TO_TIMESTAMP('1500-03-01 12:34:56.00789', 'YYYY-MM-DD HH24:MI:SS.FF5')"
+                + ", TO_TIMESTAMP_TZ('1500-03-01 01:34:56.00789 -05:00', 'YYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"
+                + ", TO_TIMESTAMP_TZ('1500-03-01 01:34:56.00789 -05:00', 'YYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"
+                + ")");
+        connection.execute("COMMIT");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BC_DATETIME_TEST")
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        SourceRecords records = consumeRecordsByTopic(3);
+        List<SourceRecord> testRecords = records.recordsForTopic("server1.DEBEZIUM.BC_DATETIME_TEST");
+        assertThat(testRecords).hasSize(3);
+
+        Struct after = afterStruct(testRecords.get(0));
+        assertThat(after.get("VAL_DATE")).isEqualTo(toEpochMillis(LocalDateTime.of(-2017, 3, 27, 12, 34, 56)));
+        assertThat(after.get("VAL_TS")).isEqualTo(toEpochMicros(LocalDateTime.of(-2017, 3, 27, 12, 34, 56, 7_890_000)));
+        assertThat(after.get("VAL_TSTZ")).isEqualTo("-2017-03-27T01:34:56.007890-11:00");
+        assertThat(after.get("VAL_TSLTZ")).isEqualTo("-2017-03-27T12:34:56.007890Z");
+
+        after = afterStruct(testRecords.get(1));
+        assertThat(after.get("VAL_DATE")).isEqualTo(toEpochMillis(LocalDateTime.of(0, 12, 31, 23, 59, 59)));
+        assertThat(after.get("VAL_TS")).isEqualTo(toEpochMicros(LocalDateTime.of(0, 12, 31, 23, 59, 59, 999_990_000)));
+        assertThat(after.get("VAL_TSTZ")).isNull();
+        assertThat(after.get("VAL_TSLTZ")).isNull();
+
+        after = afterStruct(testRecords.get(2));
+        assertThat(after.get("VAL_DATE")).isEqualTo(toEpochMillis(LocalDateTime.of(1500, 3, 1, 0, 0)));
+        assertThat(after.get("VAL_TS")).isEqualTo(toEpochMicros(LocalDateTime.of(1500, 3, 1, 12, 34, 56, 7_890_000)));
+        assertThat(after.get("VAL_TSTZ")).isEqualTo("1500-03-01T01:34:56.007890-05:00");
+        assertThat(after.get("VAL_TSLTZ")).isEqualTo("1500-03-01T06:34:56.007890Z");
+    }
+
+    private static Struct afterStruct(SourceRecord record) {
+        return (Struct) ((Struct) record.value()).get(FieldName.AFTER);
+    }
+
+    private static long toEpochMillis(LocalDateTime dateTime) {
+        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    private static long toEpochMicros(LocalDateTime dateTime) {
+        return dateTime.toInstant(ZoneOffset.UTC).getEpochSecond() * 1_000_000 + dateTime.getNano() / 1_000;
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -22,6 +23,7 @@ import org.mockito.Mockito;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.time.StructuredDuration;
@@ -31,6 +33,7 @@ import io.debezium.time.StructuredZonedTimestamp;
 
 import oracle.jdbc.OracleTypes;
 import oracle.sql.CharacterSet;
+import oracle.sql.DATE;
 import oracle.sql.INTERVALDS;
 import oracle.sql.INTERVALYM;
 import oracle.sql.TIMESTAMP;
@@ -167,6 +170,74 @@ public class OracleValueConvertersTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldConvertBcTimestampPreservingEra() {
+        final Column column = Column.editor()
+                .name("TS")
+                .type("TIMESTAMP")
+                .jdbcType(Types.TIMESTAMP)
+                .scale(6)
+                .optional(true)
+                .create();
+        final Field field = adaptiveFieldFor(column);
+
+        // Oracle year -2018 (2018 BC) is ISO proleptic year -2017
+        final LocalDateTime bc = LocalDateTime.of(-2017, 3, 27, 12, 34, 56, 7_890_000);
+        final Object result = convertersUtf8.converter(column, field).convert(new TIMESTAMP(bc));
+        assertThat(result).isEqualTo(toEpochMicros(bc));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldConvertBcDatePreservingEra() throws Exception {
+        final Column column = dateColumn();
+        final Field field = adaptiveFieldFor(column);
+
+        final LocalDateTime bc = LocalDateTime.of(-2017, 3, 27, 0, 0);
+        assertThat(convertersUtf8.converter(column, field).convert(new DATE(bc)))
+                .isEqualTo(bc.toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        // 1 BC (Oracle year -1) is ISO proleptic year 0
+        final LocalDateTime oneBc = LocalDateTime.of(0, 12, 31, 23, 59, 59);
+        assertThat(convertersUtf8.converter(column, field).convert(new DATE(oneBc)))
+                .isEqualTo(oneBc.toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        // Oracle's minimum date, 4712 BC
+        final LocalDateTime minimum = LocalDateTime.of(-4711, 1, 1, 0, 0);
+        assertThat(convertersUtf8.converter(column, field).convert(new DATE(minimum)))
+                .isEqualTo(minimum.toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldConvertBcTimestampWithTimeZonePreservingEra() throws Exception {
+        final Column column = Column.editor()
+                .name("TSTZ")
+                .type("TIMESTAMP WITH TIME ZONE")
+                .jdbcType(OracleTypes.TIMESTAMPTZ)
+                .scale(6)
+                .optional(true)
+                .create();
+        final Field field = adaptiveFieldFor(column);
+
+        final OffsetDateTime bc = OffsetDateTime.of(-2017, 3, 27, 1, 34, 56, 7_890_000, ZoneOffset.ofHours(-11));
+        final Object result = convertersUtf8.converter(column, field).convert(new TIMESTAMPTZ(bc));
+        assertThat(result).isEqualTo("-2017-03-27T01:34:56.007890-11:00");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void shouldConvertPreGregorianCutoverDateWithoutDayShift() throws Exception {
+        final Column column = dateColumn();
+        final Field field = adaptiveFieldFor(column);
+
+        // java.sql.Timestamp interprets this date in the Julian calendar, shifting it by 10 days
+        final LocalDateTime preCutover = LocalDateTime.of(1500, 3, 1, 0, 0);
+        assertThat(convertersUtf8.converter(column, field).convert(new DATE(preCutover)))
+                .isEqualTo(preCutover.toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
     public void shouldPreserveStructuredTimestampBeyondNanoTimestampRange() {
         final Column column = Column.editor()
                 .name("TS")
@@ -265,5 +336,25 @@ public class OracleValueConvertersTest {
     private Field fieldFor(Column column) {
         final Schema schema = convertersStructured.schemaBuilder(column).optional().build();
         return new Field(column.name(), 0, schema);
+    }
+
+    private Field adaptiveFieldFor(Column column) {
+        final Schema schema = convertersUtf8.schemaBuilder(column).optional().build();
+        return new Field(column.name(), 0, schema);
+    }
+
+    private static Column dateColumn() {
+        return Column.editor()
+                .name("VAL_DATE")
+                .type("DATE")
+                .jdbcType(Types.TIMESTAMP)
+                .scale(0)
+                .optional(true)
+                .create();
+    }
+
+    private static long toEpochMicros(LocalDateTime dateTime) {
+        final Instant instant = dateTime.toInstant(ZoneOffset.UTC);
+        return instant.getEpochSecond() * 1_000_000 + instant.getNano() / 1_000;
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
@@ -223,6 +223,11 @@ public class OracleValueConvertersTest {
         final OffsetDateTime bc = OffsetDateTime.of(-2017, 3, 27, 1, 34, 56, 7_890_000, ZoneOffset.ofHours(-11));
         final Object result = convertersUtf8.converter(column, field).convert(new TIMESTAMPTZ(bc));
         assertThat(result).isEqualTo("-2017-03-27T01:34:56.007890-11:00");
+
+        // The era-suffixed streaming representation, as mined with NLS_TIMESTAMP_TZ_FORMAT
+        final Object streamed = convertersUtf8.converter(column, field)
+                .convert("TO_TIMESTAMP_TZ('2018-03-27 01:34:56.007890000 -11:00 BC')");
+        assertThat(streamed).isEqualTo("-2017-03-27T01:34:56.007890-11:00");
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TimestampUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TimestampUtilsTest.java
@@ -54,4 +54,45 @@ public class TimestampUtilsTest {
         final Instant expected = LocalDateTime.of(0, 1, 2, 0, 0, 0, 123456789).toInstant(ZoneOffset.UTC);
         assertThat(TimestampUtils.convertTimestampNoZoneToInstant(value)).isEqualTo(expected);
     }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void testEraSuffixedDate() {
+        // 2018 BC (Oracle year -2018) is ISO proleptic year -2017
+        final String bc = "TO_DATE('2018-03-27 12:34:56 BC', 'YYYY-MM-DD HH24:MI:SS AD')";
+        assertThat(TimestampUtils.convertTimestampNoZoneToInstant(bc))
+                .isEqualTo(LocalDateTime.of(-2017, 3, 27, 12, 34, 56).toInstant(ZoneOffset.UTC));
+
+        final String ad = "TO_DATE('2018-03-27 12:34:56 AD', 'YYYY-MM-DD HH24:MI:SS AD')";
+        assertThat(TimestampUtils.convertTimestampNoZoneToInstant(ad))
+                .isEqualTo(LocalDateTime.of(2018, 3, 27, 12, 34, 56).toInstant(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void testEraSuffixedTimestamp() {
+        final String bc = "TO_TIMESTAMP('2018-03-27 12:34:56.007890000 BC')";
+        assertThat(TimestampUtils.convertTimestampNoZoneToInstant(bc))
+                .isEqualTo(LocalDateTime.of(-2017, 3, 27, 12, 34, 56, 7_890_000).toInstant(ZoneOffset.UTC));
+
+        final String ad = "TO_TIMESTAMP('2018-03-27 12:34:56.007890000 AD')";
+        assertThat(TimestampUtils.convertTimestampNoZoneToInstant(ad))
+                .isEqualTo(LocalDateTime.of(2018, 3, 27, 12, 34, 56, 7_890_000).toInstant(ZoneOffset.UTC));
+
+        // 1 BC (Oracle year -1) is ISO proleptic year 0
+        final String oneBc = "TO_TIMESTAMP('0001-12-31 23:59:59 BC')";
+        assertThat(TimestampUtils.convertTimestampNoZoneToInstant(oneBc))
+                .isEqualTo(LocalDateTime.of(0, 12, 31, 23, 59, 59).toInstant(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1286")
+    public void testEraSuffixedSqlCompliantFunctionCall() {
+        assertThat(TimestampUtils.toSqlCompliantFunctionCall("TO_TIMESTAMP('2018-03-27 12:34:56.00789 BC')"))
+                .isEqualTo("TO_TIMESTAMP('2018-03-27 12:34:56.00789 BC', 'YYYY-MM-DD HH24:MI:SS.FF AD')");
+        assertThat(TimestampUtils.toSqlCompliantFunctionCall("TO_TIMESTAMP('2018-03-27 12:34:56.00789 AD')"))
+                .isEqualTo("TO_TIMESTAMP('2018-03-27 12:34:56.00789 AD', 'YYYY-MM-DD HH24:MI:SS.FF AD')");
+        assertThat(TimestampUtils.toSqlCompliantFunctionCall("TO_TIMESTAMP('2018-03-27 12:34:56.00789')"))
+                .isEqualTo("TO_TIMESTAMP('2018-03-27 12:34:56.00789', 'YYYY-MM-DD HH24:MI:SS.FF')");
+    }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2673,6 +2673,25 @@ A string representation of a timestamp in UTC.
 
 |===
 
+[id="oracle-temporal-types-bc-era"]
+==== BC era and pre-Gregorian dates
+
+The connector emits temporal values that precede the common era (BC) or the Gregorian calendar cut-over in 1582 by using the proleptic Gregorian calendar of ISO 8601, matching the `java.time` semantics used across {prodname}.
+Temporal values in the common era (AD) from the year 1582 onward are unaffected by this mapping and are emitted exactly as described in the preceding sections.
+
+Because ISO 8601 includes a year zero and the Oracle calendar does not, BC years are offset by one in emitted values: Oracle year `-N` (N BC) corresponds to ISO year `-(N-1)`.
+For example, the Oracle date `-2018-03-27` (2018 BC) is emitted with the ISO year `-2017`.
+
+For epoch-based semantic types such as `io.debezium.time.Timestamp` and `io.debezium.time.MicroTimestamp`, BC values are emitted as negative values relative to the UNIX epoch.
+For string-based semantic types such as `io.debezium.time.ZonedTimestamp` and `io.debezium.time.IsoTimestamp`, BC values are emitted as ISO 8601 strings with a signed year, for example, `-2017-03-27T01:34:56.007890-11:00`.
+Consumers must be prepared to handle the leading sign in the year component.
+
+[IMPORTANT]
+====
+BC values stored in `TIMESTAMP(7 - 9)` columns exceed the representable range of `io.debezium.time.NanoTimestamp`, as described in the preceding note about the nanosecond range.
+If a column may contain BC values at nanosecond precision, use `time.precision.mode` set to `isostring` or `structured` to represent the values without loss.
+====
+
 [id="oracle-rowid-types"]
 === ROWID types
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1286
Supersedes #5644 

## Description
This PR adds support for Oracle's BC-era timestamp by emitting common era (BC) values with negative year values. Because Oracle stored BC years do not include a 0 year and ISO 8601 does, the BC values are always emitted using the formula:
```
Oracle Year -N (N BC) = ISO Year -(N - 1)
```
For example, Oracle date `-2018-03-27` (2018 BC) is ISO year `-2017`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
