### PR TITLE
debezium/dbz#1474 MySQL/MariaDB support binlog keep alive max reconnect attempts

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnectorConfig.java
@@ -396,6 +396,19 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
             .withDescription("Interval for connection checking if keep alive thread is used, given in milliseconds "
                     + "Defaults to 1 minute (60,000 ms).");
 
+    public static final Field KEEP_ALIVE_MAX_RECONNECT_ATTEMPTS = Field.create("connect.keep.alive.max.reconnect.attempts")
+            .withDisplayName("Keep alive maximum reconnect attempts")
+            .withType(ConfigDef.Type.INT)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(0)
+            .withValidation(Field::isNonNegativeInteger)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED))
+            .withDescription("Number of consecutive attempts the keep alive thread makes to restore a lost binlog "
+                    + "connection before the connector fails. A connection that can never be restored otherwise "
+                    + "leaves the connector running without emitting any change events. Defaults to 0, meaning the "
+                    + "keep alive thread retries indefinitely.");
+
     public static final Field USE_NONGRACEFUL_DISCONNECT = Field.create("use.nongraceful.disconnect")
             .withDisplayName("Use Non-graceful Disconnect")
             .withType(ConfigDef.Type.BOOLEAN)
@@ -643,7 +656,7 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
                     RelationalDatabaseConnectorConfig.DATABASE_NAME)
             .group(Field.Group.CONNECTION, HOSTNAME, PORT, USER, PASSWORD, QUERY_TIMEOUT_MS, SERVER_ID)
             .group(Field.Group.CONNECTION_ADVANCED, ON_CONNECT_STATEMENTS, SERVER_ID_OFFSET, CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS,
-                    USE_NONGRACEFUL_DISCONNECT, BINLOG_NET_WRITE_TIMEOUT, BINLOG_NET_READ_TIMEOUT)
+                    KEEP_ALIVE_MAX_RECONNECT_ATTEMPTS, USE_NONGRACEFUL_DISCONNECT, BINLOG_NET_WRITE_TIMEOUT, BINLOG_NET_READ_TIMEOUT)
             .group(Field.Group.CONNECTION_ADVANCED_SSL, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD, SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD)
             .group(Field.Group.CONNECTOR, BIGINT_UNSIGNED_HANDLING_MODE, TIME_PRECISION_MODE, ENABLE_TIME_ADJUSTER, SCHEMA_NAME_ADJUSTMENT_MODE, GTID_SOURCE_INCLUDES,
                     GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS)
@@ -950,5 +963,13 @@ public abstract class BinlogConnectorConfig extends HistorizedRelationalDatabase
      */
     public long getBinlogNetReadTimeout() {
         return config.getLong(BINLOG_NET_READ_TIMEOUT);
+    }
+
+    /**
+     * @return the number of consecutive failed reconnect attempts after which the connector fails,
+     *         0 means the keep alive thread reconnects indefinitely
+     */
+    public int getKeepAliveMaxReconnectAttempts() {
+        return config.getInteger(KEEP_ALIVE_MAX_RECONNECT_ATTEMPTS);
     }
 }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -476,6 +476,13 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
         client.setKeepAlive(configuration.getBoolean(BinlogConnectorConfig.KEEP_ALIVE));
         client.setKeepAliveInterval(keepAliveInterval);
 
+        final int keepAliveMaxReconnectAttempts = connectorConfig.getKeepAliveMaxReconnectAttempts();
+        client.setKeepAliveMaxReconnectAttempts(keepAliveMaxReconnectAttempts);
+        if (keepAliveMaxReconnectAttempts > 0) {
+            LOGGER.info("Binlog client will fail the connector after {} consecutive failed reconnect attempts",
+                    keepAliveMaxReconnectAttempts);
+        }
+
         // Considering heartbeatInterval should be less than keepAliveInterval, use the heartbeatIntervalFactor
         // multiply by keepAliveInterval and set the result value to heartbeatInterval. The default value of
         // heartbeatIntervalFactor is 0.0, and we believe the left time (0.2 * keepAliveInterval) is enough
@@ -1520,6 +1527,16 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                 LOGGER.debug("Exception while closing client", e);
             }
             errorHandler.setProducerThrowable(wrap(ex));
