### PR TITLE
debezium/dbz#2494 Fix empty JMH benchmark jars when building with JDK 23+

### DIFF
--- a/debezium-microbenchmark-engine/pom.xml
+++ b/debezium-microbenchmark-engine/pom.xml
@@ -61,6 +61,21 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- JDK 23+ no longer runs annotation processors found on the classpath implicitly;
+                         declare the JMH processor explicitly so META-INF/BenchmarkList is generated -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${version.jmh}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/debezium-microbenchmark-engine/pom.xml
+++ b/debezium-microbenchmark-engine/pom.xml
@@ -65,11 +65,11 @@
                 <configuration>
                     <!-- JDK 23+ no longer runs annotation processors found on the classpath implicitly;
                          declare the JMH processor explicitly so META-INF/BenchmarkList is generated -->
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.openjdk.jmh</groupId>
                             <artifactId>jmh-generator-annprocess</artifactId>
-                            <version>${version.jmh}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -98,6 +98,21 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- JDK 23+ no longer runs annotation processors found on the classpath implicitly;
+                         declare the JMH processor explicitly so META-INF/BenchmarkList is generated -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${version.jmh}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -102,11 +102,11 @@
                 <configuration>
                     <!-- JDK 23+ no longer runs annotation processors found on the classpath implicitly;
                          declare the JMH processor explicitly so META-INF/BenchmarkList is generated -->
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.openjdk.jmh</groupId>
                             <artifactId>jmh-generator-annprocess</artifactId>
-                            <version>${version.jmh}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
Fixes debezium/dbz#2494

JDK 23+ no longer runs annotation processors discovered implicitly on the classpath, so
the JMH benchmark jars were built without `META-INF/BenchmarkList`. This declares
`jmh-generator-annprocess` explicitly in `annotationProcessorPaths` of
`maven-compiler-plugin` for both benchmark modules. It is the only annotation processor
on their classpath, so the generated output is unchanged.

### Verification

- JDK 25, before: jars missing `META-INF/BenchmarkList`, runtime fails with
  `Unable to find the resource: /META-INF/BenchmarkList`
- JDK 25, after: benchmarks generated and listed by `java -jar ... -l`; jar contents
  identical to a `-Dmaven.compiler.proc=full` build
- JDK 21: jar contents identical before/after (both modules); the
  implicit-annotation-processing warning is gone
