### PR TITLE
debezium/dbz#1008 Support Oracle BC-era timestamps in JDBC sink w/timestamp value clamping

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -74,6 +74,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     public static final String FLUSH_MAX_RETRIES = "flush.max.retries";
     public static final String FLUSH_RETRY_DELAY_MS = "flush.retry.delay.ms";
     public static final String CONNECTION_RESTART_ON_ERRORS = "connection.restart.on.errors";
+    public static final String TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES = "timestamp.clamp.out.of.range.values";
 
     // todo add support for the ValueConverter contract
 
@@ -278,6 +279,19 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     "In environments where the sink database uses asynchronous replication, enabling this option may risk data loss or inconsistencies " +
                     "during failover if the replica has not fully caught up with the primary.");
 
+    public static final Field TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES_FIELD = Field.create(TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES)
+            .withDisplayName("Clamp out-of-range timestamp values")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(false)
+            .withDescription("Specifies whether temporal values that cannot be represented by the target database, " +
+                    "for example BC-era timestamps emitted by an Oracle source, are clamped to the target database's " +
+                    "minimum or maximum supported timestamp, mirroring how explicit infinity markers are handled. " +
+                    "When set to false (the default), out-of-range values are passed to the target database unchanged " +
+                    "and may cause the write to fail.");
+
     public static final Field COLLECTION_TABLE_FORMAT_FIELD = Field.create(COLLECTION_TABLE_FORMAT)
             .withDisplayName("Format string using table name")
             .withType(Type.STRING)
@@ -319,6 +333,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
                     FLUSH_MAX_RETRIES_FIELD,
                     FLUSH_RETRY_DELAY_MS_FIELD,
                     CONNECTION_RESTART_ON_ERRORS_FIELD,
+                    TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES_FIELD,
                     CLOUDEVENTS_SCHEMA_NAME_PATTERN_FIELD)
             .create();
 
@@ -450,6 +465,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
     private final boolean useReductionBuffer;
     private final KeyedMessageBatchMode keyedMessageBatchMode;
     private final boolean connectionRestartOnErrors;
+    private final boolean timestampClampOutOfRangeValues;
     private final String cloudEventsSchemaNamePattern;
     private final PrimaryKeyMode primaryKeyMode;
     private final Set<String> primaryKeyFields;
@@ -475,6 +491,7 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
         this.flushMaxRetries = config.getInteger(FLUSH_MAX_RETRIES_FIELD);
         this.flushRetryDelayMs = config.getLong(FLUSH_RETRY_DELAY_MS_FIELD);
         this.connectionRestartOnErrors = config.getBoolean(CONNECTION_RESTART_ON_ERRORS_FIELD);
+        this.timestampClampOutOfRangeValues = config.getBoolean(TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES_FIELD);
         this.cloudEventsSchemaNamePattern = config.getString(CLOUDEVENTS_SCHEMA_NAME_PATTERN_FIELD);
         this.collectionNamingStrategy = resolveCollectionNamingStrategy(config, props);
         this.columnNamingStrategy = resolveColumnNamingStrategy(config, props);
@@ -610,6 +627,10 @@ public class JdbcSinkConnectorConfig implements SinkConnectorConfig {
 
     public boolean isConnectionRestartOnErrors() {
         return connectionRestartOnErrors;
+    }
+
+    public boolean isTimestampClampForOutOfRangeValuesEnabled() {
+        return timestampClampOutOfRangeValues;
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/ZonedTimestampType.java
@@ -39,8 +39,11 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
     @Override
     protected List<ValueBindDescriptor> normalTimestampValue(int index, Object value) {
 
-        final ZonedDateTime zdt = ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
+        final ZonedDateTime zdt = clampIfOutOfRange(ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER)).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
 
-        return List.of(new ValueBindDescriptor(index, Timestamp.from(zdt.toInstant())));
+        // Bind the wall-clock in the database time zone rather than the instant; Timestamp.from
+        // relabels pre-Gregorian instants through the hybrid Julian calendar and the JVM zone,
+        // corrupting values clamped to the dialect's year-1 minimum.
+        return List.of(new ValueBindDescriptor(index, Timestamp.valueOf(zdt.toLocalDateTime())));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/connect/ConnectTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/connect/ConnectTimestampType.java
@@ -45,7 +45,7 @@ public class ConnectTimestampType extends AbstractTimestampType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         if (value instanceof java.util.Date) {
-            final LocalDateTime localDateTime = DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value);
+            final LocalDateTime localDateTime = clampIfOutOfRange(DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value));
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,
                         java.sql.Timestamp.valueOf(localDateTime.atZone(getDatabaseTimeZone().toZoneId()).toLocalDateTime())));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/debezium/AbstractDebeziumTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2/debezium/AbstractDebeziumTimestampType.java
