### PR TITLE
[ci] Parametrize maven command in test script

### DIFF
--- a/debezium-testing/tmt/tests/debezium/test.sh
+++ b/debezium-testing/tmt/tests/debezium/test.sh
@@ -4,9 +4,11 @@ cd ../../../..
 
 echo $PWD
 
+MVN_CMD="${MAVEN_COMMAND:-mvn}"
+
 if [ "$TEST_PROFILE" = "mysql" ]
 then
-  mvn clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-mysql \
+  $MVN_CMD clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-mysql \
     -Dversion.mysql.server=${MYSQL_VERSION} \
     ${EXECUTION_ARG:-} \
     -Dmysql.port=4301 \
@@ -16,7 +18,7 @@ then
     -P${PROFILE}
 elif [ "$TEST_PROFILE" = "postgres" ]
 then
-  mvn clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-postgres \
+  $MVN_CMD clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-postgres \
   -Dpostgres.port=55432 \
   ${ORACLE_ARG:-}                            \
   ${EXECUTION_ARG:-}                            \
@@ -39,7 +41,7 @@ then
   if [[ "$ORACLE_VERSION" = *noncdb ]]; then
     DATABASE_USER="dbzuser"
   fi
-  mvn clean verify -U -pl debezium-connector-oracle -am -fae \
+  $MVN_CMD clean verify -U -pl debezium-connector-oracle -am -fae \
     -Poracle-tests                              \
     ${ORACLE_PROFILE_ARGS:-}                    \
     ${ORACLE_ARG:-}                            \
@@ -63,11 +65,11 @@ then
   else
     export DATABASE_IMAGE="mcr.microsoft.com/mssql/server:2022-latest"
   fi
-  mvn clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-sqlserver \
+  $MVN_CMD clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-sqlserver \
   ${EXECUTION_ARG:-}                            \
   -Ddocker.db="${DATABASE_IMAGE}"
 else
-  mvn clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-mongodb \
+  $MVN_CMD clean verify ${CUSTOM_MAVEN_ARGS},debezium-connector-mongodb \
   ${EXECUTION_ARG:-}                            \
   -Dversion.mongo.server=${MONGODB_VERSION}
 fi


### PR DESCRIPTION
This will allow us to switch between plain `mvn` command and maven wrapper `./mvnw` as needed, just by setting `MAVEN_COMMND` env. variable. The default is still plain `mvn` command.