+        }
+
+        @Override
+        public void onReconnectAbandoned(BinaryLogClient client, Throwable cause, int failedAttempts) {
+            // The keep alive thread has stopped, so nothing will restore the connection any more. Unlike a
+            // communication failure this arrives after onDisconnect and on the keep alive thread itself, so the
+            // client is already torn down and must not be disconnected again from here.
+            LOGGER.error("Binlog client gave up restoring the connection after {} failed attempt(s)", failedAttempts, cause);
+            logStreamingSourceState();
+            errorHandler.setProducerThrowable(wrap(cause));
         }
 
         @Override

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStaleConnectionIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogStaleConnectionIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.util.DatabaseTcpProxy;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
+
+/**
+ * Verifies that the connector fails instead of staying in a running state without emitting events when the
+ * binlog connection is lost and cannot be restored.
+ *
+ * @author Chris Cranford
+ */
+public abstract class BinlogStaleConnectionIT<C extends SourceConnector> extends AbstractBinlogConnectorIT<C> {
+
+    private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-stale-connection.txt")
+            .toAbsolutePath();
+
+    private static final int KEEP_ALIVE_INTERVAL_MS = 1_000;
+    private static final int MAX_RECONNECT_ATTEMPTS = 2;
+
+    private final UniqueDatabase DATABASE = TestHelper.getUniqueDatabase("staleconn", "empty")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    @BeforeEach
+    void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @AfterEach
+    void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1474")
+    void shouldFailWhenBinlogConnectionCannotBeRestored() throws SQLException, IOException, InterruptedException {
+        final LogInterceptor logInterceptor = new LogInterceptor(BinlogStreamingChangeEventSource.class);
+
+        // Route the connector through a proxy so the connection can be broken at the network level ...
+        try (DatabaseTcpProxy proxy = DatabaseTcpProxy.forward(
+                System.getProperty("database.hostname", "localhost"),
+                Integer.parseInt(System.getProperty("database.port", "3306")))) {
+
+            config = DATABASE.defaultConfig()
+                    .with(BinlogConnectorConfig.HOSTNAME, proxy.getHostname())
+                    .with(BinlogConnectorConfig.PORT, proxy.getPort())
+                    .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.NO_DATA)
+                    .with(BinlogConnectorConfig.KEEP_ALIVE_INTERVAL_MS, KEEP_ALIVE_INTERVAL_MS)
+                    .with(BinlogConnectorConfig.KEEP_ALIVE_MAX_RECONNECT_ATTEMPTS, MAX_RECONNECT_ATTEMPTS)
+                    .build();
+
+            final AtomicReference<Throwable> engineFailure = new AtomicReference<>();
+            start(getConnectorClass(), config, (success, message, error) -> engineFailure.set(error));
+            assertConnectorIsRunning();
+            waitForStreamingRunning(getConnectorName(), DATABASE.getServerName(), getStreamingNamespace());
+
+            // Prove that change events really are flowing through the proxy before it is broken. The
+            // statements are executed directly against the database, not through the proxy ...
+            executeStatements(DATABASE.getDatabaseName(),
+                    "CREATE TABLE dbz9755 (id INT PRIMARY KEY, name VARCHAR(64))",
+                    "INSERT INTO dbz9755 VALUES (1, 'before')");
+            assertThat(consumeRecordsByTopic(1).allRecordsInOrder()).hasSize(1);
+
+            // The TCP connection stays ESTABLISHED but nothing flows over it any more, and no new
+            // connection can be established either ...
+            proxy.blackhole();
+
+            // Detection takes one keep alive interval, then every reconnect attempt takes another, so the
+            // task must fail shortly after (MAX_RECONNECT_ATTEMPTS + 1) intervals ...
+            Awaitility.await()
+                    .alias("connector to fail after the binlog connection could not be restored")
+                    .atMost(Duration.ofSeconds(60))
+                    .pollInterval(Duration.ofMillis(200))
+                    .until(() -> engineFailure.get() != null);
+
+            assertConnectorNotRunning();
+            assertThat(logInterceptor.containsErrorMessage("Binlog client gave up restoring the connection")).isTrue();
+        }
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/DatabaseTcpProxy.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/util/DatabaseTcpProxy.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * A TCP proxy that forwards traffic to a database, so that a test can break a connection at the network
+ * level instead of shutting the database down.
+ *
+ * <p>{@link #blackhole()} reproduces the failure mode where the TCP connection stays ESTABLISHED while the
+ * database session is gone: traffic stops flowing in both directions, the sockets that are already open are
+ * left open so that neither side observes an error, and further connection attempts are refused so that a
+ * reconnect cannot succeed.
+ *
+ * @author Chris Cranford
+ */
+public class DatabaseTcpProxy implements Closeable {
+
+    private final String targetHost;
+    private final int targetPort;
+    private final ServerSocket serverSocket;
+    private final List<Socket> sockets = new CopyOnWriteArrayList<>();
+
+    private volatile boolean blackholed;
+    private volatile boolean closed;
+
+    private DatabaseTcpProxy(String targetHost, int targetPort) throws IOException {
+        this.targetHost = targetHost;
+        this.targetPort = targetPort;
+        this.serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+
+        final Thread acceptThread = new Thread(this::acceptLoop, "database-tcp-proxy-accept");
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+    }
+
+    /**
+     * Starts a proxy on an ephemeral loopback port that forwards to the given database.
+     *
+     * @param targetHost the database hostname
+     * @param targetPort the database port
+     * @return the started proxy, never null
+     */
+    public static DatabaseTcpProxy forward(String targetHost, int targetPort) throws IOException {
+        return new DatabaseTcpProxy(targetHost, targetPort);
+    }
+
+    public String getHostname() {
+        return serverSocket.getInetAddress().getHostAddress();
+    }
+
+    public int getPort() {
+        return serverSocket.getLocalPort();
+    }
+
+    /**
+     * Stops forwarding traffic without closing the connections that are already established, and refuses
+     * any further connection attempt.
+     */
+    public void blackhole() {
+        blackholed = true;
+        // reconnect attempts now fail immediately rather than hanging
+        closeQuietly(serverSocket);
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        closeQuietly(serverSocket);
+        sockets.forEach(DatabaseTcpProxy::closeQuietly);
+        sockets.clear();
+    }
+
+    private void acceptLoop() {
+        while (!closed) {
+            final Socket incoming;
+            try {
+                incoming = serverSocket.accept();
+            }
+            catch (IOException e) {
+                // the server socket was closed, either by blackhole() or by close()
+                return;
+            }
+
+            try {
+                final Socket outgoing = new Socket();
+                outgoing.connect(new InetSocketAddress(targetHost, targetPort));
+                sockets.add(incoming);
+                sockets.add(outgoing);
+                pump(incoming, outgoing);
+                pump(outgoing, incoming);
+            }
+            catch (IOException e) {
+                closeQuietly(incoming);
+            }
+        }
+    }
+
+    private void pump(Socket from, Socket to) {
+        final Thread thread = new Thread(() -> {
+            final byte[] buffer = new byte[8192];
+            try {
+                final InputStream input = from.getInputStream();
+                final OutputStream output = to.getOutputStream();
+                while (!closed) {
+                    final int read = input.read(buffer);
+                    if (read == -1) {
+                        break;
+                    }
+                    if (blackholed) {
+                        // keep draining so that the sender never blocks, but deliver nothing
+                        continue;
+                    }
+                    output.write(buffer, 0, read);
+                    output.flush();
+                }
+            }
+            catch (IOException e) {
+                // the connection is gone, there is nothing left to forward
+            }
+            finally {
+                if (!blackholed) {
+                    // while blackholed the sockets are deliberately left open so that neither side
+                    // notices that the connection is dead; close() tears them down at the end
+                    closeQuietly(from);
+                    closeQuietly(to);
+                }
+            }
+        }, "database-tcp-proxy-pump");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        try {
+            closeable.close();
+        }
+        catch (IOException e) {
+            // ignored
+        }
+    }
+}

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/StaleConnectionIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/StaleConnectionIT.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import io.debezium.connector.binlog.BinlogStaleConnectionIT;
+
+/**
+ * @author Chris Cranford
+ */
+public class StaleConnectionIT extends BinlogStaleConnectionIT<MariaDbConnector> implements MariaDbCommon {
+
+}

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlStaleConnectionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlStaleConnectionIT.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.binlog.BinlogStaleConnectionIT;
+
+/**
+ * @author Chris Cranford
+ */
+public class MySqlStaleConnectionIT extends BinlogStaleConnectionIT<MySqlConnector> implements MySqlCommon {
+
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -71,6 +71,24 @@ Description:::
 A Boolean value that specifies whether a separate thread should be used to ensure that the connection to the {connector-name} server or cluster is kept alive.
 
 
+[id="{context}-property-connect-keep-alive-max-reconnect-attempts"]
+xref:{context}-property-connect-keep-alive-max-reconnect-attempts[`connect.keep.alive.max.reconnect.attempts`]::
+
+Default value::: `0`
+
+Description:::
+The number of consecutive attempts that the keep alive thread makes to restore a lost binlog connection before the connector fails.
+A value of `0` means that the keep alive thread retries indefinitely.
++
+If a connection can never be restored, for example because the {connector-name} session ended while the TCP connection remained established, retrying indefinitely leaves the connector in the `RUNNING` state without emitting any change events.
+Set this property to fail the connector task instead, so that it can be restarted with a fresh connection.
++
+Each attempt is separated by `connect.keep.alive.interval.ms`, so the connector tolerates an outage of approximately `connect.keep.alive.max.reconnect.attempts` multiplied by `connect.keep.alive.interval.ms` before it fails.
+Set a value that exceeds the length of any planned maintenance window, to avoid failing the task during a routine restart of the database.
++
+This property has no effect when `connect.keep.alive` is set to `false`.
+
+
 [id="{context}-property-converters"]
 xref:{context}-property-converters[`converters`]::
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.7.13</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
-        <version.mysql.binlog>0.41.2</version.mysql.binlog>
+        <version.mysql.binlog>0.41.3</version.mysql.binlog>
         <version.singlestore.driver>1.2.11</version.singlestore.driver>
         <version.starrocks.driver>1.1.1</version.starrocks.driver>
         <version.mongo.driver>5.9.2</version.mongo.driver>


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1474
Requires https://github.com/debezium/mysql-binlog-connector-java/pull/30 and binlog client bumped to 0.41.3.

Supersedes https://github.com/debezium/debezium/pull/7461

## Description
This introduces a new `connect.keep.alive.max.reconnect.attempts` binlog connector property that sets the maximum number of keepalive retry attempts in the Binlog client. By default, this is `0` (disabled), but you can set it to a positive value to trigger a connector failure if the keepalive thread can no longer connect after X attempts.

This is useful for AWS users where the NAT gateway breaks the network connection due to idle connections, and the connector doesn't recognize the failure and continues uninterrupted.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
