### PR TITLE
debezium/dbz#2491 LogMinerDmlParser performance improvements

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableImpl.java
@@ -6,10 +6,13 @@
 package io.debezium.relational;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.PackagePrivate;
 import io.debezium.util.Interner;
@@ -17,10 +20,12 @@ import io.debezium.util.Strings;
 
 final class TableImpl implements Table {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableImpl.class);
+
     private final TableId id;
     private final List<Column> columnDefs;
     private final List<String> pkColumnNames;
-    private final Map<String, Column> columnsByLowercaseName;
+    private final Map<String, Column> columnsByName;
     private final String defaultCharsetName;
     private final String comment;
     private final List<Attribute> attributes;
@@ -35,11 +40,15 @@ final class TableImpl implements Table {
         this.id = Interner.intern(id);
         this.columnDefs = Interner.intern(Collections.unmodifiableList(sortedColumns));
         this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Interner.intern(Collections.unmodifiableList(pkColumnNames));
-        Map<String, Column> defsByLowercaseName = new LinkedHashMap<>();
+        Map<String, Column> defsByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (Column def : this.columnDefs) {
-            defsByLowercaseName.put(Interner.intern(def.name().toLowerCase()), def);
+            final Column shadowed = defsByName.put(Interner.intern(def.name()), def);
+            if (shadowed != null) {
+                LOGGER.warn("Table '{}' defines columns '{}' and '{}' whose names differ only by case; lookups by column name will resolve to '{}'",
+                        this.id, shadowed.name(), def.name(), def.name());
+            }
         }
-        this.columnsByLowercaseName = Interner.intern(Collections.unmodifiableMap(defsByLowercaseName));
+        this.columnsByName = Interner.intern(Collections.unmodifiableMap(defsByName));
         this.defaultCharsetName = Interner.intern(defaultCharsetName);
         this.comment = Interner.intern(comment);
         this.attributes = attributes == null ? null : Interner.intern(Collections.unmodifiableList(attributes));
@@ -69,7 +78,7 @@ final class TableImpl implements Table {
 
     @Override
     public Column columnWithName(String name) {
-        return columnsByLowercaseName.get(name.toLowerCase());
+        return columnsByName.get(name);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -301,23 +301,29 @@ public class LogMinerDmlParser implements DmlParser {
 
         int columnIndex = 0;
         int sqlLength = sql.length();
-        StringBuilder collectedValue = null;
+        String collectedValue = null;
+        StringBuilder valueBuffer = null;
+        int valueStart = -1;
         for (; index < sqlLength; ++index) {
             char c = sql.charAt(index);
-            char lookAhead = (index + 1 < sqlLength) ? sql.charAt(index + 1) : 0;
 
             if (inQuote) {
                 if (c != '\'') {
-                    collectedValue.append(c);
+                    // part of the quoted value, collected in bulk when the segment or value ends
+                    continue;
                 }
-                else if (lookAhead == '\'') {
-                    collectedValue.append('\'');
+                char lookAhead = (index + 1 < sqlLength) ? sql.charAt(index + 1) : 0;
+                if (lookAhead == '\'') {
+                    // escaped single quote, collect the segment up to and including the quote character
+                    valueBuffer = appendValueSegment(valueBuffer, sql, valueStart, index + 1);
                     // In relaxed mode, '' before an end-of-value boundary means (lone ') + (closing ').
                     // Check whether the following after '' chars signal end-of-value.
                     lookAhead = (index + 2 < sqlLength) ? sql.charAt(index + 2) : 0;
                     if (useRelaxedQuotes && (lookAhead == ',' || lookAhead == ')')) {
+                        valueStart = index + 1;
                         continue;
                     }
+                    valueStart = index + 2;
                     index = index + 1;
                     continue;
                 }
@@ -328,27 +334,26 @@ public class LogMinerDmlParser implements DmlParser {
                     // signify the next value, or the end parenthesis to identify that being the last column value.
                     // Obviously if the text has "'," or "')" as the text sequence, this rule will fail, but there
                     // really is no other way to identify this.
-                    collectedValue.append(c);
                     continue;
                 }
+                inQuote = false;
+                collectedValue = collectValue(valueBuffer, sql, valueStart, index);
+                valueBuffer = null;
+                continue;
             }
 
-            if (c == '(' && !inQuote && !inValues) {
+            if (c == '(' && !inValues) {
                 inValues = true;
                 start = index + 1;
             }
-            else if (c == '(' && !inQuote) {
+            else if (c == '(') {
                 nested++;
             }
             else if (c == '\'') {
-                if (inQuote) {
-                    inQuote = false;
-                    continue;
-                }
                 inQuote = true;
-                collectedValue = new StringBuilder();
+                valueStart = index + 1;
             }
-            else if (!inQuote && (c == ',' || c == ')')) {
+            else if (c == ',' || c == ')') {
                 if (c == ')' && nested != 0) {
                     nested--;
                     continue;
@@ -364,9 +369,9 @@ public class LogMinerDmlParser implements DmlParser {
                 }
 
                 if (sql.charAt(start) == '\'' && sql.charAt(index - 1) == '\'') {
-                    // value is single-quoted at the start/end, substring without the quotes.
+                    // value is single-quoted at the start/end, use the collected value without the quotes.
                     int position = getColumnIndexByName(columnNames[columnIndex], table);
-                    values[position] = collectedValue.toString();
+                    values[position] = collectedValue;
                     collectedValue = null;
                 }
                 else {
@@ -417,31 +422,33 @@ public class LogMinerDmlParser implements DmlParser {
 
         int index = start;
         String currentColumnName = null;
-        StringBuilder collectedValue = null;
+        StringBuilder valueBuffer = null;
+        int valueStart = -1;
         for (; index < sql.length(); ++index) {
             char c = sql.charAt(index);
+            if (inSingleQuote && c != '\'') {
+                // part of the quoted value, collected in bulk when the segment or value ends
+                continue;
+            }
+
             char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
             char lookAhead2 = (index + 2 < sql.length()) ? sql.charAt(index + 2) : 0;
             char lookAhead3 = (index + 3 < sql.length()) ? sql.charAt(index + 3) : 0;
 
-            if (inSingleQuote) {
-                if (c != '\'') {
-                    collectedValue.append(c);
+            if (inSingleQuote && lookAhead == '\'') {
+                // escaped single quote, collect the segment up to and including the quote character
+                valueBuffer = appendValueSegment(valueBuffer, sql, valueStart, index + 1);
+                // In relaxed mode, '' before an end-of-value boundary means (lone ') + (closing ').
+                // Check whether the following after '' chars signal end-of-value.
+                if (useRelaxedQuotes && (sql.startsWith(", \"", index + 2) ||
+                        sql.startsWith(" where ", index + 2) ||
+                        (lookAhead2 == ';' && lookAhead3 == 0))) {
+                    valueStart = index + 1;
+                    continue;
                 }
-                else {
-                    if (lookAhead == '\'') {
-                        collectedValue.append('\'');
-                        // In relaxed mode, '' before an end-of-value boundary means (lone ') + (closing ').
-                        // Check whether the following after '' chars signal end-of-value.
-                        if (useRelaxedQuotes && (sql.startsWith(", \"", index + 2) ||
-                                sql.startsWith(" where ", index + 2) ||
-                                (lookAhead2 == ';' && lookAhead3 == 0))) {
-                            continue;
-                        }
-                        index = index + 1;
-                        continue;
-                    }
-                }
+                valueStart = index + 2;
+                index = index + 1;
+                continue;
             }
 
             if (c == '"' && inColumnName) {
@@ -492,8 +499,7 @@ public class LogMinerDmlParser implements DmlParser {
                         // reached end of the SQL
                     }
                     else {
-                        // found a solo single quote, treat it as part of value
-                        collectedValue.append(c);
+                        // found a solo single quote, treat it as part of value; it remains in the current segment
                         continue;
                     }
                 }
@@ -501,19 +507,20 @@ public class LogMinerDmlParser implements DmlParser {
                 if (inSingleQuote) {
                     inSingleQuote = false;
                     if (nested == 0) {
-                        setColumnValue(currentColumnName, collectedValue, table, newValues);
-                        collectedValue = null;
+                        setColumnValue(currentColumnName, collectValue(valueBuffer, sql, valueStart, index), table, newValues);
                         start = index + 1;
                         inColumnValue = false;
                         inColumnName = false;
                     }
+                    valueBuffer = null;
                     continue;
                 }
                 if (!inSpecial) {
                     start = index;
                 }
                 inSingleQuote = true;
-                collectedValue = new StringBuilder();
+                valueStart = index + 1;
+                valueBuffer = null;
             }
             else if (c == ',' && !inColumnValue && !inColumnName) {
                 // Set clause uses ', ' skip following space
@@ -625,21 +632,21 @@ public class LogMinerDmlParser implements DmlParser {
 
         int index = start;
         String currentColumnName = null;
-        StringBuilder collectedValue = null;
+        StringBuilder valueBuffer = null;
+        int valueStart = -1;
         for (; index < sql.length(); ++index) {
             char c = sql.charAt(index);
+            if (inSingleQuote && c != '\'') {
+                // part of the quoted value, collected in bulk when the segment or value ends
+                continue;
+            }
             char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
-            if (inSingleQuote) {
-                if (c != '\'') {
-                    collectedValue.append(c);
-                }
-                else {
-                    if (lookAhead == '\'') {
-                        collectedValue.append('\'');
-                        index = index + 1;
-                        continue;
-                    }
-                }
+            if (inSingleQuote && lookAhead == '\'') {
+                // escaped single quote, collect the segment up to and including the quote character
+                valueBuffer = appendValueSegment(valueBuffer, sql, valueStart, index + 1);
+                valueStart = index + 2;
+                index = index + 1;
+                continue;
             }
             if (c == '"' && inColumnName) {
                 // Where clause column names are double-quoted
@@ -676,19 +683,20 @@ public class LogMinerDmlParser implements DmlParser {
                 if (inSingleQuote) {
                     inSingleQuote = false;
                     if (nested == 0) {
-                        setColumnValue(currentColumnName, collectedValue, table, values);
-                        collectedValue = null;
+                        setColumnValue(currentColumnName, collectValue(valueBuffer, sql, valueStart, index), table, values);
                         start = index + 1;
                         inColumnValue = false;
                         inColumnName = false;
                     }
+                    valueBuffer = null;
                     continue;
                 }
                 if (!inSpecial) {
                     start = index;
                 }
                 inSingleQuote = true;
-                collectedValue = new StringBuilder();
+                valueStart = index + 1;
+                valueBuffer = null;
             }
             else if (inColumnValue && !inSingleQuote) {
                 if (!inSpecial) {
@@ -757,10 +765,38 @@ public class LogMinerDmlParser implements DmlParser {
         }
     }
 
-    private void setColumnValue(String columnName, StringBuilder columnValue, Table table, Object[] values) {
-        if (!ORA_ARCHIVE_STATE.equals(columnName)) {
-            int position = getColumnIndexByName(columnName, table);
-            values[position] = columnValue.toString();
+    /**
+     * Appends the SQL fragment between {@code start} (inclusive) and {@code end} (exclusive) to the
+     * buffer, materializing the buffer if it does not yet exist.  A buffer is only materialized when
+     * a quoted value contains an escape sequence; values without escapes are collected directly from
+     * the SQL text by {@link #collectValue(StringBuilder, String, int, int)} without intermediate copies.
+     *
+     * @param buffer the current value buffer, may be {@code null} if no escape has been seen yet
+     * @param sql the sql statement
+     * @param start the segment start index, inclusive
+     * @param end the segment end index, exclusive
+     * @return the buffer with the segment appended, never {@code null}
+     */
+    private static StringBuilder appendValueSegment(StringBuilder buffer, String sql, int start, int end) {
+        if (buffer == null) {
+            buffer = new StringBuilder(Math.max(16, (end - start) * 2));
         }
+        return buffer.append(sql, start, end);
+    }
+
+    /**
+     * Collects the final text of a quoted column value that ends at {@code end}, exclusive.
+     *
+     * @param buffer the current value buffer, {@code null} when the value contains no escape sequences
+     * @param sql the sql statement
+     * @param start the start index of the trailing value segment, inclusive
+     * @param end the end index of the trailing value segment, exclusive
+     * @return the collected column value, never {@code null}
+     */
+    private static String collectValue(StringBuilder buffer, String sql, int start, int end) {
+        if (buffer == null) {
+            return sql.substring(start, end);
+        }
+        return buffer.append(sql, start, end).toString();
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -493,7 +493,7 @@ public class LogMinerDmlParser implements DmlParser {
                     if (lookAhead == ',' && lookAhead2 == ' ' && (lookAhead3 == '\"' || lookAhead3 == 'w')) {
                         // reached end of value
                     }
-                    else if (lookAhead == ' ' && lookAhead2 == 'w' && sql.substring(index + 1).startsWith(" where ")) {
+                    else if (lookAhead == ' ' && lookAhead2 == 'w' && sql.startsWith(" where ", index + 1)) {
                         // reached each of set clause and moving onto where condition
                     }
                     else if (lookAhead == ';' && lookAhead2 == 0) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -294,7 +294,7 @@ public class LogMinerDmlParser implements DmlParser {
         boolean inValues = false;
 
         // verify entering values-clause
-        if (sql.indexOf(VALUES, index) != index) {
+        if (!sql.startsWith(VALUES, index)) {
             throw new DebeziumException("Failed to parse DML: " + sql);
         }
         index += VALUES_LENGTH;
@@ -421,19 +421,18 @@ public class LogMinerDmlParser implements DmlParser {
         start += SET_LENGTH;
 
         int index = start;
+        int sqlLength = sql.length();
         String currentColumnName = null;
         StringBuilder valueBuffer = null;
         int valueStart = -1;
-        for (; index < sql.length(); ++index) {
+        for (; index < sqlLength; ++index) {
             char c = sql.charAt(index);
             if (inSingleQuote && c != '\'') {
                 // part of the quoted value, collected in bulk when the segment or value ends
                 continue;
             }
 
-            char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
-            char lookAhead2 = (index + 2 < sql.length()) ? sql.charAt(index + 2) : 0;
-            char lookAhead3 = (index + 3 < sql.length()) ? sql.charAt(index + 3) : 0;
+            char lookAhead = (index + 1 < sqlLength) ? sql.charAt(index + 1) : 0;
 
             if (inSingleQuote && lookAhead == '\'') {
                 // escaped single quote, collect the segment up to and including the quote character
@@ -442,7 +441,7 @@ public class LogMinerDmlParser implements DmlParser {
                 // Check whether the following after '' chars signal end-of-value.
                 if (useRelaxedQuotes && (sql.startsWith(", \"", index + 2) ||
                         sql.startsWith(" where ", index + 2) ||
-                        (lookAhead2 == ';' && lookAhead3 == 0))) {
+                        (index + 3 == sqlLength && sql.charAt(index + 2) == ';'))) {
                     valueStart = index + 1;
                     continue;
                 }
@@ -474,7 +473,7 @@ public class LogMinerDmlParser implements DmlParser {
             }
             else if (nested == 0 && c == '|' && lookAhead == '|' && !inSingleQuote) {
                 // Concatenation
-                for (int i = index + 2; i < sql.length(); ++i) {
+                for (int i = index + 2; i < sqlLength; ++i) {
                     if (sql.charAt(i) != ' ') {
                         // found next non-whitespace character
                         index = i - 1;
@@ -489,6 +488,8 @@ public class LogMinerDmlParser implements DmlParser {
                     continue;
                 }
                 if (useRelaxedQuotes && inSingleQuote && nested == 0) {
+                    char lookAhead2 = (index + 2 < sqlLength) ? sql.charAt(index + 2) : 0;
+                    char lookAhead3 = (index + 3 < sqlLength) ? sql.charAt(index + 3) : 0;
                     if (lookAhead == ',' && lookAhead2 == ' ' && (lookAhead3 == '\"' || lookAhead3 == 'w')) {
                         // reached end of value
                     }
@@ -528,20 +529,20 @@ public class LogMinerDmlParser implements DmlParser {
                 index += 1;
                 start = index;
             }
-            else if (c == '/' && lookAhead == '*' && lookAhead2 == ' ' && inColumnValue && !inSingleQuote) {
+            else if (c == '/' && lookAhead == '*' && index + 2 < sqlLength && sql.charAt(index + 2) == ' ' && inColumnValue && !inSingleQuote) {
                 // Handles special use cases of hints, e.g. '/* JSON */' in values
                 if (!inSpecial) {
                     start = index;
                     inSpecial = true;
                 }
-                for (int i = index + 2; i < sql.length() - 1; i++) {
+                for (int i = index + 2; i < sqlLength - 1; i++) {
                     if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
                         index = i + 1;
                         break;
                     }
                 }
                 // Skip whitespace between comment and the actual value
-                while (index + 1 < sql.length() && sql.charAt(index + 1) == ' ') {
+                while (index + 1 < sqlLength && sql.charAt(index + 1) == ' ') {
                     index++;
                 }
             }
@@ -585,7 +586,7 @@ public class LogMinerDmlParser implements DmlParser {
                 }
             }
             else if (!inDoubleQuote && !inSingleQuote) {
-                if (c == 'w' && lookAhead == 'h' && sql.indexOf(WHERE, index - 1) == index - 1) {
+                if (c == 'w' && lookAhead == 'h' && sql.startsWith(WHERE, index - 1)) {
                     index -= 1;
                     break;
                 }
@@ -631,16 +632,17 @@ public class LogMinerDmlParser implements DmlParser {
         start += WHERE_LENGTH;
 
         int index = start;
+        int sqlLength = sql.length();
         String currentColumnName = null;
         StringBuilder valueBuffer = null;
         int valueStart = -1;
-        for (; index < sql.length(); ++index) {
+        for (; index < sqlLength; ++index) {
             char c = sql.charAt(index);
             if (inSingleQuote && c != '\'') {
                 // part of the quoted value, collected in bulk when the segment or value ends
                 continue;
             }
-            char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
+            char lookAhead = (index + 1 < sqlLength) ? sql.charAt(index + 1) : 0;
             if (inSingleQuote && lookAhead == '\'') {
                 // escaped single quote, collect the segment up to and including the quote character
                 valueBuffer = appendValueSegment(valueBuffer, sql, valueStart, index + 1);
@@ -667,7 +669,7 @@ public class LogMinerDmlParser implements DmlParser {
                 start = index + 1;
             }
             else if (c == 'I' && !inColumnName && !inColumnValue) {
-                if (sql.indexOf(IS_NULL, index) == index) {
+                if (sql.startsWith(IS_NULL, index)) {
                     index += 6;
                     start = index;
                     continue;
@@ -714,7 +716,7 @@ public class LogMinerDmlParser implements DmlParser {
                 }
                 else if (nested == 0 && c == '|' && lookAhead == '|') {
                     // Concatenation
-                    for (int i = index + 2; i < sql.length(); ++i) {
+                    for (int i = index + 2; i < sqlLength; ++i) {
                         if (sql.charAt(i) != ' ') {
                             // found next non-whitespace character
                             index = i - 1;
@@ -742,12 +744,12 @@ public class LogMinerDmlParser implements DmlParser {
                 }
             }
             else if (!inColumnValue && !inColumnName) {
-                if (c == 'a' && lookAhead == 'n' && sql.indexOf(AND, index) == index) {
+                if (c == 'a' && lookAhead == 'n' && sql.startsWith(AND, index)) {
                     index += 3;
                     start = index;
                     inColumnName = true;
                 }
-                else if (c == 'o' && lookAhead == 'r' && sql.indexOf(OR, index) == index) {
+                else if (c == 'o' && lookAhead == 'r' && sql.startsWith(OR, index)) {
                     index += 2;
                     start = index;
                     inColumnName = true;

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserUpdatePerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserUpdatePerf.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.connector.oracle.parser;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.logminer.parser.DmlParser;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlParser;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+
+/**
+ * A benchmark that measures the performance of parsing {@code UPDATE} statements by the
+ * LogMiner DML parser when column values are large character payloads, such as standard
+ * {@code VARCHAR2} columns or 32K extended strings.
+ *
+ * Two value shapes are measured for each value size:
+ * <ul>
+ *     <li>plain values that contain no single quotes</li>
+ *     <li>values that contain escaped single quotes ({@code ''}) at regular intervals</li>
+ * </ul>
+ *
+ * The SQL text is generated from a fixed random seed so that runs before and after parser
+ * changes operate on byte-identical statements.
+ *
+ * @author Chris Cranford
+ */
+public class LogMinerDmlParserUpdatePerf {
+
+    @State(Scope.Thread)
+    public static class ParserState {
+
+        private static final int QUOTE_INTERVAL = 64;
+        private static final long SEED = 42L;
+        private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 abcdefghijklmnopqrstuvwxyz";
+
+        public DmlParser dmlParser;
+        public Table table;
+        public String plainValuesUpdateDml;
+        public String escapedQuotesUpdateDml;
+
+        @Param({ "2", "10", "50" })
+        public int columnCount;
+
+        @Param({ "50", "4000", "32000" })
+        public int valueLength;
+
+        @Setup(Level.Trial)
+        public void doSetup() {
+            dmlParser = new LogMinerDmlParser(new OracleConnectorConfig(Configuration.empty()));
+            table = createTable();
+            plainValuesUpdateDml = updateStatement(false);
+            escapedQuotesUpdateDml = updateStatement(true);
+        }
+
+        private Table createTable() {
+            TableEditor editor = Table.editor()
+                    .tableId(TableId.parse("DEBEZIUM.TEST"))
+                    .addColumn(Column.editor().name("ID").create());
+
+            for (int i = 0; i < columnCount; ++i) {
+                editor.addColumn(Column.editor().name("COL" + i).create());
+            }
+
+            return editor.create();
+        }
+
+        private String updateStatement(boolean withEscapedQuotes) {
+            final Random random = new Random(SEED);
+            final StringBuilder sb = new StringBuilder("update \"DEBEZIUM\".\"TEST\" set \"ID\" = '1'");
+            for (int i = 0; i < columnCount; ++i) {
+                sb.append(", \"COL").append(i).append("\" = '").append(getColumnValue(random, withEscapedQuotes)).append("'");
+            }
+            sb.append(" where \"ID\" = '1'");
+            for (int i = 0; i < columnCount; ++i) {
+                sb.append(" and \"COL").append(i).append("\" = '").append(getColumnValue(random, withEscapedQuotes)).append("'");
+            }
+            return sb.append(";").toString();
+        }
+
+        private String getColumnValue(Random random, boolean withEscapedQuotes) {
+            final StringBuilder sb = new StringBuilder(valueLength + 16);
+            for (int i = 0; i < valueLength; ++i) {
+                if (withEscapedQuotes && i > 0 && i % QUOTE_INTERVAL == 0) {
+                    // an escaped single quote, contributing one literal quote character to the value
+                    sb.append("''");
+                }
+                else {
+                    sb.append(CHARS.charAt(random.nextInt(CHARS.length())));
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(value = 1)
+    @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+    public LogMinerDmlEntry testUpdateWithPlainValues(ParserState state) {
+        return state.dmlParser.parse(state.plainValuesUpdateDml, state.table);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(value = 1)
+    @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+    public LogMinerDmlEntry testUpdateWithEscapedQuoteValues(ParserState state) {
+        return state.dmlParser.parse(state.escapedQuotesUpdateDml, state.table);
+    }
+}

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserUpdatePerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/parser/LogMinerDmlParserUpdatePerf.java
@@ -115,6 +115,74 @@ public class LogMinerDmlParserUpdatePerf {
         }
     }
 
+    @State(Scope.Thread)
+    public static class RelaxedParserState {
+
+        private static final int QUOTE_INTERVAL = 64;
+        private static final int COLUMN_COUNT = 10;
+        private static final long SEED = 42L;
+        private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 abcdefghijklmnopqrstuvwxyz";
+
+        public DmlParser dmlParser;
+        public Table table;
+        public String loneQuoteUpdateDml;
+
+        @Param({ "50", "4000", "32000" })
+        public int valueLength;
+
+        @Setup(Level.Trial)
+        public void doSetup() {
+            dmlParser = new LogMinerDmlParser(new OracleConnectorConfig(Configuration.create()
+                    .with(OracleConnectorConfig.LOG_MINING_SQL_RELAXED_QUOTE_DETECTION, "true")
+                    .build()));
+            table = createTable();
+            loneQuoteUpdateDml = updateStatement();
+            // fail fast during setup if the statement shape cannot be parsed
+            dmlParser.parse(loneQuoteUpdateDml, table);
+        }
+
+        private Table createTable() {
+            TableEditor editor = Table.editor()
+                    .tableId(TableId.parse("DEBEZIUM.TEST"))
+                    .addColumn(Column.editor().name("ID").create());
+
+            for (int i = 0; i < COLUMN_COUNT; ++i) {
+                editor.addColumn(Column.editor().name("COL" + i).create());
+            }
+
+            return editor.create();
+        }
+
+        private String updateStatement() {
+            final Random random = new Random(SEED);
+            final StringBuilder sb = new StringBuilder("update \"DEBEZIUM\".\"TEST\" set \"ID\" = '1'");
+            for (int i = 0; i < COLUMN_COUNT; ++i) {
+                sb.append(", \"COL").append(i).append("\" = '").append(getColumnValue(random)).append("'");
+            }
+            sb.append(" where \"ID\" = '1'");
+            for (int i = 0; i < COLUMN_COUNT; ++i) {
+                sb.append(" and \"COL").append(i).append("\" = '").append(getColumnValue(random)).append("'");
+            }
+            return sb.append(";").toString();
+        }
+
+        private String getColumnValue(Random random) {
+            final StringBuilder sb = new StringBuilder(valueLength + 16);
+            for (int i = 0; i < valueLength; ++i) {
+                if (i > 0 && i % QUOTE_INTERVAL == 0) {
+                    // an unescaped apostrophe followed by " w", the sequence that forces relaxed
+                    // quote detection to test whether the where-clause starts at this position;
+                    // the trailing "x" guarantees the value never contains a real " where " token
+                    sb.append("' wx");
+                }
+                else {
+                    sb.append(CHARS.charAt(random.nextInt(CHARS.length())));
+                }
+            }
+            return sb.toString();
+        }
+    }
+
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
@@ -123,6 +191,16 @@ public class LogMinerDmlParserUpdatePerf {
     @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
     public LogMinerDmlEntry testUpdateWithPlainValues(ParserState state) {
         return state.dmlParser.parse(state.plainValuesUpdateDml, state.table);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(value = 1)
+    @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+    public LogMinerDmlEntry testUpdateWithLoneQuoteRelaxedValues(RelaxedParserState state) {
+        return state.dmlParser.parse(state.loneQuoteUpdateDml, state.table);
     }
 
     @Benchmark


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2491

## Description
This PR introduces 5 improvements to the Oracle LogMiner DML parser to increase throughput, especially for wide tables or SQL operations with large values. All details about each change improvement can be found in the above GitHub issue.

With all changes applied, UPDATE parse throughput improves 1.7x to 2.6x (70% to 160%) across every measured shape (2-50 columns, 50-32,000-char values, with and without escaped quotes), and up to 94x (9300%) in relaxed quote detection mode for large column values. 

The net change here should be pure performance, no behavioral changes.

@jpechane this is the PR I mentioned would drop the `TreeMap` in `TableImpl`.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
