### PR TITLE
debezium/dbz#2497 Exit XStream attach loop if shutdown requested

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -114,7 +114,12 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema,
                 partition, offsetContext, isTableCaseInsensitive(), this, streamingMetrics);
 
-        try (OracleConnection xsConnection = connectAndAttachWithRetries(getStartPosition(offsetContext))) {
+        try (OracleConnection xsConnection = connectAndAttachWithRetries(context, getStartPosition(offsetContext))) {
+            if (xsConnection == null) {
+                // The connector was stopped while attempting to attach to the outbound server.
+                LOGGER.info("Streaming stopped before the attach to outbound server {} completed.", xstreamOutboundServerName);
+                return;
+            }
             try {
                 // 2. receive events while running
                 while (context.isRunning()) {
@@ -192,10 +197,18 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         return convertScnToPosition(offsetContext.getScn());
     }
 
-    private OracleConnection connectAndAttachWithRetries(byte[] startPosition) throws Exception {
+    private OracleConnection connectAndAttachWithRetries(ChangeEventSourceContext context, byte[] startPosition) throws Exception {
         OracleConnection connection = null;
         final DelayStrategy retryStrategy = DelayStrategy.exponential(Duration.ofSeconds(1), Duration.ofMinutes(1));
         for (int attempt = 1; attempt <= DEFAULT_MAX_ATTACH_RETRIES; attempt++) {
+            // The delay between attempts restores the thread's interrupt flag rather than propagating the
+            // interrupt, so both the running state and the interrupt flag must be checked here; otherwise
+            // the remaining attempts would be made back-to-back after a shutdown request.
+            if (!context.isRunning() || Thread.currentThread().isInterrupted()) {
+                LOGGER.info("Abandoning attach to outbound server {}, the connector is stopping.", xstreamOutboundServerName);
+                return null;
+            }
+
             XStreamOut out = null;
             try {
                 connection = connectionFactory.streamingConnectionFactory().newConnection();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
@@ -5,23 +5,40 @@
  */
 package io.debezium.connector.oracle.junit;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.oracle.util.TestHelper;
-import io.debezium.junit.logging.LogInterceptor;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 
 /**
- * JUnit 5 extension that dumps the state of the XStream outbound server whenever a test failed to
+ * JUnit 5 extension that captures the state of the XStream outbound server whenever a test fails to
  * attach to it.
  *
  * <p>Attach failures, in practice {@code ORA-26812}, have been observed to wedge the outbound server
  * for the remainder of a test run: the connector detaches cleanly, and every later attach is refused.
  * The connector logs cannot distinguish a genuinely orphaned client session from an outbound server
- * that only believes one is attached, so this extension captures the database side state at the point
- * of failure. It is diagnostic only, reads nothing but dictionary and dynamic performance views, and
- * never affects the outcome of a test.
+ * that only believes one is attached, so this extension captures the database side state instead. It
+ * is diagnostic only, reads nothing but dictionary and dynamic performance views, and never affects
+ * the outcome of a test.
+ *
+ * <p>The full dump is triggered from a log appender rather than from {@link #afterEach}, because a
+ * test that cannot attach then sits in its consume loop against the XStream poll timeout: measured
+ * over a wedged run, {@code afterEach} ran a median of six minutes, and up to sixteen, behind the
+ * failure it was meant to describe. Firing from the appender captures the server within a fraction of
+ * a second of the failed attach, while {@code afterEach} remains as a fallback should that dump fail.
+ *
+ * <p>Separately, and on every test rather than only failing ones, the identity of the outbound
+ * server's capture and apply sessions is tracked so that a restart on an ordinary detach can be told
+ * apart from one peculiar to the wedge. See
+ * {@link TestHelper#getXStreamOutboundServerSessionIdentity()}.
  *
  * <p>Registered automatically for the module via {@code META-INF/services}, since extension
  * autodetection is enabled for the build.
@@ -29,6 +46,8 @@ import io.debezium.junit.logging.LogInterceptor;
  * @author Chris Cranford
  */
 public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XStreamAttachFailureDiagnosticsExtension.class);
 
     /**
      * Referenced by name rather than by class: the {@code xstream} package is excluded from the build
@@ -44,30 +63,105 @@ public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallb
     private static final String ATTACH_FAILURE_MESSAGE = "Failed to attach to outbound server";
 
     /**
-     * A {@link LogInterceptor} registers itself as a logback appender and offers no way to detach, so a
-     * single instance is reused and cleared between tests rather than created per test.
+     * Attached to the streaming source's logger once and reused, since logback offers no way to detach
+     * an appender and a per-test instance would accumulate over a run.
      */
-    private static LogInterceptor interceptor;
+    private static AttachFailureAppender appender;
+
+    /**
+     * Last observed identity of the outbound server's capture and apply sessions, so that only changes
+     * are reported. Static because the comparison spans test classes.
+     */
+    private static String lastSessionIdentity;
 
     @Override
     public void beforeEach(ExtensionContext context) {
         if (!TestHelper.isXStream()) {
             return;
         }
-        if (interceptor == null) {
-            interceptor = new LogInterceptor(XSTREAM_SOURCE_LOGGER);
+        if (appender == null) {
+            appender = new AttachFailureAppender();
+            final ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
+                    .getLogger(XSTREAM_SOURCE_LOGGER);
+            appender.setContext(logger.getLoggerContext());
+            appender.start();
+            logger.addAppender(appender);
         }
-        interceptor.clear();
+        appender.resetFor(context.getDisplayName());
     }
 
     @Override
     public void afterEach(ExtensionContext context) {
-        if (!TestHelper.isXStream() || interceptor == null) {
+        if (!TestHelper.isXStream() || appender == null) {
             return;
         }
-        if (interceptor.containsMessage(ATTACH_FAILURE_MESSAGE)) {
-            TestHelper.logXStreamOutboundServerDiagnostics("after " + context.getDisplayName());
+
+        // Fallback only. Under normal operation the appender has already dumped, far closer to the
+        // failure than this point; this covers the dump itself having failed.
+        if (appender.sawFailureWithoutDump()) {
+            TestHelper.logXStreamOutboundServerDiagnostics("after " + context.getDisplayName()
+                    + " (fallback, inline capture did not complete)");
         }
-        interceptor.clear();
+
+        // Tracked on every boundary, not just failing ones: the point is to establish whether the
+        // outbound server's capture and apply sessions restart on an ordinary detach. Only changes are
+        // logged, so a run in which they restart on every test looks obviously different from one in
+        // which they restart once. A lookup failure changes the identity too, so it cannot pass silently.
+        final String identity = TestHelper.getXStreamOutboundServerSessionIdentity();
+        if (identity != null && !identity.equals(lastSessionIdentity)) {
+            LOGGER.warn("XStream outbound server sessions changed after {}{}  before: {}{}  after:  {}",
+                    context.getDisplayName(), System.lineSeparator(),
+                    lastSessionIdentity == null ? "<first observation>" : lastSessionIdentity,
+                    System.lineSeparator(), identity);
+            lastSessionIdentity = identity;
+        }
+    }
+
+    /**
+     * Fires the diagnostics collection on the first failed attach of each test, from the thread that
+     * logged it, so the outbound server is observed while the connector is still retrying.
+     */
+    private static final class AttachFailureAppender extends AppenderBase<ILoggingEvent> {
+
+        private final AtomicBoolean sawFailure = new AtomicBoolean();
+        private final AtomicBoolean dumped = new AtomicBoolean();
+        private volatile String testName = "<unknown test>";
+
+        void resetFor(String testName) {
+            this.testName = testName;
+            sawFailure.set(false);
+            dumped.set(false);
+        }
+
+        /**
+         * @return whether this test saw an attach failure that the inline capture did not manage to
+         *         report, meaning the fallback should run
+         */
+        boolean sawFailureWithoutDump() {
+            return sawFailure.get() && !dumped.get();
+        }
+
+        @Override
+        protected void append(ILoggingEvent event) {
+            if (!event.getFormattedMessage().contains(ATTACH_FAILURE_MESSAGE)) {
+                return;
+            }
+            sawFailure.set(true);
+
+            // Only the first failure of a test is captured; a retry loop would otherwise produce ten
+            // near-identical dumps.
+            if (!dumped.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                TestHelper.logXStreamOutboundServerDiagnostics("at first failed attach during " + testName);
+            }
+            catch (Throwable t) {
+                // Never allow a diagnostic to break the connector thread that happened to log the
+                // failure; clearing the flag lets afterEach retry the capture.
+                dumped.set(false);
+                addError("Failed to collect XStream diagnostics inline", t);
+            }
+        }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.junit;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.junit.logging.LogInterceptor;
+
+/**
+ * JUnit 5 extension that dumps the state of the XStream outbound server whenever a test failed to
+ * attach to it.
+ *
+ * <p>Attach failures, in practice {@code ORA-26812}, have been observed to wedge the outbound server
+ * for the remainder of a test run: the connector detaches cleanly, and every later attach is refused.
+ * The connector logs cannot distinguish a genuinely orphaned client session from an outbound server
+ * that only believes one is attached, so this extension captures the database side state at the point
+ * of failure. It is diagnostic only, reads nothing but dictionary and dynamic performance views, and
+ * never affects the outcome of a test.
+ *
+ * <p>Registered automatically for the module via {@code META-INF/services}, since extension
+ * autodetection is enabled for the build.
+ *
+ * @author Chris Cranford
+ */
+public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallback, AfterEachCallback {
+
+    /**
+     * Referenced by name rather than by class: the {@code xstream} package is excluded from the build
+     * unless the {@code oracle-xstream} profile is active, so a direct class reference would not compile
+     * for the other adapters.
+     */
+    private static final String XSTREAM_SOURCE_LOGGER = "io.debezium.connector.oracle.xstream.XstreamStreamingChangeEventSource";
+
+    /**
+     * Logged by the XStream streaming source for every failed attach attempt, and again when the
+     * retries are exhausted.
+     */
+    private static final String ATTACH_FAILURE_MESSAGE = "Failed to attach to outbound server";
+
+    /**
+     * A {@link LogInterceptor} registers itself as a logback appender and offers no way to detach, so a
+     * single instance is reused and cleared between tests rather than created per test.
+     */
+    private static LogInterceptor interceptor;
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        if (!TestHelper.isXStream()) {
+            return;
+        }
+        if (interceptor == null) {
+            interceptor = new LogInterceptor(XSTREAM_SOURCE_LOGGER);
+        }
+        interceptor.clear();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        if (!TestHelper.isXStream() || interceptor == null) {
+            return;
+        }
+        if (interceptor.containsMessage(ATTACH_FAILURE_MESSAGE)) {
+            TestHelper.logXStreamOutboundServerDiagnostics("after " + context.getDisplayName());
+        }
+        interceptor.clear();
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/XStreamAttachFailureDiagnosticsExtension.java
@@ -63,6 +63,13 @@ public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallb
     private static final String ATTACH_FAILURE_MESSAGE = "Failed to attach to outbound server";
 
     /**
+     * How long {@code afterEach} waits for an in-flight collection. Generous, because it is only ever
+     * reached on a test that has already failed to attach, and the collection is a handful of short
+     * dictionary queries.
+     */
+    private static final long COLLECTION_TIMEOUT_MS = 30_000L;
+
+    /**
      * Attached to the streaming source's logger once and reused, since logback offers no way to detach
      * an appender and a per-test instance would accumulate over a run.
      */
@@ -98,6 +105,7 @@ public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallb
 
         // Fallback only. Under normal operation the appender has already dumped, far closer to the
         // failure than this point; this covers the dump itself having failed.
+        appender.awaitCollection();
         if (appender.sawFailureWithoutDump()) {
             TestHelper.logXStreamOutboundServerDiagnostics("after " + context.getDisplayName()
                     + " (fallback, inline capture did not complete)");
@@ -118,24 +126,43 @@ public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallb
     }
 
     /**
-     * Fires the diagnostics collection on the first failed attach of each test, from the thread that
-     * logged it, so the outbound server is observed while the connector is still retrying.
+     * Fires the diagnostics collection on the first failed attach of each test, so the outbound server
+     * is observed while the connector is still retrying rather than minutes later.
      */
     private static final class AttachFailureAppender extends AppenderBase<ILoggingEvent> {
 
         private final AtomicBoolean sawFailure = new AtomicBoolean();
         private final AtomicBoolean dumped = new AtomicBoolean();
         private volatile String testName = "<unknown test>";
+        private volatile Thread collector;
 
         void resetFor(String testName) {
             this.testName = testName;
             sawFailure.set(false);
             dumped.set(false);
+            collector = null;
         }
 
         /**
-         * @return whether this test saw an attach failure that the inline capture did not manage to
-         *         report, meaning the fallback should run
+         * Waits briefly for an in-flight collection so that {@link #sawFailureWithoutDump()} reflects
+         * its outcome rather than racing it.
+         */
+        void awaitCollection() {
+            final Thread inFlight = collector;
+            if (inFlight == null) {
+                return;
+            }
+            try {
+                inFlight.join(COLLECTION_TIMEOUT_MS);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        /**
+         * @return whether this test saw an attach failure that the capture did not manage to report,
+         *         meaning the fallback should run
          */
         boolean sawFailureWithoutDump() {
             return sawFailure.get() && !dumped.get();
@@ -153,15 +180,25 @@ public class XStreamAttachFailureDiagnosticsExtension implements BeforeEachCallb
             if (!dumped.compareAndSet(false, true)) {
                 return;
             }
-            try {
-                TestHelper.logXStreamOutboundServerDiagnostics("at first failed attach during " + testName);
-            }
-            catch (Throwable t) {
-                // Never allow a diagnostic to break the connector thread that happened to log the
-                // failure; clearing the flag lets afterEach retry the capture.
-                dumped.set(false);
-                addError("Failed to collect XStream diagnostics inline", t);
-            }
+
+            // Deliberately not collected on the thread that logged the failure. That is the connector's
+            // streaming thread, and an attach failure is very often followed immediately by the test
+            // stopping the connector, which interrupts it. Opening a JDBC connection from an interrupted
+            // thread fails at once with ORA-17002 / InterruptedIOException, losing exactly the capture
+            // that matters. Clearing the interrupt to work around that is not an option either, since
+            // the attach retry loop reads that flag to decide whether to abandon.
+            //
+            // A plain thread rather than a pool: this runs at most once per test, and afterEach joins it.
+            final String test = testName;
+            final Thread thread = new Thread(() -> {
+                if (!TestHelper.logXStreamOutboundServerDiagnostics("at first failed attach during " + test)) {
+                    // Let afterEach try again rather than leaving the failure undescribed.
+                    dumped.set(false);
+                }
+            }, "xstream-attach-diagnostics");
+            thread.setDaemon(true);
+            collector = thread;
+            thread.start();
         }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -407,10 +407,13 @@ public class TestHelper {
      * are logged and never propagated; this is diagnostic only and must not influence test outcome.
      *
      * @param reason short description of what triggered the collection, included in the log output
+     * @return {@code true} if a report was collected and logged, {@code false} if the collection
+     *         itself failed and the caller should arrange another attempt; an individual query that
+     *         fails is reported in place and still counts as a successful collection
      */
-    public static void logXStreamOutboundServerDiagnostics(String reason) {
+    public static boolean logXStreamOutboundServerDiagnostics(String reason) {
         if (!isXStream()) {
-            return;
+            return false;
         }
 
         final StringBuilder report = new StringBuilder();
@@ -477,10 +480,12 @@ public class TestHelper {
                     "SELECT POOL, NAME, BYTES FROM V$SGASTAT WHERE NAME = 'free memory'");
 
             LOGGER.warn("{}", report);
+            return true;
         }
         catch (Exception e) {
             LOGGER.warn("Failed to collect XStream outbound server diagnostics ({}){}{}",
                     reason, System.lineSeparator(), report, e);
+            return false;
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -433,7 +433,7 @@ public class TestHelper {
             // a non-idle class or a wait that keeps climbing, and BLOCKING_SESSION names any blocker.
             // DBA_APPLY cannot answer this, as its STATUS is configuration state, not liveness.
             appendQuery(admin, report, "V$SESSION (MODULE = 'XStream')",
-                    "SELECT SID, SERIAL#, USERNAME, STATUS, LAST_CALL_ET, "
+                    "SELECT SID, SERIAL#, USERNAME, STATUS, LOGON_TIME, LAST_CALL_ET, "
                             + "EVENT, WAIT_CLASS, SECONDS_IN_WAIT, BLOCKING_SESSION, "
                             + "SUBSTR(PROGRAM, INSTR(PROGRAM, '(') + 1, 4) AS XSTREAM_PROCESS "
                             + "FROM V$SESSION WHERE MODULE = 'XStream'");
@@ -454,6 +454,43 @@ public class TestHelper {
         catch (Exception e) {
             LOGGER.warn("Failed to collect XStream outbound server diagnostics ({}){}{}",
                     reason, System.lineSeparator(), report, e);
+        }
+    }
+
+    /**
+     * Returns a compact identity of the XStream outbound server's capture and apply sessions, as
+     * {@code PROCESS=SID/SERIAL#@LOGON_TIME} entries in a stable order.
+     *
+     * <p>This is the control for the observation that, in every wedge captured so far, those sessions
+     * date to the instant the connector detached. That is only meaningful if they do <em>not</em>
+     * restart on an ordinary detach, and the diagnostics dump cannot answer it because it only runs
+     * when an attach has already failed. Comparing this identity across successful test boundaries
+     * distinguishes the two.
+     *
+     * <p>{@code LOGON_TIME} is used rather than deriving a start time from {@code LAST_CALL_ET},
+     * because the latter merely tracks session age on an idle server and says nothing about restarts.
+     *
+     * @return the session identity, or {@code null} when not running against XStream; never throws
+     */
+    public static String getXStreamOutboundServerSessionIdentity() {
+        if (!isXStream()) {
+            return null;
+        }
+        try (OracleConnection admin = adminConnection(true)) {
+            final StringJoiner entries = new StringJoiner(", ");
+            admin.query("SELECT SUBSTR(PROGRAM, INSTR(PROGRAM, '(') + 1, 4) || '=' || SID || '/' || SERIAL# "
+                    + "|| '@' || TO_CHAR(LOGON_TIME, 'HH24:MI:SS') AS ENTRY "
+                    + "FROM V$SESSION WHERE MODULE = 'XStream' ORDER BY 1", rs -> {
+                        while (rs.next()) {
+                            entries.add(rs.getString(1));
+                        }
+                    });
+            return entries.length() == 0 ? "<none>" : entries.toString();
+        }
+        catch (Exception e) {
+            // Returned rather than thrown so a lookup failure shows up as a change in the tracked
+            // identity instead of silently dropping an observation or failing an unrelated test.
+            return "<unavailable: " + e.getMessage() + ">";
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -468,6 +468,22 @@ public class TestHelper {
                             + "SUBSTR(PROGRAM, INSTR(PROGRAM, '(') + 1, 4) AS XSTREAM_PROCESS "
                             + "FROM V$SESSION WHERE MODULE = 'XStream'");
 
+            // The query above is the sole basis for concluding that no client is attached, and it is
+            // only as good as its filter: MODULE = 'XStream' matches the outbound server's own
+            // background processes and a client that is attached right now. A session left behind by a
+            // previous test would not necessarily still carry that module, and would then be invisible
+            // there while remaining exactly the orphan ORA-26812 claims exists. So the same question is
+            // asked again without the filter, over every session belonging to the connector user.
+            //
+            // An empty result, or only sessions belonging to the test in flight, confirms the reading
+            // taken so far. A session that outlives the test that opened it is the missing client.
+            final String connectorUser = getConnectorUserName();
+            appendQuery(admin, report, "V$SESSION (USERNAME = '" + connectorUser + "')",
+                    "SELECT SID, SERIAL#, STATUS, MODULE, PROGRAM, LOGON_TIME, LAST_CALL_ET, "
+                            + "EVENT, WAIT_CLASS, SECONDS_IN_WAIT "
+                            + "FROM V$SESSION WHERE UPPER(USERNAME) = UPPER('" + connectorUser + "') "
+                            + "ORDER BY LOGON_TIME");
+
             appendQuery(admin, report, "DBA_CAPTURE",
                     "SELECT CAPTURE_NAME, STATUS, ERROR_NUMBER, ERROR_MESSAGE FROM DBA_CAPTURE");
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -9,12 +9,14 @@ import static io.debezium.connector.oracle.jdbc.OracleJdbcConfiguration.SECONDAR
 
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -387,6 +389,98 @@ public class TestHelper {
             connection.resetSessionToCdb();
         }
         return connection;
+    }
+
+    /**
+     * Queries and logs the state of the XStream outbound server and the components it depends on.
+     *
+     * <p>This exists to answer a question the connector logs cannot: when an attach fails with
+     * {@code ORA-26812}, is there genuinely a client session still attached to the outbound server,
+     * or does the server merely believe there is one after the client has cleanly detached? The two
+     * cases require different fixes and are indistinguishable from the connector side.
+     *
+     * <p>Every statement is read-only and each is isolated, so a view that is unavailable in a given
+     * database configuration is reported in place rather than hiding the remaining output. Failures
+     * are logged and never propagated; this is diagnostic only and must not influence test outcome.
+     *
+     * @param reason short description of what triggered the collection, included in the log output
+     */
+    public static void logXStreamOutboundServerDiagnostics(String reason) {
+        if (!isXStream()) {
+            return;
+        }
+
+        final StringBuilder report = new StringBuilder();
+        report.append("XStream outbound server diagnostics (").append(reason).append(')');
+
+        // The outbound server, its capture, and its apply all live in the root of a CDB.
+        try (OracleConnection admin = adminConnection(true)) {
+            appendQuery(admin, report, "V$XSTREAM_OUTBOUND_SERVER",
+                    "SELECT SERVER_NAME, STATE, STARTUP_TIME, TOTAL_MESSAGES_SENT, BYTES_SENT FROM V$XSTREAM_OUTBOUND_SERVER");
+
+            // Per Oracle's XStream Out monitoring documentation, the row whose XStream program name is
+            // 'TNS' is the attached client application's session. Its absence while ORA-26812 is being
+            // raised means no client is attached and the server state itself is stale.
+            appendQuery(admin, report, "V$SESSION (MODULE = 'XStream')",
+                    "SELECT SID, SERIAL#, USERNAME, STATUS, LAST_CALL_ET, "
+                            + "SUBSTR(PROGRAM, INSTR(PROGRAM, '(') + 1, 4) AS XSTREAM_PROCESS "
+                            + "FROM V$SESSION WHERE MODULE = 'XStream'");
+
+            appendQuery(admin, report, "DBA_CAPTURE",
+                    "SELECT CAPTURE_NAME, STATUS, ERROR_NUMBER, ERROR_MESSAGE FROM DBA_CAPTURE");
+
+            appendQuery(admin, report, "DBA_APPLY",
+                    "SELECT APPLY_NAME, APPLY_CAPTURED, STATUS, ERROR_NUMBER, ERROR_MESSAGE FROM DBA_APPLY");
+
+            // Shared and streams pool headroom; XStream capture and apply allocate from these, and an
+            // outbound server that cannot allocate while tearing down is one way to strand the session.
+            appendQuery(admin, report, "V$SGASTAT (free memory)",
+                    "SELECT POOL, NAME, BYTES FROM V$SGASTAT WHERE NAME = 'free memory'");
+
+            LOGGER.warn("{}", report);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to collect XStream outbound server diagnostics ({}){}{}",
+                    reason, System.lineSeparator(), report, e);
+        }
+    }
+
+    /**
+     * Runs a single diagnostic query and appends its result set to {@code report} as a text table.
+     * A failing query is recorded in the report rather than aborting the wider collection.
+     */
+    private static void appendQuery(OracleConnection connection, StringBuilder report, String label, String sql) {
+        final String newLine = System.lineSeparator();
+        report.append(newLine).append("  ").append(label).append(':');
+        try {
+            connection.query(sql, rs -> {
+                final ResultSetMetaData metaData = rs.getMetaData();
+                final int columnCount = metaData.getColumnCount();
+
+                final StringJoiner header = new StringJoiner(" | ");
+                for (int i = 1; i <= columnCount; i++) {
+                    header.add(metaData.getColumnLabel(i));
+                }
+                report.append(newLine).append("    ").append(header);
+
+                boolean empty = true;
+                while (rs.next()) {
+                    empty = false;
+                    final StringJoiner row = new StringJoiner(" | ");
+                    for (int i = 1; i <= columnCount; i++) {
+                        row.add(String.valueOf(rs.getString(i)));
+                    }
+                    report.append(newLine).append("    ").append(row);
+                }
+
+                if (empty) {
+                    report.append(newLine).append("    <no rows>");
+                }
+            });
+        }
+        catch (Exception e) {
+            report.append(newLine).append("    <query failed: ").append(e.getMessage()).append('>');
+        }
     }
 
     /**

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -397,7 +397,10 @@ public class TestHelper {
      * <p>This exists to answer a question the connector logs cannot: when an attach fails with
      * {@code ORA-26812}, is there genuinely a client session still attached to the outbound server,
      * or does the server merely believe there is one after the client has cleanly detached? The two
-     * cases require different fixes and are indistinguishable from the connector side.
+     * cases require different fixes and are indistinguishable from the connector side. Captured
+     * within a fraction of a second of the first refusal, it is the latter: no client session is
+     * present at any point, so the follow-on question is what the server's own capture and apply
+     * pipeline is doing while it refuses, which the {@code V$XSTREAM_} runtime views below report.
      *
      * <p>Every statement is read-only and each is isolated, so a view that is unavailable in a given
      * database configuration is reported in place rather than hiding the remaining output. Failures
@@ -417,6 +420,30 @@ public class TestHelper {
         try (OracleConnection admin = adminConnection(true)) {
             appendQuery(admin, report, "V$XSTREAM_OUTBOUND_SERVER",
                     "SELECT SERVER_NAME, STATE, STARTUP_TIME, TOTAL_MESSAGES_SENT, BYTES_SENT FROM V$XSTREAM_OUTBOUND_SERVER");
+
+            // V$XSTREAM_OUTBOUND_SERVER above is empty unless a client is attached, and the DBA_ views
+            // below report configuration rather than runtime state, so neither describes what the
+            // outbound server is actually doing while an attach is being refused. These four do: they
+            // were confirmed to populate on a 19c server with no client attached, and are the only
+            // runtime view of the capture and apply pipeline available in that state.
+            //
+            // STATE is the column of interest in each. A healthy idle capture reads 'WAITING FOR
+            // TRANSACTION' or 'CAPTURING CHANGES'; 'PAUSED FOR FLOW CONTROL' means the apply side has
+            // stopped draining, which is a documented XStream stall and would not surface anywhere else
+            // in this dump. STATE_CHANGED_TIME dates the current state directly, rather than leaving it
+            // to be inferred from session logon times.
+            appendQuery(admin, report, "V$XSTREAM_CAPTURE",
+                    "SELECT CAPTURE_NAME, STATE, TOTAL_MESSAGES_CAPTURED, TOTAL_MESSAGES_ENQUEUED, "
+                            + "STATE_CHANGED_TIME FROM V$XSTREAM_CAPTURE");
+
+            appendQuery(admin, report, "V$XSTREAM_APPLY_READER",
+                    "SELECT APPLY_NAME, STATE, TOTAL_MESSAGES_DEQUEUED FROM V$XSTREAM_APPLY_READER");
+
+            appendQuery(admin, report, "V$XSTREAM_APPLY_COORDINATOR",
+                    "SELECT APPLY_NAME, STATE, TOTAL_RECEIVED, TOTAL_APPLIED FROM V$XSTREAM_APPLY_COORDINATOR");
+
+            appendQuery(admin, report, "V$XSTREAM_APPLY_SERVER",
+                    "SELECT APPLY_NAME, SERVER_ID, STATE FROM V$XSTREAM_APPLY_SERVER ORDER BY SERVER_ID");
 
             // Per Oracle's XStream Out monitoring documentation, the row whose XStream program name is
             // 'TNS' is the attached client application's session. Its absence while ORA-26812 is being

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -421,8 +421,20 @@ public class TestHelper {
             // Per Oracle's XStream Out monitoring documentation, the row whose XStream program name is
             // 'TNS' is the attached client application's session. Its absence while ORA-26812 is being
             // raised means no client is attached and the server state itself is stale.
+            //
+            // LAST_CALL_ET dates each session back to the start of its current call, which is useful for
+            // correlating the capture and apply processes against connector activity. It says nothing
+            // about health: on an idle outbound server it simply tracks session age, so a large value is
+            // expected rather than a sign of a hang.
+            //
+            // Liveness comes from EVENT, WAIT_CLASS and SECONDS_IN_WAIT. A healthy idle 19c server sits
+            // on 'rdbms ipc message', 'REPL Capture/Apply: messages' or 'LogMiner reader: redo (idle)'
+            // with WAIT_CLASS 'Idle' and SECONDS_IN_WAIT cycling within a few seconds; a stuck one shows
+            // a non-idle class or a wait that keeps climbing, and BLOCKING_SESSION names any blocker.
+            // DBA_APPLY cannot answer this, as its STATUS is configuration state, not liveness.
             appendQuery(admin, report, "V$SESSION (MODULE = 'XStream')",
                     "SELECT SID, SERIAL#, USERNAME, STATUS, LAST_CALL_ET, "
+                            + "EVENT, WAIT_CLASS, SECONDS_IN_WAIT, BLOCKING_SESSION, "
                             + "SUBSTR(PROGRAM, INSTR(PROGRAM, '(') + 1, 4) AS XSTREAM_PROCESS "
                             + "FROM V$SESSION WHERE MODULE = 'XStream'");
 
@@ -432,8 +444,8 @@ public class TestHelper {
             appendQuery(admin, report, "DBA_APPLY",
                     "SELECT APPLY_NAME, APPLY_CAPTURED, STATUS, ERROR_NUMBER, ERROR_MESSAGE FROM DBA_APPLY");
 
-            // Shared and streams pool headroom; XStream capture and apply allocate from these, and an
-            // outbound server that cannot allocate while tearing down is one way to strand the session.
+            // Shared and streams pool headroom, included as a control rather than a lead: capture and
+            // apply allocate from these, so a healthy reading here rules memory out at a glance.
             appendQuery(admin, report, "V$SGASTAT (free memory)",
                     "SELECT POOL, NAME, BYTES FROM V$SGASTAT WHERE NAME = 'free memory'");
 

--- a/debezium-connector-oracle/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/debezium-connector-oracle/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.debezium.connector.oracle.junit.XStreamAttachFailureDiagnosticsExtension


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2497

## Description
The current design did not break the XStream attach loop if a shutdown was requested while the connector had not yet attached to the outbound server. This lead to issues with tests overlapping and trying to gain access to DBZXOUT across multiple clients, which isn't allowed.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

## Note

There is a follow-up in debezium/dbz#2498 to refactor this to use the `RetryingCallable` class; however, that class needs changes to work in this context, so this PR addresses the immediate concern and is relatively safe for backports. The refactor of the retrying class and implementation can be done separately.
