### PR TITLE
debezium/dbz#2167 Expose the number of read events as a connector metric

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -585,6 +585,7 @@ Raf Liwoch
 Rafael Câmara
 Rafael Rain
 Raghava Ponnam
+Ragul Shanmugam
 Rajendra Dangwal
 Ram Satish
 Ramesh Reddy

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
@@ -27,6 +27,7 @@ public class CommonEventMeter implements CommonEventMetricsMXBean {
     protected final AtomicLong totalNumberOfCreateEventsSeen = new AtomicLong();
     protected final AtomicLong totalNumberOfUpdateEventsSeen = new AtomicLong();
     protected final AtomicLong totalNumberOfDeleteEventsSeen = new AtomicLong();
+    protected final AtomicLong totalNumberOfReadEventsSeen = new AtomicLong();
     private final AtomicLong numberOfEventsFiltered = new AtomicLong();
     protected final AtomicLong numberOfErroneousEvents = new AtomicLong();
     protected final AtomicLong lastEventTimestamp = new AtomicLong(-1);
@@ -63,6 +64,9 @@ public class CommonEventMeter implements CommonEventMetricsMXBean {
                     break;
                 case DELETE:
                     totalNumberOfDeleteEventsSeen.incrementAndGet();
+                    break;
+                case READ:
+                    totalNumberOfReadEventsSeen.incrementAndGet();
                     break;
                 default:
                     break;
@@ -121,6 +125,11 @@ public class CommonEventMeter implements CommonEventMetricsMXBean {
     }
 
     @Override
+    public long getTotalNumberOfReadEventsSeen() {
+        return totalNumberOfReadEventsSeen.get();
+    }
+
+    @Override
     public long getNumberOfEventsFiltered() {
         return numberOfEventsFiltered.get();
     }
@@ -135,6 +144,7 @@ public class CommonEventMeter implements CommonEventMetricsMXBean {
         totalNumberOfCreateEventsSeen.set(0);
         totalNumberOfUpdateEventsSeen.set(0);
         totalNumberOfDeleteEventsSeen.set(0);
+        totalNumberOfReadEventsSeen.set(0);
         lastEventTimestamp.set(-1);
         numberOfEventsFiltered.set(0);
         numberOfErroneousEvents.set(0);

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
@@ -116,6 +116,11 @@ public abstract class PipelineMetrics<P extends Partition> extends Metrics
     }
 
     @Override
+    public long getTotalNumberOfReadEventsSeen() {
+        return commonEventMeter.getTotalNumberOfReadEventsSeen();
+    }
+
+    @Override
     public long getNumberOfEventsFiltered() {
         return commonEventMeter.getNumberOfEventsFiltered();
     }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/metrics/traits/CommonEventMetricsMXBean.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/metrics/traits/CommonEventMetricsMXBean.java
@@ -22,6 +22,8 @@ public interface CommonEventMetricsMXBean {
 
     long getTotalNumberOfDeleteEventsSeen();
 
+    long getTotalNumberOfReadEventsSeen();
+
     long getNumberOfEventsFiltered();
 
     long getNumberOfErroneousEvents();

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/meters/CommonEventMeterTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/meters/CommonEventMeterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Envelope.Operation;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.TableId;
+import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.util.Clock;
+
+/**
+ * Unit tests for {@link CommonEventMeter}.
+ */
+public class CommonEventMeterTest {
+
+    private final EventMetadataProvider metadataProvider = new EventMetadataProvider() {
+        @Override
+        public Instant getEventTimestamp(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return Instant.now();
+        }
+
+        @Override
+        public Map<String, String> getEventSourcePosition(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return Map.of("pos", "1");
+        }
+
+        @Override
+        public String getTransactionId(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return "tx-1";
+        }
+    };
+
+    private CommonEventMeter meter;
+    private static final TableId TABLE_ID = TableId.parse("db.schema.table");
+    private static final Schema VALUE_SCHEMA = SchemaBuilder.struct().field("id", Schema.INT32_SCHEMA).build();
+
+    @BeforeEach
+    public void setUp() {
+        meter = new CommonEventMeter(Clock.system(), metadataProvider);
+    }
+
+    @Test
+    public void shouldReportZeroForAllMetricsWhenNewlyCreated() {
+        assertThat(meter.getTotalNumberOfEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfCreateEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfUpdateEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfDeleteEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfReadEventsSeen()).isEqualTo(0);
+        assertThat(meter.getNumberOfEventsFiltered()).isEqualTo(0);
+        assertThat(meter.getNumberOfErroneousEvents()).isEqualTo(0);
+        assertThat(meter.getLastEvent()).isNull();
+        assertThat(meter.getMilliSecondsSinceLastEvent()).isEqualTo(-1);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2167")
+    public void shouldCountReadEventsSeparatelyFromOtherOperations() {
+        final Struct value = new Struct(VALUE_SCHEMA).put("id", 1);
+
+        meter.onEvent(TABLE_ID, null, 1L, value, Operation.CREATE);
+        meter.onEvent(TABLE_ID, null, 2L, value, Operation.READ);
+        meter.onEvent(TABLE_ID, null, 3L, value, Operation.READ);
+        meter.onEvent(TABLE_ID, null, 4L, value, Operation.UPDATE);
+        meter.onEvent(TABLE_ID, null, 5L, value, Operation.DELETE);
+
+        assertThat(meter.getTotalNumberOfEventsSeen()).isEqualTo(5);
+        assertThat(meter.getTotalNumberOfCreateEventsSeen()).isEqualTo(1);
+        assertThat(meter.getTotalNumberOfReadEventsSeen()).isEqualTo(2);
+        assertThat(meter.getTotalNumberOfUpdateEventsSeen()).isEqualTo(1);
+        assertThat(meter.getTotalNumberOfDeleteEventsSeen()).isEqualTo(1);
+        assertThat(meter.getLastEvent()).isNotNull();
+        assertThat(meter.getMilliSecondsSinceLastEvent()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2167")
+    public void shouldCountReadEventsWhenFilteredOrErroneous() {
+        meter.onFilteredEvent(Operation.READ);
+        meter.onErroneousEvent(Operation.READ);
+
+        assertThat(meter.getTotalNumberOfEventsSeen()).isEqualTo(2);
+        assertThat(meter.getTotalNumberOfReadEventsSeen()).isEqualTo(2);
+        assertThat(meter.getNumberOfEventsFiltered()).isEqualTo(1);
+        assertThat(meter.getNumberOfErroneousEvents()).isEqualTo(1);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2167")
+    public void shouldResetReadEventCountWhenResetIsCalled() {
+        final Struct value = new Struct(VALUE_SCHEMA).put("id", 1);
+
+        meter.onEvent(TABLE_ID, null, 1L, value, Operation.READ);
+        meter.onEvent(TABLE_ID, null, 2L, value, Operation.CREATE);
+        meter.onFilteredEvent(Operation.READ);
+        meter.onErroneousEvent(Operation.READ);
+
+        meter.reset();
+
+        assertThat(meter.getTotalNumberOfEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfCreateEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfUpdateEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfDeleteEventsSeen()).isEqualTo(0);
+        assertThat(meter.getTotalNumberOfReadEventsSeen()).isEqualTo(0);
+        assertThat(meter.getNumberOfEventsFiltered()).isEqualTo(0);
+        assertThat(meter.getNumberOfErroneousEvents()).isEqualTo(0);
+        assertThat(meter.getLastEvent()).isNull();
+        assertThat(meter.getMilliSecondsSinceLastEvent()).isEqualTo(-1);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerPartitionMetrics.java
@@ -67,6 +67,11 @@ abstract public class AbstractSqlServerPartitionMetrics extends Metrics implemen
     }
 
     @Override
+    public long getTotalNumberOfReadEventsSeen() {
+        return commonEventMeter.getTotalNumberOfReadEventsSeen();
+    }
+
+    @Override
     public long getNumberOfEventsFiltered() {
         return commonEventMeter.getNumberOfEventsFiltered();
     }

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -26,6 +26,10 @@ If the snapshot is interrupted, and the connector task restarts, the metric coun
 |`long`
 |The total number of events that this connector has seen since last started or reset.
 
+|[[connectors-snaps-metric-totalnumberofreadeventsseen_{context}]]<<connectors-snaps-metric-totalnumberofreadeventsseen_{context}, `TotalNumberOfReadEventsSeen`>>
+|`long`
+|The total number of read events that this connector has seen since last started or reset.
+
 |[[connectors-snaps-metric-numberofeventsfiltered_{context}]]<<connectors-snaps-metric-numberofeventsfiltered_{context}, `NumberOfEventsFiltered`>>
 |`long`
 | The number of events that have been filtered by include/exclude list filtering rules configured on the connector.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -409,3 +409,4 @@ surya-dl,Surya Dhaneshwar
 suryadanny,Surya Dhaneshwar
 Rohith,Rohith Devarshetty
 soepic1,Oladele Oluwaseun
+ragulshanmugam,Ragul Shanmugam


### PR DESCRIPTION
### Related Issue 

- https://github.com/debezium/dbz/issues/2167

Adds a `TotalNumberOfReadEventsSeen` counter to the common connector event metrics.

`CommonEventMeter#updateCommonEventMetrics` handles `CREATE`, `UPDATE` and `DELETE`, but `READ` falls through to `default: break`. Since `SnapshotChangeRecordEmitter` emits `Operation.READ`, snapshot events only ever move `TotalNumberOfEventsSeen` which is a superset (`total = read + create + update + delete`) and cannot isolate read events without subtraction. The result is that snapshot event throughput is invisible in monitoring.

Changes:

- `CommonEventMetricsMXBean` - new `getTotalNumberOfReadEventsSeen()` attribute
- `CommonEventMeter` - counter, `READ` case in the switch, getter, and inclusion in `reset()`
- `PipelineMetrics` and `AbstractSqlServerPartitionMetrics` - delegate the new getter, so the  attribute is exposed on the snapshot and streaming MBeans and on the SQL Server  partition-scoped MBeans
- `CommonEventMeterTest` - new unit test covering the `READ` path, the superset relationship with `TotalNumberOfEventsSeen`, filtered/erroneous read events, and `reset()`
- Documentation (per @Naros's request on the issue) - the new attribute added to the snapshot and streaming monitoring reference tables

### Why the attribute is documented in both the snapshot and streaming tables

Incremental snapshots run concurrently with streaming. `EventDispatcher#dispatchSnapshotEvent` notifies the ambient `eventListener` which is `streamingMetrics` during the streaming phase in addition to the receiver's `dataListener` (`snapshotMetrics`). So the counter is observable on both MBeans, not just the snapshot one.

### Scope

This PR covers the core change only. Items 3 and 4 from the issue live in other repositories and will follow separately:

- `debezium-jmx-config.yaml` and `debezium-jmx-config-legacy.yaml` in **debezium-server**
  (`debezium-server-dist/src/main/resources/distro/config/`) - the OTel JMX mapping. Both files map the existing create/update/delete counters and would need the new attribute. The operator points at that path via `OTEL_JMX_CONFIG` in `DeploymentDependent` rather than generating the file, so I don't think anything is needed in debezium-operator.
- The dashboard panel in **debezium-platform**.

The MBean attribute has to exist before anything can map it, and debezium-server tracks the same `3.7.0-SNAPSHOT` line, so those follow-ups are unblocked as soon as this merges.

@mfvitale - happy to reorder or fold these together differently if you'd prefer.

### Known limitation

As noted in the issue, `CommonEventMeter` is shared by the initial and incremental snapshot, so the counter includes both. They do not run in the same time frame, so this should be acceptable.

### AI assistance

I used Claude to help navigate the codebase, trace the metrics dispatch path, and run builds and tests locally. I wrote and reviewed the changes myself, verified them against existing conventions in the repository, and confirmed the build and unit tests pass.