@@ -30,7 +30,7 @@ public abstract class AbstractDebeziumTimestampType extends AbstractTimestampTyp
         }
         if (value instanceof Number) {
 
-            final LocalDateTime localDateTime = getLocalDateTime(((Number) value).longValue());
+            final LocalDateTime localDateTime = clampIfOutOfRange(getLocalDateTime(((Number) value).longValue()));
 
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/ZonedTimestampType.java
@@ -39,8 +39,11 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
     @Override
     protected List<ValueBindDescriptor> normalTimestampValue(int index, Object value) {
 
-        final ZonedDateTime zdt = ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
+        final ZonedDateTime zdt = clampIfOutOfRange(ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER)).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
 
-        return List.of(new ValueBindDescriptor(index, Timestamp.from(zdt.toInstant())));
+        // Bind the wall-clock in the database time zone rather than the instant; Timestamp.from
+        // relabels pre-Gregorian instants through the hybrid Julian calendar and the JVM zone,
+        // corrupting values clamped to the dialect's year-1 minimum.
+        return List.of(new ValueBindDescriptor(index, Timestamp.valueOf(zdt.toLocalDateTime())));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/connect/ConnectTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/connect/ConnectTimestampType.java
@@ -45,7 +45,7 @@ public class ConnectTimestampType extends AbstractTimestampType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         if (value instanceof java.util.Date) {
-            final LocalDateTime localDateTime = DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value);
+            final LocalDateTime localDateTime = clampIfOutOfRange(DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value));
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,
                         java.sql.Timestamp.valueOf(localDateTime.atZone(getDatabaseTimeZone().toZoneId()).toLocalDateTime())));

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/debezium/AbstractDebeziumTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/db2i/debezium/AbstractDebeziumTimestampType.java
@@ -30,7 +30,7 @@ public abstract class AbstractDebeziumTimestampType extends AbstractTimestampTyp
         }
         if (value instanceof Number) {
 
-            final LocalDateTime localDateTime = getLocalDateTime(((Number) value).longValue());
+            final LocalDateTime localDateTime = clampIfOutOfRange(getLocalDateTime(((Number) value).longValue()));
 
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTemporalLiteral.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.jdbc.dialect.mysql;
 
+import java.time.LocalDateTime;
+
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -31,6 +33,17 @@ final class StructuredTemporalLiteral {
                 value.getInt8(StructuredTemporal.MINUTE_FIELD),
                 value.getInt8(StructuredTemporal.SECOND_FIELD),
                 (nanos == null ? 0 : nanos) / 1_000);
+    }
+
+    static String timestamp(LocalDateTime value) {
+        return String.format("%04d-%02d-%02d %02d:%02d:%02d.%06d",
+                value.getYear(),
+                value.getMonthValue(),
+                value.getDayOfMonth(),
+                value.getHour(),
+                value.getMinute(),
+                value.getSecond(),
+                value.getNano() / 1_000);
     }
 
     static String duration(Struct value) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructuredTimestampType.java
