### PR TITLE
debezium/dbz#1201 Mask passwords in task configuration debug logging

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/async/AsyncEmbeddedEngine.java
@@ -392,7 +392,7 @@ public final class AsyncEmbeddedEngine<R> implements DebeziumEngine<R>, AsyncEng
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Following task configurations will be used for creating tasks:");
             for (int i = 0; i < taskConfigs.size(); i++) {
-                LOGGER.debug("Config #{}: {}", i, taskConfigs.get(i));
+                LOGGER.debug("Config #{}: {}", i, Configuration.from(taskConfigs.get(i)).withMaskedPasswords());
             }
         }
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/async/AsyncEmbeddedEngineTest.java
@@ -184,6 +184,52 @@ public class AsyncEmbeddedEngineTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1201")
+    void testTaskConfigurationIsLoggedWithMaskedPasswords() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(AsyncEmbeddedEngine.class);
+        logInterceptor.setLoggerLevel(AsyncEmbeddedEngine.class, Level.DEBUG);
+
+        final Properties props = new Properties();
+        props.put(EmbeddedEngineConfig.ENGINE_NAME.name(), "testing-connector");
+        props.setProperty(CommonConnectorConfig.TASKS_MAX.name(), "1");
+        props.put(EmbeddedEngineConfig.CONNECTOR_CLASS.name(), SimpleSourceConnector.class.getName());
+        props.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, OFFSET_STORE_PATH.toAbsolutePath().toString());
+        props.put(SimpleSourceConnector.BATCH_COUNT, 1);
+        props.setProperty("database.password", "this-should-be-masked");
+
+        final AtomicInteger recordsRead = new AtomicInteger(0);
+        DebeziumEngine.Builder<SourceRecord> builder = new AsyncEmbeddedEngine.AsyncEngineBuilder<>();
+        engine = builder
+                .using(props)
+                .notifying((records, committer) -> {
+                    for (SourceRecord record : records) {
+                        recordsRead.incrementAndGet();
+                        committer.markProcessed(record);
+                    }
+                })
+                .using(this.getClass().getClassLoader())
+                .build();
+
+        ExecutorService exec = Executors.newFixedThreadPool(1);
+        exec.execute(() -> {
+            LoggingContext.forConnector(getClass().getSimpleName(), "", "engine");
+            engine.run();
+        });
+
+        Awaitility.await()
+                .alias("Haven't read the record in time")
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(AbstractConnectorTest.waitTimeForEngine(), TimeUnit.SECONDS)
+                .until(() -> recordsRead.get() >= 1);
+
+        stopEngine();
+
+        // The task configuration is logged at DEBUG level with passwords masked
+        assertThat(logInterceptor.containsMessage("Config #0")).isTrue();
+        assertThat(logInterceptor.containsMessage("this-should-be-masked")).isFalse();
+    }
+
+    @Test
     void testTasksAreStoppedIfSomeFailsToStart() {
         final int NUMBER_OF_TASKS = 10;
         final Properties props = new Properties();


### PR DESCRIPTION
Fixes debezium/dbz#1201

The code originally referenced in the issue (`DebeziumServer.java`) was removed when the
server bootstrap moved to the Quarkus extensions, but the same exposure remains in the
shared engine: `AsyncEmbeddedEngine` logs raw task configurations — including
`database.password` — at DEBUG level when creating source tasks.

Mask the values via `Configuration#withMaskedPasswords()`, as `BaseSourceTask` already
does for its startup configuration logging. Verified with a unit test that fails before
the fix (plaintext password present in the log output) and passes after.
