### PR TITLE
debezium/dbz#2492 Optimize JMX LastEvent metric rendering with JsonStringEncoder

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/SchemaUtil.java
@@ -28,8 +28,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
 /**
  * Utilities for obtaining JSON string representations of {@link Schema}, {@link Struct}, and {@link Field} objects.
@@ -132,7 +131,6 @@ public class SchemaUtil {
     }
 
     private static class RecordWriter {
-        private final ObjectMapper om = new ObjectMapper();
         private final StringBuilder sb = new StringBuilder();
         private boolean detailed = false;
 
@@ -243,13 +241,7 @@ public class SchemaUtil {
                 sb.append('}');
             }
             else if (obj instanceof String) {
-                try {
-                    String escaped = om.writeValueAsString(obj.toString());
-                    sb.append(escaped);
-                }
-                catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                sb.append('"').append(JsonStringEncoder.getInstance().quoteAsString(obj.toString())).append('"');
             }
             else if (obj instanceof Type) {
                 sb.append('"').append(obj.toString()).append('"');

--- a/debezium-connector-common/src/test/java/io/debezium/data/SchemaUtilTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/SchemaUtilTest.java
@@ -8,6 +8,8 @@ package io.debezium.data;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -66,5 +68,26 @@ public class SchemaUtilTest {
         var mapper = new ObjectMapper();
         var read = mapper.readValue(escapedText, String.class);
         assertThat(read).isEqualTo(originalText);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2492")
+    public void escapesStringsIdenticallyToObjectMapper() throws JsonProcessingException {
+        var samples = new ArrayList<>(List.of(
+                "",
+                "plain",
+                "quote\" backslash\\ slash/",
+                "café ✓ 🚀",
+                "lone surrogate: \ud800 end"));
+        var controlChars = new StringBuilder();
+        for (char c = 0; c < 0x20; c++) {
+            controlChars.append(c);
+        }
+        samples.add(controlChars.toString());
+
+        var mapper = new ObjectMapper();
+        for (String sample : samples) {
+            assertThat(SchemaUtil.asString(sample)).isEqualTo(mapper.writeValueAsString(sample));
+        }
     }
 }

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/core/EventSummaryPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/core/EventSummaryPerf.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.core;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.debezium.data.SchemaUtil;
+
+/**
+ * Measures the per-event cost of rendering an event as a JSON-ish string, as done by the
+ * pipeline metrics' last-event summary ({@code CommonEventMeter#onEvent} via
+ * {@code EventFormatter} and {@link SchemaUtil#asDetailedString(Struct)}) for every
+ * dispatched change record.
+ */
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode({ Mode.AverageTime })
+public class EventSummaryPerf {
+
+    @Param({ "4", "16" })
+    private int stringFieldCount;
+
+    private Struct value;
+
+    @Setup
+    public void setup() {
+        final SchemaBuilder builder = SchemaBuilder.struct().name("bench.value");
+        for (int i = 0; i < stringFieldCount; i++) {
+            builder.field("col" + i, Schema.STRING_SCHEMA);
+        }
+        final Schema schema = builder.build();
+        final Struct struct = new Struct(schema);
+        for (int i = 0; i < stringFieldCount; i++) {
+            struct.put("col" + i, "value-" + i + "-0123456789abcdef0123456789abcdef");
+        }
+        this.value = struct;
+    }
+
+    @Benchmark
+    public String benchmarkAsDetailedStringStruct() {
+        return SchemaUtil.asDetailedString(value);
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2492

The pipeline metrics render every dispatched event into a JSON summary string for the JMX `LastEvent` attribute, constructing a new Jackson `ObjectMapper` per event. The mapper was only used for string escaping, so this change replaces it with jackson-core's stateless `JsonStringEncoder`. The rendered output is byte-identical — a unit test asserts equivalence against `ObjectMapper` output for quotes, backslashes, control characters, and non-ASCII input. No new dependency and no behavior change.

### Measured effect

Per event (JMH with `-prof gc`, benchmark added in this PR):

| | 4 string fields | 16 string fields |
|---|---|---|
| before | 1,340 ns/op · 12,800 B/op | 2,757 ns/op · 25,824 B/op |
| after | 188 ns/op · 2,352 B/op | 767 ns/op · 9,128 B/op |

End-to-end:

| connector | throughput | allocation/row | GC count | process CPU |
|---|---|---|---|---|
| PostgreSQL 18 | +47% (231k → 339k rows/s) | −54% (16.9 → 7.8 KB) | 15 → 8 | −28% |
| MySQL 8.4 | +38% (274k → 377k rows/s) | −50% (18.1 → 9.1 KB) | 19 → 11 | −21% |

<details>
<summary>How these were measured</summary>

Embedded-engine snapshot of a 1M-row table (6 text columns, ~240 bytes of text per row) against a Docker database; fresh JVM per run (fixed 2 GB heap), before/after builds run interleaved, medians of n=5. throughput = rows/s from first to last received record; allocation/row = `ThreadMXBean#getTotalThreadAllocatedBytes` delta ÷ rows; GC count = `GarbageCollectorMXBean` delta; process CPU = `OperatingSystemMXBean#getProcessCpuTime` delta. JMH: average-time mode, 1 fork, 5×1s warmup + 5×1s measurement, `-prof gc` for B/op, following the existing `debezium-microbenchmark` conventions. Environment: Apple Silicon — deltas are the signal, not absolute numbers.
</details>

Also adds a microbenchmark covering this path, following the existing `debezium-microbenchmark` conventions, so the cost stays measurable for future changes.
