### PR TITLE
debezium/dbz#2420 JDBC type + length detection

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -139,9 +139,13 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
         final boolean[] maxColumns = new boolean[columnCount];
         boolean hasAnyMaxColumn = false;
         for (int i = 0; i < columnCount; ++i) {
-            resultColumns.add(rsmd.getColumnName(columnDataOffset + i));
+            final String columnName = rsmd.getColumnName(columnDataOffset + i);
+            resultColumns.add(columnName);
+            final Column column = columnMap.getSourceTableColumns().get(columnName);
             final int jdbcType = rsmd.getColumnType(columnDataOffset + i);
-            maxColumns[i] = SqlServerDatabaseSchema.isMaxColumnJdbcType(jdbcType);
+            maxColumns[i] = column != null
+                    ? SqlServerDatabaseSchema.isMaxColumn(column)
+                    : SqlServerDatabaseSchema.isMaxColumnJdbcType(jdbcType);
             if (maxColumns[i]) {
                 hasAnyMaxColumn = true;
             }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -142,10 +142,13 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
             final String columnName = rsmd.getColumnName(columnDataOffset + i);
             resultColumns.add(columnName);
             final Column column = columnMap.getSourceTableColumns().get(columnName);
-            final int jdbcType = rsmd.getColumnType(columnDataOffset + i);
-            maxColumns[i] = column != null
-                    ? SqlServerDatabaseSchema.isMaxColumn(column)
-                    : SqlServerDatabaseSchema.isMaxColumnJdbcType(jdbcType);
+            if (column != null) {
+                maxColumns[i] = SqlServerDatabaseSchema.isMaxColumn(column);
+            }
+            else {
+                final int jdbcType = rsmd.getColumnType(columnDataOffset + i);
+                maxColumns[i] = SqlServerDatabaseSchema.isMaxColumnJdbcType(jdbcType);
+            }
             if (maxColumns[i]) {
                 hasAnyMaxColumn = true;
             }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -91,16 +91,20 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
      * @return {@code true} if the column is a max-type column
      */
     public static boolean isMaxColumn(Column column) {
-        switch (column.jdbcType()) {
+        return isMaxColumn(column.jdbcType(), column.length());
+    }
+
+    private static boolean isMaxColumn(int jdbcType, int length) {
+        switch (jdbcType) {
             case Types.LONGVARCHAR:
             case Types.LONGNVARCHAR:
             case Types.LONGVARBINARY:
                 return true;
             case Types.VARCHAR:
             case Types.VARBINARY:
-                return column.length() == SQL_SERVER_MAX_BYTE_LENGTH;
+                return length == SQL_SERVER_MAX_BYTE_LENGTH;
             case Types.NVARCHAR:
-                return column.length() == SQL_SERVER_MAX_NATIONAL_CHARACTER_LENGTH;
+                return length == SQL_SERVER_MAX_NATIONAL_CHARACTER_LENGTH;
             default:
                 return false;
         }
@@ -114,9 +118,7 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
      * @return {@code true} if the JDBC type is a max-type
      */
     public static boolean isMaxColumnJdbcType(int jdbcType) {
-        return jdbcType == Types.LONGVARCHAR
-                || jdbcType == Types.LONGNVARCHAR
-                || jdbcType == Types.LONGVARBINARY;
+        return isMaxColumn(jdbcType, Column.UNSET_INT_VALUE);
     }
 
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -34,6 +34,8 @@ import io.debezium.spi.topic.TopicNamingStrategy;
 public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerDatabaseSchema.class);
+    private static final int SQL_SERVER_MAX_BYTE_LENGTH = Integer.MAX_VALUE;
+    private static final int SQL_SERVER_MAX_NATIONAL_CHARACTER_LENGTH = Integer.MAX_VALUE / 2;
 
     public SqlServerDatabaseSchema(SqlServerConnectorConfig connectorConfig, SqlServerDefaultValueConverter defaultValueConverter,
                                    ValueConverterProvider valueConverter, TopicNamingStrategy<TableId> topicNamingStrategy,
@@ -89,7 +91,19 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
      * @return {@code true} if the column is a max-type column
      */
     public static boolean isMaxColumn(Column column) {
-        return isMaxColumnJdbcType(column.jdbcType());
+        switch (column.jdbcType()) {
+            case Types.LONGVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.LONGVARBINARY:
+                return true;
+            case Types.VARCHAR:
+            case Types.VARBINARY:
+                return column.length() == SQL_SERVER_MAX_BYTE_LENGTH;
+            case Types.NVARCHAR:
+                return column.length() == SQL_SERVER_MAX_NATIONAL_CHARACTER_LENGTH;
+            default:
+                return false;
+        }
     }
 
     /**

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMaxColumnTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMaxColumnTest.java
@@ -74,6 +74,48 @@ public class SqlServerMaxColumnTest {
     }
 
     @Test
+    @FixFor("dbz#2420")
+    void shouldIdentifyMaxColumnFromSqlServerMaxLengthColumnModel() {
+        final var varcharMax = Column.editor()
+                .name("col_varchar_max")
+                .jdbcType(Types.VARCHAR)
+                .length(Integer.MAX_VALUE)
+                .create();
+        final var nvarcharMax = Column.editor()
+                .name("col_nvarchar_max")
+                .jdbcType(Types.NVARCHAR)
+                .length(Integer.MAX_VALUE / 2)
+                .create();
+        final var varbinaryMax = Column.editor()
+                .name("col_varbinary_max")
+                .jdbcType(Types.VARBINARY)
+                .length(Integer.MAX_VALUE)
+                .create();
+        final var varchar100 = Column.editor()
+                .name("col_varchar")
+                .jdbcType(Types.VARCHAR)
+                .length(100)
+                .create();
+        final var nvarchar100 = Column.editor()
+                .name("col_nvarchar")
+                .jdbcType(Types.NVARCHAR)
+                .length(100)
+                .create();
+        final var varbinary100 = Column.editor()
+                .name("col_varbinary")
+                .jdbcType(Types.VARBINARY)
+                .length(100)
+                .create();
+
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varcharMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(nvarcharMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varbinaryMax)).isTrue();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varchar100)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(nvarchar100)).isFalse();
+        assertThat(SqlServerDatabaseSchema.isMaxColumn(varbinary100)).isFalse();
+    }
+
+    @Test
     @FixFor("dbz#1164")
     void shouldConvertUnavailableValueToPlaceholderString() {
         final var converters = new SqlServerValueConverters(


### PR DESCRIPTION
Fixes debezium/dbz#2420

This change fixes SQL Server max-column detection for `varchar(max)`, `nvarchar(max)`, and `varbinary(max)` columns when the JDBC result-set metadata reports them as regular `VARCHAR`, `NVARCHAR`, or `VARBINARY` types.

The change now checks the source table column model, including JDBC type and length, before falling back to result-set JDBC type detection. This allows unchanged max columns in SQL Server CDC update events to use the configured `unavailable.value.placeholder`.

 Added test coverage for max-length column detection.
