### PR TITLE
debezium/dbz#2506 Compare binlog positions as long in the history record comparator

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/history/BinlogHistoryRecordComparator.java
@@ -143,9 +143,9 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
         }
 
         // With the filenames the same, compare positions
-        final int recordedPosition = getBinlogPosition(recorded);
-        final int desiredPosition = getBinlogPosition(desired);
-        final int positionCheck = recordedPosition - desiredPosition;
+        final long recordedPosition = getBinlogPosition(recorded);
+        final long desiredPosition = getBinlogPosition(desired);
+        final int positionCheck = Long.compare(recordedPosition, desiredPosition);
         if (positionCheck != 0) {
             return positionCheck < 0;
         }
@@ -191,8 +191,10 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
      * @param document the document to inspect, should not be null
      * @return the unique server identifier
      */
-    protected int getServerId(Document document) {
-        return document.getInteger(BinlogSourceInfo.SERVER_ID_KEY, 0);
+    protected long getServerId(Document document) {
+        // server_id is a 32-bit unsigned value, so identifiers above Integer.MAX_VALUE are
+        // legitimate and must be read as a long for the same reason as the binlog position
+        return document.getLong(BinlogSourceInfo.SERVER_ID_KEY, 0);
     }
 
     /**
@@ -231,8 +233,11 @@ public abstract class BinlogHistoryRecordComparator extends HistoryRecordCompara
      * @param document the document to inspect, should not be null
      * @return the binlog position value
      */
-    protected int getBinlogPosition(Document document) {
-        return document.getInteger(BinlogSourceInfo.BINLOG_POSITION_OFFSET_KEY, -1);
+    protected long getBinlogPosition(Document document) {
+        // Positions are unsigned and a binlog file can exceed Integer.MAX_VALUE bytes, so the
+        // value must be read as a long; Document#getInteger would return null for such values,
+        // silently turning every large position into the default
+        return document.getLong(BinlogSourceInfo.BINLOG_POSITION_OFFSET_KEY, -1);
     }
 
     /**

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
@@ -553,6 +553,25 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
     }
 
     @Test
+    @FixFor("debezium/dbz#2506")
+    void shouldComparePositionsWithoutGtidsBeyondIntegerRange() {
+        // Binlog positions are unsigned and a single file can exceed Integer.MAX_VALUE bytes,
+        // e.g. when one transaction is larger than max_binlog_size; positions must not be read
+        // back or compared through int
+        long fourGiB = 4_294_967_296L;
+
+        // schema history records stay at small positions while the restart offset is far into the file
+        assertPositionWithoutGtids("fn.01", 5_000, 0, 0).isBefore(positionWithoutGtids("fn.01", 9_886_193_806L, 0, 0));
+        assertPositionWithoutGtids("fn.01", 100, 0, 0).isBefore(positionWithoutGtids("fn.01", 4_000_000_000L, 0, 0));
+        assertPositionWithoutGtids("fn.01", 4_000_000_000L, 0, 0).isAfter(positionWithoutGtids("fn.01", 100, 0, 0));
+
+        // both positions beyond Integer.MAX_VALUE keep their ordering
+        assertPositionWithoutGtids("fn.01", fourGiB, 0, 0).isBefore(positionWithoutGtids("fn.01", fourGiB + 100, 0, 0));
+        assertPositionWithoutGtids("fn.01", fourGiB + 100, 0, 0).isAfter(positionWithoutGtids("fn.01", fourGiB, 0, 0));
+        assertPositionWithoutGtids("fn.01", fourGiB, 0, 0).isAt(positionWithoutGtids("fn.01", fourGiB, 0, 0));
+    }
+
+    @Test
     void shouldComparePositionsWithDifferentFields() {
         Document history = positionWith("mysql-bin.000008", 380941551, "01261278-6ade-11e6-b36a-42010af00790:1-378422946,"
                 + "4d1a4918-44ba-11e6-bf12-42010af0040b:1-11002284,"
@@ -607,6 +626,23 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
         // The same server keeps comparing by coordinates, even when the timestamps disagree.
         assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 223344, 2_000))
                 .isAtOrBefore(positionWithServerId("mysql-bin.000007", 154, 223344, 1_000));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2506")
+    void shouldCompareServerIdsBeyondIntegerRange() {
+        // server_id is a 32-bit unsigned value, so identifiers above Integer.MAX_VALUE are
+        // legitimate; they must not collapse to the default when read back, which would make
+        // two different servers look like the same one. The file names are ordered against the
+        // timestamps so a positional comparison would give the opposite answer.
+        assertThatDocument(positionWithServerId("mysql-bin.000007", 900, 3_000_000_000L, 1_000))
+                .isAtOrBefore(positionWithServerId("mysql-bin.000003", 154, 3_500_000_000L, 2_000));
+        assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 3_000_000_000L, 2_000))
+                .isAfter(positionWithServerId("mysql-bin.000007", 154, 3_500_000_000L, 1_000));
+
+        // The same large identifier still compares by coordinates.
+        assertThatDocument(positionWithServerId("mysql-bin.000003", 900, 3_000_000_000L, 2_000))
+                .isAtOrBefore(positionWithServerId("mysql-bin.000007", 154, 3_000_000_000L, 1_000));
     }
 
     @Test
@@ -745,15 +781,15 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
         return Document.create(BinlogOffsetContext.GTID_SET_KEY, gtids);
     }
 
-    protected Document positionWithoutGtids(String filename, int position, int event, int row) {
+    protected Document positionWithoutGtids(String filename, long position, int event, int row) {
         return positionWithoutGtids(filename, position, event, row, false);
     }
 
-    protected Document positionWithoutGtids(String filename, int position, int event, int row, boolean snapshot) {
+    protected Document positionWithoutGtids(String filename, long position, int event, int row, boolean snapshot) {
         return positionWith(filename, position, null, event, row, snapshot);
     }
 
-    protected Document positionWith(String filename, int position, String gtids, int event, int row, boolean snapshot) {
+    protected Document positionWith(String filename, long position, String gtids, int event, int row, boolean snapshot) {
         Document pos = Document.create(BinlogSourceInfo.BINLOG_FILENAME_OFFSET_KEY, filename,
                 BinlogSourceInfo.BINLOG_POSITION_OFFSET_KEY, position);
         if (row >= 0) {
@@ -771,7 +807,7 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
         return pos;
     }
 
-    protected Document positionWithServerId(String filename, int position, int serverId, long timestamp) {
+    protected Document positionWithServerId(String filename, long position, long serverId, long timestamp) {
         return positionWithoutGtids(filename, position, 0, 0)
                 .set(BinlogSourceInfo.SERVER_ID_KEY, serverId)
                 .set(BinlogOffsetContext.TIMESTAMP_KEY, timestamp);
@@ -789,11 +825,11 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
         return assertThatDocument(positionWithGtids(gtids, snapshot));
     }
 
-    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int event, int row) {
+    protected PositionAssert assertPositionWithoutGtids(String filename, long position, int event, int row) {
         return assertPositionWithoutGtids(filename, position, event, row, false);
     }
 
-    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int event, int row, boolean snapshot) {
+    protected PositionAssert assertPositionWithoutGtids(String filename, long position, int event, int row, boolean snapshot) {
         return assertThatDocument(positionWithoutGtids(filename, position, event, row, snapshot));
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2506

`BinlogHistoryRecordComparator` read binlog positions using `Document#getInteger`. When a stored
position exceeds `Integer.MAX_VALUE`, it is represented as a `Long` and the lookup falls back to
`-1`, causing schema history recovery to incorrectly skip recorded entries.

This changes the comparator to read positions as `long` and use `Long.compare` for comparison.
The `server_id` field is a 32-bit unsigned value with the same defect and is widened to `long`
as well.

The shared test helpers are also updated to accept `long` positions.
