### PR TITLE
debezium/dbz#2501 Key by the lower-cased name when appending in reorderColumn

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -46,11 +47,19 @@ class TableEditorImpl implements TableEditor {
 
     @Override
     public Column columnWithName(String name) {
-        return sortedColumns.get(name.toLowerCase());
+        return sortedColumns.get(key(name));
     }
 
     protected boolean hasColumnWithName(String name) {
         return columnWithName(name) != null;
+    }
+
+    /**
+     * Computes the case-insensitive map key for a column or attribute name. Uses {@link Locale#ROOT}
+     * so the mapping is stable regardless of the default locale (e.g. the Turkish dotless-i rule).
+     */
+    private static String key(String name) {
+        return name.toLowerCase(Locale.ROOT);
     }
 
     @Override
@@ -78,7 +87,7 @@ class TableEditorImpl implements TableEditor {
         if (defn != null) {
             Column existing = columnWithName(defn.name());
             int position = existing != null ? existing.position() : sortedColumns.size() + 1;
-            sortedColumns.put(defn.name().toLowerCase(), defn.edit().position(position).create());
+            sortedColumns.put(key(defn.name()), defn.edit().position(position).create());
         }
         assert positionsAreValid();
     }
@@ -162,7 +171,7 @@ class TableEditorImpl implements TableEditor {
 
     @Override
     public TableEditor removeColumn(String columnName) {
-        Column existing = sortedColumns.remove(columnName.toLowerCase());
+        Column existing = sortedColumns.remove(key(columnName));
         if (existing != null) {
             updatePositions();
             columnName = existing.name();
@@ -188,22 +197,22 @@ class TableEditorImpl implements TableEditor {
         }
         Column afterColumn = afterColumnName == null ? null : columnWithName(afterColumnName);
         if (afterColumn != null && afterColumn.position() == sortedColumns.size()) {
-            // Just append ...
-            sortedColumns.remove(columnName);
-            sortedColumns.put(columnName, columnToMove);
+            // Just append; sortedColumns is keyed by the lower-cased name, like everywhere else.
+            sortedColumns.remove(key(columnName));
+            sortedColumns.put(key(columnToMove.name()), columnToMove);
         }
         else {
             LinkedHashMap<String, Column> newColumns = new LinkedHashMap<>();
-            sortedColumns.remove(columnName.toLowerCase());
+            sortedColumns.remove(key(columnName));
             if (afterColumn == null) {
                 // Then the column to move comes first ...
-                newColumns.put(columnToMove.name().toLowerCase(), columnToMove);
+                newColumns.put(key(columnToMove.name()), columnToMove);
             }
             sortedColumns.forEach((key, defn) -> {
                 newColumns.put(key, defn);
                 if (defn == afterColumn) {
                     // We just added the column that came before, so add our column here ...
-                    newColumns.put(columnToMove.name().toLowerCase(), columnToMove);
+                    newColumns.put(key(columnToMove.name()), columnToMove);
                 }
             });
             sortedColumns = newColumns;
@@ -232,7 +241,7 @@ class TableEditorImpl implements TableEditor {
             removeColumn(existing.name());
         }
         else {
-            sortedColumns.replace(existingName.toLowerCase(), existing, newColumn);
+            sortedColumns.replace(key(existingName), existing, newColumn);
         }
         if (newPkNames != null) {
             setPrimaryKeyNames(newPkNames);
@@ -247,13 +256,13 @@ class TableEditorImpl implements TableEditor {
 
     @Override
     public Attribute attributeWithName(String attributeName) {
-        return attributes.get(attributeName.toLowerCase());
+        return attributes.get(key(attributeName));
     }
 
     @Override
     public TableEditor addAttribute(Attribute attribute) {
         if (attribute != null) {
-            attributes.put(attribute.name().toLowerCase(), attribute);
+            attributes.put(key(attribute.name()), attribute);
         }
         return this;
     }
@@ -269,7 +278,7 @@ class TableEditorImpl implements TableEditor {
     @Override
     public TableEditor removeAttribute(String attributeName) {
         if (attributeName != null) {
-            attributes.remove(attributeName.toLowerCase());
+            attributes.remove(key(attributeName));
         }
         return this;
     }

--- a/debezium-connector-common/src/test/java/io/debezium/relational/TableEditorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/relational/TableEditorTest.java
@@ -178,6 +178,25 @@ public class TableEditorTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2501")
+    public void shouldReorderMixedCaseColumnAfterLastColumn() {
+        editor.tableId(id);
+        Column c1 = columnEditor.name("C1").type("VARCHAR").jdbcType(Types.VARCHAR).length(10).position(1).create();
+        Column c2 = columnEditor.name("C2").type("NUMBER").jdbcType(Types.NUMERIC).length(5).autoIncremented(true).create();
+        Column c3 = columnEditor.name("C3").type("DATE").jdbcType(Types.DATE).autoIncremented(true).create();
+        editor.addColumns(c1, c2, c3);
+
+        // Move the first column to after the current last column. This exercises the append fast-path
+        // with a mixed-case name: the column must move, not be duplicated.
+        editor.reorderColumn("C1", "C3");
+
+        assertThat(editor.columns()).containsExactly(editor.columnWithName("C2"),
+                editor.columnWithName("C3"),
+                editor.columnWithName("C1"));
+        assertValidPositions(editor);
+    }
+
+    @Test
     void shouldNotReorderColumnIfNameDoesNotMatch() {
         assertThrows(IllegalArgumentException.class, () -> {
             editor.tableId(id);


### PR DESCRIPTION
Fixes [debezium/dbz#2501](https://github.com/debezium/dbz/issues/2501).

### Problem

`TableEditorImpl.reorderColumn(...)`'s "just append" fast-path removed and re-inserted the moved column using the **raw** column name, while `sortedColumns` is keyed by the **lower-cased** name everywhere else in the class (`add`, `columnWithName`, `removeColumn`, `replaceColumn`, and the `else` branch of this same method):

```java
if (afterColumn != null && afterColumn.position() == sortedColumns.size()) {
    sortedColumns.remove(columnName);            // raw name
    sortedColumns.put(columnName, columnToMove);  // raw name
}
```

Moving a column whose name has an uppercase letter to after the current last column therefore removes nothing (the real key is lower-cased) and inserts a second entry — **duplicating** the column instead of moving it.

```java
// columns C1, C2, C3 (keys c1, c2, c3)
editor.reorderColumn("C1", "C3");
// today: [C1, C2, C3, C1] (4 columns) — expected [C2, C3, C1]
```

### Impact (MySQL / MariaDB)

The Antlr DDL parsers preserve identifier case, and `AlterTableParserListener.handleExitModifyColumn`/`handleExitChangeColumn` call `reorderColumn(column.name(), afterColumn)`. So `ALTER TABLE t MODIFY COLUMN Foo ... AFTER <last-column>` duplicates `Foo`, and `TableSchemaBuilder` then emits two Connect fields named `Foo`, throwing `SchemaBuilderException: ... field name duplication` and halting the connector on an otherwise-valid ALTER.

### Fix

Lower-case the key in the append branch, mirroring the rest of the class:

```java
sortedColumns.remove(columnName.toLowerCase());
sortedColumns.put(columnToMove.name().toLowerCase(), columnToMove);
```

### Test

`TableEditorTest.shouldReorderColumns()` uses uppercase names but never moves a column to *after the last* one, so the append branch was untested. `shouldReorderMixedCaseColumnAfterLastColumn` moves the first column after the last and asserts the column moved and was not duplicated. Verified it fails against the previous code (4 columns, `C1` duplicated) and passes with the fix; the full `TableEditorTest` is green.
