### PR TITLE
debezium/dbz#2503 Centralize scattered Image names in one single class ImageNames 

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -878,3 +878,4 @@ Björn Bärtschi
 Raju Surarapu
 dingqianwen
 Surya Dhaneshwar
+Mohamed Elkholy

--- a/debezium-ai/debezium-ai-docling/pom.xml
+++ b/debezium-ai/debezium-ai-docling/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>debezium-archunit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debezium-ai/debezium-ai-docling/src/test/java/io/debezium/ai/docling/DoclingSmtIT.java
+++ b/debezium-ai/debezium-ai-docling/src/test/java/io/debezium/ai/docling/DoclingSmtIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.data.Envelope;
 import io.debezium.junit.SkipLongRunning;
+import io.debezium.testing.testcontainers.ImageNames;
 
 import ai.docling.testcontainers.serve.DoclingServeContainer;
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
@@ -32,7 +33,7 @@ import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
  */
 @SkipLongRunning("Downloading Docling container takes too long")
 public class DoclingSmtIT {
-    private static final String DOCLING_IMAGE_NAME = "quay.io/docling-project/docling-serve:v1.15.0";
+    private static final String DOCLING_IMAGE_NAME = ImageNames.DOCLING_1_15_IMAGE;
 
     public static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
             .name("mysql.inventory.products.Value")

--- a/debezium-ai/debezium-ai-embeddings-ollama/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings-ollama/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>debezium-archunit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debezium-ai/debezium-ai-embeddings-ollama/src/test/java/io/debezium/ai/embeddings/EmbeddingsOllamaIT.java
+++ b/debezium-ai/debezium-ai-embeddings-ollama/src/test/java/io/debezium/ai/embeddings/EmbeddingsOllamaIT.java
@@ -22,13 +22,15 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.ollama.OllamaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.debezium.testing.testcontainers.ImageNames;
+
 /**
  * Integrations tests for {@link FieldToEmbedding} SMT which uses {@link OllamaModelFactory}.
  *
  * @author vjuranek
  */
 public class EmbeddingsOllamaIT {
-    private static final String OLLAMA_IMAGE_NAME = "mirror.gcr.io/ollama/ollama:0.6.2";
+    private static final String OLLAMA_IMAGE_NAME = ImageNames.OLLAMA_0_6_2_IMAGE;
     private static final String OLLAMA_TEST_MODEL = "all-minilm";
 
     private static final OllamaContainer ollama = new OllamaContainer(

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/CockroachDbSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/CockroachDbSinkDatabaseContextProvider.java
@@ -10,6 +10,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for CockroachDB.
@@ -19,8 +20,7 @@ import io.debezium.connector.jdbc.junit.TestHelper;
 public class CockroachDbSinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
 
     // Registry-qualified so the image name is not rewritten by the configured image name substitutor.
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("docker.io/cockroachdb/cockroach:v25.4.12")
-            .asCompatibleSubstituteFor("cockroachdb/cockroach");
+    private static final DockerImageName IMAGE_NAME = ImageNames.COCKROACHDB_25_4_12_IMAGE_NAME;
 
     @SuppressWarnings("resource")
     public CockroachDbSinkDatabaseContextProvider() {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/Db2SinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/Db2SinkDatabaseContextProvider.java
@@ -10,6 +10,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for Db2.
@@ -18,7 +19,7 @@ import io.debezium.connector.jdbc.junit.TestHelper;
  */
 public class Db2SinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
 
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("icr.io/db2_community/db2:11.5.9.0");
+    private static final DockerImageName IMAGE_NAME = ImageNames.DB2_11_5_9_IMAGE_NAME;
 
     @SuppressWarnings("resource")
     public Db2SinkDatabaseContextProvider() {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/MySqlSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/MySqlSinkDatabaseContextProvider.java
@@ -10,6 +10,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for MySQL.
@@ -18,7 +19,7 @@ import io.debezium.connector.jdbc.junit.TestHelper;
  */
 public class MySqlSinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
 
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("container-registry.oracle.com/mysql/community-server:9.0")
+    private static final DockerImageName IMAGE_NAME = ImageNames.MYSQL_9_IMAGE_NAME
             .asCompatibleSubstituteFor("mysql");
 
     @SuppressWarnings("resource")

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/OracleSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/OracleSinkDatabaseContextProvider.java
@@ -10,6 +10,7 @@ import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for Oracle.
@@ -18,7 +19,7 @@ import io.debezium.connector.jdbc.junit.TestHelper;
  */
 public class OracleSinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
 
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("quay.io/rh_integration/dbz-oracle:19.3.0")
+    private static final DockerImageName IMAGE_NAME = ImageNames.ORACLE_DBZ_19_3_0_IMAGE_NAME
             .asCompatibleSubstituteFor("gvenzl/oracle-xe");
 
     @SuppressWarnings("resource")

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/PostgresSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/PostgresSinkDatabaseContextProvider.java
@@ -16,6 +16,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.PostgresExtensionUtils;
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for PostgreSQL.
@@ -26,8 +27,7 @@ public class PostgresSinkDatabaseContextProvider extends AbstractSinkDatabaseCon
 
     // We explicitly use debezium/postgres which has the POSTGIS extension available.
     // The standard postgres image does not ship with POSTGIS available by default.
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("quay.io/debezium/postgres:17")
-            .asCompatibleSubstituteFor("postgres");
+    private static final DockerImageName IMAGE_NAME = ImageNames.POSTGRES_17_IMAGE_NAME;
 
     @SuppressWarnings("resource")
     public PostgresSinkDatabaseContextProvider() {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/SqlServerSinkDatabaseContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/SqlServerSinkDatabaseContextProvider.java
@@ -10,6 +10,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.connector.jdbc.junit.TestHelper;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * An implementation of {@link AbstractSinkDatabaseContextProvider} for SQL Server.
@@ -18,7 +19,7 @@ import io.debezium.connector.jdbc.junit.TestHelper;
  */
 public class SqlServerSinkDatabaseContextProvider extends AbstractSinkDatabaseContextProvider {
 
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest");
+    private static final DockerImageName IMAGE_NAME = ImageNames.SQLSERVER_22_IMAGE_NAME;
 
     @SuppressWarnings("resource")
     public SqlServerSinkDatabaseContextProvider() {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/e2e/source/SourcePipelineInvocationContextProvider.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/junit/jupiter/e2e/source/SourcePipelineInvocationContextProvider.java
@@ -58,6 +58,7 @@ import io.debezium.connector.jdbc.junit.jupiter.e2e.WithTemporalPrecisionMode;
 import io.debezium.connector.jdbc.util.RandomTableNameGenerator;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.testing.testcontainers.DebeziumContainer;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.strimzi.test.container.StrimziKafkaCluster;
 
 /**
@@ -73,18 +74,18 @@ public class SourcePipelineInvocationContextProvider implements BeforeAllCallbac
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SourcePipelineInvocationContextProvider.class);
 
-    private static final String MYSQL_IMAGE_NAME = "container-registry.oracle.com/mysql/community-server:9.0";
+    private static final String MYSQL_IMAGE_NAME = ImageNames.MYSQL_9_IMAGE;
     private static final String MYSQL_USERNAME = "mysqluser";
     private static final String MYSQL_PASSWORD = "debezium";
 
-    private static final String POSTGRES_IMAGE_NAME = "quay.io/debezium/example-postgres";
+    private static final String POSTGRES_IMAGE_NAME = ImageNames.POSTGRES_EXAMPLE_IMAGE;
     private static final String POSTGRES_USERNAME = "postgres";
     private static final String POSTGRES_PASSWORD = "postgres";
 
-    private static final String SQLSERVER_IMAGE_NAME = "mcr.microsoft.com/mssql/server:2022-latest";
+    private static final String SQLSERVER_IMAGE_NAME = ImageNames.SQLSERVER_22_IMAGE;
     private static final String SQLSERVER_PASSWORD = "Debezium1!";
 
-    private static final String ORACLE_IMAGE_NAME = "quay.io/rh_integration/dbz-oracle:19.3.0";
+    private static final String ORACLE_IMAGE_NAME = ImageNames.ORACLE_DBZ_19_3_0_IMAGE;
     private static final String ORACLE_USERNAME = "debezium";
     private static final String ORACLE_PASSWORD = "dbz";
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaggedGtidWatermarkIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaggedGtidWatermarkIT.java
@@ -42,6 +42,7 @@ import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.kafka.KafkaClusterUtils;
 import io.debezium.pipeline.signal.channels.KafkaSignalChannel;
 import io.debezium.storage.file.history.FileSchemaHistory;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 import io.strimzi.test.container.StrimziKafkaCluster;
 
@@ -61,7 +62,7 @@ import io.strimzi.test.container.StrimziKafkaCluster;
 public class MySqlTaggedGtidWatermarkIT extends AbstractAsyncEngineConnectorTest {
 
     /** MySQL 9.7 supports tagged GTIDs */
-    private static final String MYSQL_IMAGE = "container-registry.oracle.com/mysql/community-server:9.7";
+    private static final String MYSQL_IMAGE = ImageNames.MYSQL_9_7_IMAGE;
 
     private static final String DB_NAME = "gtid_watermark_test";
     private static final String TABLE_NAME = "a";

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
@@ -32,6 +32,7 @@ import io.debezium.heartbeat.DatabaseHeartbeatImpl;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.testing.testcontainers.ImageNames;
+import io.debezium.testing.testcontainers.util.ContainerImageVersions;
 
 /**
  * Integration test for {@link PostgresConnector} using an {@link AsyncEmbeddedEngine} and Testcontainers infrastructure for when Postgres is shutdown during streaming
@@ -45,7 +46,7 @@ public class PostgresShutdownIT extends AbstractAsyncEngineConnectorTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresShutdownIT.class);
 
-    private static final String POSTGRES_IMAGE = ImageNames.POSTGRES_EXAMPLE_IMAGE;
+    private static final String POSTGRES_IMAGE = ContainerImageVersions.getStableImage(ImageNames.POSTGRES_EXAMPLE_IMAGE);
 
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
@@ -31,7 +31,7 @@ import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import io.debezium.heartbeat.DatabaseHeartbeatImpl;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.testing.testcontainers.util.ContainerImageVersions;
+import io.debezium.testing.testcontainers.ImageNames;
 
 /**
  * Integration test for {@link PostgresConnector} using an {@link AsyncEmbeddedEngine} and Testcontainers infrastructure for when Postgres is shutdown during streaming
@@ -45,7 +45,7 @@ public class PostgresShutdownIT extends AbstractAsyncEngineConnectorTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresShutdownIT.class);
 
-    private static final String POSTGRES_IMAGE = ContainerImageVersions.getStableImage("quay.io/debezium/example-postgres");
+    private static final String POSTGRES_IMAGE = ImageNames.POSTGRES_EXAMPLE_IMAGE;
 
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";

--- a/debezium-storage/debezium-storage-jdbc/pom.xml
+++ b/debezium-storage/debezium-storage-jdbc/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!--

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
@@ -35,6 +35,7 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.SkipWhenDatabaseVersion;
 import io.debezium.storage.jdbc.history.JdbcSchemaHistory;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
 /**
@@ -50,7 +51,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
     private static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     private static final String ROOT_PASSWORD = "debezium";
     private static final String DBNAME = "inventory";
-    private static final String IMAGE = "quay.io/debezium/example-mysql";
+    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
     private static final Integer PORT = 3306;
     private static final String TOPIC_PREFIX = "test";
     private static final String TABLE_NAME = "schematest";

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreIT.java
@@ -51,7 +51,7 @@ public class JdbcOffsetBackingStoreIT extends AbstractAsyncEngineConnectorTest {
     private static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     private static final String ROOT_PASSWORD = "debezium";
     private static final String DBNAME = "inventory";
-    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
+    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_PRIMARY_IMAGE;
     private static final Integer PORT = 3306;
     private static final String TOPIC_PREFIX = "test";
     private static final String TABLE_NAME = "schematest";

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryIT.java
@@ -35,6 +35,7 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.storage.jdbc.offset.JdbcOffsetBackingStoreConfig;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
 public class JdbcSchemaHistoryIT extends AbstractAsyncEngineConnectorTest {
@@ -47,7 +48,7 @@ public class JdbcSchemaHistoryIT extends AbstractAsyncEngineConnectorTest {
     private static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     private static final String ROOT_PASSWORD = "debezium";
     private static final String DBNAME = "inventory";
-    private static final String IMAGE = "quay.io/debezium/example-mysql";
+    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
     private static final Integer PORT = 3306;
     private static final String TOPIC_PREFIX = "test";
     private static final String TABLE_NAME = "schematest";

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryIT.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryIT.java
@@ -48,7 +48,7 @@ public class JdbcSchemaHistoryIT extends AbstractAsyncEngineConnectorTest {
     private static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     private static final String ROOT_PASSWORD = "debezium";
     private static final String DBNAME = "inventory";
-    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
+    private static final String IMAGE = ImageNames.MYSQL_EXAMPLE_PRIMARY_IMAGE;
     private static final Integer PORT = 3306;
     private static final String TOPIC_PREFIX = "test";
     private static final String TABLE_NAME = "schematest";

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!--

--- a/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
+++ b/debezium-storage/debezium-storage-redis/src/test/java/io/debezium/storage/redis/offset/RedisOffsetBackingStoreIT.java
@@ -40,6 +40,7 @@ import io.debezium.config.Configuration;
 import io.debezium.storage.redis.RedisClient;
 import io.debezium.storage.redis.RedisClientConnectionException;
 import io.debezium.storage.redis.RedisConnection;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
 @Testcontainers
@@ -53,7 +54,7 @@ class RedisOffsetBackingStoreIT {
     public static ComposeContainer redisCluster;
 
     private static final String PROP_PREFIX = "offset.storage.redis.";
-    private static final String REDIS_CONTAINER_IMAGE = "redis:5.0.3-alpine";
+    private static final String REDIS_CONTAINER_IMAGE = ImageNames.REDIS_ALPINE_IMAGE;
     private static final String NEW_LINE = "\n";
 
     // Cluster configuration constants

--- a/debezium-storage/debezium-storage-rocksdb/src/test/java/io/debezium/storage/rocksdb/tablemapping/RocksDbTableMappingStorageIT.java
+++ b/debezium-storage/debezium-storage-rocksdb/src/test/java/io/debezium/storage/rocksdb/tablemapping/RocksDbTableMappingStorageIT.java
@@ -29,6 +29,7 @@ import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
 /**
@@ -47,7 +48,7 @@ public class RocksDbTableMappingStorageIT extends AbstractAsyncEngineConnectorTe
     private static final String PRIVILEGED_USER = "mysqluser";
     private static final String PRIVILEGED_PASSWORD = "mysqlpw";
     private static final String ROOT_PASSWORD = PRIVILEGED_PASSWORD;
-    private static final DockerImageName IMAGE = DockerImageName.parse("quay.io/debezium/example-mysql")
+    private static final DockerImageName IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE_NAME
             .asCompatibleSubstituteFor("mysql");
 
     private static final MySQLContainer container = new MySQLContainer(IMAGE)

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -131,6 +131,11 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debezium-storage/debezium-storage-tests/src/test/java/io/debezium/storage/azure/blob/history/AzureBlobSchemaHistoryIT.java
+++ b/debezium-storage/debezium-storage-tests/src/test/java/io/debezium/storage/azure/blob/history/AzureBlobSchemaHistoryIT.java
@@ -33,6 +33,7 @@ import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.storage.AbstractSchemaHistoryTest;
+import io.debezium.testing.testcontainers.ImageNames;
 
 public class AzureBlobSchemaHistoryIT extends AbstractSchemaHistoryTest {
 
@@ -47,7 +48,7 @@ public class AzureBlobSchemaHistoryIT extends AbstractSchemaHistoryTest {
             "AccountKey=key;" +
             "BlobEndpoint=http://127.0.0.1:%s/account;";
 
-    final private static GenericContainer<?> container = new GenericContainer(String.format("mcr.microsoft.com/azure-storage/azurite:%s", IMAGE_TAG))
+    final private static GenericContainer<?> container = new GenericContainer(String.format("%s:%s", ImageNames.AZURITE_IMAGE, IMAGE_TAG))
             .withCommand("azurite --blobHost 0.0.0.0 --blobPort 10000")
             .withEnv("AZURITE_ACCOUNTS", "account:key")
             .withExposedPorts(10000);

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.testing.testcontainers.ImageNames;
+
 /**
  * @author Jakub Cechacek
  */
@@ -29,16 +31,16 @@ public final class ConfigProperties {
 
     // DockerConfiguration configuration
     public static final String DOCKER_IMAGE_KAFKA_RHEL = System.getProperty("test.docker.image.kc");
-    public static final String DOCKER_IMAGE_MYSQL = System.getProperty("test.docker.image.mysql", "quay.io/debezium/example-mysql-master:latest");
-    public static final String DOCKER_IMAGE_MYSQL_REPLICA = System.getProperty("test.docker.image.mysql.replica", "quay.io/debezium/example-mysql-replica:latest");
+    public static final String DOCKER_IMAGE_MYSQL = System.getProperty("test.docker.image.mysql", ImageNames.MYSQL_LATEST_IMAGE);
+    public static final String DOCKER_IMAGE_MYSQL_REPLICA = System.getProperty("test.docker.image.mysql.replica", ImageNames.MYSQL_REPLICA_IMAGE);
 
-    public static final String DOCKER_IMAGE_POSTGRESQL = System.getProperty("test.docker.image.postgresql", "quay.io/debezium/example-postgres:latest");
-    public static final String DOCKER_IMAGE_MONGO = System.getProperty("test.docker.image.mongo", "quay.io/debezium/example-mongodb:2.6");
-    public static final String DOCKER_IMAGE_MONGO_SHARDED = System.getProperty("test.docker.image.mongo.sharded", "quay.io/debezium/example-mongodb:2.6");
-    public static final String DOCKER_IMAGE_SQLSERVER = System.getProperty("test.docker.image.sqlserver", "mcr.microsoft.com/mssql/server:2019-latest");
-    public static final String DOCKER_IMAGE_DB2 = System.getProperty("test.docker.image.db2", "quay.io/debezium/db2-cdc:latest");
-    public static final String DOCKER_IMAGE_ORACLE = System.getProperty("test.docker.image.oracle", "quay.io/rh_integration/dbz-oracle:19.3.0");
-    public static final String DOCKER_IMAGE_INFORMIX = System.getProperty("test.docker.image.informix", "quay.io/rh_integration/dbz-informix:14");
+    public static final String DOCKER_IMAGE_POSTGRESQL = System.getProperty("test.docker.image.postgresql", ImageNames.POSTGRES_EXAMPLE_LATEST_IMAGE);
+    public static final String DOCKER_IMAGE_MONGO = System.getProperty("test.docker.image.mongo", ImageNames.MONGO_EXAMPLE_IMAGE);
+    public static final String DOCKER_IMAGE_MONGO_SHARDED = System.getProperty("test.docker.image.mongo.sharded", ImageNames.MONGO_EXAMPLE_IMAGE);
+    public static final String DOCKER_IMAGE_SQLSERVER = System.getProperty("test.docker.image.sqlserver", ImageNames.SQLSERVER_2019_IMAGE);
+    public static final String DOCKER_IMAGE_DB2 = System.getProperty("test.docker.image.db2", ImageNames.DB2_IMAGE);
+    public static final String DOCKER_IMAGE_ORACLE = System.getProperty("test.docker.image.oracle", ImageNames.ORACLE_DBZ_19_3_0_IMAGE);
+    public static final String DOCKER_IMAGE_INFORMIX = System.getProperty("test.docker.image.informix", ImageNames.INFORMIX_IMAGE);
 
     // OpenShift configuration
     public static final Optional<String> OCP_URL = stringOptionalProperty("test.ocp.url");

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/ConfigProperties.java
@@ -31,10 +31,10 @@ public final class ConfigProperties {
 
     // DockerConfiguration configuration
     public static final String DOCKER_IMAGE_KAFKA_RHEL = System.getProperty("test.docker.image.kc");
-    public static final String DOCKER_IMAGE_MYSQL = System.getProperty("test.docker.image.mysql", ImageNames.MYSQL_LATEST_IMAGE);
-    public static final String DOCKER_IMAGE_MYSQL_REPLICA = System.getProperty("test.docker.image.mysql.replica", ImageNames.MYSQL_REPLICA_IMAGE);
+    public static final String DOCKER_IMAGE_MYSQL = System.getProperty("test.docker.image.mysql", ImageNames.MYSQL_EXAMPLE_PRIMARY_IMAGE);
+    public static final String DOCKER_IMAGE_MYSQL_REPLICA = System.getProperty("test.docker.image.mysql.replica", ImageNames.MYSQL_EXAMPLE_REPLICA_IMAGE);
 
-    public static final String DOCKER_IMAGE_POSTGRESQL = System.getProperty("test.docker.image.postgresql", ImageNames.POSTGRES_EXAMPLE_LATEST_IMAGE);
+    public static final String DOCKER_IMAGE_POSTGRESQL = System.getProperty("test.docker.image.postgresql", ImageNames.POSTGRES_EXAMPLE_IMAGE);
     public static final String DOCKER_IMAGE_MONGO = System.getProperty("test.docker.image.mongo", ImageNames.MONGO_EXAMPLE_IMAGE);
     public static final String DOCKER_IMAGE_MONGO_SHARDED = System.getProperty("test.docker.image.mongo.sharded", ImageNames.MONGO_EXAMPLE_IMAGE);
     public static final String DOCKER_IMAGE_SQLSERVER = System.getProperty("test.docker.image.sqlserver", ImageNames.SQLSERVER_2019_IMAGE);

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
@@ -17,7 +17,7 @@ public class ApicurioRegistryContainer extends GenericContainer<ApicurioRegistry
     private static final String APICURIO_VERSION = getApicurioVersion();
     private static final Integer APICURIO_PORT = 8080;
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
-    public static final String APICURIO_REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry";
+    public static final String APICURIO_REGISTRY_IMAGE = ImageNames.APICURIO_IMAGE;
 
     public ApicurioRegistryContainer() {
         super(APICURIO_REGISTRY_IMAGE + ":" + APICURIO_VERSION);

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ApicurioRegistryContainer.java
@@ -17,7 +17,7 @@ public class ApicurioRegistryContainer extends GenericContainer<ApicurioRegistry
     private static final String APICURIO_VERSION = getApicurioVersion();
     private static final Integer APICURIO_PORT = 8080;
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
-    public static final String APICURIO_REGISTRY_IMAGE = ImageNames.APICURIO_IMAGE;
+    public static final String APICURIO_REGISTRY_IMAGE = ImageNames.APICURIO_REGISTRY_IMAGE;
 
     public ApicurioRegistryContainer() {
         super(APICURIO_REGISTRY_IMAGE + ":" + APICURIO_VERSION);

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -49,7 +49,7 @@ import okhttp3.ResponseBody;
  */
 public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
 
-    private static final String DEBEZIUM_CONTAINER = "quay.io/debezium/connect";
+    private static final String DEBEZIUM_CONTAINER = ImageNames.DEBEZIUM_IMAGE;
     private static final String DEBEZIUM_NIGHTLY_TAG = "nightly";
 
     private static final int KAFKA_CONNECT_PORT = 8083;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -49,7 +49,7 @@ import okhttp3.ResponseBody;
  */
 public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
 
-    private static final String DEBEZIUM_CONTAINER = ImageNames.DEBEZIUM_IMAGE;
+    private static final String DEBEZIUM_CONTAINER = ImageNames.DEBEZIUM_CONNECT_IMAGE;
     private static final String DEBEZIUM_NIGHTLY_TAG = "nightly";
 
     private static final int KAFKA_CONNECT_PORT = 8083;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
@@ -21,6 +21,54 @@ public final class ImageNames {
 
     public static final String OFFICIAL_MONGODB_IMAGE = "quay.io/debezium/official-mongo:8.0";
 
+    public static final String MYSQL_EXAMPLE_IMAGE = "quay.io/debezium/example-mysql";
+
+    public static final String SQLSERVER_22_IMAGE = "mcr.microsoft.com/mssql/server:2022-latest";
+
+    public static final String MYSQL_9_IMAGE = "container-registry.oracle.com/mysql/community-server:9.0";
+
+    public static final String POSTGRES_EXAMPLE_IMAGE = "quay.io/debezium/example-postgres";
+
+    public static final String MYSQL_LATEST_IMAGE = "quay.io/debezium/example-mysql-master:latest";
+
+    public static final String MYSQL_REPLICA_IMAGE = "quay.io/debezium/example-mysql-replica:latest";
+
+    public static final String POSTGRES_EXAMPLE_LATEST_IMAGE = "quay.io/debezium/example-postgres:latest";
+
+    public static final String MONGO_EXAMPLE_IMAGE = "quay.io/debezium/example-mongodb:2.6";
+
+    public static final String SQLSERVER_2019_IMAGE = "mcr.microsoft.com/mssql/server:2019-latest";
+
+    public static final String DB2_IMAGE = "quay.io/debezium/db2-cdc:latest";
+
+    public static final String ORACLE_DBZ_19_3_0_IMAGE = "quay.io/rh_integration/dbz-oracle:19.3.0";
+
+    public static final String INFORMIX_IMAGE = "quay.io/rh_integration/dbz-informix:14";
+
+    public static final String DEBEZIUM_IMAGE = "quay.io/debezium/connect";
+
+    public static final String SCHEMA_REGISTERY_IMAGE = "quay.io/debezium/confluentinc-cp-schema-registry:6.0.2";
+
+    public static final String APICURIO_IMAGE = "quay.io/apicurio/apicurio-registry";
+
+    public static final String REDIS_ALPINE_IMAGE = "redis:5.0.3-alpine";
+
+    public static final String MYSQL_9_7_IMAGE = "container-registry.oracle.com/mysql/community-server:9.7";
+
+    public static final String DOCLING_1_15_IMAGE = "quay.io/docling-project/docling-serve:v1.15.0";
+
+    public static final String OLLAMA_0_6_2_IMAGE = "mirror.gcr.io/ollama/ollama:0.6.2";
+
+    public static final String AZURITE_IMAGE = "mcr.microsoft.com/azure-storage/azurite";
+
+    public static final String MONGO_OFFICIAL_IMAGE = "quay.io/debezium/official-mongo";
+
+    public static final String DBZ_ORACLE_IMAGE = "quay.io/rh_integration/dbz-oracle";
+
+    public static final String MARIADB_IMAGE = "quay.io/debezium/example-mariadb";
+
+    public static final String KAFKA_IMAGE = "quay.io/debezium/confluentinc-cp-kafka:7.2.10";
+
     public static final DockerImageName POSTGRES_DOCKER_IMAGE_NAME = DockerImageName.parse(POSTGRES_IMAGE)
             .asCompatibleSubstituteFor("postgres");
 
@@ -33,4 +81,61 @@ public final class ImageNames {
 
     public static final DockerImageName OFFICIAL_DOCKER_IMAGE_NAME = DockerImageName.parse(OFFICIAL_MONGODB_IMAGE)
             .asCompatibleSubstituteFor("mongodb");
+
+    public static final DockerImageName MYSQL_EXAMPLE_IMAGE_NAME = DockerImageName.parse(MYSQL_EXAMPLE_IMAGE);
+
+    public static final DockerImageName SQLSERVER_22_IMAGE_NAME = DockerImageName.parse(SQLSERVER_22_IMAGE);
+
+    public static final DockerImageName MYSQL_9_IMAGE_NAME = DockerImageName.parse(MYSQL_9_IMAGE);
+
+    public static final DockerImageName POSTGRES_EXAMPLE_IMAGE_NAME = DockerImageName.parse(POSTGRES_EXAMPLE_IMAGE);
+
+    public static final DockerImageName MYSQL_LATEST_IMAGE_NAME = DockerImageName.parse(MYSQL_LATEST_IMAGE);
+
+    public static final DockerImageName MYSQL_REPLICA_IMAGE_NAME = DockerImageName.parse(MYSQL_REPLICA_IMAGE);
+
+    public static final DockerImageName POSTGRES_EXAMPLE_LATEST_IMAGE_NAME = DockerImageName.parse(POSTGRES_EXAMPLE_LATEST_IMAGE);
+
+    public static final DockerImageName MONGO_EXAMPLE_IMAGE_NAME = DockerImageName.parse(MONGO_EXAMPLE_IMAGE);
+
+    public static final DockerImageName SQLSERVER_2019_IMAGE_NAME = DockerImageName.parse(SQLSERVER_2019_IMAGE);
+
+    public static final DockerImageName DB2_IMAGE_NAME = DockerImageName.parse(DB2_IMAGE)
+            .asCompatibleSubstituteFor("ibmcom/db2");
+
+    public static final DockerImageName ORACLE_DBZ_19_3_0_IMAGE_NAME = DockerImageName.parse(ORACLE_DBZ_19_3_0_IMAGE);
+
+    public static final DockerImageName INFORMIX_IMAGE_NAME = DockerImageName.parse(INFORMIX_IMAGE);
+
+    public static final DockerImageName APICURIO_IMAGE_NAME = DockerImageName.parse(APICURIO_IMAGE);
+
+    public static final DockerImageName REDIS_ALPINE_IMAGE_NAME = DockerImageName.parse(REDIS_ALPINE_IMAGE);
+
+    public static final DockerImageName MYSQL_9_7_IMAGE_NAME = DockerImageName.parse(MYSQL_9_7_IMAGE);
+
+    public static final DockerImageName DOCLING_1_15_IMAGE_NAME = DockerImageName.parse(DOCLING_1_15_IMAGE);
+
+    public static final DockerImageName OLLAMA_0_6_2_IMAGE_NAME = DockerImageName.parse(OLLAMA_0_6_2_IMAGE);
+
+    public static final DockerImageName DEBEZIUM_IMAGE_NAME = DockerImageName.parse(DEBEZIUM_IMAGE);
+
+    public static final DockerImageName SCHEMA_REGISTERY_IMAGE_NAME = DockerImageName.parse(SCHEMA_REGISTERY_IMAGE);
+
+    public static final DockerImageName DB2_11_5_9_IMAGE_NAME = DockerImageName.parse("icr.io/db2_community/db2:11.5.9.0");
+
+    public static final DockerImageName COCKROACHDB_25_4_12_IMAGE_NAME = DockerImageName.parse("docker.io/cockroachdb/cockroach:v25.4.12")
+            .asCompatibleSubstituteFor("cockroachdb/cockroach");
+
+    public static final DockerImageName POSTGRES_17_IMAGE_NAME = DockerImageName.parse("quay.io/debezium/postgres:17")
+            .asCompatibleSubstituteFor("postgres");
+
+    public static final DockerImageName AZURITE_IMAGE_NAME = DockerImageName.parse(AZURITE_IMAGE);
+
+    public static final DockerImageName MONGO_OFFICIAL_IMAGE_NAME = DockerImageName.parse(MONGO_OFFICIAL_IMAGE);
+
+    public static final DockerImageName DBZ_ORACLE_IMAGE_NAME = DockerImageName.parse(DBZ_ORACLE_IMAGE);
+
+    public static final DockerImageName MARIADB_IMAGE_NAME = DockerImageName.parse(MARIADB_IMAGE);
+
+    public static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse(KAFKA_IMAGE);
 }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ImageNames.java
@@ -9,7 +9,35 @@ import org.testcontainers.utility.DockerImageName;
 
 public final class ImageNames {
 
-    private static final String POSTGRES_IMAGE = "quay.io/debezium/postgres:15";
+    private static final String POSTGRES_IMAGE_STEM = "quay.io/debezium/postgres";
+
+    private static final String POSTGRES_15_IMAGE = POSTGRES_IMAGE_STEM + ":15";
+
+    private static final String POSTGRES_17_IMAGE = POSTGRES_IMAGE_STEM + ":17";
+
+    private static final String MONGO_IMAGE_STEM = "quay.io/debezium/official-mongo";
+
+    public static final String MONGO_8_0_OFFICIAL_IMAGE = MONGO_IMAGE_STEM + ":8.0";
+
+    public static final String MONGO_OFFICIAL_IMAGE = MONGO_IMAGE_STEM;
+
+    private static final String SQLSERVER_IMAGE_STEM = "mcr.microsoft.com/mssql/server";
+
+    public static final String SQLSERVER_22_IMAGE = SQLSERVER_IMAGE_STEM + ":2022-latest";
+
+    public static final String SQLSERVER_2019_IMAGE = SQLSERVER_IMAGE_STEM + ":2019-latest";
+
+    private static final String MYSQL_IMAGE_STEM = "container-registry.oracle.com/mysql/community-server";
+
+    public static final String MYSQL_9_IMAGE = MYSQL_IMAGE_STEM + ":9.0";
+
+    public static final String MYSQL_9_7_IMAGE = MYSQL_IMAGE_STEM + ":9.7";
+
+    private static final String ORACLE_IMAGE_STEM = "quay.io/rh_integration/dbz-oracle";
+
+    public static final String ORACLE_DBZ_19_3_0_IMAGE = ORACLE_IMAGE_STEM + ":19.3.0";
+
+    public static final String ORACLE_DBZ_IMAGE = ORACLE_IMAGE_STEM;
 
     private static final String TIMESCALE_DB_IMAGE = "quay.io/debezium/timescale-timescaledb:latest-pg15";
 
@@ -19,41 +47,27 @@ public final class ImageNames {
     // hub.image.name.prefix substitution; the image is only published on Docker Hub.
     private static final String STARROCKS_IMAGE = "docker.io/starrocks/allin1-ubuntu:4.1.1";
 
-    public static final String OFFICIAL_MONGODB_IMAGE = "quay.io/debezium/official-mongo:8.0";
-
     public static final String MYSQL_EXAMPLE_IMAGE = "quay.io/debezium/example-mysql";
-
-    public static final String SQLSERVER_22_IMAGE = "mcr.microsoft.com/mssql/server:2022-latest";
-
-    public static final String MYSQL_9_IMAGE = "container-registry.oracle.com/mysql/community-server:9.0";
 
     public static final String POSTGRES_EXAMPLE_IMAGE = "quay.io/debezium/example-postgres";
 
-    public static final String MYSQL_LATEST_IMAGE = "quay.io/debezium/example-mysql-master:latest";
+    public static final String MYSQL_EXAMPLE_PRIMARY_IMAGE = "quay.io/debezium/example-mysql-master:latest";
 
-    public static final String MYSQL_REPLICA_IMAGE = "quay.io/debezium/example-mysql-replica:latest";
-
-    public static final String POSTGRES_EXAMPLE_LATEST_IMAGE = "quay.io/debezium/example-postgres:latest";
+    public static final String MYSQL_EXAMPLE_REPLICA_IMAGE = "quay.io/debezium/example-mysql-replica:latest";
 
     public static final String MONGO_EXAMPLE_IMAGE = "quay.io/debezium/example-mongodb:2.6";
 
-    public static final String SQLSERVER_2019_IMAGE = "mcr.microsoft.com/mssql/server:2019-latest";
-
     public static final String DB2_IMAGE = "quay.io/debezium/db2-cdc:latest";
-
-    public static final String ORACLE_DBZ_19_3_0_IMAGE = "quay.io/rh_integration/dbz-oracle:19.3.0";
 
     public static final String INFORMIX_IMAGE = "quay.io/rh_integration/dbz-informix:14";
 
-    public static final String DEBEZIUM_IMAGE = "quay.io/debezium/connect";
+    public static final String DEBEZIUM_CONNECT_IMAGE = "quay.io/debezium/connect";
 
-    public static final String SCHEMA_REGISTERY_IMAGE = "quay.io/debezium/confluentinc-cp-schema-registry:6.0.2";
+    public static final String CONFLUENT_REGISTRY_IMAGE = "quay.io/debezium/confluentinc-cp-schema-registry:6.0.2";
 
-    public static final String APICURIO_IMAGE = "quay.io/apicurio/apicurio-registry";
+    public static final String APICURIO_REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry";
 
     public static final String REDIS_ALPINE_IMAGE = "redis:5.0.3-alpine";
-
-    public static final String MYSQL_9_7_IMAGE = "container-registry.oracle.com/mysql/community-server:9.7";
 
     public static final String DOCLING_1_15_IMAGE = "quay.io/docling-project/docling-serve:v1.15.0";
 
@@ -61,15 +75,11 @@ public final class ImageNames {
 
     public static final String AZURITE_IMAGE = "mcr.microsoft.com/azure-storage/azurite";
 
-    public static final String MONGO_OFFICIAL_IMAGE = "quay.io/debezium/official-mongo";
-
-    public static final String DBZ_ORACLE_IMAGE = "quay.io/rh_integration/dbz-oracle";
-
     public static final String MARIADB_IMAGE = "quay.io/debezium/example-mariadb";
 
-    public static final String KAFKA_IMAGE = "quay.io/debezium/confluentinc-cp-kafka:7.2.10";
+    public static final String CONFLUENT_KAFKA_IMAGE = "quay.io/debezium/confluentinc-cp-kafka:7.2.10";
 
-    public static final DockerImageName POSTGRES_DOCKER_IMAGE_NAME = DockerImageName.parse(POSTGRES_IMAGE)
+    public static final DockerImageName POSTGRES_15_IMAGE_NAME = DockerImageName.parse(POSTGRES_15_IMAGE)
             .asCompatibleSubstituteFor("postgres");
 
     public static final DockerImageName TIMESCALE_DB_IMAGE_NAME = DockerImageName.parse(TIMESCALE_DB_IMAGE)
@@ -79,7 +89,7 @@ public final class ImageNames {
 
     public static final DockerImageName STARROCKS_DOCKER_IMAGE_NAME = DockerImageName.parse(STARROCKS_IMAGE);
 
-    public static final DockerImageName OFFICIAL_DOCKER_IMAGE_NAME = DockerImageName.parse(OFFICIAL_MONGODB_IMAGE)
+    public static final DockerImageName MONGO_8_0_OFFICIAL_IMAGE_NAME = DockerImageName.parse(MONGO_8_0_OFFICIAL_IMAGE)
             .asCompatibleSubstituteFor("mongodb");
 
     public static final DockerImageName MYSQL_EXAMPLE_IMAGE_NAME = DockerImageName.parse(MYSQL_EXAMPLE_IMAGE);
@@ -90,11 +100,9 @@ public final class ImageNames {
 
     public static final DockerImageName POSTGRES_EXAMPLE_IMAGE_NAME = DockerImageName.parse(POSTGRES_EXAMPLE_IMAGE);
 
-    public static final DockerImageName MYSQL_LATEST_IMAGE_NAME = DockerImageName.parse(MYSQL_LATEST_IMAGE);
+    public static final DockerImageName MYSQL_EXAMPLE_PRIMARY_IMAGE_NAME = DockerImageName.parse(MYSQL_EXAMPLE_PRIMARY_IMAGE);
 
-    public static final DockerImageName MYSQL_REPLICA_IMAGE_NAME = DockerImageName.parse(MYSQL_REPLICA_IMAGE);
-
-    public static final DockerImageName POSTGRES_EXAMPLE_LATEST_IMAGE_NAME = DockerImageName.parse(POSTGRES_EXAMPLE_LATEST_IMAGE);
+    public static final DockerImageName MYSQL_EXAMPLE_REPLICA_IMAGE_NAME = DockerImageName.parse(MYSQL_EXAMPLE_REPLICA_IMAGE);
 
     public static final DockerImageName MONGO_EXAMPLE_IMAGE_NAME = DockerImageName.parse(MONGO_EXAMPLE_IMAGE);
 
@@ -107,7 +115,7 @@ public final class ImageNames {
 
     public static final DockerImageName INFORMIX_IMAGE_NAME = DockerImageName.parse(INFORMIX_IMAGE);
 
-    public static final DockerImageName APICURIO_IMAGE_NAME = DockerImageName.parse(APICURIO_IMAGE);
+    public static final DockerImageName APICURIO_REGISTRY_IMAGE_NAME = DockerImageName.parse(APICURIO_REGISTRY_IMAGE);
 
     public static final DockerImageName REDIS_ALPINE_IMAGE_NAME = DockerImageName.parse(REDIS_ALPINE_IMAGE);
 
@@ -117,25 +125,25 @@ public final class ImageNames {
 
     public static final DockerImageName OLLAMA_0_6_2_IMAGE_NAME = DockerImageName.parse(OLLAMA_0_6_2_IMAGE);
 
-    public static final DockerImageName DEBEZIUM_IMAGE_NAME = DockerImageName.parse(DEBEZIUM_IMAGE);
+    public static final DockerImageName DEBEZIUM_CONNECT_IMAGE_NAME = DockerImageName.parse(DEBEZIUM_CONNECT_IMAGE);
 
-    public static final DockerImageName SCHEMA_REGISTERY_IMAGE_NAME = DockerImageName.parse(SCHEMA_REGISTERY_IMAGE);
+    public static final DockerImageName CONFLUENT_REGISTRY_IMAGE_NAME = DockerImageName.parse(CONFLUENT_REGISTRY_IMAGE);
 
     public static final DockerImageName DB2_11_5_9_IMAGE_NAME = DockerImageName.parse("icr.io/db2_community/db2:11.5.9.0");
 
     public static final DockerImageName COCKROACHDB_25_4_12_IMAGE_NAME = DockerImageName.parse("docker.io/cockroachdb/cockroach:v25.4.12")
             .asCompatibleSubstituteFor("cockroachdb/cockroach");
 
-    public static final DockerImageName POSTGRES_17_IMAGE_NAME = DockerImageName.parse("quay.io/debezium/postgres:17")
+    public static final DockerImageName POSTGRES_17_IMAGE_NAME = DockerImageName.parse(POSTGRES_17_IMAGE)
             .asCompatibleSubstituteFor("postgres");
 
     public static final DockerImageName AZURITE_IMAGE_NAME = DockerImageName.parse(AZURITE_IMAGE);
 
     public static final DockerImageName MONGO_OFFICIAL_IMAGE_NAME = DockerImageName.parse(MONGO_OFFICIAL_IMAGE);
 
-    public static final DockerImageName DBZ_ORACLE_IMAGE_NAME = DockerImageName.parse(DBZ_ORACLE_IMAGE);
+    public static final DockerImageName ORACLE_DBZ_IMAGE_NAME = DockerImageName.parse(ORACLE_DBZ_IMAGE);
 
     public static final DockerImageName MARIADB_IMAGE_NAME = DockerImageName.parse(MARIADB_IMAGE);
 
-    public static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse(KAFKA_IMAGE);
+    public static final DockerImageName CONFLUENT_KAFKA_IMAGE_NAME = DockerImageName.parse(CONFLUENT_KAFKA_IMAGE);
 }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/InformixContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/InformixContainer.java
@@ -16,7 +16,7 @@ import org.testcontainers.utility.DockerImageName;
 public class InformixContainer extends JdbcDatabaseContainer<InformixContainer> {
 
     public static final String NAME = "informix";
-    public static final String DOCKER_IMAGE = parameterWithDefault("test.docker.image.informix", "quay.io/rh_integration/dbz-informix:14");
+    public static final String DOCKER_IMAGE = parameterWithDefault("test.docker.image.informix", ImageNames.INFORMIX_IMAGE);
     private static final String INFORMIX_USERNAME = parameterWithDefault("test.database.informix.username", "informix");
     private static final String INFORMIX_PASSWORD = parameterWithDefault("test.database.informix.password", "in4mix");
     public static final String INFORMIX_DBNAME = parameterWithDefault("test.database.informix.dbz.dbname", "testdb");

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
@@ -54,7 +54,7 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
      * Default should match {@code version.mongo.server} in parent {@code pom.xml}.
      */
     public static final String IMAGE_VERSION = System.getProperty("version.mongo.server", "8.0");
-    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("quay.io/debezium/official-mongo").withTag(IMAGE_VERSION);
+    private static final DockerImageName IMAGE_NAME = DockerImageName.parse(ImageNames.MONGO_OFFICIAL_IMAGE).withTag(IMAGE_VERSION);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String CONTAINER_KEYFILE_PATH = "/data/replica.key";

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MySqlTestResourceLifecycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MySqlTestResourceLifecycleManager.java
@@ -25,7 +25,7 @@ public class MySqlTestResourceLifecycleManager implements QuarkusTestResourceLif
     public static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     public static final String ROOT_PASSWORD = "debezium";
     public static final String DBNAME = "inventory";
-    public static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
+    public static final String IMAGE = ImageNames.MYSQL_EXAMPLE_PRIMARY_IMAGE;
     public static final String HOST = "localhost";
     public static final Integer PORT = 3306;
 

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MySqlTestResourceLifecycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MySqlTestResourceLifecycleManager.java
@@ -25,7 +25,7 @@ public class MySqlTestResourceLifecycleManager implements QuarkusTestResourceLif
     public static final String PRIVILEGED_PASSWORD = "mysqlpassword";
     public static final String ROOT_PASSWORD = "debezium";
     public static final String DBNAME = "inventory";
-    public static final String IMAGE = "quay.io/debezium/example-mysql";
+    public static final String IMAGE = ImageNames.MYSQL_EXAMPLE_IMAGE;
     public static final String HOST = "localhost";
     public static final Integer PORT = 3306;
 

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/OracleContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/OracleContainer.java
@@ -17,7 +17,7 @@ public class OracleContainer extends org.testcontainers.containers.OracleContain
 
     private static final String FALLBACK_ORACLE_SERVER_VERSION = "21.3.0";
     public static final String DEFAULT_TAG = parameterWithDefault(System.getProperty("version.oracle.server"), FALLBACK_ORACLE_SERVER_VERSION);
-    public static final DockerImageName DEFAULT_IMAGE_NAME = ImageNames.DBZ_ORACLE_IMAGE_NAME;
+    public static final DockerImageName DEFAULT_IMAGE_NAME = ImageNames.ORACLE_DBZ_IMAGE_NAME;
     public final String ORACLE_DBNAME = parameterWithDefault(System.getProperty("database.dbname"), "ORCLCDB");
     public final String ORACLE_PDB_NAME = parameterWithDefault(System.getProperty("database.pdb.name"), "ORCLPDB1");
     private static final String ORACLE_USERNAME = parameterWithDefault(System.getProperty("database.username"), "debezium");

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/OracleContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/OracleContainer.java
@@ -17,7 +17,7 @@ public class OracleContainer extends org.testcontainers.containers.OracleContain
 
     private static final String FALLBACK_ORACLE_SERVER_VERSION = "21.3.0";
     public static final String DEFAULT_TAG = parameterWithDefault(System.getProperty("version.oracle.server"), FALLBACK_ORACLE_SERVER_VERSION);
-    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("quay.io/rh_integration/dbz-oracle");
+    public static final DockerImageName DEFAULT_IMAGE_NAME = ImageNames.DBZ_ORACLE_IMAGE_NAME;
     public final String ORACLE_DBNAME = parameterWithDefault(System.getProperty("database.dbname"), "ORCLCDB");
     public final String ORACLE_PDB_NAME = parameterWithDefault(System.getProperty("database.pdb.name"), "ORCLPDB1");
     private static final String ORACLE_USERNAME = parameterWithDefault(System.getProperty("database.username"), "debezium");

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/PostgresTestResourceLifecycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/PostgresTestResourceLifecycleManager.java
@@ -22,7 +22,7 @@ public class PostgresTestResourceLifecycleManager implements QuarkusTestResource
     public static final String POSTGRES_USER = "postgres";
     public static final String POSTGRES_PASSWORD = "postgres";
     public static final String POSTGRES_DBNAME = "postgres";
-    public static final String POSTGRES_IMAGE = "quay.io/debezium/example-postgres";
+    public static final String POSTGRES_IMAGE = ImageNames.POSTGRES_EXAMPLE_IMAGE;
     public static final String POSTGRES_HOST = "localhost";
     public static final Integer POSTGRES_PORT = 5432;
     public static final String JDBC_POSTGRESQL_URL_FORMAT = "jdbc:postgresql://%s:%s/";

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryContainer.java
@@ -12,7 +12,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = ImageNames.SCHEMA_REGISTERY_IMAGE;
+    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = ImageNames.CONFLUENT_REGISTRY_IMAGE;
     private static final DockerImageName SCHEMA_REGISTRY_DOCKER_IMAGE = DockerImageName.parse(SCHEMA_REGISTRY_DOCKER_IMAGE_NAME)
             .asCompatibleSubstituteFor("confluentinc/cp-schema-registry");
     private static final Integer SCHEMA_REGISTRY_EXPOSED_PORT = 8081;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryContainer.java
@@ -12,7 +12,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = "quay.io/debezium/confluentinc-cp-schema-registry:6.0.2";
+    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = ImageNames.SCHEMA_REGISTERY_IMAGE;
     private static final DockerImageName SCHEMA_REGISTRY_DOCKER_IMAGE = DockerImageName.parse(SCHEMA_REGISTRY_DOCKER_IMAGE_NAME)
             .asCompatibleSubstituteFor("confluentinc/cp-schema-registry");
     private static final Integer SCHEMA_REGISTRY_EXPOSED_PORT = 8081;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryTestResourceLifecycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryTestResourceLifecycleManager.java
@@ -23,7 +23,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 public class SchemaRegistryTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegistryTestResourceLifecycleManager.class);
-    private static final String defaultImage = "quay.io/debezium/confluentinc-cp-kafka:7.2.10";
+    private static final String defaultImage = ImageNames.KAFKA_IMAGE;
 
     private static final Network network = Network.newNetwork();
     private static final Integer PORT = 8081;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryTestResourceLifecycleManager.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/SchemaRegistryTestResourceLifecycleManager.java
@@ -23,7 +23,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 public class SchemaRegistryTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegistryTestResourceLifecycleManager.class);
-    private static final String defaultImage = ImageNames.KAFKA_IMAGE;
+    private static final String defaultImage = ImageNames.CONFLUENT_KAFKA_IMAGE;
 
     private static final Network network = Network.newNetwork();
     private static final Integer PORT = 8081;

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/testhelper/TestInfrastructureHelper.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/testhelper/TestInfrastructureHelper.java
@@ -82,7 +82,7 @@ public class TestInfrastructureHelper {
             .withNetworkAliases("postgres");
 
     private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(
-            DockerImageName.parse(ImageNames.MYSQL_EXAMPLE_IMAGE + ":" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mysql"))
+            DockerImageName.parse(ImageNames.MYSQL_EXAMPLE_PRIMARY_IMAGE + ":" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mysql"))
             .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(8)))
             .withNetwork(NETWORK)
             .withUsername("mysqluser")

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/testhelper/TestInfrastructureHelper.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/testhelper/TestInfrastructureHelper.java
@@ -32,6 +32,7 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.testing.testcontainers.DebeziumContainer;
+import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.testing.testcontainers.OracleContainer;
 import io.debezium.testing.testcontainers.util.MoreStartables;
 import io.strimzi.test.container.StrimziKafkaCluster;
@@ -75,13 +76,13 @@ public class TestInfrastructureHelper {
     private static DebeziumContainer DEBEZIUM_CONTAINER = null;
 
     private static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>(
-            DockerImageName.parse("quay.io/debezium/example-postgres:" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("postgres"))
+            DockerImageName.parse(ImageNames.POSTGRES_EXAMPLE_IMAGE + ":" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("postgres"))
             .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(8)))
             .withNetwork(NETWORK)
             .withNetworkAliases("postgres");
 
     private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(
-            DockerImageName.parse("quay.io/debezium/example-mysql:" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mysql"))
+            DockerImageName.parse(ImageNames.MYSQL_EXAMPLE_IMAGE + ":" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mysql"))
             .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(8)))
             .withNetwork(NETWORK)
             .withUsername("mysqluser")
@@ -90,7 +91,7 @@ public class TestInfrastructureHelper {
             .withNetworkAliases("mysql");
 
     private static final MariaDBContainer<?> MARIADB_CONTAINER = new MariaDBContainer<>(
-            DockerImageName.parse("quay.io/debezium/example-mariadb:" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mariadb"))
+            DockerImageName.parse(ImageNames.MARIADB_IMAGE + ":" + DEBEZIUM_CONTAINER_IMAGE_VERSION_LATEST).asCompatibleSubstituteFor("mariadb"))
             .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(8)))
             .withNetwork(NETWORK)
             .withUsername("mariadbuser")
@@ -98,7 +99,7 @@ public class TestInfrastructureHelper {
             .withEnv("MARIADB_ROOT_PASSWORD", "debezium")
             .withNetworkAliases("mariadb");
 
-    private static final MSSQLServerContainer<?> SQL_SERVER_CONTAINER = new MSSQLServerContainer<>(DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest"))
+    private static final MSSQLServerContainer<?> SQL_SERVER_CONTAINER = new MSSQLServerContainer<>(ImageNames.SQLSERVER_2019_IMAGE_NAME)
             .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(8)))
             .withNetwork(NETWORK)
             .withNetworkAliases("sqlserver")

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTestIT.java
@@ -65,7 +65,7 @@ public class ApicurioRegistryTestIT {
 
     private static StrimziKafkaCluster kafkaCluster;
 
-    public static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(ImageNames.POSTGRES_DOCKER_IMAGE_NAME)
+    public static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(ImageNames.POSTGRES_15_IMAGE_NAME)
             .withNetwork(NETWORK)
             .withNetworkAliases("postgres");
 

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerIT.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerIT.java
@@ -53,7 +53,7 @@ public class DebeziumContainerIT {
 
     private static StrimziKafkaCluster kafkaCluster;
 
-    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(ImageNames.POSTGRES_DOCKER_IMAGE_NAME)
+    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(ImageNames.POSTGRES_15_IMAGE_NAME)
             .withNetwork(network)
             .withNetworkAliases("postgres");
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -411,3 +411,4 @@ Rohith,Rohith Devarshetty
 soepic1,Oladele Oluwaseun
 ragulshanmugam,Ragul Shanmugam
 tusharsaini18899,Tushar Saini
+MoMoUsama, Mohamed Elkholy


### PR DESCRIPTION
Fixes debezium/dbz#2503

## Description
Centralizes Docker/Testcontainers image name were previously scattered and duplicated across multiple locations in the codebase into a single source of truth: `ImageNames` in `debezium-testing-testcontainers`.

## New test-scope dependency on `debezium-testing-testcontainers`

The following 5 modules didn't previously depend on `debezium-testing-testcontainers` and needed it added (test scope only, no runtime/compile impact) to reach the centralized constants:

- `debezium-ai/debezium-ai-embeddings-ollama`
- `debezium-ai/debezium-ai-docling`
- `debezium-storage/debezium-storage-jdbc`
- `debezium-storage/debezium-storage-redis`
- `debezium-storage/debezium-storage-tests`

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
