### PR TITLE
Dbz 9969 3.6 adds smt short descriptions

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
+++ b/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
@@ -103,21 +103,18 @@ To make all string and bytes fields eligible for truncation, set `min.field.size
 [[enforce-record-size-behavior]]
 == Behavior details
 
-* The SMT only processes records whose value is a {prodname} change event envelope (a `Struct` with `before` and/or `after` fields).
-  Non-envelope records (such as schema change events or tombstones) pass through unchanged.
-* Truncation is applied to both the `before` and `after` sections of the envelope.
-  The excess is distributed between the two sections in proportion to their truncatable content.
-* The SMT does not guarantee that the final serialized record will be exactly at or below `max.bytes`.
-  The size estimate is approximate, and actual serialized size depends on the converter (JSON, Avro, Protobuf) and its overhead.
+The enforce record size SMT evaluates only {prodname} change event records and applies truncation to the `before` and `after` fields of the event envelope.
+Size estimates are approximate; the actual serialized size depends on the converter you use.
+
 During processing, the enforce record size transformation applies the following constraints and behaviors.
 
-* The SMT processes only records whose value contains a {prodname} change event envelope, that is, a Struct with `before` and `after` fields. 
+* The SMT processes only records whose value contains a {prodname} change event envelope, that is, a Struct with `before` and `after` fields.
 It passes non-envelope records, such as schema change events or tombstones, unchanged.
 
 * The SMT applies truncation to both the `before` and `after` sections of the envelope and distributes the excess between the two sections in proportion to their truncatable content.
 
-* The SMT does not guarantee that the final serialized record is exactly at or below max.bytes, because it estimates size approximately and the actual serialized size depends on the converter (JSON, Avro, or Protobuf) and its associated overhead. 
-To provide a safety margin, configure a conservative max.bytes value or adjust the compression.ratio setting.
+* The SMT does not guarantee that the final serialized record is exactly at or below `max.bytes`, because it estimates size approximately and the actual serialized size depends on the converter (JSON, Avro, or Protobuf) and its associated overhead.
+To provide a safety margin, configure a conservative `max.bytes` value or adjust the `compression.ratio` setting.
 
 // Type: reference
 // ModuleID: options-for-configuring-the-enforce-record-size-transformation

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -570,8 +570,13 @@ Set one of the following options:
 `avro_unicode`:: Similar to `avro`, but replaces invalid characters with their Unicode equivalent (e.g., `_u0031` for a leading `1`).
 |===
 
+// Type: reference
+// Title: Known limitations of the MongoDB event flattening SMT
+// ModuleID: mongodb-event-flattening-smt-known-limitations
 [id="debezium-event-flattening-smt-for-mongodb-known-limitations"]
 == Known limitations
+
+Because MongoDB is schemaless and sink connectors require specific message formats, the following constraints apply when you configure the MongoDB event flattening transformation.
 
 * Because MongoDB is a schemaless database, to ensure consistent column definitions when you use {prodname} to stream changes to a schema-based data relational database, fields within a collection that have the same name must store the same type of data.
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-9969](https://redhat.atlassian.net/browse/DBZ-9969)
## Description
Cherry-pick from `main`.
Adds missing short descriptions and annotations and applies minor edits to topics in the following SMT docs:

- Enforce record size SMT
- MongoDB event flattening SMT

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
