### PR TITLE
debezium/dbz#2493 Apply the field default in Configuration.getList(Field)

### DIFF
--- a/debezium-config/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-config/src/main/java/io/debezium/config/Configuration.java
@@ -1039,7 +1039,7 @@ public interface Configuration {
     String getString(String key);
 
     default List<String> getList(Field field) {
-        return getList(field.name());
+        return getList(field, ",", Function.identity());
     }
 
     default List<String> getList(String key) {
@@ -1047,11 +1047,16 @@ public interface Configuration {
     }
 
     default <T> List<T> getList(Field field, String separator, Function<String, T> converter) {
-        return getList(field.name(), separator, converter);
+        // Resolve through getString(Field) so the field's default value (and deprecated aliases) are
+        // applied, consistent with getString(Field)/getInteger(Field)/etc.
+        return splitToList(getString(field), separator, converter);
     }
 
     default <T> List<T> getList(String key, String separator, Function<String, T> converter) {
-        var value = getString(key);
+        return splitToList(getString(key), separator, converter);
+    }
+
+    private static <T> List<T> splitToList(String value, String separator, Function<String, T> converter) {
         return value == null ? List.of()
                 : Arrays.stream(value.split(Pattern.quote(separator)))
                         .map(String::trim)
@@ -1133,7 +1138,13 @@ public interface Configuration {
      * @see String#split(String)
      */
     default List<String> getStrings(Field field, String regex) {
-        return getStrings(field.name(), regex);
+        // Resolve through getString(Field) so the field's default value (and deprecated aliases) are
+        // applied, consistent with getString(Field) and getList(Field).
+        String value = getString(field);
+        if (value == null) {
+            return null;
+        }
+        return Collect.arrayListOf(value.split(regex));
     }
 
     /**

--- a/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -73,6 +73,35 @@ public class ConfigurationTest {
         assertThat(config.getString("A")).isEqualTo("a");
     }
 
+    @Test
+    @FixFor("debezium/dbz#2493")
+    public void getListShouldFallBackToFieldDefault() {
+        final Field field = Field.create("list.field").withDefault("a,b,c");
+
+        // getList(Field) must apply the field's default when the key is absent, the same way
+        // getString(Field) and the other Field-based accessors do.
+        assertThat(Configuration.empty().getList(field)).containsExactly("a", "b", "c");
+        assertThat(Configuration.empty().getString(field)).isEqualTo("a,b,c");
+
+        // An explicitly configured value still takes precedence and is split and trimmed.
+        config = Configuration.create().with("list.field", "x, y").build();
+        assertThat(config.getList(field)).containsExactly("x", "y");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2493")
+    public void getStringsShouldFallBackToFieldDefault() {
+        final Field field = Field.create("strings.field").withDefault("a,b,c");
+
+        // getStrings(Field, regex) must apply the field's default when the key is absent, the same way
+        // getString(Field) and getList(Field) do.
+        assertThat(Configuration.empty().getStrings(field, ",")).containsExactly("a", "b", "c");
+
+        // An explicitly configured value still takes precedence.
+        config = Configuration.create().with("strings.field", "x,y").build();
+        assertThat(config.getStrings(field, ",")).containsExactly("x", "y");
+    }
+
     /**
      * Test verifying that a Configuration object cannot be modified after creation.
      */


### PR DESCRIPTION
Fixes [debezium/dbz#2493](https://github.com/debezium/dbz/issues/2493).

### Problem

`Configuration.getList(Field)` ignored the field's declared default value, unlike every sibling `Field`-based accessor (`getString(Field)`, `getInteger(Field)`, `getLong(Field)`, `getBoolean(Field)`):

```java
Field field = Field.create("list.field").withDefault("a,b,c");
Configuration.empty().getList(field);    // [] — expected [a, b, c]
Configuration.empty().getString(field);  // "a,b,c" — correct
```

Both `getList(Field ...)` overloads forwarded to the raw, key-based path, which calls the abstract `getString(String)` and never applies `field.defaultValueAsString()`.

`io.debezium.config.Configuration`/`Field` is the base configuration abstraction used by every connector and by third-party connector authors, so this is a public-API trap. It is currently **latent**: the two in-repo call sites that read a defaulted `LIST` field via `getList` both hand-roll a guard *because* of this gap — good corroboration that it's an oversight rather than intentional:

- `CommonConnectorConfig.getSignalEnabledChannels()` checks `hasKey(...)` first, then parses `defaultValueAsString()` by hand.
- `AbstractTimescaleDbMetadata` reads `getList(...)` then adds the field's default if the result is empty.

### Fix

Resolve the `getList(Field ...)` overloads through `getString(Field)`, which already applies the field's default and deprecated aliases. The raw key-based overloads (`getList(String ...)`) are unchanged, and the split/trim logic is shared via a small private helper.

Kept intentionally minimal; the two guards above can be simplified in a follow-up once this lands.

### Test

`getList` had no test coverage. `ConfigurationTest.getListShouldFallBackToFieldDefault` asserts that `getList(Field)` returns the field's default when the key is absent (matching `getString(Field)`) and that an explicit value still wins. Verified it fails against the previous code and passes with the fix; the full `ConfigurationTest` (29 tests) is green.