@@ -6,11 +6,16 @@
 package io.debezium.connector.jdbc.dialect.mysql;
 
 import java.sql.Types;
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 
+import io.debezium.connector.jdbc.type.debezium.StructuredTemporalSupport;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
+import io.debezium.time.StructuredTemporal;
 
 /**
  * MySQL implementation of {@link io.debezium.time.StructuredTimestamp} values.
@@ -29,6 +34,31 @@ public class StructuredTimestampType extends io.debezium.connector.jdbc.type.deb
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(requireStruct(value)), Types.VARCHAR));
+        final Struct struct = requireStruct(value);
+        final LocalDateTime clamped = clampIfOutOfRange(struct);
+        if (clamped != null) {
+            return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(clamped), Types.VARCHAR));
+        }
+        return List.of(new ValueBindDescriptor(index, StructuredTemporalLiteral.timestamp(struct), Types.VARCHAR));
+    }
+
+    /**
+     * Returns the clamped date-time when the structured value is a finite, valid calendar value that
+     * lies outside the dialect's supported range; otherwise returns {@code null} so that the value is
+     * bound from its raw components, preserving MySQL's tolerance for invalid calendar literals.
+     */
+    private LocalDateTime clampIfOutOfRange(Struct struct) {
+        if (!StructuredTemporal.isFinite(struct)) {
+            return null;
+        }
+        final LocalDateTime localDateTime;
+        try {
+            localDateTime = StructuredTemporalSupport.toLocalDateTime(struct);
+        }
+        catch (DateTimeException e) {
+            return null;
+        }
+        final LocalDateTime clamped = clampIfOutOfRange(localDateTime);
+        return clamped.equals(localDateTime) ? null : clamped;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/ZonedTimestampType.java
@@ -38,7 +38,7 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
     @Override
     protected List<ValueBindDescriptor> normalTimestampValue(int index, Object value) {
 
-        final ZonedDateTime zdt = ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
+        final ZonedDateTime zdt = clampIfOutOfRange(ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER)).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
 
         return List.of(new ValueBindDescriptor(index, zdt, getJdbcBindType()));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/AbstractTemporalType.java
@@ -5,14 +5,20 @@
  */
 package io.debezium.connector.jdbc.type;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.sink.SinkConnectorConfig;
+import io.debezium.time.ZonedTimestamp;
 
 /**
  * An abstract base class for all temporal implementations of {@link JdbcType}.
@@ -24,10 +30,18 @@ public abstract class AbstractTemporalType extends AbstractType {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTemporalType.class);
 
     private TimeZone databaseTimeZone;
+    private boolean clampOutOfRangeValues;
+    private boolean timestampBoundsResolved;
+    private ZonedDateTime minimumTimestampValue;
+    private ZonedDateTime maximumTimestampValue;
 
     @Override
     public void configure(SinkConnectorConfig config, DatabaseDialect dialect) {
         super.configure(config, dialect);
+
+        if (config instanceof JdbcSinkConnectorConfig jdbcConfig) {
+            this.clampOutOfRangeValues = jdbcConfig.isTimestampClampForOutOfRangeValuesEnabled();
+        }
 
         final String databaseTimeZone = config.useTimeZone();
         try {
@@ -41,6 +55,74 @@ public abstract class AbstractTemporalType extends AbstractType {
 
     protected TimeZone getDatabaseTimeZone() {
         return databaseTimeZone;
+    }
+
+    /**
+     * Clamps the supplied value to the dialect's minimum or maximum supported timestamp when the
+     * value lies outside that range and {@code timestamp.clamp.out.of.range.values} is enabled;
+     * otherwise the value is returned unchanged.
+     */
+    protected ZonedDateTime clampIfOutOfRange(ZonedDateTime value) {
+        if (clampOutOfRangeValues) {
+            final ZonedDateTime minimum = getMinimumTimestampValue();
+            if (minimum != null && value.toInstant().isBefore(minimum.toInstant())) {
+                return minimum;
+            }
+            final ZonedDateTime maximum = getMaximumTimestampValue();
+            if (maximum != null && value.toInstant().isAfter(maximum.toInstant())) {
+                return maximum;
+            }
+        }
+        return value;
+    }
+
+    protected OffsetDateTime clampIfOutOfRange(OffsetDateTime value) {
+        return clampIfOutOfRange(value.toZonedDateTime()).toOffsetDateTime();
+    }
+
+    protected LocalDateTime clampIfOutOfRange(LocalDateTime value) {
+        if (clampOutOfRangeValues) {
+            final ZonedDateTime minimum = getMinimumTimestampValue();
+            if (minimum != null && value.isBefore(minimum.toLocalDateTime())) {
+                return minimum.toLocalDateTime();
+            }
+            final ZonedDateTime maximum = getMaximumTimestampValue();
+            if (maximum != null && value.isAfter(maximum.toLocalDateTime())) {
+                return maximum.toLocalDateTime();
+            }
+        }
+        return value;
+    }
+
+    private ZonedDateTime getMinimumTimestampValue() {
+        if (!timestampBoundsResolved) {
+            resolveTimestampBounds();
+        }
+        return minimumTimestampValue;
+    }
+
+    private ZonedDateTime getMaximumTimestampValue() {
+        if (!timestampBoundsResolved) {
+            resolveTimestampBounds();
+        }
+        return maximumTimestampValue;
+    }
+
+    private void resolveTimestampBounds() {
+        minimumTimestampValue = parseTimestampBound(getDialect().getTimestampNegativeInfinityValue());
+        maximumTimestampValue = parseTimestampBound(getDialect().getTimestampPositiveInfinityValue());
+        timestampBoundsResolved = true;
+    }
+
+    private static ZonedDateTime parseTimestampBound(String value) {
+        try {
+            return ZonedDateTime.parse(value, ZonedTimestamp.FORMATTER);
+        }
+        catch (DateTimeParseException e) {
+            // Dialects such as PostgreSQL represent infinity with markers the database understands
+            // natively rather than a finite timestamp; such dialects have no bound to clamp against.
+            return null;
+        }
     }
 
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectTimestampType.java
@@ -45,7 +45,7 @@ public class ConnectTimestampType extends AbstractTimestampType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         if (value instanceof java.util.Date) {
-            final LocalDateTime localDateTime = DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value);
+            final LocalDateTime localDateTime = clampIfOutOfRange(DateTimeUtils.toLocalDateTimeFromDate((java.util.Date) value));
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,
                         localDateTime.atZone(getDatabaseTimeZone().toZoneId()).toLocalDateTime(),

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/AbstractDebeziumTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/AbstractDebeziumTimestampType.java
@@ -29,7 +29,7 @@ public abstract class AbstractDebeziumTimestampType extends AbstractTimestampTyp
         }
         if (value instanceof Number) {
 
-            final LocalDateTime localDateTime = getLocalDateTime(((Number) value).longValue());
+            final LocalDateTime localDateTime = clampIfOutOfRange(getLocalDateTime(((Number) value).longValue()));
 
             if (getDialect().isTimeZoneSet()) {
                 return List.of(new ValueBindDescriptor(index,

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/DebeziumZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/DebeziumZonedTimestampType.java
@@ -73,7 +73,7 @@ public class DebeziumZonedTimestampType extends AbstractTimestampType {
     protected List<ValueBindDescriptor> normalTimestampValue(int index, Object value) {
 
         final ZonedDateTime zdt;
-        zdt = ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
+        zdt = clampIfOutOfRange(ZonedDateTime.parse((String) value, ZonedTimestamp.FORMATTER)).withZoneSameInstant(getDatabaseTimeZone().toZoneId());
 
         return List.of(new ValueBindDescriptor(index, zdt.toOffsetDateTime(), getJdbcBindType()));
     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredTimestampType.java
@@ -48,7 +48,7 @@ public class StructuredTimestampType extends AbstractTimestampType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        final LocalDateTime localDateTime = StructuredTemporalSupport.toLocalDateTime(requireStruct(value));
+        final LocalDateTime localDateTime = clampIfOutOfRange(StructuredTemporalSupport.toLocalDateTime(requireStruct(value)));
         return List.of(new ValueBindDescriptor(index, localDateTime, getJdbcType()));
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/StructuredZonedTimestampType.java
@@ -54,7 +54,7 @@ public class StructuredZonedTimestampType extends AbstractTimestampType {
         if (value == null) {
             return List.of(new ValueBindDescriptor(index, null));
         }
-        final OffsetDateTime offsetDateTime = StructuredTemporalSupport.toOffsetDateTime(requireStruct(value));
+        final OffsetDateTime offsetDateTime = clampIfOutOfRange(StructuredTemporalSupport.toOffsetDateTime(requireStruct(value)));
         return List.of(new ValueBindDescriptor(index, offsetDateTime, getJdbcType()));
     }
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/e2e/AbstractJdbcSinkPipelineIT.java
@@ -17,9 +17,11 @@ import java.sql.Clob;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
@@ -2867,6 +2869,132 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
     }
 
     @TestTemplate
+    @ForSource(value = { SourceType.ORACLE }, reason = "Only the Oracle source emits BC-era timestamp values")
+    // ISOSTRING values are stored as strings and have no range to clamp;
+    // NANOSECONDS cannot represent BC-era values as they exceed the range of io.debezium.time.NanoTimestamp
+    @WithTemporalPrecisionMode(exclude = { TemporalPrecisionMode.ISOSTRING, TemporalPrecisionMode.NANOSECONDS })
+    public void testTimestampDataTypeWithBcEraValueClamped(Source source, Sink sink) throws Exception {
+
+        final Properties sinkProperties = new Properties();
+        sinkProperties.put(JdbcSinkConnectorConfig.TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES, "true");
+
+        // 2018 BC (Oracle year -2018, ISO proleptic year -2017)
+        setUtcReadSessionTimeZone(sink);
+        try {
+            assertDataTypesNonKeyOnly(source,
+                    sink,
+                    List.of("timestamp(6)"),
+                    List.of("TO_TIMESTAMP('-2018-03-27 12:34:56', 'SYYYY-MM-DD HH24:MI:SS')"),
+                    List.of(getExpectedBcEraLocalDateTime(sink, LocalDateTime.of(-2017, 3, 27, 12, 34, 56))),
+                    null,
+                    sinkProperties,
+                    (record) -> assertColumn(sink, record, "data0", getTimestampType(source, false, 6)),
+                    (rs, index) -> readLocalDateTimeEraSafe(sink, rs, index));
+        }
+        finally {
+            resetReadSessionTimeZone(sink);
+        }
+    }
+
+    @TestTemplate
+    @ForSource(value = { SourceType.ORACLE }, reason = "Only the Oracle source emits BC-era timestamp values")
+    // ISOSTRING values are stored as strings and have no range to clamp;
+    // NANOSECONDS cannot represent BC-era values as they exceed the range of io.debezium.time.NanoTimestamp
+    @WithTemporalPrecisionMode(exclude = { TemporalPrecisionMode.ISOSTRING, TemporalPrecisionMode.NANOSECONDS })
+    public void testTimestampWithTimeZoneDataTypeWithBcEraValueClamped(Source source, Sink sink) throws Exception {
+
+        final Properties sinkProperties = new Properties();
+        sinkProperties.put(JdbcSinkConnectorConfig.TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES, "true");
+
+        // 2018 BC (Oracle year -2018, ISO proleptic year -2017), instant -2017-03-27T12:34:56Z
+        setUtcReadSessionTimeZone(sink);
+        try {
+            assertDataTypesNonKeyOnly(source,
+                    sink,
+                    List.of("timestamp(6) with time zone"),
+                    List.of("TO_TIMESTAMP_TZ('-2018-03-27 01:34:56 -11:00', 'SYYYY-MM-DD HH24:MI:SS TZH:TZM')"),
+                    List.of(getExpectedBcEraZonedDateTime(sink, ZonedDateTime.of(-2017, 3, 27, 12, 34, 56, 0, ZoneOffset.UTC))),
+                    null,
+                    sinkProperties,
+                    (record) -> assertColumn(sink, record, "data0", getTimestampWithTimezoneType(source, false, 6)),
+                    (rs, index) -> readZonedDateTimeEraSafe(sink, rs, index));
+        }
+        finally {
+            resetReadSessionTimeZone(sink);
+        }
+    }
+
+    private static LocalDateTime getExpectedBcEraLocalDateTime(Sink sink, LocalDateTime bcValue) {
+        return getExpectedBcEraZonedDateTime(sink, bcValue.atZone(ZoneOffset.UTC)).toLocalDateTime();
+    }
+
+    private static ZonedDateTime getExpectedBcEraZonedDateTime(Sink sink, ZonedDateTime bcValue) {
+        if (sink.getType().is(SinkType.MYSQL)) {
+            return ZonedDateTime.of(1970, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
+        }
+        else if (sink.getType().is(SinkType.SQLSERVER) || sink.getType().is(SinkType.DB2) || sink.getType().is(SinkType.DB2I)) {
+            return ZonedDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        }
+        // Oracle represents BC values natively and PostgreSQL has no finite clamp bounds
+        return bcValue;
+    }
+
+    private static boolean isBcEraCapableSink(Sink sink) {
+        return sink.getType().is(SinkType.ORACLE) || sink.getType().is(SinkType.POSTGRES) || sink.getType().is(SinkType.COCKROACHDB);
+    }
+
+    /**
+     * The PostgreSQL driver defaults the read session's time zone to the JVM default. CockroachDB
+     * renders BC-era {@code timestamptz} text inconsistently for region-based zones, pairing a wall
+     * clock computed at the zone's historic local-mean-time offset with the modern offset label, which
+     * corrupts the value on read. Pin the verification session to UTC around BC-era assertions only,
+     * so that other tests continue to read with the driver's default session behavior.
+     */
+    private static void setUtcReadSessionTimeZone(Sink sink) throws Exception {
+        if (sink.getType().is(SinkType.POSTGRES) || sink.getType().is(SinkType.COCKROACHDB)) {
+            try (Statement statement = sink.getConnection().createStatement()) {
+                statement.execute("SET TIME ZONE 'UTC'");
+            }
+        }
+    }
+
+    private static void resetReadSessionTimeZone(Sink sink) throws Exception {
+        if (sink.getType().is(SinkType.POSTGRES) || sink.getType().is(SinkType.COCKROACHDB)) {
+            try (Statement statement = sink.getConnection().createStatement()) {
+                statement.execute("RESET timezone");
+            }
+        }
+    }
+
+    /**
+     * Reads temporal columns through the driver's {@code java.time} accessors rather than
+     * {@link java.sql.Timestamp}: the hybrid Julian/Gregorian calendar of {@code java.sql.Timestamp}
+     * cannot faithfully represent BC-era values, and its wall-clock/instant conversions depend on the
+     * reading JVM's default time zone, which would make the absolute expectations of the BC-era tests
+     * dependent on the machine running the tests.
+     */
+    private static LocalDateTime readLocalDateTimeEraSafe(Sink sink, ResultSet rs, int index) throws Exception {
+        if (sink.getType().is(SinkType.DB2) || sink.getType().is(SinkType.DB2I)) {
+            // The JCC and JT400 drivers do not support the JDBC 4.2 java.time conversions. Their
+            // TIMESTAMP type is zoneless so the java.sql.Timestamp wall-clock round trip is
+            // symmetric regardless of the JVM's zone, and these sinks clamp BC values to an AD
+            // minimum, so the era hazard cannot arise.
+            return rs.getTimestamp(index).toLocalDateTime();
+        }
+        return rs.getObject(index, LocalDateTime.class);
+    }
+
+    private static ZonedDateTime readZonedDateTimeEraSafe(Sink sink, ResultSet rs, int index) throws Exception {
+        if (isBcEraCapableSink(sink) || sink.getType().is(SinkType.SQLSERVER)) {
+            // These sinks store the time zone with the value
+            return rs.getObject(index, OffsetDateTime.class).atZoneSameInstant(ZoneOffset.UTC);
+        }
+        // The remaining sinks store the value as a wall clock in the sink connector's configured
+        // use.time.zone, so reattach that zone to recover the instant
+        return readLocalDateTimeEraSafe(sink, rs, index).atZone(SINK_ZONE_ID).withZoneSameInstant(ZoneOffset.UTC);
+    }
+
+    @TestTemplate
     @ForSource(value = SourceType.POSTGRES, reason = "The SPARSEVEC data type only applies to PostgreSQL")
     @SkipWhenSink(value = SinkType.POSTGRES, reason = "This mapping is not designed to fail for PostgreSQL sinks")
     @WithPostgresExtension("vector")
@@ -3708,6 +3836,13 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
                                                     ConfigurationAdjuster configAdjuster, DataTypeColumnAssert columnAssert,
                                                     ColumnReader<U> columnReader)
             throws Exception {
+        assertDataTypesNonKeyOnly(source, sink, typeNames, values, expectedValues, configAdjuster, new Properties(), columnAssert, columnReader);
+    }
+
+    protected <T, U> void assertDataTypesNonKeyOnly(Source source, Sink sink, List<String> typeNames, List<T> values, List<U> expectedValues,
+                                                    ConfigurationAdjuster configAdjuster, Properties additionalSinkProperties,
+                                                    DataTypeColumnAssert columnAssert, ColumnReader<U> columnReader)
+            throws Exception {
         final String tableName = source.randomTableName();
 
         final String createSql = createTableFromTypes(source, tableName, false, typeNames, values);
@@ -3719,6 +3854,7 @@ public abstract class AbstractJdbcSinkPipelineIT extends AbstractJdbcSinkIT {
         sinkProperties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
         sinkProperties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.NONE.getValue());
         sinkProperties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.INSERT.getValue());
+        sinkProperties.putAll(additionalSinkProperties);
         startSink(source, sinkProperties, tableName);
 
         consumeAndAssert(sink, columnAssert, expectedValues, columnReader);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/TimestampClampOutOfRangeValuesTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/type/TimestampClampOutOfRangeValuesTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.connect.ConnectTimestampType;
+import io.debezium.connector.jdbc.type.debezium.DebeziumZonedTimestampType;
+import io.debezium.connector.jdbc.type.debezium.MicroTimestampType;
+import io.debezium.connector.jdbc.type.debezium.StructuredTimestampType;
+import io.debezium.connector.jdbc.type.debezium.StructuredZonedTimestampType;
+import io.debezium.doc.FixFor;
+import io.debezium.time.StructuredTimestamp;
+import io.debezium.time.StructuredZonedTimestamp;
+import io.debezium.time.ZonedTimestamp;
+
+/**
+ * Unit tests for the {@code timestamp.clamp.out.of.range.values} behavior of the temporal types,
+ * verifying that values outside the dialect's representable timestamp range, such as BC-era
+ * timestamps emitted by an Oracle source, are clamped to the dialect bounds when enabled.
+ *
+ * @author Chris Cranford
+ */
+@Tag("UnitTests")
+class TimestampClampOutOfRangeValuesTest {
+
+    // Bounds modeled on the MySQL dialect's TIMESTAMP range
+    private static final String MINIMUM_TIMESTAMP = "1970-01-01T00:00:01+00:00";
+    private static final String MAXIMUM_TIMESTAMP = "2038-01-19T03:14:07+00:00";
+
+    // 2018 BC (ISO proleptic year -2017), as emitted by the Oracle source for BC values
+    private static final LocalDateTime BC_DATE_TIME = LocalDateTime.of(-2017, 3, 27, 12, 34, 56);
+    private static final LocalDateTime ABOVE_MAXIMUM_DATE_TIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+    private static final LocalDateTime IN_RANGE_DATE_TIME = LocalDateTime.of(2018, 3, 27, 12, 34, 56);
+
+    private static final LocalDateTime MINIMUM_DATE_TIME = LocalDateTime.of(1970, 1, 1, 0, 0, 1);
+    private static final LocalDateTime MAXIMUM_DATE_TIME = LocalDateTime.of(2038, 1, 19, 3, 14, 7);
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range ZonedTimestamp values to the dialect bounds when enabled")
+    void shouldClampOutOfRangeZonedTimestampValues() {
+        final var type = new DebeziumZonedTimestampType();
+        type.configure(config(true), dialect());
+
+        final var below = type.bind(0, null, ZonedTimestamp.toIsoString(BC_DATE_TIME.atOffset(ZoneOffset.UTC), null));
+        assertThat(below.get(0).getValue()).isEqualTo(MINIMUM_DATE_TIME.atOffset(ZoneOffset.UTC));
+
+        final var above = type.bind(0, null, ZonedTimestamp.toIsoString(ABOVE_MAXIMUM_DATE_TIME.atOffset(ZoneOffset.UTC), null));
+        assertThat(above.get(0).getValue()).isEqualTo(MAXIMUM_DATE_TIME.atOffset(ZoneOffset.UTC));
+
+        final var inRange = type.bind(0, null, ZonedTimestamp.toIsoString(IN_RANGE_DATE_TIME.atOffset(ZoneOffset.UTC), null));
+        assertThat(inRange.get(0).getValue()).isEqualTo(IN_RANGE_DATE_TIME.atOffset(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should pass out-of-range ZonedTimestamp values through unchanged when disabled")
+    void shouldNotClampZonedTimestampValuesByDefault() {
+        final var type = new DebeziumZonedTimestampType();
+        type.configure(config(false), dialect());
+
+        final var below = type.bind(0, null, ZonedTimestamp.toIsoString(BC_DATE_TIME.atOffset(ZoneOffset.UTC), null));
+        assertThat(below.get(0).getValue()).isEqualTo(BC_DATE_TIME.atOffset(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range epoch-based timestamp values to the dialect bounds when enabled")
+    void shouldClampOutOfRangeEpochTimestampValues() {
+        final var type = new MicroTimestampType();
+        type.configure(config(true), dialect());
+
+        final var below = type.bind(0, null, toEpochMicros(BC_DATE_TIME));
+        assertThat(below.get(0).getValue()).isEqualTo(MINIMUM_DATE_TIME);
+
+        final var above = type.bind(0, null, toEpochMicros(ABOVE_MAXIMUM_DATE_TIME));
+        assertThat(above.get(0).getValue()).isEqualTo(MAXIMUM_DATE_TIME);
+
+        final var inRange = type.bind(0, null, toEpochMicros(IN_RANGE_DATE_TIME));
+        assertThat(inRange.get(0).getValue()).isEqualTo(IN_RANGE_DATE_TIME);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should pass out-of-range epoch-based timestamp values through unchanged when disabled")
+    void shouldNotClampEpochTimestampValuesByDefault() {
+        final var type = new MicroTimestampType();
+        type.configure(config(false), dialect());
+
+        final var below = type.bind(0, null, toEpochMicros(BC_DATE_TIME));
+        assertThat(below.get(0).getValue()).isEqualTo(BC_DATE_TIME);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range Kafka Connect timestamp values to the dialect bounds when enabled")
+    void shouldClampOutOfRangeConnectTimestampValues() {
+        final var type = new ConnectTimestampType();
+        type.configure(config(true), dialect());
+
+        final var below = type.bind(0, null, Date.from(BC_DATE_TIME.toInstant(ZoneOffset.UTC)));
+        assertThat(below.get(0).getValue()).isEqualTo(MINIMUM_DATE_TIME);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range structured timestamp values to the dialect bounds when enabled")
+    void shouldClampOutOfRangeStructuredTimestampValues() {
+        final var type = new StructuredTimestampType();
+        type.configure(config(true), dialect());
+
+        final var below = type.bind(0, null, StructuredTimestamp.from(BC_DATE_TIME));
+        assertThat(below.get(0).getValue()).isEqualTo(MINIMUM_DATE_TIME);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range structured zoned timestamp values to the dialect bounds when enabled")
+    void shouldClampOutOfRangeStructuredZonedTimestampValues() {
+        final var type = new StructuredZonedTimestampType();
+        type.configure(config(true), dialect());
+
+        final var below = type.bind(0, null, StructuredZonedTimestamp.from(BC_DATE_TIME.atOffset(ZoneOffset.UTC)));
+        assertThat(below.get(0).getValue()).isEqualTo(MINIMUM_DATE_TIME.atOffset(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should clamp out-of-range ZonedTimestamp values in dialects that override the normal value binding")
+    void shouldClampOutOfRangeZonedTimestampValuesInDialectOverrides() {
+        final var bcValue = ZonedTimestamp.toIsoString(BC_DATE_TIME.atOffset(ZoneOffset.UTC), null);
+
+        final var db2Type = new io.debezium.connector.jdbc.dialect.db2.ZonedTimestampType();
+        db2Type.configure(config(true), dialect());
+        assertThat(db2Type.bind(0, null, bcValue).get(0).getValue())
+                .isEqualTo(java.sql.Timestamp.valueOf(MINIMUM_DATE_TIME));
+
+        final var db2iType = new io.debezium.connector.jdbc.dialect.db2i.ZonedTimestampType();
+        db2iType.configure(config(true), dialect());
+        assertThat(db2iType.bind(0, null, bcValue).get(0).getValue())
+                .isEqualTo(java.sql.Timestamp.valueOf(MINIMUM_DATE_TIME));
+
+        final var oracleType = new io.debezium.connector.jdbc.dialect.oracle.ZonedTimestampType();
+        oracleType.configure(config(true), dialect());
+        assertThat(((java.time.ZonedDateTime) oracleType.bind(0, null, bcValue).get(0).getValue()).toInstant())
+                .isEqualTo(MINIMUM_DATE_TIME.toInstant(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should not clamp when the dialect has no finite timestamp bounds")
+    void shouldNotClampWhenDialectBoundsAreNotFiniteTimestamps() {
+        // PostgreSQL represents infinity with markers the database understands natively
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getTimestampNegativeInfinityValue()).thenReturn("-infinity");
+        when(dialect.getTimestampPositiveInfinityValue()).thenReturn("infinity");
+
+        final var type = new DebeziumZonedTimestampType();
+        type.configure(config(true), dialect);
+
+        final var below = type.bind(0, null, ZonedTimestamp.toIsoString(BC_DATE_TIME.atOffset(ZoneOffset.UTC), null));
+        assertThat(below.get(0).getValue()).isEqualTo(BC_DATE_TIME.atOffset(ZoneOffset.UTC));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1008")
+    @DisplayName("Should default timestamp.clamp.out.of.range.values to disabled")
+    void shouldDefaultToDisabled() {
+        final var config = new JdbcSinkConnectorConfig(Map.of());
+        assertThat(config.isTimestampClampForOutOfRangeValuesEnabled()).isFalse();
+
+        final var enabled = new JdbcSinkConnectorConfig(Map.of(JdbcSinkConnectorConfig.TIMESTAMP_CLAMP_OUT_OF_RANGE_VALUES, "true"));
+        assertThat(enabled.isTimestampClampForOutOfRangeValuesEnabled()).isTrue();
+    }
+
+    private static long toEpochMicros(LocalDateTime dateTime) {
+        final var instant = dateTime.toInstant(ZoneOffset.UTC);
+        return instant.getEpochSecond() * 1_000_000 + instant.getNano() / 1_000;
+    }
+
+    private static JdbcSinkConnectorConfig config(boolean clampEnabled) {
+        final JdbcSinkConnectorConfig config = mock(JdbcSinkConnectorConfig.class);
+        when(config.useTimeZone()).thenReturn("UTC");
+        when(config.isTimestampClampForOutOfRangeValuesEnabled()).thenReturn(clampEnabled);
+        return config;
+    }
+
+    private static DatabaseDialect dialect() {
+        final DatabaseDialect dialect = mock(DatabaseDialect.class);
+        when(dialect.getTimestampNegativeInfinityValue()).thenReturn(MINIMUM_TIMESTAMP);
+        when(dialect.getTimestampPositiveInfinityValue()).thenReturn(MAXIMUM_TIMESTAMP);
+        when(dialect.isTimeZoneSet()).thenReturn(false);
+        return dialect;
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -2176,6 +2176,17 @@ If the number of retries exceeds the retry value, the sink connector enters a _F
 When you set both the `flush.retry.delay.ms` and xref:jdbc-property-flush-max-retries[`flush.max.retries`] properties, it can affect the behavior of the Kafka link:https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms[max.poll.interval.ms] property.
 To prevent the connector from rebalancing, set the total retry time (flush.retry.delay.ms * flush.max.retries) to a value that is less than the value of `max.poll.interval.ms` (default is 5 minutes).
 ====
+
+|[[jdbc-property-timestamp-clamp-out-of-range-values]]<<jdbc-property-timestamp-clamp-out-of-range-values, `+timestamp.clamp.out.of.range.values+`>>
+|`false`
+|Specifies whether the connector clamps temporal values that the target database cannot represent to the minimum or maximum timestamp that the database supports.
+
+Some source databases can store temporal values that exceed the range of the target database.
+For example, an Oracle source can emit BC-era timestamps, which cannot be stored in a MySQL `TIMESTAMP` column, whose range begins at the UNIX epoch, or in a SQL Server `datetime2` column, whose range begins at year 1.
+When this property is set to `true`, the connector replaces such values with the target database's minimum or maximum supported timestamp, mirroring the way that it converts the explicit `infinity` and `-infinity` markers that a PostgreSQL source emits.
+When this property is set to `false` (the default), the connector passes out-of-range values to the target database unchanged, which typically causes the write to fail.
+
+Clamping alters the stored value; enable this option only when a lossy representation of out-of-range timestamps is acceptable for downstream consumers.
 |===
 
 // Type: reference


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1008
Supersedes https://github.com/debezium/debezium/pull/5996

## Description
Every database handles timestamps differently and offers a wide range of value sets, with Oracle predominately being the most expressive with BC-era timestamps. 

This change introduces `timestamp.clamp.out.of.range.values`, an opt-in feature that, when enabled, forces Oracle BC-era values to be clamped to the min timestamp value for the target dialect. Additionally, for timestamp values in AD-era, the same clamp logic is applied to the max timestamp value for the target dialect.

## Requirements
This PR builds on debezium/dbz#1286 and requires that PR to be merged and available in the nightly connect image before this PR's tests pass.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
